### PR TITLE
fix(tests): tolerance-based EXP_VAL check for OpenMP determinism test

### DIFF
--- a/tests/test_openmp.cc
+++ b/tests/test_openmp.cc
@@ -15,6 +15,7 @@
 #include "clifft/svm/svm_internal.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <string>
 
 #ifdef _OPENMP
@@ -138,7 +139,10 @@ TEST_CASE("OpenMP: EXP_VAL determinism across thread counts at high rank", "[ope
     auto r2 = sample(mod, 1, uint64_t{77});
 
     REQUIRE(r1.exp_vals.size() == r2.exp_vals.size());
+    // Tolerance, not bit-equality: OpenMP reductions can sum partial results
+    // in different orders across thread counts, so the last bits of a float
+    // expectation value can differ even when the algorithm is deterministic.
     for (size_t i = 0; i < r1.exp_vals.size(); ++i) {
-        CHECK(r1.exp_vals[i] == r2.exp_vals[i]);
+        CHECK_THAT(r1.exp_vals[i], Catch::Matchers::WithinAbs(r2.exp_vals[i], 1e-12));
     }
 }


### PR DESCRIPTION
## Summary

\`tests/test_openmp.cc:142\` was bit-comparing floats from a parallel reduction across two different thread counts. That's stricter than OpenMP can promise: when partial sums add in a different order, the last bits of the result can differ even when the algorithm is fully deterministic. CI on PR #19 hit it twice in a row, and locally I reproduced 4/20 fails on pristine main.

The test's stated purpose (file header) is twofold:

1. Exercise the parallel-reduce path at high rank so Thread Sanitizer can catch data races.
2. Confirm the same seed produces the same answer regardless of thread count.

Both are preserved here. The fix swaps \`==\` for \`Catch::Matchers::WithinAbs(..., 1e-12)\` on the \`exp_vals\` comparison only — well below any meaningful precision but well above reduction-order noise. The integer measurement-determinism tests in the same file are unchanged and stay bit-exact.

## Test plan

- [x] 30/30 runs pass locally with the new tolerance (vs. 16/20 on main without)
- [x] Full \`[openmp]\` suite (5 cases / 301 assertions) passes