### PR TITLE
fix: use manylinux_2_28 for Linux wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,9 @@ jobs:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: "*-musllinux*"
+          # manylinux_2_28 (AlmaLinux 8, GCC 12) needed for -march=x86-64-v3
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT: >-
             CLIFFT_CPU_BASELINE=${{ matrix.cpu_baseline }}
             ${{ matrix.cibw_environment || '' }}


### PR DESCRIPTION
## Summary

- Switch Linux wheel builds from `manylinux2014` (GCC 10) to `manylinux_2_28` (AlmaLinux 8, GCC 12)
- GCC 10 doesn't support `-march=x86-64-v3`, which is needed for the x86_64 wheel's AVX2/BMI2/FMA baseline
- Also sets `manylinux_2_28` for aarch64 for consistency (that build succeeded but benefits from the newer toolchain)

Note: this raises the minimum glibc from 2.17 to 2.28, which means RHEL/CentOS 7 is no longer supported. That's fine — RHEL 7 hit EOL in 2024 and Python 3.12 itself requires glibc 2.17+. Most modern distros ship glibc 2.28+.

## Test plan

- [ ] After merging both this and #5, re-run `gh workflow run release.yml` and verify all 4 wheel builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)