### PR TITLE
chore: tighten test comments in svm/

### DIFF
--- a/tests/test_svm.cc
+++ b/tests/test_svm.cc
@@ -989,12 +989,9 @@ TEST_CASE("VM Gamma: Frame S accumulates i phase") {
         make_program({make_frame_s(0), make_frame_s(0), make_frame_s(0), make_frame_s(0)}, 2);
     execute(prog, state);
 
-    // Four applications of S with X error: gamma *= i four times = i^4 = 1
-    // But S also updates p_z each time. Let's trace:
-    // Start: p_x=1, p_z=0. S: gamma*=i, p_z^=1 -> p_z=1
-    // p_x=1, p_z=1. S: gamma*=i (now -1), p_z^=1 -> p_z=0
-    // p_x=1, p_z=0. S: gamma*=i (now -i), p_z^=1 -> p_z=1
-    // p_x=1, p_z=1. S: gamma*=i (now 1), p_z^=1 -> p_z=0
+    // S on X-error qubit: gamma *= i, then p_z ^= 1 (toggles per call).
+    // Start p_x=1, p_z=0. Four calls cycle gamma through i, -1, -i, 1
+    // and p_z through 1, 0, 1, 0.
     check_complex(state.gamma(), {1.0, 0.0});
     CHECK(state.p_z == NONE);
 }

--- a/tests/test_svm_avx512_axis01.cc
+++ b/tests/test_svm_avx512_axis01.cc
@@ -237,10 +237,7 @@ TEST_CASE("AVX512 axis01: U2 on axis 1 at rank 10") {
         orig[i] = state.v()[i];
     }
 
-    // Use a complex unitary to exercise real+imag paths:
-    // [[0.6+0.1i, -0.3+0.2i], [0.3+0.2i, 0.6-0.1i]] (approximately unitary)
-    // Actually use a proper unitary: e^{i*pi/4 * Y} = [[c, -s], [s, c]] with c,s complex
-    // Use T gate as the matrix: diag(1, e^{i*pi/4})
+    // T gate matrix diag(1, e^{i*pi/4}) -- complex m11 exercises real+imag paths.
     std::complex<double> m00 = {1.0, 0.0};
     std::complex<double> m01 = {0.0, 0.0};
     std::complex<double> m10 = {0.0, 0.0};


### PR DESCRIPTION
## Summary
- Drop the abandoned-unitary discussion in `tests/test_svm_avx512_axis01.cc` (the test ended up using the T gate; the prior attempts were noise).
- Replace the "Let's trace:" four-line expansion in `tests/test_svm.cc` with a two-sentence description of the gamma / p_z cycle.

The svm/ source files (`svm.{h,cc}`, `svm_state.cc`, `svm_internal.h`, `svm_math.h`, `svm_scalar.cc`, `svm_avx2.cc`, `svm_avx512.cc`, `svm_kernels.inl`) were reviewed in full — their comments are load-bearing (citations, SIMD layout details, mathematical derivations) and need no changes. This PR is the test-side cleanup flagged in the prior svm review.

## Test plan
- [x] `cmake --build build-tests --target clifft_tests` succeeds
- [x] Full ctest suite: 650/650 pass
- [x] `pre-commit run` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)