### PR TITLE
feat: migrate AOT-side Pauli mask storage to runtime-width arenas

### DIFF
--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -348,8 +348,8 @@ void emit_swap(CompilerContext& ctx, uint16_t a, uint16_t b) {
 }
 
 // Map an HIR Pauli (at t=0) into the current virtual frame.
-stim::PauliString<kStimWidth> map_to_virtual(CompilerContext& ctx, const PauliBitMask& destab_mask,
-                                             const PauliBitMask& stab_mask, bool sign, uint32_t n) {
+stim::PauliString<kStimWidth> map_to_virtual(CompilerContext& ctx, MaskView destab_mask,
+                                             MaskView stab_mask, bool sign, uint32_t n) {
     return ctx.virtual_frame.map_pauli(destab_mask, stab_mask, sign, n);
 }
 
@@ -420,10 +420,15 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
     const uint32_t n = ctx.reg_manager.num_qubits();
     const uint32_t words = (n + 63) / 64;
 
-    PauliBitMask x_bits, z_bits;
-    MutableMaskView x_view = mut_view(x_bits);
-    MutableMaskView z_view = mut_view(z_bits);
-    for (uint32_t w = 0; w < words && w < kMaxInlineWords; ++w) {
+    // Runtime-width scratch storage. PauliBitMask (BitMask<128>) would
+    // truncate the input for circuits with n > kMaxInlineQubits, hiding
+    // bits in qubits 128+ and producing a spuriously-empty Pauli that
+    // tripped the identity-Pauli assertion below.
+    std::vector<uint64_t> x_bits(words, 0);
+    std::vector<uint64_t> z_bits(words, 0);
+    MutableMaskView x_view{std::span<uint64_t>(x_bits)};
+    MutableMaskView z_view{std::span<uint64_t>(z_bits)};
+    for (uint32_t w = 0; w < words; ++w) {
         x_view.words[w] = pauli.xs.u64[w];
         z_view.words[w] = pauli.zs.u64[w];
     }
@@ -451,8 +456,8 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
         // Z propagation: Z_t -> Z_c Z_t, so z_pivot ^= z_q.
         // Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1).
         // Here x_pivot=1, x_q=1, so: sign ^= z_q & z_pivot.
-        PauliBitMask to_clear_x_buf = x_bits;
-        MutableMaskView to_clear_x = mut_view(to_clear_x_buf);
+        std::vector<uint64_t> to_clear_x_buf(x_bits);
+        MutableMaskView to_clear_x{std::span<uint64_t>(to_clear_x_buf)};
         to_clear_x.bit_set(pivot, false);
         while (!to_clear_x.is_zero()) {
             uint32_t q = to_clear_x.lowest_bit();
@@ -468,8 +473,8 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
         // Z-localization: CZ(pivot, q) clears residual Z_q.
         // Sign rule: CZ(a,b) flips sign iff x_a & x_b & (z_a ^ z_b).
         // Here x_q=0 (already cleared), so sign NEVER flips.
-        PauliBitMask to_clear_z_buf = z_bits;
-        MutableMaskView to_clear_z = mut_view(to_clear_z_buf);
+        std::vector<uint64_t> to_clear_z_buf(z_bits);
+        MutableMaskView to_clear_z{std::span<uint64_t>(to_clear_z_buf)};
         to_clear_z.bit_set(pivot, false);
         while (!to_clear_z.is_zero()) {
             uint32_t q = to_clear_z.lowest_bit();
@@ -497,8 +502,8 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
         // Z-localization: CNOT(q -> pivot) folds Z_q onto pivot.
         // Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1).
         // Here x_c=x_q=0, so sign NEVER flips.
-        PauliBitMask to_clear_z_buf = z_bits;
-        MutableMaskView to_clear_z = mut_view(to_clear_z_buf);
+        std::vector<uint64_t> to_clear_z_buf(z_bits);
+        MutableMaskView to_clear_z{std::span<uint64_t>(to_clear_z_buf)};
         to_clear_z.bit_set(pivot, false);
         while (!to_clear_z.is_zero()) {
             uint32_t q = to_clear_z.lowest_bit();
@@ -526,9 +531,49 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
     using internal::LocalizedBasis;
 
     const uint32_t n = hir.num_qubits;
+    // Two ceilings:
+    //   - kMaxInlineQubits: SVM frame storage (state.p_x / p_z) is still a
+    //     fixed-width BitMask<kMaxInlineQubits>, so any conditional Pauli
+    //     or noise channel touching higher qubits would be silently dropped
+    //     at execution time. Lifting this requires runtime-width SVM frame
+    //     storage (planned for the next migration PR).
+    //   - 65536: bytecode axis operands are uint16_t. trace() enforces
+    //     this; lower() repeats the check defensively.
+    if (n > kMaxInlineQubits) {
+        throw std::runtime_error(
+            "Circuit num_qubits (" + std::to_string(n) + ") exceeds the SVM frame width (" +
+            std::to_string(kMaxInlineQubits) +
+            "). The HIR supports wider circuits but the runtime frame does not yet; "
+            "lifting this gate is the subject of a follow-up migration PR.");
+    }
+    if (n > 65536) {
+        throw std::runtime_error("Circuit exceeds 65536-qubit VM axis limit: " + std::to_string(n) +
+                                 " qubits");
+    }
     CompilerContext ctx(n);
     uint32_t det_emit_idx = 0;
     uint32_t total_meas_slots = hir.num_measurements + hir.num_hidden_measurements;
+
+    // Pre-size ConstantPool arenas. CONDITIONAL_PAULI emits exactly one
+    // OP_APPLY_PAULI per op; EXP_VAL emits exactly one OP_EXP_VAL. Each
+    // HIR noise channel maps into one ConstantPool channel slot.
+    size_t num_apply_paulis = 0;
+    size_t num_exp_val_masks = 0;
+    for (const auto& op : hir.ops) {
+        if (op.op_type() == OpType::CONDITIONAL_PAULI)
+            ++num_apply_paulis;
+        else if (op.op_type() == OpType::EXP_VAL)
+            ++num_exp_val_masks;
+    }
+    size_t num_noise_channels = 0;
+    for (const auto& site : hir.noise_sites)
+        num_noise_channels += site.channels.size();
+    ctx.constant_pool.pauli_masks = PauliMaskArena(n, num_apply_paulis);
+    ctx.constant_pool.exp_val_masks = PauliMaskArena(n, num_exp_val_masks);
+    ctx.constant_pool.noise_channel_masks = PauliMaskArena(n, num_noise_channels);
+    size_t next_cp_pauli = 0;
+    size_t next_cp_exp_val = 0;
+    size_t next_cp_noise = 0;
 
     bool has_source_map = hir.source_map.size() == hir.ops.size();
     bool has_postselection = false;
@@ -539,7 +584,8 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
 
         switch (op.op_type()) {
             case OpType::T_GATE: {
-                auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
+                auto p_v =
+                    map_to_virtual(ctx, hir.destab_mask(op), hir.stab_mask(op), hir.sign(op), n);
                 auto result = localize_pauli(ctx, p_v);
 
                 route_to_active_z(ctx, result);
@@ -568,22 +614,23 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
 
             case OpType::PHASE_ROTATION: {
                 double alpha = op.alpha();
-                auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
+                auto p_v =
+                    map_to_virtual(ctx, hir.destab_mask(op), hir.stab_mask(op), hir.sign(op), n);
                 auto result = localize_pauli(ctx, p_v);
 
                 route_to_active_z(ctx, result);
 
                 // The Front-End unconditionally extracted the physical global phase.
                 // If localize_pauli dynamically flipped the geometric sign
-                // (result.sign != op.sign()), correct the global phase artifact
+                // (result.sign != hir.sign(op)), correct the global phase artifact
                 // left behind by the VM's diagonal factorization.
-                if (result.sign != op.sign()) {
-                    double corr = op.alpha() * std::numbers::pi * (op.sign() ? -1.0 : 1.0);
+                if (result.sign != hir.sign(op)) {
+                    double corr = op.alpha() * std::numbers::pi * (hir.sign(op) ? -1.0 : 1.0);
                     ctx.constant_pool.global_weight *=
                         std::complex<double>(std::cos(corr), std::sin(corr));
                 }
 
-                // result.sign absorbs both the original op.sign() and any
+                // result.sign absorbs both the original hir.sign(op) and any
                 // localization flips.
                 if (result.sign)
                     alpha = -alpha;
@@ -601,16 +648,23 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
             case OpType::MEASURE: {
                 uint32_t classical_idx = static_cast<uint32_t>(op.meas_record_idx());
 
-                auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
+                auto p_v =
+                    map_to_virtual(ctx, hir.destab_mask(op), hir.stab_mask(op), hir.sign(op), n);
 
-                PauliBitMask pv_x, pv_z;
-                uint32_t pv_words = (n + 63) / 64;
-                for (uint32_t w = 0; w < pv_words && w < kMaxInlineWords; ++w) {
-                    pv_x.w[w] = p_v.xs.u64[w];
-                    pv_z.w[w] = p_v.zs.u64[w];
+                // Identity Pauli check: walk the full mapped width directly,
+                // not through a fixed-width PauliBitMask intermediate (which
+                // would silently treat any high-qubit-only support as zero
+                // and emit a deterministic measurement).
+                const uint32_t pv_words = (n + 63) / 64;
+                bool is_identity = true;
+                for (uint32_t w = 0; w < pv_words; ++w) {
+                    if (p_v.xs.u64[w] != 0 || p_v.zs.u64[w] != 0) {
+                        is_identity = false;
+                        break;
+                    }
                 }
-                if ((pv_x | pv_z).is_zero()) {
-                    // Identity Pauli: outcome is determined solely by the sign
+                if (is_identity) {
+                    // Identity Pauli: outcome is determined solely by the sign.
                     Instruction id_meas =
                         make_meas(Opcode::OP_MEAS_DORMANT_STATIC, 0, classical_idx, p_v.sign);
                     id_meas.flags |= Instruction::FLAG_IDENTITY;
@@ -664,22 +718,18 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
             }
 
             case OpType::CONDITIONAL_PAULI: {
-                auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
+                auto p_v =
+                    map_to_virtual(ctx, hir.destab_mask(op), hir.stab_mask(op), hir.sign(op), n);
 
-                PauliMask pm;
-                uint32_t pm_words = (n + 63) / 64;
-                for (uint32_t w = 0; w < pm_words && w < kMaxInlineWords; ++w) {
-                    pm.x.w[w] = p_v.xs.u64[w];
-                    pm.z.w[w] = p_v.zs.u64[w];
-                }
-                pm.sign = p_v.sign;
-
-                uint32_t cp_idx = static_cast<uint32_t>(ctx.constant_pool.pauli_masks.size());
-                ctx.constant_pool.pauli_masks.push_back(pm);
+                auto cp_handle = static_cast<PauliMaskHandle>(next_cp_pauli++);
+                auto slot = ctx.constant_pool.pauli_masks.mut_at(cp_handle);
+                stim_to_mask_view(p_v.xs, n, slot.x());
+                stim_to_mask_view(p_v.zs, n, slot.z());
+                slot.set_sign(p_v.sign);
 
                 uint32_t cond_idx = static_cast<uint32_t>(op.controlling_meas());
 
-                ctx.emit(make_apply_pauli(cp_idx, cond_idx));
+                ctx.emit(make_apply_pauli(static_cast<uint32_t>(cp_handle), cond_idx));
                 break;
             }
 
@@ -690,7 +740,12 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
 
                 NoiseSite mapped_site;
                 for (const auto& ch : hir_site.channels) {
-                    mapped_site.channels.push_back(ctx.virtual_frame.map_noise_channel(ch, n));
+                    auto in_view = hir.noise_channel_masks.at(ch.mask);
+                    auto out_handle = static_cast<PauliMaskHandle>(next_cp_noise++);
+                    auto out_slot = ctx.constant_pool.noise_channel_masks.mut_at(out_handle);
+                    ctx.virtual_frame.map_noise_channel(in_view.x(), in_view.z(), out_slot.x(),
+                                                        out_slot.z(), n);
+                    mapped_site.channels.push_back(NoiseChannel{out_handle, ch.prob});
                 }
 
                 // Compute total channel probability for gap sampling
@@ -764,20 +819,17 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
             }
 
             case OpType::EXP_VAL: {
-                auto p_v = map_to_virtual(ctx, op.destab_mask(), op.stab_mask(), op.sign(), n);
+                auto p_v =
+                    map_to_virtual(ctx, hir.destab_mask(op), hir.stab_mask(op), hir.sign(op), n);
 
-                PauliMask pm;
-                uint32_t pm_words = (n + 63) / 64;
-                for (uint32_t w = 0; w < pm_words && w < kMaxInlineWords; ++w) {
-                    pm.x.w[w] = p_v.xs.u64[w];
-                    pm.z.w[w] = p_v.zs.u64[w];
-                }
-                pm.sign = p_v.sign;
+                auto cp_handle = static_cast<PauliMaskHandle>(next_cp_exp_val++);
+                auto slot = ctx.constant_pool.exp_val_masks.mut_at(cp_handle);
+                stim_to_mask_view(p_v.xs, n, slot.x());
+                stim_to_mask_view(p_v.zs, n, slot.z());
+                slot.set_sign(p_v.sign);
 
-                uint32_t cp_idx = static_cast<uint32_t>(ctx.constant_pool.exp_val_masks.size());
-                ctx.constant_pool.exp_val_masks.push_back(pm);
-
-                ctx.emit(make_exp_val(cp_idx, static_cast<uint32_t>(op.exp_val_idx())));
+                ctx.emit(make_exp_val(static_cast<uint32_t>(cp_handle),
+                                      static_cast<uint32_t>(op.exp_val_idx())));
                 break;
             }
 

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -203,15 +203,6 @@ enum class ExpectedParity : uint8_t { Zero = 0, One = 1 };
 // Heavy data referenced by index from Instructions. Kept separate to maintain
 // the 32-byte Instruction size constraint.
 
-/// Full Pauli mask stored in the ConstantPool for OP_APPLY_PAULI.
-/// Uses BitMask<kMaxInlineQubits> instead of stim::PauliString to avoid
-/// heap allocations on the VM execution hot path.
-struct PauliMask {
-    PauliBitMask x;
-    PauliBitMask z;
-    bool sign = false;
-};
-
 // Pre-computed 2x2 unitary for OP_ARRAY_U2 (single-axis CISC fusion).
 // For each of 4 possible incoming Pauli frame states on the target axis
 // ((p_z << 1) | p_x: 0=I, 1=X, 2=Z, 3=Y), stores the fused matrix,
@@ -255,16 +246,23 @@ struct ConstantPool {
     // Global scalar gamma accumulated during compilation
     std::complex<double> global_weight = {1.0, 0.0};
 
-    // Full N-bit Pauli masks for OP_APPLY_PAULI (indexed by cp_mask_idx)
-    std::vector<PauliMask> pauli_masks;
+    // Full N-bit Pauli masks for OP_APPLY_PAULI. Bytecode references slots
+    // by cp_mask_idx, treated as a PauliMaskHandle into this arena.
+    PauliMaskArena pauli_masks;
 
-    // Full N-bit Pauli masks for OP_EXP_VAL (indexed by cp_exp_val_idx).
-    // Separate from pauli_masks to avoid index collision between frame
-    // mutation (APPLY_PAULI) and read-only probing (EXP_VAL).
-    std::vector<PauliMask> exp_val_masks;
+    // Full N-bit Pauli masks for OP_EXP_VAL. Separate from pauli_masks to
+    // avoid index collision between frame mutation (APPLY_PAULI) and
+    // read-only probing (EXP_VAL).
+    PauliMaskArena exp_val_masks;
 
-    // Noise sites for OP_NOISE (virtual-frame-mapped channels)
+    // Noise sites for OP_NOISE (virtual-frame-mapped channels). Each
+    // NoiseChannel inside a NoiseSite carries a handle into
+    // noise_channel_masks below.
     std::vector<NoiseSite> noise_sites;
+
+    // Pauli mask arena for the (virtual-frame-mapped) noise channel
+    // masks referenced from noise_sites.
+    PauliMaskArena noise_channel_masks;
 
     // Readout noise entries for OP_READOUT_NOISE
     std::vector<ReadoutNoiseEntry> readout_noise;

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -141,16 +141,15 @@ class VirtualFrame {
         pending_gates_.clear();
     }
 
-    [[nodiscard]] stim::PauliString<kStimWidth> map_pauli(const PauliBitMask& destab_mask,
-                                                          const PauliBitMask& stab_mask, bool sign,
-                                                          uint32_t n) {
+    [[nodiscard]] stim::PauliString<kStimWidth> map_pauli(MaskView destab_mask, MaskView stab_mask,
+                                                          bool sign, uint32_t n) {
         maybe_flush();
 
         stim::PauliString<kStimWidth> p(n);
         uint32_t words = (n + 63) / 64;
-        for (uint32_t w = 0; w < words && w < kMaxInlineWords; ++w) {
-            p.xs.u64[w] = destab_mask.w[w];
-            p.zs.u64[w] = stab_mask.w[w];
+        for (uint32_t w = 0; w < words && w < destab_mask.num_words(); ++w) {
+            p.xs.u64[w] = destab_mask.words[w];
+            p.zs.u64[w] = stab_mask.words[w];
         }
         p.sign = sign;
 
@@ -158,43 +157,55 @@ class VirtualFrame {
         if (pending_gates_.empty())
             return mapped;
 
-        PauliBitMask x_out = stim_to_bitmask(mapped.xs, n);
-        PauliBitMask z_out = stim_to_bitmask(mapped.zs, n);
+        // Apply pending gates directly on the stim::PauliString's u64
+        // storage as runtime-width MaskViews. Restrict to the live `words`
+        // prefix; stim's simd_bits may pad above that.
         bool s_out = mapped.sign;
-        apply_pending_to_pauli(x_out, z_out, s_out);
-
-        for (uint32_t w = 0; w < words && w < kMaxInlineWords; ++w) {
-            mapped.xs.u64[w] = x_out.w[w];
-            mapped.zs.u64[w] = z_out.w[w];
-        }
+        MutableMaskView x_view{std::span<uint64_t>(mapped.xs.u64, words)};
+        MutableMaskView z_view{std::span<uint64_t>(mapped.zs.u64, words)};
+        apply_pending_to_pauli(x_view, z_view, s_out);
         mapped.sign = s_out;
         return mapped;
     }
 
-    [[nodiscard]] NoiseChannel map_noise_channel(const NoiseChannel& channel, uint32_t n) {
+    /// Map a noise channel's (X, Z) masks through the current virtual frame
+    /// and write the result into `out_x` and `out_z`. Sign is unused for
+    /// noise channels.
+    void map_noise_channel(MaskView in_x, MaskView in_z, MutableMaskView out_x,
+                           MutableMaskView out_z, uint32_t n) {
         maybe_flush();
 
-        PauliBitMask mapped_x, mapped_z;
-        PauliBitMask x_bits = channel.destab_mask;
-        while (!x_bits.is_zero()) {
-            uint32_t q = x_bits.lowest_bit();
-            mapped_x ^= stim_to_bitmask(materialized_.xs[q].xs, n);
-            mapped_z ^= stim_to_bitmask(materialized_.xs[q].zs, n);
-            x_bits.clear_lowest_bit();
+        out_x.zero_out();
+        out_z.zero_out();
+        const uint32_t words = (n + 63) / 64;
+
+        auto xor_row = [&](const stim::PauliString<kStimWidth>& row) {
+            for (uint32_t w = 0; w < words && w < out_x.num_words(); ++w) {
+                out_x.words[w] ^= row.xs.u64[w];
+                out_z.words[w] ^= row.zs.u64[w];
+            }
+        };
+
+        // Iterate set X-bits via a local copy.
+        std::vector<uint64_t> x_scratch(in_x.words.begin(), in_x.words.end());
+        MutableMaskView x_iter{std::span<uint64_t>(x_scratch)};
+        while (!x_iter.is_zero()) {
+            uint32_t q = x_iter.lowest_bit();
+            xor_row(materialized_.xs[q]);
+            x_iter.clear_lowest_bit();
         }
-        PauliBitMask z_bits = channel.stab_mask;
-        while (!z_bits.is_zero()) {
-            uint32_t q = z_bits.lowest_bit();
-            mapped_x ^= stim_to_bitmask(materialized_.zs[q].xs, n);
-            mapped_z ^= stim_to_bitmask(materialized_.zs[q].zs, n);
-            z_bits.clear_lowest_bit();
+        std::vector<uint64_t> z_scratch(in_z.words.begin(), in_z.words.end());
+        MutableMaskView z_iter{std::span<uint64_t>(z_scratch)};
+        while (!z_iter.is_zero()) {
+            uint32_t q = z_iter.lowest_bit();
+            xor_row(materialized_.zs[q]);
+            z_iter.clear_lowest_bit();
         }
 
         if (!pending_gates_.empty()) {
             bool dummy_sign = false;
-            apply_pending_to_pauli(mapped_x, mapped_z, dummy_sign);
+            apply_pending_to_pauli(out_x, out_z, dummy_sign);
         }
-        return {mapped_x, mapped_z, channel.prob};
     }
 
     [[nodiscard]] const stim::Tableau<kStimWidth>& materialized_tableau() const {
@@ -208,7 +219,7 @@ class VirtualFrame {
     }
 
   private:
-    static void apply_gate_to_pauli(const PendingGate& g, PauliBitMask& x, PauliBitMask& z,
+    static void apply_gate_to_pauli(const PendingGate& g, MutableMaskView x, MutableMaskView z,
                                     bool& sign) {
         bool xa = x.bit_get(g.axis_1);
         bool za = z.bit_get(g.axis_1);
@@ -255,7 +266,7 @@ class VirtualFrame {
         }
     }
 
-    void apply_pending_to_pauli(PauliBitMask& x, PauliBitMask& z, bool& sign) const {
+    void apply_pending_to_pauli(MutableMaskView x, MutableMaskView z, bool& sign) const {
         for (const auto& g : pending_gates_) {
             apply_gate_to_pauli(g, x, z, sign);
         }

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -349,6 +349,14 @@ size_t count_pauli_masks(const Circuit& circuit) {
 }  // namespace
 
 HirModule trace(const Circuit& circuit) {
+    // The downstream VM uses uint16_t axis operands, so anything above
+    // 65536 cannot be lowered. Reject early to avoid the cost of
+    // allocating a Stim TableauSimulator (~O(n^2) bits) we'll discard.
+    if (circuit.num_qubits > 65536) {
+        throw std::runtime_error("Circuit exceeds 65536-qubit VM axis limit: " +
+                                 std::to_string(circuit.num_qubits) + " qubits");
+    }
+
     HirModule hir(circuit.num_qubits, count_pauli_masks(circuit), count_noise_channels(circuit));
     hir.num_measurements = circuit.num_measurements;
     hir.num_detectors = circuit.num_detectors;

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -1,7 +1,5 @@
 #include "clifft/frontend/frontend.h"
 
-#include "clifft/util/config.h"
-
 #include "stim.h"
 
 #include <cmath>
@@ -14,16 +12,15 @@ namespace clifft {
 
 namespace {
 
-// Helper to apply a single-qubit Clifford gate to the simulator.
-// We directly prepend to inv_state for O(n) performance instead of going through
-// safe_do_circuit() which has significant overhead (Circuit allocation, string lookup).
-// Since we only need the inverse tableau for Heisenberg rewinding, this is safe.
+// Apply a single-qubit Clifford to the rewinding inverse tableau.
+// We prepend directly to inv_state for O(n) performance (safe_do_circuit
+// has Circuit-allocation + string-lookup overhead). Heisenberg rewinding
+// only needs the inverse tableau, so this is safe.
 void apply_single_qubit_clifford(stim::TableauSimulator<kStimWidth>& sim, GateType gate,
                                  uint32_t qubit) {
-    // Fast path for high-frequency gates using Stim's native inline methods.
-    // We prepend to inv_state, so we need the INVERSE of each gate.
-    // Self-inverse gates (H, X, Y, Z) are unchanged; S and S_DAG swap.
     size_t q = static_cast<size_t>(qubit);
+    // Fast path for high-frequency gates. We prepend, so we need the INVERSE
+    // of each gate. Self-inverse gates (H, X, Y, Z) are unchanged; S↔S_DAG.
     switch (gate) {
         case GateType::H:
             sim.inv_state.prepend_H_XZ(q);
@@ -52,13 +49,13 @@ void apply_single_qubit_clifford(stim::TableauSimulator<kStimWidth>& sim, GateTy
     sim.inv_state.inplace_scatter_prepend(inv_tab, {q});
 }
 
-// Helper to apply a two-qubit Clifford gate to the simulator.
-// Same optimization as single-qubit: direct prepend to inv_state.
+// Apply a two-qubit Clifford to the rewinding inverse tableau.
+// Same prepend-to-inv_state optimization as the single-qubit path.
 void apply_two_qubit_clifford(stim::TableauSimulator<kStimWidth>& sim, GateType gate, uint32_t q1,
                               uint32_t q2) {
-    // Fast path for high-frequency gates using Stim's native inline methods.
     size_t a = static_cast<size_t>(q1);
     size_t b = static_cast<size_t>(q2);
+    // Fast path for high-frequency gates.
     switch (gate) {
         case GateType::CX:
             sim.inv_state.prepend_ZCX(a, b);
@@ -75,95 +72,114 @@ void apply_two_qubit_clifford(stim::TableauSimulator<kStimWidth>& sim, GateType 
         default:
             break;
     }
-    // Generic path for the long tail of two-qubit Cliffords.
+    // Generic path.
     const auto& inv_gate = stim::GATE_DATA.at(gate_name(gate)).inverse();
     auto inv_tab = inv_gate.tableau<kStimWidth>();
     sim.inv_state.inplace_scatter_prepend(inv_tab, {a, b});
 }
 
-// Extract the rewound Z observable for a qubit as PauliBitMask masks
-void extract_rewound_z(const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
-                       PauliBitMask& destab_mask, PauliBitMask& stab_mask, bool& sign) {
+/// Write the rewound Z observable for `qubit` into pre-zeroed MutableMaskViews.
+void extract_rewound_z_into(const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
+                            MutableMaskView destab, MutableMaskView stab, bool& sign) {
     const auto& pauli = sim.inv_state.zs[qubit];
     uint32_t n = sim.inv_state.num_qubits;
-    destab_mask = stim_to_bitmask(pauli.xs, n);
-    stab_mask = stim_to_bitmask(pauli.zs, n);
+    stim_to_mask_view(pauli.xs, n, destab);
+    stim_to_mask_view(pauli.zs, n, stab);
     sign = pauli.sign;
 }
 
-// Extract the rewound X observable for a qubit as PauliBitMask masks
-void extract_rewound_x(const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
-                       PauliBitMask& destab_mask, PauliBitMask& stab_mask, bool& sign) {
+/// Write the rewound X observable for `qubit` into pre-zeroed MutableMaskViews.
+void extract_rewound_x_into(const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
+                            MutableMaskView destab, MutableMaskView stab, bool& sign) {
     const auto& pauli = sim.inv_state.xs[qubit];
     uint32_t n = sim.inv_state.num_qubits;
-    destab_mask = stim_to_bitmask(pauli.xs, n);
-    stab_mask = stim_to_bitmask(pauli.zs, n);
+    stim_to_mask_view(pauli.xs, n, destab);
+    stim_to_mask_view(pauli.zs, n, stab);
     sign = pauli.sign;
 }
 
-// Accumulate bitmasks from a single-qubit Pauli generator's tableau row.
-// For X (type=1): read xs[q]; for Z (type=3): read zs[q]; for Y (type=2): XOR both rows.
-// Sign is irrelevant for noise channels since E and -E are physically identical.
+/// Write the rewound Y observable for `qubit` into pre-zeroed MutableMaskViews.
+void extract_rewound_y_into(const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
+                            MutableMaskView destab, MutableMaskView stab, bool& sign) {
+    auto pauli = sim.inv_state.y_output(qubit);
+    uint32_t n = sim.inv_state.num_qubits;
+    stim_to_mask_view(pauli.xs, n, destab);
+    stim_to_mask_view(pauli.zs, n, stab);
+    sign = pauli.sign;
+}
+
+/// Copy a rewound stim::PauliString into pre-zeroed MutableMaskViews.
+void copy_rewound_into(const stim::PauliString<kStimWidth>& rewound, uint32_t n,
+                       MutableMaskView destab, MutableMaskView stab) {
+    stim_to_mask_view(rewound.xs, n, destab);
+    stim_to_mask_view(rewound.zs, n, stab);
+}
+
+/// XOR a single-qubit Pauli generator's tableau row into the destination
+/// views. pauli_type: 1=X, 2=Y, 3=Z. Sign is irrelevant for noise channels.
 void accumulate_pauli_row(const stim::Tableau<kStimWidth>& tab, uint32_t qubit, int pauli_type,
-                          uint32_t n, PauliBitMask& xs_out, PauliBitMask& zs_out) {
-    if (pauli_type == 1) {  // X
-        xs_out ^= stim_to_bitmask(tab.xs[qubit].xs, n);
-        zs_out ^= stim_to_bitmask(tab.xs[qubit].zs, n);
-    } else if (pauli_type == 3) {  // Z
-        xs_out ^= stim_to_bitmask(tab.zs[qubit].xs, n);
-        zs_out ^= stim_to_bitmask(tab.zs[qubit].zs, n);
-    } else if (pauli_type == 2) {  // Y = iXZ -> XOR both rows
-        xs_out ^= stim_to_bitmask(tab.xs[qubit].xs, n);
-        zs_out ^= stim_to_bitmask(tab.xs[qubit].zs, n);
-        xs_out ^= stim_to_bitmask(tab.zs[qubit].xs, n);
-        zs_out ^= stim_to_bitmask(tab.zs[qubit].zs, n);
+                          uint32_t n, MutableMaskView destab, MutableMaskView stab) {
+    const uint32_t words = (n + 63) / 64;
+    auto xor_row = [&](const stim::PauliString<kStimWidth>& row) {
+        for (uint32_t w = 0; w < words; ++w) {
+            destab.words[w] ^= row.xs.u64[w];
+            stab.words[w] ^= row.zs.u64[w];
+        }
+    };
+    if (pauli_type == 1 || pauli_type == 2) {
+        xor_row(tab.xs[qubit]);
+    }
+    if (pauli_type == 2 || pauli_type == 3) {
+        xor_row(tab.zs[qubit]);
     }
 }
 
-// Rewind a single-qubit Pauli (X, Y, or Z) through the tableau.
-// pauli_type: 1=X, 2=Y, 3=Z
-// Reads tableau rows directly instead of constructing a PauliString.
-NoiseChannel rewind_single_pauli(const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
-                                 int pauli_type, double prob) {
-    uint32_t n = sim.inv_state.num_qubits;
-    PauliBitMask xs{}, zs{};
-    accumulate_pauli_row(sim.inv_state, qubit, pauli_type, n, xs, zs);
-    return NoiseChannel{xs, zs, prob};
+/// Rewind a single-qubit Pauli (X, Y, or Z) through the tableau into a
+/// freshly claimed noise_channel_masks slot. Returns the channel.
+NoiseChannel rewind_single_pauli(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                 uint32_t qubit, int pauli_type, double prob) {
+    auto h = hir.claim_empty_noise_channel_mask();
+    auto slot = hir.noise_channel_masks.mut_at(h);
+    slot.x().zero_out();
+    slot.z().zero_out();
+    accumulate_pauli_row(sim.inv_state, qubit, pauli_type, sim.inv_state.num_qubits, slot.x(),
+                         slot.z());
+    return NoiseChannel{h, prob};
 }
 
-// Rewind a two-qubit Pauli through the tableau.
-// pauli1, pauli2: 0=I, 1=X, 2=Y, 3=Z
-// XORs tableau rows directly instead of constructing a PauliString.
-NoiseChannel rewind_two_qubit_pauli(const stim::TableauSimulator<kStimWidth>& sim, uint32_t q1,
-                                    uint32_t q2, int pauli1, int pauli2, double prob) {
+/// Rewind a two-qubit Pauli through the tableau into a freshly claimed slot.
+NoiseChannel rewind_two_qubit_pauli(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                    uint32_t q1, uint32_t q2, int pauli1, int pauli2, double prob) {
+    auto h = hir.claim_empty_noise_channel_mask();
+    auto slot = hir.noise_channel_masks.mut_at(h);
+    slot.x().zero_out();
+    slot.z().zero_out();
     uint32_t n = sim.inv_state.num_qubits;
-    PauliBitMask xs{}, zs{};
     if (pauli1 != 0)
-        accumulate_pauli_row(sim.inv_state, q1, pauli1, n, xs, zs);
+        accumulate_pauli_row(sim.inv_state, q1, pauli1, n, slot.x(), slot.z());
     if (pauli2 != 0)
-        accumulate_pauli_row(sim.inv_state, q2, pauli2, n, xs, zs);
-    return NoiseChannel{xs, zs, prob};
+        accumulate_pauli_row(sim.inv_state, q2, pauli2, n, slot.x(), slot.z());
+    return NoiseChannel{h, prob};
 }
 
-// Create a NoiseSite for a single-qubit noise channel.
-NoiseSite make_single_qubit_noise_site(const stim::TableauSimulator<kStimWidth>& sim, GateType gate,
+NoiseSite make_single_qubit_noise_site(HirModule& hir,
+                                       const stim::TableauSimulator<kStimWidth>& sim, GateType gate,
                                        uint32_t qubit, double prob) {
     NoiseSite site;
     switch (gate) {
         case GateType::X_ERROR:
-            site.channels.push_back(rewind_single_pauli(sim, qubit, 1, prob));
+            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 1, prob));
             break;
         case GateType::Y_ERROR:
-            site.channels.push_back(rewind_single_pauli(sim, qubit, 2, prob));
+            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 2, prob));
             break;
         case GateType::Z_ERROR:
-            site.channels.push_back(rewind_single_pauli(sim, qubit, 3, prob));
+            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 3, prob));
             break;
         case GateType::DEPOLARIZE1:
-            // DEP1(p) = X, Y, Z each with probability p/3
-            site.channels.push_back(rewind_single_pauli(sim, qubit, 1, prob / 3.0));
-            site.channels.push_back(rewind_single_pauli(sim, qubit, 2, prob / 3.0));
-            site.channels.push_back(rewind_single_pauli(sim, qubit, 3, prob / 3.0));
+            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 1, prob / 3.0));
+            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 2, prob / 3.0));
+            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 3, prob / 3.0));
             break;
         default:
             throw std::runtime_error("Not a single-qubit noise gate");
@@ -171,103 +187,186 @@ NoiseSite make_single_qubit_noise_site(const stim::TableauSimulator<kStimWidth>&
     return site;
 }
 
-// Create a NoiseSite for DEPOLARIZE2 on a qubit pair.
-// 15 channels: all non-II two-qubit Paulis, each with prob p/15.
-NoiseSite make_depolarize2_noise_site(const stim::TableauSimulator<kStimWidth>& sim, uint32_t q1,
-                                      uint32_t q2, double prob) {
+NoiseSite make_depolarize2_noise_site(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                      uint32_t q1, uint32_t q2, double prob) {
     NoiseSite site;
     double channel_prob = prob / 15.0;
-
-    // Enumerate all (p1, p2) where p1,p2 in {0,1,2,3} (I,X,Y,Z) excluding (0,0)
     for (int p1 = 0; p1 <= 3; ++p1) {
         for (int p2 = 0; p2 <= 3; ++p2) {
             if (p1 == 0 && p2 == 0)
-                continue;  // Skip II
-            site.channels.push_back(rewind_two_qubit_pauli(sim, q1, q2, p1, p2, channel_prob));
+                continue;
+            site.channels.push_back(rewind_two_qubit_pauli(hir, sim, q1, q2, p1, p2, channel_prob));
         }
     }
     return site;
 }
 
-// Accumulate the global phase for R_Z(alpha) into hir.global_weight.
-// R_Z(alpha) = exp(-i*alpha*pi/2 * Z) factors as:
-//   global: e^{-i*alpha*pi/2}
+// Accumulate the global phase contribution of R_Z(alpha) into hir.global_weight.
+// R_Z(alpha) = exp(-i*alpha*pi/2 * Z) factors as
+//   global:   e^{-i*alpha*pi/2}
 //   relative: diag(1, e^{i*alpha*pi})
+// This function tracks only the global piece; the relative phase is encoded
+// by the emitted PHASE_ROTATION op.
 void accumulate_rz_global_phase(HirModule& hir, double alpha) {
     double angle = -alpha * std::numbers::pi / 2.0;
     hir.global_weight *= std::complex<double>(std::cos(angle), std::sin(angle));
 }
 
-// Trace an R_Z(alpha) on a single qubit: extract rewound Z, emit PHASE_ROTATION,
-// accumulate global phase.
+// Trace R_Z(alpha) on a single qubit: extract the rewound Z, emit
+// PHASE_ROTATION, accumulate global phase.
 //
-// When sign is true the rewound Pauli is -Z, so the physical operator is
-// exp(-i*alpha*pi/2 * (-Z)) = exp(+i*alpha*pi/2 * Z), whose global phase
-// is e^{+i*alpha*pi/2}.  We pass the sign-adjusted alpha to the global
-// phase accumulator so the tracked phase is always correct.
-void trace_rz(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir, uint32_t qubit, double alpha,
-              auto& emit) {
-    PauliBitMask destab_mask, stab_mask;
-    bool sign;
-    extract_rewound_z(sim, qubit, destab_mask, stab_mask, sign);
+// When the rewound sign is negative, the rewound Pauli is -Z, so the
+// physical operator is exp(-i*alpha*pi/2 * (-Z)) = exp(+i*alpha*pi/2 * Z),
+// whose global phase is e^{+i*alpha*pi/2}. We pass the sign-adjusted alpha
+// to the global phase accumulator so the tracked phase stays correct.
+void trace_rz(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir, uint32_t qubit,
+              double alpha) {
+    bool sign = false;
+    hir.append_phase_rotation(alpha, [&](MutablePauliMaskView slot) {
+        extract_rewound_z_into(sim, qubit, slot.x(), slot.z(), sign);
+        slot.set_sign(sign);
+    });
     double effective_alpha = sign ? -alpha : alpha;
     accumulate_rz_global_phase(hir, effective_alpha);
-    emit(HeisenbergOp::make_phase_rotation(destab_mask, stab_mask, sign, alpha));
 }
 
-// Trace an arbitrary Pauli rotation exp(-i*alpha*pi/2 * P) where P is built
-// from a stim::PauliString.  Same sign-adjusted global phase logic as trace_rz.
+// Trace an arbitrary Pauli rotation exp(-i*alpha*pi/2 * P) where P is a
+// stim::PauliString. Same sign-adjusted global phase logic as trace_rz.
 void trace_pauli_rotation(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir,
-                          const stim::PauliString<kStimWidth>& obs, double alpha, auto& emit) {
+                          const stim::PauliString<kStimWidth>& obs, double alpha) {
     stim::PauliString<kStimWidth> rewound = sim.inv_state(obs);
     uint32_t n = sim.inv_state.num_qubits;
-    PauliBitMask destab_mask = stim_to_bitmask(rewound.xs, n);
-    PauliBitMask stab_mask = stim_to_bitmask(rewound.zs, n);
-    bool sign = rewound.sign;
-    double effective_alpha = sign ? -alpha : alpha;
+    hir.append_phase_rotation(alpha, [&](MutablePauliMaskView slot) {
+        copy_rewound_into(rewound, n, slot.x(), slot.z());
+        slot.set_sign(rewound.sign);
+    });
+    double effective_alpha = rewound.sign ? -alpha : alpha;
     accumulate_rz_global_phase(hir, effective_alpha);
-    emit(HeisenbergOp::make_phase_rotation(destab_mask, stab_mask, sign, alpha));
+}
+
+/// Build a stim::PauliString from an MPP/EXP_VAL/R_PAULI target list.
+/// Sets `inversion_parity_out` if any target carries an inversion bang.
+stim::PauliString<kStimWidth> build_pauli_string(const std::vector<Target>& targets,
+                                                 uint32_t num_qubits, bool& inversion_parity_out) {
+    stim::PauliString<kStimWidth> obs(num_qubits);
+    inversion_parity_out = false;
+    for (const auto& target : targets) {
+        uint32_t q = target.value();
+        inversion_parity_out ^= target.is_inverted();
+        if (target.pauli() == Target::kPauliX) {
+            obs.xs[q] = true;
+        } else if (target.pauli() == Target::kPauliY) {
+            obs.xs[q] = true;
+            obs.zs[q] = true;
+        } else {
+            obs.zs[q] = true;
+        }
+    }
+    return obs;
+}
+
+/// Conservative upper bound on the number of noise channel masks the
+/// trace will emit. Some channels with prob = 0 are skipped, so the
+/// actual count may be lower; the unused arena slots stay zero-init.
+size_t count_noise_channels(const Circuit& circuit) {
+    size_t count = 0;
+    for (const auto& node : circuit.nodes) {
+        const size_t n_targets = node.targets.size();
+        switch (node.gate) {
+            case GateType::X_ERROR:
+            case GateType::Y_ERROR:
+            case GateType::Z_ERROR:
+                count += n_targets;
+                break;
+            case GateType::DEPOLARIZE1:
+            case GateType::PAULI_CHANNEL_1:
+                count += 3 * n_targets;
+                break;
+            case GateType::DEPOLARIZE2:
+            case GateType::PAULI_CHANNEL_2:
+                count += 15 * (n_targets / 2);
+                break;
+            default:
+                break;
+        }
+    }
+    return count;
+}
+
+/// Pre-count the number of mask-carrying HIR ops the trace will emit.
+/// Must mirror the dispatch in trace().
+size_t count_pauli_masks(const Circuit& circuit) {
+    size_t count = 0;
+    for (const auto& node : circuit.nodes) {
+        const size_t n_targets = node.targets.size();
+        switch (node.gate) {
+            case GateType::T:
+            case GateType::T_DAG:
+            case GateType::M:
+            case GateType::MX:
+            case GateType::MY:
+            case GateType::MPAD:
+            case GateType::R_Z:
+            case GateType::R_X:
+            case GateType::R_Y:
+                count += n_targets;
+                break;
+            case GateType::U3:
+                count += 3 * n_targets;
+                break;
+            case GateType::R_XX:
+            case GateType::R_YY:
+            case GateType::R_ZZ:
+                count += n_targets / 2;
+                break;
+            case GateType::R_PAULI:
+            case GateType::EXP_VAL:
+            case GateType::MPP:
+                count += 1;
+                break;
+            case GateType::R:
+            case GateType::RX:
+            case GateType::RY:
+            case GateType::MR:
+            case GateType::MRX:
+            case GateType::MRY:
+                count += 2 * n_targets;
+                break;
+            case GateType::CX:
+            case GateType::CY:
+            case GateType::CZ:
+                if (!node.targets.empty() && node.targets[0].is_rec()) {
+                    count += n_targets / 2;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+    return count;
 }
 
 }  // namespace
 
 HirModule trace(const Circuit& circuit) {
-    if (circuit.num_qubits > kMaxInlineQubits) {
-        throw std::runtime_error(
-            "Circuit exceeds " + std::to_string(kMaxInlineQubits) +
-            "-qubit compile-time limit: " + std::to_string(circuit.num_qubits) + " qubits");
-    }
-
-    HirModule hir;
-    hir.num_qubits = circuit.num_qubits;
+    HirModule hir(circuit.num_qubits, count_pauli_masks(circuit), count_noise_channels(circuit));
     hir.num_measurements = circuit.num_measurements;
     hir.num_detectors = circuit.num_detectors;
     hir.num_observables = circuit.num_observables;
     hir.num_exp_vals = circuit.num_exp_vals;
 
-    // Initialize tableau simulator with a fixed seed (deterministic for testing)
-    // The RNG is only used for measurement collapse, which we handle separately
     std::mt19937_64 rng(0);
     stim::TableauSimulator<kStimWidth> sim(std::move(rng), circuit.num_qubits);
 
-    // Track measurement index for rec[-k] resolution
     MeasRecordIdx meas_idx{0};
-
-    // Hidden measurements get indices starting after all visible ones
     uint32_t hidden_meas_idx = circuit.num_measurements;
-
-    // Track expectation value index (one per Pauli product)
     ExpValIdx exp_val_idx{0};
 
     for (const auto& node : circuit.nodes) {
-        // Emit helper: appends an HIR op and its source provenance in lockstep.
-        auto emit = [&](HeisenbergOp op) {
-            hir.ops.push_back(op);
-            hir.source_map.push_back({node.source_line});
-        };
+        const size_t ops_before = hir.ops.size();
 
         switch (node.gate) {
-            // Single-qubit Clifford gates - absorb into tableau
+            // Single-qubit Cliffords
             case GateType::H:
             case GateType::S:
             case GateType::S_DAG:
@@ -292,13 +391,11 @@ HirModule trace(const Circuit& circuit) {
             case GateType::C_ZNYX:
             case GateType::C_ZYNX: {
                 for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    apply_single_qubit_clifford(sim, node.gate, qubit);
+                    apply_single_qubit_clifford(sim, node.gate, target.value());
                 }
                 break;
             }
 
-            // Two-qubit Clifford gates - absorb into tableau
             case GateType::CX:
             case GateType::CY:
             case GateType::CZ:
@@ -320,108 +417,78 @@ HirModule trace(const Circuit& circuit) {
             case GateType::YCX:
             case GateType::YCY:
             case GateType::YCZ: {
-                // Check if this is classical feedback (first target is rec)
                 if (!node.targets.empty() && node.targets[0].is_rec()) {
-                    // Classical feedback: CX rec[-k] q or CZ rec[-k] q
-                    // This was generated by reset decomposition
-                    // Supports broadcasting: CX rec[-1] 0 rec[-2] 1 etc.
+                    // Classical feedback: CX rec[-k] q or CZ rec[-k] q.
                     for (size_t i = 0; i + 1 < node.targets.size(); i += 2) {
                         uint32_t rec_abs_idx = node.targets[i].value();
                         uint32_t target_qubit = node.targets[i + 1].value();
-
-                        // The controlling measurement is the absolute index
                         ControllingMeasIdx controlling_meas{rec_abs_idx};
 
-                        // Extract the rewound Pauli that will be conditionally applied
-                        // For CX rec[-k] q: apply X_q if measurement was 1
-                        // For CZ rec[-k] q: apply Z_q if measurement was 1
-                        PauliBitMask destab_mask, stab_mask;
-                        bool sign;
-
-                        if (node.gate == GateType::CX) {
-                            // X on target qubit, rewound through tableau
-                            extract_rewound_x(sim, target_qubit, destab_mask, stab_mask, sign);
-                        } else if (node.gate == GateType::CZ) {
-                            // Z on target qubit, rewound through tableau
-                            extract_rewound_z(sim, target_qubit, destab_mask, stab_mask, sign);
-                        } else {
-                            // CY classical feedback not supported
-                            throw std::runtime_error("CY classical feedback not supported");
-                        }
-
-                        emit(HeisenbergOp::make_conditional(destab_mask, stab_mask, sign,
-                                                            controlling_meas));
+                        hir.append_conditional(controlling_meas, [&](MutablePauliMaskView slot) {
+                            bool sign;
+                            if (node.gate == GateType::CX) {
+                                extract_rewound_x_into(sim, target_qubit, slot.x(), slot.z(), sign);
+                            } else if (node.gate == GateType::CZ) {
+                                extract_rewound_z_into(sim, target_qubit, slot.x(), slot.z(), sign);
+                            } else {
+                                throw std::runtime_error("CY classical feedback not supported");
+                            }
+                            slot.set_sign(sign);
+                        });
                     }
                 } else {
-                    // Regular two-qubit Clifford gate
                     for (size_t i = 0; i + 1 < node.targets.size(); i += 2) {
-                        uint32_t q1 = node.targets[i].value();
-                        uint32_t q2 = node.targets[i + 1].value();
-                        apply_two_qubit_clifford(sim, node.gate, q1, q2);
+                        apply_two_qubit_clifford(sim, node.gate, node.targets[i].value(),
+                                                 node.targets[i + 1].value());
                     }
                 }
                 break;
             }
 
-            // T gate - emit HeisenbergOp with rewound Z
-            case GateType::T: {
-                for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    PauliBitMask destab_mask, stab_mask;
-                    bool sign;
-                    extract_rewound_z(sim, qubit, destab_mask, stab_mask, sign);
-                    emit(HeisenbergOp::make_tgate(destab_mask, stab_mask, sign, /*dagger=*/false));
-                }
-                break;
-            }
-
-            // T_DAG gate - emit HeisenbergOp with rewound Z and is_dagger=true
+            case GateType::T:
             case GateType::T_DAG: {
+                bool dagger = (node.gate == GateType::T_DAG);
                 for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    PauliBitMask destab_mask, stab_mask;
-                    bool sign;
-                    extract_rewound_z(sim, qubit, destab_mask, stab_mask, sign);
-                    emit(HeisenbergOp::make_tgate(destab_mask, stab_mask, sign, /*dagger=*/true));
+                    hir.append_tgate(dagger, [&](MutablePauliMaskView slot) {
+                        bool sign;
+                        extract_rewound_z_into(sim, target.value(), slot.x(), slot.z(), sign);
+                        slot.set_sign(sign);
+                    });
                 }
                 break;
             }
 
-            // R_Z: emit PHASE_ROTATION with rewound Z
             case GateType::R_Z: {
                 double alpha = node.args[0];
                 for (const auto& target : node.targets) {
-                    trace_rz(sim, hir, target.value(), alpha, emit);
+                    trace_rz(sim, hir, target.value(), alpha);
                 }
                 break;
             }
 
-            // R_X: H * R_Z * H (conjugate by Hadamard)
             case GateType::R_X: {
                 double alpha = node.args[0];
                 for (const auto& target : node.targets) {
                     size_t q = static_cast<size_t>(target.value());
                     sim.inv_state.prepend_H_XZ(q);
-                    trace_rz(sim, hir, target.value(), alpha, emit);
+                    trace_rz(sim, hir, target.value(), alpha);
                     sim.inv_state.prepend_H_XZ(q);
                 }
                 break;
             }
 
-            // R_Y: H_YZ * R_Z * H_YZ (conjugate by Y-Z Hadamard)
             case GateType::R_Y: {
                 double alpha = node.args[0];
                 for (const auto& target : node.targets) {
                     size_t q = static_cast<size_t>(target.value());
                     sim.inv_state.prepend_H_YZ(q);
-                    trace_rz(sim, hir, target.value(), alpha, emit);
+                    trace_rz(sim, hir, target.value(), alpha);
                     sim.inv_state.prepend_H_YZ(q);
                 }
                 break;
             }
 
             // U3(theta, phi, lambda) = R_Z(phi) * R_Y(theta) * R_Z(lambda)
-            // All params in half-turn units.
             case GateType::U3: {
                 double theta = node.args[0];
                 double phi = node.args[1];
@@ -430,18 +497,14 @@ HirModule trace(const Circuit& circuit) {
                     uint32_t qubit = target.value();
                     size_t q = static_cast<size_t>(qubit);
 
-                    // R_Z(lambda)
-                    trace_rz(sim, hir, qubit, lambda, emit);
+                    trace_rz(sim, hir, qubit, lambda);
 
-                    // R_Y(theta) = H_YZ * R_Z(theta) * H_YZ
                     sim.inv_state.prepend_H_YZ(q);
-                    trace_rz(sim, hir, qubit, theta, emit);
+                    trace_rz(sim, hir, qubit, theta);
                     sim.inv_state.prepend_H_YZ(q);
 
-                    // R_Z(phi)
-                    trace_rz(sim, hir, qubit, phi, emit);
+                    trace_rz(sim, hir, qubit, phi);
 
-                    // Align global phase with Qiskit's U3 definition
                     double u3_phase = (phi + lambda) * std::numbers::pi / 2.0;
                     hir.global_weight *=
                         std::complex<double>(std::cos(u3_phase), std::sin(u3_phase));
@@ -449,7 +512,6 @@ HirModule trace(const Circuit& circuit) {
                 break;
             }
 
-            // R_XX, R_YY, R_ZZ: two-qubit Pauli rotations
             case GateType::R_XX:
             case GateType::R_YY:
             case GateType::R_ZZ: {
@@ -474,104 +536,71 @@ HirModule trace(const Circuit& circuit) {
                         obs.zs[q1] = true;
                         obs.zs[q2] = true;
                     }
-                    trace_pauli_rotation(sim, hir, obs, alpha, emit);
+                    trace_pauli_rotation(sim, hir, obs, alpha);
                 }
                 break;
             }
 
-            // R_PAULI: N-qubit Pauli rotation from tagged targets
             case GateType::R_PAULI: {
                 double alpha = node.args[0];
-                stim::PauliString<kStimWidth> obs(circuit.num_qubits);
-                for (const auto& target : node.targets) {
-                    uint32_t q = target.value();
-                    if (target.pauli() == Target::kPauliX) {
-                        obs.xs[q] = true;
-                    } else if (target.pauli() == Target::kPauliY) {
-                        obs.xs[q] = true;
-                        obs.zs[q] = true;
-                    } else {
-                        obs.zs[q] = true;
-                    }
-                }
-                trace_pauli_rotation(sim, hir, obs, alpha, emit);
+                bool _;
+                auto obs = build_pauli_string(node.targets, circuit.num_qubits, _);
+                trace_pauli_rotation(sim, hir, obs, alpha);
                 break;
             }
 
-            // Z-basis measurement
             case GateType::M: {
                 for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    PauliBitMask destab_mask, stab_mask;
-                    bool sign;
-                    extract_rewound_z(sim, qubit, destab_mask, stab_mask, sign);
-                    sign ^= target.is_inverted();
-                    emit(HeisenbergOp::make_measure(destab_mask, stab_mask, sign, meas_idx));
+                    hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
+                        bool sign;
+                        extract_rewound_z_into(sim, target.value(), slot.x(), slot.z(), sign);
+                        slot.set_sign(sign ^ target.is_inverted());
+                    });
                     ++meas_idx;
                 }
                 break;
             }
 
-            // X-basis measurement
             case GateType::MX: {
                 for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    PauliBitMask destab_mask, stab_mask;
-                    bool sign;
-                    extract_rewound_x(sim, qubit, destab_mask, stab_mask, sign);
-                    sign ^= target.is_inverted();
-                    emit(HeisenbergOp::make_measure(destab_mask, stab_mask, sign, meas_idx));
+                    hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
+                        bool sign;
+                        extract_rewound_x_into(sim, target.value(), slot.x(), slot.z(), sign);
+                        slot.set_sign(sign ^ target.is_inverted());
+                    });
                     ++meas_idx;
                 }
                 break;
             }
 
-            // Y-basis measurement
             case GateType::MY: {
                 for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    auto pauli = sim.inv_state.y_output(qubit);
-                    uint32_t n = sim.inv_state.num_qubits;
-                    PauliBitMask destab_mask = stim_to_bitmask(pauli.xs, n);
-                    PauliBitMask stab_mask = stim_to_bitmask(pauli.zs, n);
-                    bool sign = pauli.sign ^ target.is_inverted();
-                    emit(HeisenbergOp::make_measure(destab_mask, stab_mask, sign, meas_idx));
+                    hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
+                        bool sign;
+                        extract_rewound_y_into(sim, target.value(), slot.x(), slot.z(), sign);
+                        slot.set_sign(sign ^ target.is_inverted());
+                    });
                     ++meas_idx;
                 }
                 break;
             }
 
-            // Multi-Pauli measurement (MPP)
             case GateType::MPP: {
-                stim::PauliString<kStimWidth> obs(circuit.num_qubits);
-                bool inversion_parity = false;
-                for (const auto& target : node.targets) {
-                    uint32_t q = target.value();
-                    inversion_parity ^= target.is_inverted();
-                    if (target.pauli() == Target::kPauliX) {
-                        obs.xs[q] = true;
-                    } else if (target.pauli() == Target::kPauliY) {
-                        obs.xs[q] = true;
-                        obs.zs[q] = true;
-                    } else {
-                        obs.zs[q] = true;
-                    }
-                }
+                bool inversion_parity;
+                auto obs = build_pauli_string(node.targets, circuit.num_qubits, inversion_parity);
                 stim::PauliString<kStimWidth> rewound = sim.inv_state(obs);
                 uint32_t n = sim.inv_state.num_qubits;
-                PauliBitMask destab_mask = stim_to_bitmask(rewound.xs, n);
-                PauliBitMask stab_mask = stim_to_bitmask(rewound.zs, n);
-                bool sign = rewound.sign ^ inversion_parity;
-                emit(HeisenbergOp::make_measure(destab_mask, stab_mask, sign, meas_idx));
+                hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
+                    copy_rewound_into(rewound, n, slot.x(), slot.z());
+                    slot.set_sign(rewound.sign ^ inversion_parity);
+                });
                 ++meas_idx;
                 break;
             }
 
-            // Unified reset / measure-reset decomposition.
-            // Pattern: extract measurement observable -> emit meas -> extract
-            // correction -> emit conditional -> (MR only) emit readout noise.
-            // Basis pairings: Z -> X correction, X -> Z correction,
-            //                 Y -> Z correction (X injects unphysical -i phase).
+            // Reset / measure-reset decomposition.
+            // Pattern: extract measurement observable -> emit MEASURE -> extract
+            // correction -> emit CONDITIONAL_PAULI -> (MR only) optional readout noise.
             case GateType::R:
             case GateType::RX:
             case GateType::RY:
@@ -596,98 +625,98 @@ HirModule trace(const Circuit& circuit) {
                         break;
                 }
 
-                auto extract_meas = [&](uint32_t q, PauliBitMask& dm, PauliBitMask& sm, bool& s) {
+                auto extract_meas = [&](uint32_t q, MutableMaskView dm, MutableMaskView sm,
+                                        bool& s) {
                     switch (basis) {
                         case Basis::Z:
-                            extract_rewound_z(sim, q, dm, sm, s);
+                            extract_rewound_z_into(sim, q, dm, sm, s);
                             break;
                         case Basis::X:
-                            extract_rewound_x(sim, q, dm, sm, s);
+                            extract_rewound_x_into(sim, q, dm, sm, s);
                             break;
-                        case Basis::Y: {
-                            auto pauli = sim.inv_state.y_output(q);
-                            uint32_t n = sim.inv_state.num_qubits;
-                            dm = stim_to_bitmask(pauli.xs, n);
-                            sm = stim_to_bitmask(pauli.zs, n);
-                            s = pauli.sign;
+                        case Basis::Y:
+                            extract_rewound_y_into(sim, q, dm, sm, s);
                             break;
-                        }
                     }
                 };
 
-                auto extract_corr = [&](uint32_t q, PauliBitMask& dm, PauliBitMask& sm, bool& s) {
+                auto extract_corr = [&](uint32_t q, MutableMaskView dm, MutableMaskView sm,
+                                        bool& s) {
                     if (basis == Basis::Z)
-                        extract_rewound_x(sim, q, dm, sm, s);
+                        extract_rewound_x_into(sim, q, dm, sm, s);
                     else
-                        extract_rewound_z(sim, q, dm, sm, s);
+                        extract_rewound_z_into(sim, q, dm, sm, s);
                 };
 
                 for (const auto& target : node.targets) {
                     uint32_t qubit = target.value();
-                    PauliBitMask destab_mask, stab_mask;
-                    bool sign;
-                    extract_meas(qubit, destab_mask, stab_mask, sign);
 
                     uint32_t this_meas;
                     if (hidden) {
                         this_meas = hidden_meas_idx++;
-                        auto meas_op = HeisenbergOp::make_measure(destab_mask, stab_mask, sign,
-                                                                  MeasRecordIdx{this_meas});
+                        auto& meas_op = hir.append_measure(
+                            MeasRecordIdx{this_meas}, [&](MutablePauliMaskView slot) {
+                                bool sign;
+                                extract_meas(qubit, slot.x(), slot.z(), sign);
+                                slot.set_sign(sign);
+                            });
                         meas_op.set_hidden(true);
-                        emit(meas_op);
                     } else {
                         this_meas = static_cast<uint32_t>(meas_idx);
-                        emit(HeisenbergOp::make_measure(destab_mask, stab_mask, sign, meas_idx));
+                        hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
+                            bool sign;
+                            extract_meas(qubit, slot.x(), slot.z(), sign);
+                            slot.set_sign(sign);
+                        });
                         ++meas_idx;
                     }
 
-                    PauliBitMask corr_destab, corr_stab;
-                    bool corr_sign;
-                    extract_corr(qubit, corr_destab, corr_stab, corr_sign);
-                    auto cond_op = HeisenbergOp::make_conditional(corr_destab, corr_stab, corr_sign,
-                                                                  ControllingMeasIdx{this_meas});
-                    emit(cond_op);
+                    hir.append_conditional(ControllingMeasIdx{this_meas},
+                                           [&](MutablePauliMaskView slot) {
+                                               bool corr_sign;
+                                               extract_corr(qubit, slot.x(), slot.z(), corr_sign);
+                                               slot.set_sign(corr_sign);
+                                           });
 
                     if (!hidden && target.is_inverted()) {
                         ReadoutNoiseIdx idx{static_cast<uint32_t>(hir.readout_noise.size())};
                         hir.readout_noise.push_back({this_meas, 1.0});
-                        emit(HeisenbergOp::make_readout_noise(idx));
+                        hir.append_readout_noise(idx);
                     }
                 }
                 break;
             }
 
-            // MPAD: deterministic classical padding (zero-weight measurement)
             case GateType::MPAD: {
                 for (const auto& target : node.targets) {
                     bool sign = (target.value() != 0) ^ target.is_inverted();
-                    emit(HeisenbergOp::make_measure(0, 0, sign, meas_idx));
+                    hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
+                        // Slot is zero-initialized by claim_empty_pauli_mask.
+                        slot.set_sign(sign);
+                    });
                     ++meas_idx;
                 }
                 break;
             }
 
-            // TICK is a no-op annotation
             case GateType::TICK:
                 break;
 
-            // Single-qubit noise gates
             case GateType::X_ERROR:
             case GateType::Y_ERROR:
             case GateType::Z_ERROR:
             case GateType::DEPOLARIZE1: {
                 double prob = node.args.empty() ? 0.0 : node.args[0];
                 for (const auto& target : node.targets) {
-                    uint32_t qubit = target.value();
-                    NoiseSite site = make_single_qubit_noise_site(sim, node.gate, qubit, prob);
+                    NoiseSite site =
+                        make_single_qubit_noise_site(hir, sim, node.gate, target.value(), prob);
                     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
                     hir.noise_sites.push_back(std::move(site));
-                    emit(HeisenbergOp::make_noise(idx));
+                    hir.append_noise(idx);
                 }
                 break;
             }
 
-            // Single-qubit Pauli channel with 3 explicit probabilities
             case GateType::PAULI_CHANNEL_1: {
                 if (node.args.size() < 3) {
                     throw std::runtime_error(
@@ -696,21 +725,20 @@ HirModule trace(const Circuit& circuit) {
                 for (const auto& target : node.targets) {
                     uint32_t qubit = target.value();
                     NoiseSite site;
-                    // pauli_type: 1=X, 2=Y, 3=Z
                     for (int p = 0; p < 3; ++p) {
                         double prob = node.args[static_cast<size_t>(p)];
                         if (prob > 0.0) {
-                            site.channels.push_back(rewind_single_pauli(sim, qubit, p + 1, prob));
+                            site.channels.push_back(
+                                rewind_single_pauli(hir, sim, qubit, p + 1, prob));
                         }
                     }
                     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
                     hir.noise_sites.push_back(std::move(site));
-                    emit(HeisenbergOp::make_noise(idx));
+                    hir.append_noise(idx);
                 }
                 break;
             }
 
-            // Two-qubit Pauli channel with 15 explicit probabilities
             case GateType::PAULI_CHANNEL_2: {
                 if (node.args.size() < 15) {
                     throw std::runtime_error("PAULI_CHANNEL_2 requires 15 arguments");
@@ -719,8 +747,6 @@ HirModule trace(const Circuit& circuit) {
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
                     NoiseSite site;
-                    // Enumerate all non-II two-qubit Paulis in Stim order:
-                    // IX, IY, IZ, XI, XX, XY, XZ, YI, YX, YY, YZ, ZI, ZX, ZY, ZZ
                     size_t arg_idx = 0;
                     for (int p1 = 0; p1 <= 3; ++p1) {
                         for (int p2 = 0; p2 <= 3; ++p2) {
@@ -729,92 +755,74 @@ HirModule trace(const Circuit& circuit) {
                             double prob = node.args[arg_idx];
                             if (prob > 0.0) {
                                 site.channels.push_back(
-                                    rewind_two_qubit_pauli(sim, q1, q2, p1, p2, prob));
+                                    rewind_two_qubit_pauli(hir, sim, q1, q2, p1, p2, prob));
                             }
                             ++arg_idx;
                         }
                     }
                     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
                     hir.noise_sites.push_back(std::move(site));
-                    emit(HeisenbergOp::make_noise(idx));
+                    hir.append_noise(idx);
                 }
                 break;
             }
 
-            // Two-qubit depolarizing noise
             case GateType::DEPOLARIZE2: {
                 double prob = node.args.empty() ? 0.0 : node.args[0];
                 for (size_t i = 0; i + 1 < node.targets.size(); i += 2) {
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
-                    NoiseSite site = make_depolarize2_noise_site(sim, q1, q2, prob);
+                    NoiseSite site = make_depolarize2_noise_site(hir, sim, q1, q2, prob);
                     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
                     hir.noise_sites.push_back(std::move(site));
-                    emit(HeisenbergOp::make_noise(idx));
+                    hir.append_noise(idx);
                 }
                 break;
             }
 
-            // Readout noise (classical bit-flip on measurement result)
             case GateType::READOUT_NOISE: {
-                // Parser stores absolute measurement index in target, probability in arg
                 for (const auto& target : node.targets) {
                     uint32_t abs_meas_idx = target.value();
                     double prob = node.args.empty() ? 0.0 : node.args[0];
                     ReadoutNoiseIdx idx{static_cast<uint32_t>(hir.readout_noise.size())};
                     hir.readout_noise.push_back({abs_meas_idx, prob});
-                    emit(HeisenbergOp::make_readout_noise(idx));
+                    hir.append_readout_noise(idx);
                 }
                 break;
             }
 
-            // Detector: parity check over measurement records
             case GateType::DETECTOR: {
                 std::vector<uint32_t> targets;
                 for (const auto& target : node.targets) {
-                    targets.push_back(target.value());  // Already absolute indices
+                    targets.push_back(target.value());
                 }
                 DetectorIdx idx{static_cast<uint32_t>(hir.detector_targets.size())};
                 hir.detector_targets.push_back(std::move(targets));
-                emit(HeisenbergOp::make_detector(idx));
+                hir.append_detector(idx);
                 break;
             }
 
-            // Observable: logical observable accumulator
             case GateType::OBSERVABLE_INCLUDE: {
                 std::vector<uint32_t> targets;
                 for (const auto& target : node.targets) {
-                    targets.push_back(target.value());  // Already absolute indices
+                    targets.push_back(target.value());
                 }
                 uint32_t obs_idx = static_cast<uint32_t>(node.args.empty() ? 0.0 : node.args[0]);
                 uint32_t target_list_idx = static_cast<uint32_t>(hir.observable_targets.size());
                 hir.observable_targets.push_back(std::move(targets));
-                emit(HeisenbergOp::make_observable(ObservableIdx{obs_idx}, target_list_idx));
+                hir.append_observable(ObservableIdx{obs_idx}, target_list_idx);
                 break;
             }
 
-            // Non-destructive expectation value probe
             case GateType::EXP_VAL: {
-                stim::PauliString<kStimWidth> obs(circuit.num_qubits);
-                bool inversion_parity = false;
-                for (const auto& target : node.targets) {
-                    uint32_t q = target.value();
-                    inversion_parity ^= target.is_inverted();
-                    if (target.pauli() == Target::kPauliX) {
-                        obs.xs[q] = true;
-                    } else if (target.pauli() == Target::kPauliY) {
-                        obs.xs[q] = true;
-                        obs.zs[q] = true;
-                    } else {
-                        obs.zs[q] = true;
-                    }
-                }
+                bool inversion_parity;
+                auto obs = build_pauli_string(node.targets, circuit.num_qubits, inversion_parity);
                 stim::PauliString<kStimWidth> rewound = sim.inv_state(obs);
                 uint32_t n = sim.inv_state.num_qubits;
-                PauliBitMask destab_mask = stim_to_bitmask(rewound.xs, n);
-                PauliBitMask stab_mask = stim_to_bitmask(rewound.zs, n);
-                bool sign = rewound.sign ^ inversion_parity;
-                emit(HeisenbergOp::make_exp_val(destab_mask, stab_mask, sign, exp_val_idx));
+                hir.append_exp_val(exp_val_idx, [&](MutablePauliMaskView slot) {
+                    copy_rewound_into(rewound, n, slot.x(), slot.z());
+                    slot.set_sign(rewound.sign ^ inversion_parity);
+                });
                 exp_val_idx = ExpValIdx{static_cast<uint32_t>(exp_val_idx) + 1};
                 break;
             }
@@ -823,12 +831,15 @@ HirModule trace(const Circuit& circuit) {
                 throw std::runtime_error("Unsupported gate type in Front-End: " +
                                          std::string(gate_name(node.gate)));
         }
+
+        // Source map: append one entry per op produced by this node.
+        const size_t ops_after = hir.ops.size();
+        for (size_t i = ops_before; i < ops_after; ++i) {
+            hir.source_map.push_back({node.source_line});
+        }
     }
 
-    // Record how many hidden measurements were emitted
     hir.num_hidden_measurements = hidden_meas_idx - circuit.num_measurements;
-
-    // Store forward tableau for statevector expansion
     hir.final_tableau = sim.inv_state.inverse();
 
     return hir;

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -385,39 +385,6 @@ struct HirModule {
         return pauli_masks.mut_at(op.mask_handle());
     }
 
-    // --- Builders that take pre-built MaskViews ---
-    //
-    // Convenient for tests and any caller that already has the mask data
-    // in MaskView form. Fails (via copy_from's contract) if the source
-    // mask has set bits beyond the arena's width.
-
-    HeisenbergOp& append_tgate(MaskView destab, MaskView stab, bool s, bool dagger = false) {
-        auto h = claim_pauli_mask(destab, stab, s);
-        ops.push_back(HeisenbergOp::make_tgate(h, dagger));
-        return ops.back();
-    }
-    HeisenbergOp& append_measure(MaskView destab, MaskView stab, bool s, MeasRecordIdx idx) {
-        auto h = claim_pauli_mask(destab, stab, s);
-        ops.push_back(HeisenbergOp::make_measure(h, idx));
-        return ops.back();
-    }
-    HeisenbergOp& append_conditional(MaskView destab, MaskView stab, bool s,
-                                     ControllingMeasIdx idx) {
-        auto h = claim_pauli_mask(destab, stab, s);
-        ops.push_back(HeisenbergOp::make_conditional(h, idx));
-        return ops.back();
-    }
-    HeisenbergOp& append_phase_rotation(MaskView destab, MaskView stab, bool s, double alpha) {
-        auto h = claim_pauli_mask(destab, stab, s);
-        ops.push_back(HeisenbergOp::make_phase_rotation(h, alpha));
-        return ops.back();
-    }
-    HeisenbergOp& append_exp_val(MaskView destab, MaskView stab, bool s, ExpValIdx idx) {
-        auto h = claim_pauli_mask(destab, stab, s);
-        ops.push_back(HeisenbergOp::make_exp_val(h, idx));
-        return ops.back();
-    }
-
     // --- Lambda-fill builders ---
     //
     // The mask slot is claimed, the fill callable is invoked with a
@@ -493,15 +460,6 @@ struct HirModule {
 
     // --- Noise channel mask claims (analogous to pauli_masks) ---
 
-    /// Claim the next noise_channel_masks slot, populate (X, Z), return the handle.
-    PauliMaskHandle claim_noise_channel_mask(MaskView destab, MaskView stab) {
-        auto h = claim_empty_noise_channel_mask();
-        auto slot = noise_channel_masks.mut_at(h);
-        slot.x().copy_from(destab);
-        slot.z().copy_from(stab);
-        return h;
-    }
-
     /// Claim the next noise_channel_masks slot zero-initialized; caller
     /// fills via noise_channel_masks.mut_at(h). Throws (rather than
     /// asserting) so a stale count_noise_channels() upper bound is
@@ -515,13 +473,6 @@ struct HirModule {
     }
 
     // --- In-place mutation of existing op slots ---
-
-    void set_pauli(const HeisenbergOp& op, MaskView destab, MaskView stab, bool s) {
-        auto m = mask_at(op);
-        m.x().copy_from(destab);
-        m.z().copy_from(stab);
-        m.set_sign(s);
-    }
 
     void set_sign(const HeisenbergOp& op, bool s) { mask_at(op).set_sign(s); }
 
@@ -554,15 +505,6 @@ struct HirModule {
     }
 
   private:
-    PauliMaskHandle claim_pauli_mask(MaskView destab, MaskView stab, bool s) {
-        auto h = claim_empty_pauli_mask();
-        auto slot = pauli_masks.mut_at(h);
-        slot.x().copy_from(destab);
-        slot.z().copy_from(stab);
-        slot.set_sign(s);
-        return h;
-    }
-
     /// Throws (rather than asserting) so a stale count_pauli_masks() upper
     /// bound is caught in Release as well as Debug.
     PauliMaskHandle claim_empty_pauli_mask() {

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -7,14 +7,15 @@
 // with explicit masks and weights. Clifford gates are absorbed into the tableau and do not
 // appear in the HIR.
 //
-// Key design decisions:
-// - Uses BitMask<N> for Pauli masks (compile-time width, N = CLIFFT_MAX_QUBITS)
-// - 32-byte HeisenbergOp for optimal cache alignment (2 ops per 64-byte L1 cache line)
-// - Variable-sized payloads (noise channels, detector/observable target lists) live
-//   in side-tables on HirModule; HeisenbergOp stores only an index
+// Pauli masks live in HirModule-owned arenas and are referenced from each
+// HeisenbergOp by an opaque PauliMaskHandle. Variable-sized payloads (noise
+// channels, detector/observable target lists) live in side-tables on HirModule.
 
 #include "clifft/util/bitmask.h"
 #include "clifft/util/config.h"
+#include "clifft/util/mask_view.h"
+#include "clifft/util/pauli_arena.h"
+#include "clifft/util/stim_mask.h"
 
 #include "stim.h"
 
@@ -22,6 +23,7 @@
 #include <complex>
 #include <cstdint>
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 namespace clifft {
@@ -29,10 +31,6 @@ namespace clifft {
 // =============================================================================
 // Strong Typedefs for Index Types
 // =============================================================================
-//
-// Zero-overhead strong types using enum class over integer types.
-// Prevents accidental argument swapping at compile time (e.g., swapping
-// meas_idx and ag_idx in make_measure). Compiles to raw integers in registers.
 
 /// Index into the measurement record (absolute position)
 enum class MeasRecordIdx : uint32_t {};
@@ -58,43 +56,27 @@ enum class ObservableIdx : uint32_t {};
 /// Index into the expectation value record (absolute position)
 enum class ExpValIdx : uint32_t {};
 
-// SIMD lane width for Stim types. Stim's TableauSimulator<W> handles
-// arbitrary qubit counts via dynamic heap allocation at any W; this
-// controls only the SIMD register width for internal bit operations.
-constexpr size_t kStimWidth = 64;
-
-// Inline Pauli mask type used throughout the HIR and SVM.
+// Fixed-width Pauli mask, sized to kMaxInlineQubits. Retained because the
+// SchrodingerState VM frame still uses it for state.p_x / state.p_z; that
+// migration is the next PR (#45 PR3) at which point this typedef and its
+// supporting BitMask machinery can go away.
 using PauliBitMask = BitMask<kMaxInlineQubits>;
-
-// Copy a Stim PauliString row (xs or zs) into our fixed-width PauliBitMask.
-inline PauliBitMask stim_to_bitmask(const stim::simd_bits_range_ref<kStimWidth>& bits, uint32_t n) {
-    PauliBitMask m;
-    uint32_t words = (n + 63) / 64;
-    for (uint32_t w = 0; w < words && w < kMaxInlineWords; ++w) {
-        m.w[w] = bits.u64[w];
-    }
-    return m;
-}
 
 // =============================================================================
 // Noise Channel Structures
 // =============================================================================
 //
-// Quantum noise is represented as a set of mutually exclusive Pauli channels.
-// Each channel has a rewound Pauli mask (at t=0) and a probability.
-// The Back-End will extract these into a noise schedule for gap sampling.
+// A NoiseSite is a list of NoiseChannels; each channel has a Pauli mask
+// (handle into the surrounding arena -- HirModule::noise_channel_masks for
+// HIR-side sites, ConstantPool::noise_channel_masks for compiled sites)
+// and a firing probability. Channel signs are unused (E and -E act
+// identically as stochastic Pauli errors).
 
-/// A single Pauli error channel with its rewound masks and probability.
 struct NoiseChannel {
-    PauliBitMask destab_mask;  // X-bits of the rewound Pauli
-    PauliBitMask stab_mask;    // Z-bits of the rewound Pauli
-    double prob;               // Probability of this channel firing
+    PauliMaskHandle mask;
+    double prob;
 };
 
-/// A noise site: a collection of mutually exclusive Pauli channels.
-/// For X_ERROR(p): single channel with prob p.
-/// For DEPOLARIZE1(p): 3 channels (X, Y, Z) each with prob p/3.
-/// For DEPOLARIZE2(p): 15 channels (all non-II two-qubit Paulis) each with prob p/15.
 struct NoiseSite {
     std::vector<NoiseChannel> channels;
 };
@@ -122,37 +104,35 @@ enum class OpType : uint8_t {
     NUM_OP_TYPES        // Sentinel: must remain last for binding completeness checks
 };
 
+/// Sentinel handle value indicating that an op carries no Pauli mask.
+inline constexpr PauliMaskHandle kNoMask = static_cast<PauliMaskHandle>(~uint32_t{0});
+
 // A single operation in the Heisenberg IR.
 //
-// Layout optimized for 32-byte cache alignment (2 ops per 64-byte L1 cache line):
-// - Largest fields first (8-byte masks)
-// - Union payload (12 bytes)
-// - Small fields at end (type, sign, is_dagger + 1 byte padding)
+// Layout: 16 bytes, aligned to 8 (4 ops per 64-byte L1 cache line).
+//   offset 0: PauliMaskHandle mask_handle_  (4 bytes; kNoMask for non-mask ops)
+//   offset 4: OpType type_                  (1 byte)
+//   offset 5: uint8_t flags_                (1 byte)
+//   offset 6: padding                       (2 bytes)
+//   offset 8: union payload                 (8 bytes; double-aligned)
 //
-// The destab_mask and stab_mask encode the Pauli string in the computational basis:
-// - Bit i of destab_mask = 1 means X_i is present
-// - Bit i of stab_mask = 1 means Z_i is present
-// - Both bits set means Y_i is present (Y = iXZ)
+// For mask-carrying ops, mask_handle_ indexes into HirModule::pauli_masks.
+// The (X, Z, sign) triple is stored in the arena slot. The Pauli string is
+// encoded in the computational basis: X_i set means bit i of x; Z_i set
+// means bit i of z; both set means Y_i.
 //
-// Uses stim::bitword<64> instead of raw uint64_t for cleaner bitwise operations
-// (.popcount(), ^=, &) that align with Stim idioms. Zero memory overhead.
-//
-// All construction goes through static factory methods (make_tgate, make_measure,
-// make_conditional) to ensure type-safe initialization of the union payload.
+// Construct via HirModule::append_* builders. For mask-carrying ops, the
+// builders take a fill callable that writes (X, Z, sign) into a freshly
+// claimed arena slot -- the frontend uses this to populate masks directly
+// from stim rows without a fixed-width PauliBitMask intermediate.
 struct HeisenbergOp {
-    // Flag constants (matching Instruction flags)
     static constexpr uint8_t FLAG_IS_DAGGER = 1 << 0;
     static constexpr uint8_t FLAG_HIDDEN = 1 << 2;
 
-    // --- Accessors (common to all OpTypes) ---
-
     [[nodiscard]] OpType op_type() const { return type_; }
-    [[nodiscard]] const PauliBitMask& destab_mask() const { return destab_mask_; }
-    [[nodiscard]] const PauliBitMask& stab_mask() const { return stab_mask_; }
-    [[nodiscard]] bool sign() const { return sign_; }
+    [[nodiscard]] PauliMaskHandle mask_handle() const { return mask_handle_; }
+    [[nodiscard]] bool has_mask() const { return mask_handle_ != kNoMask; }
     [[nodiscard]] uint8_t flags() const { return flags_; }
-
-    // --- Flag accessors and setters ---
 
     [[nodiscard]] bool is_dagger() const { return (flags_ & FLAG_IS_DAGGER) != 0; }
     void set_dagger(bool v) {
@@ -170,14 +150,10 @@ struct HeisenbergOp {
             flags_ &= ~FLAG_HIDDEN;
     }
 
-    // --- MEASURE accessor (debug-asserted) ---
-
     [[nodiscard]] MeasRecordIdx meas_record_idx() const {
         assert(type_ == OpType::MEASURE && "meas_record_idx called on non-MEASURE op");
         return static_cast<MeasRecordIdx>(measure_.meas_record_idx);
     }
-
-    // --- CONDITIONAL_PAULI accessor (debug-asserted) ---
 
     [[nodiscard]] ControllingMeasIdx controlling_meas() const {
         assert(type_ == OpType::CONDITIONAL_PAULI &&
@@ -185,14 +161,10 @@ struct HeisenbergOp {
         return static_cast<ControllingMeasIdx>(conditional_.controlling_meas);
     }
 
-    // --- NOISE accessor (debug-asserted) ---
-
     [[nodiscard]] NoiseSiteIdx noise_site_idx() const {
         assert(type_ == OpType::NOISE && "noise_site_idx called on non-NOISE op");
         return static_cast<NoiseSiteIdx>(noise_.site_idx);
     }
-
-    // --- READOUT_NOISE accessor (debug-asserted) ---
 
     [[nodiscard]] ReadoutNoiseIdx readout_noise_idx() const {
         assert(type_ == OpType::READOUT_NOISE &&
@@ -200,14 +172,10 @@ struct HeisenbergOp {
         return static_cast<ReadoutNoiseIdx>(readout_.entry_idx);
     }
 
-    // --- DETECTOR accessor (debug-asserted) ---
-
     [[nodiscard]] DetectorIdx detector_idx() const {
         assert(type_ == OpType::DETECTOR && "detector_idx called on non-DETECTOR op");
         return static_cast<DetectorIdx>(detector_.target_list_idx);
     }
-
-    // --- OBSERVABLE accessors (debug-asserted) ---
 
     [[nodiscard]] ObservableIdx observable_idx() const {
         assert(type_ == OpType::OBSERVABLE && "observable_idx called on non-OBSERVABLE op");
@@ -220,235 +188,392 @@ struct HeisenbergOp {
         return observable_.target_list_idx;
     }
 
-    // --- EXP_VAL accessor (debug-asserted) ---
-
     [[nodiscard]] ExpValIdx exp_val_idx() const {
         assert(type_ == OpType::EXP_VAL && "exp_val_idx called on non-EXP_VAL op");
         return static_cast<ExpValIdx>(exp_val_.exp_val_idx);
     }
-
-    // --- PHASE_ROTATION accessor (debug-asserted) ---
 
     [[nodiscard]] double alpha() const {
         assert(type_ == OpType::PHASE_ROTATION && "alpha called on non-PHASE_ROTATION op");
         return phase_.alpha;
     }
 
-    // --- Factory Methods ---
-
-    // Factory for T/T_dag gates
-    static HeisenbergOp make_tgate(PauliBitMask destab, PauliBitMask stab, bool s,
-                                   bool dagger = false) {
-        HeisenbergOp op(OpType::T_GATE, destab, stab, s);
+    // Static factories. Each takes the mask handle (or kNoMask for ops with
+    // no Pauli) plus the per-op payload, and produces a fully-initialized
+    // HeisenbergOp. Use HirModule::append_* or claim_*_pauli_mask helpers
+    // to allocate the slot first; these factories do not validate that the
+    // handle belongs to any specific arena.
+    static HeisenbergOp make_tgate(PauliMaskHandle handle, bool dagger) {
+        HeisenbergOp op(OpType::T_GATE, handle);
         op.set_dagger(dagger);
         return op;
     }
-
-    // Factory for MEASURE
-    static HeisenbergOp make_measure(PauliBitMask destab, PauliBitMask stab, bool s,
-                                     MeasRecordIdx meas_idx) {
-        HeisenbergOp op(OpType::MEASURE, destab, stab, s);
+    static HeisenbergOp make_measure(PauliMaskHandle handle, MeasRecordIdx meas_idx) {
+        HeisenbergOp op(OpType::MEASURE, handle);
         op.measure_.meas_record_idx = static_cast<uint32_t>(meas_idx);
         return op;
     }
-
-    // Factory for CONDITIONAL_PAULI
-    static HeisenbergOp make_conditional(PauliBitMask destab, PauliBitMask stab, bool s,
+    static HeisenbergOp make_conditional(PauliMaskHandle handle,
                                          ControllingMeasIdx controlling_meas) {
-        HeisenbergOp op(OpType::CONDITIONAL_PAULI, destab, stab, s);
+        HeisenbergOp op(OpType::CONDITIONAL_PAULI, handle);
         op.conditional_.controlling_meas = static_cast<uint32_t>(controlling_meas);
         return op;
     }
-
-    // Factory for NOISE (quantum Pauli channel)
     static HeisenbergOp make_noise(NoiseSiteIdx site_idx) {
-        HeisenbergOp op(OpType::NOISE, 0, 0, false);
+        HeisenbergOp op(OpType::NOISE, kNoMask);
         op.noise_.site_idx = static_cast<uint32_t>(site_idx);
         return op;
     }
-
-    // Factory for READOUT_NOISE (classical bit-flip)
     static HeisenbergOp make_readout_noise(ReadoutNoiseIdx entry_idx) {
-        HeisenbergOp op(OpType::READOUT_NOISE, 0, 0, false);
+        HeisenbergOp op(OpType::READOUT_NOISE, kNoMask);
         op.readout_.entry_idx = static_cast<uint32_t>(entry_idx);
         return op;
     }
-
-    // Factory for DETECTOR
     static HeisenbergOp make_detector(DetectorIdx target_list_idx) {
-        HeisenbergOp op(OpType::DETECTOR, 0, 0, false);
+        HeisenbergOp op(OpType::DETECTOR, kNoMask);
         op.detector_.target_list_idx = static_cast<uint32_t>(target_list_idx);
         return op;
     }
-
-    // Factory for OBSERVABLE
     static HeisenbergOp make_observable(ObservableIdx obs_idx, uint32_t target_list_idx) {
-        HeisenbergOp op(OpType::OBSERVABLE, 0, 0, false);
+        HeisenbergOp op(OpType::OBSERVABLE, kNoMask);
         op.observable_.obs_idx = static_cast<uint32_t>(obs_idx);
         op.observable_.target_list_idx = target_list_idx;
         return op;
     }
-
-    // Factory for EXP_VAL (non-destructive expectation value probe)
-    static HeisenbergOp make_exp_val(PauliBitMask destab, PauliBitMask stab, bool s,
-                                     ExpValIdx idx) {
-        HeisenbergOp op(OpType::EXP_VAL, destab, stab, s);
+    static HeisenbergOp make_exp_val(PauliMaskHandle handle, ExpValIdx idx) {
+        HeisenbergOp op(OpType::EXP_VAL, handle);
         op.exp_val_.exp_val_idx = static_cast<uint32_t>(idx);
         return op;
     }
-
-    // Factory for PHASE_ROTATION (continuous Z-rotation)
-    static HeisenbergOp make_phase_rotation(PauliBitMask destab, PauliBitMask stab, bool s,
-                                            double alpha) {
-        HeisenbergOp op(OpType::PHASE_ROTATION, destab, stab, s);
+    static HeisenbergOp make_phase_rotation(PauliMaskHandle handle, double alpha) {
+        HeisenbergOp op(OpType::PHASE_ROTATION, handle);
         op.phase_.alpha = alpha;
         return op;
     }
 
-    // Replace the Pauli masks and sign in-place, preserving OpType and flags.
-    void set_pauli(PauliBitMask destab, PauliBitMask stab, bool sign) {
-        destab_mask_ = destab;
-        stab_mask_ = stab;
-        sign_ = sign;
-    }
-
-  private:
-    // Private constructor - use factory methods
-    HeisenbergOp(OpType t, PauliBitMask destab, PauliBitMask stab, bool s)
-        : destab_mask_(destab), stab_mask_(stab), type_(t), sign_(s), flags_(0) {
-        // Zero-initialize the union
+    /// In-place rewrite the op as a T_GATE while preserving its mask handle.
+    /// Used by optimizer passes (HirModule::demote_to_tgate) that fold a
+    /// PHASE_ROTATION at alpha = +/-1/4 into a T gate. Caller is responsible
+    /// for resetting the mask slot's sign.
+    void reset_to_tgate(bool dagger) {
+        type_ = OpType::T_GATE;
+        flags_ = 0;
+        set_dagger(dagger);
         measure_ = {0};
     }
 
-    // --- Data Members ---
+    /// In-place rewrite the op as a PHASE_ROTATION(alpha) while preserving
+    /// its mask handle. Caller is responsible for resetting the mask slot's
+    /// sign.
+    void reset_to_phase_rotation(double alpha) {
+        type_ = OpType::PHASE_ROTATION;
+        flags_ = 0;
+        phase_.alpha = alpha;
+    }
 
-    // The rewound Pauli string (topological geometry at t=0)
-    PauliBitMask destab_mask_;  // X-bits (destabilizer component)
-    PauliBitMask stab_mask_;    // Z-bits (stabilizer component)
+  private:
+    HeisenbergOp(OpType t, PauliMaskHandle h) : mask_handle_(h), type_(t), flags_(0), pad_{0, 0} {
+        measure_ = {0};
+    }
 
-    // Payload (interpretation depends on OpType) - 12 bytes
-    union {
-        // T_GATE: no payload needed (weight is implicit: tan(pi/8))
-        // is_dagger_ determines +/-i phase of spawned branch
+    PauliMaskHandle mask_handle_;  // 4 bytes (kNoMask for ops with no Pauli)
 
-        // MEASURE: measurement metadata
-        struct {
-            uint32_t meas_record_idx;  // Index in measurement record (for rec[-k] resolution)
-        } measure_;
+    OpType type_;     // 1 byte
+    uint8_t flags_;   // 1 byte
+    uint8_t pad_[2];  // 2 bytes
 
-        // CONDITIONAL_PAULI: classical feedback metadata
-        struct {
-            uint32_t controlling_meas;  // Absolute index of controlling measurement
-        } conditional_;
-
-        // NOISE: index into noise_sites side-table
-        struct {
-            uint32_t site_idx;
-        } noise_;
-
-        // READOUT_NOISE: index into readout_noise side-table
-        struct {
-            uint32_t entry_idx;
-        } readout_;
-
-        // DETECTOR: index into detector_targets side-table
-        struct {
-            uint32_t target_list_idx;
-        } detector_;
-
-        // OBSERVABLE: observable index and target list index
-        struct {
-            uint32_t obs_idx;          // Which logical observable (0, 1, 2, ...)
-            uint32_t target_list_idx;  // Index into observable_targets side-table
-        } observable_;
-
-        // PHASE_ROTATION: continuous angle in half-turn units
-        struct {
-            double alpha;  // Rotation angle: R_Z(alpha) = exp(-i*alpha*pi/2 * Z)
-        } phase_;
-
-        // EXP_VAL: index into expectation value record
-        struct {
-            uint32_t exp_val_idx;
-        } exp_val_;
+    // Per-OpType payload variants. Named to keep clang's
+    // -Wgnu-anonymous-struct-in-union extension warning quiet.
+    struct MeasurePayload {
+        uint32_t meas_record_idx;
+    };
+    struct ConditionalPayload {
+        uint32_t controlling_meas;
+    };
+    struct NoisePayload {
+        uint32_t site_idx;
+    };
+    struct ReadoutPayload {
+        uint32_t entry_idx;
+    };
+    struct DetectorPayload {
+        uint32_t target_list_idx;
+    };
+    struct ObservablePayload {
+        uint32_t obs_idx;
+        uint32_t target_list_idx;
+    };
+    struct PhasePayload {
+        double alpha;
+    };
+    struct ExpValPayload {
+        uint32_t exp_val_idx;
     };
 
-    OpType type_;    // 1 byte
-    bool sign_;      // Phase sign: false = +, true = -  (1 byte)
-    uint8_t flags_;  // Bitfield flags (1 byte)
-    // 1 byte padding -> Total: 32 bytes
+    union {
+        MeasurePayload measure_;
+        ConditionalPayload conditional_;
+        NoisePayload noise_;
+        ReadoutPayload readout_;
+        DetectorPayload detector_;
+        ObservablePayload observable_;
+        PhasePayload phase_;
+        ExpValPayload exp_val_;
+    };
 };
 
-// At kMaxInlineQubits == 64 the HIR struct is exactly 32 bytes (2 per cache line).
-// At larger widths the struct grows (offline AOT data, not hot-path).
-#if CLIFFT_MAX_QUBITS == 64
-static_assert(sizeof(HeisenbergOp) == 32,
-              "HeisenbergOp must be exactly 32 bytes at 64-qubit width");
-#endif
+static_assert(sizeof(HeisenbergOp) == 16, "HeisenbergOp must be exactly 16 bytes");
 
-// The complete HIR module - output of the Front-End.
-//
-// Holds the linear ops vector plus side-tables for variable-sized payloads
-// (noise channels, readout-noise entries, detector and observable target lists)
-// and circuit metadata. final_tableau is an optional debugging artifact used
-// by the statevector path to map GF(2) indices back to the physical basis.
+/// HIR module: parsed, traced output of the Front-End. Owns Pauli mask
+/// arenas, op vector, side-tables, and circuit metadata. Construct with
+/// (num_qubits, num_pauli_masks[, num_noise_channels]) so the arenas are
+/// pre-sized; default construction yields empty arenas.
 struct HirModule {
-    // Operations in execution order
+    HirModule() = default;
+
+    HirModule(uint32_t n_qubits, size_t num_pauli_masks, size_t num_noise_channels = 0)
+        : pauli_masks(n_qubits, num_pauli_masks),
+          noise_channel_masks(n_qubits, num_noise_channels) {
+        num_qubits = n_qubits;
+    }
+
+    PauliMaskArena pauli_masks;
+    PauliMaskArena noise_channel_masks;
+
     std::vector<HeisenbergOp> ops;
-
-    // Side-table for noise sites (indexed by HeisenbergOp::noise_.site_idx)
-    // Each NoiseSite contains the rewound Pauli channels for a quantum noise operation.
     std::vector<NoiseSite> noise_sites;
-
-    // Side-table for readout noise entries (indexed by HeisenbergOp::readout_.entry_idx)
     std::vector<ReadoutNoiseEntry> readout_noise;
-
-    // Side-tables for detector and observable measurement targets.
-    // Each entry is a list of absolute measurement indices to XOR together.
     std::vector<std::vector<uint32_t>> detector_targets;
     std::vector<std::vector<uint32_t>> observable_targets;
 
-    // Circuit metadata
     uint32_t num_qubits = 0;
-    uint32_t num_measurements = 0;         // Visible measurements only (M, MX, MY, MPP, MR, MRX)
-    uint32_t num_hidden_measurements = 0;  // Hidden measurements (from reset decomposition)
+    uint32_t num_measurements = 0;
+    uint32_t num_hidden_measurements = 0;
     uint32_t num_detectors = 0;
     uint32_t num_observables = 0;
     uint32_t num_exp_vals = 0;
 
-    // Global weight accumulator.
-    // The Front-End accumulates the dominant terms factored out of each gate.
-    // For T gates: exp(ipi/8) * cos(pi/8)
-    // The VM ignores this (deferred normalization), but it's needed for
-    // correct amplitude tracking if exporting to physical routing tools.
     std::complex<double> global_weight = {1.0, 0.0};
 
-    // --- Source Mapping (Playground) ---
-    // Parallel to ops: source_map[i] lists the original source line(s)
-    // that produced ops[i]. Inner vector has multiple entries when an
-    // optimizer fuses operations (e.g. T+T -> S carries both lines).
-    // Empty vector means the entire map was invalidated by an optimization
-    // pass that could not maintain it.
+    /// Parallel to ops: source_map[i] lists the source line(s) that
+    /// produced ops[i]. Empty inner vector means an optimizer pass
+    /// invalidated the map for that op.
     std::vector<std::vector<uint32_t>> source_map;
 
-    // --- Optional Debugging Artifacts ---
-    // If statevector debugging is enabled, the Front-End saves the final
-    // forward tableau here. This represents the geometric reference frame
-    // at t=end, needed to map GF(2) indices back to physical qubit basis.
     std::optional<stim::Tableau<kStimWidth>> final_tableau;
 
-    // Convenience accessors
+    // --- Mask accessors ---
+
+    [[nodiscard]] MaskView destab_mask(const HeisenbergOp& op) const {
+        assert(op.has_mask());
+        return pauli_masks.at(op.mask_handle()).x();
+    }
+    [[nodiscard]] MaskView stab_mask(const HeisenbergOp& op) const {
+        assert(op.has_mask());
+        return pauli_masks.at(op.mask_handle()).z();
+    }
+    [[nodiscard]] bool sign(const HeisenbergOp& op) const {
+        assert(op.has_mask());
+        return pauli_masks.at(op.mask_handle()).sign();
+    }
+    [[nodiscard]] PauliMaskView mask_view(const HeisenbergOp& op) const {
+        assert(op.has_mask());
+        return pauli_masks.at(op.mask_handle());
+    }
+    [[nodiscard]] MutablePauliMaskView mask_at(const HeisenbergOp& op) {
+        assert(op.has_mask());
+        return pauli_masks.mut_at(op.mask_handle());
+    }
+
+    // --- Builders that take pre-built MaskViews ---
+    //
+    // Convenient for tests and any caller that already has the mask data
+    // in MaskView form. Fails (via copy_from's contract) if the source
+    // mask has set bits beyond the arena's width.
+
+    HeisenbergOp& append_tgate(MaskView destab, MaskView stab, bool s, bool dagger = false) {
+        auto h = claim_pauli_mask(destab, stab, s);
+        ops.push_back(HeisenbergOp::make_tgate(h, dagger));
+        return ops.back();
+    }
+    HeisenbergOp& append_measure(MaskView destab, MaskView stab, bool s, MeasRecordIdx idx) {
+        auto h = claim_pauli_mask(destab, stab, s);
+        ops.push_back(HeisenbergOp::make_measure(h, idx));
+        return ops.back();
+    }
+    HeisenbergOp& append_conditional(MaskView destab, MaskView stab, bool s,
+                                     ControllingMeasIdx idx) {
+        auto h = claim_pauli_mask(destab, stab, s);
+        ops.push_back(HeisenbergOp::make_conditional(h, idx));
+        return ops.back();
+    }
+    HeisenbergOp& append_phase_rotation(MaskView destab, MaskView stab, bool s, double alpha) {
+        auto h = claim_pauli_mask(destab, stab, s);
+        ops.push_back(HeisenbergOp::make_phase_rotation(h, alpha));
+        return ops.back();
+    }
+    HeisenbergOp& append_exp_val(MaskView destab, MaskView stab, bool s, ExpValIdx idx) {
+        auto h = claim_pauli_mask(destab, stab, s);
+        ops.push_back(HeisenbergOp::make_exp_val(h, idx));
+        return ops.back();
+    }
+
+    // --- Lambda-fill builders ---
+    //
+    // The mask slot is claimed, the fill callable is invoked with a
+    // MutablePauliMaskView pointing at the freshly claimed (zeroed) slot,
+    // and the op is appended -- atomically at the call site. The Front-End
+    // uses this to write rewound-Pauli data straight from a stim::PauliString
+    // into the arena, avoiding any fixed-width PauliBitMask intermediate
+    // that would silently truncate qubits beyond kMaxInlineQubits. Example:
+    //
+    //     hir.append_tgate(/*dagger=*/false, [&](MutablePauliMaskView slot) {
+    //         stim_to_mask_view(rewound.xs, n, slot.x());
+    //         stim_to_mask_view(rewound.zs, n, slot.z());
+    //         slot.set_sign(rewound.sign);
+    //     });
+    //
+    // The fill callable's MutablePauliMaskView argument starts zeroed; the
+    // callable need only write the bits it cares about.
+
+    template <typename Fill>
+    HeisenbergOp& append_tgate(bool dagger, Fill&& fill) {
+        auto h = claim_empty_pauli_mask();
+        fill(pauli_masks.mut_at(h));
+        ops.push_back(HeisenbergOp::make_tgate(h, dagger));
+        return ops.back();
+    }
+    template <typename Fill>
+    HeisenbergOp& append_measure(MeasRecordIdx idx, Fill&& fill) {
+        auto h = claim_empty_pauli_mask();
+        fill(pauli_masks.mut_at(h));
+        ops.push_back(HeisenbergOp::make_measure(h, idx));
+        return ops.back();
+    }
+    template <typename Fill>
+    HeisenbergOp& append_conditional(ControllingMeasIdx idx, Fill&& fill) {
+        auto h = claim_empty_pauli_mask();
+        fill(pauli_masks.mut_at(h));
+        ops.push_back(HeisenbergOp::make_conditional(h, idx));
+        return ops.back();
+    }
+    template <typename Fill>
+    HeisenbergOp& append_phase_rotation(double alpha, Fill&& fill) {
+        auto h = claim_empty_pauli_mask();
+        fill(pauli_masks.mut_at(h));
+        ops.push_back(HeisenbergOp::make_phase_rotation(h, alpha));
+        return ops.back();
+    }
+    template <typename Fill>
+    HeisenbergOp& append_exp_val(ExpValIdx idx, Fill&& fill) {
+        auto h = claim_empty_pauli_mask();
+        fill(pauli_masks.mut_at(h));
+        ops.push_back(HeisenbergOp::make_exp_val(h, idx));
+        return ops.back();
+    }
+
+    // --- Builders for ops that don't carry a Pauli mask ---
+
+    HeisenbergOp& append_noise(NoiseSiteIdx idx) {
+        ops.push_back(HeisenbergOp::make_noise(idx));
+        return ops.back();
+    }
+    HeisenbergOp& append_readout_noise(ReadoutNoiseIdx idx) {
+        ops.push_back(HeisenbergOp::make_readout_noise(idx));
+        return ops.back();
+    }
+    HeisenbergOp& append_detector(DetectorIdx idx) {
+        ops.push_back(HeisenbergOp::make_detector(idx));
+        return ops.back();
+    }
+    HeisenbergOp& append_observable(ObservableIdx obs_idx, uint32_t target_list_idx) {
+        ops.push_back(HeisenbergOp::make_observable(obs_idx, target_list_idx));
+        return ops.back();
+    }
+
+    // --- Noise channel mask claims (analogous to pauli_masks) ---
+
+    /// Claim the next noise_channel_masks slot, populate (X, Z), return the handle.
+    PauliMaskHandle claim_noise_channel_mask(MaskView destab, MaskView stab) {
+        auto h = claim_empty_noise_channel_mask();
+        auto slot = noise_channel_masks.mut_at(h);
+        slot.x().copy_from(destab);
+        slot.z().copy_from(stab);
+        return h;
+    }
+
+    /// Claim the next noise_channel_masks slot zero-initialized; caller
+    /// fills via noise_channel_masks.mut_at(h). Throws (rather than
+    /// asserting) so a stale count_noise_channels() upper bound is
+    /// caught in Release as well as Debug.
+    PauliMaskHandle claim_empty_noise_channel_mask() {
+        if (next_noise_channel_mask_ >= noise_channel_masks.size()) {
+            throw std::runtime_error(
+                "noise_channel_masks arena exhausted: pre-trace counter was too low");
+        }
+        return static_cast<PauliMaskHandle>(next_noise_channel_mask_++);
+    }
+
+    // --- In-place mutation of existing op slots ---
+
+    void set_pauli(const HeisenbergOp& op, MaskView destab, MaskView stab, bool s) {
+        auto m = mask_at(op);
+        m.x().copy_from(destab);
+        m.z().copy_from(stab);
+        m.set_sign(s);
+    }
+
+    void set_sign(const HeisenbergOp& op, bool s) { mask_at(op).set_sign(s); }
+
+    /// Convert an existing mask-carrying op to a T_GATE while preserving
+    /// its mask handle. Resets the arena slot's sign to false to match
+    /// the peephole pass's normalization convention.
+    void demote_to_tgate(HeisenbergOp& op, bool dagger) {
+        assert(op.has_mask());
+        mask_at(op).set_sign(false);
+        op.reset_to_tgate(dagger);
+    }
+
+    /// Convert an existing mask-carrying op to a PHASE_ROTATION while
+    /// preserving its mask handle. Resets the arena slot's sign to false.
+    void demote_to_phase_rotation(HeisenbergOp& op, double alpha) {
+        assert(op.has_mask());
+        mask_at(op).set_sign(false);
+        op.reset_to_phase_rotation(alpha);
+    }
+
     [[nodiscard]] size_t num_ops() const { return ops.size(); }
 
     [[nodiscard]] size_t num_t_gates() const {
         size_t count = 0;
         for (const auto& op : ops) {
-            if (op.op_type() == OpType::T_GATE) {
+            if (op.op_type() == OpType::T_GATE)
                 ++count;
-            }
         }
         return count;
     }
+
+  private:
+    PauliMaskHandle claim_pauli_mask(MaskView destab, MaskView stab, bool s) {
+        auto h = claim_empty_pauli_mask();
+        auto slot = pauli_masks.mut_at(h);
+        slot.x().copy_from(destab);
+        slot.z().copy_from(stab);
+        slot.set_sign(s);
+        return h;
+    }
+
+    /// Throws (rather than asserting) so a stale count_pauli_masks() upper
+    /// bound is caught in Release as well as Debug.
+    PauliMaskHandle claim_empty_pauli_mask() {
+        if (next_pauli_mask_ >= pauli_masks.size()) {
+            throw std::runtime_error("pauli_masks arena exhausted: pre-trace counter was too low");
+        }
+        return static_cast<PauliMaskHandle>(next_pauli_mask_++);
+    }
+
+    size_t next_pauli_mask_ = 0;
+    size_t next_noise_channel_mask_ = 0;
 };
 
 }  // namespace clifft

--- a/src/clifft/optimizer/commutation.cc
+++ b/src/clifft/optimizer/commutation.cc
@@ -46,9 +46,10 @@ bool accesses_classical_index(const HeisenbergOp& op, uint32_t target_idx, const
 }
 
 /// Check Pauli commutativity between an op's masks and a noise site's channels.
-bool anti_commutes_with_noise(const HeisenbergOp& op, const NoiseSite& site) {
+bool anti_commutes_with_noise(const HeisenbergOp& op, const NoiseSite& site, const HirModule& hir) {
     for (const auto& ch : site.channels) {
-        if (anti_commute(op.destab_mask(), op.stab_mask(), ch.destab_mask, ch.stab_mask)) {
+        auto ch_view = hir.noise_channel_masks.at(ch.mask);
+        if (anti_commute(hir.destab_mask(op), hir.stab_mask(op), ch_view.x(), ch_view.z())) {
             return true;
         }
     }
@@ -56,10 +57,12 @@ bool anti_commutes_with_noise(const HeisenbergOp& op, const NoiseSite& site) {
 }
 
 /// Check Pauli anti-commutativity between any channel pair of two noise sites.
-bool noise_sites_anti_commute(const NoiseSite& a, const NoiseSite& b) {
+bool noise_sites_anti_commute(const NoiseSite& a, const NoiseSite& b, const HirModule& hir) {
     for (const auto& ch_a : a.channels) {
+        auto va = hir.noise_channel_masks.at(ch_a.mask);
         for (const auto& ch_b : b.channels) {
-            if (anti_commute(ch_a.destab_mask, ch_a.stab_mask, ch_b.destab_mask, ch_b.stab_mask)) {
+            auto vb = hir.noise_channel_masks.at(ch_b.mask);
+            if (anti_commute(va.x(), va.z(), vb.x(), vb.z())) {
                 return true;
             }
         }
@@ -101,17 +104,17 @@ bool can_swap(const HeisenbergOp& left, const HeisenbergOp& right, const HirModu
     if (left_is_noise && right_is_noise) {
         auto li = static_cast<uint32_t>(left.noise_site_idx());
         auto ri = static_cast<uint32_t>(right.noise_site_idx());
-        return !noise_sites_anti_commute(hir.noise_sites[li], hir.noise_sites[ri]);
+        return !noise_sites_anti_commute(hir.noise_sites[li], hir.noise_sites[ri], hir);
     }
 
     if (left_is_noise) {
         auto li = static_cast<uint32_t>(left.noise_site_idx());
-        return !anti_commutes_with_noise(right, hir.noise_sites[li]);
+        return !anti_commutes_with_noise(right, hir.noise_sites[li], hir);
     }
 
     if (right_is_noise) {
         auto ri = static_cast<uint32_t>(right.noise_site_idx());
-        return !anti_commutes_with_noise(left, hir.noise_sites[ri]);
+        return !anti_commutes_with_noise(left, hir.noise_sites[ri], hir);
     }
 
     // DETECTOR, OBSERVABLE, READOUT_NOISE have no quantum Pauli footprint
@@ -126,8 +129,8 @@ bool can_swap(const HeisenbergOp& left, const HeisenbergOp& right, const HirModu
     }
 
     // Standard Pauli anti-commutation check
-    return !anti_commute(left.destab_mask(), left.stab_mask(), right.destab_mask(),
-                         right.stab_mask());
+    return !anti_commute(hir.destab_mask(left), hir.stab_mask(left), hir.destab_mask(right),
+                         hir.stab_mask(right));
 }
 
 }  // namespace clifft

--- a/src/clifft/optimizer/commutation.h
+++ b/src/clifft/optimizer/commutation.h
@@ -1,14 +1,30 @@
 #pragma once
 
 #include "clifft/frontend/hir.h"
+#include "clifft/util/mask_view.h"
+
+#include <cassert>
+#include <cstdint>
 
 namespace clifft {
 
-/// Symplectic inner product over BitMask masks.
+/// Symplectic inner product over fixed-width BitMask masks.
 /// Returns true if the two Pauli strings anti-commute.
 inline bool anti_commute(const PauliBitMask& x1, const PauliBitMask& z1, const PauliBitMask& x2,
                          const PauliBitMask& z2) {
     return (((x1 & z2) ^ (z1 & x2)).popcount() & 1) != 0;
+}
+
+/// Symplectic inner product over runtime-width mask views. Returns true if
+/// the two Pauli strings anti-commute. All four views must share num_words().
+inline bool anti_commute(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
+    assert(x1.num_words() == z1.num_words() && z1.num_words() == x2.num_words() &&
+           x2.num_words() == z2.num_words());
+    int parity = 0;
+    for (uint32_t i = 0; i < x1.num_words(); ++i) {
+        parity += std::popcount((x1.words[i] & z2.words[i]) ^ (z1.words[i] & x2.words[i]));
+    }
+    return (parity & 1) != 0;
 }
 
 /// Returns true if the two HIR operations can be safely swapped in the

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -17,8 +17,7 @@ namespace {
 // Symplectic conjugation: absorb a virtual S gate into downstream ops
 // =========================================================================
 
-/// Conjugate Pauli Q by S_P: computes S_P^dag Q S_P (downstream direction)
-/// or S_P Q S_P^dag (tableau direction) depending on is_dagger.
+/// Conjugate Pauli Q by S_P in place.
 ///
 /// For S gate (is_dagger=false), c_phase=3 computes S^dag Q S.
 /// For S_dag gate (is_dagger=true), c_phase=1 computes S Q S^dag.
@@ -27,9 +26,8 @@ namespace {
 /// a phase i^{+1} when A*B advances cyclically (X->Y->Z->X) and i^{-1}
 /// when it retreats. The total phase from the commutator [P, Q] is
 /// i^{sum of per-qubit contributions}.
-inline void conjugate_pauli_by_S(const PauliBitMask& x_p, const PauliBitMask& z_p, bool sign_p,
-                                 PauliBitMask& x_q, PauliBitMask& z_q, bool& sign_q,
-                                 bool is_dagger) {
+inline void conjugate_pauli_by_S(MaskView x_p, MaskView z_p, bool sign_p, MutableMaskView x_q,
+                                 MutableMaskView z_q, bool& sign_q, bool is_dagger) {
     if (!anti_commute(x_p, z_p, x_q, z_q))
         return;
 
@@ -37,11 +35,11 @@ inline void conjugate_pauli_by_S(const PauliBitMask& x_p, const PauliBitMask& z_
     // Each qubit pair (A_i, B_i) contributes +1 or -1 to the total phase
     // exponent based on the cyclic ordering X->Y->Z->X.
     int phase = 0;
-    for (size_t w = 0; w < PauliBitMask::kWords; ++w) {
-        uint64_t X1 = x_p.w[w];
-        uint64_t Z1 = z_p.w[w];
-        uint64_t X2 = x_q.w[w];
-        uint64_t Z2 = z_q.w[w];
+    for (uint32_t w = 0; w < x_p.num_words(); ++w) {
+        uint64_t X1 = x_p.words[w];
+        uint64_t Z1 = z_p.words[w];
+        uint64_t X2 = x_q.words[w];
+        uint64_t Z2 = z_q.words[w];
 
         // +1 phase contributions: XY->Z, YZ->X, ZX->Y
         uint64_t mask_plus = (X1 & ~Z1 & X2 & Z2) | (X1 & Z1 & ~X2 & Z2) | (~X1 & Z1 & X2 & ~Z2);
@@ -64,15 +62,14 @@ inline void conjugate_pauli_by_S(const PauliBitMask& x_p, const PauliBitMask& z_
         total_phase = (total_phase + 2) % 4;
 
     sign_q = (total_phase == 2);
-    x_q ^= x_p;
-    z_q ^= z_p;
+    x_q.xor_with(x_p);
+    z_q.xor_with(z_p);
 }
 
 /// Absorb a virtual S gate on Pauli generator (x_v, z_v) into all
 /// downstream HIR operations and the final tableau.
-void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, const PauliBitMask& x_v,
-                                const PauliBitMask& z_v, bool sign_v, bool is_dagger,
-                                const std::vector<uint8_t>& deleted) {
+void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, MaskView x_v, MaskView z_v,
+                                bool sign_v, bool is_dagger, const std::vector<uint8_t>& deleted) {
     // 1. Conjugate all downstream ops
     for (size_t k = start_idx; k < hir.ops.size(); ++k) {
         if (deleted[k])
@@ -84,21 +81,18 @@ void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, const PauliBit
             case OpType::MEASURE:
             case OpType::CONDITIONAL_PAULI:
             case OpType::EXP_VAL: {
-                PauliBitMask x_i = op.destab_mask();
-                PauliBitMask z_i = op.stab_mask();
-                bool sign_i = op.sign();
-
-                conjugate_pauli_by_S(x_v, z_v, sign_v, x_i, z_i, sign_i, is_dagger);
-                op.set_pauli(x_i, z_i, sign_i);
+                auto m = hir.mask_at(op);
+                bool sign_i = m.sign();
+                conjugate_pauli_by_S(x_v, z_v, sign_v, m.x(), m.z(), sign_i, is_dagger);
+                m.set_sign(sign_i);
                 break;
             }
 
             case OpType::PHASE_ROTATION: {
-                PauliBitMask x_i = op.destab_mask();
-                PauliBitMask z_i = op.stab_mask();
-                bool sign_i = op.sign();
-
-                conjugate_pauli_by_S(x_v, z_v, sign_v, x_i, z_i, sign_i, is_dagger);
+                auto m = hir.mask_at(op);
+                bool sign_before = m.sign();
+                bool sign_i = sign_before;
+                conjugate_pauli_by_S(x_v, z_v, sign_v, m.x(), m.z(), sign_i, is_dagger);
 
                 // If S-conjugation flipped the Pauli axis sign, do NOT
                 // negate alpha. The physical SU(2) rotation direction is
@@ -106,21 +100,21 @@ void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, const PauliBit
                 // However, the front-end extracted the U(1) global phase
                 // using the OLD sign, and the backend expects global_weight
                 // to match the NEW sign. Patch the difference.
-                if (sign_i != op.sign()) {
-                    double corr = op.alpha() * std::numbers::pi * (op.sign() ? -1.0 : 1.0);
+                if (sign_i != sign_before) {
+                    double corr = op.alpha() * std::numbers::pi * (sign_before ? -1.0 : 1.0);
                     hir.global_weight *= std::complex<double>(std::cos(corr), std::sin(corr));
                 }
 
-                op.set_pauli(x_i, z_i, sign_i);
+                m.set_sign(sign_i);
                 break;
             }
 
             case OpType::NOISE: {
                 auto site_idx = static_cast<uint32_t>(op.noise_site_idx());
                 for (auto& ch : hir.noise_sites[site_idx].channels) {
+                    auto m = hir.noise_channel_masks.mut_at(ch.mask);
                     bool dummy_sign = false;
-                    conjugate_pauli_by_S(x_v, z_v, sign_v, ch.destab_mask, ch.stab_mask, dummy_sign,
-                                         is_dagger);
+                    conjugate_pauli_by_S(x_v, z_v, sign_v, m.x(), m.z(), dummy_sign, is_dagger);
                 }
                 break;
             }
@@ -135,44 +129,52 @@ void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, const PauliBit
 
     // 2. Final Tableau: U_C' = U_C S (requires inverted dagger flag)
     // Map P_virt forward through U_C to get P_phys in O(n^2), then
-    // conjugate all physical rows by P_phys in O(n^2).
+    // conjugate all physical rows by P_phys in O(n^2). All scratch is
+    // runtime-width to avoid the kMaxInlineQubits truncation bug that
+    // would silently miscompile S/S_dag fusions on high-qubit axes.
     if (hir.final_tableau.has_value()) {
         stim::Tableau<kStimWidth>& tab = *hir.final_tableau;
-        size_t words = (tab.num_qubits + 63) / 64;
-        if (words > PauliBitMask::kWords)
-            words = PauliBitMask::kWords;
+        const size_t words = std::min<size_t>((tab.num_qubits + 63) / 64, x_v.num_words());
 
         stim::PauliString<kStimWidth> p_virt(tab.num_qubits);
         for (size_t w = 0; w < words; ++w) {
-            p_virt.xs.u64[w] = x_v.w[w];
-            p_virt.zs.u64[w] = z_v.w[w];
+            p_virt.xs.u64[w] = x_v.words[w];
+            p_virt.zs.u64[w] = z_v.words[w];
         }
         p_virt.sign = sign_v;
 
         stim::PauliString<kStimWidth> p_phys = tab(p_virt);
 
-        PauliBitMask px_phys, pz_phys;
+        std::vector<uint64_t> px_phys(words, 0);
+        std::vector<uint64_t> pz_phys(words, 0);
         for (size_t w = 0; w < words; ++w) {
-            px_phys.w[w] = p_phys.xs.u64[w];
-            pz_phys.w[w] = p_phys.zs.u64[w];
+            px_phys[w] = p_phys.xs.u64[w];
+            pz_phys[w] = p_phys.zs.u64[w];
         }
         bool psign_phys = p_phys.sign;
+        MaskView px_view{std::span<const uint64_t>(px_phys)};
+        MaskView pz_view{std::span<const uint64_t>(pz_phys)};
+
+        std::vector<uint64_t> q_x(words, 0);
+        std::vector<uint64_t> q_z(words, 0);
+        MutableMaskView qx_view{std::span<uint64_t>(q_x)};
+        MutableMaskView qz_view{std::span<uint64_t>(q_z)};
 
         // Tableau generators: S_P X_q S_P^dag, so pass !is_dagger
         for (size_t q = 0; q < tab.num_qubits; ++q) {
             auto apply_to_ps = [&](stim::PauliStringRef<kStimWidth> row) {
-                PauliBitMask q_x, q_z;
                 for (size_t w = 0; w < words; ++w) {
-                    q_x.w[w] = row.xs.u64[w];
-                    q_z.w[w] = row.zs.u64[w];
+                    q_x[w] = row.xs.u64[w];
+                    q_z[w] = row.zs.u64[w];
                 }
                 bool q_sign = row.sign;
 
-                conjugate_pauli_by_S(px_phys, pz_phys, psign_phys, q_x, q_z, q_sign, !is_dagger);
+                conjugate_pauli_by_S(px_view, pz_view, psign_phys, qx_view, qz_view, q_sign,
+                                     !is_dagger);
 
                 for (size_t w = 0; w < words; ++w) {
-                    row.xs.u64[w] = q_x.w[w];
-                    row.zs.u64[w] = q_z.w[w];
+                    row.xs.u64[w] = q_x[w];
+                    row.zs.u64[w] = q_z[w];
                 }
                 row.sign = q_sign;
             };
@@ -193,11 +195,12 @@ void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, const PauliBit
 ///   T_dag(-P) = exp(-i*pi/4) * T(+P)
 /// After normalization, all T gates have sign=false and the effective
 /// rotation direction is determined solely by the dagger flag.
-inline void normalize_t_sign(HeisenbergOp& op, std::complex<double>& global_weight) {
-    if (op.op_type() == OpType::T_GATE && op.sign()) {
+inline void normalize_t_sign(HirModule& hir, HeisenbergOp& op,
+                             std::complex<double>& global_weight) {
+    if (op.op_type() == OpType::T_GATE && hir.sign(op)) {
         global_weight *= op.is_dagger() ? kExpMinusIPiOver4 : kExpIPiOver4;
         op.set_dagger(!op.is_dagger());
-        op.set_pauli(op.destab_mask(), op.stab_mask(), false);
+        hir.set_sign(op, false);
     }
 }
 
@@ -209,15 +212,15 @@ inline bool is_blocked(const HeisenbergOp& op_i, const HeisenbergOp& op_j, const
         case OpType::PHASE_ROTATION:
         case OpType::MEASURE:
         case OpType::CONDITIONAL_PAULI:
-            return anti_commute(op_i.destab_mask(), op_i.stab_mask(), op_j.destab_mask(),
-                                op_j.stab_mask());
+            return anti_commute(hir.destab_mask(op_i), hir.stab_mask(op_i), hir.destab_mask(op_j),
+                                hir.stab_mask(op_j));
 
         case OpType::NOISE: {
             auto site_idx = static_cast<uint32_t>(op_j.noise_site_idx());
             const auto& channels = hir.noise_sites[site_idx].channels;
             for (const auto& ch : channels) {
-                if (anti_commute(op_i.destab_mask(), op_i.stab_mask(), ch.destab_mask,
-                                 ch.stab_mask)) {
+                auto cv = hir.noise_channel_masks.at(ch.mask);
+                if (anti_commute(hir.destab_mask(op_i), hir.stab_mask(op_i), cv.x(), cv.z())) {
                     return true;
                 }
             }
@@ -257,10 +260,11 @@ void PeepholeFusionPass::run(HirModule& hir) {
             if (hir.ops[i].op_type() != OpType::T_GATE)
                 continue;
 
-            normalize_t_sign(hir.ops[i], hir.global_weight);
-            auto& op_i = hir.ops[i];
-            auto destab_i = op_i.destab_mask();
-            auto stab_i = op_i.stab_mask();
+            normalize_t_sign(hir, hir.ops[i], hir.global_weight);
+            // After normalization the mask handle is unchanged; capture the
+            // arena-resident views once so we can compare against later ops.
+            auto destab_i = hir.destab_mask(hir.ops[i]);
+            auto stab_i = hir.stab_mask(hir.ops[i]);
 
             for (size_t j = i + 1; j < n; ++j) {
                 if (deleted[j])
@@ -269,15 +273,18 @@ void PeepholeFusionPass::run(HirModule& hir) {
                 // Normalize candidate T gates before comparison so that
                 // sign-induced dagger flips are accounted for in effective_angle.
                 if (hir.ops[j].op_type() == OpType::T_GATE)
-                    normalize_t_sign(hir.ops[j], hir.global_weight);
+                    normalize_t_sign(hir, hir.ops[j], hir.global_weight);
 
+                // Re-fetch op_i in case anything mutated it (it didn't, but
+                // be explicit since views must remain valid).
+                const auto& op_i = hir.ops[i];
                 const auto& op_j = hir.ops[j];
 
                 // Check if op_j is a matching T gate on the same axis.
                 // After normalization both ops have sign=false, so
                 // effective_angle depends only on the dagger flag.
-                if (op_j.op_type() == OpType::T_GATE && op_j.destab_mask() == destab_i &&
-                    op_j.stab_mask() == stab_i) {
+                if (op_j.op_type() == OpType::T_GATE && hir.destab_mask(op_j) == destab_i &&
+                    hir.stab_mask(op_j) == stab_i) {
                     int dir_i = op_i.is_dagger() ? -1 : 1;
                     int dir_j = op_j.is_dagger() ? -1 : 1;
                     int total = dir_i + dir_j;
@@ -316,21 +323,21 @@ void PeepholeFusionPass::run(HirModule& hir) {
             if (hir.ops[i].op_type() != OpType::PHASE_ROTATION)
                 continue;
 
-            const auto& op_i = hir.ops[i];
-            auto destab_i = op_i.destab_mask();
-            auto stab_i = op_i.stab_mask();
+            auto destab_i = hir.destab_mask(hir.ops[i]);
+            auto stab_i = hir.stab_mask(hir.ops[i]);
 
             for (size_t j = i + 1; j < n; ++j) {
                 if (deleted[j])
                     continue;
 
+                const auto& op_i = hir.ops[i];
                 const auto& op_j = hir.ops[j];
 
-                if (op_j.op_type() == OpType::PHASE_ROTATION && op_j.destab_mask() == destab_i &&
-                    op_j.stab_mask() == stab_i) {
+                if (op_j.op_type() == OpType::PHASE_ROTATION && hir.destab_mask(op_j) == destab_i &&
+                    hir.stab_mask(op_j) == stab_i) {
                     // Compute fused angle accounting for sign bits.
-                    double alpha_i = op_i.alpha() * (op_i.sign() ? -1.0 : 1.0);
-                    double alpha_j = op_j.alpha() * (op_j.sign() ? -1.0 : 1.0);
+                    double alpha_i = op_i.alpha() * (hir.sign(op_i) ? -1.0 : 1.0);
+                    double alpha_j = op_j.alpha() * (hir.sign(op_j) ? -1.0 : 1.0);
                     double fused = alpha_i + alpha_j;
 
                     // Normalize to [0, 2) relative phase range
@@ -356,7 +363,7 @@ void PeepholeFusionPass::run(HirModule& hir) {
                                                    deleted);
                         ++fusions_;
                     } else if (std::abs(fused - 0.25) < kDemoteEps) {
-                        hir.ops[i] = HeisenbergOp::make_tgate(destab_i, stab_i, false, false);
+                        hir.demote_to_tgate(hir.ops[i], false);
                         if (has_source_map) {
                             auto& dst = hir.source_map[i];
                             auto& src = hir.source_map[j];
@@ -365,8 +372,7 @@ void PeepholeFusionPass::run(HirModule& hir) {
                         deleted[j] = true;
                         ++fusions_;
                     } else if (std::abs(fused - 1.75) < kDemoteEps) {
-                        hir.ops[i] =
-                            HeisenbergOp::make_tgate(destab_i, stab_i, false, /*dagger=*/true);
+                        hir.demote_to_tgate(hir.ops[i], /*dagger=*/true);
                         if (has_source_map) {
                             auto& dst = hir.source_map[i];
                             auto& src = hir.source_map[j];
@@ -375,8 +381,7 @@ void PeepholeFusionPass::run(HirModule& hir) {
                         deleted[j] = true;
                         ++fusions_;
                     } else {
-                        hir.ops[i] = HeisenbergOp::make_phase_rotation(destab_i, stab_i,
-                                                                       /*sign=*/false, fused);
+                        hir.demote_to_phase_rotation(hir.ops[i], fused);
                         if (has_source_map) {
                             auto& dst = hir.source_map[i];
                             auto& src = hir.source_map[j];
@@ -403,7 +408,7 @@ void PeepholeFusionPass::run(HirModule& hir) {
             if (deleted[i] || hir.ops[i].op_type() != OpType::PHASE_ROTATION)
                 continue;
 
-            double alpha = hir.ops[i].alpha() * (hir.ops[i].sign() ? -1.0 : 1.0);
+            double alpha = hir.ops[i].alpha() * (hir.sign(hir.ops[i]) ? -1.0 : 1.0);
             double a_mod2 = alpha - 2.0 * std::floor(alpha / 2.0);
 
             constexpr double kDemoteEps = 1e-12;
@@ -413,26 +418,24 @@ void PeepholeFusionPass::run(HirModule& hir) {
                 changed = true;
             } else if (std::abs(a_mod2 - 0.5) < kDemoteEps) {
                 // S: absorb downstream (phase already in global_weight)
-                apply_virtual_s_downstream(hir, i + 1, hir.ops[i].destab_mask(),
-                                           hir.ops[i].stab_mask(), false, false, deleted);
+                apply_virtual_s_downstream(hir, i + 1, hir.destab_mask(hir.ops[i]),
+                                           hir.stab_mask(hir.ops[i]), false, false, deleted);
                 deleted[i] = true;
                 ++fusions_;
                 changed = true;
             } else if (std::abs(a_mod2 - 1.5) < kDemoteEps) {
                 // S_dag: absorb downstream (phase already in global_weight)
-                apply_virtual_s_downstream(hir, i + 1, hir.ops[i].destab_mask(),
-                                           hir.ops[i].stab_mask(), false, true, deleted);
+                apply_virtual_s_downstream(hir, i + 1, hir.destab_mask(hir.ops[i]),
+                                           hir.stab_mask(hir.ops[i]), false, true, deleted);
                 deleted[i] = true;
                 ++fusions_;
                 changed = true;
             } else if (std::abs(a_mod2 - 0.25) < kDemoteEps) {
-                hir.ops[i] = HeisenbergOp::make_tgate(hir.ops[i].destab_mask(),
-                                                      hir.ops[i].stab_mask(), false, false);
+                hir.demote_to_tgate(hir.ops[i], false);
                 ++fusions_;
                 changed = true;
             } else if (std::abs(a_mod2 - 1.75) < kDemoteEps) {
-                hir.ops[i] = HeisenbergOp::make_tgate(hir.ops[i].destab_mask(),
-                                                      hir.ops[i].stab_mask(), false, true);
+                hir.demote_to_tgate(hir.ops[i], /*dagger=*/true);
                 ++fusions_;
                 changed = true;
             }

--- a/src/clifft/optimizer/remove_noise_pass.cc
+++ b/src/clifft/optimizer/remove_noise_pass.cc
@@ -9,6 +9,10 @@ void RemoveNoisePass::run(HirModule& hir) {
 
     hir.noise_sites.clear();
     hir.readout_noise.clear();
+    // The noise_channel_masks arena is fixed-capacity and references can't
+    // be dropped without dropping the arena itself. Replace with an empty
+    // arena so the slots don't sit around as dead weight after removal.
+    hir.noise_channel_masks = PauliMaskArena{};
     hir.source_map.clear();
 }
 

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1807,16 +1807,23 @@ static inline void exec_swap_meas_interfere(SchrodingerState& state, uint16_t f,
 // =============================================================================
 
 // Apply a Pauli error to the Pauli frame (shared logic for APPLY_PAULI and NOISE).
-static inline void apply_pauli_to_frame(SchrodingerState& state, const PauliBitMask& err_x,
-                                        const PauliBitMask& err_z, bool sign) {
+static inline void apply_pauli_to_frame(SchrodingerState& state, MaskView err_x, MaskView err_z,
+                                        bool sign) {
     // Phase: (-1)^popcount(err_z & current_x)
     // When composing E*P, we commute Z^{e_z} past X^{p_x}, picking up (-1)^{e_z . p_x}.
-    if ((state.p_x & err_z).popcount() & 1) {
+    int parity = 0;
+    const uint32_t nw = err_x.num_words();
+    for (uint32_t i = 0; i < nw && i < kMaxInlineWords; ++i) {
+        parity += std::popcount(state.p_x.w[i] & err_z.words[i]);
+    }
+    if (parity & 1) {
         state.multiply_phase({-1.0, 0.0});
     }
 
-    state.p_x ^= err_x;
-    state.p_z ^= err_z;
+    for (uint32_t i = 0; i < nw && i < kMaxInlineWords; ++i) {
+        state.p_x.w[i] ^= err_x.words[i];
+        state.p_z.w[i] ^= err_z.words[i];
+    }
 
     if (sign) {
         state.multiply_phase({-1.0, 0.0});
@@ -1834,8 +1841,8 @@ static inline void exec_apply_pauli(SchrodingerState& state, const ConstantPool&
         return;
     }
 
-    const auto& pm = pool.pauli_masks[cp_mask_idx];
-    apply_pauli_to_frame(state, pm.x, pm.z, pm.sign);
+    auto pm = pool.pauli_masks.at(static_cast<PauliMaskHandle>(cp_mask_idx));
+    apply_pauli_to_frame(state, pm.x(), pm.z(), pm.sign());
 }
 
 // NOISE: stochastic Pauli channel with gap-based skip optimization.
@@ -1863,7 +1870,8 @@ static inline void exec_noise(SchrodingerState& state, const ConstantPool& pool,
     for (const auto& ch : site.channels) {
         cumulative += ch.prob;
         if (rand < cumulative) {
-            apply_pauli_to_frame(state, ch.destab_mask, ch.stab_mask, false);
+            auto m = pool.noise_channel_masks.at(ch.mask);
+            apply_pauli_to_frame(state, m.x(), m.z(), false);
             break;
         }
     }
@@ -1992,17 +2000,31 @@ exec_exp_val(SchrodingerState& state, const ConstantPool& pool, uint32_t cp_exp_
     assert(cp_exp_val_idx < pool.exp_val_masks.size());
     assert(exp_val_idx < state.exp_vals.size());
 
-    const auto& pm = pool.exp_val_masks[cp_exp_val_idx];
+    auto pm = pool.exp_val_masks.at(static_cast<PauliMaskHandle>(cp_exp_val_idx));
+    auto pm_x = pm.x();
+    auto pm_z = pm.z();
 
     // Step 1: Frame conjugation.
     // Compute symplectic anti-commutation parity between stored Pauli P
     // and the current runtime Pauli frame. If P anti-commutes with the
     // frame, the expectation sign flips.
-    bool frame_sign = pm.sign;
-    if ((pm.x & state.p_z).popcount() & 1)
-        frame_sign = !frame_sign;
-    if ((pm.z & state.p_x).popcount() & 1)
-        frame_sign = !frame_sign;
+    bool frame_sign = pm.sign();
+    {
+        int parity = 0;
+        const uint32_t nw = pm_x.num_words();
+        for (uint32_t w = 0; w < nw && w < kMaxInlineWords; ++w)
+            parity += std::popcount(pm_x.words[w] & state.p_z.w[w]);
+        if (parity & 1)
+            frame_sign = !frame_sign;
+    }
+    {
+        int parity = 0;
+        const uint32_t nw = pm_z.num_words();
+        for (uint32_t w = 0; w < nw && w < kMaxInlineWords; ++w)
+            parity += std::popcount(pm_z.words[w] & state.p_x.w[w]);
+        if (parity & 1)
+            frame_sign = !frame_sign;
+    }
 
     // Step 2: Dormant/active split.
     // Dormant qubits (axes >= active_k) are in |0> state.
@@ -2010,32 +2032,39 @@ exec_exp_val(SchrodingerState& state, const ConstantPool& pool, uint32_t cp_exp_
     // Z support on a dormant qubit contributes +1 (identity for Z|0>=|0>).
     uint32_t k = state.active_k;
 
-    // Check if any dormant qubit has X support by masking out the active bits.
-    // Any X bit set in the dormant range means the result is 0.
+    // Check if any dormant qubit has X support. Active region is [0, k);
+    // any bit in the suffix means the result is 0.
     {
-        PauliBitMask dormant_x = pm.x;
-        // Clear active bits [0, k)
-        uint32_t full_words = k / 64;
-        uint32_t remaining = k % 64;
-        for (uint32_t w = 0; w < full_words && w < kMaxInlineWords; ++w)
-            dormant_x.w[w] = 0;
-        if (remaining > 0 && full_words < kMaxInlineWords)
-            dormant_x.w[full_words] &= ~((uint64_t{1} << remaining) - 1);
-        if (!dormant_x.is_zero()) {
+        const uint32_t full_words = k / 64;
+        const uint32_t remaining = k % 64;
+        const uint32_t nw = pm_x.num_words();
+        bool any_dormant_x = false;
+        // Word straddling k: bits [remaining, 64) are dormant.
+        if (remaining > 0 && full_words < nw) {
+            uint64_t dormant_in_word = pm_x.words[full_words] & ~((uint64_t{1} << remaining) - 1);
+            if (dormant_in_word != 0)
+                any_dormant_x = true;
+        }
+        // Words entirely above k: any bit is dormant.
+        const uint32_t start = (remaining == 0) ? full_words : full_words + 1;
+        for (uint32_t w = start; w < nw && !any_dormant_x; ++w) {
+            if (pm_x.words[w] != 0)
+                any_dormant_x = true;
+        }
+        if (any_dormant_x) {
             state.exp_vals[exp_val_idx] = 0.0;
             return;
         }
     }
 
     // Step 3: Active-space evaluation.
-    // Extract active-space X and Z masks (bits 0..k-1).
+    // peak_rank < 63 invariant -> all active bits are in word[0].
     uint64_t x_active = 0;
     uint64_t z_active = 0;
-    for (uint32_t q = 0; q < k && q < 64; ++q) {
-        if (bit_get(pm.x, q))
-            x_active |= (uint64_t{1} << q);
-        if (bit_get(pm.z, q))
-            z_active |= (uint64_t{1} << q);
+    if (k > 0 && pm_x.num_words() > 0) {
+        uint64_t active_mask = (k == 64) ? ~uint64_t{0} : ((uint64_t{1} << k) - 1);
+        x_active = pm_x.words[0] & active_mask;
+        z_active = pm_z.words[0] & active_mask;
     }
 
     // Compute the constant phase factor: i^popcount(x_active & z_active)

--- a/src/clifft/util/introspection.cc
+++ b/src/clifft/util/introspection.cc
@@ -58,21 +58,21 @@ std::string op_type_to_str(OpType type) {
     }
 }
 
-std::string format_hir_op(const HeisenbergOp& op, const HirModule& hir) {
+std::string format_hir_op(const HeisenbergOp& op, std::optional<PauliMaskView> mask) {
     std::ostringstream ss;
     switch (op.op_type()) {
         case OpType::T_GATE:
-            ss << (op.is_dagger() ? "T_DAG " : "T ") << format_pauli_mask(hir.mask_view(op));
+            ss << (op.is_dagger() ? "T_DAG " : "T ") << format_pauli_mask(*mask);
             break;
         case OpType::MEASURE:
-            ss << "MEASURE " << format_pauli_mask(hir.mask_view(op)) << " -> rec["
+            ss << "MEASURE " << format_pauli_mask(*mask) << " -> rec["
                << static_cast<uint32_t>(op.meas_record_idx()) << "]";
             if (op.is_hidden())
                 ss << " (hidden)";
             break;
         case OpType::CONDITIONAL_PAULI:
             ss << "IF rec[" << static_cast<uint32_t>(op.controlling_meas()) << "] THEN "
-               << format_pauli_mask(hir.mask_view(op));
+               << format_pauli_mask(*mask);
             break;
         case OpType::NOISE:
             ss << "NOISE site=" << static_cast<uint32_t>(op.noise_site_idx());
@@ -88,11 +88,10 @@ std::string format_hir_op(const HeisenbergOp& op, const HirModule& hir) {
                << " target_list=" << op.observable_target_list_idx();
             break;
         case OpType::PHASE_ROTATION:
-            ss << "PHASE_ROTATION " << format_pauli_mask(hir.mask_view(op))
-               << " alpha=" << op.alpha();
+            ss << "PHASE_ROTATION " << format_pauli_mask(*mask) << " alpha=" << op.alpha();
             break;
         case OpType::EXP_VAL:
-            ss << "EXP_VAL " << format_pauli_mask(hir.mask_view(op)) << " -> exp["
+            ss << "EXP_VAL " << format_pauli_mask(*mask) << " -> exp["
                << static_cast<uint32_t>(op.exp_val_idx()) << "]";
             break;
         case OpType::NUM_OP_TYPES:

--- a/src/clifft/util/introspection.cc
+++ b/src/clifft/util/introspection.cc
@@ -4,17 +4,18 @@
 
 namespace clifft {
 
-std::string format_pauli_mask(const HeisenbergOp& op) {
-    const auto& x_mask = op.destab_mask();
-    const auto& z_mask = op.stab_mask();
-    bool sign = op.sign();
+std::string format_pauli_mask(PauliMaskView mask) {
+    MaskView x_mask = mask.x();
+    MaskView z_mask = mask.z();
+    bool sign = mask.sign();
 
     if (x_mask.is_zero() && z_mask.is_zero())
         return sign ? "-I" : "+I";
 
     std::string result = sign ? "-" : "+";
     bool first = true;
-    for (uint32_t i = 0; i < kMaxInlineQubits; ++i) {
+    const uint32_t bits = x_mask.num_words() * 64;
+    for (uint32_t i = 0; i < bits; ++i) {
         bool x = x_mask.bit_get(i);
         bool z = z_mask.bit_get(i);
         if (x || z) {
@@ -57,21 +58,21 @@ std::string op_type_to_str(OpType type) {
     }
 }
 
-std::string format_hir_op(const HeisenbergOp& op) {
+std::string format_hir_op(const HeisenbergOp& op, const HirModule& hir) {
     std::ostringstream ss;
     switch (op.op_type()) {
         case OpType::T_GATE:
-            ss << (op.is_dagger() ? "T_DAG " : "T ") << format_pauli_mask(op);
+            ss << (op.is_dagger() ? "T_DAG " : "T ") << format_pauli_mask(hir.mask_view(op));
             break;
         case OpType::MEASURE:
-            ss << "MEASURE " << format_pauli_mask(op) << " -> rec["
+            ss << "MEASURE " << format_pauli_mask(hir.mask_view(op)) << " -> rec["
                << static_cast<uint32_t>(op.meas_record_idx()) << "]";
             if (op.is_hidden())
                 ss << " (hidden)";
             break;
         case OpType::CONDITIONAL_PAULI:
             ss << "IF rec[" << static_cast<uint32_t>(op.controlling_meas()) << "] THEN "
-               << format_pauli_mask(op);
+               << format_pauli_mask(hir.mask_view(op));
             break;
         case OpType::NOISE:
             ss << "NOISE site=" << static_cast<uint32_t>(op.noise_site_idx());
@@ -87,10 +88,11 @@ std::string format_hir_op(const HeisenbergOp& op) {
                << " target_list=" << op.observable_target_list_idx();
             break;
         case OpType::PHASE_ROTATION:
-            ss << "PHASE_ROTATION " << format_pauli_mask(op) << " alpha=" << op.alpha();
+            ss << "PHASE_ROTATION " << format_pauli_mask(hir.mask_view(op))
+               << " alpha=" << op.alpha();
             break;
         case OpType::EXP_VAL:
-            ss << "EXP_VAL " << format_pauli_mask(op) << " -> exp["
+            ss << "EXP_VAL " << format_pauli_mask(hir.mask_view(op)) << " -> exp["
                << static_cast<uint32_t>(op.exp_val_idx()) << "]";
             break;
         case OpType::NUM_OP_TYPES:

--- a/src/clifft/util/introspection.h
+++ b/src/clifft/util/introspection.h
@@ -10,13 +10,13 @@
 
 namespace clifft {
 
-// Format a HeisenbergOp's Pauli mask as a human-readable string.
+// Format a Pauli mask (X bits, Z bits, sign) as a human-readable string.
 // Example: "+X0*Z3" for destab bit 0 and stab bit 3.
-std::string format_pauli_mask(const HeisenbergOp& op);
+std::string format_pauli_mask(PauliMaskView mask);
 
 std::string op_type_to_str(OpType type);
 
-std::string format_hir_op(const HeisenbergOp& op);
+std::string format_hir_op(const HeisenbergOp& op, const HirModule& hir);
 
 std::string opcode_to_str(Opcode op);
 

--- a/src/clifft/util/introspection.h
+++ b/src/clifft/util/introspection.h
@@ -6,6 +6,7 @@
 #include "clifft/backend/backend.h"
 #include "clifft/frontend/hir.h"
 
+#include <optional>
 #include <string>
 
 namespace clifft {
@@ -16,7 +17,11 @@ std::string format_pauli_mask(PauliMaskView mask);
 
 std::string op_type_to_str(OpType type);
 
-std::string format_hir_op(const HeisenbergOp& op, const HirModule& hir);
+// Format a HIR op as a human-readable string. For mask-carrying ops the
+// caller passes the op's mask via `hir.mask_view(op)`; for non-mask ops
+// (NOISE, READOUT_NOISE, DETECTOR, OBSERVABLE) the caller passes
+// std::nullopt and the mask argument is unused.
+std::string format_hir_op(const HeisenbergOp& op, std::optional<PauliMaskView> mask);
 
 std::string opcode_to_str(Opcode op);
 

--- a/src/clifft/util/mask_view.h
+++ b/src/clifft/util/mask_view.h
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
 
 namespace clifft {
@@ -128,12 +129,24 @@ struct BasicMaskView {
             words[i] |= other.words[i];
     }
 
+    /// Copy `other` into this view. The source must fit within the
+    /// destination width: if `other` is narrower, trailing destination
+    /// words are zero-padded; if `other` is wider, the call throws unless
+    /// every excess word is already zero (so no information is lost).
+    /// Use `std::span` truncation at the call site if you genuinely want
+    /// to drop bits (e.g. `dst.copy_from({other.words.first(dst.num_words())})`).
     constexpr void copy_from(BasicMaskView<const uint64_t> other)
         requires(!std::is_const_v<Word>)
     {
-        assert(words.size() == other.words.size());
-        for (size_t i = 0; i < words.size(); ++i)
+        const size_t common = std::min(words.size(), other.words.size());
+        for (size_t i = common; i < other.words.size(); ++i) {
+            if (other.words[i] != 0)
+                throw std::runtime_error("copy_from: source has set bits above destination width");
+        }
+        for (size_t i = 0; i < common; ++i)
             words[i] = other.words[i];
+        for (size_t i = common; i < words.size(); ++i)
+            words[i] = 0;
     }
 };
 

--- a/src/clifft/util/mask_view.h
+++ b/src/clifft/util/mask_view.h
@@ -86,6 +86,17 @@ struct BasicMaskView {
         words[idx / 64] ^= (1ULL << (idx % 64));
     }
 
+    constexpr void bit_swap(uint32_t i, uint32_t j)
+        requires(!std::is_const_v<Word>)
+    {
+        if (i == j)
+            return;
+        bool a = bit_get(i);
+        bool b = bit_get(j);
+        bit_set(i, b);
+        bit_set(j, a);
+    }
+
     /// Multi-word analog of `x &= x - 1`. Clears the lowest set bit.
     constexpr void clear_lowest_bit()
         requires(!std::is_const_v<Word>)
@@ -152,6 +163,18 @@ struct BasicMaskView {
 
 using MaskView = BasicMaskView<const uint64_t>;
 using MutableMaskView = BasicMaskView<uint64_t>;
+
+/// Bitwise equality on runtime-width mask views: same width and identical
+/// contents. Mutable views convert implicitly so `mut == const` works.
+[[nodiscard]] inline bool operator==(MaskView a, MaskView b) {
+    if (a.words.size() != b.words.size())
+        return false;
+    for (size_t i = 0; i < a.words.size(); ++i) {
+        if (a.words[i] != b.words[i])
+            return false;
+    }
+    return true;
+}
 
 // Adapters: expose a fixed-width BitMask<N> through the runtime view API.
 template <size_t N>

--- a/src/clifft/util/mask_view.h
+++ b/src/clifft/util/mask_view.h
@@ -16,7 +16,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
-#include <stdexcept>
 #include <type_traits>
 
 namespace clifft {
@@ -138,26 +137,6 @@ struct BasicMaskView {
         assert(words.size() == other.words.size());
         for (size_t i = 0; i < words.size(); ++i)
             words[i] |= other.words[i];
-    }
-
-    /// Copy `other` into this view. The source must fit within the
-    /// destination width: if `other` is narrower, trailing destination
-    /// words are zero-padded; if `other` is wider, the call throws unless
-    /// every excess word is already zero (so no information is lost).
-    /// Use `std::span` truncation at the call site if you genuinely want
-    /// to drop bits (e.g. `dst.copy_from({other.words.first(dst.num_words())})`).
-    constexpr void copy_from(BasicMaskView<const uint64_t> other)
-        requires(!std::is_const_v<Word>)
-    {
-        const size_t common = std::min(words.size(), other.words.size());
-        for (size_t i = common; i < other.words.size(); ++i) {
-            if (other.words[i] != 0)
-                throw std::runtime_error("copy_from: source has set bits above destination width");
-        }
-        for (size_t i = 0; i < common; ++i)
-            words[i] = other.words[i];
-        for (size_t i = common; i < words.size(); ++i)
-            words[i] = 0;
     }
 };
 

--- a/src/clifft/util/pauli_arena.h
+++ b/src/clifft/util/pauli_arena.h
@@ -62,6 +62,9 @@ class MutablePauliMaskView {
 
 class PauliMaskArena {
   public:
+    /// Default construction yields a zero-width, zero-capacity arena.
+    PauliMaskArena() : PauliMaskArena(0, 0) {}
+
     /// Construct with fixed capacity. All masks initialized to zero.
     PauliMaskArena(uint32_t num_qubits, size_t num_masks)
         : num_words_((num_qubits + 63) / 64),

--- a/src/clifft/util/pauli_arena.h
+++ b/src/clifft/util/pauli_arena.h
@@ -95,6 +95,12 @@ class PauliMaskArena {
     }
 
     uint32_t num_words_;
+    // Capacity is fixed at construction. Resizing these vectors after
+    // construction would invalidate any outstanding PauliMaskView /
+    // MutablePauliMaskView, since their span/pointer fields reference
+    // the underlying storage directly. Any future change that needs to
+    // grow an arena post-construction must move to a stable-handle
+    // representation (e.g. chunked storage) before doing so.
     std::vector<uint64_t> x_;
     std::vector<uint64_t> z_;
     std::vector<uint8_t> signs_;

--- a/src/clifft/util/stim_mask.h
+++ b/src/clifft/util/stim_mask.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// Stim <-> MaskView interop helpers.
+//
+// These bridge stim's simd_bits_range_ref Pauli rows and clifft's
+// runtime-width MaskView storage. Kept in a separate header so neither
+// hir.h nor mask_view.h needs to take a Stim dependency on its own.
+
+#include "clifft/util/mask_view.h"
+
+#include "stim.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace clifft {
+
+// Stim SIMD lane width. Stim's TableauSimulator<W> handles arbitrary qubit
+// counts via dynamic heap allocation at any W; this controls only the SIMD
+// register width for internal bit operations.
+constexpr size_t kStimWidth = 64;
+
+/// Copy the first `n` bits of a Stim PauliString row into a destination
+/// MutableMaskView. Trailing destination words are zeroed. The destination
+/// must be at least `(n + 63) / 64` words wide.
+inline void stim_to_mask_view(const stim::simd_bits_range_ref<kStimWidth>& bits, uint32_t n,
+                              MutableMaskView dst) {
+    const uint32_t words = (n + 63) / 64;
+    assert(words <= dst.num_words() && "stim_to_mask_view: destination too narrow");
+    for (uint32_t w = 0; w < words; ++w)
+        dst.words[w] = bits.u64[w];
+    for (uint32_t w = words; w < dst.num_words(); ++w)
+        dst.words[w] = 0;
+}
+
+}  // namespace clifft

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -370,9 +370,14 @@ NB_MODULE(_clifft_core, m) {
             },
             "Return a JSON-friendly dictionary representation.")
         .def("__str__",
-             [](const PyHeisenbergOp& w) { return clifft::format_hir_op(*w.op, *w.hir); })
+             [](const PyHeisenbergOp& w) {
+                 auto mask =
+                     w.op->has_mask() ? std::optional{w.hir->mask_view(*w.op)} : std::nullopt;
+                 return clifft::format_hir_op(*w.op, mask);
+             })
         .def("__repr__", [](const PyHeisenbergOp& w) {
-            return "<HeisenbergOp: " + clifft::format_hir_op(*w.op, *w.hir) + ">";
+            auto mask = w.op->has_mask() ? std::optional{w.hir->mask_view(*w.op)} : std::nullopt;
+            return "<HeisenbergOp: " + clifft::format_hir_op(*w.op, mask) + ">";
         });
 
     nb::class_<clifft::HirModule>(m, "HirModule", "Heisenberg Intermediate Representation")
@@ -438,8 +443,11 @@ NB_MODULE(_clifft_core, m) {
         .def("__str__",
              [](const clifft::HirModule& h) {
                  std::ostringstream ss;
-                 for (size_t i = 0; i < h.ops.size(); ++i)
-                     ss << i << ": " << clifft::format_hir_op(h.ops[i], h) << "\n";
+                 for (size_t i = 0; i < h.ops.size(); ++i) {
+                     const auto& op = h.ops[i];
+                     auto mask = op.has_mask() ? std::optional{h.mask_view(op)} : std::nullopt;
+                     ss << i << ": " << clifft::format_hir_op(op, mask) << "\n";
+                 }
                  return ss.str();
              })
         .def("__repr__", [](const clifft::HirModule& h) {

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -301,23 +301,41 @@ NB_MODULE(_clifft_core, m) {
         .value("OBSERVABLE", clifft::OpType::OBSERVABLE)
         .value("EXP_VAL", clifft::OpType::EXP_VAL);
 
-    nb::class_<clifft::HeisenbergOp>(m, "HeisenbergOp",
-                                     "A single abstract operation in the Heisenberg IR")
-        .def_prop_ro("op_type", [](const clifft::HeisenbergOp& op) { return op.op_type(); })
-        .def_prop_ro("is_dagger", [](const clifft::HeisenbergOp& op) { return op.is_dagger(); })
-        .def_prop_ro("is_hidden", [](const clifft::HeisenbergOp& op) { return op.is_hidden(); })
-        .def_prop_ro("sign", [](const clifft::HeisenbergOp& op) { return op.sign(); })
+    // Python view of a HeisenbergOp paired with the HirModule that owns its
+    // mask data. Holds an nb::object ref to the module so the Python
+    // wrapper keeps it alive: any wrapper handed out by __getitem__ or
+    // __iter__ stays valid until the wrapper itself is collected.
+    struct PyHeisenbergOp {
+        const clifft::HeisenbergOp* op;
+        const clifft::HirModule* hir;
+        nb::object module_owner;
+    };
+
+    nb::class_<PyHeisenbergOp>(m, "HeisenbergOp",
+                               "A single abstract operation in the Heisenberg IR")
+        .def_prop_ro("op_type", [](const PyHeisenbergOp& w) { return w.op->op_type(); })
+        .def_prop_ro("is_dagger", [](const PyHeisenbergOp& w) { return w.op->is_dagger(); })
+        .def_prop_ro("is_hidden", [](const PyHeisenbergOp& w) { return w.op->is_hidden(); })
+        .def_prop_ro(
+            "sign",
+            [](const PyHeisenbergOp& w) { return w.op->has_mask() ? w.hir->sign(*w.op) : false; })
         .def_prop_ro("pauli_string",
-                     [](const clifft::HeisenbergOp& op) { return clifft::format_pauli_mask(op); })
+                     [](const PyHeisenbergOp& w) {
+                         return w.op->has_mask()
+                                    ? clifft::format_pauli_mask(w.hir->mask_view(*w.op))
+                                    : std::string("+I");
+                     })
         .def(
             "as_dict",
-            [](const clifft::HeisenbergOp& op) {
+            [](const PyHeisenbergOp& w) {
+                const auto& op = *w.op;
                 nb::dict d;
                 d["op_type"] = clifft::op_type_to_str(op.op_type());
-                d["pauli_string"] = clifft::format_pauli_mask(op);
+                d["pauli_string"] = op.has_mask() ? clifft::format_pauli_mask(w.hir->mask_view(op))
+                                                  : std::string("+I");
                 d["is_dagger"] = op.is_dagger();
                 d["is_hidden"] = op.is_hidden();
-                d["sign"] = op.sign();
+                d["sign"] = op.has_mask() ? w.hir->sign(op) : false;
 
                 switch (op.op_type()) {
                     case clifft::OpType::MEASURE:
@@ -351,9 +369,10 @@ NB_MODULE(_clifft_core, m) {
                 return d;
             },
             "Return a JSON-friendly dictionary representation.")
-        .def("__str__", [](const clifft::HeisenbergOp& op) { return clifft::format_hir_op(op); })
-        .def("__repr__", [](const clifft::HeisenbergOp& op) {
-            return "<HeisenbergOp: " + clifft::format_hir_op(op) + ">";
+        .def("__str__",
+             [](const PyHeisenbergOp& w) { return clifft::format_hir_op(*w.op, *w.hir); })
+        .def("__repr__", [](const PyHeisenbergOp& w) {
+            return "<HeisenbergOp: " + clifft::format_hir_op(*w.op, *w.hir) + ">";
         });
 
     nb::class_<clifft::HirModule>(m, "HirModule", "Heisenberg Intermediate Representation")
@@ -380,33 +399,38 @@ NB_MODULE(_clifft_core, m) {
             "Return the number of HIR operations.")
         .def(
             "__getitem__",
-            [](const clifft::HirModule& h, int64_t idx) -> const clifft::HeisenbergOp& {
+            [](nb::handle self, int64_t idx) {
+                const auto& h = nb::cast<const clifft::HirModule&>(self);
                 int64_t size = static_cast<int64_t>(h.ops.size());
                 if (idx < 0)
                     idx += size;
                 if (idx < 0 || idx >= size)
                     throw nb::index_error();
-                return h.ops[static_cast<size_t>(idx)];
+                return PyHeisenbergOp{&h.ops[static_cast<size_t>(idx)], &h, nb::borrow(self)};
             },
-            nb::rv_policy::reference_internal, "Return the HIR operation at the given index.")
-        .def(
-            "__iter__",
-            [](const clifft::HirModule& h) {
-                return nb::make_iterator(nb::type<clifft::HirModule>(), "hir_iter", h.ops.begin(),
-                                         h.ops.end());
-            },
-            nb::keep_alive<0, 1>())
+            "Return the HIR operation at the given index.")
+        .def("__iter__",
+             [](nb::handle self) {
+                 const auto& h = nb::cast<const clifft::HirModule&>(self);
+                 nb::list items;
+                 for (const auto& op : h.ops)
+                     items.append(nb::cast(PyHeisenbergOp{&op, &h, nb::borrow(self)}));
+                 return items.attr("__iter__")();
+             })
         .def(
             "as_dict",
-            [](const clifft::HirModule& h) {
+            [](nb::handle self) {
+                const auto& h = nb::cast<const clifft::HirModule&>(self);
                 nb::dict d;
                 d["num_qubits"] = h.num_qubits;
                 d["num_measurements"] = h.num_measurements;
                 d["num_detectors"] = h.num_detectors;
                 d["num_observables"] = h.num_observables;
                 nb::list ops;
-                for (const auto& op : h.ops)
-                    ops.append(nb::cast(op).attr("as_dict")());
+                for (const auto& op : h.ops) {
+                    PyHeisenbergOp w{&op, &h, nb::borrow(self)};
+                    ops.append(nb::cast(w).attr("as_dict")());
+                }
                 d["ops"] = ops;
                 return d;
             },
@@ -415,7 +439,7 @@ NB_MODULE(_clifft_core, m) {
              [](const clifft::HirModule& h) {
                  std::ostringstream ss;
                  for (size_t i = 0; i < h.ops.size(); ++i)
-                     ss << i << ": " << clifft::format_hir_op(h.ops[i]) << "\n";
+                     ss << i << ": " << clifft::format_hir_op(h.ops[i], h) << "\n";
                  return ss.str();
              })
         .def("__repr__", [](const clifft::HirModule& h) {

--- a/src/wasm/bindings.cc
+++ b/src/wasm/bindings.cc
@@ -98,7 +98,7 @@ std::string compile_to_json(const std::string& source, const std::string& passes
     std::vector<std::string> hir_strs;
     hir_strs.reserve(hir.ops.size());
     for (const auto& op : hir.ops) {
-        hir_strs.push_back(clifft::format_hir_op(op));
+        hir_strs.push_back(clifft::format_hir_op(op, hir));
     }
 
     std::vector<std::string> bc_strs;

--- a/src/wasm/bindings.cc
+++ b/src/wasm/bindings.cc
@@ -98,7 +98,8 @@ std::string compile_to_json(const std::string& source, const std::string& passes
     std::vector<std::string> hir_strs;
     hir_strs.reserve(hir.ops.size());
     for (const auto& op : hir.ops) {
-        hir_strs.push_back(clifft::format_hir_op(op, hir));
+        auto mask = op.has_mask() ? std::optional{hir.mask_view(op)} : std::nullopt;
+        hir_strs.push_back(clifft::format_hir_op(op, mask));
     }
 
     std::vector<std::string> bc_strs;

--- a/tests/python/test_introspection.py
+++ b/tests/python/test_introspection.py
@@ -92,6 +92,44 @@ class TestHirIntrospection:
         assert parsed["num_qubits"] == 2
         assert len(parsed["ops"]) == len(hir)
 
+    def test_iter_wrapper_keeps_module_alive(self) -> None:
+        """Regression: HeisenbergOp wrappers from __iter__ must keep the
+        owning HirModule alive. If the module is collected first, accessing
+        the wrapper's mask data would dereference freed arena memory.
+        """
+        import gc
+
+        def make_op() -> Any:
+            hir = clifft.trace(clifft.parse("H 0\nT 0"))
+            it = iter(hir)
+            op = next(it)
+            # Drop local refs; the returned op must hold the HirModule
+            # alive on its own.
+            return op
+
+        op = make_op()
+        gc.collect()
+        # Mask access must still work -- if the module were collected,
+        # this would hit freed memory.
+        assert "X" in op.pauli_string
+        assert isinstance(op.sign, bool)
+        assert isinstance(op.as_dict(), dict)
+
+    def test_getitem_wrapper_keeps_module_alive(self) -> None:
+        """Same regression as test_iter_wrapper_keeps_module_alive but
+        through __getitem__ rather than __iter__.
+        """
+        import gc
+
+        def make_op() -> Any:
+            hir = clifft.trace(clifft.parse("H 0\nT 0"))
+            return hir[0]
+
+        op = make_op()
+        gc.collect()
+        assert "X" in op.pauli_string
+        assert isinstance(op.as_dict(), dict)
+
 
 class TestProgramIntrospection:
     """Program-level introspection: Instruction, Opcode, iteration."""

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1353,6 +1353,8 @@ TEST_CASE("RemoveNoisePass strips noise ops and clears side-tables") {
     CHECK(hir.ops.size() < original_ops);
     CHECK(hir.noise_sites.empty());
     CHECK(hir.readout_noise.empty());
+    // Arena slots that backed the removed channels are released.
+    CHECK(hir.noise_channel_masks.size() == 0);
 
     // No NOISE ops remain
     for (const auto& op : hir.ops) {

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -15,6 +15,7 @@
 #include <string>
 
 using namespace clifft;
+using clifft::test::MaskBuf;
 using namespace clifft::internal;
 using clifft::test::test_lcg;
 using clifft::test::X;
@@ -736,22 +737,21 @@ TEST_CASE("VirtualRegisterManager: peak tracking") {
 TEST_CASE("Backend: Gap sampling hazard array accumulation") {
     CompilerContext ctx(3);
 
+    HirModule hir(3, /*pauli_capacity=*/16, /*noise_channel_capacity=*/3);
     NoiseSite site1;
-    site1.channels.push_back({1, 0, 0.5});
+    site1.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(1), MaskBuf(0)), 0.5});
     NoiseSite site2;
-    site2.channels.push_back({2, 0, 0.75});
+    site2.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(2), MaskBuf(0)), 0.75});
     NoiseSite site3;
-    site3.channels.push_back({4, 0, 1.0});  // clamped to 1.0 - 2^-53
+    site3.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(4), MaskBuf(0)), 1.0});
 
-    HirModule hir;
-    hir.num_qubits = 3;
     hir.noise_sites.push_back(std::move(site1));
     hir.noise_sites.push_back(std::move(site2));
     hir.noise_sites.push_back(std::move(site3));
 
-    hir.ops.push_back(HeisenbergOp::make_noise(NoiseSiteIdx{0}));
-    hir.ops.push_back(HeisenbergOp::make_noise(NoiseSiteIdx{1}));
-    hir.ops.push_back(HeisenbergOp::make_noise(NoiseSiteIdx{2}));
+    hir.append_noise(NoiseSiteIdx{0});
+    hir.append_noise(NoiseSiteIdx{1});
+    hir.append_noise(NoiseSiteIdx{2});
 
     CompiledModule prog = lower(hir);
 
@@ -1242,16 +1242,15 @@ TEST_CASE("Lower: ARRAY_ROTATION geometric artifact correction", "[backend][rota
     // Manually construct a ARRAY_ROTATION with a +Y Pauli on qubit 0.
     // +Y localizes to -Z via the virtual frame, flipping result.sign.
     // The Back-End must correct global_weight for this geometric artifact.
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
     hir.global_weight = {1.0, 0.0};
 
     // +Y on qubit 0: destab=X(0), stab=Z(0), sign=false
-    hir.ops.push_back(HeisenbergOp::make_phase_rotation(X(0), Z(0), false, 0.5));
+    hir.append_phase_rotation(MaskBuf(X(0)), MaskBuf(Z(0)), false, 0.5);
 
     auto mod = clifft::lower(hir);
 
-    // +Y localizes to -Z, so result.sign is true while op.sign() is false.
+    // +Y localizes to -Z, so result.sign is true while hir.sign(op) is false.
     // The Back-End should apply a phase correction of e^{i * 0.5 * pi} = +i.
     CHECK_THAT(mod.constant_pool.global_weight.real(), Catch::Matchers::WithinAbs(0.0, 1e-12));
     CHECK_THAT(mod.constant_pool.global_weight.imag(), Catch::Matchers::WithinAbs(1.0, 1e-12));
@@ -1423,10 +1422,10 @@ TEST_CASE("Lower: EXP_VAL constant pool mask is correct") {
     // Z0 after no Cliffords: virtual Pauli should be Z on axis 0
     auto mod = compile_circuit("EXP_VAL Z0");
     REQUIRE(mod.constant_pool.exp_val_masks.size() == 1);
-    const auto& pm = mod.constant_pool.exp_val_masks[0];
-    CHECK(pm.x.is_zero());  // No X support
-    CHECK(pm.z.w[0] == 1);  // Z on qubit 0
-    CHECK(!pm.sign);
+    auto pm = mod.constant_pool.exp_val_masks.at(clifft::PauliMaskHandle{0});
+    CHECK(pm.x().is_zero());      // No X support
+    CHECK(pm.z().words[0] == 1);  // Z on qubit 0
+    CHECK(!pm.sign());
 }
 
 TEST_CASE("Lower: EXP_VAL does not affect measurement count") {
@@ -1436,33 +1435,31 @@ TEST_CASE("Lower: EXP_VAL does not affect measurement count") {
 }
 
 TEST_CASE("Lower: queued virtual gates affect later EXP_VAL masks") {
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
     hir.num_exp_vals = 1;
 
     // T on an X-basis dormant axis queues a virtual H and EXPAND without
     // immediately materializing the H into v_cum.
-    hir.ops.push_back(HeisenbergOp::make_tgate(X(0), 0, false));
-    hir.ops.push_back(HeisenbergOp::make_exp_val(X(0), 0, false, ExpValIdx{0}));
+    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);
+    hir.append_exp_val(MaskBuf(X(0)), MaskBuf(0), false, ExpValIdx{0});
 
     auto mod = lower(hir);
 
     REQUIRE(mod.constant_pool.exp_val_masks.size() == 1);
-    const auto& pm = mod.constant_pool.exp_val_masks[0];
-    CHECK(pm.x.is_zero());
-    CHECK(pm.z == Z(0));
-    CHECK(!pm.sign);
+    auto pm = mod.constant_pool.exp_val_masks.at(clifft::PauliMaskHandle{0});
+    CHECK(pm.x().is_zero());
+    CHECK(pm.z() == Z(0));
+    CHECK(!pm.sign());
 }
 
 TEST_CASE("Lower: queued virtual gates affect later measurements") {
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
     hir.num_measurements = 1;
 
     // The queued virtual H from the T gate should map a later X probe to Z,
     // making the active measurement diagonal instead of interfering.
-    hir.ops.push_back(HeisenbergOp::make_tgate(X(0), 0, false));
-    hir.ops.push_back(HeisenbergOp::make_measure(X(0), 0, false, MeasRecordIdx{0}));
+    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);
+    hir.append_measure(MaskBuf(X(0)), MaskBuf(0), false, MeasRecordIdx{0});
 
     auto mod = lower(hir);
 
@@ -1472,23 +1469,23 @@ TEST_CASE("Lower: queued virtual gates affect later measurements") {
 }
 
 TEST_CASE("Lower: queued virtual gates affect later noise masks") {
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/1);
 
     NoiseSite site;
-    site.channels.push_back({X(0), 0, 0.25});
+    site.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(X(0)), MaskBuf(0)), 0.25});
     hir.noise_sites.push_back(site);
 
     // Leave a virtual H pending, then map an X-error noise site through it.
-    hir.ops.push_back(HeisenbergOp::make_tgate(X(0), 0, false));
-    hir.ops.push_back(HeisenbergOp::make_noise(NoiseSiteIdx{0}));
+    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);
+    hir.append_noise(NoiseSiteIdx{0});
 
     auto mod = lower(hir);
 
     REQUIRE(mod.constant_pool.noise_sites.size() == 1);
     REQUIRE(mod.constant_pool.noise_sites[0].channels.size() == 1);
     const auto& ch = mod.constant_pool.noise_sites[0].channels[0];
-    CHECK(ch.destab_mask.is_zero());
-    CHECK(ch.stab_mask == Z(0));
+    auto cv = mod.constant_pool.noise_channel_masks.at(ch.mask);
+    CHECK(cv.x().is_zero());
+    CHECK(cv.z() == Z(0));
     CHECK_THAT(ch.prob, Catch::Matchers::WithinAbs(0.25, 1e-12));
 }

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -15,7 +15,6 @@
 #include <string>
 
 using namespace clifft;
-using clifft::test::MaskBuf;
 using namespace clifft::internal;
 using clifft::test::test_lcg;
 using clifft::test::X;
@@ -739,11 +738,11 @@ TEST_CASE("Backend: Gap sampling hazard array accumulation") {
 
     HirModule hir(3, /*pauli_capacity=*/16, /*noise_channel_capacity=*/3);
     NoiseSite site1;
-    site1.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(1), MaskBuf(0)), 0.5});
+    site1.channels.push_back({clifft::test::claim_noise_channel_mask(hir, 1, 0), 0.5});
     NoiseSite site2;
-    site2.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(2), MaskBuf(0)), 0.75});
+    site2.channels.push_back({clifft::test::claim_noise_channel_mask(hir, 2, 0), 0.75});
     NoiseSite site3;
-    site3.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(4), MaskBuf(0)), 1.0});
+    site3.channels.push_back({clifft::test::claim_noise_channel_mask(hir, 4, 0), 1.0});
 
     hir.noise_sites.push_back(std::move(site1));
     hir.noise_sites.push_back(std::move(site2));
@@ -1246,7 +1245,7 @@ TEST_CASE("Lower: ARRAY_ROTATION geometric artifact correction", "[backend][rota
     hir.global_weight = {1.0, 0.0};
 
     // +Y on qubit 0: destab=X(0), stab=Z(0), sign=false
-    hir.append_phase_rotation(MaskBuf(X(0)), MaskBuf(Z(0)), false, 0.5);
+    clifft::test::append_phase_rotation(hir, X(0), Z(0), false, 0.5);
 
     auto mod = clifft::lower(hir);
 
@@ -1442,8 +1441,8 @@ TEST_CASE("Lower: queued virtual gates affect later EXP_VAL masks") {
 
     // T on an X-basis dormant axis queues a virtual H and EXPAND without
     // immediately materializing the H into v_cum.
-    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);
-    hir.append_exp_val(MaskBuf(X(0)), MaskBuf(0), false, ExpValIdx{0});
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_exp_val(hir, X(0), 0, false, ExpValIdx{0});
 
     auto mod = lower(hir);
 
@@ -1460,8 +1459,8 @@ TEST_CASE("Lower: queued virtual gates affect later measurements") {
 
     // The queued virtual H from the T gate should map a later X probe to Z,
     // making the active measurement diagonal instead of interfering.
-    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);
-    hir.append_measure(MaskBuf(X(0)), MaskBuf(0), false, MeasRecordIdx{0});
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_measure(hir, X(0), 0, false, MeasRecordIdx{0});
 
     auto mod = lower(hir);
 
@@ -1474,11 +1473,11 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
     HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/1);
 
     NoiseSite site;
-    site.channels.push_back({hir.claim_noise_channel_mask(MaskBuf(X(0)), MaskBuf(0)), 0.25});
+    site.channels.push_back({clifft::test::claim_noise_channel_mask(hir, X(0), 0), 0.25});
     hir.noise_sites.push_back(site);
 
     // Leave a virtual H pending, then map an X-error noise site through it.
-    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);
+    clifft::test::append_tgate(hir, X(0), 0, false);
     hir.append_noise(NoiseSiteIdx{0});
 
     auto mod = lower(hir);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -4,6 +4,7 @@
 // Key invariant: Clifford gates are absorbed, T gates emit HeisenbergOps
 // with correctly rewound Pauli masks.
 
+#include "clifft/backend/backend.h"
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 
@@ -18,8 +19,14 @@ using namespace clifft;
 using clifft::test::X;
 using clifft::test::Z;
 
-static NoiseChannel rewind_single_pauli_reference(const stim::TableauSimulator<kStimWidth>& sim,
-                                                  uint32_t qubit, int pauli_type, double prob) {
+struct NoiseChannelMasks {
+    PauliBitMask destab_mask;
+    PauliBitMask stab_mask;
+    double prob;
+};
+
+static NoiseChannelMasks rewind_single_pauli_reference(
+    const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit, int pauli_type, double prob) {
     stim::PauliString<kStimWidth> pauli(sim.inv_state.num_qubits);
     if (pauli_type == 1 || pauli_type == 2)
         pauli.xs[qubit] = true;
@@ -31,9 +38,9 @@ static NoiseChannel rewind_single_pauli_reference(const stim::TableauSimulator<k
     return {stim_to_bitmask(rewound.xs, n), stim_to_bitmask(rewound.zs, n), prob};
 }
 
-static NoiseChannel rewind_two_qubit_pauli_reference(const stim::TableauSimulator<kStimWidth>& sim,
-                                                     uint32_t q1, uint32_t q2, int pauli1,
-                                                     int pauli2, double prob) {
+static NoiseChannelMasks rewind_two_qubit_pauli_reference(
+    const stim::TableauSimulator<kStimWidth>& sim, uint32_t q1, uint32_t q2, int pauli1, int pauli2,
+    double prob) {
     stim::PauliString<kStimWidth> pauli(sim.inv_state.num_qubits);
 
     if (pauli1 == 1 || pauli1 == 2)
@@ -81,9 +88,9 @@ TEST_CASE("Frontend: single T gate on qubit 0", "[frontend]") {
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
 
     // Without any Cliffords, rewound Z0 is just Z0
-    REQUIRE(hir.ops[0].destab_mask() == 0);   // No X
-    REQUIRE(hir.ops[0].stab_mask() == Z(0));  // Z on qubit 0
-    REQUIRE(hir.ops[0].sign() == false);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);   // No X
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));  // Z on qubit 0
+    REQUIRE(hir.sign(hir.ops[0]) == false);
 }
 
 TEST_CASE("Frontend: H then T - rewound Z becomes X", "[frontend]") {
@@ -99,9 +106,9 @@ TEST_CASE("Frontend: H then T - rewound Z becomes X", "[frontend]") {
 
     // After H, the Z observable is conjugated to X
     // So the T gate's rewound Z is X on qubit 0
-    REQUIRE(hir.ops[0].destab_mask() == X(0));  // X on qubit 0
-    REQUIRE(hir.ops[0].stab_mask() == 0);       // No Z
-    REQUIRE(hir.ops[0].sign() == false);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));  // X on qubit 0
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);       // No Z
+    REQUIRE(hir.sign(hir.ops[0]) == false);
 }
 
 TEST_CASE("Frontend: H; S; T - rewound Z is still X (S commutes with Z)", "[frontend]") {
@@ -116,8 +123,8 @@ TEST_CASE("Frontend: H; S; T - rewound Z is still X (S commutes with Z)", "[fron
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
 
     // S commutes with Z, so rewound Z after H;S is still X
-    REQUIRE(hir.ops[0].destab_mask() == X(0));  // X on qubit 0
-    REQUIRE(hir.ops[0].stab_mask() == 0);       // No Z
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));  // X on qubit 0
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);       // No Z
 }
 
 TEST_CASE("Frontend: T_DAG gate", "[frontend]") {
@@ -129,8 +136,8 @@ TEST_CASE("Frontend: T_DAG gate", "[frontend]") {
 
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
-    REQUIRE(hir.ops[0].is_dagger() == true);    // T_dag, not T
-    REQUIRE(hir.ops[0].destab_mask() == X(0));  // X on qubit 0
+    REQUIRE(hir.ops[0].is_dagger() == true);       // T_dag, not T
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));  // X on qubit 0
 }
 
 TEST_CASE("Frontend: multiple T gates on different qubits", "[frontend]") {
@@ -145,13 +152,13 @@ TEST_CASE("Frontend: multiple T gates on different qubits", "[frontend]") {
 
     // T on qubit 0: rewound Z is X0
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
-    REQUIRE(hir.ops[0].destab_mask() == X(0));  // X on qubit 0
-    REQUIRE(hir.ops[0].stab_mask() == 0);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));  // X on qubit 0
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);
 
     // T on qubit 1: rewound Z is X1
     REQUIRE(hir.ops[1].op_type() == OpType::T_GATE);
-    REQUIRE(hir.ops[1].destab_mask() == X(1));  // X on qubit 1
-    REQUIRE(hir.ops[1].stab_mask() == 0);
+    REQUIRE(hir.destab_mask(hir.ops[1]) == X(1));  // X on qubit 1
+    REQUIRE(hir.stab_mask(hir.ops[1]) == 0);
 }
 
 TEST_CASE("Frontend: CX entangles qubits - T sees multi-qubit Pauli", "[frontend]") {
@@ -167,8 +174,8 @@ TEST_CASE("Frontend: CX entangles qubits - T sees multi-qubit Pauli", "[frontend
 
     // After H 0; CX 0 1:
     // Z1 rewound = (CX H)_dag Z1 (CX H) = H_dag CX_dag Z1 CX H = H_dag (Z0 Z1) H = X0 Z1
-    REQUIRE(hir.ops[0].destab_mask() == X(0));  // X on qubit 0
-    REQUIRE(hir.ops[0].stab_mask() == Z(1));    // Z on qubit 1
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));  // X on qubit 0
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(1));    // Z on qubit 1
 }
 
 TEST_CASE("Frontend: Z-basis measurement", "[frontend]") {
@@ -182,8 +189,8 @@ TEST_CASE("Frontend: Z-basis measurement", "[frontend]") {
     REQUIRE(hir.ops[0].op_type() == OpType::MEASURE);
 
     // After H, Z0 is conjugated to X0
-    REQUIRE(hir.ops[0].destab_mask() == X(0));  // X on qubit 0
-    REQUIRE(hir.ops[0].stab_mask() == 0);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));  // X on qubit 0
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);
     REQUIRE(hir.ops[0].meas_record_idx() == MeasRecordIdx{0});
 }
 
@@ -199,8 +206,8 @@ TEST_CASE("Frontend: X-basis measurement", "[frontend]") {
 
     // MX measures X observable
     // After H, X0 is conjugated to Z0
-    REQUIRE(hir.ops[0].destab_mask() == 0);
-    REQUIRE(hir.ops[0].stab_mask() == Z(0));  // Z on qubit 0
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));  // Z on qubit 0
 }
 
 TEST_CASE("Frontend: reset R as first-class operation", "[frontend]") {
@@ -326,8 +333,8 @@ TEST_CASE("Frontend: MPP single Pauli product", "[frontend]") {
     // MPP X0*X1 measures the X0tensorX1 observable
     // After H on both qubits, X is conjugated to Z
     // So rewound X0*X1 = Z0*Z1
-    REQUIRE(hir.ops[0].destab_mask() == 0);            // No X
-    REQUIRE(hir.ops[0].stab_mask() == (Z(0) | Z(1)));  // Z on qubits 0 and 1
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);            // No X
+    REQUIRE(hir.stab_mask(hir.ops[0]) == (Z(0) | Z(1)));  // Z on qubits 0 and 1
 }
 
 TEST_CASE("Frontend: MPP Z product", "[frontend]") {
@@ -344,8 +351,8 @@ TEST_CASE("Frontend: MPP Z product", "[frontend]") {
     // Z0 rewound = X0
     // Z1 rewound = X0 Z1
     // Product Z0*Z1 = X0 * (X0 Z1) = Z1 (X0 cancels)
-    REQUIRE(hir.ops[0].destab_mask() == 0);
-    REQUIRE(hir.ops[0].stab_mask() == Z(1));  // Just Z1
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(1));  // Just Z1
 }
 
 // =============================================================================
@@ -359,8 +366,8 @@ TEST_CASE("Frontend: EXP_VAL single Z product - no Cliffords", "[frontend][exp_v
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::EXP_VAL);
     REQUIRE(hir.ops[0].exp_val_idx() == ExpValIdx{0});
-    REQUIRE(hir.ops[0].destab_mask() == 0);
-    REQUIRE(hir.ops[0].stab_mask() == Z(0));
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
     REQUIRE(hir.num_exp_vals == 1);
 }
 
@@ -374,8 +381,8 @@ TEST_CASE("Frontend: EXP_VAL X after Hadamard rewinds to Z", "[frontend][exp_val
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::EXP_VAL);
     // After H, X0 is conjugated to Z0
-    REQUIRE(hir.ops[0].destab_mask() == 0);
-    REQUIRE(hir.ops[0].stab_mask() == Z(0));
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
 }
 
 TEST_CASE("Frontend: EXP_VAL multi-qubit product with Cliffords", "[frontend][exp_val]") {
@@ -389,8 +396,8 @@ TEST_CASE("Frontend: EXP_VAL multi-qubit product with Cliffords", "[frontend][ex
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::EXP_VAL);
     // After H on both qubits, X is conjugated to Z
-    REQUIRE(hir.ops[0].destab_mask() == 0);
-    REQUIRE(hir.ops[0].stab_mask() == (Z(0) | Z(1)));
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == (Z(0) | Z(1)));
 }
 
 TEST_CASE("Frontend: EXP_VAL multiple products get consecutive indices", "[frontend][exp_val]") {
@@ -417,13 +424,13 @@ TEST_CASE("Frontend: EXP_VAL single instruction with multiple products", "[front
 
     REQUIRE(hir.ops[0].op_type() == OpType::EXP_VAL);
     REQUIRE(hir.ops[0].exp_val_idx() == ExpValIdx{0});
-    REQUIRE(hir.ops[0].destab_mask() == X(0));
-    REQUIRE(hir.ops[0].stab_mask() == 0);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);
 
     REQUIRE(hir.ops[1].op_type() == OpType::EXP_VAL);
     REQUIRE(hir.ops[1].exp_val_idx() == ExpValIdx{1});
-    REQUIRE(hir.ops[1].destab_mask() == 0);
-    REQUIRE(hir.ops[1].stab_mask() == Z(1));
+    REQUIRE(hir.destab_mask(hir.ops[1]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[1]) == Z(1));
 }
 
 TEST_CASE("Frontend: EXP_VAL does not affect measurement indices", "[frontend][exp_val]") {
@@ -497,9 +504,9 @@ TEST_CASE("Frontend: EXP_VAL rewind matches MPP rewind", "[frontend][exp_val]") 
 
     REQUIRE(hir_mpp.num_ops() == 1);
     REQUIRE(hir_ev.num_ops() == 1);
-    REQUIRE(hir_mpp.ops[0].destab_mask() == hir_ev.ops[0].destab_mask());
-    REQUIRE(hir_mpp.ops[0].stab_mask() == hir_ev.ops[0].stab_mask());
-    REQUIRE(hir_mpp.ops[0].sign() == hir_ev.ops[0].sign());
+    REQUIRE(hir_mpp.destab_mask(hir_mpp.ops[0]) == hir_ev.destab_mask(hir_ev.ops[0]));
+    REQUIRE(hir_mpp.stab_mask(hir_mpp.ops[0]) == hir_ev.stab_mask(hir_ev.ops[0]));
+    REQUIRE(hir_mpp.sign(hir_mpp.ops[0]) == hir_ev.sign(hir_ev.ops[0]));
 }
 
 TEST_CASE("Frontend: EXP_VAL inversion parity flips sign", "[frontend][exp_val]") {
@@ -516,16 +523,136 @@ TEST_CASE("Frontend: EXP_VAL inversion parity flips sign", "[frontend][exp_val]"
 
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::EXP_VAL);
-    REQUIRE(hir.ops[0].destab_mask() == (X(0) | X(1)));
-    REQUIRE(hir.ops[0].stab_mask() == Z(1));
-    REQUIRE(hir.ops[0].sign());
+    REQUIRE(hir.destab_mask(hir.ops[0]) == (X(0) | X(1)));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(1));
+    REQUIRE(hir.sign(hir.ops[0]));
 }
 
-TEST_CASE("Frontend: exceeds max qubit limit", "[frontend]") {
+TEST_CASE("Frontend: accepts circuits above the old fixed mask width", "[frontend]") {
+    // Circuits above kMaxInlineQubits used to throw at trace(). With
+    // runtime-width Pauli mask storage, trace() now accepts any width;
+    // the bytecode-axis ceiling is enforced later by lower().
     Circuit circuit;
     circuit.num_qubits = kMaxInlineQubits + 1;
+    REQUIRE_NOTHROW(trace(circuit));
+}
 
-    REQUIRE_THROWS_AS(trace(circuit), std::runtime_error);
+TEST_CASE("Frontend: high-qubit Pauli bits survive the runtime-arena round trip",
+          "[frontend][high_qubit]") {
+    // Regression: with the old fixed-width PauliBitMask intermediate, any
+    // Pauli touching qubits >= kMaxInlineQubits was silently truncated by
+    // the frontend before reaching the arena. This test traces a circuit
+    // wider than that bound and asserts the high-qubit bits round-trip
+    // intact through trace(). lower() at this width is gated until the
+    // SVM frame migration; the gate is checked in a separate case below.
+
+    const uint32_t kHigh = 150;  // > kMaxInlineQubits (128)
+    REQUIRE(kHigh > kMaxInlineQubits);
+
+    auto circuit = parse(R"(
+        H 150
+        T 150
+        H 199
+        M 199
+    )");
+    circuit.num_qubits = 200;
+    circuit.num_measurements = 1;
+
+    auto hir = trace(circuit);
+
+    // T 150 after H 150: rewound Z on q150 becomes X on q150.
+    REQUIRE(hir.ops.size() == 2);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.destab_mask(hir.ops[0]).bit_get(kHigh));
+    REQUIRE(hir.destab_mask(hir.ops[0]).num_words() == 200 / 64 + 1);
+
+    // M 199 after H 199: rewound Z on q199 becomes X on q199.
+    REQUIRE(hir.ops[1].op_type() == OpType::MEASURE);
+    REQUIRE(hir.destab_mask(hir.ops[1]).bit_get(199));
+}
+
+TEST_CASE("Backend: rejects circuits above the SVM frame width", "[frontend]") {
+    // The SVM frame storage (state.p_x / p_z) is still BitMask<kMaxInlineQubits>.
+    // Until the SVM frame migrates to runtime-width storage, lower() must
+    // refuse circuits whose num_qubits exceeds that bound -- otherwise high-
+    // qubit conditional Paulis and noise channels would be silently dropped
+    // at execution time.
+    HirModule hir;
+    hir.num_qubits = kMaxInlineQubits + 1;
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
+}
+
+TEST_CASE("Backend: high-axis measurement is not silently demoted to identity",
+          "[frontend][high_qubit]") {
+    // Regression for the lower() identity-Pauli check that previously
+    // copied the mapped Pauli through PauliBitMask before testing
+    // is_zero(). At qubit positions in the upper half of word[1] (still
+    // within the kMaxInlineQubits gate, so lower() runs) this would
+    // have been correct, but the same pattern was wrong above the gate.
+    // The fix makes the check walk full mapped width directly; this
+    // test exercises a measurement at the high end of the supported
+    // range to lock down that the resulting opcode is *not* a static
+    // identity measurement.
+    auto circuit = parse(R"(
+        H 127
+        M 127
+    )");
+    circuit.num_qubits = 128;
+    circuit.num_measurements = 1;
+
+    auto hir = trace(circuit);
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::MEASURE);
+    REQUIRE(hir.destab_mask(hir.ops[0]).bit_get(127));
+
+    auto mod = lower(hir);
+    bool found_non_identity_measure = false;
+    for (const auto& instr : mod.bytecode) {
+        if (instr.opcode == Opcode::OP_MEAS_DORMANT_STATIC ||
+            instr.opcode == Opcode::OP_MEAS_DORMANT_RANDOM ||
+            instr.opcode == Opcode::OP_MEAS_ACTIVE_DIAGONAL ||
+            instr.opcode == Opcode::OP_MEAS_ACTIVE_INTERFERE) {
+            CHECK_FALSE(instr.flags & Instruction::FLAG_IDENTITY);
+            found_non_identity_measure = true;
+        }
+    }
+    REQUIRE(found_non_identity_measure);
+}
+
+TEST_CASE("Frontend: high-qubit Paulis preserved across width boundaries",
+          "[frontend][high_qubit]") {
+    // Walk a few values straddling word and the old kMaxInlineQubits limit.
+    auto check_at = [](uint32_t n, uint32_t high_q) {
+        Circuit circuit;
+        circuit.num_qubits = n;
+        AstNode h{};
+        h.gate = GateType::H;
+        h.targets.push_back(Target::qubit(high_q));
+        circuit.nodes.push_back(h);
+        AstNode t{};
+        t.gate = GateType::T;
+        t.targets.push_back(Target::qubit(high_q));
+        circuit.nodes.push_back(t);
+
+        auto hir = trace(circuit);
+        REQUIRE(hir.ops.size() == 1);
+        INFO("n=" << n << " high_q=" << high_q);
+        CHECK(hir.destab_mask(hir.ops[0]).bit_get(high_q));
+    };
+
+    check_at(70, 65);    // straddles word 0/1 boundary
+    check_at(150, 130);  // beyond old fixed mask width (128)
+    check_at(200, 199);  // last qubit at n=200
+    check_at(513, 512);  // bit 512 (word 8); 513 qubits => 9-word arena
+}
+
+TEST_CASE("Backend: rejects circuits above the VM axis ceiling", "[frontend]") {
+    // Skip trace() because allocating a TableauSimulator for 65k+ qubits
+    // is itself prohibitively expensive. The ceiling lives in lower(),
+    // so feed it an empty HIR with the high qubit count directly.
+    HirModule hir;
+    hir.num_qubits = 65537;
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
 }
 
 TEST_CASE("Frontend: T count tracking", "[frontend]") {
@@ -565,8 +692,8 @@ TEST_CASE("Frontend: classical feedback sees un-collapsed tableau", "[frontend][
     REQUIRE(hir.ops[1].controlling_meas() == ControllingMeasIdx{0});
 
     // Un-collapsed tableau after H: xs[0] = Z_0
-    REQUIRE(hir.ops[1].destab_mask() == 0);
-    REQUIRE(hir.ops[1].stab_mask() == Z(0));
+    REQUIRE(hir.destab_mask(hir.ops[1]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[1]) == Z(0));
 }
 
 TEST_CASE("Frontend: classical feedback on entangled qubits", "[frontend][classical]") {
@@ -586,8 +713,8 @@ TEST_CASE("Frontend: classical feedback on entangled qubits", "[frontend][classi
     REQUIRE(hir.ops[1].controlling_meas() == ControllingMeasIdx{0});
 
     // Un-collapsed: rewound Z_1 through H 0; CX 0 1 gives X_0 * Z_1
-    REQUIRE(hir.ops[1].destab_mask() == X(0));
-    REQUIRE(hir.ops[1].stab_mask() == Z(1));
+    REQUIRE(hir.destab_mask(hir.ops[1]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[1]) == Z(1));
 }
 
 TEST_CASE("Frontend: multiple resets in sequence", "[frontend][classical]") {
@@ -614,10 +741,10 @@ TEST_CASE("Frontend: multiple resets in sequence", "[frontend][classical]") {
 
     // Without collapse, the tableau after H still maps Z_0 -> X_0, Z_1 -> X_1.
     // The T gates see the un-collapsed rewound Pauli.
-    REQUIRE(hir.ops[4].destab_mask() == X(0));
-    REQUIRE(hir.ops[4].stab_mask() == 0);
-    REQUIRE(hir.ops[5].destab_mask() == X(1));
-    REQUIRE(hir.ops[5].stab_mask() == 0);
+    REQUIRE(hir.destab_mask(hir.ops[4]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[4]) == 0);
+    REQUIRE(hir.destab_mask(hir.ops[5]) == X(1));
+    REQUIRE(hir.stab_mask(hir.ops[5]) == 0);
 }
 
 // =============================================================================
@@ -771,8 +898,8 @@ TEST_CASE("Frontend: X_ERROR produces single channel", "[frontend][noise]") {
     REQUIRE(site.channels[0].prob == Catch::Approx(0.001));
 
     // X on qubit 0 at t=0 (identity tableau): destab=1, stab=0
-    REQUIRE(site.channels[0].destab_mask == 1);
-    REQUIRE(site.channels[0].stab_mask == 0);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).x() == 1);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).z() == 0);
 }
 
 TEST_CASE("Frontend: Z_ERROR produces single channel", "[frontend][noise]") {
@@ -793,8 +920,8 @@ TEST_CASE("Frontend: Z_ERROR produces single channel", "[frontend][noise]") {
     REQUIRE(site.channels[0].prob == Catch::Approx(0.002));
 
     // Z on qubit 0 at t=0: destab=0, stab=1
-    REQUIRE(site.channels[0].destab_mask == 0);
-    REQUIRE(site.channels[0].stab_mask == 1);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).x() == 0);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).z() == 1);
 }
 
 TEST_CASE("Frontend: Y_ERROR produces single channel", "[frontend][noise]") {
@@ -815,8 +942,8 @@ TEST_CASE("Frontend: Y_ERROR produces single channel", "[frontend][noise]") {
     REQUIRE(site.channels[0].prob == Catch::Approx(0.003));
 
     // Y = iXZ on qubit 0 at t=0: destab=1, stab=1
-    REQUIRE(site.channels[0].destab_mask == 1);
-    REQUIRE(site.channels[0].stab_mask == 1);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).x() == 1);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).z() == 1);
 }
 
 TEST_CASE("Frontend: DEPOLARIZE2 produces 15 channels", "[frontend][noise]") {
@@ -869,8 +996,8 @@ TEST_CASE("Frontend: noise rewinding through H gate", "[frontend][noise]") {
     REQUIRE(site.channels.size() == 1);
 
     // X after H = Z at t=0: destab=0, stab=1
-    REQUIRE(site.channels[0].destab_mask == 0);
-    REQUIRE(site.channels[0].stab_mask == 1);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).x() == 0);
+    REQUIRE(hir.noise_channel_masks.at(site.channels[0].mask).z() == 1);
 }
 
 TEST_CASE("Frontend: Y_ERROR rewinds through entangling Cliffords", "[frontend][noise]") {
@@ -889,8 +1016,8 @@ TEST_CASE("Frontend: Y_ERROR rewinds through entangling Cliffords", "[frontend][
     auto expected = rewind_single_pauli_reference(sim, 1, 2, 0.02);
 
     const auto& actual = hir.noise_sites[0].channels[0];
-    CHECK(actual.destab_mask == expected.destab_mask);
-    CHECK(actual.stab_mask == expected.stab_mask);
+    CHECK(hir.noise_channel_masks.at(actual.mask).x() == expected.destab_mask);
+    CHECK(hir.noise_channel_masks.at(actual.mask).z() == expected.stab_mask);
     CHECK(actual.prob == Catch::Approx(expected.prob));
 }
 
@@ -909,7 +1036,7 @@ TEST_CASE("Frontend: DEPOLARIZE2 rewinds through entangling Cliffords", "[fronte
     sim.inv_state.prepend_ZCX(0, 1);
 
     double channel_prob = 0.15 / 15.0;
-    std::vector<NoiseChannel> expected;
+    std::vector<NoiseChannelMasks> expected;
     for (int p1 = 0; p1 <= 3; ++p1) {
         for (int p2 = 0; p2 <= 3; ++p2) {
             if (p1 == 0 && p2 == 0)
@@ -921,8 +1048,9 @@ TEST_CASE("Frontend: DEPOLARIZE2 rewinds through entangling Cliffords", "[fronte
     const auto& actual_site = hir.noise_sites[0];
     REQUIRE(actual_site.channels.size() == expected.size());
     for (size_t i = 0; i < expected.size(); ++i) {
-        CHECK(actual_site.channels[i].destab_mask == expected[i].destab_mask);
-        CHECK(actual_site.channels[i].stab_mask == expected[i].stab_mask);
+        auto av = hir.noise_channel_masks.at(actual_site.channels[i].mask);
+        CHECK(av.x() == expected[i].destab_mask);
+        CHECK(av.z() == expected[i].stab_mask);
         CHECK(actual_site.channels[i].prob == Catch::Approx(expected[i].prob));
     }
 }
@@ -1088,9 +1216,9 @@ TEST_CASE("Frontend: noise broadcasting", "[frontend][noise]") {
 
     // Each site should have X error on its respective qubit
     // Qubit 0: destab=1, Qubit 1: destab=2, Qubit 2: destab=4
-    REQUIRE(hir.noise_sites[0].channels[0].destab_mask == 1);
-    REQUIRE(hir.noise_sites[1].channels[0].destab_mask == 2);
-    REQUIRE(hir.noise_sites[2].channels[0].destab_mask == 4);
+    REQUIRE(hir.noise_channel_masks.at(hir.noise_sites[0].channels[0].mask).x() == 1);
+    REQUIRE(hir.noise_channel_masks.at(hir.noise_sites[1].channels[0].mask).x() == 2);
+    REQUIRE(hir.noise_channel_masks.at(hir.noise_sites[2].channels[0].mask).x() == 4);
 }
 
 TEST_CASE("Frontend: DEPOLARIZE2 broadcasting", "[frontend][noise]") {
@@ -1212,12 +1340,12 @@ TEST_CASE("Frontend: MPAD emits zero-weight measurements", "[frontend]") {
     REQUIRE(hir.num_ops() == 3);
     for (size_t i = 0; i < 3; ++i) {
         CHECK(hir.ops[i].op_type() == OpType::MEASURE);
-        CHECK(hir.ops[i].destab_mask() == 0);
-        CHECK(hir.ops[i].stab_mask() == 0);
+        CHECK(hir.destab_mask(hir.ops[i]) == 0);
+        CHECK(hir.stab_mask(hir.ops[i]) == 0);
     }
-    CHECK(hir.ops[0].sign() == true);   // MPAD 1
-    CHECK(hir.ops[1].sign() == false);  // MPAD 0
-    CHECK(hir.ops[2].sign() == true);   // MPAD 1
+    CHECK(hir.sign(hir.ops[0]) == true);   // MPAD 1
+    CHECK(hir.sign(hir.ops[1]) == false);  // MPAD 0
+    CHECK(hir.sign(hir.ops[2]) == true);   // MPAD 1
 }
 
 TEST_CASE("Frontend: inverted M flips sign", "[frontend]") {
@@ -1228,7 +1356,7 @@ TEST_CASE("Frontend: inverted M flips sign", "[frontend]") {
 
     REQUIRE(hir.num_ops() == 1);
     CHECK(hir.ops[0].op_type() == OpType::MEASURE);
-    CHECK(hir.ops[0].sign() == true);
+    CHECK(hir.sign(hir.ops[0]) == true);
 }
 
 TEST_CASE("Frontend: non-inverted M has sign false on fresh qubit", "[frontend]") {
@@ -1237,7 +1365,7 @@ TEST_CASE("Frontend: non-inverted M has sign false on fresh qubit", "[frontend]"
 
     REQUIRE(hir.num_ops() == 1);
     CHECK(hir.ops[0].op_type() == OpType::MEASURE);
-    CHECK(hir.ops[0].sign() == false);
+    CHECK(hir.sign(hir.ops[0]) == false);
 }
 
 TEST_CASE("Frontend: alias ZCX produces same HIR as CX", "[frontend]") {
@@ -1247,8 +1375,8 @@ TEST_CASE("Frontend: alias ZCX produces same HIR as CX", "[frontend]") {
     REQUIRE(hir_cx.num_ops() > 0);
     REQUIRE(hir_cx.num_ops() == hir_zcx.num_ops());
     for (size_t i = 0; i < hir_cx.num_ops(); ++i) {
-        CHECK(hir_cx.ops[i].destab_mask() == hir_zcx.ops[i].destab_mask());
-        CHECK(hir_cx.ops[i].stab_mask() == hir_zcx.ops[i].stab_mask());
+        CHECK(hir_cx.destab_mask(hir_cx.ops[i]) == hir_zcx.destab_mask(hir_zcx.ops[i]));
+        CHECK(hir_cx.stab_mask(hir_cx.ops[i]) == hir_zcx.stab_mask(hir_zcx.ops[i]));
     }
 }
 
@@ -1366,9 +1494,9 @@ TEST_CASE("Frontend: R_ZZ emits PHASE_ROTATION on two-qubit Pauli", "[frontend][
     CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
     CHECK(hir.ops[0].alpha() == Catch::Approx(0.3));
     // ZZ: stab_mask should have bits 0 and 1 set, destab should be zero
-    CHECK(hir.ops[0].stab_mask().bit_get(0));
-    CHECK(hir.ops[0].stab_mask().bit_get(1));
-    CHECK(hir.ops[0].destab_mask().is_zero());
+    CHECK(hir.stab_mask(hir.ops[0]).bit_get(0));
+    CHECK(hir.stab_mask(hir.ops[0]).bit_get(1));
+    CHECK(hir.destab_mask(hir.ops[0]).is_zero());
 }
 
 TEST_CASE("Frontend: R_XX emits PHASE_ROTATION with X masks", "[frontend][rotation]") {
@@ -1378,9 +1506,9 @@ TEST_CASE("Frontend: R_XX emits PHASE_ROTATION with X masks", "[frontend][rotati
     REQUIRE(hir.num_ops() == 1);
     CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
     // XX: destab_mask should have bits 0 and 1 set
-    CHECK(hir.ops[0].destab_mask().bit_get(0));
-    CHECK(hir.ops[0].destab_mask().bit_get(1));
-    CHECK(hir.ops[0].stab_mask().is_zero());
+    CHECK(hir.destab_mask(hir.ops[0]).bit_get(0));
+    CHECK(hir.destab_mask(hir.ops[0]).bit_get(1));
+    CHECK(hir.stab_mask(hir.ops[0]).is_zero());
 }
 
 TEST_CASE("Frontend: R_PAULI emits PHASE_ROTATION on arbitrary Pauli", "[frontend][rotation]") {
@@ -1391,12 +1519,12 @@ TEST_CASE("Frontend: R_PAULI emits PHASE_ROTATION on arbitrary Pauli", "[fronten
     CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
     CHECK(hir.ops[0].alpha() == Catch::Approx(0.1));
     // X0: destab bit 0, Y1: both bits 1, Z2: stab bit 2
-    CHECK(hir.ops[0].destab_mask().bit_get(0));
-    CHECK(hir.ops[0].destab_mask().bit_get(1));
-    CHECK(!hir.ops[0].destab_mask().bit_get(2));
-    CHECK(!hir.ops[0].stab_mask().bit_get(0));
-    CHECK(hir.ops[0].stab_mask().bit_get(1));
-    CHECK(hir.ops[0].stab_mask().bit_get(2));
+    CHECK(hir.destab_mask(hir.ops[0]).bit_get(0));
+    CHECK(hir.destab_mask(hir.ops[0]).bit_get(1));
+    CHECK(!hir.destab_mask(hir.ops[0]).bit_get(2));
+    CHECK(!hir.stab_mask(hir.ops[0]).bit_get(0));
+    CHECK(hir.stab_mask(hir.ops[0]).bit_get(1));
+    CHECK(hir.stab_mask(hir.ops[0]).bit_get(2));
 }
 
 TEST_CASE("Frontend: R_Z global phase accumulation", "[frontend][rotation]") {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -653,6 +653,94 @@ TEST_CASE("Frontend: high-qubit Paulis preserved across width boundaries",
     check_at(513, 512);  // bit 512 (word 8); 513 qubits => 9-word arena
 }
 
+// =============================================================================
+// Per-op-type rejection at the SVM-frame-width gate
+// =============================================================================
+//
+// Each test traces a minimal circuit that produces one op of a given type
+// touching qubits >= kMaxInlineQubits, asserts that trace() preserves the
+// high-qubit support in the HIR mask, and asserts that lower() refuses to
+// compile because the SVM frame can't yet hold high-qubit state. When PR3
+// migrates the SVM frame to runtime-width storage and lifts the gate, each
+// of these flips into a Stim-oracle equivalence check.
+//
+// Use num_qubits = kMaxInlineQubits + 1 so the high qubit (kMaxInlineQubits)
+// sits exactly at the boundary. q == kMaxInlineQubits = 128 lives in word 2
+// for arena num_words = 3, which is also the first word a fixed-width
+// PauliBitMask would have dropped.
+
+TEST_CASE("Backend: rejects MEASURE above SVM frame width", "[frontend][high_qubit]") {
+    auto circuit = parse("H 128\nM 128");
+    circuit.num_qubits = kMaxInlineQubits + 1;
+    circuit.num_measurements = 1;
+
+    auto hir = trace(circuit);
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::MEASURE);
+    REQUIRE(hir.destab_mask(hir.ops[0]).bit_get(128));  // X on q128 after H
+
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
+}
+
+TEST_CASE("Backend: rejects MPP above SVM frame width", "[frontend][high_qubit]") {
+    // MPP X63 * X128 spans words 0 and 2 -- exercises the cross-word
+    // build_pauli_string path that fixed-width intermediates would clip.
+    auto circuit = parse("MPP X63*X128");
+    circuit.num_qubits = kMaxInlineQubits + 1;
+    circuit.num_measurements = 1;
+
+    auto hir = trace(circuit);
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::MEASURE);
+    REQUIRE(hir.destab_mask(hir.ops[0]).bit_get(63));
+    REQUIRE(hir.destab_mask(hir.ops[0]).bit_get(128));
+
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
+}
+
+TEST_CASE("Backend: rejects CONDITIONAL_PAULI above SVM frame width", "[frontend][high_qubit]") {
+    // Classical feedback: M 128 ; CX rec[-1] 128 emits a CONDITIONAL_PAULI.
+    auto circuit = parse("M 128\nCX rec[-1] 128");
+    circuit.num_qubits = kMaxInlineQubits + 1;
+    circuit.num_measurements = 1;
+
+    auto hir = trace(circuit);
+    REQUIRE(hir.ops.size() == 2);
+    REQUIRE(hir.ops[1].op_type() == OpType::CONDITIONAL_PAULI);
+    REQUIRE(hir.destab_mask(hir.ops[1]).bit_get(128));
+
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
+}
+
+TEST_CASE("Backend: rejects NOISE above SVM frame width", "[frontend][high_qubit]") {
+    auto circuit = parse("X_ERROR(0.1) 128");
+    circuit.num_qubits = kMaxInlineQubits + 1;
+
+    auto hir = trace(circuit);
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+    // Channel mask must reflect the high-qubit support.
+    REQUIRE(hir.noise_sites.size() == 1);
+    REQUIRE(hir.noise_sites[0].channels.size() == 1);
+    auto channel_view = hir.noise_channel_masks.at(hir.noise_sites[0].channels[0].mask);
+    REQUIRE(channel_view.x().bit_get(128));
+
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
+}
+
+TEST_CASE("Backend: rejects EXP_VAL above SVM frame width", "[frontend][high_qubit]") {
+    auto circuit = parse("EXP_VAL Z128");
+    circuit.num_qubits = kMaxInlineQubits + 1;
+    circuit.num_exp_vals = 1;
+
+    auto hir = trace(circuit);
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::EXP_VAL);
+    REQUIRE(hir.stab_mask(hir.ops[0]).bit_get(128));
+
+    REQUIRE_THROWS_AS(lower(hir), std::runtime_error);
+}
+
 TEST_CASE("Backend: rejects circuits above the VM axis ceiling", "[frontend]") {
     // Skip trace() because allocating a TableauSimulator for 65k+ qubits
     // is itself prohibitively expensive. The ceiling lives in lower(),

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -530,11 +530,18 @@ TEST_CASE("Frontend: EXP_VAL inversion parity flips sign", "[frontend][exp_val]"
 
 TEST_CASE("Frontend: accepts circuits above the old fixed mask width", "[frontend]") {
     // Circuits above kMaxInlineQubits used to throw at trace(). With
-    // runtime-width Pauli mask storage, trace() now accepts any width;
-    // the bytecode-axis ceiling is enforced later by lower().
+    // runtime-width Pauli mask storage, trace() accepts widths up to the
+    // VM axis ceiling (65536); the bytecode-axis check is shared between
+    // trace() and lower().
     Circuit circuit;
     circuit.num_qubits = kMaxInlineQubits + 1;
     REQUIRE_NOTHROW(trace(circuit));
+}
+
+TEST_CASE("Frontend: rejects circuits above the VM axis ceiling", "[frontend]") {
+    Circuit circuit;
+    circuit.num_qubits = 65537;
+    REQUIRE_THROWS_AS(trace(circuit), std::runtime_error);
 }
 
 TEST_CASE("Frontend: high-qubit Pauli bits survive the runtime-arena round trip",

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -2,12 +2,16 @@
 
 // Shared test helpers for Clifft Catch2 tests.
 
+#include "clifft/util/mask_view.h"
+
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <numbers>
+#include <span>
 #include <string>
 #include <utility>
 
@@ -24,6 +28,17 @@ inline uint64_t X(size_t qubit) {
 inline uint64_t Z(size_t qubit) {
     return 1ULL << qubit;
 }
+
+/// Test-only single-word mask buffer with implicit conversion to MaskView.
+/// Use as an rvalue argument to HirModule builders: most tests construct
+/// single-bit Paulis like `MaskBuf(X(0))` or `MaskBuf(X(0) | Z(2))`, which
+/// fit in 64 bits. The buffer must outlive any view derived from it.
+struct MaskBuf {
+    std::array<uint64_t, 1> data;
+    constexpr MaskBuf() : data{0} {}
+    constexpr MaskBuf(uint64_t low) : data{low} {}                             // NOLINT
+    constexpr operator MaskView() const { return MaskView{std::span(data)}; }  // NOLINT
+};
 
 // Convert a Pauli string like "XYZ" to (destab_mask, stab_mask) pair.
 // Qubit 0 is the rightmost character: "XYZ" means X on q2, Y on q1, Z on q0.

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -2,6 +2,7 @@
 
 // Shared test helpers for Clifft Catch2 tests.
 
+#include "clifft/frontend/hir.h"
 #include "clifft/util/bitmask.h"
 #include "clifft/util/config.h"
 #include "clifft/util/mask_view.h"
@@ -34,16 +35,70 @@ inline uint64_t Z(size_t qubit) {
     return 1ULL << qubit;
 }
 
-/// Test-only single-word mask buffer with implicit conversion to MaskView.
-/// Use as an rvalue argument to HirModule builders: most tests construct
-/// single-bit Paulis like `MaskBuf(X(0))` or `MaskBuf(X(0) | Z(2))`, which
-/// fit in 64 bits. The buffer must outlive any view derived from it.
-struct MaskBuf {
-    std::array<uint64_t, 1> data;
-    constexpr MaskBuf() : data{0} {}
-    constexpr MaskBuf(uint64_t low) : data{low} {}                             // NOLINT
-    constexpr operator MaskView() const { return MaskView{std::span(data)}; }  // NOLINT
-};
+// HirModule append_* test helpers.
+//
+// All current tests build single-word Paulis (n <= 64). Wider patterns
+// can call HirModule::append_*(args, fill_lambda) directly.
+inline HeisenbergOp& append_tgate(HirModule& hir, uint64_t destab, uint64_t stab, bool sign,
+                                  bool dagger = false) {
+    return hir.append_tgate(dagger, [&](MutablePauliMaskView slot) {
+        slot.x().words[0] = destab;
+        slot.z().words[0] = stab;
+        slot.set_sign(sign);
+    });
+}
+
+inline HeisenbergOp& append_measure(HirModule& hir, uint64_t destab, uint64_t stab, bool sign,
+                                    MeasRecordIdx idx) {
+    return hir.append_measure(idx, [&](MutablePauliMaskView slot) {
+        slot.x().words[0] = destab;
+        slot.z().words[0] = stab;
+        slot.set_sign(sign);
+    });
+}
+
+inline HeisenbergOp& append_conditional(HirModule& hir, uint64_t destab, uint64_t stab, bool sign,
+                                        ControllingMeasIdx idx) {
+    return hir.append_conditional(idx, [&](MutablePauliMaskView slot) {
+        slot.x().words[0] = destab;
+        slot.z().words[0] = stab;
+        slot.set_sign(sign);
+    });
+}
+
+inline HeisenbergOp& append_phase_rotation(HirModule& hir, uint64_t destab, uint64_t stab,
+                                           bool sign, double alpha) {
+    return hir.append_phase_rotation(alpha, [&](MutablePauliMaskView slot) {
+        slot.x().words[0] = destab;
+        slot.z().words[0] = stab;
+        slot.set_sign(sign);
+    });
+}
+
+inline HeisenbergOp& append_exp_val(HirModule& hir, uint64_t destab, uint64_t stab, bool sign,
+                                    ExpValIdx idx) {
+    return hir.append_exp_val(idx, [&](MutablePauliMaskView slot) {
+        slot.x().words[0] = destab;
+        slot.z().words[0] = stab;
+        slot.set_sign(sign);
+    });
+}
+
+inline PauliMaskHandle claim_noise_channel_mask(HirModule& hir, uint64_t destab, uint64_t stab) {
+    auto h = hir.claim_empty_noise_channel_mask();
+    auto slot = hir.noise_channel_masks.mut_at(h);
+    slot.x().words[0] = destab;
+    slot.z().words[0] = stab;
+    return h;
+}
+
+inline void set_pauli(HirModule& hir, const HeisenbergOp& op, uint64_t destab, uint64_t stab,
+                      bool sign) {
+    auto slot = hir.mask_at(op);
+    slot.x().words[0] = destab;
+    slot.z().words[0] = stab;
+    slot.set_sign(sign);
+}
 
 // Convert a Pauli string like "XYZ" to (destab_mask, stab_mask) pair.
 // Qubit 0 is the rightmost character: "XYZ" means X on q2, Y on q1, Z on q0.

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -2,7 +2,12 @@
 
 // Shared test helpers for Clifft Catch2 tests.
 
+#include "clifft/util/bitmask.h"
+#include "clifft/util/config.h"
 #include "clifft/util/mask_view.h"
+#include "clifft/util/stim_mask.h"
+
+#include "stim.h"
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
@@ -79,4 +84,62 @@ inline void check_complex(std::complex<double> actual, std::complex<double> expe
 }
 
 }  // namespace test
+
+/// Truncating copy of a Stim PauliString row into a fixed-width
+/// BitMask<kMaxInlineQubits>. Bits beyond kMaxInlineQubits are dropped.
+/// Test-only helper for building expected reference masks alongside the
+/// runtime-width arena. Sits in `clifft::` (not `clifft::test`) so call
+/// sites can use it unqualified after `using namespace clifft;`.
+inline BitMask<kMaxInlineQubits> stim_to_bitmask(const stim::simd_bits_range_ref<kStimWidth>& bits,
+                                                 uint32_t n) {
+    BitMask<kMaxInlineQubits> m;
+    uint32_t words = (n + 63) / 64;
+    for (uint32_t w = 0; w < words && w < kMaxInlineWords; ++w) {
+        m.w[w] = bits.u64[w];
+    }
+    return m;
+}
+
+/// Compare a MaskView to a fixed-width BitMask<N>. The two may have
+/// different word counts; trailing words of either side must be zero.
+template <size_t N>
+inline bool operator==(MaskView v, const BitMask<N>& m) {
+    auto vm = view(m);
+    uint32_t common = std::min(v.num_words(), vm.num_words());
+    for (uint32_t i = 0; i < common; ++i) {
+        if (v.words[i] != vm.words[i])
+            return false;
+    }
+    for (uint32_t i = common; i < v.num_words(); ++i) {
+        if (v.words[i] != 0)
+            return false;
+    }
+    for (uint32_t i = common; i < vm.num_words(); ++i) {
+        if (vm.words[i] != 0)
+            return false;
+    }
+    return true;
+}
+template <size_t N>
+inline bool operator==(const BitMask<N>& m, MaskView v) {
+    return v == m;
+}
+
+/// Compare a runtime-width MaskView to a uint64_t (interpreted as the
+/// lower 64 bits, with all higher words required to be zero).
+inline bool operator==(MaskView v, uint64_t expected) {
+    if (v.num_words() == 0)
+        return expected == 0;
+    if (v.words[0] != expected)
+        return false;
+    for (uint32_t i = 1; i < v.num_words(); ++i) {
+        if (v.words[i] != 0)
+            return false;
+    }
+    return true;
+}
+inline bool operator==(uint64_t expected, MaskView v) {
+    return v == expected;
+}
+
 }  // namespace clifft

--- a/tests/test_hir.cc
+++ b/tests/test_hir.cc
@@ -10,107 +10,123 @@
 #include <utility>
 
 using namespace clifft;
+using clifft::test::MaskBuf;
+using clifft::test::pauli_masks;
 using clifft::test::X;
 using clifft::test::Z;
 
-using clifft::test::pauli_masks;
-
 // =============================================================================
-// HeisenbergOp Tests
+// HirModule builder + accessor tests
 // =============================================================================
 
-// Note: sizeof(HeisenbergOp) == 32 is enforced by static_assert in hir.h.
-// We don't duplicate that check here - the code won't compile if it fails.
+// HeisenbergOp size is pinned to 16 bytes by static_assert in hir.h. We do
+// not duplicate that assertion here.
 
-TEST_CASE("HeisenbergOp::make_tgate", "[hir]") {
+TEST_CASE("HirModule::append_tgate stores Pauli in arena", "[hir]") {
     SECTION("T gate with Z on qubit 0") {
+        HirModule hir(64, 1);
         auto [destab, stab] = pauli_masks("Z");
-        auto op = HeisenbergOp::make_tgate(destab, stab, /*sign=*/false);
+        auto& op = hir.append_tgate(MaskBuf(destab), MaskBuf(stab), /*sign=*/false);
 
         REQUIRE(op.op_type() == OpType::T_GATE);
-        REQUIRE(op.destab_mask() == 0);    // No X
-        REQUIRE(op.stab_mask() == Z(0));   // Z on qubit 0
-        REQUIRE(op.sign() == false);       // Positive phase
-        REQUIRE(op.is_dagger() == false);  // T, not T_dag
+        REQUIRE(hir.destab_mask(op) == 0);   // No X
+        REQUIRE(hir.stab_mask(op) == Z(0));  // Z on qubit 0
+        REQUIRE(hir.sign(op) == false);
+        REQUIRE(op.is_dagger() == false);
     }
 
     SECTION("T_dag gate with X on qubit 1, negative sign") {
-        auto op = HeisenbergOp::make_tgate(X(1), 0, /*sign=*/true, /*dagger=*/true);
+        HirModule hir(64, 1);
+        auto& op = hir.append_tgate(MaskBuf(X(1)), MaskBuf(0), /*sign=*/true, /*dagger=*/true);
 
         REQUIRE(op.op_type() == OpType::T_GATE);
-        REQUIRE(op.destab_mask() == X(1));  // X on qubit 1
-        REQUIRE(op.stab_mask() == 0);       // No Z
-        REQUIRE(op.sign() == true);         // Negative phase
-        REQUIRE(op.is_dagger() == true);    // T_dag
+        REQUIRE(hir.destab_mask(op) == X(1));
+        REQUIRE(hir.stab_mask(op) == 0);
+        REQUIRE(hir.sign(op) == true);
+        REQUIRE(op.is_dagger() == true);
     }
 
     SECTION("T gate with Y on qubit 2 (both X and Z bits set)") {
-        // "Y__" means Y on qubit 2, I on qubits 1 and 0 (rightmost is qubit 0)
+        HirModule hir(64, 1);
         auto [destab, stab] = pauli_masks("Y__");
-        auto op = HeisenbergOp::make_tgate(destab, stab, false);
+        auto& op = hir.append_tgate(MaskBuf(destab), MaskBuf(stab), false);
 
-        REQUIRE(op.destab_mask() == X(2));  // X component of Y
-        REQUIRE(op.stab_mask() == Z(2));    // Z component of Y
+        REQUIRE(hir.destab_mask(op) == X(2));
+        REQUIRE(hir.stab_mask(op) == Z(2));
     }
 }
 
-TEST_CASE("HeisenbergOp::set_pauli replaces masks and sign", "[hir]") {
-    auto op = HeisenbergOp::make_tgate(0, Z(0), /*sign=*/false);
-    REQUIRE(op.stab_mask() == Z(0));
-    REQUIRE(op.sign() == false);
+TEST_CASE("HirModule::set_pauli replaces masks and sign", "[hir]") {
+    HirModule hir(64, 1);
+    auto& op = hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false);
+    REQUIRE(hir.stab_mask(op) == Z(0));
+    REQUIRE(hir.sign(op) == false);
 
-    op.set_pauli(X(1), Z(2), true);
-    REQUIRE(op.destab_mask() == X(1));
-    REQUIRE(op.stab_mask() == Z(2));
-    REQUIRE(op.sign() == true);
-    // OpType and flags are preserved
+    hir.set_pauli(op, MaskBuf(X(1)), MaskBuf(Z(2)), true);
+    REQUIRE(hir.destab_mask(op) == X(1));
+    REQUIRE(hir.stab_mask(op) == Z(2));
+    REQUIRE(hir.sign(op) == true);
     REQUIRE(op.op_type() == OpType::T_GATE);
     REQUIRE(op.is_dagger() == false);
 }
 
-TEST_CASE("HeisenbergOp bitword operations", "[hir]") {
-    // Verify bitword<64> provides expected operations for commutation checks
-    auto op1 = HeisenbergOp::make_tgate(X(1) | X(3), Z(0) | Z(2), false);  // X1 X3 Z0 Z2
-    auto op2 = HeisenbergOp::make_tgate(X(2) | X(3), Z(0) | Z(1), false);  // X2 X3 Z0 Z1
+TEST_CASE("HirModule mask access supports bitwise inspection", "[hir]") {
+    HirModule hir(64, 2);
+    hir.append_tgate(MaskBuf(X(1) | X(3)), MaskBuf(Z(0) | Z(2)), false);  // X1 X3 Z0 Z2
+    hir.append_tgate(MaskBuf(X(2) | X(3)), MaskBuf(Z(0) | Z(1)), false);  // X2 X3 Z0 Z1
 
-    // Test popcount (useful for commutation: count overlapping X-Z pairs)
-    // op1.destab & op2.stab = X1 X3 & Z0 Z1 = bit 1 only
-    REQUIRE((op1.destab_mask() & op2.stab_mask()).popcount() == 1);
-    // op1.stab & op2.destab = Z0 Z2 & X2 X3 = bit 2 only
-    REQUIRE((op1.stab_mask() & op2.destab_mask()).popcount() == 1);
+    auto destab1 = hir.destab_mask(hir.ops[0]);
+    auto stab1 = hir.stab_mask(hir.ops[0]);
+    auto destab2 = hir.destab_mask(hir.ops[1]);
+    auto stab2 = hir.stab_mask(hir.ops[1]);
 
-    // Test XOR for combining masks
-    auto xor_destab = op1.destab_mask() ^ op2.destab_mask();
-    REQUIRE(xor_destab == (X(1) | X(2)));  // X3 cancels, X1 and X2 remain
+    // destab1 & stab2 = X1 X3 & Z0 Z1 = bit 1 only
+    int popcount_d1_s2 = 0;
+    for (uint32_t i = 0; i < destab1.num_words(); ++i) {
+        popcount_d1_s2 += std::popcount(destab1.words[i] & stab2.words[i]);
+    }
+    REQUIRE(popcount_d1_s2 == 1);
+
+    // stab1 & destab2 = Z0 Z2 & X2 X3 = bit 2 only
+    int popcount_s1_d2 = 0;
+    for (uint32_t i = 0; i < stab1.num_words(); ++i) {
+        popcount_s1_d2 += std::popcount(stab1.words[i] & destab2.words[i]);
+    }
+    REQUIRE(popcount_s1_d2 == 1);
+
+    // XOR: X3 cancels, X1 and X2 remain
+    REQUIRE((destab1.words[0] ^ destab2.words[0]) == (X(1) | X(2)));
 }
 
-TEST_CASE("HeisenbergOp::make_measure", "[hir]") {
+TEST_CASE("HirModule::append_measure", "[hir]") {
     SECTION("Measurement with record index") {
-        auto op = HeisenbergOp::make_measure(X(0), 0, /*sign=*/false, MeasRecordIdx{5});
+        HirModule hir(64, 1);
+        auto& op = hir.append_measure(MaskBuf(X(0)), MaskBuf(0), /*sign=*/false, MeasRecordIdx{5});
 
         REQUIRE(op.op_type() == OpType::MEASURE);
-        REQUIRE(op.destab_mask() == X(0));
-        REQUIRE(op.stab_mask() == 0);
+        REQUIRE(hir.destab_mask(op) == X(0));
+        REQUIRE(hir.stab_mask(op) == 0);
         REQUIRE(op.meas_record_idx() == MeasRecordIdx{5});
     }
 
     SECTION("Multi-qubit measurement") {
-        auto op = HeisenbergOp::make_measure(X(0) | X(1), 0, false, MeasRecordIdx{10});
+        HirModule hir(64, 1);
+        auto& op = hir.append_measure(MaskBuf(X(0) | X(1)), MaskBuf(0), false, MeasRecordIdx{10});
         REQUIRE(op.meas_record_idx() == MeasRecordIdx{10});
     }
 }
 
-TEST_CASE("HeisenbergOp::make_conditional", "[hir]") {
-    auto op = HeisenbergOp::make_conditional(X(0), 0, /*sign=*/false, ControllingMeasIdx{7});
+TEST_CASE("HirModule::append_conditional", "[hir]") {
+    HirModule hir(64, 1);
+    auto& op =
+        hir.append_conditional(MaskBuf(X(0)), MaskBuf(0), /*sign=*/false, ControllingMeasIdx{7});
 
     REQUIRE(op.op_type() == OpType::CONDITIONAL_PAULI);
-    REQUIRE(op.destab_mask() == X(0));
+    REQUIRE(hir.destab_mask(op) == X(0));
     REQUIRE(op.controlling_meas() == ControllingMeasIdx{7});
 }
 
 TEST_CASE("pauli_masks helper", "[hir][helper]") {
-    // Verify our test helper works correctly
-
     SECTION("Single paulis") {
         auto [d, s] = pauli_masks("X");
         REQUIRE(d == X(0));
@@ -130,12 +146,10 @@ TEST_CASE("pauli_masks helper", "[hir][helper]") {
     }
 
     SECTION("Multi-qubit strings") {
-        // "XYZ" = X on q2, Y on q1, Z on q0
         auto [d, s] = pauli_masks("XYZ");
-        REQUIRE(d == (X(2) | X(1)));  // X on q2, X component of Y on q1
-        REQUIRE(s == (Z(1) | Z(0)));  // Z component of Y on q1, Z on q0
+        REQUIRE(d == (X(2) | X(1)));
+        REQUIRE(s == (Z(1) | Z(0)));
 
-        // "IXZI" = I on q3, X on q2, Z on q1, I on q0
         std::tie(d, s) = pauli_masks("IXZI");
         REQUIRE(d == X(2));
         REQUIRE(s == Z(1));
@@ -147,75 +161,64 @@ TEST_CASE("pauli_masks helper", "[hir][helper]") {
 // =============================================================================
 
 TEST_CASE("stim::Tableau identity and Hadamard", "[hir]") {
-    stim::Tableau<kStimWidth> tab(4);  // 4 qubits
+    stim::Tableau<kStimWidth> tab(4);
 
-    // Default is identity: X_k -> X_k, Z_k -> Z_k
     REQUIRE(tab.num_qubits == 4);
 
-    // Check that xs[0] is X_0 (destabilizer for qubit 0)
     auto x0 = tab.xs[0];
-    REQUIRE(x0.xs[0] == true);   // Has X component on qubit 0
-    REQUIRE(x0.zs[0] == false);  // No Z component on qubit 0
-    REQUIRE(x0.sign == false);   // Positive sign
+    REQUIRE(x0.xs[0] == true);
+    REQUIRE(x0.zs[0] == false);
+    REQUIRE(x0.sign == false);
 
-    // Check that zs[0] is Z_0 (stabilizer for qubit 0)
     auto z0 = tab.zs[0];
-    REQUIRE(z0.xs[0] == false);  // No X component on qubit 0
-    REQUIRE(z0.zs[0] == true);   // Has Z component on qubit 0
-    REQUIRE(z0.sign == false);   // Positive sign
+    REQUIRE(z0.xs[0] == false);
+    REQUIRE(z0.zs[0] == true);
+    REQUIRE(z0.sign == false);
 
-    // Apply a Hadamard to qubit 0 - should swap X and Z
     tab.prepend_H_XZ(0);
     auto x0_after = tab.xs[0];
     auto z0_after = tab.zs[0];
 
-    // After H: X_0 -> Z_0, Z_0 -> X_0
-    REQUIRE(x0_after.xs[0] == false);  // No X
-    REQUIRE(x0_after.zs[0] == true);   // Has Z
-    REQUIRE(z0_after.xs[0] == true);   // Has X
-    REQUIRE(z0_after.zs[0] == false);  // No Z
+    REQUIRE(x0_after.xs[0] == false);
+    REQUIRE(x0_after.zs[0] == true);
+    REQUIRE(z0_after.xs[0] == true);
+    REQUIRE(z0_after.zs[0] == false);
 }
 
 // =============================================================================
-// HirModule Tests
+// HirModule integration
 // =============================================================================
 
 TEST_CASE("HirModule construction and accessors", "[hir]") {
-    HirModule hir;
-    hir.num_qubits = 4;
+    HirModule hir(4, 4);
 
     REQUIRE(hir.num_ops() == 0);
     REQUIRE(hir.num_t_gates() == 0);
     REQUIRE(hir.global_weight == std::complex<double>(1.0, 0.0));
 
-    // Add some operations: 2 T gates, 1 T_dag gate, 1 measurement
-    hir.ops.push_back(HeisenbergOp::make_tgate(X(0), 0, false));        // T
-    hir.ops.push_back(HeisenbergOp::make_tgate(X(1), 0, false, true));  // T_dag
-    hir.ops.push_back(HeisenbergOp::make_measure(X(0), Z(0), false, MeasRecordIdx{0}));
-    hir.ops.push_back(HeisenbergOp::make_tgate(X(2), 0, false));  // T
+    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);        // T
+    hir.append_tgate(MaskBuf(X(1)), MaskBuf(0), false, true);  // T_dag
+    hir.append_measure(MaskBuf(X(0)), MaskBuf(Z(0)), false, MeasRecordIdx{0});
+    hir.append_tgate(MaskBuf(X(2)), MaskBuf(0), false);  // T
 
     REQUIRE(hir.num_ops() == 4);
-    REQUIRE(hir.num_t_gates() == 3);  // All T_GATE ops (regardless of is_dagger)
+    REQUIRE(hir.num_t_gates() == 3);
 }
 
 TEST_CASE("HirModule with noise sites", "[hir]") {
-    HirModule hir;
-    hir.num_qubits = 2;
+    HirModule hir(2, /*num_pauli_masks=*/0, /*num_noise_channels=*/1);
 
-    // Add a noise site
     NoiseSite site;
-    site.channels.push_back({X(0), 0, 0.1});
+    auto h = hir.claim_noise_channel_mask(MaskBuf(X(0)), MaskBuf(0));
+    site.channels.push_back({h, 0.1});
     hir.noise_sites.push_back(std::move(site));
 
-    hir.ops.push_back(HeisenbergOp::make_noise(NoiseSiteIdx{0}));
+    hir.append_noise(NoiseSiteIdx{0});
     REQUIRE(hir.noise_sites.size() == 1);
     REQUIRE(hir.ops[0].noise_site_idx() == NoiseSiteIdx{0});
 }
 
 TEST_CASE("Tableau composition via then() and inverse()", "[hir]") {
-    // after.then(before.inverse()) extracts the operator inserted between
-    // `before` and `after`. Here `before = H` and `after = H; CNOT`, so the
-    // composition should equal CNOT alone.
     stim::Tableau<kStimWidth> before(2);
     before.prepend_H_XZ(0);
 
@@ -226,13 +229,12 @@ TEST_CASE("Tableau composition via then() and inverse()", "[hir]") {
     auto inv_before = before.inverse();
     auto composed = after.then(inv_before);
 
-    // CNOT: X_0 -> X_0 X_1, Z_1 -> Z_0 Z_1, X_1 -> X_1, Z_0 -> Z_0
     REQUIRE(composed.xs[0].xs[0] == true);
-    REQUIRE(composed.xs[0].xs[1] == true);  // X_0 -> X_0 X_1
+    REQUIRE(composed.xs[0].xs[1] == true);
     REQUIRE(composed.xs[1].xs[1] == true);
-    REQUIRE(composed.xs[1].xs[0] == false);  // X_1 -> X_1 (no change)
+    REQUIRE(composed.xs[1].xs[0] == false);
     REQUIRE(composed.zs[0].zs[0] == true);
-    REQUIRE(composed.zs[0].zs[1] == false);  // Z_0 -> Z_0 (no change)
+    REQUIRE(composed.zs[0].zs[1] == false);
     REQUIRE(composed.zs[1].zs[0] == true);
-    REQUIRE(composed.zs[1].zs[1] == true);  // Z_1 -> Z_0 Z_1
+    REQUIRE(composed.zs[1].zs[1] == true);
 }

--- a/tests/test_hir.cc
+++ b/tests/test_hir.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 using namespace clifft;
-using clifft::test::MaskBuf;
 using clifft::test::pauli_masks;
 using clifft::test::X;
 using clifft::test::Z;
@@ -26,7 +25,7 @@ TEST_CASE("HirModule::append_tgate stores Pauli in arena", "[hir]") {
     SECTION("T gate with Z on qubit 0") {
         HirModule hir(64, 1);
         auto [destab, stab] = pauli_masks("Z");
-        auto& op = hir.append_tgate(MaskBuf(destab), MaskBuf(stab), /*sign=*/false);
+        auto& op = clifft::test::append_tgate(hir, destab, stab, /*sign=*/false);
 
         REQUIRE(op.op_type() == OpType::T_GATE);
         REQUIRE(hir.destab_mask(op) == 0);   // No X
@@ -37,7 +36,7 @@ TEST_CASE("HirModule::append_tgate stores Pauli in arena", "[hir]") {
 
     SECTION("T_dag gate with X on qubit 1, negative sign") {
         HirModule hir(64, 1);
-        auto& op = hir.append_tgate(MaskBuf(X(1)), MaskBuf(0), /*sign=*/true, /*dagger=*/true);
+        auto& op = clifft::test::append_tgate(hir, X(1), 0, /*sign=*/true, /*dagger=*/true);
 
         REQUIRE(op.op_type() == OpType::T_GATE);
         REQUIRE(hir.destab_mask(op) == X(1));
@@ -49,20 +48,20 @@ TEST_CASE("HirModule::append_tgate stores Pauli in arena", "[hir]") {
     SECTION("T gate with Y on qubit 2 (both X and Z bits set)") {
         HirModule hir(64, 1);
         auto [destab, stab] = pauli_masks("Y__");
-        auto& op = hir.append_tgate(MaskBuf(destab), MaskBuf(stab), false);
+        auto& op = clifft::test::append_tgate(hir, destab, stab, false);
 
         REQUIRE(hir.destab_mask(op) == X(2));
         REQUIRE(hir.stab_mask(op) == Z(2));
     }
 }
 
-TEST_CASE("HirModule::set_pauli replaces masks and sign", "[hir]") {
+TEST_CASE("set_pauli replaces masks and sign", "[hir]") {
     HirModule hir(64, 1);
-    auto& op = hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false);
+    auto& op = clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/false);
     REQUIRE(hir.stab_mask(op) == Z(0));
     REQUIRE(hir.sign(op) == false);
 
-    hir.set_pauli(op, MaskBuf(X(1)), MaskBuf(Z(2)), true);
+    clifft::test::set_pauli(hir, op, X(1), Z(2), true);
     REQUIRE(hir.destab_mask(op) == X(1));
     REQUIRE(hir.stab_mask(op) == Z(2));
     REQUIRE(hir.sign(op) == true);
@@ -72,8 +71,8 @@ TEST_CASE("HirModule::set_pauli replaces masks and sign", "[hir]") {
 
 TEST_CASE("HirModule mask access supports bitwise inspection", "[hir]") {
     HirModule hir(64, 2);
-    hir.append_tgate(MaskBuf(X(1) | X(3)), MaskBuf(Z(0) | Z(2)), false);  // X1 X3 Z0 Z2
-    hir.append_tgate(MaskBuf(X(2) | X(3)), MaskBuf(Z(0) | Z(1)), false);  // X2 X3 Z0 Z1
+    clifft::test::append_tgate(hir, X(1) | X(3), Z(0) | Z(2), false);  // X1 X3 Z0 Z2
+    clifft::test::append_tgate(hir, X(2) | X(3), Z(0) | Z(1), false);  // X2 X3 Z0 Z1
 
     auto destab1 = hir.destab_mask(hir.ops[0]);
     auto stab1 = hir.stab_mask(hir.ops[0]);
@@ -101,7 +100,7 @@ TEST_CASE("HirModule mask access supports bitwise inspection", "[hir]") {
 TEST_CASE("HirModule::append_measure", "[hir]") {
     SECTION("Measurement with record index") {
         HirModule hir(64, 1);
-        auto& op = hir.append_measure(MaskBuf(X(0)), MaskBuf(0), /*sign=*/false, MeasRecordIdx{5});
+        auto& op = clifft::test::append_measure(hir, X(0), 0, /*sign=*/false, MeasRecordIdx{5});
 
         REQUIRE(op.op_type() == OpType::MEASURE);
         REQUIRE(hir.destab_mask(op) == X(0));
@@ -111,7 +110,7 @@ TEST_CASE("HirModule::append_measure", "[hir]") {
 
     SECTION("Multi-qubit measurement") {
         HirModule hir(64, 1);
-        auto& op = hir.append_measure(MaskBuf(X(0) | X(1)), MaskBuf(0), false, MeasRecordIdx{10});
+        auto& op = clifft::test::append_measure(hir, X(0) | X(1), 0, false, MeasRecordIdx{10});
         REQUIRE(op.meas_record_idx() == MeasRecordIdx{10});
     }
 }
@@ -119,7 +118,7 @@ TEST_CASE("HirModule::append_measure", "[hir]") {
 TEST_CASE("HirModule::append_conditional", "[hir]") {
     HirModule hir(64, 1);
     auto& op =
-        hir.append_conditional(MaskBuf(X(0)), MaskBuf(0), /*sign=*/false, ControllingMeasIdx{7});
+        clifft::test::append_conditional(hir, X(0), 0, /*sign=*/false, ControllingMeasIdx{7});
 
     REQUIRE(op.op_type() == OpType::CONDITIONAL_PAULI);
     REQUIRE(hir.destab_mask(op) == X(0));
@@ -196,10 +195,10 @@ TEST_CASE("HirModule construction and accessors", "[hir]") {
     REQUIRE(hir.num_t_gates() == 0);
     REQUIRE(hir.global_weight == std::complex<double>(1.0, 0.0));
 
-    hir.append_tgate(MaskBuf(X(0)), MaskBuf(0), false);        // T
-    hir.append_tgate(MaskBuf(X(1)), MaskBuf(0), false, true);  // T_dag
-    hir.append_measure(MaskBuf(X(0)), MaskBuf(Z(0)), false, MeasRecordIdx{0});
-    hir.append_tgate(MaskBuf(X(2)), MaskBuf(0), false);  // T
+    clifft::test::append_tgate(hir, X(0), 0, false);        // T
+    clifft::test::append_tgate(hir, X(1), 0, false, true);  // T_dag
+    clifft::test::append_measure(hir, X(0), Z(0), false, MeasRecordIdx{0});
+    clifft::test::append_tgate(hir, X(2), 0, false);  // T
 
     REQUIRE(hir.num_ops() == 4);
     REQUIRE(hir.num_t_gates() == 3);
@@ -209,7 +208,7 @@ TEST_CASE("HirModule with noise sites", "[hir]") {
     HirModule hir(2, /*num_pauli_masks=*/0, /*num_noise_channels=*/1);
 
     NoiseSite site;
-    auto h = hir.claim_noise_channel_mask(MaskBuf(X(0)), MaskBuf(0));
+    auto h = clifft::test::claim_noise_channel_mask(hir, X(0), 0);
     site.channels.push_back({h, 0.1});
     hir.noise_sites.push_back(std::move(site));
 

--- a/tests/test_mask_view.cc
+++ b/tests/test_mask_view.cc
@@ -143,6 +143,31 @@ TEST_CASE("MutableMaskView: copy_from replaces contents") {
     REQUIRE(a[2] == 3);
 }
 
+TEST_CASE("MutableMaskView: copy_from zero-pads when source is narrower") {
+    std::array<uint64_t, 3> dst{0xFF, 0xFF, 0xFF};
+    std::array<uint64_t, 1> src{0x42};
+    MutableMaskView{std::span<uint64_t>(dst)}.copy_from(MaskView{std::span<const uint64_t>(src)});
+    REQUIRE(dst[0] == 0x42);
+    REQUIRE(dst[1] == 0);  // zero-padded
+    REQUIRE(dst[2] == 0);
+}
+
+TEST_CASE("MutableMaskView: copy_from accepts wider source when excess bits are zero") {
+    std::array<uint64_t, 1> dst{0};
+    std::array<uint64_t, 3> src{0x42, 0, 0};
+    REQUIRE_NOTHROW(MutableMaskView{std::span<uint64_t>(dst)}.copy_from(
+        MaskView{std::span<const uint64_t>(src)}));
+    REQUIRE(dst[0] == 0x42);
+}
+
+TEST_CASE("MutableMaskView: copy_from throws when wider source has set bits above destination") {
+    std::array<uint64_t, 1> dst{0};
+    std::array<uint64_t, 3> src{0x42, 0x1, 0};
+    REQUIRE_THROWS_AS(MutableMaskView{std::span<uint64_t>(dst)}.copy_from(
+                          MaskView{std::span<const uint64_t>(src)}),
+                      std::runtime_error);
+}
+
 // =========================================================================
 // BitMask<N> adapters
 // =========================================================================

--- a/tests/test_mask_view.cc
+++ b/tests/test_mask_view.cc
@@ -134,40 +134,6 @@ TEST_CASE("MutableMaskView: zero_out clears all words") {
     REQUIRE(ma.is_zero());
 }
 
-TEST_CASE("MutableMaskView: copy_from replaces contents") {
-    std::array<uint64_t, 3> a{0, 0, 0};
-    std::array<uint64_t, 3> b{1, 2, 3};
-    MutableMaskView{std::span<uint64_t>(a)}.copy_from(MaskView{std::span<const uint64_t>(b)});
-    REQUIRE(a[0] == 1);
-    REQUIRE(a[1] == 2);
-    REQUIRE(a[2] == 3);
-}
-
-TEST_CASE("MutableMaskView: copy_from zero-pads when source is narrower") {
-    std::array<uint64_t, 3> dst{0xFF, 0xFF, 0xFF};
-    std::array<uint64_t, 1> src{0x42};
-    MutableMaskView{std::span<uint64_t>(dst)}.copy_from(MaskView{std::span<const uint64_t>(src)});
-    REQUIRE(dst[0] == 0x42);
-    REQUIRE(dst[1] == 0);  // zero-padded
-    REQUIRE(dst[2] == 0);
-}
-
-TEST_CASE("MutableMaskView: copy_from accepts wider source when excess bits are zero") {
-    std::array<uint64_t, 1> dst{0};
-    std::array<uint64_t, 3> src{0x42, 0, 0};
-    REQUIRE_NOTHROW(MutableMaskView{std::span<uint64_t>(dst)}.copy_from(
-        MaskView{std::span<const uint64_t>(src)}));
-    REQUIRE(dst[0] == 0x42);
-}
-
-TEST_CASE("MutableMaskView: copy_from throws when wider source has set bits above destination") {
-    std::array<uint64_t, 1> dst{0};
-    std::array<uint64_t, 3> src{0x42, 0x1, 0};
-    REQUIRE_THROWS_AS(MutableMaskView{std::span<uint64_t>(dst)}.copy_from(
-                          MaskView{std::span<const uint64_t>(src)}),
-                      std::runtime_error);
-}
-
 // =========================================================================
 // BitMask<N> adapters
 // =========================================================================

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -13,6 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 using namespace clifft;
+using clifft::test::MaskBuf;
 using clifft::test::X;
 using clifft::test::Z;
 
@@ -225,8 +226,7 @@ TEST_CASE("Peephole: READOUT_NOISE is transparent", "[optimizer]") {
 }
 
 TEST_CASE("Peephole: empty HIR is a no-op", "[optimizer]") {
-    HirModule hir;
-    hir.num_qubits = 0;
+    HirModule hir(0, /*pauli_capacity=*/16);
 
     PeepholeFusionPass pass;
     pass.run(hir);
@@ -276,11 +276,10 @@ TEST_CASE("Peephole: three T gates produce one T after S absorption", "[optimize
 TEST_CASE("Peephole: sign inversion makes T behave as T_dag", "[optimizer]") {
     // T with negative sign has eff=-1, same as T_dag with positive sign
     // So T(sign=true) + T(sign=false) should cancel
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true));
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/false));
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false);
 
     PeepholeFusionPass pass;
     pass.run(hir);
@@ -292,11 +291,10 @@ TEST_CASE("Peephole: sign inversion makes T behave as T_dag", "[optimizer]") {
 TEST_CASE("Peephole: sign inversion makes same-direction absorb", "[optimizer]") {
     // T(sign=true) has eff=-1, T_dag(sign=false) has eff=-1
     // total = -2 -> fuse to S_dag (absorbed)
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true));
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/false, /*dagger=*/true));
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false, /*dagger=*/true);
 
     PeepholeFusionPass pass;
     pass.run(hir);
@@ -317,7 +315,7 @@ TEST_CASE("Peephole: S absorption propagates through downstream T", "[optimizer]
 
     REQUIRE(hir.ops.size() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
-    REQUIRE(hir.ops[0].stab_mask() == Z(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
 }
 
 TEST_CASE("Peephole: T plus T fusion leaves global_weight unchanged", "[optimizer]") {
@@ -391,8 +389,8 @@ TEST_CASE("Peephole: S absorption conjugates anti-commuting downstream measure",
     // After conjugation, X(0) -> Y(0): both X and Z bits set
     auto y_destab = X(0);
     auto y_stab = Z(0);
-    REQUIRE(hir.ops[0].destab_mask() == y_destab);
-    REQUIRE(hir.ops[0].stab_mask() == y_stab);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == y_destab);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == y_stab);
 }
 
 TEST_CASE("Peephole: S absorption conjugates noise and conditional Pauli", "[optimizer]") {
@@ -418,18 +416,19 @@ TEST_CASE("Peephole: S absorption conjugates noise and conditional Pauli", "[opt
     // Check noise channel conjugation: X(0) -> Y(0)
     auto site_idx = static_cast<uint32_t>(hir.ops[0].noise_site_idx());
     const auto& ch = hir.noise_sites[site_idx].channels[0];
-    CHECK(ch.destab_mask.bit_get(0));  // X bit set
-    CHECK(ch.stab_mask.bit_get(0));    // Z bit set -> Y
+    auto ch_view = hir.noise_channel_masks.at(ch.mask);
+    CHECK(ch_view.x().bit_get(0));  // X bit set
+    CHECK(ch_view.z().bit_get(0));  // Z bit set -> Y
 
     // Check MEASURE conjugation: X(0) -> Y(0) with sign
-    CHECK(hir.ops[1].destab_mask().bit_get(0));
-    CHECK(hir.ops[1].stab_mask().bit_get(0));
-    CHECK(hir.ops[1].sign() == true);  // -Y
+    CHECK(hir.destab_mask(hir.ops[1]).bit_get(0));
+    CHECK(hir.stab_mask(hir.ops[1]).bit_get(0));
+    CHECK(hir.sign(hir.ops[1]) == true);  // -Y
 
     // Check CONDITIONAL_PAULI conjugation: X(0) -> Y(0) with sign
-    CHECK(hir.ops[2].destab_mask().bit_get(0));
-    CHECK(hir.ops[2].stab_mask().bit_get(0));
-    CHECK(hir.ops[2].sign() == true);  // -Y
+    CHECK(hir.destab_mask(hir.ops[2]).bit_get(0));
+    CHECK(hir.stab_mask(hir.ops[2]).bit_get(0));
+    CHECK(hir.sign(hir.ops[2]) == true);  // -Y
 }
 
 // =============================================================================
@@ -445,11 +444,10 @@ TEST_CASE("Peephole: S absorption conjugates noise and conditional Pauli", "[opt
 TEST_CASE("Peephole: negative-sign T plus T preserves global phase", "[optimizer]") {
     // X conjugates Z -> -Z, so both T gates see -Z axis (sign=true).
     // T(-Z) = exp(i*pi/4) * T_dag(+Z), so T(-Z)+T(-Z) = exp(i*pi/2) * S_dag(+Z) = i * S_dag.
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true));
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true));
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
     auto initial_weight = hir.global_weight;
 
     PeepholeFusionPass pass;
@@ -469,11 +467,10 @@ TEST_CASE("Peephole: negative-sign T plus T preserves global phase", "[optimizer
 
 TEST_CASE("Peephole: negative-sign T_dag plus T_dag preserves global phase", "[optimizer]") {
     // T_dag(-Z) = exp(-i*pi/4) * T(+Z), two of them: exp(-i*pi/2) * S(+Z) = -i * S.
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true, /*dagger=*/true));
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true, /*dagger=*/true));
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true, /*dagger=*/true);
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true, /*dagger=*/true);
     auto initial_weight = hir.global_weight;
 
     PeepholeFusionPass pass;
@@ -492,11 +489,10 @@ TEST_CASE("Peephole: mixed-sign T cancellation preserves global phase", "[optimi
     // T(+Z) + T(-Z): effective_angles sum to 0 (cancellation), but
     // T(-Z) = exp(i*pi/4) * T_dag(+Z), so the physical result is
     // T(+Z) * exp(i*pi/4) * T_dag(+Z) = exp(i*pi/4) * I.
-    HirModule hir;
-    hir.num_qubits = 1;
+    HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/false));
-    hir.ops.push_back(HeisenbergOp::make_tgate(0, Z(0), /*sign=*/true));
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false);
+    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
     auto initial_weight = hir.global_weight;
 
     PeepholeFusionPass pass;
@@ -687,8 +683,8 @@ TEST_CASE("Peephole: virtual S conjugation updates EXP_VAL masks", "[optimizer][
     REQUIRE(pass.fusions() == 1);
 
     // S^dag X S = Y: both X and Z bits set on qubit 0
-    REQUIRE(hir.ops[0].destab_mask() == X(0));
-    REQUIRE(hir.ops[0].stab_mask() == Z(0));
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
 }
 
 TEST_CASE("Peephole: commuting NOISE does not bypass EXP_VAL barrier", "[optimizer][exp_val]") {

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -13,7 +13,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 using namespace clifft;
-using clifft::test::MaskBuf;
 using clifft::test::X;
 using clifft::test::Z;
 
@@ -278,8 +277,8 @@ TEST_CASE("Peephole: sign inversion makes T behave as T_dag", "[optimizer]") {
     // So T(sign=true) + T(sign=false) should cancel
     HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/false);
 
     PeepholeFusionPass pass;
     pass.run(hir);
@@ -293,8 +292,8 @@ TEST_CASE("Peephole: sign inversion makes same-direction absorb", "[optimizer]")
     // total = -2 -> fuse to S_dag (absorbed)
     HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false, /*dagger=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/false, /*dagger=*/true);
 
     PeepholeFusionPass pass;
     pass.run(hir);
@@ -446,8 +445,8 @@ TEST_CASE("Peephole: negative-sign T plus T preserves global phase", "[optimizer
     // T(-Z) = exp(i*pi/4) * T_dag(+Z), so T(-Z)+T(-Z) = exp(i*pi/2) * S_dag(+Z) = i * S_dag.
     HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true);
     auto initial_weight = hir.global_weight;
 
     PeepholeFusionPass pass;
@@ -469,8 +468,8 @@ TEST_CASE("Peephole: negative-sign T_dag plus T_dag preserves global phase", "[o
     // T_dag(-Z) = exp(-i*pi/4) * T(+Z), two of them: exp(-i*pi/2) * S(+Z) = -i * S.
     HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true, /*dagger=*/true);
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true, /*dagger=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true, /*dagger=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true, /*dagger=*/true);
     auto initial_weight = hir.global_weight;
 
     PeepholeFusionPass pass;
@@ -491,8 +490,8 @@ TEST_CASE("Peephole: mixed-sign T cancellation preserves global phase", "[optimi
     // T(+Z) * exp(i*pi/4) * T_dag(+Z) = exp(i*pi/4) * I.
     HirModule hir(1, /*pauli_capacity=*/16);
 
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/false);
-    hir.append_tgate(MaskBuf(0), MaskBuf(Z(0)), /*sign=*/true);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/false);
+    clifft::test::append_tgate(hir, 0, Z(0), /*sign=*/true);
     auto initial_weight = hir.global_weight;
 
     PeepholeFusionPass pass;

--- a/tests/test_svm.cc
+++ b/tests/test_svm.cc
@@ -848,9 +848,9 @@ TEST_CASE("VM ApplyPauli: X error flips p_x bit") {
     mod.num_measurements = 1;
     mod.peak_rank = 4;
 
-    PauliMask pm;
-    pm.x.bit_set(1, true);
-    mod.constant_pool.pauli_masks.push_back(pm);
+    mod.constant_pool.pauli_masks = clifft::PauliMaskArena(mod.peak_rank, 1);
+    auto pm = mod.constant_pool.pauli_masks.mut_at(clifft::PauliMaskHandle{0});
+    pm.x().bit_set(1, true);
 
     Instruction instr{};
     instr.opcode = Opcode::OP_APPLY_PAULI;
@@ -875,9 +875,9 @@ TEST_CASE("VM ApplyPauli: Z error flips p_z bit") {
     mod.num_measurements = 1;
     mod.peak_rank = 4;
 
-    PauliMask pm;
-    pm.z.bit_set(2, true);
-    mod.constant_pool.pauli_masks.push_back(pm);
+    mod.constant_pool.pauli_masks = clifft::PauliMaskArena(mod.peak_rank, 1);
+    auto pm = mod.constant_pool.pauli_masks.mut_at(clifft::PauliMaskHandle{0});
+    pm.z().bit_set(2, true);
 
     Instruction instr{};
     instr.opcode = Opcode::OP_APPLY_PAULI;
@@ -903,9 +903,9 @@ TEST_CASE("VM ApplyPauli: X error on Z frame has no anticommutation phase") {
     mod.num_measurements = 1;
     mod.peak_rank = 4;
 
-    PauliMask pm;
-    pm.x.bit_set(0, true);
-    mod.constant_pool.pauli_masks.push_back(pm);
+    mod.constant_pool.pauli_masks = clifft::PauliMaskArena(mod.peak_rank, 1);
+    auto pm = mod.constant_pool.pauli_masks.mut_at(clifft::PauliMaskHandle{0});
+    pm.x().bit_set(0, true);
 
     Instruction instr{};
     instr.opcode = Opcode::OP_APPLY_PAULI;
@@ -931,9 +931,9 @@ TEST_CASE("VM ApplyPauli: Z error on X frame negates gamma") {
     mod.num_measurements = 1;
     mod.peak_rank = 4;
 
-    PauliMask pm;
-    pm.z.bit_set(0, true);
-    mod.constant_pool.pauli_masks.push_back(pm);
+    mod.constant_pool.pauli_masks = clifft::PauliMaskArena(mod.peak_rank, 1);
+    auto pm = mod.constant_pool.pauli_masks.mut_at(clifft::PauliMaskHandle{0});
+    pm.z().bit_set(0, true);
 
     Instruction instr{};
     instr.opcode = Opcode::OP_APPLY_PAULI;
@@ -958,10 +958,10 @@ TEST_CASE("VM ApplyPauli: signed Pauli mask negates gamma") {
     mod.num_measurements = 1;
     mod.peak_rank = 4;
 
-    PauliMask pm;
-    pm.x.bit_set(0, true);
-    pm.sign = true;
-    mod.constant_pool.pauli_masks.push_back(pm);
+    mod.constant_pool.pauli_masks = clifft::PauliMaskArena(mod.peak_rank, 1);
+    auto pm = mod.constant_pool.pauli_masks.mut_at(clifft::PauliMaskHandle{0});
+    pm.x().bit_set(0, true);
+    pm.set_sign(true);
 
     Instruction instr{};
     instr.opcode = Opcode::OP_APPLY_PAULI;


### PR DESCRIPTION
## Summary

PR2 of the issue #45 staged migration. Replaces fixed-width `BitMask<N>` Pauli storage in HIR, NoiseChannel, and ConstantPool with runtime-width `PauliMaskArena`s, and shrinks `HeisenbergOp` to a fixed 16 bytes. The frontend writes stim PauliString rows directly into arena slots via `stim_to_mask_view`, so qubits beyond `kMaxInlineQubits` round-trip without truncation.

This is a clean rewrite of the work in #50, organized so each commit is correct on landing — no patches-on-patches. #50 will be closed in favor of this.

## Commit summary

1. **`chore: document arena resize invalidation`** — comment in `pauli_arena.h`.
2. **`feat(util): tighten copy_from semantics, add MaskBuf test helper`** — `copy_from` throws (not asserts) on truncation; production same-size case has zero overhead. 1-word `MaskBuf` test helper.
3. **`feat: migrate Pauli mask storage to runtime-width arenas`** — the big one. HirModule + ConstantPool arenas, NoiseChannel becomes `{handle, prob}`, frontend writes stim → arena directly with no PauliBitMask intermediate, optimizer/backend/SVM read masks via arena, `HeisenbergOp` shrinks to 16 B. Includes high-qubit regression tests at n = 70, 150, 200, 513.
4. **`feat(frontend): reject circuits above the VM axis ceiling early`** — `trace()` rejects `n > 65536` so we don't allocate a giant Stim TableauSimulator before `lower()` would reject anyway.
5. **`fix(python): keep HirModule alive through HeisenbergOp wrappers`** — `PyHeisenbergOp` holds `nb::object module_owner`; both `__getitem__` and `__iter__` capture `nb::borrow(self)`. Includes Python regression tests for both.
6. **`chore(optimizer): clear noise_channel_masks in RemoveNoisePass`** — replace the arena with an empty one after stripping noise.
7. **`test: add surface d=11 r=11 benchmark above the old 128-qubit cap`** — `n ≈ 274`, exercises the regime the migration unlocks.

## Test plan

- [x] `uv tool run pre-commit run --all-files`
- [x] `ctest --test-dir build/cmake -E Bench --timeout 60` — 691 cases pass, full suite in ~3 s
- [x] `uv run pytest tests/python/` — 597 cases pass
- [x] Local Release benches (n=10 samples)

## Bench (Release, this dev machine)

| Benchmark | PR0 baseline | This branch | Δ |
|---|---:|---:|---:|
| `QV-10 x100 shots` | 24.74 ms | 22.9 ms | -7.4% |
| `cultivation-d5 x1000 shots` | 38.95 ms | 39.7 ms | +1.8% |
| `surface-d7-r7 p=1e-3 x10000 shots` | 71.74 ms | 72.3 ms | +0.8% |
| `surface-d5-r5 p=0.05 x10000 shots` | 81.68 ms | 82.4 ms | +0.9% |
| `exp-val 20q 200 probes x100000 shots` | 138.59 ms | 190.4 ms | +37% |
| `surface-d11-r11 p=1e-3 x1000 shots` | (n/a, > old cap) | 18.8 ms | — |

EXP_VAL is the only meaningful regression. As flagged in the migration plan: the previously fully-unrolled `BitMask<128>` popcount/XOR is now a runtime-bounded loop, and the `(X, Z, sign)` tuple is split across three storage regions. PR3 will add template specialization on common `num_words` values for the hot `APPLY_PAULI` / `EXP_VAL` paths to recover this.

## What's still pending (PR3)

- SVM frame `p_x` / `p_z` runtime sizing.
- Removal of `CLIFFT_MAX_QUBITS` and `BitMask<N>`.
- Template specialization on `num_words` for hot mask widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
