### PR TITLE
fix: update playground links after docs page removal

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -53,7 +53,7 @@ jobs:
           enable-cache: true
 
       - name: Build docs
-        run: uv run --only-group docs mkdocs build
+        run: uv run --only-group docs mkdocs build --strict
         env:
           SITE_URL: https://unitaryfoundation.github.io/clifft/pr-preview/pr-${{ github.event.number }}/
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -149,7 +149,7 @@ cmake -B build
 
 ## WebAssembly Build
 
-For the browser-based [Playground](../playground.md):
+For the browser-based [Playground](../playground/):
 
 ```bash
 # Requires Docker
@@ -157,7 +157,7 @@ just build-wasm
 just test-wasm
 ```
 
-Outputs `playground/public/clifft_wasm.{js,wasm}`. See the [Playground](../playground.md) page.
+Outputs `playground/public/clifft_wasm.{js,wasm}`. See the [Playground](../playground/) page.
 
 ## IDE Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,4 +65,4 @@ print(result.measurements[:5])  # First 5 shots
 ## Get Started
 
 [Install Clifft](getting-started/installation.md){ .md-button .md-button--primary }
-[Try the Playground](playground.md){ .md-button }
+[Try the Playground](playground/){ .md-button }

--- a/docs/reference/instructions.md
+++ b/docs/reference/instructions.md
@@ -5,7 +5,7 @@ levels of the pipeline: the **Heisenberg IR** (HIR) produced by the front-end,
 and the **VM Opcodes** (RISC bytecode) executed by the Schrodinger Virtual Machine.
 
 The same data powers the hover tooltips in the
-[Playground](../playground.md).
+[Playground](../playground/).
 
 !!! tip "Playground Tooltips"
     In the Playground, hover over any opcode or HIR keyword to see


### PR DESCRIPTION
## Summary

- Fix 4 dangling `playground.md` links in `index.md`, `building.md`, and `instructions.md`
- Links now point to `playground/` (the SPA directory) instead of the removed markdown file
- Fixes `mkdocs build --strict` failure on main

## Test plan

- [ ] Docs deploy workflow passes (no strict mode warnings)
- [ ] Playground links in docs navigate to the SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)