### PR TITLE
refactor: rename OP_PHASE_* bytecode opcodes to OP_ARRAY_*

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -141,7 +141,7 @@ def define_env(env: Any) -> None:
             "python_name": "ExpandTPass",
             "summary": "Fuses EXPAND + T-phase into a single array pass.",
             "detail": (
-                "Fuses contiguous OP_EXPAND + OP_PHASE_T (or T_DAG) pairs into "
+                "Fuses contiguous OP_EXPAND + OP_ARRAY_T (or T_DAG) pairs into "
                 "single OP_EXPAND_T (or OP_EXPAND_T_DAG) instructions. The separate "
                 "instructions cause two array passes; the fused instruction performs "
                 "both in one loop: arr[i+half] = arr[i] * exp(+/-i*pi/4)."
@@ -154,7 +154,7 @@ def define_env(env: Any) -> None:
             "python_name": "ExpandRotPass",
             "summary": "Fuses EXPAND + continuous rotation into a single array pass.",
             "detail": (
-                "Fuses contiguous OP_EXPAND + OP_PHASE_ROT pairs into single "
+                "Fuses contiguous OP_EXPAND + OP_ARRAY_ROT pairs into single "
                 "OP_EXPAND_ROT instructions, eliminating the two-pass penalty of "
                 "separate expand and phase-rotate operations."
             ),
@@ -195,8 +195,8 @@ def define_env(env: Any) -> None:
             "python_name": "SingleAxisFusionPass",
             "summary": "Fuses single-axis operation chains into precomputed 2x2 unitaries.",
             "detail": (
-                "Fuses consecutive single-axis operations (ARRAY_H, ARRAY_S, PHASE_T, "
-                "PHASE_ROT, etc.) on the same virtual axis into a single OP_ARRAY_U2 "
+                "Fuses consecutive single-axis operations (ARRAY_H, ARRAY_S, ARRAY_T, "
+                "ARRAY_ROT, etc.) on the same virtual axis into a single OP_ARRAY_U2 "
                 "instruction. Pre-computes 2x2 unitary matrices for all 4 possible "
                 "incoming Pauli frame states (I, X, Z, Y). A run is fused if it "
                 "contains at least 3 array-touching operations, or at least 2 when "

--- a/docs/opcodes.json
+++ b/docs/opcodes.json
@@ -90,28 +90,28 @@
             "detail": "Doubles the state vector by applying a virtual Hadamard on a dormant axis: k -> k+1 and gamma is divided by sqrt(2). The new axis is initialized to equal superposition. This is the only instruction that grows the active subspace.",
             "operands": "axis_1"
         },
-        "OP_PHASE_T": {
-            "category": "Subspace",
+        "OP_ARRAY_T": {
+            "category": "Array",
             "summary": "T-gate (pi/8 phase rotation) on an active axis.",
             "detail": "Applies diag(1, exp(i*pi/4)) to one active virtual axis. This is the primary non-Clifford gate -- it cannot be absorbed into the offline Clifford frame U_C and requires direct state vector work.",
             "operands": "axis_1"
         },
-        "OP_PHASE_T_DAG": {
-            "category": "Subspace",
+        "OP_ARRAY_T_DAG": {
+            "category": "Array",
             "summary": "T-dagger (inverse pi/8 phase rotation) on an active axis.",
-            "detail": "Applies diag(1, exp(-i*pi/4)) to one active virtual axis. The conjugate of OP_PHASE_T.",
+            "detail": "Applies diag(1, exp(-i*pi/4)) to one active virtual axis. The conjugate of OP_ARRAY_T.",
             "operands": "axis_1"
         },
         "OP_EXPAND_T": {
             "category": "Subspace",
             "summary": "Fused EXPAND + T-gate in one array pass.",
-            "detail": "Combines OP_EXPAND and OP_PHASE_T into a single instruction. Promotes a dormant qubit to active (k -> k+1) and immediately applies the T phase rotation, saving one pass over the state vector.",
+            "detail": "Combines OP_EXPAND and OP_ARRAY_T into a single instruction. Promotes a dormant qubit to active (k -> k+1) and immediately applies the T phase rotation, saving one pass over the state vector.",
             "operands": "axis_1"
         },
         "OP_EXPAND_T_DAG": {
             "category": "Subspace",
             "summary": "Fused EXPAND + T-dagger in one array pass.",
-            "detail": "Combines OP_EXPAND and OP_PHASE_T_DAG into a single instruction. Promotes a dormant qubit to active (k -> k+1) and immediately applies the T-dagger phase rotation, saving one pass over the state vector.",
+            "detail": "Combines OP_EXPAND and OP_ARRAY_T_DAG into a single instruction. Promotes a dormant qubit to active (k -> k+1) and immediately applies the T-dagger phase rotation, saving one pass over the state vector.",
             "operands": "axis_1"
         },
         "OP_MEAS_DORMANT_STATIC": {
@@ -192,26 +192,26 @@
             "detail": "Evaluates the expectation value <P> of a Pauli product on the current state without mutating anything. The full virtual Pauli mask is stored in the constant pool. Accounts for Pauli frame conjugation and dormant/active qubit splitting. Result is a float64 in [-1, 1] written to exp_vals[exp_val_idx].",
             "operands": "cp_exp_val_idx (constant pool exp val mask index) -> exp[exp_val_idx]"
         },
-        "OP_PHASE_ROT": {
-            "category": "Subspace",
+        "OP_ARRAY_ROT": {
+            "category": "Array",
             "summary": "Continuous Z-rotation on an active axis with arbitrary phase.",
             "detail": "Applies diag(1, z) where z = e^{i*alpha*pi} is stored as (weight_re, weight_im) in the instruction math payload. If the Pauli frame has p_x set on this axis, the array receives z* and gamma absorbs z to preserve the factored state.",
             "operands": "axis_1, math.weight_re, math.weight_im"
         },
         "OP_EXPAND_ROT": {
             "category": "Subspace",
-            "summary": "Fused EXPAND + PHASE_ROT in a single array pass.",
-            "detail": "Activates a dormant axis and applies diag(1, z) in one fused loop: arr[i+half] = arr[i] * phase. Avoids the two-pass penalty of separate EXPAND + PHASE_ROT. The phase z is stored in the instruction math payload.",
+            "summary": "Fused EXPAND + ARRAY_ROT in a single array pass.",
+            "detail": "Activates a dormant axis and applies diag(1, z) in one fused loop: arr[i+half] = arr[i] * phase. Avoids the two-pass penalty of separate EXPAND + ARRAY_ROT. The phase z is stored in the instruction math payload.",
             "operands": "axis_1, math.weight_re, math.weight_im"
         },
         "OP_ARRAY_U2": {
-            "category": "Subspace",
+            "category": "Array",
             "summary": "Fused single-axis 2x2 unitary gate from ConstantPool.",
-            "detail": "Applies a precomputed 2x2 unitary matrix to all amplitude pairs on one virtual axis in a single butterfly sweep. The pass precomputes 4 matrices (one per incoming Pauli frame state: I, X, Z, Y) to eliminate runtime branching. Replaces sequences of ARRAY_H, ARRAY_S, PHASE_ROT, etc. on the same axis.",
+            "detail": "Applies a precomputed 2x2 unitary matrix to all amplitude pairs on one virtual axis in a single butterfly sweep. The pass precomputes 4 matrices (one per incoming Pauli frame state: I, X, Z, Y) to eliminate runtime branching. Replaces sequences of ARRAY_H, ARRAY_S, ARRAY_ROT, etc. on the same axis.",
             "operands": "axis_1, u2.cp_idx"
         },
         "OP_ARRAY_U4": {
-            "category": "Subspace",
+            "category": "Array",
             "summary": "Fused 2-axis 4x4 unitary gate from ConstantPool.",
             "detail": "Applies a precomputed 4x4 unitary matrix to all blocks of 4 amplitudes spanning two virtual axes in a single array sweep. The pass precomputes 16 matrices (one per incoming Pauli frame state on the two axes) and the corresponding output frame states. Replaces entire tile runs of interleaved 1Q and 2Q operations on a fixed axis pair.",
             "operands": "axis_1 (lo), axis_2 (hi), u4.cp_idx"

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -91,7 +91,7 @@ const STEPS: TourStep[] = [
       "- `OP_FRAME_*` -- update the runtime virtual Pauli frame (bitmask XOR)\n" +
       "- `OP_ARRAY_*` -- touch the Schrodinger state vector\n" +
       "- `OP_EXPAND` -- grows the active subspace\n" +
-      "- `OP_PHASE_T` -- applies T rotations\n" +
+      "- `OP_ARRAY_T` -- applies T rotations\n" +
       "- `OP_MEAS_*` -- performs measurements",
     target: ".editor-pane:nth-child(3)",
   },

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -135,16 +135,16 @@ Instruction make_expand(uint16_t axis) {
     return i;
 }
 
-Instruction make_phase_t(uint16_t axis) {
+Instruction make_array_t(uint16_t axis) {
     Instruction i{};
-    i.opcode = Opcode::OP_PHASE_T;
+    i.opcode = Opcode::OP_ARRAY_T;
     i.axis_1 = axis;
     return i;
 }
 
-Instruction make_phase_t_dag(uint16_t axis) {
+Instruction make_array_t_dag(uint16_t axis) {
     Instruction i{};
-    i.opcode = Opcode::OP_PHASE_T_DAG;
+    i.opcode = Opcode::OP_ARRAY_T_DAG;
     i.axis_1 = axis;
     return i;
 }
@@ -163,9 +163,9 @@ Instruction make_expand_t_dag(uint16_t axis) {
     return i;
 }
 
-Instruction make_phase_rot(uint16_t axis, double re, double im) {
+Instruction make_array_rot(uint16_t axis, double re, double im) {
     Instruction i{};
-    i.opcode = Opcode::OP_PHASE_ROT;
+    i.opcode = Opcode::OP_ARRAY_ROT;
     i.axis_1 = axis;
     i.math.weight_re = re;
     i.math.weight_im = im;
@@ -571,9 +571,9 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
 
                 bool phase_flip = result.sign ^ op.is_dagger();
                 if (phase_flip) {
-                    ctx.emit(make_phase_t_dag(result.pivot));
+                    ctx.emit(make_array_t_dag(result.pivot));
                 } else {
-                    ctx.emit(make_phase_t(result.pivot));
+                    ctx.emit(make_array_t(result.pivot));
                 }
 
                 break;
@@ -606,7 +606,7 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                 double z_re = std::cos(angle);
                 double z_im = std::sin(angle);
 
-                ctx.emit(make_phase_rot(result.pivot, z_re, z_im));
+                ctx.emit(make_array_rot(result.pivot, z_re, z_im));
 
                 break;
             }

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -30,7 +30,7 @@ enum class Opcode : uint8_t {
     OP_FRAME_S_DAG,
     OP_FRAME_SWAP,
 
-    // Array Opcodes (Update p_x, p_z AND loop over v[] to swap/mix)
+    // Array Opcodes (Fixed k. Update p_x, p_z AND loop over v[] to swap/mix)
     OP_ARRAY_CNOT,
     OP_ARRAY_CZ,
     OP_ARRAY_SWAP,
@@ -39,17 +39,17 @@ enum class Opcode : uint8_t {
     OP_ARRAY_H,           // Hadamard on active axis (butterfly + frame swap)
     OP_ARRAY_S,           // Phase S on active axis (diag(1, i) + frame update)
     OP_ARRAY_S_DAG,       // Phase S-dagger on active axis (diag(1, -i) + frame update)
+    OP_ARRAY_T,           // Active diagonal T phase (non-Clifford)
+    OP_ARRAY_T_DAG,       // Active diagonal T-dagger phase (non-Clifford)
+    OP_ARRAY_ROT,         // Continuous Z-rotation on active axis (arbitrary angle)
+    OP_ARRAY_U2,          // Fused single-axis 2x2 unitary (ConstantPool lookup)
+    OP_ARRAY_U4,          // Fused 2-axis 4x4 unitary (ConstantPool lookup)
 
-    // Local Math & Expansion
+    // Subspace Expansion (k -> k+1; non-Clifford rotations may be fused in)
     OP_EXPAND,        // Virtual H_v on dormant: k -> k+1, gamma /= sqrt(2)
-    OP_PHASE_T,       // Active diagonal T phase
-    OP_PHASE_T_DAG,   // Active diagonal T-dagger phase
-    OP_EXPAND_T,      // Fused EXPAND + PHASE_T in one array pass
-    OP_EXPAND_T_DAG,  // Fused EXPAND + PHASE_T_DAG in one array pass
-    OP_PHASE_ROT,     // Continuous Z-rotation on active axis (arbitrary angle)
-    OP_EXPAND_ROT,    // Fused EXPAND + PHASE_ROT in one array pass
-    OP_ARRAY_U2,      // Fused single-axis 2x2 unitary (ConstantPool lookup)
-    OP_ARRAY_U4,      // Fused 2-axis 4x4 unitary (ConstantPool lookup)
+    OP_EXPAND_T,      // Fused EXPAND + ARRAY_T in one array pass
+    OP_EXPAND_T_DAG,  // Fused EXPAND + ARRAY_T_DAG in one array pass
+    OP_EXPAND_ROT,    // Fused EXPAND + ARRAY_ROT in one array pass
 
     // Measurement
     OP_MEAS_DORMANT_STATIC,    // Deterministic outcome from p_x
@@ -169,15 +169,15 @@ static_assert(sizeof(Instruction) == 32, "Instruction must be exactly 32 bytes")
 [[nodiscard]] Instruction make_array_h(uint16_t axis);
 [[nodiscard]] Instruction make_array_s(uint16_t axis);
 [[nodiscard]] Instruction make_array_s_dag(uint16_t axis);
-[[nodiscard]] Instruction make_expand(uint16_t axis);
-[[nodiscard]] Instruction make_phase_t(uint16_t axis);
-[[nodiscard]] Instruction make_phase_t_dag(uint16_t axis);
-[[nodiscard]] Instruction make_expand_t(uint16_t axis);
-[[nodiscard]] Instruction make_expand_t_dag(uint16_t axis);
-[[nodiscard]] Instruction make_phase_rot(uint16_t axis, double re, double im);
-[[nodiscard]] Instruction make_expand_rot(uint16_t axis, double re, double im);
+[[nodiscard]] Instruction make_array_t(uint16_t axis);
+[[nodiscard]] Instruction make_array_t_dag(uint16_t axis);
+[[nodiscard]] Instruction make_array_rot(uint16_t axis, double re, double im);
 [[nodiscard]] Instruction make_array_u2(uint16_t axis, uint32_t cp_idx);
 [[nodiscard]] Instruction make_array_u4(uint16_t axis_lo, uint16_t axis_hi, uint32_t cp_idx);
+[[nodiscard]] Instruction make_expand(uint16_t axis);
+[[nodiscard]] Instruction make_expand_t(uint16_t axis);
+[[nodiscard]] Instruction make_expand_t_dag(uint16_t axis);
+[[nodiscard]] Instruction make_expand_rot(uint16_t axis, double re, double im);
 [[nodiscard]] Instruction make_swap_meas_interfere(uint16_t swap_from, uint16_t swap_to,
                                                    uint32_t classical_idx, bool sign);
 [[nodiscard]] Instruction make_meas(Opcode meas_opcode, uint16_t axis, uint32_t classical_idx,

--- a/src/clifft/optimizer/expand_t_pass.cc
+++ b/src/clifft/optimizer/expand_t_pass.cc
@@ -19,10 +19,10 @@ void ExpandTPass::run(CompiledModule& module) {
             uint16_t axis = old_bc[i].axis_1;
             Opcode next_op = old_bc[i + 1].opcode;
 
-            if ((next_op == Opcode::OP_PHASE_T || next_op == Opcode::OP_PHASE_T_DAG) &&
+            if ((next_op == Opcode::OP_ARRAY_T || next_op == Opcode::OP_ARRAY_T_DAG) &&
                 old_bc[i + 1].axis_1 == axis) {
                 Opcode fused_op =
-                    (next_op == Opcode::OP_PHASE_T) ? Opcode::OP_EXPAND_T : Opcode::OP_EXPAND_T_DAG;
+                    (next_op == Opcode::OP_ARRAY_T) ? Opcode::OP_EXPAND_T : Opcode::OP_EXPAND_T_DAG;
                 Instruction fused{};
                 fused.opcode = fused_op;
                 fused.axis_1 = axis;
@@ -63,7 +63,7 @@ void ExpandRotPass::run(CompiledModule& module) {
         if (i + 1 < old_bc.size() && old_bc[i].opcode == Opcode::OP_EXPAND) {
             uint16_t axis = old_bc[i].axis_1;
 
-            if (old_bc[i + 1].opcode == Opcode::OP_PHASE_ROT && old_bc[i + 1].axis_1 == axis) {
+            if (old_bc[i + 1].opcode == Opcode::OP_ARRAY_ROT && old_bc[i + 1].axis_1 == axis) {
                 new_bc.push_back(make_expand_rot(axis, old_bc[i + 1].math.weight_re,
                                                  old_bc[i + 1].math.weight_im));
                 if (has_sm)

--- a/src/clifft/optimizer/expand_t_pass.h
+++ b/src/clifft/optimizer/expand_t_pass.h
@@ -4,7 +4,7 @@
 
 namespace clifft {
 
-/// Fuses contiguous OP_EXPAND + OP_PHASE_T (or T_DAG) pairs into single
+/// Fuses contiguous OP_EXPAND + OP_ARRAY_T (or T_DAG) pairs into single
 /// OP_EXPAND_T (or OP_EXPAND_T_DAG) instructions.
 ///
 /// Every T-gate injection in the factored state architecture requires an
@@ -17,7 +17,7 @@ class ExpandTPass : public BytecodePass {
     void run(CompiledModule& module) override;
 };
 
-/// Fuses contiguous OP_EXPAND + OP_PHASE_ROT pairs into single
+/// Fuses contiguous OP_EXPAND + OP_ARRAY_ROT pairs into single
 /// OP_EXPAND_ROT instructions.
 class ExpandRotPass : public BytecodePass {
   public:

--- a/src/clifft/optimizer/single_axis_fusion_pass.cc
+++ b/src/clifft/optimizer/single_axis_fusion_pass.cc
@@ -18,9 +18,9 @@ bool is_fusible(Opcode op) {
         case Opcode::OP_ARRAY_H:
         case Opcode::OP_ARRAY_S:
         case Opcode::OP_ARRAY_S_DAG:
-        case Opcode::OP_PHASE_T:
-        case Opcode::OP_PHASE_T_DAG:
-        case Opcode::OP_PHASE_ROT:
+        case Opcode::OP_ARRAY_T:
+        case Opcode::OP_ARRAY_T_DAG:
+        case Opcode::OP_ARRAY_ROT:
         case Opcode::OP_FRAME_H:
         case Opcode::OP_FRAME_S:
         case Opcode::OP_FRAME_S_DAG:
@@ -36,9 +36,9 @@ bool is_array_op(Opcode op) {
         case Opcode::OP_ARRAY_H:
         case Opcode::OP_ARRAY_S:
         case Opcode::OP_ARRAY_S_DAG:
-        case Opcode::OP_PHASE_T:
-        case Opcode::OP_PHASE_T_DAG:
-        case Opcode::OP_PHASE_ROT:
+        case Opcode::OP_ARRAY_T:
+        case Opcode::OP_ARRAY_T_DAG:
+        case Opcode::OP_ARRAY_ROT:
             return true;
         default:
             return false;
@@ -88,7 +88,7 @@ void simulate_instruction(const Instruction& inst, uint8_t& px, uint8_t& pz, Mat
             pz ^= px;
             break;
 
-        case Opcode::OP_PHASE_T:
+        case Opcode::OP_ARRAY_T:
             if (px) {
                 U[3] = kExpMinusIPiOver4;
                 gamma *= kExpIPiOver4;
@@ -97,7 +97,7 @@ void simulate_instruction(const Instruction& inst, uint8_t& px, uint8_t& pz, Mat
             }
             break;
 
-        case Opcode::OP_PHASE_T_DAG:
+        case Opcode::OP_ARRAY_T_DAG:
             if (px) {
                 U[3] = kExpIPiOver4;
                 gamma *= kExpMinusIPiOver4;
@@ -106,7 +106,7 @@ void simulate_instruction(const Instruction& inst, uint8_t& px, uint8_t& pz, Mat
             }
             break;
 
-        case Opcode::OP_PHASE_ROT: {
+        case Opcode::OP_ARRAY_ROT: {
             std::complex<double> z(inst.math.weight_re, inst.math.weight_im);
             if (px) {
                 U[3] = std::conj(z);
@@ -194,13 +194,13 @@ void SingleAxisFusionPass::run(CompiledModule& module) {
         size_t run_start = i;
         size_t run_end = i + 1;
         int array_op_count = is_array_op(old_bc[i].opcode) ? 1 : 0;
-        bool has_rot = (old_bc[i].opcode == Opcode::OP_PHASE_ROT);
+        bool has_rot = (old_bc[i].opcode == Opcode::OP_ARRAY_ROT);
 
         while (run_end < old_bc.size() && is_fusible(old_bc[run_end].opcode) &&
                fusible_axis(old_bc[run_end]) == axis) {
             if (is_array_op(old_bc[run_end].opcode))
                 ++array_op_count;
-            if (old_bc[run_end].opcode == Opcode::OP_PHASE_ROT)
+            if (old_bc[run_end].opcode == Opcode::OP_ARRAY_ROT)
                 has_rot = true;
             ++run_end;
         }

--- a/src/clifft/optimizer/single_axis_fusion_pass.h
+++ b/src/clifft/optimizer/single_axis_fusion_pass.h
@@ -5,7 +5,7 @@
 namespace clifft {
 
 /// Fuses consecutive single-axis operations (ARRAY_H, ARRAY_S, ARRAY_S_DAG,
-/// PHASE_T, PHASE_T_DAG, PHASE_ROT, FRAME_H, FRAME_S, FRAME_S_DAG) on the
+/// ARRAY_T, ARRAY_T_DAG, ARRAY_ROT, FRAME_H, FRAME_S, FRAME_S_DAG) on the
 /// same virtual axis into a single OP_ARRAY_U2 instruction.
 ///
 /// For each fusible run, the pass pre-computes 2x2 unitary matrices for all
@@ -20,7 +20,7 @@ namespace clifft {
 ///   - Is a measurement, noise, or classical op
 ///
 /// A run is only fused if it contains at least 3 array-touching operations,
-/// or at least 2 array ops when one is a continuous rotation (OP_PHASE_ROT).
+/// or at least 2 array ops when one is a continuous rotation (OP_ARRAY_ROT).
 /// Isolated length-2 sequences of lightweight ops (e.g. H+T) are cheaper
 /// unfused than a dense 2x2 matrix sweep.
 class SingleAxisFusionPass : public BytecodePass {

--- a/src/clifft/optimizer/tile_axis_fusion_pass.cc
+++ b/src/clifft/optimizer/tile_axis_fusion_pass.cc
@@ -21,9 +21,9 @@ bool is_1q_array_op(Opcode op) {
         case Opcode::OP_ARRAY_H:
         case Opcode::OP_ARRAY_S:
         case Opcode::OP_ARRAY_S_DAG:
-        case Opcode::OP_PHASE_T:
-        case Opcode::OP_PHASE_T_DAG:
-        case Opcode::OP_PHASE_ROT:
+        case Opcode::OP_ARRAY_T:
+        case Opcode::OP_ARRAY_T_DAG:
+        case Opcode::OP_ARRAY_ROT:
             return true;
         default:
             return false;
@@ -244,7 +244,7 @@ void simulate_tile_instruction(const Instruction& inst, uint8_t& px_lo, uint8_t&
             mat4_mul_left(M, U);
             break;
         }
-        case Opcode::OP_PHASE_T: {
+        case Opcode::OP_ARRAY_T: {
             Mat2 u = {1.0, 0.0, 0.0, 1.0};
             if (px) {
                 u[3] = kExpMinusIPiOver4;
@@ -255,7 +255,7 @@ void simulate_tile_instruction(const Instruction& inst, uint8_t& px_lo, uint8_t&
             mat4_mul_left(M, kron_axis(u, on_hi_axis));
             break;
         }
-        case Opcode::OP_PHASE_T_DAG: {
+        case Opcode::OP_ARRAY_T_DAG: {
             Mat2 u = {1.0, 0.0, 0.0, 1.0};
             if (px) {
                 u[3] = kExpIPiOver4;
@@ -266,7 +266,7 @@ void simulate_tile_instruction(const Instruction& inst, uint8_t& px_lo, uint8_t&
             mat4_mul_left(M, kron_axis(u, on_hi_axis));
             break;
         }
-        case Opcode::OP_PHASE_ROT: {
+        case Opcode::OP_ARRAY_ROT: {
             std::complex<double> z(inst.math.weight_re, inst.math.weight_im);
             Mat2 u = {1.0, 0.0, 0.0, 1.0};
             if (px) {

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -947,8 +947,8 @@ static inline void expand_with_phase(std::complex<double>* __restrict arr, uint6
 // to array indices where bit v is set. If p_x[v]=1 (T anticommutes with X),
 // the array gets T_dag instead and gamma absorbs e^{i*pi/4} to preserve
 // the factored state identity.
-static inline void exec_phase_t(SchrodingerState& state, uint16_t v) {
-    assert(v < 64 && "PHASE_T: axis out of range");
+static inline void exec_array_t(SchrodingerState& state, uint16_t v) {
+    assert(v < 64 && "ARRAY_T: axis out of range");
     bool px = bit_get(state.p_x, v);
 
     if (v >= state.active_k) {
@@ -968,8 +968,8 @@ static inline void exec_phase_t(SchrodingerState& state, uint16_t v) {
 // T_dag gate (-pi/4 Z-rotation) on active axis v: applies diag(1, e^{-i*pi/4}).
 // Mirror of T: if p_x[v]=1, the array gets T instead and gamma absorbs
 // e^{-i*pi/4}.
-static inline void exec_phase_t_dag(SchrodingerState& state, uint16_t v) {
-    assert(v < 64 && "PHASE_T_DAG: axis out of range");
+static inline void exec_array_t_dag(SchrodingerState& state, uint16_t v) {
+    assert(v < 64 && "ARRAY_T_DAG: axis out of range");
     bool px = bit_get(state.p_x, v);
 
     if (v >= state.active_k) {
@@ -986,7 +986,7 @@ static inline void exec_phase_t_dag(SchrodingerState& state, uint16_t v) {
     }
 }
 
-// Fused EXPAND + PHASE_T: duplicates the array into the upper half while
+// Fused EXPAND + ARRAY_T: duplicates the array into the upper half while
 // applying the T phase to the new axis in a single pass.  The expand
 // operation sets v[i + half] = v[i] for all i < 2^k, then T multiplies
 // v[idx] by exp(i*pi/4) for all idx with the new bit set.  By fusing,
@@ -1011,7 +1011,7 @@ static inline void exec_expand_t(SchrodingerState& state, uint16_t v) {
     }
 }
 
-// Fused EXPAND + PHASE_T_DAG: same fusion but with T-dagger phase.
+// Fused EXPAND + ARRAY_T_DAG: same fusion but with T-dagger phase.
 static inline void exec_expand_t_dag(SchrodingerState& state, uint16_t v) {
     assert(v == state.active_k && "EXPAND_T_DAG must target the next dormant axis");
     assert(state.v_size() <= state.array_size() / 2);
@@ -1040,8 +1040,8 @@ static inline void exec_expand_t_dag(SchrodingerState& state, uint16_t v) {
 // z = weight_re + i*weight_im = e^{i*alpha*pi}. If p_x[v]=1 (X error),
 // the array gets z* instead and gamma absorbs z to preserve the factored
 // state identity.
-static inline void exec_phase_rot(SchrodingerState& state, uint16_t v, double z_re, double z_im) {
-    assert(v < 64 && "PHASE_ROT: axis out of range");
+static inline void exec_array_rot(SchrodingerState& state, uint16_t v, double z_re, double z_im) {
+    assert(v < 64 && "ARRAY_ROT: axis out of range");
     bool px = bit_get(state.p_x, v);
     std::complex<double> z(z_re, z_im);
 
@@ -1059,7 +1059,7 @@ static inline void exec_phase_rot(SchrodingerState& state, uint16_t v, double z_
     }
 }
 
-// Fused EXPAND + PHASE_ROT: duplicates the array into the upper half while
+// Fused EXPAND + ARRAY_ROT: duplicates the array into the upper half while
 // applying the continuous phase to the new axis in a single pass.
 static inline void exec_expand_rot(SchrodingerState& state, uint16_t v, double z_re, double z_im) {
     assert(v == state.active_k && "EXPAND_ROT must target the next dormant axis");
@@ -2140,16 +2140,16 @@ void execute_internal(const CompiledModule& program, SchrodingerState& state) {
         [static_cast<uint8_t>(Opcode::OP_ARRAY_H)] = &&L_OP_ARRAY_H,
         [static_cast<uint8_t>(Opcode::OP_ARRAY_S)] = &&L_OP_ARRAY_S,
         [static_cast<uint8_t>(Opcode::OP_ARRAY_S_DAG)] = &&L_OP_ARRAY_S_DAG,
-
-        [static_cast<uint8_t>(Opcode::OP_EXPAND)] = &&L_OP_EXPAND,
-        [static_cast<uint8_t>(Opcode::OP_PHASE_T)] = &&L_OP_PHASE_T,
-        [static_cast<uint8_t>(Opcode::OP_PHASE_T_DAG)] = &&L_OP_PHASE_T_DAG,
-        [static_cast<uint8_t>(Opcode::OP_EXPAND_T)] = &&L_OP_EXPAND_T,
-        [static_cast<uint8_t>(Opcode::OP_EXPAND_T_DAG)] = &&L_OP_EXPAND_T_DAG,
-        [static_cast<uint8_t>(Opcode::OP_PHASE_ROT)] = &&L_OP_PHASE_ROT,
-        [static_cast<uint8_t>(Opcode::OP_EXPAND_ROT)] = &&L_OP_EXPAND_ROT,
+        [static_cast<uint8_t>(Opcode::OP_ARRAY_T)] = &&L_OP_ARRAY_T,
+        [static_cast<uint8_t>(Opcode::OP_ARRAY_T_DAG)] = &&L_OP_ARRAY_T_DAG,
+        [static_cast<uint8_t>(Opcode::OP_ARRAY_ROT)] = &&L_OP_ARRAY_ROT,
         [static_cast<uint8_t>(Opcode::OP_ARRAY_U2)] = &&L_OP_ARRAY_U2,
         [static_cast<uint8_t>(Opcode::OP_ARRAY_U4)] = &&L_OP_ARRAY_U4,
+
+        [static_cast<uint8_t>(Opcode::OP_EXPAND)] = &&L_OP_EXPAND,
+        [static_cast<uint8_t>(Opcode::OP_EXPAND_T)] = &&L_OP_EXPAND_T,
+        [static_cast<uint8_t>(Opcode::OP_EXPAND_T_DAG)] = &&L_OP_EXPAND_T_DAG,
+        [static_cast<uint8_t>(Opcode::OP_EXPAND_ROT)] = &&L_OP_EXPAND_ROT,
 
         [static_cast<uint8_t>(Opcode::OP_MEAS_DORMANT_STATIC)] = &&L_OP_MEAS_DORMANT_STATIC,
         [static_cast<uint8_t>(Opcode::OP_MEAS_DORMANT_RANDOM)] = &&L_OP_MEAS_DORMANT_RANDOM,
@@ -2239,12 +2239,12 @@ L_OP_EXPAND:
     exec_expand(state, pc->axis_1);
     DISPATCH();
 
-L_OP_PHASE_T:
-    exec_phase_t(state, pc->axis_1);
+L_OP_ARRAY_T:
+    exec_array_t(state, pc->axis_1);
     DISPATCH();
 
-L_OP_PHASE_T_DAG:
-    exec_phase_t_dag(state, pc->axis_1);
+L_OP_ARRAY_T_DAG:
+    exec_array_t_dag(state, pc->axis_1);
     DISPATCH();
 
 L_OP_EXPAND_T:
@@ -2255,8 +2255,8 @@ L_OP_EXPAND_T_DAG:
     exec_expand_t_dag(state, pc->axis_1);
     DISPATCH();
 
-L_OP_PHASE_ROT:
-    exec_phase_rot(state, pc->axis_1, pc->math.weight_re, pc->math.weight_im);
+L_OP_ARRAY_ROT:
+    exec_array_rot(state, pc->axis_1, pc->math.weight_re, pc->math.weight_im);
     DISPATCH();
 
 L_OP_EXPAND_ROT:
@@ -2387,11 +2387,11 @@ L_OP_EXP_VAL:
             case Opcode::OP_EXPAND:
                 exec_expand(state, instr.axis_1);
                 break;
-            case Opcode::OP_PHASE_T:
-                exec_phase_t(state, instr.axis_1);
+            case Opcode::OP_ARRAY_T:
+                exec_array_t(state, instr.axis_1);
                 break;
-            case Opcode::OP_PHASE_T_DAG:
-                exec_phase_t_dag(state, instr.axis_1);
+            case Opcode::OP_ARRAY_T_DAG:
+                exec_array_t_dag(state, instr.axis_1);
                 break;
             case Opcode::OP_EXPAND_T:
                 exec_expand_t(state, instr.axis_1);
@@ -2399,8 +2399,8 @@ L_OP_EXP_VAL:
             case Opcode::OP_EXPAND_T_DAG:
                 exec_expand_t_dag(state, instr.axis_1);
                 break;
-            case Opcode::OP_PHASE_ROT:
-                exec_phase_rot(state, instr.axis_1, instr.math.weight_re, instr.math.weight_im);
+            case Opcode::OP_ARRAY_ROT:
+                exec_array_rot(state, instr.axis_1, instr.math.weight_re, instr.math.weight_im);
                 break;
             case Opcode::OP_EXPAND_ROT:
                 exec_expand_rot(state, instr.axis_1, instr.math.weight_re, instr.math.weight_im);

--- a/src/clifft/util/introspection.cc
+++ b/src/clifft/util/introspection.cc
@@ -131,16 +131,16 @@ std::string opcode_to_str(Opcode op) {
             return "OP_ARRAY_S_DAG";
         case Opcode::OP_EXPAND:
             return "OP_EXPAND";
-        case Opcode::OP_PHASE_T:
-            return "OP_PHASE_T";
-        case Opcode::OP_PHASE_T_DAG:
-            return "OP_PHASE_T_DAG";
+        case Opcode::OP_ARRAY_T:
+            return "OP_ARRAY_T";
+        case Opcode::OP_ARRAY_T_DAG:
+            return "OP_ARRAY_T_DAG";
         case Opcode::OP_EXPAND_T:
             return "OP_EXPAND_T";
         case Opcode::OP_EXPAND_T_DAG:
             return "OP_EXPAND_T_DAG";
-        case Opcode::OP_PHASE_ROT:
-            return "OP_PHASE_ROT";
+        case Opcode::OP_ARRAY_ROT:
+            return "OP_ARRAY_ROT";
         case Opcode::OP_EXPAND_ROT:
             return "OP_EXPAND_ROT";
         case Opcode::OP_ARRAY_U2:
@@ -184,7 +184,7 @@ std::string format_instruction(const Instruction& inst) {
 
     if (is_two_axis_opcode(inst.opcode)) {
         ss << inst.axis_1 << ", " << inst.axis_2;
-    } else if (inst.opcode == Opcode::OP_PHASE_ROT || inst.opcode == Opcode::OP_EXPAND_ROT) {
+    } else if (inst.opcode == Opcode::OP_ARRAY_ROT || inst.opcode == Opcode::OP_EXPAND_ROT) {
         ss << inst.axis_1 << " z=(" << inst.math.weight_re << ", " << inst.math.weight_im << ")";
     } else if (inst.opcode == Opcode::OP_ARRAY_U2) {
         ss << inst.axis_1 << " cp_idx=" << inst.u2.cp_idx;

--- a/src/clifft/util/introspection.h
+++ b/src/clifft/util/introspection.h
@@ -34,9 +34,9 @@ std::string opcode_to_str(Opcode op);
 [[nodiscard]] constexpr bool is_one_axis_opcode(Opcode op) noexcept {
     return op == Opcode::OP_FRAME_H || op == Opcode::OP_FRAME_S || op == Opcode::OP_FRAME_S_DAG ||
            op == Opcode::OP_ARRAY_H || op == Opcode::OP_ARRAY_S || op == Opcode::OP_ARRAY_S_DAG ||
-           op == Opcode::OP_EXPAND || op == Opcode::OP_PHASE_T || op == Opcode::OP_PHASE_T_DAG ||
+           op == Opcode::OP_EXPAND || op == Opcode::OP_ARRAY_T || op == Opcode::OP_ARRAY_T_DAG ||
            op == Opcode::OP_EXPAND_T || op == Opcode::OP_EXPAND_T_DAG ||
-           op == Opcode::OP_PHASE_ROT || op == Opcode::OP_EXPAND_ROT || op == Opcode::OP_ARRAY_U2;
+           op == Opcode::OP_ARRAY_ROT || op == Opcode::OP_EXPAND_ROT || op == Opcode::OP_ARRAY_U2;
 }
 
 [[nodiscard]] constexpr bool is_meas_opcode(Opcode op) noexcept {

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -518,12 +518,12 @@ NB_MODULE(_clifft_core, m) {
         .def(nb::init<>());
 
     nb::class_<clifft::ExpandTPass, clifft::BytecodePass>(
-        m, "ExpandTPass", "Fuses OP_EXPAND + OP_PHASE_T into single OP_EXPAND_T instructions.")
+        m, "ExpandTPass", "Fuses OP_EXPAND + OP_ARRAY_T into single OP_EXPAND_T instructions.")
         .def(nb::init<>());
 
     nb::class_<clifft::ExpandRotPass, clifft::BytecodePass>(
         m, "ExpandRotPass",
-        "Fuses OP_EXPAND + OP_PHASE_ROT into single OP_EXPAND_ROT instructions.")
+        "Fuses OP_EXPAND + OP_ARRAY_ROT into single OP_EXPAND_ROT instructions.")
         .def(nb::init<>());
 
     nb::class_<clifft::SwapMeasPass, clifft::BytecodePass>(
@@ -589,11 +589,11 @@ NB_MODULE(_clifft_core, m) {
         .value("OP_ARRAY_S", clifft::Opcode::OP_ARRAY_S)
         .value("OP_ARRAY_S_DAG", clifft::Opcode::OP_ARRAY_S_DAG)
         .value("OP_EXPAND", clifft::Opcode::OP_EXPAND)
-        .value("OP_PHASE_T", clifft::Opcode::OP_PHASE_T)
-        .value("OP_PHASE_T_DAG", clifft::Opcode::OP_PHASE_T_DAG)
+        .value("OP_ARRAY_T", clifft::Opcode::OP_ARRAY_T)
+        .value("OP_ARRAY_T_DAG", clifft::Opcode::OP_ARRAY_T_DAG)
         .value("OP_EXPAND_T", clifft::Opcode::OP_EXPAND_T)
         .value("OP_EXPAND_T_DAG", clifft::Opcode::OP_EXPAND_T_DAG)
-        .value("OP_PHASE_ROT", clifft::Opcode::OP_PHASE_ROT)
+        .value("OP_ARRAY_ROT", clifft::Opcode::OP_ARRAY_ROT)
         .value("OP_EXPAND_ROT", clifft::Opcode::OP_EXPAND_ROT)
         .value("OP_ARRAY_U2", clifft::Opcode::OP_ARRAY_U2)
         .value("OP_ARRAY_U4", clifft::Opcode::OP_ARRAY_U4)
@@ -649,7 +649,7 @@ NB_MODULE(_clifft_core, m) {
                 } else if (i.opcode == clifft::Opcode::OP_ARRAY_MULTI_CNOT ||
                            i.opcode == clifft::Opcode::OP_ARRAY_MULTI_CZ) {
                     d["mask"] = i.multi_gate.mask;
-                } else if (i.opcode == clifft::Opcode::OP_PHASE_ROT ||
+                } else if (i.opcode == clifft::Opcode::OP_ARRAY_ROT ||
                            i.opcode == clifft::Opcode::OP_EXPAND_ROT) {
                     d["weight_re"] = i.math.weight_re;
                     d["weight_im"] = i.math.weight_im;

--- a/tests/python/test_introspection.py
+++ b/tests/python/test_introspection.py
@@ -196,7 +196,7 @@ class TestEnumBindings:
 
     def test_opcode_values(self) -> None:
         assert clifft.Opcode.OP_EXPAND is not None
-        assert clifft.Opcode.OP_PHASE_T is not None
+        assert clifft.Opcode.OP_ARRAY_T is not None
         assert clifft.Opcode.OP_MEAS_ACTIVE_DIAGONAL is not None
         assert clifft.Opcode.OP_POSTSELECT is not None
         assert clifft.Opcode.OP_EXP_VAL is not None

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1116,13 +1116,13 @@ TEST_CASE("Lower: two simultaneous T gates may raise peak rank to 2") {
 }
 
 TEST_CASE("Lower: pure Clifford circuit emits no EXPAND or T opcodes") {
-    // A pure Clifford circuit should emit no EXPAND, no PHASE_T, no PHASE_T_DAG.
+    // A pure Clifford circuit should emit no EXPAND, no ARRAY_T, no ARRAY_T_DAG.
     // All gates are absorbed into the tableau.
     auto mod = compile_circuit("H 0\nCX 0 1\nS 1\nH 1\nM 0\nM 1");
 
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_EXPAND) == 0);
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T) == 0);
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T_DAG) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T_DAG) == 0);
 }
 
 // =============================================================================
@@ -1144,8 +1144,8 @@ TEST_CASE("Lower: H-T-T absorbs S -- no S or T opcodes emitted") {
     // No runtime S or T opcodes should appear.
     auto mod = compile_optimized("H 0\nT 0\nT 0");
 
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T) == 0);
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T_DAG) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T_DAG) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_S) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_FRAME_S) == 0);
     CHECK(mod.peak_rank == 0);
@@ -1155,7 +1155,7 @@ TEST_CASE("Lower: T-T on dormant Z absorbs S offline -- no runtime ops") {
     // T 0; T 0 (no H): fused S absorbed into frame. Nothing to lower.
     auto mod = compile_optimized("T 0\nT 0");
 
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_EXPAND) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_FRAME_S) == 0);
     CHECK(mod.peak_rank == 0);
@@ -1164,8 +1164,8 @@ TEST_CASE("Lower: T-T on dormant Z absorbs S offline -- no runtime ops") {
 TEST_CASE("Lower: T_dag-T_dag absorbs S_dag offline") {
     auto mod = compile_optimized("T_DAG 0\nT_DAG 0");
 
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T) == 0);
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T_DAG) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T_DAG) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_S) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_S_DAG) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_FRAME_S) == 0);
@@ -1175,8 +1175,8 @@ TEST_CASE("Lower: T_dag-T_dag absorbs S_dag offline") {
 TEST_CASE("Lower: T-T_dag cancels completely") {
     auto mod = compile_optimized("T 0\nT_DAG 0");
 
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T) == 0);
-    CHECK(count_opcodes(mod.bytecode, Opcode::OP_PHASE_T_DAG) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T) == 0);
+    CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_T_DAG) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_ARRAY_S) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_FRAME_S) == 0);
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_EXPAND) == 0);
@@ -1238,8 +1238,8 @@ TEST_CASE("Lower: short postselection_mask only affects present indices") {
     CHECK(count_opcodes(mod.bytecode, Opcode::OP_DETECTOR) == 2);
 }
 
-TEST_CASE("Lower: PHASE_ROTATION geometric artifact correction", "[backend][rotation]") {
-    // Manually construct a PHASE_ROTATION with a +Y Pauli on qubit 0.
+TEST_CASE("Lower: ARRAY_ROTATION geometric artifact correction", "[backend][rotation]") {
+    // Manually construct a ARRAY_ROTATION with a +Y Pauli on qubit 0.
     // +Y compresses to -Z via the virtual frame, flipping result.sign.
     // The Back-End must correct global_weight for this geometric artifact.
     HirModule hir;
@@ -1260,7 +1260,7 @@ TEST_CASE("Lower: PHASE_ROTATION geometric artifact correction", "[backend][rota
     // z = e^{i * (-0.5) * pi} = -i
     bool found_rot = false;
     for (const auto& instr : mod.bytecode) {
-        if (instr.opcode == Opcode::OP_PHASE_ROT || instr.opcode == Opcode::OP_EXPAND_ROT) {
+        if (instr.opcode == Opcode::OP_ARRAY_ROT || instr.opcode == Opcode::OP_EXPAND_ROT) {
             CHECK_THAT(instr.math.weight_re, Catch::Matchers::WithinAbs(0.0, 1e-12));
             CHECK_THAT(instr.math.weight_im, Catch::Matchers::WithinAbs(-1.0, 1e-12));
             found_rot = true;

--- a/tests/test_bytecode_passes.cc
+++ b/tests/test_bytecode_passes.cc
@@ -508,7 +508,7 @@ TEST_CASE("BytecodePassManager: NoiseBlock then MultiGate", "[bytecode-pass]") {
 TEST_CASE("ExpandTPass: EXPAND + T fused into EXPAND_T", "[bytecode-pass]") {
     auto m = make_module({
         make_expand(3),
-        make_phase_t(3),
+        make_array_t(3),
     });
     ExpandTPass().run(m);
     REQUIRE(m.bytecode.size() == 1);
@@ -519,7 +519,7 @@ TEST_CASE("ExpandTPass: EXPAND + T fused into EXPAND_T", "[bytecode-pass]") {
 TEST_CASE("ExpandTPass: EXPAND + T_DAG fused into EXPAND_T_DAG", "[bytecode-pass]") {
     auto m = make_module({
         make_expand(5),
-        make_phase_t_dag(5),
+        make_array_t_dag(5),
     });
     ExpandTPass().run(m);
     REQUIRE(m.bytecode.size() == 1);
@@ -530,12 +530,12 @@ TEST_CASE("ExpandTPass: EXPAND + T_DAG fused into EXPAND_T_DAG", "[bytecode-pass
 TEST_CASE("ExpandTPass: mismatched axes not fused", "[bytecode-pass]") {
     auto m = make_module({
         make_expand(3),
-        make_phase_t(4),  // different axis
+        make_array_t(4),  // different axis
     });
     ExpandTPass().run(m);
     REQUIRE(m.bytecode.size() == 2);
     CHECK(m.bytecode[0].opcode == Opcode::OP_EXPAND);
-    CHECK(m.bytecode[1].opcode == Opcode::OP_PHASE_T);
+    CHECK(m.bytecode[1].opcode == Opcode::OP_ARRAY_T);
 }
 
 TEST_CASE("ExpandTPass: standalone EXPAND kept", "[bytecode-pass]") {
@@ -550,7 +550,7 @@ TEST_CASE("ExpandTPass: standalone EXPAND kept", "[bytecode-pass]") {
 
 TEST_CASE("ExpandTPass: preserves source map", "[bytecode-pass]") {
     CompiledModule m;
-    m.bytecode = {make_expand(3), make_phase_t(3), make_frame_h(0)};
+    m.bytecode = {make_expand(3), make_array_t(3), make_frame_h(0)};
     set_source_map(m, {{10}, {11}, {20}}, {3, 4, 4});
 
     ExpandTPass().run(m);

--- a/tests/test_single_axis_fusion.cc
+++ b/tests/test_single_axis_fusion.cc
@@ -59,11 +59,11 @@ SchrodingerState run_raw(CompiledModule& prog, uint8_t init_px = 0, uint8_t init
 // =============================================================================
 
 TEST_CASE("U2 fusion: 4-state oracle for H-T-S sequence") {
-    // Build a 1-qubit program: ARRAY_H(0), PHASE_T(0), ARRAY_S(0)
-    auto unfused = make_program({make_array_h(0), make_phase_t(0), make_array_s(0)}, 1);
+    // Build a 1-qubit program: ARRAY_H(0), ARRAY_T(0), ARRAY_S(0)
+    auto unfused = make_program({make_array_h(0), make_array_t(0), make_array_s(0)}, 1);
 
     // Apply fusion pass
-    auto fused = make_program({make_array_h(0), make_phase_t(0), make_array_s(0)}, 1);
+    auto fused = make_program({make_array_h(0), make_array_t(0), make_array_s(0)}, 1);
     SingleAxisFusionPass().run(fused);
 
     REQUIRE(fused.bytecode.size() == 1);
@@ -100,10 +100,10 @@ TEST_CASE("U2 fusion: 4-state oracle for Rz-H-Rz sequence") {
     double re2 = std::cos(angle2), im2 = std::sin(angle2);
 
     auto unfused = make_program(
-        {make_phase_rot(0, re1, im1), make_array_h(0), make_phase_rot(0, re2, im2)}, 1);
+        {make_array_rot(0, re1, im1), make_array_h(0), make_array_rot(0, re2, im2)}, 1);
 
     auto fused = make_program(
-        {make_phase_rot(0, re1, im1), make_array_h(0), make_phase_rot(0, re2, im2)}, 1);
+        {make_array_rot(0, re1, im1), make_array_h(0), make_array_rot(0, re2, im2)}, 1);
     SingleAxisFusionPass().run(fused);
 
     REQUIRE(fused.bytecode.size() == 1);
@@ -129,12 +129,12 @@ TEST_CASE("U2 fusion: 4-state oracle for S-H-Rz-H-Rz sequence") {
     double re1 = std::cos(1.2), im1 = std::sin(1.2);
     double re2 = std::cos(-0.5), im2 = std::sin(-0.5);
 
-    auto unfused = make_program({make_array_s(0), make_array_h(0), make_phase_rot(0, re1, im1),
-                                 make_array_h(0), make_phase_rot(0, re2, im2)},
+    auto unfused = make_program({make_array_s(0), make_array_h(0), make_array_rot(0, re1, im1),
+                                 make_array_h(0), make_array_rot(0, re2, im2)},
                                 1);
 
-    auto fused = make_program({make_array_s(0), make_array_h(0), make_phase_rot(0, re1, im1),
-                               make_array_h(0), make_phase_rot(0, re2, im2)},
+    auto fused = make_program({make_array_s(0), make_array_h(0), make_array_rot(0, re1, im1),
+                               make_array_h(0), make_array_rot(0, re2, im2)},
                               1);
     SingleAxisFusionPass().run(fused);
 
@@ -169,34 +169,34 @@ TEST_CASE("U2 fusion: does not fuse single array op") {
     CHECK(mod.bytecode[0].opcode == Opcode::OP_ARRAY_H);
 }
 
-TEST_CASE("U2 fusion: does not fuse isolated PHASE_ROT") {
-    auto mod = make_program({make_phase_rot(0, 1.0, 0.0)}, 1);
+TEST_CASE("U2 fusion: does not fuse isolated ARRAY_ROT") {
+    auto mod = make_program({make_array_rot(0, 1.0, 0.0)}, 1);
     SingleAxisFusionPass().run(mod);
 
     REQUIRE(mod.bytecode.size() == 1);
-    CHECK(mod.bytecode[0].opcode == Opcode::OP_PHASE_ROT);
+    CHECK(mod.bytecode[0].opcode == Opcode::OP_ARRAY_ROT);
 }
 
 TEST_CASE("U2 fusion: terminates at two-qubit gate boundary") {
     // H(0), T(0) -> NOT fusible (only 2 array ops, no ROT)
     // CNOT(0,1) -> boundary
     // H(1), T(1), S(1) -> fusible (3 array ops)
-    auto mod = make_program({make_array_h(0), make_phase_t(0), make_array_cnot(0, 1),
-                             make_array_h(1), make_phase_t(1), make_array_s(1)},
+    auto mod = make_program({make_array_h(0), make_array_t(0), make_array_cnot(0, 1),
+                             make_array_h(1), make_array_t(1), make_array_s(1)},
                             2);
     SingleAxisFusionPass().run(mod);
 
     REQUIRE(mod.bytecode.size() == 4);
     CHECK(mod.bytecode[0].opcode == Opcode::OP_ARRAY_H);  // H(0) unfused
-    CHECK(mod.bytecode[1].opcode == Opcode::OP_PHASE_T);  // T(0) unfused
+    CHECK(mod.bytecode[1].opcode == Opcode::OP_ARRAY_T);  // T(0) unfused
     CHECK(mod.bytecode[2].opcode == Opcode::OP_ARRAY_CNOT);
     CHECK(mod.bytecode[3].opcode == Opcode::OP_ARRAY_U2);  // H(1)+T(1)+S(1) fused
     CHECK(mod.bytecode[3].axis_1 == 1);
 }
 
 TEST_CASE("U2 fusion: terminates at EXPAND boundary") {
-    auto mod = make_program({make_array_h(0), make_phase_rot(0, 0.5, 0.866), make_expand(1),
-                             make_array_h(1), make_phase_rot(1, 0.707, 0.707)},
+    auto mod = make_program({make_array_h(0), make_array_rot(0, 0.5, 0.866), make_expand(1),
+                             make_array_h(1), make_array_rot(1, 0.707, 0.707)},
                             2);
     SingleAxisFusionPass().run(mod);
 
@@ -208,12 +208,12 @@ TEST_CASE("U2 fusion: terminates at EXPAND boundary") {
 
 TEST_CASE("U2 fusion: different axes break runs") {
     // H(0), Rz(1) -> axis changes, each is length 1, no fusion
-    auto mod = make_program({make_array_h(0), make_phase_rot(1, 0.5, 0.866)}, 2);
+    auto mod = make_program({make_array_h(0), make_array_rot(1, 0.5, 0.866)}, 2);
     SingleAxisFusionPass().run(mod);
 
     REQUIRE(mod.bytecode.size() == 2);
     CHECK(mod.bytecode[0].opcode == Opcode::OP_ARRAY_H);
-    CHECK(mod.bytecode[1].opcode == Opcode::OP_PHASE_ROT);
+    CHECK(mod.bytecode[1].opcode == Opcode::OP_ARRAY_ROT);
 }
 
 TEST_CASE("U2 fusion: frame-only ops contribute to run but need array partner") {
@@ -231,9 +231,9 @@ TEST_CASE("U2 fusion: frame-only ops contribute to run but need array partner") 
     CHECK(mod2.bytecode[0].opcode == Opcode::OP_FRAME_S);
     CHECK(mod2.bytecode[1].opcode == Opcode::OP_ARRAY_H);
 
-    // FRAME_S(0) + ARRAY_H(0) + PHASE_ROT(0) -> 2 array ops -> fuse!
+    // FRAME_S(0) + ARRAY_H(0) + ARRAY_ROT(0) -> 2 array ops -> fuse!
     double re = std::cos(0.5), im = std::sin(0.5);
-    auto mod3 = make_program({make_frame_s(0), make_array_h(0), make_phase_rot(0, re, im)}, 1);
+    auto mod3 = make_program({make_frame_s(0), make_array_h(0), make_array_rot(0, re, im)}, 1);
     SingleAxisFusionPass().run(mod3);
     REQUIRE(mod3.bytecode.size() == 1);
     CHECK(mod3.bytecode[0].opcode == Opcode::OP_ARRAY_U2);
@@ -241,7 +241,7 @@ TEST_CASE("U2 fusion: frame-only ops contribute to run but need array partner") 
 
 TEST_CASE("U2 fusion: measurement terminates run") {
     auto meas = make_meas(Opcode::OP_MEAS_ACTIVE_DIAGONAL, 0, 0, false);
-    auto mod = make_program({make_array_h(0), make_phase_rot(0, 0.5, 0.866), meas}, 1, 1);
+    auto mod = make_program({make_array_h(0), make_array_rot(0, 0.5, 0.866), meas}, 1, 1);
     SingleAxisFusionPass().run(mod);
 
     REQUIRE(mod.bytecode.size() == 2);
@@ -261,15 +261,15 @@ TEST_CASE("U2 fusion: Rz-H-Rz blocks around CNOT on 2 qubits") {
     double r4 = std::cos(-0.2), i4 = std::sin(-0.2);
 
     auto unfused =
-        make_program({make_phase_rot(0, r1, i1), make_array_h(0), make_phase_rot(0, r2, i2),
-                      make_array_cnot(0, 1), make_phase_rot(1, r3, i3), make_array_h(1),
-                      make_phase_rot(1, r4, i4)},
+        make_program({make_array_rot(0, r1, i1), make_array_h(0), make_array_rot(0, r2, i2),
+                      make_array_cnot(0, 1), make_array_rot(1, r3, i3), make_array_h(1),
+                      make_array_rot(1, r4, i4)},
                      2);
 
     auto fused =
-        make_program({make_phase_rot(0, r1, i1), make_array_h(0), make_phase_rot(0, r2, i2),
-                      make_array_cnot(0, 1), make_phase_rot(1, r3, i3), make_array_h(1),
-                      make_phase_rot(1, r4, i4)},
+        make_program({make_array_rot(0, r1, i1), make_array_h(0), make_array_rot(0, r2, i2),
+                      make_array_cnot(0, 1), make_array_rot(1, r3, i3), make_array_h(1),
+                      make_array_rot(1, r4, i4)},
                      2);
     SingleAxisFusionPass().run(fused);
 

--- a/tests/test_svm_avx512_axis01.cc
+++ b/tests/test_svm_avx512_axis01.cc
@@ -519,7 +519,7 @@ TEST_CASE("AVX512 axis01: phase rotation on axis 0 at rank 10") {
     // T gate: e^{i*pi/4}
     double angle = std::numbers::pi / 4.0;
     std::complex<double> phase = {std::cos(angle), std::sin(angle)};
-    auto prog = make_program({make_phase_rot(0, phase.real(), phase.imag())}, kHighRank);
+    auto prog = make_program({make_array_rot(0, phase.real(), phase.imag())}, kHighRank);
     execute(prog, state);
 
     // Phase on axis 0: multiply |1> amplitudes (bit 0 = 1) by phase
@@ -545,7 +545,7 @@ TEST_CASE("AVX512 axis01: phase rotation on axis 1 at rank 10") {
 
     double angle = std::numbers::pi / 3.0;
     std::complex<double> phase = {std::cos(angle), std::sin(angle)};
-    auto prog = make_program({make_phase_rot(1, phase.real(), phase.imag())}, kHighRank);
+    auto prog = make_program({make_array_rot(1, phase.real(), phase.imag())}, kHighRank);
     execute(prog, state);
 
     for (uint64_t i = 0; i < n; ++i) {

--- a/tests/test_svm_risc.cc
+++ b/tests/test_svm_risc.cc
@@ -422,7 +422,7 @@ TEST_CASE("RISC Phase: T on active axis - no frame error") {
     state.v()[1] = {1.0, 0.0};
     state.set_gamma({1.0 / std::sqrt(2.0), 0.0});
 
-    auto prog = make_program({make_phase_t(0)}, 2);
+    auto prog = make_program({make_array_t(0)}, 2);
     execute(prog, state);
 
     // T applies e^{i*pi/4} to |1> component (no frame error)
@@ -440,7 +440,7 @@ TEST_CASE("RISC Phase: T on active axis - with X frame error") {
     state.v()[1] = {1.0, 0.0};
     state.p_x = X(0);  // X error on qubit 0
 
-    auto prog = make_program({make_phase_t(0)}, 2);
+    auto prog = make_program({make_array_t(0)}, 2);
     execute(prog, state);
 
     // With p_x[0]=1: apply T_dag to array, gamma *= e^{i*pi/4}
@@ -455,7 +455,7 @@ TEST_CASE("RISC Phase: T_dag on active axis - no frame error") {
     state.v()[0] = {1.0, 0.0};
     state.v()[1] = {1.0, 0.0};
 
-    auto prog = make_program({make_phase_t_dag(0)}, 2);
+    auto prog = make_program({make_array_t_dag(0)}, 2);
     execute(prog, state);
 
     check_complex(state.v()[0], {1.0, 0.0});
@@ -470,7 +470,7 @@ TEST_CASE("RISC Phase: T then T_dag cancels") {
     auto v0_orig = state.v()[0];
     auto v1_orig = state.v()[1];
 
-    auto prog = make_program({make_phase_t(0), make_phase_t_dag(0)}, 2);
+    auto prog = make_program({make_array_t(0), make_array_t_dag(0)}, 2);
     execute(prog, state);
 
     check_complex(state.v()[0], v0_orig);
@@ -484,7 +484,7 @@ TEST_CASE("RISC Phase: Two T gates equal S - applies i to 1-component") {
     state.v()[0] = {1.0, 0.0};
     state.v()[1] = {1.0, 0.0};
 
-    auto prog = make_program({make_phase_t(0), make_phase_t(0)}, 2);
+    auto prog = make_program({make_array_t(0), make_array_t(0)}, 2);
     execute(prog, state);
 
     // Two T gates = S = diag(1, i)
@@ -496,15 +496,15 @@ TEST_CASE("RISC Phase: Two T gates equal S - applies i to 1-component") {
 // Expand + Phase: T gate on dormant qubit via H then T
 // =============================================================================
 
-TEST_CASE("RISC: EXPAND then PHASE_T - single T gate circuit") {
+TEST_CASE("RISC: EXPAND then ARRAY_T - single T gate circuit") {
     SchrodingerState state(2, 0);
     // Initial state: |0>, active_k = 0, v = [1]
 
-    auto prog = make_program({make_expand(0), make_phase_t(0)}, 2);
+    auto prog = make_program({make_expand(0), make_array_t(0)}, 2);
     execute(prog, state);
 
     // After EXPAND(0): v = [1, 1], gamma = 1/sqrt(2), active_k = 1
-    // After PHASE_T(0): v = [1, e^{i*pi/4}]
+    // After ARRAY_T(0): v = [1, e^{i*pi/4}]
     CHECK(state.active_k == 1);
     check_complex(state.v()[0], {1.0, 0.0});
     check_complex(state.v()[1], {kInvSqrt2, kInvSqrt2});
@@ -665,7 +665,7 @@ TEST_CASE("RISC Integration: Expand-T-MeasDiag gives correct statistics") {
 
     SchrodingerState state(2, 1);
     auto prog =
-        make_program({make_expand(0), make_phase_t(0), make_meas_active_diagonal(0, 0)}, 2, 1);
+        make_program({make_expand(0), make_array_t(0), make_meas_active_diagonal(0, 0)}, 2, 1);
     for (uint32_t trial = 0; trial < num_trials; ++trial) {
         INFO("Trial: " << trial);
         state.reseed(trial * 77 + 13);

--- a/tests/test_tile_axis_fusion.cc
+++ b/tests/test_tile_axis_fusion.cc
@@ -233,7 +233,7 @@ TEST_CASE("U4 fusion: all 16 Pauli frame input states produce correct results") 
 
     // A non-trivial tile: CNOT + H_lo + S_hi + CZ + T_lo
     auto bc = std::vector<Instruction>{make_array_cnot(lo, hi), make_array_h(lo), make_array_s(hi),
-                                       make_array_cz(lo, hi), make_phase_t(lo)};
+                                       make_array_cz(lo, hi), make_array_t(lo)};
 
     for (uint8_t in_state = 0; in_state < 16; ++in_state) {
         CAPTURE(in_state);
@@ -308,7 +308,7 @@ TEST_CASE("U4 fusion: axes 3 and 5 - fully strided 3D loops") {
     uint16_t lo = 3, hi = 5;
 
     auto bc = std::vector<Instruction>{make_array_cnot(hi, lo), make_array_h(lo),
-                                       make_array_cz(lo, hi), make_phase_t(hi)};
+                                       make_array_cz(lo, hi), make_array_t(hi)};
 
     check_statevectors_equal(run_fused(bc, rank), run_unfused(bc, rank));
 }
@@ -318,7 +318,7 @@ TEST_CASE("U4 fusion: axes 2 and 3 at high rank 10 - AVX-512 structured stride")
     uint16_t lo = 2, hi = 3;
 
     auto bc = std::vector<Instruction>{make_array_cnot(lo, hi), make_array_h(lo), make_array_s(hi),
-                                       make_array_cz(lo, hi), make_phase_t(lo)};
+                                       make_array_cz(lo, hi), make_array_t(lo)};
 
     check_statevectors_equal(run_fused(bc, rank), run_unfused(bc, rank));
 }
@@ -474,14 +474,14 @@ TEST_CASE("U4 fusion: QV-like tile sequence matches unfused") {
 
     auto bc = std::vector<Instruction>{
         make_array_cnot(lo, hi), make_array_h(lo), make_array_h(hi),        make_array_cz(lo, hi),
-        make_phase_t(lo),        make_phase_t(hi), make_array_cnot(hi, lo), make_array_s(lo),
+        make_array_t(lo),        make_array_t(hi), make_array_cnot(hi, lo), make_array_s(lo),
         make_array_cz(lo, hi),   make_array_h(hi), make_array_cnot(lo, hi), make_array_cz(lo, hi),
         make_array_s(hi),        make_array_h(lo)};
 
     check_statevectors_equal(run_fused(bc, rank), run_unfused(bc, rank));
 }
 
-TEST_CASE("U4 fusion: tile with T-dagger and PHASE_ROT") {
+TEST_CASE("U4 fusion: tile with T-dagger and ARRAY_ROT") {
     constexpr uint32_t rank = 4;
     uint16_t lo = 0, hi = 2;
 
@@ -489,8 +489,8 @@ TEST_CASE("U4 fusion: tile with T-dagger and PHASE_ROT") {
     double re = std::cos(0.3);
     double im = std::sin(0.3);
 
-    auto bc = std::vector<Instruction>{make_array_cnot(lo, hi), make_phase_t_dag(hi),
-                                       make_phase_rot(lo, re, im), make_array_cz(lo, hi)};
+    auto bc = std::vector<Instruction>{make_array_cnot(lo, hi), make_array_t_dag(hi),
+                                       make_array_rot(lo, re, im), make_array_cz(lo, hi)};
 
     check_statevectors_equal(run_fused(bc, rank), run_unfused(bc, rank));
 }
@@ -637,7 +637,7 @@ TEST_CASE("U4 fusion: long tile run at rank 10") {
 
     auto bc =
         std::vector<Instruction>{make_array_cnot(lo, hi), make_array_h(lo),        make_array_s(hi),
-                                 make_array_cz(lo, hi),   make_phase_t(lo),        make_phase_t(hi),
+                                 make_array_cz(lo, hi),   make_array_t(lo),        make_array_t(hi),
                                  make_array_cnot(hi, lo), make_array_h(hi),        make_array_s(lo),
                                  make_array_cz(lo, hi),   make_array_cnot(lo, hi), make_array_h(lo),
                                  make_array_cz(lo, hi)};


### PR DESCRIPTION
## Summary

The Subspace category in `docs/opcodes.json` was conflating two distinct runtime semantics:

1. **k-mutators** — `OP_EXPAND`, `OP_EXPAND_T`, `OP_EXPAND_T_DAG`, `OP_EXPAND_ROT`. These genuinely change the active dimension $k$.
2. **Non-Clifford at fixed k** — `OP_PHASE_T`, `OP_PHASE_T_DAG`, `OP_PHASE_ROT`. These touch one virtual axis of the state vector, $k$ unchanged. The runtime work shape is identical to `OP_ARRAY_S` (`exec_phase_t` and `exec_array_s` apply `diag(1, *)` via the same waterfall) — only "non-Clifford" sets them apart.

Lumping (2) under "Subspace" reads the category along the wrong axis (Clifford vs non-Clifford) instead of along runtime cost shape (frame-only / fixed-k state vector / k-mutating). This PR splits them: the renamed and recategorized ops join the Array block; Subspace now contains only the genuine k-mutators.

It also resolves a pre-existing inconsistency: `OP_ARRAY_U2` / `OP_ARRAY_U4` were named `ARRAY` but filed under Subspace because they fuse non-Clifford rotations. Under the cleaner split they land where their name says they should.

### Renames

| Before | After |
|---|---|
| `OP_PHASE_T` | `OP_ARRAY_T` |
| `OP_PHASE_T_DAG` | `OP_ARRAY_T_DAG` |
| `OP_PHASE_ROT` | `OP_ARRAY_ROT` |
| `make_phase_t` / `make_phase_t_dag` / `make_phase_rot` | `make_array_t` / `make_array_t_dag` / `make_array_rot` |
| `exec_phase_t` / `exec_phase_t_dag` / `exec_phase_rot` | `exec_array_t` / `exec_array_t_dag` / `exec_array_rot` |
| Dispatch labels `L_OP_PHASE_*` | `L_OP_ARRAY_*` |

### Recategorization in `docs/opcodes.json`

Subspace → Array: `OP_ARRAY_T`, `OP_ARRAY_T_DAG`, `OP_ARRAY_ROT`, `OP_ARRAY_U2`, `OP_ARRAY_U4`.
Subspace stays: `OP_EXPAND`, `OP_EXPAND_T`, `OP_EXPAND_T_DAG`, `OP_EXPAND_ROT`.

### Intentionally unchanged

The HIR layer keeps `HeisenbergOp::make_phase_rotation` and `OpType::PHASE_ROTATION`. At HIR level (before Pauli localization) this is a phase rotation on a Pauli product — a distinct concept from the post-localization runtime opcode, and the existing name is correct there.

### Files changed

- `src/clifft/backend/backend.{h,cc}` — `Opcode` enum (entries reordered to group all `ARRAY_*` together), factory declarations and definitions.
- `src/clifft/svm/svm_kernels.inl` — kernel function names, computed-goto labels, dispatch table (reordered to keep designated-initializer indices monotonic — see note below), generic `case` switch.
- `src/clifft/optimizer/{expand_t,single_axis_fusion,tile_axis_fusion}_pass.{cc,h}` — opcode references in pattern matchers.
- `src/clifft/util/introspection.{cc,h}` — opcode-name strings, "is array op" predicate.
- `src/python/bindings.cc` — `Opcode` enum bindings, pass docstrings.
- `docs/opcodes.json` — keys, categories, cross-references in `detail` text.
- `docs/macros.py` — `ExpandTPass` / `ExpandRotPass` / `SingleAxisFusionPass` `detail` strings.
- `playground/src/components/GuidedTour.tsx` — VM Bytecode tour bullet (`OP_PHASE_T` → `OP_ARRAY_T`).
- Tests (`tests/*.cc`, `tests/python/test_introspection.py`) — opcode references.

### Note on the dispatch table

Reordering the enum to group `ARRAY_*` together broke GCC's monotonic-index requirement for the C99 designated-initializer dispatch table in `svm_kernels.inl`. Reordering the table block to match the new enum order resolves it (the table still uses `static_cast<uint8_t>(Opcode::...)` keys, so it's robust to any future enum tweaks as long as the source-order matches the enum-value order).

## Test plan

- [x] `uv run pytest tests/python` — 595 passed.
- [x] Standalone CMake build (`cmake -S . -B build-tests -G "Unix Makefiles"`) + `./build-tests/tests/clifft_tests` — 650 cases, 113,390 assertions, all pass.
- [x] `uv run mkdocs build` — clean (Array category in `docs/reference/instructions.md` now contains the renamed ops as expected).
- [x] No stray `OP_PHASE_*` / `make_phase_t*` / `make_phase_rot(` / `exec_phase_*` / `L_OP_PHASE_*` references remain (`grep -rn` clean across `src/`, `tests/`, `docs/`, `playground/src/`).
- [ ] Spot-check the Playground guided tour and `instructions.md` rendering after this lands.

## Sequencing

PR #12 (docs–paper alignment) will rebase on top of this so its docs already reference the new names.