### PR TITLE
chore: gate benches out of default ctest and align docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 <!-- How was this tested? Check all that apply. -->
 
-- [ ] C++ tests pass (`ctest --test-dir build --output-on-failure`)
+- [ ] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
 - [ ] Python tests pass (`uv run pytest tests/python/ -v`)
 - [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
 - [ ] Pre-commit checks pass (`uv run pre-commit run --all-files`)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,11 @@ jobs:
         run: cmake --build build --parallel
 
       - name: Run C++ tests
-        run: ctest --test-dir build --output-on-failure
+        # Exclude [bench] cases: they re-exercise paths already covered by
+        # the unit and integration tests, but each runs Catch2's default
+        # sample count and would add tens of minutes of wall-clock for no
+        # extra coverage signal.
+        run: ctest --test-dir build --output-on-failure -E "Bench"
 
       - name: Capture C++ test coverage
         run: |

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -78,7 +78,15 @@ For pure C++ development without Python:
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j
-ctest --test-dir build --output-on-failure
+ctest --test-dir build -E Bench --output-on-failure
+```
+
+`-E Bench` excludes the [bench] performance cases (which add minutes of
+wall-clock for no correctness signal). Run them explicitly when
+collecting timing data:
+
+```bash
+ctest --test-dir build -R Bench
 ```
 
 OpenMP is optional for standalone C++ builds too. Linux toolchains usually find it automatically. On macOS with Apple clang, install Homebrew `libomp` first:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -84,8 +84,12 @@ uv run pre-commit run --all-files
     ```bash
     cmake -B build -DCMAKE_BUILD_TYPE=Debug
     cmake --build build -j
-    ctest --test-dir build --output-on-failure
+    ctest --test-dir build -E Bench --output-on-failure
     ```
+
+    `-E Bench` skips the [bench] performance cases. Run them
+    explicitly with `ctest --test-dir build -R Bench` when you want
+    timing data.
 
 === "Both"
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -69,10 +69,14 @@ We use `pytest` for the Python oracles and `CTest` for the C++ units. You can ru
     ```bash
     cmake -B build -DCMAKE_BUILD_TYPE=Debug
     cmake --build build -j
-    ctest --test-dir build --output-on-failure
+    ctest --test-dir build -E Bench --output-on-failure
     # Or using just:
     just test
     ```
+
+    `-E Bench` skips the [bench] performance cases. Run them
+    explicitly with `ctest --test-dir build -R Bench` when collecting
+    timing data.
 
 To generate HTML coverage reports for both layers of the application to ensure new features are thoroughly exercised:
 

--- a/tests/test_benchmarks.cc
+++ b/tests/test_benchmarks.cc
@@ -1,12 +1,16 @@
 // Clifft Performance Benchmarks
 //
-// Catch2 benchmark tests for regression tracking. Run with:
-//   ctest --test-dir build -R Bench
-// Or for detailed output:
-//   ./build/tests/clifft_tests "[bench]" --benchmark-samples 10
+// Opt-in performance regression checks. Excluded from the default
+// correctness/coverage CI; the cases below run Catch2's default sample
+// count (100) at multi-hundred-millisecond per-iteration cost, which
+// adds tens of minutes of wall-clock without contributing coverage
+// signal that the unit and integration suites do not already provide.
 //
-// Each benchmark targets ~100ms per iteration to keep CI fast while
-// providing meaningful measurements.
+// Run explicitly via ctest:
+//   ctest --test-dir build -R Bench
+//
+// Or directly through the test binary for detailed Catch2 output:
+//   ./build/tests/clifft_tests "[bench]" --benchmark-samples 10
 
 #include "clifft/backend/backend.h"
 #include "clifft/circuit/parser.h"


### PR DESCRIPTION
## Summary

`ci.yml` and `tsan.yml` already exclude `[bench]` cases via `-E "Bench"`; this PR brings `coverage.yml` and four user-facing docs in line, and reframes the `test_benchmarks.cc` preamble that still advertised them as CI-fast.

Three small fixes:

- **`.github/workflows/coverage.yml`** — add `-E "Bench"` to the C++ test step. The bench cases re-exercise paths already covered by the unit and integration tests; running them under the coverage build adds tens of minutes of wall-clock for no extra signal.
- **PR template + 3 docs** (`PULL_REQUEST_TEMPLATE.md`, `docs/development/{building,contributing,testing}.md`) — change the example from `ctest --test-dir build --output-on-failure` to `ctest --test-dir build -E Bench --output-on-failure`, with a one-line pointer at `ctest -R Bench` for opt-in timing runs.
- **`tests/test_benchmarks.cc` preamble** — the old text claimed each bench targets "~100 ms per iteration to keep CI fast." Each case actually runs Catch2's default 100 samples, taking multi-second wall-clock per case, and the suite is intentionally not in default CI. Reframe as opt-in regression checks with the explicit run command.

No behavior changes — this aligns docs and coverage CI with how the benchmark suite is already used in practice.

## Test plan

- [x] Pre-commit clean
- [x] No source files outside docs/ci/comments touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)