### PR TITLE
Fix unresolved playground links in docs

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -149,7 +149,7 @@ cmake -B build
 
 ## WebAssembly Build
 
-For the browser-based [Playground](../playground/):
+For the browser-based [Playground]({{ playground_url }}):
 
 ```bash
 # Requires Docker
@@ -157,7 +157,7 @@ just build-wasm
 just test-wasm
 ```
 
-Outputs `playground/public/clifft_wasm.{js,wasm}`. See the [Playground](../playground/) page.
+Outputs `playground/public/clifft_wasm.{js,wasm}`. See the [Playground]({{ playground_url }}) page.
 
 ## IDE Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,4 +81,4 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 
 [Install Clifft](getting-started/installation.md){ .md-button .md-button--primary }
 
-[Try the Playground](playground/){ .md-button }
+[Try the Playground]({{ playground_url }}){ .md-button }

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -32,6 +32,9 @@ def define_env(env: Any) -> None:
             opcodes_by_category[cat] = []
         opcodes_by_category[cat].append(entry)
 
+    site_url = env.conf["site_url"].rstrip("/")
+    env.variables["playground_url"] = f"{site_url}/playground/"
+
     env.variables["opcodes"] = opcodes
     env.variables["opcode_categories"] = [
         c for c in opcode_categories_order if opcodes_by_category.get(c)

--- a/docs/reference/instructions.md
+++ b/docs/reference/instructions.md
@@ -5,7 +5,7 @@ levels of the pipeline: the **Heisenberg IR** (HIR) produced by the front-end,
 and the **VM Opcodes** (bytecode) executed by the Schrodinger Virtual Machine.
 
 The same data powers the hover tooltips in the
-[Playground](../playground/).
+[Playground]({{ playground_url }}).
 
 !!! tip "Playground Tooltips"
     In the Playground, hover over any opcode or HIR keyword to see

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Clifft
-site_url: https://unitaryfoundation.github.io/clifft/
+site_url: !ENV [SITE_URL, "https://unitaryfoundation.github.io/clifft/"]
 repo_url: https://github.com/unitaryfoundation/clifft
 repo_name: unitaryfoundation/clifft
 copyright: Copyright &copy; 2026 <a href="https://unitary.foundation" target="_blank">Unitary Foundation</a>


### PR DESCRIPTION
## Summary

- Add a docs macro for the hosted playground URL.
- Allow `SITE_URL` to override MkDocs `site_url` for PR preview builds.
- Update playground links in docs to use the resolved hosted URL instead of unresolved relative paths.

Fixes #33

## Test plan

- [ ] C++ tests pass (`ctest --test-dir build --output-on-failure`)
- [ ] Python tests pass (`uv run pytest tests/python/ -v`)
- [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [ ] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [x] Docs build passes (`python3 -m uv run --only-group docs mkdocs build --strict`)
- [x] Docs build passes with preview URL override (`SITE_URL=https://unitaryfoundation.github.io/clifft/pr-preview/pr-123/ python3 -m uv run --only-group docs mkdocs build --strict`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
