### PR TITLE
docs: make README URLs absolute so PyPI renders correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logos/clifft-logo-dark.png">
-    <img src="docs/assets/logos/clifft-logo-light.png" alt="Clifft" width="420">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/unitaryfoundation/clifft/main/docs/assets/logos/clifft-logo-dark.png">
+    <img src="https://raw.githubusercontent.com/unitaryfoundation/clifft/main/docs/assets/logos/clifft-logo-light.png" alt="Clifft" width="420">
   </picture>
 </p>
 
@@ -9,7 +9,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/clifft.svg)](https://pypi.org/project/clifft/)
 [![CI](https://github.com/unitaryfoundation/clifft/actions/workflows/ci.yml/badge.svg)](https://github.com/unitaryfoundation/clifft/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/unitaryfoundation/clifft/graph/badge.svg)](https://codecov.io/gh/unitaryfoundation/clifft)
-[![License](https://img.shields.io/github/license/unitaryfoundation/clifft.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/unitaryfoundation/clifft.svg)](https://github.com/unitaryfoundation/clifft/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://unitaryfoundation.github.io/clifft/)
 [![Discord](https://img.shields.io/badge/Discord-Unitary%20Foundation-orange.svg)](http://discord.unitary.foundation)
 
@@ -54,7 +54,7 @@ pip install clifft
 | Windows `amd64` | Supported |
 
 All other platforms and CPU families should build from source. See the
-[installation docs](docs/getting-started/installation.md#from-source).
+[installation docs](https://unitaryfoundation.github.io/clifft/getting-started/installation/#from-source).
 
 ## Quick Start
 
@@ -86,7 +86,7 @@ Citation information coming soon.
 
 ## Development
 
-See the [building from source](docs/development/building.md) guide for build
+See the [building from source](https://unitaryfoundation.github.io/clifft/development/building/) guide for build
 instructions.
 
 ## AI Acknowledgement


### PR DESCRIPTION
## Summary
Ahead of the next release: the project description on PyPI is built from `README.md`, but its renderer only resolves absolute URLs. Four references in the current README are relative and would 404 on the PyPI page:

| Was | Now |
|---|---|
| `srcset="docs/assets/logos/clifft-logo-dark.png"` | `https://raw.githubusercontent.com/unitaryfoundation/clifft/main/docs/assets/logos/clifft-logo-dark.png` |
| `src="docs/assets/logos/clifft-logo-light.png"` | `https://raw.githubusercontent.com/.../clifft-logo-light.png` |
| `[License](LICENSE)` | `https://github.com/unitaryfoundation/clifft/blob/main/LICENSE` |
| `[installation docs](docs/getting-started/installation.md#from-source)` | `https://unitaryfoundation.github.io/clifft/getting-started/installation/#from-source` |
| `[building from source](docs/development/building.md)` | `https://unitaryfoundation.github.io/clifft/development/building/` |

GitHub still resolves all of these; PyPI now renders them correctly.

## Caveats
PyPI's bleach allowlist strips `<source>` tags inside `<picture>`, so the dark-theme logo variant won't render on PyPI — only the light-theme `<img>` survives. GitHub continues to render both. Acceptable; addressing it would require dropping the `<picture>` block entirely or maintaining a PyPI-only README.

## Test plan
- [x] Rendered `README.md` locally through `readme_renderer[md]` (the library PyPI uses) — no relative paths remain in output, all four edited links/images appear with absolute URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)