### PR TITLE
chore: trim over-specific and stale comments in optimizer/

### DIFF
--- a/src/clifft/optimizer/hir_pass.h
+++ b/src/clifft/optimizer/hir_pass.h
@@ -5,10 +5,6 @@
 namespace clifft {
 
 /// Abstract base class for HIR optimization passes.
-///
-/// Each pass receives a mutable HirModule and may rewrite, reorder,
-/// or remove operations. Passes operate on the timeless Heisenberg IR
-/// using purely symplectic geometry -- no DAG or time assumptions.
 class HirPass {
   public:
     virtual void run(HirModule& hir) = 0;

--- a/src/clifft/optimizer/noise_block_pass.h
+++ b/src/clifft/optimizer/noise_block_pass.h
@@ -5,13 +5,8 @@
 namespace clifft {
 
 /// Coalesces contiguous OP_NOISE instructions with consecutive site indices
-/// into single OP_NOISE_BLOCK instructions.
-///
-/// The VM's exponential gap-sampling already skips silent noise sites in O(1)
-/// RNG time, but without this pass, the dispatch loop still individually
-/// fetches and decodes each OP_NOISE instruction. For the d=5 surface code
-/// circuit, this collapses 3471 OP_NOISE instructions into 24 OP_NOISE_BLOCK
-/// instructions, eliminating ~68% of all bytecode dispatch overhead.
+/// into single OP_NOISE_BLOCK instructions, reducing dispatch overhead in
+/// noise-heavy circuits.
 class NoiseBlockPass : public BytecodePass {
   public:
     void run(CompiledModule& module) override;

--- a/src/clifft/optimizer/pass_factory.h
+++ b/src/clifft/optimizer/pass_factory.h
@@ -22,7 +22,7 @@ HirPassManager default_hir_pass_manager();
 /// Build a BytecodePassManager with all default-enabled bytecode passes.
 BytecodePassManager default_bytecode_pass_manager();
 
-/// Serialize the pass registry to a JSON string (no nlohmann dependency).
+/// Serialize the pass registry to a JSON string.
 /// Format: [{"name":"...","kind":"hir"|"bytecode","default":true|false}, ...]
 std::string pass_registry_json();
 

--- a/tests/test_single_axis_fusion.cc
+++ b/tests/test_single_axis_fusion.cc
@@ -223,8 +223,7 @@ TEST_CASE("U2 fusion: frame-only ops contribute to run but need array partner") 
     REQUIRE(mod.bytecode.size() == 1);
     CHECK(mod.bytecode[0].opcode == Opcode::OP_FRAME_S);
 
-    // FRAME_S(0) + ARRAY_H(0) -> 1 array op + 1 frame op = fuse (array_count >= 2? No, only 1).
-    // Actually: frame_s has 0 array ops, array_h has 1. Total array = 1. Not fused.
+    // FRAME_S(0) + ARRAY_H(0) -> only 1 array op total, below threshold of 2. Not fused.
     auto mod2 = make_program({make_frame_s(0), make_array_h(0)}, 1);
     SingleAxisFusionPass().run(mod2);
     REQUIRE(mod2.bytecode.size() == 2);


### PR DESCRIPTION
## Summary
Comment cleanup pass over `src/clifft/optimizer/` (and one matching test).

- `hir_pass.h` — strip "timeless HIR / no DAG / symplectic geometry" editorializing; the one-line "Abstract base class for HIR optimization passes" is enough.
- `noise_block_pass.h` — drop the d=5 surface-code numbers (3471 → 24 OP_NOISE, ~68% dispatch reduction). They're specific to one circuit; the general "reduces dispatch overhead in noise-heavy circuits" rationale stays.
- `pass_factory.h` — drop the stale `(no nlohmann dependency)` parenthetical. The format comment underneath still describes the output.
- `tests/test_single_axis_fusion.cc` — replace an LLM-style "Actually:" self-correction with a single clean explanation.

No code-behavior changes. Source files in `src/clifft/optimizer/` are otherwise dense load-bearing math/derivation comments and were left alone.

## Test plan
- [x] `cmake --build build-tests --target clifft_tests` clean
- [x] `[bytecode-pass],[hir],[optimizer]` filter — 342 assertions in 94 cases, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)