### PR TITLE
fix: version playground wasm assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build playground
         run: |
           cd playground && npm ci
-          VITE_BASE_PATH=/clifft/playground/ npm run build
+          VITE_BASE_PATH=/clifft/playground/ VITE_BUILD_SHA=${{ github.sha }} npm run build
 
       # --- Build MkDocs (docs group only, no C++ extension needed) ---
       - name: Install uv

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build playground
         run: |
           cd playground && npm ci
-          VITE_BASE_PATH=/clifft/pr-preview/pr-${{ github.event.number }}/playground/ npm run build
+          VITE_BASE_PATH=/clifft/pr-preview/pr-${{ github.event.number }}/playground/ VITE_BUILD_SHA=${{ github.sha }} npm run build
 
       # --- Build MkDocs (docs group only, no C++ extension needed) ---
       - name: Install uv

--- a/playground/src/hooks/useClifftWasm.ts
+++ b/playground/src/hooks/useClifftWasm.ts
@@ -11,18 +11,23 @@ export type WasmStatus = "loading" | "ready" | "error";
 // double-mounts and concurrent hook instances.
 let modulePromise: Promise<ClifftModule> | null = null;
 
+function wasmUrl(path: string): string {
+  const url = `${import.meta.env.BASE_URL}${path}`;
+  const version = import.meta.env.VITE_BUILD_SHA as string | undefined;
+  return version ? `${url}?v=${encodeURIComponent(version)}` : url;
+}
+
 function loadModule(): Promise<ClifftModule> {
   if (modulePromise) return modulePromise;
 
   modulePromise = new Promise<ClifftModule>((resolve, reject) => {
     const script = document.createElement("script");
-    script.src = `${import.meta.env.BASE_URL}clifft_wasm.js`;
+    script.src = wasmUrl("clifft_wasm.js");
     script.async = true;
     script.setAttribute("data-clifft-wasm", "true");
     script.onload = () => {
-      const base = import.meta.env.BASE_URL;
       createClifftModule({
-        locateFile: (path: string) => `${base}${path}`,
+        locateFile: wasmUrl,
       }).then(resolve, reject);
     };
     script.onerror = () => reject(new Error("Failed to load clifft_wasm.js"));


### PR DESCRIPTION
## Summary
- append the build SHA as a query parameter when loading playground Wasm assets
- pass GitHub SHA into docs and PR preview playground builds
- preserve unversioned asset URLs for local builds without VITE_BUILD_SHA

## Test plan
- VITE_BASE_PATH=/clifft/playground/ VITE_BUILD_SHA=test-sha npm run build
- npm run lint
- uv run pre-commit run --all-files