### PR TITLE
feat(playground): Load-from-URL button and origin-aware Share

### DIFF
--- a/playground/src/App.css
+++ b/playground/src/App.css
@@ -871,3 +871,137 @@ html, body, #root {
   letter-spacing: 0.5px;
   vertical-align: middle;
 }
+
+/* --- Load-from-URL modal --- */
+.load-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+}
+
+.load-backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--backdrop-bg);
+}
+
+.load-card {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px 20px 16px;
+  max-width: 480px;
+  width: 90%;
+  box-shadow: 0 8px 32px var(--shadow-color);
+  animation: tour-in 0.18s ease-out;
+}
+
+.load-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.load-close:hover { color: var(--text); }
+
+.load-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+.load-help-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  display: inline-flex;
+}
+
+.load-help-btn:hover { color: var(--text); }
+
+.load-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  margin-bottom: 10px;
+}
+
+.load-desc code,
+.load-help code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.load-help {
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+
+.load-help ul {
+  margin: 6px 0;
+  padding-left: 18px;
+}
+
+.load-help li { margin: 3px 0; }
+
+.load-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  outline: none;
+}
+
+.load-input:focus {
+  border-color: var(--accent);
+}
+
+.load-input:disabled {
+  opacity: 0.6;
+}
+
+.load-error {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #ef5350;
+}
+
+.load-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 14px;
+}

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -15,7 +15,7 @@ import { ExpValTable } from "./components/ExpValTable";
 import { GuidedTour } from "./components/GuidedTour";
 import { registerLanguages } from "./languages";
 import { isCompileSuccess, isSimulateSuccess } from "./types";
-import type { CompileResult, CompileSuccess, SimulateResult } from "./types";
+import type { CompileResult, CompileSuccess, SimulateResult, SourceOrigin } from "./types";
 
 const DEFAULT_SOURCE = `H 0
 CNOT 0 1
@@ -40,8 +40,8 @@ function getInitialSource(): string {
       // ignore bad encoded data
     }
   }
-  // For ?gist= and ?url= we return the default/draft immediately and load
-  // async in a useEffect (see useRemoteCircuit below).
+  // For ?url= we return the default/draft immediately and load async
+  // in a useEffect (see useRemoteCircuit below).
   const draft = loadDraft();
   if (draft) return draft;
   return DEFAULT_SOURCE;
@@ -51,16 +51,6 @@ type RemoteLoadState =
   | { status: "idle" }
   | { status: "loading"; label: string }
   | { status: "error"; message: string };
-
-async function fetchGist(id: string): Promise<string> {
-  const resp = await fetch(`https://api.github.com/gists/${id}`);
-  if (!resp.ok) throw new Error(`GitHub API returned ${resp.status}`);
-  const data = await resp.json();
-  const files = data.files as Record<string, { content: string }>;
-  const first = Object.values(files)[0];
-  if (!first) throw new Error("Gist has no files");
-  return first.content;
-}
 
 async function fetchUrl(url: string): Promise<string> {
   const resp = await fetch(url);
@@ -72,17 +62,16 @@ function getInitialRemoteState(): RemoteLoadState {
   const params = new URLSearchParams(window.location.search);
   // ?code= takes precedence — don't fetch remote if inline code is present
   if (params.get("code")) return { status: "idle" };
-  if (params.get("gist")) {
-    const id = params.get("gist")!;
-    return { status: "loading", label: `Loading gist ${id.slice(0, 8)}...` };
-  }
   if (params.get("url")) {
     return { status: "loading", label: "Loading circuit from URL..." };
   }
   return { status: "idle" };
 }
 
-function useRemoteCircuit(onLoad: (source: string) => void, userHasEditedRef: React.RefObject<boolean>) {
+function useRemoteCircuit(
+  onLoad: (source: string, url: string) => void,
+  userHasEditedRef: React.RefObject<boolean>,
+) {
   const [state, setState] = useState<RemoteLoadState>(getInitialRemoteState);
   const ranRef = useRef(false);
 
@@ -91,29 +80,20 @@ function useRemoteCircuit(onLoad: (source: string) => void, userHasEditedRef: Re
     const params = new URLSearchParams(window.location.search);
     // ?code= takes precedence over remote params
     if (params.get("code")) return;
-    const gistId = params.get("gist");
     const url = params.get("url");
+    if (!url) return;
 
-    const handleResult = (content: string) => {
-      setState({ status: "idle" });
-      // Don't clobber user edits or manual circuit selections that
-      // happened while the fetch was in flight.
-      if (!userHasEditedRef.current) {
-        onLoad(content);
-      }
-    };
-
-    if (gistId) {
-      ranRef.current = true;
-      fetchGist(gistId)
-        .then(handleResult)
-        .catch((err) => setState({ status: "error", message: `Failed to load gist: ${err.message}` }));
-    } else if (url) {
-      ranRef.current = true;
-      fetchUrl(url)
-        .then(handleResult)
-        .catch((err) => setState({ status: "error", message: `Failed to load URL: ${err.message}` }));
-    }
+    ranRef.current = true;
+    fetchUrl(url)
+      .then((content) => {
+        setState({ status: "idle" });
+        // Don't clobber user edits or manual circuit selections that
+        // happened while the fetch was in flight.
+        if (!userHasEditedRef.current) {
+          onLoad(content, url);
+        }
+      })
+      .catch((err) => setState({ status: "error", message: `Failed to load URL: ${err.message}` }));
   }, [onLoad, userHasEditedRef]);
 
   return state;
@@ -130,10 +110,19 @@ export default function App() {
   const rulerColor = theme === "dark" ? "#4fc3f7" : "#0277bd";
 
   const [source, setSourceRaw] = useState(getInitialSource);
+  const [sourceOrigin, setSourceOrigin] = useState<SourceOrigin>(null);
   const userHasEditedRef = useRef(false);
+  // When we push text into the Monaco editor programmatically, we skip
+  // the resulting onChange so it doesn't clear sourceOrigin.
+  const skipNextOnChangeRef = useRef(false);
   const setSource = useCallback((v: string) => {
+    if (skipNextOnChangeRef.current) {
+      skipNextOnChangeRef.current = false;
+      return;
+    }
     userHasEditedRef.current = true;
     setSourceRaw(v);
+    setSourceOrigin(null);
   }, []);
   const defaultPassConfig = useMemo<PassConfig>(() => {
     if (availablePasses.length === 0) return { hir: [], bc: [] };
@@ -405,14 +394,35 @@ export default function App() {
     localStorage.setItem(TOUR_SEEN_KEY, "1");
   }, []);
 
-  const handleLoadCircuit = useCallback((circuitSource: string) => {
-    setSource(circuitSource);
+  // Unified entry point for non-edit source updates. origin=null means
+  // "this content has no remote URL to share back" (e.g. Recents). A
+  // non-null origin makes Share emit a `?url=` link until the user edits.
+  const loadWithOrigin = useCallback((circuitSource: string, origin: SourceOrigin) => {
+    userHasEditedRef.current = true;
+    setSourceRaw(circuitSource);
+    setSourceOrigin(origin);
     if (sourceEditorRef.current) {
+      skipNextOnChangeRef.current = true;
       sourceEditorRef.current.setValue(circuitSource);
     }
-  }, [setSource]);
+  }, []);
 
-  const remoteState = useRemoteCircuit(handleLoadCircuit, userHasEditedRef);
+  const handleLoadCircuit = useCallback(
+    (circuitSource: string) => loadWithOrigin(circuitSource, null),
+    [loadWithOrigin],
+  );
+  const handleLoadFromUrl = useCallback(
+    (circuitSource: string, url: string) =>
+      loadWithOrigin(circuitSource, { kind: "url", value: url }),
+    [loadWithOrigin],
+  );
+  const handleRemoteLoad = useCallback(
+    (circuitSource: string, url: string) =>
+      loadWithOrigin(circuitSource, { kind: "url", value: url }),
+    [loadWithOrigin],
+  );
+
+  const remoteState = useRemoteCircuit(handleRemoteLoad, userHasEditedRef);
 
   // --- Stats bar ---
   const stats: CompileSuccess | null =
@@ -468,7 +478,9 @@ export default function App() {
         savedCircuits={saved}
         onSaveCircuit={saveCircuit}
         onLoadCircuit={handleLoadCircuit}
+        onLoadFromUrl={handleLoadFromUrl}
         onDeleteCircuit={deleteCircuit}
+        sourceOrigin={sourceOrigin}
       />
 
       {stats && (

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -130,9 +130,11 @@ const STEPS: TourStep[] = [
     title: "Sharing & Options",
     content:
       "The `Share` button compresses your circuit into a URL you can send to " +
-      "anyone. For larger circuits, you can also load from external sources by " +
-      "adding `?gist=<id>` (GitHub Gist) or `?url=<encoded-url>` (any " +
-      "CORS-enabled URL) to the playground URL.\n\n" +
+      "anyone.\n\n" +
+      "For larger circuits, host the `.stim` file somewhere with CORS " +
+      "(e.g. a GitHub Gist's raw URL, or `raw.githubusercontent.com`) and " +
+      "click `Load` to paste its URL. Until you edit the circuit, `Share` " +
+      "will emit a compact `?url=<...>` link pointing to that file.\n\n" +
       "The `Save` button stores circuits in your browser's local storage, " +
       "and `Recents` shows previously saved circuits.\n\n" +
       "The `Passes` button lets you individually toggle each HIR and bytecode " +

--- a/playground/src/components/Toolbar.tsx
+++ b/playground/src/components/Toolbar.tsx
@@ -12,11 +12,13 @@ import {
   Clock,
   Trash2,
   Columns2,
+  Download,
+  X,
 } from "lucide-react";
 import LZString from "lz-string";
 import type { WasmStatus, PassConfig } from "../hooks/useClifftWasm";
 import type { Theme } from "../hooks/useTheme";
-import type { PassInfo } from "../types";
+import type { PassInfo, SourceOrigin } from "../types";
 import type { SavedCircuit } from "../hooks/useCircuitStorage";
 
 interface Props {
@@ -37,7 +39,9 @@ interface Props {
   savedCircuits: SavedCircuit[];
   onSaveCircuit: (name: string, source: string) => void;
   onLoadCircuit: (source: string) => void;
+  onLoadFromUrl: (source: string, url: string) => void;
   onDeleteCircuit: (id: string) => void;
+  sourceOrigin: SourceOrigin;
 }
 
 const SAFE_URL_LENGTH = 8000;
@@ -61,20 +65,31 @@ export function Toolbar({
   savedCircuits,
   onSaveCircuit,
   onLoadCircuit,
+  onLoadFromUrl,
   onDeleteCircuit,
+  sourceOrigin,
 }: Props) {
   const [copied, setCopied] = useState(false);
   const [shotsOpen, setShotsOpen] = useState(false);
   const [passesOpen, setPassesOpen] = useState(false);
   const [recentsOpen, setRecentsOpen] = useState(false);
+  const [loadOpen, setLoadOpen] = useState(false);
+  const [loadUrl, setLoadUrl] = useState("");
+  const [loadBusy, setLoadBusy] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadHelpOpen, setLoadHelpOpen] = useState(false);
   const shotsRef = useRef<HTMLDivElement>(null);
   const passesRef = useRef<HTMLDivElement>(null);
   const recentsRef = useRef<HTMLDivElement>(null);
+  const loadInputRef = useRef<HTMLInputElement>(null);
 
   const buildShareUrl = useCallback(() => {
+    if (sourceOrigin) {
+      return `${window.location.origin}${window.location.pathname}?url=${encodeURIComponent(sourceOrigin.value)}`;
+    }
     const compressed = LZString.compressToEncodedURIComponent(source);
     return `${window.location.origin}${window.location.pathname}?code=${compressed}`;
-  }, [source]);
+  }, [source, sourceOrigin]);
 
   const handleShare = async () => {
     const url = buildShareUrl();
@@ -143,9 +158,49 @@ export function Toolbar({
   const totalEnabled = passConfig.hir.length + passConfig.bc.length;
 
   const shareUrl = useMemo(() => buildShareUrl(), [buildShareUrl]);
-  const canShare = shareUrl.length <= MAX_URL_LENGTH;
-  const shareWarning = shareUrl.length > SAFE_URL_LENGTH && shareUrl.length <= MAX_URL_LENGTH;
+  // When sharing via ?url=, the link size doesn't depend on the source length.
+  const canShare = sourceOrigin !== null || shareUrl.length <= MAX_URL_LENGTH;
+  const shareWarning =
+    !sourceOrigin &&
+    shareUrl.length > SAFE_URL_LENGTH &&
+    shareUrl.length <= MAX_URL_LENGTH;
   const canSimulate = wasmStatus === "ready" && !simulating;
+
+  // Auto-focus URL input on open
+  useEffect(() => {
+    if (loadOpen) {
+      loadInputRef.current?.focus();
+    }
+  }, [loadOpen]);
+
+  const closeLoadModal = useCallback(() => {
+    setLoadOpen(false);
+    setLoadError(null);
+    setLoadBusy(false);
+    setLoadHelpOpen(false);
+  }, []);
+
+  const submitLoad = useCallback(async () => {
+    const url = loadUrl.trim();
+    if (!url) {
+      setLoadError("Enter a URL.");
+      return;
+    }
+    setLoadBusy(true);
+    setLoadError(null);
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`Fetch returned ${resp.status}`);
+      const text = await resp.text();
+      onLoadFromUrl(text, url);
+      setLoadUrl("");
+      closeLoadModal();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setLoadError(`Failed to load: ${msg}`);
+      setLoadBusy(false);
+    }
+  }, [loadUrl, onLoadFromUrl, closeLoadModal]);
 
   return (
     <div className="toolbar">
@@ -298,6 +353,16 @@ export function Toolbar({
           Save
         </button>
 
+        {/* Load from URL */}
+        <button
+          className="toolbar-btn"
+          onClick={() => setLoadOpen(true)}
+          title="Load a circuit from a CORS-enabled URL"
+        >
+          <Download size={14} />
+          Load
+        </button>
+
         {/* Recents dropdown */}
         <div className="recents-group" ref={recentsRef}>
           <button
@@ -348,10 +413,12 @@ export function Toolbar({
           disabled={!canShare}
           title={
             !canShare
-              ? "Circuit too large to share via URL. Use a GitHub Gist and share with ?gist=<id>"
+              ? "Circuit too large to share via URL. Host it somewhere CORS-enabled and use Load to paste its URL."
               : shareWarning
-                ? "URL is long and may not work in all browsers. Consider using a GitHub Gist."
-                : "Copy shareable link"
+                ? "URL is long and may not work in all browsers. Host the circuit externally and use Load to paste its URL."
+                : sourceOrigin
+                  ? "Copy shareable link (pointing at the loaded URL)"
+                  : "Copy shareable link"
           }
         >
           <Share2 size={14} />
@@ -366,6 +433,98 @@ export function Toolbar({
           {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
         </button>
       </div>
+
+      {loadOpen && (
+        <div
+          className="load-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Load circuit from URL"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") closeLoadModal();
+          }}
+        >
+          <div className="load-backdrop" onClick={closeLoadModal} />
+          <div className="load-card">
+            <button
+              className="load-close"
+              onClick={closeLoadModal}
+              title="Close"
+              aria-label="Close"
+            >
+              <X size={16} />
+            </button>
+            <div className="load-title">
+              Load circuit from URL
+              <button
+                className="load-help-btn"
+                onClick={() => setLoadHelpOpen((v) => !v)}
+                title="What kind of URL?"
+                aria-label="Help"
+              >
+                <HelpCircle size={14} />
+              </button>
+            </div>
+            <div className="load-desc">
+              Paste a direct URL to a raw <code>.stim</code> file. The host must
+              allow CORS. After loading, the Share link will point to this URL
+              until you edit the circuit.
+            </div>
+            {loadHelpOpen && (
+              <div className="load-help">
+                <strong>Works with any CORS-enabled raw text URL</strong>, for
+                example:
+                <ul>
+                  <li>
+                    GitHub Gist raw file:
+                    {" "}<code>https://gist.githubusercontent.com/&lt;user&gt;/&lt;id&gt;/raw/&lt;name&gt;.stim</code>
+                  </li>
+                  <li>
+                    GitHub repo raw file:
+                    {" "}<code>https://raw.githubusercontent.com/&lt;user&gt;/&lt;repo&gt;/&lt;ref&gt;/&lt;path&gt;.stim</code>
+                  </li>
+                  <li>Any public static host that serves plain text with CORS.</li>
+                </ul>
+                Not a playground share URL &mdash; use a URL that points
+                directly at the circuit file itself.
+              </div>
+            )}
+            <input
+              ref={loadInputRef}
+              type="url"
+              className="load-input"
+              placeholder="https://example.com/circuit.stim"
+              value={loadUrl}
+              onChange={(e) => setLoadUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !loadBusy) {
+                  e.preventDefault();
+                  void submitLoad();
+                }
+              }}
+              disabled={loadBusy}
+            />
+            {loadError && <div className="load-error">{loadError}</div>}
+            <div className="load-actions">
+              <button
+                className="toolbar-btn"
+                onClick={closeLoadModal}
+                disabled={loadBusy}
+              >
+                Cancel
+              </button>
+              <button
+                className="toolbar-btn toolbar-btn-primary"
+                onClick={() => void submitLoad()}
+                disabled={loadBusy || !loadUrl.trim()}
+              >
+                {loadBusy ? <Loader2 size={14} className="spin" /> : <Download size={14} />}
+                Load
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -57,3 +57,5 @@ export interface ClifftModule {
   compile_to_json: (source: string, passes_json: string) => string;
   simulate_wasm: (source: string, shots: number, passes_json: string) => string;
 }
+
+export type SourceOrigin = { kind: "url"; value: string } | null;


### PR DESCRIPTION
## Summary
- Add a **Load** button to the playground toolbar that opens a small inline modal for pasting a CORS-enabled URL to a raw `.stim` file (e.g. a Gist raw URL, a `raw.githubusercontent.com` link, or any public static host). Replaces the need to hand-craft a `?url=<encoded>` deep link.
- **Share** is now origin-aware: when a circuit was loaded from a URL (either via Load or the initial `?url=` query param) and hasn't been edited, Share emits `?url=<original>` instead of `?code=<compressed>`. This keeps share links compact for large circuits hosted externally. Editing the source, or loading from Recents, clears the origin and Share reverts to `?code=`.
- Drops the `?gist=` deep link / `fetchGist` code path. Raw gist URLs work fine through `?url=` / Load, and the GitHub Gist API path added nothing the general URL path doesn't cover.
- Guided tour step 7 rewritten to describe Load + `?url=`.

## Implementation notes
- New `SourceOrigin` type in `types.ts` (moved there instead of `App.tsx` to keep react-refresh happy).
- Programmatic `editor.setValue(...)` fires Monaco's `onChange`, which would otherwise clear `sourceOrigin`; guarded with a `skipNextOnChangeRef` so only real user edits clear it.
- Single `loadWithOrigin(source, origin)` helper now backs Recents (`origin = null`), the initial `?url=` fetch, and the Load modal.

## Test plan
- [ ] Paste a raw gist/GitHub URL into Load → circuit loads; Share copies a `?url=<encoded>` link.
- [ ] Open that shared `?url=` link in a new tab → same circuit loads; Share still emits `?url=...`.
- [ ] Edit the circuit after loading → Share flips back to `?code=...`.
- [ ] Load from Recents while a URL origin is set → origin clears; Share is `?code=...`.
- [ ] Bad URL / non-CORS host → modal shows an inline error and stays open.
- [ ] Circuit larger than `MAX_URL_LENGTH` with no origin → Share is disabled (unchanged).
- [ ] Guided tour step 7 no longer mentions `?gist=`.

Assisted-by: Claude (Opus 4.7) <noreply@anthropic.com>