### PR TITLE
feat(playground): highlight target panes during guided tour

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "allotment": "^1.20.5",
+        "driver.js": "^1.4.0",
         "lucide-react": "^0.577.0",
         "lz-string": "^1.5.0",
         "monaco-editor": "^0.55.1",
@@ -2357,6 +2358,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",

--- a/playground/package.json
+++ b/playground/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "allotment": "^1.20.5",
+    "driver.js": "^1.4.0",
     "lucide-react": "^0.577.0",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.55.1",

--- a/playground/src/App.css
+++ b/playground/src/App.css
@@ -532,102 +532,23 @@ html, body, #root {
 }
 
 /* --- Guided Tour overlay --- */
-.tour-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  outline: none;
-}
-
-.tour-backdrop {
-  position: absolute;
-  inset: 0;
-  background: var(--backdrop-bg);
-}
-
-.tour-card {
-  position: relative;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 24px;
-  max-width: 520px;
-  width: 90%;
-  box-shadow: 0 8px 32px var(--shadow-color);
-  animation: tour-in 0.2s ease-out;
-}
-
-@keyframes tour-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.tour-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  transition: color 0.15s;
-}
-
-.tour-close:hover {
-  color: var(--text);
-}
-
-.tour-step-indicator {
-  font-size: 10px;
-  color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  margin-bottom: 8px;
-}
-
-.tour-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--accent);
-  margin-bottom: 12px;
-}
-
-.tour-content {
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--text);
-  margin-bottom: 20px;
-}
-
-.tour-content p {
-  margin-bottom: 8px;
-}
-
-.tour-content p:last-child,
-.tour-content ul:last-child {
-  margin-bottom: 0;
-}
+/* --- driver.js tour theme overrides --- */
 
 .tour-code {
   font-family: var(--font-mono, "Roboto Mono", monospace);
   font-size: 0.9em;
   padding: 1px 5px;
   border-radius: 3px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.06);
   color: var(--accent);
 }
 
-[data-theme="light"] .tour-code {
-  background: rgba(0, 0, 0, 0.06);
+[data-theme="dark"] .tour-code {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .tour-list {
-  margin: 0 0 8px 0;
+  margin: 4px 0 8px 0;
   padding-left: 18px;
   list-style: disc;
 }
@@ -636,74 +557,73 @@ html, body, #root {
   margin-bottom: 3px;
 }
 
-.tour-list li:last-child {
-  margin-bottom: 0;
-}
-
-.tour-nav {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.tour-nav-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 12px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
+.driver-popover {
+  background: var(--bg-surface);
   color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px var(--shadow-color);
+}
+
+.driver-popover-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.driver-popover-description {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.driver-popover-progress-text {
+  color: var(--text-dim);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.driver-popover-close-btn {
+  color: var(--text-dim);
+}
+
+.driver-popover-close-btn:hover {
+  color: var(--text);
+}
+
+.driver-popover-prev-btn,
+.driver-popover-next-btn {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  text-shadow: none;
   font-size: 12px;
-  cursor: pointer;
-  transition: all 0.15s;
-  min-width: 70px;
-  justify-content: center;
 }
 
-.tour-nav-btn:hover:not(:disabled) {
+.driver-popover-prev-btn:hover,
+.driver-popover-next-btn:hover {
+  background: var(--bg-hover);
   border-color: var(--accent);
+  color: var(--text);
 }
 
-.tour-nav-btn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-}
-
-.tour-nav-btn-primary {
+.driver-popover-next-btn {
   border-color: var(--accent);
   color: var(--accent);
 }
 
-.tour-nav-btn-primary:hover:not(:disabled) {
-  background: var(--tour-glow);
+.driver-popover-arrow-side-top.driver-popover-arrow {
+  border-top-color: var(--bg-surface);
 }
-
-.tour-dots {
-  display: flex;
-  gap: 6px;
-  align-items: center;
+.driver-popover-arrow-side-bottom.driver-popover-arrow {
+  border-bottom-color: var(--bg-surface);
 }
-
-.tour-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--border);
-  cursor: pointer;
-  transition: background 0.15s;
-  border: none;
-  padding: 0;
+.driver-popover-arrow-side-left.driver-popover-arrow {
+  border-left-color: var(--bg-surface);
 }
-
-.tour-dot:hover {
-  background: var(--text-dim);
-}
-
-.tour-dot-active {
-  background: var(--accent);
+.driver-popover-arrow-side-right.driver-popover-arrow {
+  border-right-color: var(--bg-surface);
 }
 
 /* --- Monaco decoration for source-map highlighting --- */

--- a/playground/src/App.css
+++ b/playground/src/App.css
@@ -531,99 +531,84 @@ html, body, #root {
   color: var(--text-dim);
 }
 
-/* --- Guided Tour overlay --- */
-/* --- driver.js tour theme overrides --- */
-
-.tour-code {
-  font-family: var(--font-mono, "Roboto Mono", monospace);
-  font-size: 0.9em;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: rgba(0, 0, 0, 0.06);
-  color: var(--accent);
-}
-
-[data-theme="dark"] .tour-code {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.tour-list {
-  margin: 4px 0 8px 0;
-  padding-left: 18px;
-  list-style: disc;
-}
-
-.tour-list li {
-  margin-bottom: 3px;
-}
-
-.driver-popover {
-  background: var(--bg-surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 32px var(--shadow-color);
-}
+/* --- driver.js tour theme overrides ---
+   Popover stays light in both site themes — driver.js's white background
+   wins over CSS variables anyway, so the contents are pinned to fixed
+   colors that read well on white. */
 
 .driver-popover-title {
   font-size: 16px;
   font-weight: 600;
-  color: var(--accent);
+  color: #3c64b4;
 }
 
 .driver-popover-description {
   font-size: 13px;
   line-height: 1.6;
-  color: var(--text);
+  color: #1e1e1e;
+}
+
+.driver-popover-description p {
+  margin: 0 0 8px 0;
+}
+
+.driver-popover-description p:last-child {
+  margin-bottom: 0;
+}
+
+.driver-popover-description ul {
+  margin: 4px 0 8px 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+
+.driver-popover-description li {
+  margin-bottom: 3px;
+}
+
+.driver-popover-description code {
+  font-family: var(--font-mono, "Roboto Mono", monospace);
+  font-size: 0.9em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(60, 100, 180, 0.12);
+  color: #3c64b4;
 }
 
 .driver-popover-progress-text {
-  color: var(--text-dim);
+  color: #666;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 1px;
 }
 
 .driver-popover-close-btn {
-  color: var(--text-dim);
+  color: #666;
 }
 
 .driver-popover-close-btn:hover {
-  color: var(--text);
+  color: #1e1e1e;
 }
 
 .driver-popover-prev-btn,
 .driver-popover-next-btn {
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
+  background: #ffffff;
+  color: #1e1e1e;
+  border: 1px solid #d0d0d0;
   text-shadow: none;
   font-size: 12px;
 }
 
 .driver-popover-prev-btn:hover,
 .driver-popover-next-btn:hover {
-  background: var(--bg-hover);
-  border-color: var(--accent);
-  color: var(--text);
+  background: #f3f3f3;
+  border-color: #3c64b4;
+  color: #1e1e1e;
 }
 
 .driver-popover-next-btn {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.driver-popover-arrow-side-top.driver-popover-arrow {
-  border-top-color: var(--bg-surface);
-}
-.driver-popover-arrow-side-bottom.driver-popover-arrow {
-  border-bottom-color: var(--bg-surface);
-}
-.driver-popover-arrow-side-left.driver-popover-arrow {
-  border-left-color: var(--bg-surface);
-}
-.driver-popover-arrow-side-right.driver-popover-arrow {
-  border-right-color: var(--bg-surface);
+  border-color: #3c64b4;
+  color: #3c64b4;
 }
 
 /* --- Monaco decoration for source-map highlighting --- */

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -500,7 +500,7 @@ export default function App() {
           <Allotment.Pane>
             <Allotment defaultSizes={[34, 33, 33]}>
               <Allotment.Pane>
-                <div className="editor-pane">
+                <div className="editor-pane" data-tour="source">
                   <div className="editor-label">Source (.stim)</div>
                   <Editor
                     defaultLanguage="stim"
@@ -521,7 +521,7 @@ export default function App() {
                 </div>
               </Allotment.Pane>
               <Allotment.Pane>
-                <div className="editor-pane">
+                <div className="editor-pane" data-tour="hir">
                   <div className="editor-label">
                     HIR (Heisenberg IR)
                     {diffView && <span className="editor-label-badge">DIFF</span>}
@@ -564,7 +564,7 @@ export default function App() {
                 </div>
               </Allotment.Pane>
               <Allotment.Pane>
-                <div className="editor-pane">
+                <div className="editor-pane" data-tour="bytecode">
                   <div className="editor-label">
                     VM Bytecode
                     {diffView && <span className="editor-label-badge">DIFF</span>}
@@ -614,7 +614,7 @@ export default function App() {
           <Allotment.Pane>
             <Allotment defaultSizes={[50, 50]}>
               <Allotment.Pane>
-                <div className="chart-pane">
+                <div className="chart-pane" data-tour="active-dim">
                   <div className="chart-label">Active Dimensions (k) Timeline</div>
                   <div className="chart-container">
                     <KHistoryChart
@@ -631,7 +631,7 @@ export default function App() {
                 </div>
               </Allotment.Pane>
               <Allotment.Pane>
-                <div className="chart-pane">
+                <div className="chart-pane" data-tour="histogram">
                   <div className="chart-label sim-tabs">
                     <button
                       className={`sim-tab${simTab === "measurements" ? " sim-tab-active" : ""}`}

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -4,132 +4,118 @@ import "driver.js/dist/driver.css";
 
 interface TourStep {
   title: string;
-  content: string;
+  html: string;
   target?: string;
 }
 
 const STEPS: TourStep[] = [
   {
     title: "Welcome to the Clifft Playground",
-    content:
-      "Write a quantum circuit in Stim format and see how Clifft compiles it. " +
-      "The panels show the original circuit, the Heisenberg IR, the VM bytecode, " +
-      "and a small in-browser simulation.",
+    html: `
+      <p>Write a quantum circuit in Stim format and see how Clifft compiles
+      it. The panels show the original circuit, the Heisenberg IR, the VM
+      bytecode, and a small in-browser simulation.</p>
+    `,
   },
   {
     title: "Source Editor (left)",
-    content:
-      "Write your circuit here using Stim syntax: gate names like `H`, `CNOT`, " +
-      "`T`, `S`, and `M`, followed by qubit indices.\n\n" +
-      "The compiler updates automatically as you type. Try deleting a line or " +
-      "adding a gate and watch the other panels change.",
     target: '[data-tour="source"]',
+    html: `
+      <p>Write your circuit here using Stim syntax: gate names like
+      <code>H</code>, <code>CNOT</code>, <code>T</code>, <code>S</code>, and
+      <code>M</code>, followed by qubit indices.</p>
+      <p>The compiler updates automatically as you type. Try deleting a line
+      or adding a gate and watch the other panels change.</p>
+    `,
   },
   {
     title: "Heisenberg IR (middle)",
-    content:
-      "The front-end absorbs Clifford gates such as `H`, `CNOT`, `S`, `CZ`, and " +
-      "`SWAP` into a Clifford frame. Those gates disappear from the IR.\n\n" +
-      "What remains are the operations that need runtime work: non-Clifford gates, " +
-      "measurements, detectors, observables, and noise. For example, a `T` gate " +
-      "appears as a phase rotation on a Pauli product, and a measurement appears " +
-      "as the effective Pauli observable being measured.\n\n" +
-      "If the IR has fewer operations than the source circuit, the compiler is " +
-      "doing useful work.",
     target: '[data-tour="hir"]',
+    html: `
+      <p>The front-end absorbs Clifford gates such as <code>H</code>,
+      <code>CNOT</code>, <code>S</code>, <code>CZ</code>, and <code>SWAP</code>
+      into a Clifford frame. Those gates disappear from the IR.</p>
+      <p>What remains are the operations that need runtime work: non-Clifford
+      gates, measurements, detectors, observables, and noise. For example, a
+      <code>T</code> gate appears as a phase rotation on a Pauli product, and
+      a measurement appears as the effective Pauli observable being
+      measured.</p>
+      <p>If the IR has fewer operations than the source circuit, the compiler
+      is doing useful work.</p>
+    `,
   },
   {
     title: "VM Bytecode (right)",
-    content:
-      "The back-end lowers the IR into the instructions executed by Clifft's " +
-      "virtual machine.\n\n" +
-      "Some instructions only update the runtime Pauli frame, which is cheap. " +
-      "Others touch the active state vector, which is where most simulation cost " +
-      "comes from.\n\n" +
-      "Useful patterns to look for:\n" +
-      "- `OP_FRAME_*` updates the runtime Pauli frame\n" +
-      "- `OP_ARRAY_*` touches the active state vector\n" +
-      "- `OP_EXPAND` grows the active subspace\n" +
-      "- `OP_ARRAY_T` applies a T rotation\n" +
-      "- `OP_MEAS_*` performs a measurement",
     target: '[data-tour="bytecode"]',
+    html: `
+      <p>The back-end lowers the IR into the instructions executed by
+      Clifft's virtual machine.</p>
+      <p>Some instructions only update the runtime Pauli frame, which is
+      cheap. Others touch the active state vector, which is where most
+      simulation cost comes from.</p>
+      <p>Useful patterns to look for:</p>
+      <ul>
+        <li><code>OP_FRAME_*</code> updates the runtime Pauli frame</li>
+        <li><code>OP_ARRAY_*</code> touches the active state vector</li>
+        <li><code>OP_EXPAND</code> grows the active subspace</li>
+        <li><code>OP_ARRAY_T</code> applies a T rotation</li>
+        <li><code>OP_MEAS_*</code> performs a measurement</li>
+      </ul>
+    `,
   },
   {
     title: "Source Map Highlighting",
-    content:
-      "Click any line in any editor to highlight the related lines in the other " +
-      "panels. Colored ticks in the scrollbars show where those related lines are.\n\n" +
-      "This lets you trace how a source instruction changes as it moves through " +
-      "the compiler.",
+    html: `
+      <p>Click any line in any editor to highlight the related lines in the
+      other panels. Colored ticks in the scrollbars show where those related
+      lines are.</p>
+      <p>This lets you trace how a source instruction changes as it moves
+      through the compiler.</p>
+    `,
   },
   {
     title: "Active Dimension Timeline",
-    content:
-      "This chart tracks the active dimension `k` across the bytecode. Clifft's " +
-      "active state vector has size `2^k`, so keeping `k` small is the key to " +
-      "fast simulation.\n\n" +
-      "`k` starts at 0 and grows when `OP_EXPAND` adds a qubit to the active state. " +
-      "Measurements can reduce `k` again.\n\n" +
-      "The red dashed line marks the browser memory limit. The yellow dashed line " +
-      "follows your cursor position in the bytecode editor.",
     target: '[data-tour="active-dim"]',
+    html: `
+      <p>This chart tracks the active dimension <code>k</code> across the
+      bytecode. Clifft's active state vector has size <code>2^k</code>, so
+      keeping <code>k</code> small is the key to fast simulation.</p>
+      <p><code>k</code> starts at 0 and grows when <code>OP_EXPAND</code>
+      adds a qubit to the active state. Measurements can reduce <code>k</code>
+      again.</p>
+      <p>The red dashed line marks the browser memory limit. The yellow
+      dashed line follows your cursor position in the bytecode editor.</p>
+    `,
   },
   {
     title: "Simulation",
-    content:
-      "Click `Simulate` to run a Monte Carlo simulation entirely in your browser " +
-      "using WebAssembly. Use the arrow next to `Simulate` to choose the number " +
-      "of shots.\n\n" +
-      "The histogram shows measurement outcome probabilities. Hover over a bar " +
-      "to see exact counts. Timing stats appear below the chart.",
     target: '[data-tour="histogram"]',
+    html: `
+      <p>Click <code>Simulate</code> to run a Monte Carlo simulation entirely
+      in your browser using WebAssembly. Use the arrow next to
+      <code>Simulate</code> to choose the number of shots.</p>
+      <p>The histogram shows measurement outcome probabilities. Hover over a
+      bar to see exact counts. Timing stats appear below the chart.</p>
+    `,
   },
   {
     title: "Sharing & Options",
-    content:
-      "Use `Share` to create a URL for the current circuit.\n\n" +
-      "For larger circuits, use `Load` to import a public `.stim` file by URL. " +
-      "The file must be readable by the browser, so raw GitHub URLs or public " +
-      "Gist raw URLs work well. Until you edit the loaded circuit, `Share` will " +
-      "create a compact link that points back to that file.\n\n" +
-      "`Save` stores circuits in your browser, and `Recents` shows circuits you " +
-      "have saved.\n\n" +
-      "`Passes` lets you toggle HIR and bytecode optimization passes. `Diff` shows " +
-      "the unoptimized and optimized outputs side by side.",
     target: '[data-tour="actions"]',
+    html: `
+      <p>Use <code>Share</code> to create a URL for the current circuit.</p>
+      <p>For larger circuits, use <code>Load</code> to import a public
+      <code>.stim</code> file by URL. The file must be readable by the
+      browser, so raw GitHub URLs or public Gist raw URLs work well. Until
+      you edit the loaded circuit, <code>Share</code> will create a compact
+      link that points back to that file.</p>
+      <p><code>Save</code> stores circuits in your browser, and
+      <code>Recents</code> shows circuits you have saved.</p>
+      <p><code>Passes</code> lets you toggle HIR and bytecode optimization
+      passes. <code>Diff</code> shows the unoptimized and optimized outputs
+      side by side.</p>
+    `,
   },
 ];
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function inlineCode(text: string): string {
-  return escapeHtml(text).replace(
-    /`([^`]+)`/g,
-    '<code class="tour-code">$1</code>',
-  );
-}
-
-function contentToHtml(content: string): string {
-  const blocks = content.split("\n\n");
-  return blocks
-    .map((block) => {
-      const lines = block.split("\n");
-      const isList = lines.every((l) => l.startsWith("- "));
-      if (isList) {
-        const items = lines
-          .map((l) => `<li>${inlineCode(l.slice(2))}</li>`)
-          .join("");
-        return `<ul class="tour-list">${items}</ul>`;
-      }
-      return `<p>${inlineCode(block)}</p>`;
-    })
-    .join("");
-}
 
 interface Props {
   onClose: () => void;
@@ -152,7 +138,7 @@ export function GuidedTour({ onClose }: Props) {
         element: step.target,
         popover: {
           title: step.title,
-          description: contentToHtml(step.content),
+          description: step.html,
         },
       })),
     });

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -1,56 +1,11 @@
-import {
-  useState,
-  useCallback,
-  useRef,
-  useEffect,
-  type KeyboardEvent,
-  type ReactNode,
-} from "react";
-import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect } from "react";
+import { driver } from "driver.js";
+import "driver.js/dist/driver.css";
 
 interface TourStep {
   title: string;
   content: string;
-  target?: string; // CSS selector to highlight
-}
-
-/** Render inline `code` spans within a text string. */
-function renderInlineCode(text: string): ReactNode[] {
-  const parts = text.split(/(`[^`]+`)/);
-  return parts.map((part, i) => {
-    if (part.startsWith("`") && part.endsWith("`")) {
-      return (
-        <code key={i} className="tour-code">
-          {part.slice(1, -1)}
-        </code>
-      );
-    }
-    return part;
-  });
-}
-
-/**
- * Render tour content with basic markdown support:
- * - Paragraphs separated by blank lines
- * - Bullet lists (lines starting with "- ")
- * - Inline `code` spans
- */
-function renderTourContent(content: string): ReactNode[] {
-  const blocks = content.split("\n\n");
-  return blocks.map((block, bi) => {
-    const lines = block.split("\n");
-    const isList = lines.every((l) => l.startsWith("- "));
-    if (isList) {
-      return (
-        <ul key={bi} className="tour-list">
-          {lines.map((line, li) => (
-            <li key={li}>{renderInlineCode(line.slice(2))}</li>
-          ))}
-        </ul>
-      );
-    }
-    return <p key={bi}>{renderInlineCode(block)}</p>;
-  });
+  target?: string;
 }
 
 const STEPS: TourStep[] = [
@@ -68,7 +23,7 @@ const STEPS: TourStep[] = [
       "`T`, `S`, and `M`, followed by qubit indices.\n\n" +
       "The compiler updates automatically as you type. Try deleting a line or " +
       "adding a gate and watch the other panels change.",
-    target: ".editor-pane:nth-child(1)",
+    target: '[data-tour="source"]',
   },
   {
     title: "Heisenberg IR (middle)",
@@ -81,7 +36,7 @@ const STEPS: TourStep[] = [
       "as the effective Pauli observable being measured.\n\n" +
       "If the IR has fewer operations than the source circuit, the compiler is " +
       "doing useful work.",
-    target: ".editor-pane:nth-child(2)",
+    target: '[data-tour="hir"]',
   },
   {
     title: "VM Bytecode (right)",
@@ -97,7 +52,7 @@ const STEPS: TourStep[] = [
       "- `OP_EXPAND` grows the active subspace\n" +
       "- `OP_ARRAY_T` applies a T rotation\n" +
       "- `OP_MEAS_*` performs a measurement",
-    target: ".editor-pane:nth-child(3)",
+    target: '[data-tour="bytecode"]',
   },
   {
     title: "Source Map Highlighting",
@@ -117,7 +72,7 @@ const STEPS: TourStep[] = [
       "Measurements can reduce `k` again.\n\n" +
       "The red dashed line marks the browser memory limit. The yellow dashed line " +
       "follows your cursor position in the bytecode editor.",
-    target: ".chart-pane:nth-child(1)",
+    target: '[data-tour="active-dim"]',
   },
   {
     title: "Simulation",
@@ -127,7 +82,7 @@ const STEPS: TourStep[] = [
       "of shots.\n\n" +
       "The histogram shows measurement outcome probabilities. Hover over a bar " +
       "to see exact counts. Timing stats appear below the chart.",
-    target: ".chart-pane:nth-child(2)",
+    target: '[data-tour="histogram"]',
   },
   {
     title: "Sharing & Options",
@@ -141,84 +96,71 @@ const STEPS: TourStep[] = [
       "have saved.\n\n" +
       "`Passes` lets you toggle HIR and bytecode optimization passes. `Diff` shows " +
       "the unoptimized and optimized outputs side by side.",
+    target: '[data-tour="actions"]',
   },
 ];
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function inlineCode(text: string): string {
+  return escapeHtml(text).replace(
+    /`([^`]+)`/g,
+    '<code class="tour-code">$1</code>',
+  );
+}
+
+function contentToHtml(content: string): string {
+  const blocks = content.split("\n\n");
+  return blocks
+    .map((block) => {
+      const lines = block.split("\n");
+      const isList = lines.every((l) => l.startsWith("- "));
+      if (isList) {
+        const items = lines
+          .map((l) => `<li>${inlineCode(l.slice(2))}</li>`)
+          .join("");
+        return `<ul class="tour-list">${items}</ul>`;
+      }
+      return `<p>${inlineCode(block)}</p>`;
+    })
+    .join("");
+}
+
 interface Props {
   onClose: () => void;
 }
 
 export function GuidedTour({ onClose }: Props) {
-  const [step, setStep] = useState(0);
-  const current = STEPS[step];
-
-  const handlePrev = useCallback(() => setStep((s) => Math.max(0, s - 1)), []);
-  const handleNext = useCallback(() => {
-    if (step < STEPS.length - 1) {
-      setStep((s) => s + 1);
-    } else {
-      onClose();
-    }
-  }, [step, onClose]);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-      if (e.key === "ArrowRight" || e.key === "Enter") handleNext();
-      if (e.key === "ArrowLeft") handlePrev();
-    },
-    [onClose, handleNext, handlePrev],
-  );
-
-  const overlayRef = useRef<HTMLDivElement>(null);
-
-  // Auto-focus on mount so keyboard events work immediately
   useEffect(() => {
-    overlayRef.current?.focus();
-  }, []);
+    const driverObj = driver({
+      showProgress: true,
+      progressText: "Step {{current}} of {{total}}",
+      nextBtnText: "Next →",
+      prevBtnText: "← Back",
+      doneBtnText: "Finish",
+      animate: true,
+      smoothScroll: true,
+      stagePadding: 6,
+      stageRadius: 6,
+      onDestroyed: onClose,
+      steps: STEPS.map((step) => ({
+        element: step.target,
+        popover: {
+          title: step.title,
+          description: contentToHtml(step.content),
+        },
+      })),
+    });
+    driverObj.drive();
+    return () => {
+      driverObj.destroy();
+    };
+  }, [onClose]);
 
-  return (
-    <div
-      className="tour-overlay"
-      onKeyDown={handleKeyDown}
-      tabIndex={-1}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Guided tour"
-      ref={overlayRef}
-    >
-      <div className="tour-backdrop" onClick={onClose} />
-      <div className="tour-card">
-        <button className="tour-close" onClick={onClose} title="Close tour">
-          <X size={16} />
-        </button>
-        <div className="tour-step-indicator">
-          {step + 1} / {STEPS.length}
-        </div>
-        <h3 className="tour-title">{current.title}</h3>
-        <div className="tour-content">{renderTourContent(current.content)}</div>
-        <div className="tour-nav">
-          <button
-            className="tour-nav-btn"
-            onClick={handlePrev}
-            disabled={step === 0}
-          >
-            <ChevronLeft size={14} /> Back
-          </button>
-          <div className="tour-dots">
-            {STEPS.map((_, i) => (
-              <button
-                key={i}
-                className={`tour-dot ${i === step ? "tour-dot-active" : ""}`}
-                onClick={() => setStep(i)}
-                aria-label={`Go to step ${i + 1}`}
-              />
-            ))}
-          </div>
-          <button className="tour-nav-btn tour-nav-btn-primary" onClick={handleNext}>
-            {step === STEPS.length - 1 ? "Finish" : "Next"} <ChevronRight size={14} />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+  return null;
 }

--- a/playground/src/components/Toolbar.tsx
+++ b/playground/src/components/Toolbar.tsx
@@ -240,7 +240,7 @@ export function Toolbar({
           {wasmStatus === "error" && "Wasm failed to load"}
         </span>
       </div>
-      <div className="toolbar-right">
+      <div className="toolbar-right" data-tour="actions">
         {/* Configure Passes */}
         <div className="passes-group" ref={passesRef}>
           <button


### PR DESCRIPTION
## Summary

The guided tour was a centered modal that didn't visually connect each step to the part of the UI it was describing. This PR migrates the tour to [driver.js](https://driverjs.com/) so each step dims the page and cuts out the relevant region.

- 8-step tour now anchors on stable `data-tour` attributes: source pane, HIR pane, bytecode pane, active-dimension chart, histogram, and the right-side toolbar (Passes, Diff, Simulate, Save, Load, Recents, Share).
- Step 1 (welcome) and step 5 (source map) stay centered since they describe the page as a whole.
- Custom `.tour-*` modal CSS is gone (~220 lines removed); replaced by a small block of `.driver-popover` theme overrides matching the playground brand color.
- Inline-code styling in popover bodies (`H`, `CNOT`, `OP_EXPAND`, etc.) is preserved.
- Bundle grows ~20 KB (driver.js + its CSS).

The previous custom box-shadow approach silently broke because Allotment's `overflow: hidden` clipped the glow on every editor pane. driver.js sidesteps that by rendering a full-page SVG overlay cutout instead.

## Test plan

- [x] `npm run build` and `npm run lint` clean
- [x] Playwright walk-through: each step renders the popover with the correct title, the highlighted element matches the step target, and the final step covers the right-side toolbar buttons
- [ ] Click through all 8 steps in light mode
- [ ] Click through all 8 steps in dark mode
- [ ] Try on mobile / narrow viewport