### PR TITLE
feat(python): run default optimization passes by default in compile()

### DIFF
--- a/docs/guide/compiling.md
+++ b/docs/guide/compiling.md
@@ -14,7 +14,8 @@ Circuit Text --> Parse --> Front-End --> Middle-End Optimizer --> Back-End --> B
 
 ## One-Step Compilation
 
-For most use cases, `clifft.compile()` runs the full pipeline:
+For most use cases, `clifft.compile()` runs the full pipeline with the
+default HIR and bytecode optimization passes:
 
 ```python
 import clifft
@@ -27,7 +28,7 @@ program = clifft.compile("""
 """)
 ```
 
-To enable HIR and bytecode optimization passes, supply pass managers:
+To skip optimization, pass `None` for the corresponding stage:
 
 ```python
 import clifft
@@ -39,12 +40,13 @@ program = clifft.compile(
     T 2
     M 0 1 2
     """,
-    hir_passes=clifft.default_hir_pass_manager(),
-    bytecode_passes=clifft.default_bytecode_pass_manager(),
+    hir_passes=None,
+    bytecode_passes=None,
 )
 ```
 
-When omitted (or `None`), the corresponding optimization stage is skipped.
+You can also supply a custom `HirPassManager` or `BytecodePassManager` to
+override the defaults (see [Optimization Passes](../reference/passes.md)).
 
 ### Syndrome Normalization
 
@@ -60,8 +62,6 @@ import clifft
 program = clifft.compile(
     circuit_text,
     normalize_syndromes=True,
-    hir_passes=clifft.default_hir_pass_manager(),
-    bytecode_passes=clifft.default_bytecode_pass_manager(),
 )
 ```
 
@@ -104,8 +104,6 @@ program = clifft.compile(
     circuit_text,
     postselection_mask=[1, 0, 0],  # Post-select on detector 0
     normalize_syndromes=True,       # Auto-normalize all syndromes
-    hir_passes=clifft.default_hir_pass_manager(),
-    bytecode_passes=clifft.default_bytecode_pass_manager(),
 )
 
 result = clifft.sample_survivors(program, shots=1_000_000, seed=42)

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -71,7 +71,6 @@ from clifft._clifft_core import (
     StatevectorSqueezePass,
     SwapMeasPass,
     Target,
-    compile as _compile_core,
     compute_reference_syndrome,
     default_bytecode_pass_manager,
     default_hir_pass_manager,
@@ -90,6 +89,9 @@ from clifft._clifft_core import (
     svm_backend,
     trace,
     version,
+)
+from clifft._clifft_core import (
+    compile as _compile_core,
 )
 from clifft._sample_result import SampleResult
 
@@ -152,6 +154,7 @@ def compile(
         hir_passes,
         bytecode_passes,
     )
+
 
 __all__ = [
     "AstNode",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -5,6 +5,7 @@ A multi-level AOT compiler and Schrodinger Virtual Machine for quantum circuits
 """
 
 # ruff: noqa: E402
+from __future__ import annotations
 
 from clifft._build_config import CPU_BASELINE, REQUIRES_X86_64_V3_BASELINE
 from clifft._cpu_check import ensure_supported_cpu
@@ -70,7 +71,7 @@ from clifft._clifft_core import (
     StatevectorSqueezePass,
     SwapMeasPass,
     Target,
-    compile,
+    compile as _compile_core,
     compute_reference_syndrome,
     default_bytecode_pass_manager,
     default_hir_pass_manager,
@@ -91,6 +92,66 @@ from clifft._clifft_core import (
     version,
 )
 from clifft._sample_result import SampleResult
+
+
+class _DefaultPasses:
+    """Sentinel marker for compile()'s default optimization passes."""
+
+
+_DEFAULT_PASSES = _DefaultPasses()
+
+
+def compile(
+    stim_text: str,
+    postselection_mask: list[int] | None = None,
+    expected_detectors: list[int] | None = None,
+    expected_observables: list[int] | None = None,
+    normalize_syndromes: bool = False,
+    hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+    bytecode_passes: BytecodePassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+) -> Program:
+    """Compile a quantum circuit string to executable bytecode.
+
+    Runs the full pipeline: parse -> trace -> [HIR optimize] ->
+    lower -> [bytecode optimize].
+
+    By default both optimization stages run with their default pass
+    managers. To skip optimization, pass ``hir_passes=None`` and/or
+    ``bytecode_passes=None``. To use a custom pipeline, pass an
+    explicit ``HirPassManager`` / ``BytecodePassManager``.
+
+    When ``normalize_syndromes=True``, a noiseless reference shot is
+    executed internally to extract expected detector and observable
+    parities. Detectors and observables are then XOR-normalized so
+    that 0 means 'matches noiseless reference' and 1 means 'error'.
+
+    Args:
+        stim_text: Circuit in .stim text format.
+        postselection_mask: Optional list of uint8 flags, one per detector.
+            Detectors where mask[i] != 0 become post-selection checks
+            that abort the shot early if their parity is non-zero.
+        expected_detectors: Optional noiseless reference parities for detectors.
+        expected_observables: Optional noiseless reference parities for observables.
+        normalize_syndromes: If True, auto-compute reference parities from a
+            noiseless reference shot (mutually exclusive with explicit parities).
+        hir_passes: HirPassManager to run on the HIR before lowering.
+            Defaults to ``default_hir_pass_manager()``. Pass ``None`` to skip.
+        bytecode_passes: BytecodePassManager to run after lowering.
+            Defaults to ``default_bytecode_pass_manager()``. Pass ``None`` to skip.
+    """
+    if isinstance(hir_passes, _DefaultPasses):
+        hir_passes = default_hir_pass_manager()
+    if isinstance(bytecode_passes, _DefaultPasses):
+        bytecode_passes = default_bytecode_pass_manager()
+    return _compile_core(
+        stim_text,
+        postselection_mask if postselection_mask is not None else [],
+        expected_detectors if expected_detectors is not None else [],
+        expected_observables if expected_observables is not None else [],
+        normalize_syndromes,
+        hir_passes,
+        bytecode_passes,
+    )
 
 __all__ = [
     "AstNode",

--- a/tests/python/test_bytecode_passes.py
+++ b/tests/python/test_bytecode_passes.py
@@ -13,12 +13,20 @@ from conftest import random_dense_clifford_t_circuit
 import clifft
 
 
+def compile_unoptimized(stim_text: str) -> clifft.Program:
+    """Compile with no HIR or bytecode optimization (baseline for A/B tests)."""
+    return clifft.compile(stim_text, hir_passes=None, bytecode_passes=None)
+
+
 def compile_optimized(stim_text: str) -> clifft.Program:
-    """Compile and run default bytecode optimization passes."""
-    prog = clifft.compile(stim_text)
-    bpm = clifft.default_bytecode_pass_manager()
-    bpm.run(prog)
-    return prog
+    """Compile with default bytecode passes only.
+
+    HIR passes are skipped so the bytecode A/B tests share an identical
+    HIR (and therefore identical PRNG trajectories) on both sides.
+    """
+    return clifft.compile(
+        stim_text, hir_passes=None, bytecode_passes=clifft.default_bytecode_pass_manager()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -45,7 +53,7 @@ def test_statevector_oracle(num_qubits: int, depth: int, seed: int) -> None:
     """Statevectors must be perfectly identical for optimized vs baseline."""
     stim_text = random_dense_clifford_t_circuit(num_qubits, depth, seed)
 
-    prog_base = clifft.compile(stim_text)
+    prog_base = compile_unoptimized(stim_text)
     prog_opt = compile_optimized(stim_text)
 
     state_base = clifft.State(
@@ -101,7 +109,7 @@ def test_exact_trajectory_noisy() -> None:
     This proves OP_NOISE_BLOCK keeps the gap-sampler perfectly synced
     with the original per-site OP_NOISE dispatch.
     """
-    prog_base = clifft.compile(NOISY_CIRCUIT)
+    prog_base = compile_unoptimized(NOISY_CIRCUIT)
     prog_opt = compile_optimized(NOISY_CIRCUIT)
 
     # Verify optimization actually changed something
@@ -148,7 +156,7 @@ def test_exact_trajectory_noiseless() -> None:
 
     Tests OP_EXPAND_T and OP_SWAP_MEAS_INTERFERE fusion correctness.
     """
-    prog_base = clifft.compile(NOISELESS_WITH_MEAS)
+    prog_base = compile_unoptimized(NOISELESS_WITH_MEAS)
     prog_opt = compile_optimized(NOISELESS_WITH_MEAS)
 
     base_result = clifft.sample(prog_base, shots=5000, seed=99)
@@ -172,7 +180,7 @@ def test_exact_trajectory_noiseless() -> None:
 
 def test_custom_bytecode_pass_manager() -> None:
     """Users can build a custom BytecodePassManager and run individual passes."""
-    prog = clifft.compile(NOISY_CIRCUIT)
+    prog = compile_unoptimized(NOISY_CIRCUIT)
     n_before = prog.num_instructions
 
     bpm = clifft.BytecodePassManager()
@@ -187,8 +195,8 @@ def test_multi_gate_pass_opt_in() -> None:
     """MultiGatePass can be added explicitly to the pipeline."""
     stim_text = random_dense_clifford_t_circuit(4, 100, 2000)
 
-    prog_base = clifft.compile(stim_text)
-    prog_opt = clifft.compile(stim_text)
+    prog_base = compile_unoptimized(stim_text)
+    prog_opt = compile_unoptimized(stim_text)
 
     bpm = clifft.BytecodePassManager()
     bpm.add(clifft.NoiseBlockPass())

--- a/tests/python/test_compile_passes.py
+++ b/tests/python/test_compile_passes.py
@@ -12,33 +12,38 @@ from conftest import random_dense_clifford_t_circuit
 import clifft
 
 # ---------------------------------------------------------------------------
-# Backward compatibility: omitting pass managers matches old behavior
+# Default behavior: omitting pass managers runs the default optimizers
 # ---------------------------------------------------------------------------
 
 
-def test_compile_no_passes_matches_manual_pipeline() -> None:
-    """compile() with no pass managers equals parse -> trace -> lower."""
+def test_compile_default_runs_default_optimizers() -> None:
+    """compile(text) with no kwargs equals the full default-optimized pipeline."""
     text = "H 0\nT 0\nCNOT 0 1\nM 0 1"
 
     prog_convenience = clifft.compile(text)
 
     circuit = clifft.parse(text)
     hir = clifft.trace(circuit)
+    clifft.default_hir_pass_manager().run(hir)
     prog_manual = clifft.lower(hir)
+    clifft.default_bytecode_pass_manager().run(prog_manual)
 
     assert prog_convenience.num_instructions == prog_manual.num_instructions
     assert prog_convenience.peak_rank == prog_manual.peak_rank
 
 
-def test_compile_explicit_none_same_as_default() -> None:
-    """Passing None explicitly is identical to omitting the arguments."""
+def test_compile_explicit_none_skips_optimization() -> None:
+    """Passing None explicitly disables the corresponding optimization stage."""
     text = "H 0\nT 0\nCNOT 0 1\nM 0 1"
 
-    p1 = clifft.compile(text)
-    p2 = clifft.compile(text, hir_passes=None, bytecode_passes=None)
+    prog_off = clifft.compile(text, hir_passes=None, bytecode_passes=None)
 
-    assert p1.num_instructions == p2.num_instructions
-    assert p1.peak_rank == p2.peak_rank
+    circuit = clifft.parse(text)
+    hir = clifft.trace(circuit)
+    prog_manual = clifft.lower(hir)
+
+    assert prog_off.num_instructions == prog_manual.num_instructions
+    assert prog_off.peak_rank == prog_manual.peak_rank
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +83,9 @@ def test_compile_hir_only_matches_manual() -> None:
     """compile() with only hir_passes matches manual trace + optimize + lower."""
     text = "H 0\nT 0\nT_DAG 0\nM 0"  # T/T_DAG cancel
 
-    prog = clifft.compile(text, hir_passes=clifft.default_hir_pass_manager())
+    prog = clifft.compile(
+        text, hir_passes=clifft.default_hir_pass_manager(), bytecode_passes=None
+    )
 
     circuit = clifft.parse(text)
     hir = clifft.trace(circuit)
@@ -94,7 +101,7 @@ def test_hir_passes_reduce_t_cancellation() -> None:
     """Peephole fusion cancels T/T_DAG, reducing peak rank."""
     text = "H 0\nT 0\nT_DAG 0\nM 0"
 
-    prog_no_opt = clifft.compile(text)
+    prog_no_opt = clifft.compile(text, hir_passes=None, bytecode_passes=None)
     prog_opt = clifft.compile(text, hir_passes=clifft.default_hir_pass_manager())
 
     # Without optimization, T and T_DAG both expand the array.
@@ -111,7 +118,9 @@ def test_compile_bytecode_only_matches_manual() -> None:
     """compile() with only bytecode_passes matches manual lower + optimize."""
     text = "H 0\nT 0\nCNOT 0 1\nM 0 1"
 
-    prog = clifft.compile(text, bytecode_passes=clifft.default_bytecode_pass_manager())
+    prog = clifft.compile(
+        text, hir_passes=None, bytecode_passes=clifft.default_bytecode_pass_manager()
+    )
 
     circuit = clifft.parse(text)
     hir = clifft.trace(circuit)
@@ -127,8 +136,10 @@ def test_bytecode_passes_fuse_instructions() -> None:
     """Bytecode passes should fuse ops, reducing instruction count."""
     text = "H 0\nT 0\nCNOT 0 1\nM 0 1"
 
-    prog_no_opt = clifft.compile(text)
-    prog_opt = clifft.compile(text, bytecode_passes=clifft.default_bytecode_pass_manager())
+    prog_no_opt = clifft.compile(text, hir_passes=None, bytecode_passes=None)
+    prog_opt = clifft.compile(
+        text, hir_passes=None, bytecode_passes=clifft.default_bytecode_pass_manager()
+    )
 
     # Fused instructions should not increase instruction count
     assert prog_opt.num_instructions <= prog_no_opt.num_instructions
@@ -161,13 +172,10 @@ def test_postselection_without_passes_unchanged() -> None:
     text = "H 0\nM 0\nDETECTOR rec[-1]"
     mask = [1]
 
-    prog_base = clifft.compile(text, postselection_mask=mask)
-    prog_opt = clifft.compile(
-        text,
-        postselection_mask=mask,
-        hir_passes=clifft.default_hir_pass_manager(),
-        bytecode_passes=clifft.default_bytecode_pass_manager(),
+    prog_base = clifft.compile(
+        text, postselection_mask=mask, hir_passes=None, bytecode_passes=None
     )
+    prog_opt = clifft.compile(text, postselection_mask=mask)
 
     assert prog_base.num_detectors == prog_opt.num_detectors
     assert prog_base.num_measurements == prog_opt.num_measurements
@@ -196,12 +204,8 @@ def test_statevector_identical_with_passes(num_qubits: int, depth: int, seed: in
     """
     stim_text = random_dense_clifford_t_circuit(num_qubits, depth, seed)
 
-    prog_base = clifft.compile(stim_text)
-    prog_opt = clifft.compile(
-        stim_text,
-        hir_passes=clifft.default_hir_pass_manager(),
-        bytecode_passes=clifft.default_bytecode_pass_manager(),
-    )
+    prog_base = clifft.compile(stim_text, hir_passes=None, bytecode_passes=None)
+    prog_opt = clifft.compile(stim_text)
 
     state_base = clifft.State(
         peak_rank=prog_base.peak_rank, num_measurements=prog_base.num_measurements
@@ -245,7 +249,7 @@ def test_custom_bytecode_pass_manager_via_compile() -> None:
     bpm = clifft.BytecodePassManager()
     bpm.add(clifft.ExpandTPass())
 
-    prog = clifft.compile(text, bytecode_passes=bpm)
+    prog = clifft.compile(text, hir_passes=None, bytecode_passes=bpm)
     # Should have fused expand+T into OP_EXPAND_T
     opcodes = [prog[i].opcode for i in range(prog.num_instructions)]
     assert clifft.Opcode.OP_EXPAND_T in opcodes or clifft.Opcode.OP_EXPAND_T_DAG in opcodes

--- a/tests/python/test_compile_passes.py
+++ b/tests/python/test_compile_passes.py
@@ -83,9 +83,7 @@ def test_compile_hir_only_matches_manual() -> None:
     """compile() with only hir_passes matches manual trace + optimize + lower."""
     text = "H 0\nT 0\nT_DAG 0\nM 0"  # T/T_DAG cancel
 
-    prog = clifft.compile(
-        text, hir_passes=clifft.default_hir_pass_manager(), bytecode_passes=None
-    )
+    prog = clifft.compile(text, hir_passes=clifft.default_hir_pass_manager(), bytecode_passes=None)
 
     circuit = clifft.parse(text)
     hir = clifft.trace(circuit)
@@ -172,9 +170,7 @@ def test_postselection_without_passes_unchanged() -> None:
     text = "H 0\nM 0\nDETECTOR rec[-1]"
     mask = [1]
 
-    prog_base = clifft.compile(
-        text, postselection_mask=mask, hir_passes=None, bytecode_passes=None
-    )
+    prog_base = clifft.compile(text, postselection_mask=mask, hir_passes=None, bytecode_passes=None)
     prog_opt = clifft.compile(text, postselection_mask=mask)
 
     assert prog_base.num_detectors == prog_opt.num_detectors

--- a/tests/python/test_optimization_invariants.py
+++ b/tests/python/test_optimization_invariants.py
@@ -42,9 +42,10 @@ def run_differential_trajectory(circuit_str: str, shots: int, seed: int) -> None
     bytecode passes (no HIR passes) so that the lowered instruction stream
     is identical up to bytecode-level rewrites.
     """
-    base_prog = clifft.compile(circuit_str)
+    base_prog = clifft.compile(circuit_str, hir_passes=None, bytecode_passes=None)
     opt_prog = clifft.compile(
         circuit_str,
+        hir_passes=None,
         bytecode_passes=clifft.default_bytecode_pass_manager(),
     )
 
@@ -162,7 +163,7 @@ class TestHirPeepholeUncomputationLadder:
     @pytest.mark.parametrize("nq,depth", _SMALL_CONFIGS)
     def test_small(self, nq: int, depth: int, seed: int) -> None:
         circuit = generate_uncomputation_ladder(nq, depth, seed=seed, noise_prob=0.0)
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         opt = clifft.compile(circuit, hir_passes=clifft.default_hir_pass_manager())
 
         assert base.peak_rank <= _MAX_PEAK_RANK
@@ -187,7 +188,7 @@ class TestHirPeepholeUncomputationLadder:
     @pytest.mark.parametrize("nq,depth", _LARGE_CONFIGS)
     def test_large(self, nq: int, depth: int, seed: int) -> None:
         circuit = generate_uncomputation_ladder(nq, depth, seed=seed, noise_prob=0.0)
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         opt = clifft.compile(circuit, hir_passes=clifft.default_hir_pass_manager())
 
         assert base.peak_rank <= _MAX_PEAK_RANK
@@ -210,7 +211,7 @@ class TestHirPeepholeUncomputationLadder:
         # peak_rank to 1. Both paths clamp dust, but the optimizer reduces it.
         circuit = generate_uncomputation_ladder(4, 50, seed=42, noise_prob=0.0)
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         assert base.peak_rank > 1, "Need active measurements to generate dust"
         base_state = clifft.State(
             peak_rank=base.peak_rank, num_measurements=base.num_measurements, seed=42
@@ -256,21 +257,21 @@ class TestHirPeepholeStatevectorOracle:
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_random_clifford_t_5q(self, seed: int) -> None:
         circuit = random_clifford_t_circuit(5, 40, seed=seed)
-        base_sv = _clifft_statevector(circuit)
+        base_sv = _clifft_statevector(circuit, hir_passes=None, bytecode_passes=None)
         opt_sv = _clifft_statevector(circuit, hir_passes=clifft.default_hir_pass_manager())
         assert_statevectors_equal(opt_sv, base_sv)
 
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_dense_clifford_t_4q(self, seed: int) -> None:
         circuit = random_dense_clifford_t_circuit(4, 50, seed=seed)
-        base_sv = _clifft_statevector(circuit)
+        base_sv = _clifft_statevector(circuit, hir_passes=None, bytecode_passes=None)
         opt_sv = _clifft_statevector(circuit, hir_passes=clifft.default_hir_pass_manager())
         assert_statevectors_equal(opt_sv, base_sv)
 
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_dense_clifford_t_8q(self, seed: int) -> None:
         circuit = random_dense_clifford_t_circuit(8, 60, seed=seed)
-        base_sv = _clifft_statevector(circuit)
+        base_sv = _clifft_statevector(circuit, hir_passes=None, bytecode_passes=None)
         opt_sv = _clifft_statevector(circuit, hir_passes=clifft.default_hir_pass_manager())
         assert_statevectors_equal(opt_sv, base_sv)
 
@@ -314,7 +315,7 @@ class TestHirPeepholeStatisticalEquivalence:
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_star_graph_noisy_10q(self, seed: int) -> None:
         circuit = generate_star_graph_honeypot(10, 100, seed=seed)
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         opt = clifft.compile(
             circuit,
             hir_passes=clifft.default_hir_pass_manager(),
@@ -328,7 +329,7 @@ class TestHirPeepholeStatisticalEquivalence:
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_commutation_gauntlet_noisy_20q(self, seed: int) -> None:
         circuit = generate_commutation_gauntlet(20, 200, seed=seed)
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         opt = clifft.compile(
             circuit,
             hir_passes=clifft.default_hir_pass_manager(),
@@ -342,7 +343,7 @@ class TestHirPeepholeStatisticalEquivalence:
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_uncomputation_ladder_noisy_10q(self, seed: int) -> None:
         circuit = generate_uncomputation_ladder(10, 100, seed=seed, noise_prob=0.02)
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         opt = clifft.compile(
             circuit,
             hir_passes=clifft.default_hir_pass_manager(),

--- a/tests/python/test_optimization_invariants.py
+++ b/tests/python/test_optimization_invariants.py
@@ -12,6 +12,8 @@ and statistical distribution matching (marginal probabilities agree
 within binomial tolerance on noisy circuits).
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 from conftest import (
@@ -236,7 +238,7 @@ class TestHirPeepholeUncomputationLadder:
 # ---------------------------------------------------------------------------
 
 
-def _clifft_statevector(circuit_str: str, **compile_kwargs: object) -> np.ndarray:
+def _clifft_statevector(circuit_str: str, **compile_kwargs: Any) -> np.ndarray:
     """Compile and execute a noiseless circuit, return dense statevector."""
     prog = clifft.compile(circuit_str, **compile_kwargs)
     state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -332,7 +332,7 @@ class TestExplicitPipelineAPI:
     def test_compile_convenience_matches_explicit(self) -> None:
         """clifft.compile() produces same result as parse -> trace -> lower."""
         text = "H 0\nT 0\nM 0"
-        prog_conv = clifft.compile(text)
+        prog_conv = clifft.compile(text, hir_passes=None, bytecode_passes=None)
 
         circuit = clifft.parse(text)
         hir = clifft.trace(circuit)
@@ -356,7 +356,7 @@ class TestExplicitPipelineAPI:
 def _assert_absorption_preserves_state(stim_text: str, atol: float = 1e-6) -> clifft.Program:
     """Compile with and without optimization; assert statevector equivalence."""
     # Baseline: no HIR or bytecode passes
-    prog_base = clifft.compile(stim_text)
+    prog_base = clifft.compile(stim_text, hir_passes=None, bytecode_passes=None)
     state_base = clifft.State(
         peak_rank=prog_base.peak_rank, num_measurements=prog_base.num_measurements
     )

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -16,7 +16,7 @@ class TestCompile:
 
     def test_compile_simple(self) -> None:
         """Compile a simple circuit."""
-        prog = clifft.compile("H 0\nT 0\nM 0")
+        prog = clifft.compile("H 0\nT 0\nM 0", hir_passes=None, bytecode_passes=None)
         assert prog.peak_rank == 1
         assert prog.num_measurements == 1
         assert prog.num_instructions >= 1

--- a/tests/python/test_statevector_squeeze.py
+++ b/tests/python/test_statevector_squeeze.py
@@ -42,7 +42,7 @@ class TestSqueezeBasicPeakRankReduction:
         """
         circuit = "H 0\nT 0\nH 1\nT 1\nM 0\nM 1"
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert base.peak_rank == 2, f"Expected baseline peak_rank=2, got {base.peak_rank}"
@@ -53,7 +53,7 @@ class TestSqueezeBasicPeakRankReduction:
     def test_three_independent_qubits(self) -> None:
         """Three independent qubits: squeeze should reduce peak_rank."""
         circuit = "H 0\nT 0\nH 1\nT 1\nH 2\nT 2\nM 0\nM 1\nM 2"
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert base.peak_rank == 3
@@ -64,7 +64,7 @@ class TestSqueezeBasicPeakRankReduction:
         circuit = "H 0\nT 0\nH 1\nT 1\nM 0\nM 1"
         shots = 10_000
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         base_result = clifft.sample(base, shots, seed=42)
@@ -86,7 +86,7 @@ class TestSqueezeBasicPeakRankReduction:
         The squeezer respects anti-commutation barriers and preserves semantics.
         """
         circuit = "H 0\nCX 0 1\nT 0\nT 1\nM 0\nM 1"
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         # Verify sampling correctness regardless of peak_rank change
@@ -107,7 +107,7 @@ class TestSqueezeBasicPeakRankReduction:
         The order of quantum-significant ops must be preserved.
         """
         circuit_str = "H 0\nT 0\nX_ERROR(0.1) 0\nM 0"
-        base = clifft.compile(circuit_str)
+        base = clifft.compile(circuit_str, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit_str, hir_passes=_squeeze_only_pass_manager())
 
         # Both should have peak_rank=1 since the noise barrier blocks
@@ -129,7 +129,7 @@ class TestSqueezeClassicalDataflow:
         """
         circuit = "H 0\nT 0\nH 1\nT 1\nM 0\nDETECTOR rec[-1]\nM 1"
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert base.peak_rank == 2
@@ -192,7 +192,7 @@ class TestSqueezeClassicalDataflow:
         """M 1 should bubble past an OBSERVABLE that only references meas_idx 0."""
         circuit = "H 0\nT 0\nH 1\nT 1\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\nM 1"
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert base.peak_rank == 2
@@ -207,7 +207,7 @@ class TestSqueezeClassicalDataflow:
         """
         circuit = "H 0\nT 0\n" "H 1\nT 1\n" "H 2\nT 2\n" "M 0\n" "DETECTOR rec[-1]\n" "M 1\nM 2"
         shots = 10_000
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert squeezed.peak_rank < base.peak_rank
@@ -248,7 +248,7 @@ class TestSqueezeSweep2Expansion:
     def test_phase_rotation_bubbles_right(self) -> None:
         """PHASE_ROTATION (from R_Z) should bubble rightward in Sweep 2."""
         circuit = "H 0\nH 1\nR_Z(0.3) 0\nR_Z(0.5) 1\nM 0\nM 1"
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         # With squeeze, the measurements should compact before the rotations
@@ -261,21 +261,21 @@ class TestSqueezeEdgeCases:
     def test_single_qubit_no_op(self) -> None:
         """A single M 0 circuit has nothing to squeeze."""
         circuit = "H 0\nM 0"
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
         assert base.peak_rank == squeezed.peak_rank
 
     def test_empty_circuit(self) -> None:
         """Empty circuit should not crash the squeezer."""
         circuit = ""
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
         assert base.peak_rank == squeezed.peak_rank == 0
 
     def test_all_cliffords_no_squeeze_needed(self) -> None:
         """Pure Clifford circuit: squeezer runs but nothing expands."""
         circuit = "H 0\nCX 0 1\nS 0\nM 0\nM 1"
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
         assert squeezed.peak_rank == base.peak_rank
 
@@ -310,7 +310,7 @@ class TestSqueezeStatevectorOracle:
         from conftest import random_clifford_t_circuit
 
         circuit = random_clifford_t_circuit(5, 40, seed=seed)
-        base_sv = _clifft_statevector(circuit)
+        base_sv = _clifft_statevector(circuit, hir_passes=None, bytecode_passes=None)
         squeezed_sv = _clifft_statevector(circuit, hir_passes=_squeeze_only_pass_manager())
         assert_statevectors_equal(squeezed_sv, base_sv)
 
@@ -340,7 +340,7 @@ class TestSqueezeStatisticalEquivalence:
     @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
     def test_noisy_uncomputation_ladder_10q(self, seed: int) -> None:
         circuit = generate_uncomputation_ladder(10, 100, seed=seed, noise_prob=0.02)
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(
             circuit,
             hir_passes=_squeeze_only_pass_manager(),
@@ -385,7 +385,7 @@ class TestSqueezeProbabilisticReordering:
         """
         circuit = "H 0\nH 1\nT 0\nT 1\nX_ERROR(0.1) 0\nM 0\nM 1"
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         # M 1 should bubble past X_ERROR(0) and M 0 since masks commute
@@ -405,7 +405,7 @@ class TestSqueezeProbabilisticReordering:
         circuit = "H 0\nH 1\nT 0\nT 1\nZ_ERROR(0.05) 0\nM 0\nM 1"
         shots = self._SHOTS
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert squeezed.peak_rank < base.peak_rank
@@ -473,7 +473,7 @@ class TestSqueezeProbabilisticReordering:
         circuit = "\n".join(lines)
         shots = self._SHOTS
 
-        base = clifft.compile(circuit)
+        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         assert squeezed.peak_rank < base.peak_rank

--- a/tests/python/test_statevector_squeeze.py
+++ b/tests/python/test_statevector_squeeze.py
@@ -4,6 +4,8 @@ Validates that bidirectional bubble sort of HIR operations reduces peak_rank
 by compacting qubit lifetimes, while preserving circuit semantics.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 from conftest import assert_statevectors_equal, cross_binomial_tolerance
@@ -19,7 +21,7 @@ def _squeeze_only_pass_manager() -> clifft.HirPassManager:
     return pm
 
 
-def _clifft_statevector(circuit_str: str, **compile_kwargs: object) -> np.ndarray:
+def _clifft_statevector(circuit_str: str, **compile_kwargs: Any) -> np.ndarray:
     """Compile and execute a noiseless circuit, return dense statevector."""
     prog = clifft.compile(circuit_str, **compile_kwargs)
     state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)

--- a/tests/python/test_structural_oracles.py
+++ b/tests/python/test_structural_oracles.py
@@ -194,13 +194,13 @@ class TestBreathingMemoryLifecycle:
     def test_peak_rank_bounded(self, n_rounds: int) -> None:
         """Peak rank stays at exactly 2 regardless of round count."""
         circuit = _breathing_circuit(n_rounds)
-        prog = clifft.compile(circuit)
+        prog = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
         assert prog.peak_rank == 2, f"n_rounds={n_rounds}: peak_rank={prog.peak_rank}, expected 2"
 
     def test_breathing_500_rounds_completes(self) -> None:
         """500-round breathing circuit runs without underflow or crash."""
         circuit = _breathing_circuit(500)
-        prog = clifft.compile(circuit)
+        prog = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
 
         assert prog.peak_rank == 2
         # Memory: 2^2 * 16 bytes = 64 bytes (trivial)
@@ -214,7 +214,7 @@ class TestBreathingMemoryLifecycle:
     def test_breathing_1000_rounds_completes(self) -> None:
         """1000-round breathing circuit -- extreme gamma stress test."""
         circuit = _breathing_circuit(1000)
-        prog = clifft.compile(circuit)
+        prog = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
 
         assert prog.peak_rank == 2
 


### PR DESCRIPTION
## Summary

- `clifft.compile()` now runs the default HIR and bytecode pass managers unless the caller opts out.
- Pass `hir_passes=None` / `bytecode_passes=None` to skip a stage; pass an explicit `HirPassManager` / `BytecodePassManager` to use a custom pipeline.
- Implemented as a Python wrapper around the C++ binding using a sentinel default — the C++ entry point is unchanged.
- Tests that used bare `clifft.compile(text)` as an unoptimized baseline are updated to pass `hir_passes=None, bytecode_passes=None` explicitly.

The previous default ran zero passes, which was an artifact of how we added optimizations later. The docs already nudged users toward calling `default_hir_pass_manager()` / `default_bytecode_pass_manager()` manually. This makes the natural call optimized.

## Test plan

- [x] `uv run pytest tests/python/` — 595 passed
- [x] `uv run mkdocs build --strict`
- [x] `uv run pytest --codeblocks docs/guide/compiling.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)