### PR TITLE
chore(util): drop redundant comments in util headers

### DIFF
--- a/src/clifft/util/bitmask.h
+++ b/src/clifft/util/bitmask.h
@@ -89,7 +89,6 @@ struct BitMask {
 
     // -- Queries --
 
-    /// True if all bits are zero.
     [[nodiscard]] constexpr bool is_zero() const {
         for (size_t i = 0; i < kWords; ++i) {
             if (w[i] != 0)
@@ -98,7 +97,6 @@ struct BitMask {
         return true;
     }
 
-    /// Population count across all words.
     [[nodiscard]] constexpr int popcount() const {
         int c = 0;
         for (size_t i = 0; i < kWords; ++i)
@@ -106,25 +104,23 @@ struct BitMask {
         return c;
     }
 
-    /// Index of the lowest set bit. Returns N (sentinel) if is_zero().
+    /// Returns N as a sentinel when no bit is set.
     [[nodiscard]] constexpr uint32_t lowest_bit() const {
         for (size_t i = 0; i < kWords; ++i) {
             if (w[i] != 0) {
                 return static_cast<uint32_t>(i * 64 + std::countr_zero(w[i]));
             }
         }
-        return static_cast<uint32_t>(N);  // sentinel: no bit set
+        return static_cast<uint32_t>(N);
     }
 
     // -- Bit-level helpers --
 
-    /// Get bit at position idx (0-indexed). Requires idx < N.
     [[nodiscard]] constexpr bool bit_get(uint32_t idx) const {
         assert(idx < N && "bit_get: index out of range");
         return (w[idx / 64] >> (idx % 64)) & 1ULL;
     }
 
-    /// Set bit at position idx to val. Requires idx < N.
     constexpr void bit_set(uint32_t idx, bool val) {
         assert(idx < N && "bit_set: index out of range");
         uint64_t mask = 1ULL << (idx % 64);
@@ -134,13 +130,11 @@ struct BitMask {
             w[idx / 64] &= ~mask;
     }
 
-    /// Toggle (XOR) bit at position idx. Requires idx < N.
     constexpr void bit_xor(uint32_t idx) {
         assert(idx < N && "bit_xor: index out of range");
         w[idx / 64] ^= (1ULL << (idx % 64));
     }
 
-    /// Swap bits at positions i and j. Requires i < N and j < N.
     constexpr void bit_swap(uint32_t i, uint32_t j) {
         assert(i < N && "bit_swap: index i out of range");
         assert(j < N && "bit_swap: index j out of range");
@@ -152,7 +146,7 @@ struct BitMask {
         bit_set(j, a);
     }
 
-    /// Clear the lowest set bit (like x &= x - 1 but multi-word safe).
+    /// Multi-word analog of x &= x - 1.
     constexpr void clear_lowest_bit() {
         for (size_t i = 0; i < kWords; ++i) {
             if (w[i] != 0) {

--- a/src/clifft/util/config.h
+++ b/src/clifft/util/config.h
@@ -1,13 +1,11 @@
 #pragma once
 
-// Clifft compile-time configuration
-// This header defines constants and limits used throughout the codebase.
+// Clifft compile-time configuration.
 
 #include <cstdint>
 
 namespace clifft {
 
-// Maximum number of qubits supported at compile-time.
 // Set via -DCLIFFT_MAX_QUBITS=N at CMake configure time (default 128).
 // Determines the width of BitMask<N> used in HIR Pauli masks and the
 // SVM Pauli frame. The VM Instruction struct stays 32 bytes regardless.

--- a/src/clifft/util/introspection.h
+++ b/src/clifft/util/introspection.h
@@ -14,13 +14,10 @@ namespace clifft {
 // Example: "+X0*Z3" for destab bit 0 and stab bit 3.
 std::string format_pauli_mask(const HeisenbergOp& op);
 
-// Convert an OpType enum to its string name.
 std::string op_type_to_str(OpType type);
 
-// Format a complete HIR operation as a human-readable string.
 std::string format_hir_op(const HeisenbergOp& op);
 
-// Convert an Opcode enum to its string name.
 std::string opcode_to_str(Opcode op);
 
 // Opcode classification helpers.
@@ -45,7 +42,6 @@ std::string opcode_to_str(Opcode op);
            op == Opcode::OP_SWAP_MEAS_INTERFERE;
 }
 
-// Format a complete VM instruction as a human-readable string.
 std::string format_instruction(const Instruction& inst);
 
 }  // namespace clifft


### PR DESCRIPTION
## Summary

First subfolder in a methodical comment-cleanup sweep across `src/clifft/`. Goal: remove silly/uninformative comments while keeping anything load-bearing (non-obvious *why*, design constraints, paper-relevant terminology).

What changed in `util/`:

- **bitmask.h** — dropped \`///\` comments that just restated the function name (\`is_zero\`, \`popcount\`, \`bit_get/set/xor/swap\`). Kept the file-level header (load-bearing why: compile-time-constant extents enabling auto-vectorization without intrinsics), the \`lowest_bit\` sentinel note (trimmed to \"Returns N as a sentinel when no bit is set\"), the \`clear_lowest_bit\` \`x &= x - 1\` analogy, and the implicit-ctor justification for the \`NOLINT\`.
- **config.h** — dropped the redundant second line of the file header and the restatement \"Maximum number of qubits supported at compile-time\". Kept the build-flag instructions, the BitMask/Pauli-frame consequence, and the \"Instruction struct stays 32 bytes regardless\" why.
- **introspection.h** — dropped pure-restatement comments above \`op_type_to_str\`, \`format_hir_op\`, \`opcode_to_str\`, and \`format_instruction\`. Kept the file header (\"used by both Python and Wasm bindings\" — explains why it lives in util) and the \`format_pauli_mask\` example.

No content changes to \`introspection.cc\`, \`constants.h\`, \`version.h.in\`, or \`tests/test_bitmask.cc\` — those were already in good shape (or the comments were genuinely useful annotations of test-case intent).

Net: 3 files, +4/-16.

## Test plan

- [x] \`clifft_tests \"BitMask:*\"\` — all 18 cases / 57 assertions pass
- [x] Library + tests compile cleanly