### PR TITLE
fix: remove unused setup-uv from wheel jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,6 @@ jobs:
         with:
           fetch-depth: 0  # Full history for setuptools-scm
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:


### PR DESCRIPTION
## Summary

- Remove the `astral-sh/setup-uv` step from the `wheels` job — cibuildwheel manages its own Python and doesn't use uv
- This fixes a spurious failure on aarch64 where the uv cache cleanup errors out because no cache exists, which cascades to skip `publish-testpypi`

## Test plan

- [ ] Re-run release workflow via manual dispatch; all 4 wheels + TestPyPI publish should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)