### PR TITLE
fix: set MACOSX_DEPLOYMENT_TARGET for macOS arm64 wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
             arch: arm64
             cibw_archs: arm64
             cpu_baseline: generic
+            cibw_environment: MACOSX_DEPLOYMENT_TARGET=14.0
           - os: windows-latest
             arch: amd64
             cibw_archs: AMD64
@@ -75,7 +76,9 @@ jobs:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: "*-musllinux*"
-          CIBW_ENVIRONMENT: CLIFFT_CPU_BASELINE=${{ matrix.cpu_baseline }}
+          CIBW_ENVIRONMENT: >-
+            CLIFFT_CPU_BASELINE=${{ matrix.cpu_baseline }}
+            ${{ matrix.cibw_environment || '' }}
           # Install build dependencies inside the cibuildwheel container
           CIBW_BEFORE_BUILD: pip install setuptools-scm
           # Install libomp on macOS for OpenMP support in wheels


### PR DESCRIPTION
## Summary

- Set `MACOSX_DEPLOYMENT_TARGET=14.0` for the macOS arm64 wheel build
- Homebrew's `libomp` on `macos-14` runners has a minimum target of 14.0, which causes `delocate-wheel` to fail when the wheel defaults to 11.0
- Uses a matrix variable so other platforms are unaffected

## Test plan

- [ ] Re-run the release workflow via manual dispatch and verify macOS wheel builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)