### PR TITLE
docs: use docs group for mkdocs recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -188,11 +188,11 @@ test-wasm:
 
 # Serve docs locally with live reload
 docs-serve:
-  uv run mkdocs serve -a 0.0.0.0:8000
+  uv run --only-group docs mkdocs serve -a 0.0.0.0:8000
 
 # Build docs to site/
 docs-build:
-  uv run mkdocs build --strict
+  uv run --only-group docs mkdocs build --strict
 
 # -------------------------
 # Playground


### PR DESCRIPTION
## Summary

Updates the local MkDocs just recipes to use `uv run --only-group docs`, matching the docs CI workflow. This lets `just docs-build` and `just docs-serve` avoid building the editable C++ package when only documentation dependencies are needed.

## Test plan

- [ ] C++ tests pass (`ctest --test-dir build --output-on-failure`)
- [ ] Python tests pass (`uv run pytest tests/python/ -v`)
- [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [x] Docs build passes (`just docs-build`)

## Contributor agreement

- [x] I confirm this contribution is my original work or I have the right to submit it and I license it under this project Apache-2.0 license.
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.