### PR TITLE
docs: trim restatement comments and stale notes in circuit/

### DIFF
--- a/src/clifft/circuit/circuit.h
+++ b/src/clifft/circuit/circuit.h
@@ -43,16 +43,14 @@ struct AstNode {
 
 // A parsed circuit ready for compilation.
 struct Circuit {
-    // Flat list of operations in execution order.
     std::vector<AstNode> nodes;
 
     uint32_t num_qubits = 0;
 
-    // Number of visible measurements (M, MX, MY, MPP, MR, MRX).
-    // R and RX are resets without visible measurements.
+    // Number of visible measurements (entries in the measurement record).
+    // Resets without measurement (R, RX, RY) don't increment this.
     uint32_t num_measurements = 0;
 
-    // Number of DETECTOR declarations.
     uint32_t num_detectors = 0;
 
     // Number of observables (max observable index + 1).

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -62,19 +62,17 @@ std::string_view trim(std::string_view s) {
     return s;
 }
 
-// Parse an integer from string_view.
 bool parse_int(std::string_view s, int& out) {
     auto result = std::from_chars(s.data(), s.data() + s.size(), out);
     return result.ec == std::errc{} && result.ptr == s.data() + s.size();
 }
 
-// Parse an unsigned integer from string_view.
 bool parse_uint(std::string_view s, uint32_t& out) {
     auto result = std::from_chars(s.data(), s.data() + s.size(), out);
     return result.ec == std::errc{} && result.ptr == s.data() + s.size();
 }
 
-// Extract the next whitespace-delimited token from a string_view.
+// Returns the next whitespace-delimited token and advances `s` past it.
 std::string_view next_token(std::string_view& s) {
     auto start = s.find_first_not_of(" \t\r\n");
     if (start == std::string_view::npos) {
@@ -92,12 +90,10 @@ std::string_view next_token(std::string_view& s) {
     return tok;
 }
 
-// Check if character is valid for gate names.
 bool is_gate_char(char c) {
     return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
 }
 
-// Parser state.
 class Parser {
   public:
     explicit Parser(std::string_view text, size_t max_ops) : text_(text), max_ops_(max_ops) {}
@@ -123,8 +119,7 @@ class Parser {
         return circuit;
     }
 
-    // Parse a block of text line-by-line into the circuit.
-    // `remaining` and `line_num` are advanced as text is consumed.
+    // Advances `remaining` and `line_num` as text is consumed.
     void parse_block(std::string_view& remaining, uint32_t& line_num, Circuit& circuit,
                      uint32_t depth) {
         while (!remaining.empty()) {
@@ -159,7 +154,6 @@ class Parser {
 
     void parse_line(std::string_view line, uint32_t& line_num, Circuit& circuit,
                     std::string_view& remaining, uint32_t depth) {
-        // Strip comments.
         auto comment_pos = line.find('#');
         if (comment_pos != std::string_view::npos) {
             line = line.substr(0, comment_pos);
@@ -479,7 +473,6 @@ class Parser {
             }
         }
 
-        // Expand based on arity.
         // Identity no-ops: validate syntax and update num_qubits, but never emit AST nodes.
         if (is_identity_noop(gate)) {
             if (arity == GateArity::PAIR && targets.size() % 2 != 0) {

--- a/src/clifft/circuit/parser.h
+++ b/src/clifft/circuit/parser.h
@@ -10,8 +10,6 @@
 // - Annotations: TICK
 //
 // Parser transformations:
-// - R q  -> M q; CX rec[-1] q  (reset decomposition)
-// - RX q -> MX q; CZ rec[-1] q (reset decomposition)
 // - MPP X0*Z1 X2 -> two separate AstNodes (unrolling)
 //
 // REPEAT handling:

--- a/src/clifft/circuit/target.h
+++ b/src/clifft/circuit/target.h
@@ -39,15 +39,12 @@ struct Target {
     // Factory functions (the canonical way to create Targets)
     // -------------------------------------------------------------------------
 
-    /// Create a plain qubit target.
     static constexpr Target qubit(uint32_t q) { return Target{q & kValueMask}; }
 
-    /// Create a measurement record reference target.
-    /// The offset is the absolute index into the measurement record.
+    /// `offset` is the absolute index into the measurement record.
     static constexpr Target rec(uint32_t offset) { return Target{(offset & kValueMask) | kRecBit}; }
 
-    /// Create a Pauli-tagged qubit target for MPP.
-    /// pauli_flag should be one of kPauliX, kPauliY, kPauliZ.
+    /// `pauli_flag` must be one of kPauliX, kPauliY, kPauliZ.
     static constexpr Target pauli(uint32_t q, uint32_t pauli_flag) {
         return Target{(q & kValueMask) | pauli_flag};
     }
@@ -56,22 +53,19 @@ struct Target {
     // Accessors
     // -------------------------------------------------------------------------
 
-    /// Check if this is a measurement record reference.
     constexpr bool is_rec() const { return (bits & kRecBit) != 0; }
 
-    /// Check if this target has the inversion flag set.
     constexpr bool is_inverted() const { return (bits & kInvertBit) != 0; }
 
-    /// Get the qubit index or record offset (the 28-bit value).
+    /// Returns the 28-bit value (qubit index or record offset).
     constexpr uint32_t value() const { return bits & kValueMask; }
 
-    /// Get the Pauli tag bits (kPauliNone, kPauliX, kPauliY, or kPauliZ).
+    /// Returns one of kPauliNone, kPauliX, kPauliY, kPauliZ.
     constexpr uint32_t pauli() const { return bits & kPauliMask; }
 
-    /// Check if this target has a Pauli tag (for MPP targets).
     constexpr bool has_pauli() const { return pauli() != kPauliNone; }
 
-    /// Get Pauli character for display ('I', 'X', 'Y', 'Z').
+    /// Pauli letter for display ('I' when untagged, else 'X' / 'Y' / 'Z').
     constexpr char pauli_char() const {
         switch (pauli()) {
             case kPauliX:
@@ -89,7 +83,6 @@ struct Target {
     // Modifiers (return new Target)
     // -------------------------------------------------------------------------
 
-    /// Return a new Target with the inversion flag set.
     constexpr Target inverted() const { return Target{bits | kInvertBit}; }
 
     // -------------------------------------------------------------------------

--- a/tests/test_stim_contract.cc
+++ b/tests/test_stim_contract.cc
@@ -152,12 +152,9 @@ TEST_CASE("Stim contract: Tableau composition", "[stim][contract]") {
     auto composed = t1.then(t2);
     REQUIRE(composed.num_qubits == 2);
 
-    // t1.then(t2) represents U = S @ H (in matrix notation)
-    // The tableau stores the forward transformation: U P U_dag
-    // So composed.zs[0] = (SH) Z (SH)_dag = H_dag S_dag Z S H = H_dag Z H = X... wait
-    // Actually for forward tableau: (SH) Z (SH)_dag
-    // Let me verify: H Z H_dag = X, then S X S_dag = Y
-    // So (SH) Z (SH)_dag = S (H Z H_dag) S_dag = S X S_dag = Y
+    // t1.then(t2) means apply t1 first, then t2, so U = S * H.
+    // The forward tableau stores U P U_dag, so composed.zs[0] is
+    //   (SH) Z (SH)_dag = S (H Z H_dag) S_dag = S X S_dag = Y.
     auto z0 = composed.zs[0];
     REQUIRE(z0.xs[0] == true);  // Y has X component
     REQUIRE(z0.zs[0] == true);  // Y has Z component

--- a/tests/test_stim_contract.cc
+++ b/tests/test_stim_contract.cc
@@ -139,8 +139,7 @@ TEST_CASE("Stim contract: mask extraction for HIR", "[stim][contract]") {
 }
 
 TEST_CASE("Stim contract: Tableau composition", "[stim][contract]") {
-    // For AG pivot computation, we need to compose tableaux:
-    // t1.then(t2) applies t1 first, then t2
+    // t1.then(t2) applies t1 first, then t2.
 
     stim::Tableau<64> t1(2);
     stim::Tableau<64> t2(2);
@@ -165,7 +164,7 @@ TEST_CASE("Stim contract: Tableau composition", "[stim][contract]") {
 }
 
 TEST_CASE("Stim contract: Tableau inverse", "[stim][contract]") {
-    // Verify inverse computation works for AG pivot diffs
+    // Verify Tableau::inverse() round-trips: fwd.then(inv) = identity.
 
     std::mt19937_64 rng(42);
     stim::TableauSimulator<64> sim(std::move(rng), 2);


### PR DESCRIPTION
## Summary

Second component in the methodical comment-cleanup pass (after #19 for `util/`). Same philosophy: drop pure restatements of well-named identifiers, keep WHYs.

- **Stale fix in `parser.h`**: header listed `R q -> M q; CX rec[-1] q` (and the RX equivalent) under "Parser transformations" — but R/RX are kept as first-class gates (matches `circuit.h:11`, `parser.cc`, and `test_parser.cc:281` "R is kept as a first-class gate, not decomposed"). Dropped.
- **Clarified in `circuit.h`**: the `num_measurements` field said "M, MX, MY, MPP, MR, MRX" but is also incremented for MRY and MPAD. Replaced with the principle: visible measurements are entries in the measurement record; resets without measurement (R, RX, RY) don't increment.
- **Dropped "AG pivot" framing** in `test_stim_contract.cc` — Aaronson-Gottesman is no longer the attribution used in the paper. (Other AG references still live in `frontend/`, `backend/`, `tests/test_hir.cc` — those will be addressed in their own subfolder passes.)
- **`target.h` / `parser.cc`**: drop `///` comments that just paraphrase the function name (e.g. `is_rec()`, `is_inverted()`, `inverted()`, `is_gate_char()`, `// Strip comments.`). Trim verbose ones (`value()`, `pauli()`, `pauli_char()`).

`gate_data.h` and `test_parser.cc` left unchanged — their comments are pulling weight (Stim-name disambiguation; concrete test expectations).

Net: 5 files, +11/-30.

## Test plan

- [x] `cmake --build build-tests` succeeds
- [x] `./build-tests/tests/clifft_tests "[parser]","[gate_data]","[stim][contract]"` — 733 assertions / 149 cases pass
- [x] `./build-tests/tests/clifft_tests` (full C++ suite) — 113390 assertions / 650 cases pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)