### PR TITLE
test: add baseline benchmarks for runtime-qubit migration

### DIFF
--- a/tests/test_benchmarks.cc
+++ b/tests/test_benchmarks.cc
@@ -21,8 +21,11 @@
 #include "clifft/optimizer/swap_meas_pass.h"
 #include "clifft/svm/svm.h"
 
+#include "stim.h"
+
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <sstream>
 #include <string>
 
 using namespace clifft;
@@ -36,9 +39,8 @@ static std::string fixture(const char* name) {
     return std::string(CLIFFT_FIXTURES_DIR) + "/" + name;
 }
 
-// Compile a circuit file through the full optimizer pipeline.
-static CompiledModule compile_circuit(const std::string& path) {
-    auto circuit = parse_file(path);
+// Compile a parsed Circuit through the full optimizer pipeline.
+static CompiledModule compile_parsed(Circuit circuit) {
     auto hir = trace(circuit);
     HirPassManager pm;
     pm.add_pass(std::make_unique<PeepholeFusionPass>());
@@ -53,6 +55,49 @@ static CompiledModule compile_circuit(const std::string& path) {
     bpm.add_pass(std::make_unique<SingleAxisFusionPass>());
     bpm.run(mod);
     return mod;
+}
+
+static CompiledModule compile_circuit(const std::string& path) {
+    return compile_parsed(parse_file(path));
+}
+
+static CompiledModule compile_text(const std::string& text) {
+    return compile_parsed(parse(text));
+}
+
+// Generate a rotated-Z-memory surface code circuit with uniform noise via Stim.
+static std::string surface_code_text(uint32_t distance, uint64_t rounds, double p) {
+    stim::CircuitGenParameters params(rounds, distance, "rotated_memory_z");
+    params.before_round_data_depolarization = p;
+    params.before_measure_flip_probability = p;
+    params.after_clifford_depolarization = p;
+    params.after_reset_flip_probability = p;
+    return stim::generate_surface_code_circuit(params).circuit.str();
+}
+
+// EXP_VAL-heavy synthetic circuit: prepares a Clifford state on n qubits,
+// then evaluates `num_probes` weight-3 multi-Pauli expectation values per shot.
+// Stays at peak_rank=0 (fully Clifford prep) so the cost is dominated by the
+// EXP_VAL frame-conjugation path.
+static std::string exp_val_heavy_text(uint32_t num_qubits, uint32_t num_probes) {
+    std::ostringstream s;
+    for (uint32_t q = 0; q < num_qubits; ++q)
+        s << "H " << q << "\n";
+    for (uint32_t i = 0; i + 1 < num_qubits; ++i)
+        s << "CX " << i << " " << (i + 1) << "\n";
+    static constexpr const char* kBasis[3] = {"X", "Y", "Z"};
+    for (uint32_t i = 0; i < num_probes; ++i) {
+        uint32_t q1 = i % num_qubits;
+        uint32_t q2 = (i * 7 + 3) % num_qubits;
+        uint32_t q3 = (i * 11 + 5) % num_qubits;
+        if (q2 == q1)
+            q2 = (q2 + 1) % num_qubits;
+        if (q3 == q1 || q3 == q2)
+            q3 = (q3 + 2) % num_qubits;
+        s << "EXP_VAL " << kBasis[i % 3] << q1 << "*" << kBasis[(i / 3) % 3] << q2 << "*"
+          << kBasis[(i / 9) % 3] << q3 << "\n";
+    }
+    return s.str();
 }
 
 // ---------------------------------------------------------------------------
@@ -79,5 +124,47 @@ TEST_CASE("Bench: cultivation d5 sampling 1000 shots", "[bench]") {
 
     BENCHMARK("cultivation-d5 x1000 shots") {
         return sample_survivors(mod, 1000, 0, false);
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Surface code d=7 r=7 p=1e-3: paper QEC throughput benchmark.
+// ~118 qubits, fully Clifford (peak_rank=0), low noise so most NOISE sites
+// stay silent. Throughput dominated by frame opcodes and the gap-sampler.
+// ---------------------------------------------------------------------------
+TEST_CASE("Bench: surface d7 r7 p1e-3 sampling 10000 shots", "[bench]") {
+    auto mod = compile_text(surface_code_text(7, 7, 1e-3));
+    REQUIRE(mod.peak_rank == 0);
+    REQUIRE(mod.num_qubits <= 128);
+
+    BENCHMARK("surface-d7-r7 p=1e-3 x10000 shots") {
+        return sample(mod, 10000, 0);
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Surface code d=5 r=5 with high physical noise (p=0.05): forces most NOISE
+// sites to fire, exercising the APPLY_PAULI / NOISE full-mask XOR + popcount
+// path. Throughput is dominated by the per-fire mask composition.
+// ---------------------------------------------------------------------------
+TEST_CASE("Bench: surface d5 r5 high-noise APPLY_PAULI heavy", "[bench]") {
+    auto mod = compile_text(surface_code_text(5, 5, 0.05));
+
+    BENCHMARK("surface-d5-r5 p=0.05 x10000 shots") {
+        return sample(mod, 10000, 0);
+    };
+}
+
+// ---------------------------------------------------------------------------
+// EXP_VAL heavy: 20 qubits, 200 weight-3 multi-Pauli probes per shot.
+// Exercises exec_exp_val (frame conjugation + dormant/active split). Each
+// probe walks the full mask twice (popcount of x & p_z, z & p_x).
+// ---------------------------------------------------------------------------
+TEST_CASE("Bench: EXP_VAL 20q 200 probes", "[bench]") {
+    auto mod = compile_text(exp_val_heavy_text(20, 200));
+    REQUIRE(mod.num_exp_vals == 200);
+
+    BENCHMARK("exp-val 20q 200 probes x100000 shots") {
+        return sample(mod, 100000, 0);
     };
 }


### PR DESCRIPTION
## Summary

PR0 of the issue #45 staged migration. Adds three Catch2 benches targeting the hot paths affected by the upcoming runtime-Pauli-mask change, so PR1+ can be compared against a frozen baseline.

- `surface-d7-r7 p=1e-3 x10000 shots` — n=118, fully Clifford. Frame opcodes + gap-sampler dominate.
- `surface-d5-r5 p=0.05 x10000 shots` — forces most NOISE sites to fire. Exercises the full-mask `APPLY_PAULI` XOR + popcount path.
- `exp-val 20q 200 probes x100000 shots` — stresses `exec_exp_val` (frame conjugation + dormant/active split). Each probe walks the full mask twice.

Surface code circuits are generated programmatically via Stim's `generate_surface_code_circuit`, so no `.stim` fixtures are checked in. The EXP_VAL circuit is synthesized inline.

No behavior change. Existing `QV-10` and `cultivation-d5` benches are untouched.

## Baseline (n=10 samples, this dev machine, `CLIFFT_MAX_QUBITS=128`, Release build)

| Benchmark | Mean | Std Dev |
|---|---:|---:|
| `QV-10 x100 shots` | 24.74 ms | 0.16 ms |
| `cultivation-d5 x1000 shots` | 38.95 ms | 0.16 ms |
| `surface-d7-r7 p=1e-3 x10000 shots` | 71.74 ms | 0.82 ms |
| `surface-d5-r5 p=0.05 x10000 shots` | 81.68 ms | 0.27 ms |
| `exp-val 20q 200 probes x100000 shots` | 138.59 ms | 1.28 ms |

These are the numbers PR1+ will be compared against. Larger surface codes (d=9, d=11, d=15 — n=188, 274, 494) are deferred to a later PR in the migration since they exceed the current 128-qubit compile-time ceiling.

## Test plan

- [x] `cmake --build build/cmake --target clifft_tests`
- [x] `build/cmake/tests/clifft_tests "[bench]" --benchmark-samples 10` — all 5 cases pass.
- [x] `uv tool run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)