### PR TITLE
ci: skip Catch2 benches in Debug build-and-test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,8 @@ jobs:
             --build-config ${{ env.CMAKE_BUILD_TYPE }} \
             --output-on-failure \
             --parallel \
-            --timeout 300
+            --timeout 300 \
+            -E "Bench"
         shell: bash
 
       - name: Run C++ tests (scalar ISA)


### PR DESCRIPTION
## Summary

The default-ISA Linux step in `build-and-test` runs Catch2 `[bench]` cases on every push, adding several minutes per CI run. The scalar/avx2 reruns and the cross-platform job already filter them out with `-E "Bench"`; this aligns the default-ISA step with the rest.

Debug-build benchmark timings are not a useful regression signal anyway — Catch2 measurements in Debug differ from Release by 10x or more on the hot loops in this project. Issue #38 will add a separate scheduled Release-mode workflow for performance history. Until then, perf comparisons should happen locally in Release.

Related to issue #45 (runtime qubit count migration). The migration's per-PR perf checks need trustworthy Release-mode baselines, which CI does not currently provide.

## Test plan

- [x] `uv tool run pre-commit run --all-files`
- [x] Verify CI: default-ISA step no longer runs `Bench:` test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)