### PR TITLE
chore: trim stale comment and dedup stim_to_bitmask in backend/

### DIFF
--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -450,7 +450,6 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
     bool sign = pauli.sign;
 
     // Gates are pushed to the pending queue (no transpose needed).
-    // Sign is tracked algebraically using Aaronson-Gottesman rules.
 
     uint32_t k = ctx.reg_manager.active_k();
 

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -208,16 +208,6 @@ class VirtualFrame {
     }
 
   private:
-    static PauliBitMask stim_to_bitmask(const stim::simd_bits_range_ref<kStimWidth>& bits,
-                                        uint32_t n) {
-        PauliBitMask m;
-        uint32_t words = (n + 63) / 64;
-        for (uint32_t w = 0; w < words && w < kMaxInlineWords; ++w) {
-            m.w[w] = bits.u64[w];
-        }
-        return m;
-    }
-
     static void apply_gate_to_pauli(const PendingGate& g, PauliBitMask& x, PauliBitMask& z,
                                     bool& sign) {
         bool xa = x.bit_get(g.axis_1);


### PR DESCRIPTION
## Summary
Comment-cleanup pass over \`src/clifft/backend/\`. Two small items:

- **\`backend.cc\`** — drop the \"Aaronson-Gottesman rules\" framing line in \`compress_pauli\`. The actual sign rules are derived inline a few lines below (\"Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1)\", etc.), so the AG label was redundant framing — the rules-as-shown ARE the rules. Continues the AG-terminology cleanup from PR #22.
- **\`compiler_context.h\`** — remove the third copy of \`stim_to_bitmask\` (a private static helper inside \`VirtualFrame\`). PR #22 hoisted the canonical version into \`frontend/hir.h\` as an inline; it's already in scope here via \`backend.h\` → \`hir.h\`. Same kind of chore-level dedup as before.

The rest of the backend subfolder (\`backend.h\`, \`source_map.h\`, \`reference_syndrome.{h,cc}\`, the bulk of \`backend.cc\`, and all 1494 lines of \`test_backend.cc\`) is dense load-bearing math/derivation and was left alone.

## Test plan
- [x] \`cmake --build build-tests --target clifft_tests\` clean
- [x] \`[backend]\` filter — all pass
- [x] \`Compress*\` — 51034 assertions in 34 cases pass
- [x] \`Lower*\` — 83 assertions in 27 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)