### PR TITLE
perf(playground): O(1) cursor highlight via reverse source maps

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -175,8 +175,7 @@ export default function App() {
   // once when an upstream pass merged provenance from fused / unrolled
   // ops (e.g. REPEAT-block expansion). Dedupe per entry via Set so the
   // reverse arrays don't grow with the duplication factor and Monaco's
-  // decoration set isn't fed redundant ranges -- exactly the fused /
-  // large cases this PR is meant to speed up.
+  // decoration set isn't fed redundant ranges.
   const reverseMaps = useMemo(() => {
     const empty = {
       hir: new Map<number, number[]>(),

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -170,6 +170,13 @@ export default function App() {
   // HIR/bytecode lines correspond to this source line" in O(1) instead
   // of scanning every output line on every click. firstBc is the first
   // bytecode index for a given source line, used by the k-history chart.
+  //
+  // A single forward entry can contain the same source line more than
+  // once when an upstream pass merged provenance from fused / unrolled
+  // ops (e.g. REPEAT-block expansion). Dedupe per entry via Set so the
+  // reverse arrays don't grow with the duplication factor and Monaco's
+  // decoration set isn't fed redundant ranges -- exactly the fused /
+  // large cases this PR is meant to speed up.
   const reverseMaps = useMemo(() => {
     const empty = {
       hir: new Map<number, number[]>(),
@@ -180,7 +187,8 @@ export default function App() {
     const hir = new Map<number, number[]>();
     compileResult.hir_source_map.forEach((lines: number[], i: number) => {
       const monacoLine = i + 1;
-      for (const ln of lines) {
+      const unique = lines.length > 1 ? new Set(lines) : lines;
+      for (const ln of unique) {
         const arr = hir.get(ln);
         if (arr) arr.push(monacoLine);
         else hir.set(ln, [monacoLine]);
@@ -190,7 +198,8 @@ export default function App() {
     const firstBc = new Map<number, number>();
     compileResult.bytecode_source_map.forEach((lines: number[], i: number) => {
       const monacoLine = i + 1;
-      for (const ln of lines) {
+      const unique = lines.length > 1 ? new Set(lines) : lines;
+      for (const ln of unique) {
         const arr = bc.get(ln);
         if (arr) arr.push(monacoLine);
         else bc.set(ln, [monacoLine]);

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -164,15 +164,47 @@ export default function App() {
   // Ref to avoid stale closures in editor cursor handlers
   const compileResultRef = useRef<CompileResult | null>(null);
 
+  // Reverse source-map indices, built once per compile result. Each
+  // forward source map is `outIdx -> source_line[]`; the cursor highlight
+  // wants the inverse `source_line -> outIdx[]` so it can answer "which
+  // HIR/bytecode lines correspond to this source line" in O(1) instead
+  // of scanning every output line on every click. firstBc is the first
+  // bytecode index for a given source line, used by the k-history chart.
+  const reverseMaps = useMemo(() => {
+    const empty = {
+      hir: new Map<number, number[]>(),
+      bc: new Map<number, number[]>(),
+      firstBc: new Map<number, number>(),
+    };
+    if (!compileResult || !isCompileSuccess(compileResult)) return empty;
+    const hir = new Map<number, number[]>();
+    compileResult.hir_source_map.forEach((lines: number[], i: number) => {
+      const monacoLine = i + 1;
+      for (const ln of lines) {
+        const arr = hir.get(ln);
+        if (arr) arr.push(monacoLine);
+        else hir.set(ln, [monacoLine]);
+      }
+    });
+    const bc = new Map<number, number[]>();
+    const firstBc = new Map<number, number>();
+    compileResult.bytecode_source_map.forEach((lines: number[], i: number) => {
+      const monacoLine = i + 1;
+      for (const ln of lines) {
+        const arr = bc.get(ln);
+        if (arr) arr.push(monacoLine);
+        else bc.set(ln, [monacoLine]);
+        if (!firstBc.has(ln)) firstBc.set(ln, i);
+      }
+    });
+    return { hir, bc, firstBc };
+  }, [compileResult]);
+
   // Derived: which bytecode PC maps to the cursor source line (for k-history highlight)
   const highlightPC = useMemo(() => {
-    if (!compileResult || !isCompileSuccess(compileResult) || cursorSourceLine === null)
-      return null;
-    const idx = compileResult.bytecode_source_map.findIndex((lines: number[]) =>
-      lines.includes(cursorSourceLine),
-    );
-    return idx >= 0 ? idx : null;
-  }, [cursorSourceLine, compileResult]);
+    if (cursorSourceLine === null) return null;
+    return reverseMaps.firstBc.get(cursorSourceLine) ?? null;
+  }, [cursorSourceLine, reverseMaps]);
 
   // --- Debounced compilation ---
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -264,17 +296,11 @@ export default function App() {
 
     const srcLine = cursorSourceLine;
 
-    // Find HIR ops that map to this source line
-    const hirLines: number[] = [];
-    compileResult.hir_source_map.forEach((lines: number[], i: number) => {
-      if (lines.includes(srcLine)) hirLines.push(i + 1); // Monaco is 1-indexed
-    });
-
-    // Find bytecode instructions that map to this source line
-    const bcLines: number[] = [];
-    compileResult.bytecode_source_map.forEach((lines: number[], i: number) => {
-      if (lines.includes(srcLine)) bcLines.push(i + 1);
-    });
+    // O(1) lookups via the precomputed reverse maps. The forward source
+    // maps stay around for direct cursor->source navigation in the HIR
+    // and bytecode editors.
+    const hirLines = reverseMaps.hir.get(srcLine) ?? [];
+    const bcLines = reverseMaps.bc.get(srcLine) ?? [];
 
     // Highlight the source line itself
     sourceDecosRef.current?.set([
@@ -327,7 +353,7 @@ export default function App() {
     } else {
       bcPcDecosRef.current?.clear();
     }
-  }, [cursorSourceLine, compileResult, rulerColor, diffView]);
+  }, [cursorSourceLine, compileResult, reverseMaps, rulerColor, diffView]);
 
   // --- Editor mount handlers ---
   const onSourceMount: OnMount = (editor) => {


### PR DESCRIPTION
## Summary

Every click in the source / HIR / bytecode editor was scanning the full forward source maps three times before the decoration set call. For large circuits (e.g. the SHYPS r=3 logical-memory file from PhotonicInc/ComputingEfficientlyInQLDPCCodes, which produces tens of thousands of HIR ops and bytecode instructions) that gave a noticeable hitch on every click.

The three offenders, all in `App.tsx`:

1. **Bidirectional highlight `useEffect`** — two `forEach` scans over `hir_source_map` and `bytecode_source_map` doing `Array.includes(srcLine)` on each entry.
2. **`highlightPC` `useMemo`** — `findIndex` over `bytecode_source_map` doing the same `includes` check.

All three were O(n_hir + n_bc) per cursor change.

## Fix

Build inverse maps once per compile result in a single `useMemo`:

- `hir: Map<srcLine, monacoLineNumbers[]>`
- `bc: Map<srcLine, monacoLineNumbers[]>`
- `firstBc: Map<srcLine, bytecodePc>` for the k-history chart

The highlight effect and `highlightPC` become O(1) `Map.get` lookups. Build cost is O(n_hir + n_bc) once per compile — a rounding error compared to the wasm compile step that produced the data.

Forward maps stay for the HIR / bytecode cursor handlers (which already index into them in O(1)).

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] Manual: clicking through source / HIR / bytecode lines on a small circuit produces the same highlights as before.
- [ ] Manual: click latency on the SHYPS r=3 file is no longer noticeable. (Reviewer to verify after the playground rebuilds and deploys.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)