### PR TITLE
fix(tsan): silence libomp false positives via ignore_noninstrumented_modules

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -20,7 +20,11 @@ jobs:
       CMAKE_GENERATOR: Ninja
       # TSan flags: compile and link with -fsanitize=thread.
       # Suppress known false positives from OpenMP runtime internals.
-      TSAN_OPTIONS: "suppressions=${{ github.workspace }}/tools/tsan/suppressions.txt second_deadlock_stack=1"
+      # ignore_noninstrumented_modules=1 silences races whose top frame is in
+      # an uninstrumented library (libomp here); the runner's libomp lacks
+      # resolvable symbols so the name-based race:__kmp_* suppressions in
+      # tools/tsan/suppressions.txt cannot match on their own.
+      TSAN_OPTIONS: "suppressions=${{ github.workspace }}/tools/tsan/suppressions.txt second_deadlock_stack=1 ignore_noninstrumented_modules=1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Nightly Thread Sanitizer run [25148505691](https://github.com/unitaryfoundation/clifft/actions/runs/25148505691) failed with 4 identical data-race reports, all inside libomp's internal pthread bookkeeping:

```
WARNING: ThreadSanitizer: data race
  Atomic read of size 1 ... in pthread_mutex_lock  ← main thread
  Previous write of size 1 ... in pthread_mutex_init  ← libomp worker T2
  Location is heap block ... allocated by libomp.so.5+0x20deb
  Thread T2 created by libomp.so.5+0xb8f46
```

The four affected tests are exactly the OpenMP determinism / high-rank tests (645–648), which is where libomp first spins up its thread pool and TSan first sees the per-worker mutex init/lock interplay.

### Why the existing suppressions don't catch it

`tools/tsan/suppressions.txt` lists `race:__kmp_resume_64`, `race:__kmp_create_worker`, etc. — those are name-based and require the symbolizer to actually name a frame. On the `ubuntu-24.04` runner, libomp ships without resolvable symbols, so every frame outside `pthread_*` shows as `<null>` from `libomp.so.5+OFFSET` and `race:__kmp_*` never matches.

### Fix

TSan literally suggests the fix in its own warning text:

> please export `TSAN_OPTIONS='ignore_noninstrumented_modules=1'` to avoid false positive reports from the OpenMP runtime!

Appended `ignore_noninstrumented_modules=1` to `TSAN_OPTIONS` in `.github/workflows/tsan.yml`. This drops races whose top frame lives in an uninstrumented library (libomp here), while real races in clifft code — even when called from inside an OMP parallel region — still surface, because their top frame is in instrumented clifft code.

## Test plan

- [ ] Re-run the Thread Sanitizer workflow (manual `workflow_dispatch`) and confirm tests 645–648 pass.
- [ ] Confirm next scheduled nightly is green.