### PR TITLE
docs: add Quantum Science Center funding acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ This work was supported by the U.S. Department of Energy, Office of Science,
 Office of Advanced Scientific Computing Research, Accelerated Research in
 Quantum Computing under Award Number DE-SC0025336.
 
+This material is also based upon work supported by the U.S. Department of
+Energy, Office of Science, National Quantum Information Science Research
+Centers, Quantum Science Center.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

Adds the standard QSC funding acknowledgement to the README, immediately after the existing DOE/ARQC award reference. Text is verbatim:

> This material is also based upon work supported by the U.S. Department of Energy, Office of Science, National Quantum Information Science Research Centers, Quantum Science Center.

## Test plan

- [x] Verified the README is the only place a funding acknowledgement currently lives — no docs site or playground footer copy to keep in sync