### PR TITLE
chore: rename Pauli compression to Pauli localization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ These constraints must not be violated:
 - **Deterministic RNG:** Do not use `std::uniform_real_distribution` (it is
   implementation-defined). Use `(rng() >> 11) * 0x1.0p-53` for `[0, 1)`.
 - **No Global Topology in the VM:** All multi-qubit Pauli interference must
-  be compressed into localized operations by the compiler, not evaluated at
+  be localized into local operations by the compiler, not evaluated at
   runtime.
 
 ## Git Workflow

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -13,8 +13,8 @@
 namespace clifft {
 
 using internal::CompilerContext;
-using internal::LocalizedBasis;
 using internal::LocalizationResult;
+using internal::LocalizedBasis;
 
 constexpr double kInvSqrt2 = std::numbers::sqrt2 / 2.0;
 
@@ -433,7 +433,8 @@ static uint16_t find_active_pivot(const PauliBitMask& bits, uint32_t k) {
     return static_cast<uint16_t>(bits.lowest_bit());
 }
 
-LocalizationResult localize_pauli(CompilerContext& ctx, const stim::PauliString<kStimWidth>& pauli) {
+LocalizationResult localize_pauli(CompilerContext& ctx,
+                                  const stim::PauliString<kStimWidth>& pauli) {
     const uint32_t n = ctx.reg_manager.num_qubits();
     const uint32_t words = (n + 63) / 64;
 

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -13,8 +13,8 @@
 namespace clifft {
 
 using internal::CompilerContext;
-using internal::CompressedBasis;
-using internal::CompressionResult;
+using internal::LocalizedBasis;
+using internal::LocalizationResult;
 
 constexpr double kInvSqrt2 = std::numbers::sqrt2 / 2.0;
 
@@ -352,16 +352,16 @@ stim::PauliString<kStimWidth> map_to_virtual(CompilerContext& ctx, const PauliBi
     return ctx.virtual_frame.map_pauli(destab_mask, stab_mask, sign, n);
 }
 
-// Route a compressed Pauli to the Z basis on an active axis.
+// Route a localized Pauli to the Z basis on an active axis.
 // Handles three cases:
 //   - Dormant Z: no-op (already diagonal in dormant frame)
 //   - Dormant X: swap to next active slot, H into Z, expand
 //   - Active X: H into Z on the array
 // Mutates result.pivot if a swap is needed.
-void route_to_active_z(CompilerContext& ctx, CompressionResult& result) {
+void route_to_active_z(CompilerContext& ctx, LocalizationResult& result) {
     bool is_dormant = result.pivot >= ctx.reg_manager.active_k();
 
-    if (is_dormant && result.basis == CompressedBasis::Z_BASIS) {
+    if (is_dormant && result.basis == LocalizedBasis::Z_BASIS) {
         return;
     }
 
@@ -381,7 +381,7 @@ void route_to_active_z(CompilerContext& ctx, CompressionResult& result) {
         return;
     }
 
-    if (result.basis == CompressedBasis::X_BASIS) {
+    if (result.basis == LocalizedBasis::X_BASIS) {
         ctx.virtual_frame.append_gate({internal::PendingGateType::H, result.pivot, 0});
         ctx.emit(make_array_h(result.pivot));
     }
@@ -392,10 +392,10 @@ void route_to_active_z(CompilerContext& ctx, CompressionResult& result) {
 namespace internal {
 
 // =========================================================================
-// compress_pauli: Greedy O(n) Pauli reduction
+// localize_pauli: Greedy O(n) Pauli reduction
 // =========================================================================
 //
-// Implements the constructive proof from Lemma (Pauli Compression).
+// Implements the constructive proof from Lemma (Pauli Localization).
 // Given a non-identity PauliString P = X^x Z^z, computes virtual Clifford V
 // such that V P V^dag = (+/-)P_v where P_v in {X_v, Z_v}.
 
@@ -433,7 +433,7 @@ static uint16_t find_active_pivot(const PauliBitMask& bits, uint32_t k) {
     return static_cast<uint16_t>(bits.lowest_bit());
 }
 
-CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<kStimWidth>& pauli) {
+LocalizationResult localize_pauli(CompilerContext& ctx, const stim::PauliString<kStimWidth>& pauli) {
     const uint32_t n = ctx.reg_manager.num_qubits();
     const uint32_t words = (n + 63) / 64;
 
@@ -443,10 +443,10 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
         z_bits.w[w] = pauli.zs.u64[w];
     }
 
-    assert(!(x_bits | z_bits).is_zero() && "Cannot compress identity Pauli");
+    assert(!(x_bits | z_bits).is_zero() && "Cannot localize identity Pauli");
 
     uint16_t pivot;
-    CompressedBasis basis;
+    LocalizedBasis basis;
     bool sign = pauli.sign;
 
     // Gates are pushed to the pending queue (no transpose needed).
@@ -462,7 +462,7 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
         pivot = find_dormant_pivot(x_bits, k);
         bool z_pivot = z_bits.bit_get(pivot);
 
-        // X-compression: CNOT(pivot -> q) annihilates X_q.
+        // X-localization: CNOT(pivot -> q) annihilates X_q.
         // Z propagation: Z_t -> Z_c Z_t, so z_pivot ^= z_q.
         // Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1).
         // Here x_pivot=1, x_q=1, so: sign ^= z_q & z_pivot.
@@ -479,7 +479,7 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
             to_clear_x.clear_lowest_bit();
         }
 
-        // Z-compression: CZ(pivot, q) clears residual Z_q.
+        // Z-localization: CZ(pivot, q) clears residual Z_q.
         // Sign rule: CZ(a,b) flips sign iff x_a & x_b & (z_a ^ z_b).
         // Here x_q=0 (already cleared), so sign NEVER flips.
         PauliBitMask to_clear_z = z_bits;
@@ -497,7 +497,7 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
             sign ^= true;
         }
 
-        basis = CompressedBasis::X_BASIS;
+        basis = LocalizedBasis::X_BASIS;
 
     } else {
         // =============================================================
@@ -507,7 +507,7 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
         // Pick pivot from Z-support, preferring active axes (< k).
         pivot = find_active_pivot(z_bits, k);
 
-        // Z-compression: CNOT(q -> pivot) folds Z_q onto pivot.
+        // Z-localization: CNOT(q -> pivot) folds Z_q onto pivot.
         // Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1).
         // Here x_c=x_q=0, so sign NEVER flips.
         PauliBitMask to_clear_z = z_bits;
@@ -518,7 +518,7 @@ CompressionResult compress_pauli(CompilerContext& ctx, const stim::PauliString<k
             to_clear_z.clear_lowest_bit();
         }
 
-        basis = CompressedBasis::Z_BASIS;
+        basis = LocalizedBasis::Z_BASIS;
     }
 
     return {pivot, basis, sign};
@@ -534,8 +534,8 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                      std::span<const uint8_t> expected_detectors,
                      std::span<const uint8_t> expected_observables) {
     using internal::CompilerContext;
-    using internal::compress_pauli;
-    using internal::CompressedBasis;
+    using internal::localize_pauli;
+    using internal::LocalizedBasis;
 
     const uint32_t n = hir.num_qubits;
     CompilerContext ctx(n);
@@ -552,11 +552,11 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
         switch (op.op_type()) {
             case OpType::T_GATE: {
                 auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
-                auto result = compress_pauli(ctx, p_v);
+                auto result = localize_pauli(ctx, p_v);
 
                 route_to_active_z(ctx, result);
 
-                // Global phase correction when compression inverted the Pauli (-Z).
+                // Global phase correction when localization inverted the Pauli (-Z).
                 // T on -Z = e^{i*pi/4} T^dag; T^dag on -Z = e^{-i*pi/4} T.
                 if (result.sign) {
                     if (!op.is_dagger()) {
@@ -581,12 +581,12 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
             case OpType::PHASE_ROTATION: {
                 double alpha = op.alpha();
                 auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
-                auto result = compress_pauli(ctx, p_v);
+                auto result = localize_pauli(ctx, p_v);
 
                 route_to_active_z(ctx, result);
 
                 // The Front-End unconditionally extracted the physical global phase.
-                // If compress_pauli dynamically flipped the geometric sign
+                // If localize_pauli dynamically flipped the geometric sign
                 // (result.sign != op.sign()), correct the global phase artifact
                 // left behind by the VM's diagonal factorization.
                 if (result.sign != op.sign()) {
@@ -596,7 +596,7 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                 }
 
                 // result.sign absorbs both the original op.sign() and any
-                // compression flips.
+                // localization flips.
                 if (result.sign)
                     alpha = -alpha;
 
@@ -630,12 +630,12 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                     break;
                 }
 
-                auto result = compress_pauli(ctx, p_v);
+                auto result = localize_pauli(ctx, p_v);
                 bool is_active = result.pivot < ctx.reg_manager.active_k();
 
                 if (!is_active) {
                     // Dormant pivot
-                    if (result.basis == CompressedBasis::Z_BASIS) {
+                    if (result.basis == LocalizedBasis::Z_BASIS) {
                         ctx.emit(make_meas(Opcode::OP_MEAS_DORMANT_STATIC, result.pivot,
                                            classical_idx, result.sign));
                     } else {
@@ -643,7 +643,7 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                                            classical_idx, result.sign));
                     }
                     // X_BASIS post-measurement: append virtual H to align coordinate system
-                    if (result.basis == CompressedBasis::X_BASIS) {
+                    if (result.basis == LocalizedBasis::X_BASIS) {
                         ctx.virtual_frame.append_gate(
                             {internal::PendingGateType::H, result.pivot, 0});
                     }
@@ -656,7 +656,7 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                         result.pivot = top;
                     }
 
-                    if (result.basis == CompressedBasis::Z_BASIS) {
+                    if (result.basis == LocalizedBasis::Z_BASIS) {
                         ctx.emit(make_meas(Opcode::OP_MEAS_ACTIVE_DIAGONAL, result.pivot,
                                            classical_idx, result.sign));
                     } else {
@@ -664,7 +664,7 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                                            classical_idx, result.sign));
                     }
 
-                    if (result.basis == CompressedBasis::X_BASIS) {
+                    if (result.basis == LocalizedBasis::X_BASIS) {
                         ctx.virtual_frame.append_gate(
                             {internal::PendingGateType::H, result.pivot, 0});
                     }

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -18,7 +18,7 @@ namespace clifft {
 // =============================================================================
 //
 // The VM uses a localized instruction set. All multi-qubit global topology
-// is compressed into local 1-qubit and 2-qubit virtual axis operations by the
+// is localized into 1-qubit and 2-qubit virtual axis operations by the
 // Back-End AOT compiler. The VM never evaluates basis spans or commutations.
 
 enum class Opcode : uint8_t {
@@ -320,7 +320,7 @@ struct CompiledModule {
 // =============================================================================
 
 /// Lower HIR to executable VM bytecode.
-/// Tracks virtual frame V_cum, compresses multi-qubit Paulis to local ops.
+/// Tracks virtual frame V_cum, localizes multi-qubit Paulis to local ops.
 /// If postselection_mask is non-empty, detectors at indices where
 /// mask[det_idx] != 0 are emitted as OP_POSTSELECT instead of OP_DETECTOR.
 /// expected_detectors/expected_observables carry noiseless reference parities

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -324,7 +324,7 @@ struct LocalizationResult {
 ///
 /// The input PauliString must be non-identity (at least one qubit set).
 [[nodiscard]] LocalizationResult localize_pauli(CompilerContext& ctx,
-                                               const stim::PauliString<kStimWidth>& pauli);
+                                                const stim::PauliString<kStimWidth>& pauli);
 
 }  // namespace internal
 }  // namespace clifft

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -294,25 +294,25 @@ struct CompilerContext {
 };
 
 // =============================================================================
-// Result of compress_pauli: identifies what the Pauli was compressed to.
+// Result of localize_pauli: identifies what the Pauli was localized to.
 // =============================================================================
 
-enum class CompressedBasis : uint8_t {
-    Z_BASIS,  // Compressed to Z_v
-    X_BASIS,  // Compressed to X_v
+enum class LocalizedBasis : uint8_t {
+    Z_BASIS,  // Localized to Z_v
+    X_BASIS,  // Localized to X_v
 };
 
-struct CompressionResult {
-    uint16_t pivot;         // The virtual qubit the Pauli was compressed onto
-    CompressedBasis basis;  // Whether it ended up as X_v or Z_v
-    bool sign;              // Accumulated sign (true = negative)
+struct LocalizationResult {
+    uint16_t pivot;        // The virtual qubit the Pauli was localized onto
+    LocalizedBasis basis;  // Whether it ended up as X_v or Z_v
+    bool sign;             // Accumulated sign (true = negative)
 };
 
 // =============================================================================
-// Core Compression Algorithm
+// Core Localization Algorithm
 // =============================================================================
 
-/// Compress an arbitrary multi-qubit Pauli string onto a single virtual qubit.
+/// Localize an arbitrary multi-qubit Pauli string onto a single virtual qubit.
 ///
 /// Given a PauliString P, computes a sequence V of virtual Clifford gates
 /// such that V P V^dag = (+/-)P_v where P_v in {X_v, Z_v}.
@@ -323,7 +323,7 @@ struct CompressionResult {
 ///   - Does NOT modify ctx.reg_manager (activation is the caller's job)
 ///
 /// The input PauliString must be non-identity (at least one qubit set).
-[[nodiscard]] CompressionResult compress_pauli(CompilerContext& ctx,
+[[nodiscard]] LocalizationResult localize_pauli(CompilerContext& ctx,
                                                const stim::PauliString<kStimWidth>& pauli);
 
 }  // namespace internal

--- a/src/clifft/optimizer/multi_gate_pass.h
+++ b/src/clifft/optimizer/multi_gate_pass.h
@@ -9,7 +9,7 @@ namespace clifft {
 /// a control axis into a single OP_ARRAY_MULTI_CZ.
 ///
 /// These "star-graph" patterns arise from the backend's greedy Pauli
-/// compressor folding multi-qubit Pauli strings onto a single pivot.
+/// localizer folding multi-qubit Pauli strings onto a single pivot.
 /// Without fusion, each CNOT/CZ triggers a separate full O(2^k) array pass.
 /// The fused instruction processes all targets/controls in one pass using
 /// popcount-based parity checks.

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1560,7 +1560,7 @@ static inline void exec_meas_dormant_random(SchrodingerState& state, uint16_t v,
     bit_set(state.p_x, v, m_abs);
     bit_set(state.p_z, v, false);
 
-    // Physical outcome includes the compression sign
+    // Physical outcome includes the localization sign
     state.meas_record[classical_idx] = m_abs ^ static_cast<uint8_t>(sign);
 }
 
@@ -1594,7 +1594,7 @@ static inline void exec_meas_active_diagonal(SchrodingerState& state, uint16_t v
 
     // Abstract outcome (determines array branch + frame state)
     uint8_t m_abs = b ^ static_cast<uint8_t>(px_v);
-    // Physical outcome (classical record includes compression sign)
+    // Physical outcome (classical record includes localization sign)
     uint8_t m_phys = m_abs ^ static_cast<uint8_t>(sign);
 
     // Phase extraction: (-1)^(p_z[v] * b) when b=1
@@ -1659,7 +1659,7 @@ static inline void exec_meas_active_interfere(SchrodingerState& state, uint16_t 
 
     // Abstract outcome (determines array fold + frame state)
     uint8_t m_abs = b_x ^ static_cast<uint8_t>(pz_v);
-    // Physical outcome (classical record includes compression sign)
+    // Physical outcome (classical record includes localization sign)
     uint8_t m_phys = m_abs ^ static_cast<uint8_t>(sign);
 
     // Fold array: v'[i] = (v[i] +/- v[i+half]) / sqrt(2)

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -80,7 +80,7 @@ def random_dense_clifford_t_circuit(
 
     Higher 2-qubit gate probability and includes CY/CZ alongside CX.
     Produces circuits with heavy multi-qubit interference that stress
-    the compiler's Pauli compression and virtual axis allocation.
+    the compiler's Pauli localization and virtual axis allocation.
 
     Args:
         num_qubits: Number of qubits.

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -139,7 +139,7 @@ class TestDenseCliffordTFuzzer:
     """Validate Clifft against Qiskit-Aer with dense entanglement circuits.
 
     Uses higher 2-qubit gate probability (50%) and all three 2-qubit gates
-    (CX, CY, CZ) to stress the compiler's Pauli compression pipeline.
+    (CX, CY, CZ) to stress the compiler's Pauli localization pipeline.
     """
 
     @pytest.mark.parametrize("num_qubits", [3, 4, 5])

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -88,14 +88,14 @@ static stim::Tableau<kStimWidth> bytecode_to_tableau(const std::vector<Instructi
 }
 
 // Verify that V_cum P V_cum^dag is a single-qubit Pauli on the expected pivot.
-// Returns the compressed PauliString for further inspection.
-static stim::PauliString<kStimWidth> verify_compression(CompilerContext& ctx,
+// Returns the localized PauliString for further inspection.
+static stim::PauliString<kStimWidth> verify_localization(CompilerContext& ctx,
                                                         const stim::PauliString<kStimWidth>& input,
-                                                        const CompressionResult& result) {
+                                                        const LocalizationResult& result) {
     ctx.virtual_frame.flush();
-    stim::PauliString<kStimWidth> compressed = ctx.virtual_frame.materialized_tableau()(input);
-    uint64_t cx = compressed.xs.u64[0];
-    uint64_t cz = compressed.zs.u64[0];
+    stim::PauliString<kStimWidth> localized = ctx.virtual_frame.materialized_tableau()(input);
+    uint64_t cx = localized.xs.u64[0];
+    uint64_t cz = localized.zs.u64[0];
 
     // Must act on exactly one qubit
     uint64_t support = cx | cz;
@@ -107,7 +107,7 @@ static stim::PauliString<kStimWidth> verify_compression(CompilerContext& ctx,
     REQUIRE(actual_pivot == result.pivot);
 
     // Basis must match
-    if (result.basis == CompressedBasis::X_BASIS) {
+    if (result.basis == LocalizedBasis::X_BASIS) {
         REQUIRE((cx & (1ULL << result.pivot)) != 0);
         REQUIRE((cz & (1ULL << result.pivot)) == 0);
     } else {
@@ -116,23 +116,23 @@ static stim::PauliString<kStimWidth> verify_compression(CompilerContext& ctx,
     }
 
     // Sign must match
-    REQUIRE(compressed.sign == result.sign);
+    REQUIRE(localized.sign == result.sign);
 
-    return compressed;
+    return localized;
 }
 
 // Verify that the emitted bytecode independently transforms the input Pauli
 // to a weight-1 Pauli on the declared pivot. This catches bugs where v_cum
 // is updated correctly but the bytecode emission is wrong (e.g., swapped
 // control/target on a CNOT).
-static void verify_bytecode_compression(const CompilerContext& ctx,
+static void verify_bytecode_localization(const CompilerContext& ctx,
                                         const stim::PauliString<kStimWidth>& input,
-                                        const CompressionResult& result) {
+                                        const LocalizationResult& result) {
     stim::Tableau<kStimWidth> tab =
         bytecode_to_tableau(ctx.bytecode, static_cast<uint32_t>(input.num_qubits));
-    stim::PauliString<kStimWidth> compressed = tab(input);
-    uint64_t cx = compressed.xs.u64[0];
-    uint64_t cz = compressed.zs.u64[0];
+    stim::PauliString<kStimWidth> localized = tab(input);
+    uint64_t cx = localized.xs.u64[0];
+    uint64_t cz = localized.zs.u64[0];
 
     uint64_t support = cx | cz;
     REQUIRE(support != 0);
@@ -141,7 +141,7 @@ static void verify_bytecode_compression(const CompilerContext& ctx,
     uint16_t actual_pivot = static_cast<uint16_t>(std::countr_zero(static_cast<uint64_t>(support)));
     REQUIRE(actual_pivot == result.pivot);
 
-    if (result.basis == CompressedBasis::X_BASIS) {
+    if (result.basis == LocalizedBasis::X_BASIS) {
         REQUIRE((cx & (1ULL << result.pivot)) != 0);
         REQUIRE((cz & (1ULL << result.pivot)) == 0);
     } else {
@@ -149,11 +149,11 @@ static void verify_bytecode_compression(const CompilerContext& ctx,
         REQUIRE((cz & (1ULL << result.pivot)) != 0);
     }
 
-    REQUIRE(compressed.sign == result.sign);
+    REQUIRE(localized.sign == result.sign);
 
     // Verify ARRAY vs FRAME opcode semantics: array opcodes must target
     // active axes (< active_k), frame opcodes must target dormant axes
-    // (>= active_k). compress_pauli never changes active_k, so the final
+    // (>= active_k). localize_pauli never changes active_k, so the final
     // value is valid for all emitted instructions.
     uint32_t k = ctx.reg_manager.active_k();
     for (const auto& instr : ctx.bytecode) {
@@ -218,170 +218,170 @@ static bool all_frame_opcodes(const std::vector<Instruction>& bytecode) {
 }
 
 // =============================================================================
-// Single-qubit Paulis: no compression needed
+// Single-qubit Paulis: no localization needed
 // =============================================================================
 
-TEST_CASE("Compress: single-qubit Z needs no gates") {
+TEST_CASE("Localize: single-qubit Z needs no gates") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, 0, Z(2));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 2);
-    REQUIRE(result.basis == CompressedBasis::Z_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::Z_BASIS);
     REQUIRE(result.sign == false);
     REQUIRE(ctx.bytecode.empty());
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: single-qubit X needs no gates") {
+TEST_CASE("Localize: single-qubit X needs no gates") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(3), 0);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 3);
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     REQUIRE(result.sign == false);
     REQUIRE(ctx.bytecode.empty());
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: single-qubit Y emits S gate") {
+TEST_CASE("Localize: single-qubit Y emits S gate") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(1), Z(1));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 1);
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     REQUIRE(result.sign == true);
     REQUIRE(count_opcodes(ctx.bytecode, Opcode::OP_FRAME_S) == 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // Pure Z-strings: Case 2
 // =============================================================================
 
-TEST_CASE("Compress: two-qubit ZZ string") {
+TEST_CASE("Localize: two-qubit ZZ string") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, 0, Z(0) | Z(2));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::Z_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::Z_BASIS);
     // One CNOT needed to fold the second Z onto the pivot
     REQUIRE(ctx.bytecode.size() == 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: three-qubit ZZZ string") {
+TEST_CASE("Localize: three-qubit ZZZ string") {
     CompilerContext ctx(5);
     auto pauli = make_pauli(5, 0, Z(0) | Z(2) | Z(4));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::Z_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::Z_BASIS);
     // Two CNOTs needed
     REQUIRE(ctx.bytecode.size() == 2);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // X-support strings: Case 1
 // =============================================================================
 
-TEST_CASE("Compress: two-qubit XX string") {
+TEST_CASE("Localize: two-qubit XX string") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(0) | X(1), 0);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     REQUIRE(ctx.bytecode.size() == 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: XX with Z residue needs CNOT plus CZ") {
+TEST_CASE("Localize: XX with Z residue needs CNOT plus CZ") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(0) | X(1), Z(1));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: XZ mixed two-qubit") {
+TEST_CASE("Localize: XZ mixed two-qubit") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(0), Z(1));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 0);
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     REQUIRE(ctx.bytecode.size() == 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // Sign tracking
 // =============================================================================
 
-TEST_CASE("Compress: negative Z preserves sign") {
+TEST_CASE("Localize: negative Z preserves sign") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, 0, Z(0), /*sign=*/true);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.sign == true);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: negative X preserves sign") {
+TEST_CASE("Localize: negative X preserves sign") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(0), 0, /*sign=*/true);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.sign == true);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: negative Y gives positive X after S") {
+TEST_CASE("Localize: negative Y gives positive X after S") {
     CompilerContext ctx(4);
     auto pauli = make_pauli(4, X(0), Z(0), /*sign=*/true);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     // -Y -> S -> -(-X) = +X, so sign should be false
     REQUIRE(result.sign == false);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // Dormant pivot preference
 // =============================================================================
 
-TEST_CASE("Compress: X-compression prefers dormant pivot") {
+TEST_CASE("Localize: X-localization prefers dormant pivot") {
     CompilerContext ctx(4);
     // Activate axis 0 (k=1), so axis 0 is active, 1..3 are dormant.
     ctx.reg_manager.activate();
 
     // X0 X1: axis 0 is active, axis 1 is dormant -> prefer dormant pivot.
     auto pauli = make_pauli(4, X(0) | X(1), 0);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 1);
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     REQUIRE(all_frame_opcodes(ctx.bytecode));
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: Z-compression prefers active pivot") {
+TEST_CASE("Localize: Z-localization prefers active pivot") {
     CompilerContext ctx(4);
     // k=1: axis 0 active, axes 1..3 dormant.
     ctx.reg_manager.activate();
@@ -389,53 +389,53 @@ TEST_CASE("Compress: Z-compression prefers active pivot") {
     // Z0 Z1: axis 0 is active -> prefer it as pivot.
     // CNOT(1->0) has dormant control -> frame opcode.
     auto pauli = make_pauli(4, 0, Z(0) | Z(1));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 0);
-    REQUIRE(result.basis == CompressedBasis::Z_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::Z_BASIS);
     REQUIRE(all_frame_opcodes(ctx.bytecode));
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // Active-active opcodes
 // =============================================================================
 
-TEST_CASE("Compress: all-active X-support emits array opcodes") {
+TEST_CASE("Localize: all-active X-support emits array opcodes") {
     CompilerContext ctx(4);
     // k=2: axes 0,1 active.
     ctx.reg_manager.activate();
     ctx.reg_manager.activate();
 
     auto pauli = make_pauli(4, X(0) | X(1), 0);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     REQUIRE(count_opcodes(ctx.bytecode, Opcode::OP_ARRAY_CNOT) == 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: all-active CZ emits array CZ") {
+TEST_CASE("Localize: all-active CZ emits array CZ") {
     CompilerContext ctx(4);
     ctx.reg_manager.activate();
     ctx.reg_manager.activate();
 
     auto pauli = make_pauli(4, X(0), Z(1));
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     REQUIRE(result.pivot == 0);
     REQUIRE(count_opcodes(ctx.bytecode, Opcode::OP_ARRAY_CZ) == 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // Heavy random Pauli strings: fuzz test
 // =============================================================================
 
-TEST_CASE("Compress: random heavy Paulis compress to weight-1") {
+TEST_CASE("Localize: random heavy Paulis localize to weight-1") {
     uint64_t seed = 0xDEADBEEF;
 
     for (int trial = 0; trial < 100; ++trial) {
@@ -457,13 +457,13 @@ TEST_CASE("Compress: random heavy Paulis compress to weight-1") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits);
-        auto result = compress_pauli(ctx, pauli);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        auto result = localize_pauli(ctx, pauli);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
-TEST_CASE("Compress: random heavy Paulis with sign") {
+TEST_CASE("Localize: random heavy Paulis with sign") {
     uint64_t seed = 0xCAFEBABE;
 
     for (int trial = 0; trial < 50; ++trial) {
@@ -485,9 +485,9 @@ TEST_CASE("Compress: random heavy Paulis with sign") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits, sign);
-        auto result = compress_pauli(ctx, pauli);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        auto result = localize_pauli(ctx, pauli);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
@@ -495,7 +495,7 @@ TEST_CASE("Compress: random heavy Paulis with sign") {
 // All-dormant: frame-only opcodes
 // =============================================================================
 
-TEST_CASE("Compress: all-dormant heavy Pauli emits only frame opcodes") {
+TEST_CASE("Localize: all-dormant heavy Pauli emits only frame opcodes") {
     uint64_t seed = 0x12345678;
 
     for (int trial = 0; trial < 50; ++trial) {
@@ -511,33 +511,33 @@ TEST_CASE("Compress: all-dormant heavy Pauli emits only frame opcodes") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits);
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
 
         REQUIRE(all_frame_opcodes(ctx.bytecode));
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
 // =============================================================================
-// Sequential compressions: V_cum accumulates correctly
+// Sequential localizations: V_cum accumulates correctly
 // =============================================================================
 
-// Verify compression for a sequential call.
-// v_cum_before: snapshot of v_cum BEFORE this compress_pauli call.
-// v_cum_after: v_cum AFTER this compress_pauli call.
+// Verify localization for a sequential call.
+// v_cum_before: snapshot of v_cum BEFORE this localize_pauli call.
+// v_cum_after: v_cum AFTER this localize_pauli call.
 // The local frame is: v_local = v_cum_before^{-1}.then(v_cum_after)
-// and v_local(input) should be the weight-1 compressed Pauli.
-static void verify_sequential_compression(const CompilerContext& ctx,
+// and v_local(input) should be the weight-1 localized Pauli.
+static void verify_sequential_localization(const CompilerContext& ctx,
                                           const stim::Tableau<kStimWidth>& v_cum_before,
                                           const stim::Tableau<kStimWidth>& v_cum_after,
                                           const stim::PauliString<kStimWidth>& input,
-                                          const CompressionResult& result, size_t bc_before) {
+                                          const LocalizationResult& result, size_t bc_before) {
     stim::Tableau<kStimWidth> v_local = v_cum_before.inverse().then(v_cum_after);
-    stim::PauliString<kStimWidth> compressed = v_local(input);
+    stim::PauliString<kStimWidth> localized = v_local(input);
 
-    uint64_t cx = compressed.xs.u64[0];
-    uint64_t cz = compressed.zs.u64[0];
+    uint64_t cx = localized.xs.u64[0];
+    uint64_t cz = localized.zs.u64[0];
     uint64_t support = cx | cz;
     REQUIRE(support != 0);
     REQUIRE((support & (support - 1)) == 0);
@@ -545,7 +545,7 @@ static void verify_sequential_compression(const CompilerContext& ctx,
     uint16_t actual_pivot = static_cast<uint16_t>(std::countr_zero(static_cast<uint64_t>(support)));
     REQUIRE(actual_pivot == result.pivot);
 
-    if (result.basis == CompressedBasis::X_BASIS) {
+    if (result.basis == LocalizedBasis::X_BASIS) {
         REQUIRE((cx & (1ULL << result.pivot)) != 0);
         REQUIRE((cz & (1ULL << result.pivot)) == 0);
     } else {
@@ -553,26 +553,26 @@ static void verify_sequential_compression(const CompilerContext& ctx,
         REQUIRE((cz & (1ULL << result.pivot)) != 0);
     }
 
-    REQUIRE(compressed.sign == result.sign);
+    REQUIRE(localized.sign == result.sign);
 
-    // Verify bytecode emitted during this compression step independently
+    // Verify bytecode emitted during this localization step independently
     // produces the correct single-qubit Pauli on the declared pivot.
     std::vector<Instruction> step_bytecode(ctx.bytecode.begin() + static_cast<ptrdiff_t>(bc_before),
                                            ctx.bytecode.end());
     stim::Tableau<kStimWidth> tab =
         bytecode_to_tableau(step_bytecode, static_cast<uint32_t>(input.num_qubits));
-    stim::PauliString<kStimWidth> bc_compressed = tab(input);
-    uint64_t bcx = bc_compressed.xs.u64[0];
-    uint64_t bcz = bc_compressed.zs.u64[0];
+    stim::PauliString<kStimWidth> bc_localized = tab(input);
+    uint64_t bcx = bc_localized.xs.u64[0];
+    uint64_t bcz = bc_localized.zs.u64[0];
     uint64_t bc_support = bcx | bcz;
     REQUIRE(bc_support != 0);
     REQUIRE((bc_support & (bc_support - 1)) == 0);
     REQUIRE(static_cast<uint16_t>(std::countr_zero(static_cast<uint64_t>(bc_support))) ==
             result.pivot);
-    REQUIRE(bc_compressed.sign == result.sign);
+    REQUIRE(bc_localized.sign == result.sign);
 }
 
-TEST_CASE("Compress: sequential compressions accumulate in V_cum") {
+TEST_CASE("Localize: sequential localizations accumulate in V_cum") {
     const uint32_t n = 6;
     CompilerContext ctx(n);
 
@@ -580,28 +580,28 @@ TEST_CASE("Compress: sequential compressions accumulate in V_cum") {
     auto p2 = make_pauli(n, 0, Z(3) | Z(4) | Z(5));
     auto p3 = make_pauli(n, X(2) | X(4), Z(1) | Z(3));
 
-    // First compression: v_cum starts as identity, so verify_compression works.
-    auto r1 = compress_pauli(ctx, p1);
-    verify_compression(ctx, p1, r1);
+    // First localization: v_cum starts as identity, so verify_localization works.
+    auto r1 = localize_pauli(ctx, p1);
+    verify_localization(ctx, p1, r1);
 
-    // Snapshot v_cum before second compression.
+    // Snapshot v_cum before second localization.
     ctx.virtual_frame.flush();
     stim::Tableau<kStimWidth> snap1 = ctx.virtual_frame.materialized_tableau();
     size_t bc1 = ctx.bytecode.size();
-    auto r2 = compress_pauli(ctx, p2);
+    auto r2 = localize_pauli(ctx, p2);
     ctx.virtual_frame.flush();
-    verify_sequential_compression(ctx, snap1, ctx.virtual_frame.materialized_tableau(), p2, r2,
+    verify_sequential_localization(ctx, snap1, ctx.virtual_frame.materialized_tableau(), p2, r2,
                                   bc1);
 
-    // Snapshot v_cum before third compression.
+    // Snapshot v_cum before third localization.
     stim::Tableau<kStimWidth> snap2 = ctx.virtual_frame.materialized_tableau();
     size_t bc2 = ctx.bytecode.size();
-    auto r3 = compress_pauli(ctx, p3);
+    auto r3 = localize_pauli(ctx, p3);
     ctx.virtual_frame.flush();
-    verify_sequential_compression(ctx, snap2, ctx.virtual_frame.materialized_tableau(), p3, r3,
+    verify_sequential_localization(ctx, snap2, ctx.virtual_frame.materialized_tableau(), p3, r3,
                                   bc2);
 
-    // V_cum should be non-identity after multiple compressions.
+    // V_cum should be non-identity after multiple localizations.
     bool is_identity = true;
     for (uint32_t q = 0; q < n; ++q) {
         const auto& v_cum = ctx.virtual_frame.materialized_tableau();
@@ -618,7 +618,7 @@ TEST_CASE("Compress: sequential compressions accumulate in V_cum") {
 // Opcode axis values use mapped array axes, not virtual qubit indices
 // =============================================================================
 
-TEST_CASE("Compress: array opcode axes are literal axis indices") {
+TEST_CASE("Localize: array opcode axes are literal axis indices") {
     CompilerContext ctx(8);
     // k=3: axes 0,1,2 are active.
     ctx.reg_manager.activate();
@@ -627,7 +627,7 @@ TEST_CASE("Compress: array opcode axes are literal axis indices") {
 
     // X0 X2: both active, CNOT will use literal axes 0 and 2.
     auto pauli = make_pauli(8, X(0) | X(2), 0);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     bool found = false;
     for (const auto& instr : ctx.bytecode) {
@@ -640,51 +640,51 @@ TEST_CASE("Compress: array opcode axes are literal axis indices") {
         }
     }
     REQUIRE(found);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
 // Edge case: wide Pauli covering all qubits
 // =============================================================================
 
-TEST_CASE("Compress: full-width X string on 20 qubits") {
+TEST_CASE("Localize: full-width X string on 20 qubits") {
     const uint32_t n = 20;
     CompilerContext ctx(n);
     uint64_t all_x = (1ULL << n) - 1;
     auto pauli = make_pauli(n, all_x, 0);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
     // n-1 CNOTs to clear all X except pivot
     REQUIRE(ctx.bytecode.size() == n - 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: full-width Z string on 20 qubits") {
+TEST_CASE("Localize: full-width Z string on 20 qubits") {
     const uint32_t n = 20;
     CompilerContext ctx(n);
     uint64_t all_z = (1ULL << n) - 1;
     auto pauli = make_pauli(n, 0, all_z);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::Z_BASIS);
+    REQUIRE(result.basis == LocalizedBasis::Z_BASIS);
     REQUIRE(ctx.bytecode.size() == n - 1);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress: full-width Y string on 10 qubits") {
+TEST_CASE("Localize: full-width Y string on 10 qubits") {
     const uint32_t n = 10;
     CompilerContext ctx(n);
     uint64_t all = (1ULL << n) - 1;
     auto pauli = make_pauli(n, all, all);  // Y on every qubit
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
 // =============================================================================
@@ -767,10 +767,10 @@ TEST_CASE("Backend: Gap sampling hazard array accumulation") {
 }
 
 // =============================================================================
-// Scaled Compressor Fuzzing
+// Scaled Localizer Fuzzing
 // =============================================================================
 
-TEST_CASE("Compress fuzz: 30-qubit heavy Paulis 500 trials") {
+TEST_CASE("Localize fuzz: 30-qubit heavy Paulis 500 trials") {
     uint64_t seed = 0xA5A5A5A5;
     const uint32_t n = 30;
 
@@ -791,13 +791,13 @@ TEST_CASE("Compress fuzz: 30-qubit heavy Paulis 500 trials") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits);
-        auto result = compress_pauli(ctx, pauli);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        auto result = localize_pauli(ctx, pauli);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
-TEST_CASE("Compress fuzz: 64-qubit max-width Paulis") {
+TEST_CASE("Localize fuzz: 64-qubit max-width Paulis") {
     uint64_t seed = 0xFEEDFACE;
     const uint32_t n = 64;
 
@@ -818,9 +818,9 @@ TEST_CASE("Compress fuzz: 64-qubit max-width Paulis") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits);
-        auto result = compress_pauli(ctx, pauli);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        auto result = localize_pauli(ctx, pauli);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
@@ -828,21 +828,21 @@ TEST_CASE("Compress fuzz: 64-qubit max-width Paulis") {
 // Adversarial Patterns
 // =============================================================================
 
-TEST_CASE("Compress adversarial: all-Y strings") {
+TEST_CASE("Localize adversarial: all-Y strings") {
     // Every qubit is Y = XZ. Maximizes S-gate emissions.
     for (uint32_t n = 2; n <= 30; n += 4) {
         CompilerContext ctx(n);
         uint64_t mask = (n < 64) ? ((1ULL << n) - 1) : ~0ULL;
         auto pauli = make_pauli(n, mask, mask);  // Y on every qubit
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
 
-        REQUIRE(result.basis == CompressedBasis::X_BASIS);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        REQUIRE(result.basis == LocalizedBasis::X_BASIS);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
-TEST_CASE("Compress adversarial: all-Y with varied active partitions") {
+TEST_CASE("Localize adversarial: all-Y with varied active partitions") {
     const uint32_t n = 20;
     uint64_t mask = (1ULL << n) - 1;
 
@@ -852,15 +852,15 @@ TEST_CASE("Compress adversarial: all-Y with varied active partitions") {
             ctx.reg_manager.activate();
         }
         auto pauli = make_pauli(n, mask, mask);
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
 
-        REQUIRE(result.basis == CompressedBasis::X_BASIS);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        REQUIRE(result.basis == LocalizedBasis::X_BASIS);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
-TEST_CASE("Compress adversarial: checkerboard X-Z pattern") {
+TEST_CASE("Localize adversarial: checkerboard X-Z pattern") {
     // Even qubits get X, odd qubits get Z. Stresses CZ residue cleanup.
     for (uint32_t n = 4; n <= 30; n += 4) {
         CompilerContext ctx(n);
@@ -873,28 +873,28 @@ TEST_CASE("Compress adversarial: checkerboard X-Z pattern") {
                 z_bits |= (1ULL << q);
         }
         auto pauli = make_pauli(n, x_bits, z_bits);
-        auto result = compress_pauli(ctx, pauli);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        auto result = localize_pauli(ctx, pauli);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
-TEST_CASE("Compress adversarial: single X rest Z") {
+TEST_CASE("Localize adversarial: single X rest Z") {
     // One X bit on q0, Z on all others. Stresses Z-cleanup after X pivot.
     for (uint32_t n = 2; n <= 30; n += 4) {
         CompilerContext ctx(n);
         uint64_t z_mask = ((n < 64) ? ((1ULL << n) - 1) : ~0ULL) & ~1ULL;
         auto pauli = make_pauli(n, X(0), z_mask);
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
 
         REQUIRE(result.pivot == 0);
-        REQUIRE(result.basis == CompressedBasis::X_BASIS);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        REQUIRE(result.basis == LocalizedBasis::X_BASIS);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
-TEST_CASE("Compress adversarial: single X rest Z with active pivot") {
+TEST_CASE("Localize adversarial: single X rest Z with active pivot") {
     // Same pattern but with the X qubit active and some Z qubits dormant.
     const uint32_t n = 20;
     CompilerContext ctx(n);
@@ -902,16 +902,16 @@ TEST_CASE("Compress adversarial: single X rest Z with active pivot") {
 
     uint64_t z_mask = ((1ULL << n) - 1) & ~1ULL;  // Z on qubits 1..19
     auto pauli = make_pauli(n, X(0), z_mask);
-    auto result = compress_pauli(ctx, pauli);
+    auto result = localize_pauli(ctx, pauli);
 
     // Pivot should still be 0 (the X qubit) since it's the only X bit
     REQUIRE(result.pivot == 0);
-    REQUIRE(result.basis == CompressedBasis::X_BASIS);
-    verify_compression(ctx, pauli, result);
-    verify_bytecode_compression(ctx, pauli, result);
+    REQUIRE(result.basis == LocalizedBasis::X_BASIS);
+    verify_localization(ctx, pauli, result);
+    verify_bytecode_localization(ctx, pauli, result);
 }
 
-TEST_CASE("Compress adversarial: dense XZ overlap") {
+TEST_CASE("Localize adversarial: dense XZ overlap") {
     // High Hamming weight on both X and Z masks (many Y qubits mixed with
     // pure X and pure Z). Maximizes total gate count.
     uint64_t seed = 0xBAADF00D;
@@ -934,17 +934,17 @@ TEST_CASE("Compress adversarial: dense XZ overlap") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits);
-        auto result = compress_pauli(ctx, pauli);
-        verify_compression(ctx, pauli, result);
-        verify_bytecode_compression(ctx, pauli, result);
+        auto result = localize_pauli(ctx, pauli);
+        verify_localization(ctx, pauli, result);
+        verify_bytecode_localization(ctx, pauli, result);
     }
 }
 
 // =============================================================================
-// Sequential Compression Stress
+// Sequential Localization Stress
 // =============================================================================
 
-TEST_CASE("Compress sequential: 20 compressions on 20 qubits") {
+TEST_CASE("Localize sequential: 20 localizations on 20 qubits") {
     uint64_t seed = 0x1337C0DE;
     const uint32_t n = 20;
     CompilerContext ctx(n);
@@ -967,14 +967,14 @@ TEST_CASE("Compress sequential: 20 compressions on 20 qubits") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits, (test_lcg(seed) & 1) != 0);
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
         ctx.virtual_frame.flush();
-        verify_sequential_compression(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
+        verify_sequential_localization(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
                                       result, bc_snap);
     }
 }
 
-TEST_CASE("Compress sequential: 30 compressions on 30 qubits all-active") {
+TEST_CASE("Localize sequential: 30 localizations on 30 qubits all-active") {
     uint64_t seed = 0xABCDEF01;
     const uint32_t n = 30;
     CompilerContext ctx(n);
@@ -996,14 +996,14 @@ TEST_CASE("Compress sequential: 30 compressions on 30 qubits all-active") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits, (test_lcg(seed) & 1) != 0);
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
         ctx.virtual_frame.flush();
-        verify_sequential_compression(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
+        verify_sequential_localization(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
                                       result, bc_snap);
     }
 }
 
-TEST_CASE("Compress sequential: 30 compressions on 30 qubits all-dormant") {
+TEST_CASE("Localize sequential: 30 localizations on 30 qubits all-dormant") {
     uint64_t seed = 0x99887766;
     const uint32_t n = 30;
     CompilerContext ctx(n);  // k=0, all dormant
@@ -1021,9 +1021,9 @@ TEST_CASE("Compress sequential: 30 compressions on 30 qubits all-dormant") {
         }
 
         auto pauli = make_pauli(n, x_bits, z_bits, (test_lcg(seed) & 1) != 0);
-        auto result = compress_pauli(ctx, pauli);
+        auto result = localize_pauli(ctx, pauli);
         ctx.virtual_frame.flush();
-        verify_sequential_compression(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
+        verify_sequential_localization(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
                                       result, bc_snap);
 
         // All-dormant should only emit frame opcodes
@@ -1073,7 +1073,7 @@ TEST_CASE("Lower: two T gates on same dormant Z-basis emit no EXPAND") {
 
 TEST_CASE("Lower: T after entanglement may require EXPAND") {
     // H 0; CX 0 1; T 0: the T gate's rewound Pauli is multi-qubit (X0*X1)
-    // because the CX entangled the qubits. After compression, the pivot
+    // because the CX entangled the qubits. After localization, the pivot
     // may land on a dormant X-basis qubit, requiring EXPAND.
     auto mod = compile_circuit("H 0\nCX 0 1\nT 0");
 
@@ -1240,7 +1240,7 @@ TEST_CASE("Lower: short postselection_mask only affects present indices") {
 
 TEST_CASE("Lower: ARRAY_ROTATION geometric artifact correction", "[backend][rotation]") {
     // Manually construct a ARRAY_ROTATION with a +Y Pauli on qubit 0.
-    // +Y compresses to -Z via the virtual frame, flipping result.sign.
+    // +Y localizes to -Z via the virtual frame, flipping result.sign.
     // The Back-End must correct global_weight for this geometric artifact.
     HirModule hir;
     hir.num_qubits = 1;
@@ -1251,7 +1251,7 @@ TEST_CASE("Lower: ARRAY_ROTATION geometric artifact correction", "[backend][rota
 
     auto mod = clifft::lower(hir);
 
-    // +Y compresses to -Z, so result.sign is true while op.sign() is false.
+    // +Y localizes to -Z, so result.sign is true while op.sign() is false.
     // The Back-End should apply a phase correction of e^{i * 0.5 * pi} = +i.
     CHECK_THAT(mod.constant_pool.global_weight.real(), Catch::Matchers::WithinAbs(0.0, 1e-12));
     CHECK_THAT(mod.constant_pool.global_weight.imag(), Catch::Matchers::WithinAbs(1.0, 1e-12));

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -90,8 +90,8 @@ static stim::Tableau<kStimWidth> bytecode_to_tableau(const std::vector<Instructi
 // Verify that V_cum P V_cum^dag is a single-qubit Pauli on the expected pivot.
 // Returns the localized PauliString for further inspection.
 static stim::PauliString<kStimWidth> verify_localization(CompilerContext& ctx,
-                                                        const stim::PauliString<kStimWidth>& input,
-                                                        const LocalizationResult& result) {
+                                                         const stim::PauliString<kStimWidth>& input,
+                                                         const LocalizationResult& result) {
     ctx.virtual_frame.flush();
     stim::PauliString<kStimWidth> localized = ctx.virtual_frame.materialized_tableau()(input);
     uint64_t cx = localized.xs.u64[0];
@@ -126,8 +126,8 @@ static stim::PauliString<kStimWidth> verify_localization(CompilerContext& ctx,
 // is updated correctly but the bytecode emission is wrong (e.g., swapped
 // control/target on a CNOT).
 static void verify_bytecode_localization(const CompilerContext& ctx,
-                                        const stim::PauliString<kStimWidth>& input,
-                                        const LocalizationResult& result) {
+                                         const stim::PauliString<kStimWidth>& input,
+                                         const LocalizationResult& result) {
     stim::Tableau<kStimWidth> tab =
         bytecode_to_tableau(ctx.bytecode, static_cast<uint32_t>(input.num_qubits));
     stim::PauliString<kStimWidth> localized = tab(input);
@@ -529,10 +529,10 @@ TEST_CASE("Localize: all-dormant heavy Pauli emits only frame opcodes") {
 // The local frame is: v_local = v_cum_before^{-1}.then(v_cum_after)
 // and v_local(input) should be the weight-1 localized Pauli.
 static void verify_sequential_localization(const CompilerContext& ctx,
-                                          const stim::Tableau<kStimWidth>& v_cum_before,
-                                          const stim::Tableau<kStimWidth>& v_cum_after,
-                                          const stim::PauliString<kStimWidth>& input,
-                                          const LocalizationResult& result, size_t bc_before) {
+                                           const stim::Tableau<kStimWidth>& v_cum_before,
+                                           const stim::Tableau<kStimWidth>& v_cum_after,
+                                           const stim::PauliString<kStimWidth>& input,
+                                           const LocalizationResult& result, size_t bc_before) {
     stim::Tableau<kStimWidth> v_local = v_cum_before.inverse().then(v_cum_after);
     stim::PauliString<kStimWidth> localized = v_local(input);
 
@@ -591,7 +591,7 @@ TEST_CASE("Localize: sequential localizations accumulate in V_cum") {
     auto r2 = localize_pauli(ctx, p2);
     ctx.virtual_frame.flush();
     verify_sequential_localization(ctx, snap1, ctx.virtual_frame.materialized_tableau(), p2, r2,
-                                  bc1);
+                                   bc1);
 
     // Snapshot v_cum before third localization.
     stim::Tableau<kStimWidth> snap2 = ctx.virtual_frame.materialized_tableau();
@@ -599,7 +599,7 @@ TEST_CASE("Localize: sequential localizations accumulate in V_cum") {
     auto r3 = localize_pauli(ctx, p3);
     ctx.virtual_frame.flush();
     verify_sequential_localization(ctx, snap2, ctx.virtual_frame.materialized_tableau(), p3, r3,
-                                  bc2);
+                                   bc2);
 
     // V_cum should be non-identity after multiple localizations.
     bool is_identity = true;
@@ -970,7 +970,7 @@ TEST_CASE("Localize sequential: 20 localizations on 20 qubits") {
         auto result = localize_pauli(ctx, pauli);
         ctx.virtual_frame.flush();
         verify_sequential_localization(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
-                                      result, bc_snap);
+                                       result, bc_snap);
     }
 }
 
@@ -999,7 +999,7 @@ TEST_CASE("Localize sequential: 30 localizations on 30 qubits all-active") {
         auto result = localize_pauli(ctx, pauli);
         ctx.virtual_frame.flush();
         verify_sequential_localization(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
-                                      result, bc_snap);
+                                       result, bc_snap);
     }
 }
 
@@ -1024,7 +1024,7 @@ TEST_CASE("Localize sequential: 30 localizations on 30 qubits all-dormant") {
         auto result = localize_pauli(ctx, pauli);
         ctx.virtual_frame.flush();
         verify_sequential_localization(ctx, snap, ctx.virtual_frame.materialized_tableau(), pauli,
-                                      result, bc_snap);
+                                       result, bc_snap);
 
         // All-dormant should only emit frame opcodes
         REQUIRE(all_frame_opcodes(ctx.bytecode));

--- a/tests/test_bytecode_passes.cc
+++ b/tests/test_bytecode_passes.cc
@@ -369,7 +369,7 @@ TEST_CASE("MultiGatePass: empty bytecode is a no-op", "[bytecode-pass]") {
 
 TEST_CASE("MULTI_CNOT: equivalent to sequential CNOTs", "[bytecode-pass][svm]") {
     // T gates activate the qubits into the statevector array.
-    // The measurement MPP Z0*Z1*Z2*Z3 forces compress_pauli to handle a pure Z-string.
+    // The measurement MPP Z0*Z1*Z2*Z3 forces localize_pauli to handle a pure Z-string.
     // It emits CNOTs that fold all Z bits onto a single pivot, natively generating
     // a sequence of contiguous ARRAY_CNOTs sharing a target.
     auto circuit = clifft::parse(
@@ -406,7 +406,7 @@ TEST_CASE("MULTI_CNOT: equivalent to sequential CNOTs", "[bytecode-pass][svm]") 
 
 TEST_CASE("MULTI_CZ: equivalent to sequential CZs", "[bytecode-pass][svm]") {
     // T gates activate the qubits.
-    // The measurement MPP X0*Z1*Z2*Z3 forces compress_pauli to handle an X-pivot
+    // The measurement MPP X0*Z1*Z2*Z3 forces localize_pauli to handle an X-pivot
     // with Z-residues. It clears the Z-residues by natively emitting a burst
     // of contiguous ARRAY_CZs sharing a control.
     auto circuit = clifft::parse(

--- a/tests/test_statevector.cc
+++ b/tests/test_statevector.cc
@@ -650,7 +650,7 @@ TEST_CASE("E2E: dense Clifford plus T on 4 qubits") {
 
 TEST_CASE("E2E: 5-qubit circuit with multiple T layers") {
     // Stress test: 5 qubits, deep entanglement, multiple non-Clifford layers.
-    // This exercises the virtual compressor on a non-trivial topology.
+    // This exercises the virtual localizer on a non-trivial topology.
     std::string circuit =
         "H 0\nH 1\nH 2\n"
         "CX 0 3\nCX 1 4\nCX 2 3\n"


### PR DESCRIPTION
## Summary
- Rename `compress_pauli` → `localize_pauli`, `CompressionResult` → `LocalizationResult`, `CompressedBasis` → `LocalizedBasis` to match the current "Pauli localization" terminology used elsewhere in the codebase.
- Update test helpers (`verify_compression`/`verify_bytecode_compression`/`verify_sequential_compression`), `TEST_CASE` labels (`Compress:` → `Localize:` and variants), `Lemma (Pauli Compression)` → `Lemma (Pauli Localization)`, and surrounding comments.
- Touch comment-only references in `svm_kernels.inl`, `AGENTS.md`, and Python test docstrings. Leave bytecode-compression-ratio mentions in `tools/profile` and `tools/bench` untouched (different concept).

## Test plan
- [x] `cmake --build build-tests --target clifft_tests` succeeds
- [x] `clifft_tests "[backend]"` passes
- [x] `clifft_tests "Localize*"` passes (51034 assertions, 34 cases)
- [x] `clifft_tests "Lower*"` passes (83 assertions, 27 cases)
- [x] Full test suite passes (113390 assertions in 650 cases)