### PR TITLE
perf(playground): decouple K-history highlight from chart re-render

### DIFF
--- a/playground/src/components/KHistoryChart.tsx
+++ b/playground/src/components/KHistoryChart.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import {
   AreaChart,
   Area,
@@ -19,84 +20,158 @@ interface Props {
 }
 
 const MEMORY_LIMIT_K = 24;
+const CHART_MARGIN = { top: 8, right: 16, bottom: 24, left: 8 };
+
+type ChartDatum = { pc: number; k?: number; baseline?: number };
+
+interface BaseChartProps {
+  data: ChartDatum[];
+  maxK: number;
+  hasBaseline: boolean;
+  colors: ChartColors;
+}
+
+// Heavy chart body. Re-renders only when the underlying data, baseline,
+// or theme colors change -- not on cursor moves. Without the memo the
+// recharts measurement pass walks every axis tick / text element on
+// every click and forces tens of thousands of synchronous layouts at
+// large circuit sizes.
+const BaseChart = memo(function BaseChart({ data, maxK, hasBaseline, colors }: BaseChartProps) {
+  return (
+    <AreaChart data={data} margin={CHART_MARGIN}>
+      <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} />
+      <XAxis
+        dataKey="pc"
+        stroke={colors.axis}
+        fontSize={11}
+        label={{
+          value: "Bytecode PC",
+          position: "insideBottom",
+          offset: -12,
+          fill: colors.axis,
+          fontSize: 11,
+        }}
+      />
+      <YAxis
+        domain={[0, maxK]}
+        stroke={colors.axis}
+        fontSize={11}
+        label={{
+          value: "Active k",
+          angle: -90,
+          position: "insideLeft",
+          fill: colors.axis,
+          fontSize: 11,
+        }}
+      />
+      <Tooltip
+        contentStyle={{
+          background: colors.tooltipBg,
+          border: `1px solid ${colors.tooltipBorder}`,
+          fontSize: 12,
+        }}
+        labelStyle={{ color: colors.tooltipText }}
+        itemStyle={{ color: colors.tooltipText }}
+        labelFormatter={(pc) => `PC: ${pc}`}
+      />
+      {hasBaseline && (
+        <Line
+          type="stepAfter"
+          dataKey="baseline"
+          stroke={colors.axis}
+          strokeWidth={1.5}
+          strokeDasharray="6 3"
+          dot={false}
+          isAnimationActive={false}
+          name="Baseline k"
+          connectNulls={false}
+        />
+      )}
+      <Area
+        type="stepAfter"
+        dataKey="k"
+        stroke={colors.accent}
+        fill={colors.accentFill}
+        fillOpacity={0.15}
+        strokeWidth={2}
+        dot={false}
+        isAnimationActive={false}
+        name="Optimized k"
+      />
+      <ReferenceLine
+        y={MEMORY_LIMIT_K}
+        stroke={colors.error}
+        strokeDasharray="6 3"
+        label={{
+          value: "Browser Memory Limit (~256 MB)",
+          position: "right",
+          fill: colors.error,
+          fontSize: 10,
+        }}
+      />
+    </AreaChart>
+  );
+});
 
 export function KHistoryChart({ history, baselineHistory, highlightPC, colors }: Props) {
+  // Build the data array once per (history, baselineHistory) pair.
+  const chartData = useMemo(() => {
+    const maxLen = Math.max(history.length, baselineHistory?.length ?? 0);
+    const data: ChartDatum[] = Array.from({ length: maxLen }, (_, i) => ({
+      pc: i,
+      k: i < history.length ? history[i] : undefined,
+      baseline:
+        baselineHistory && i < baselineHistory.length ? baselineHistory[i] : undefined,
+    }));
+    const allVals = [...history, ...(baselineHistory ?? [])];
+    const maxK = Math.max(...allVals, MEMORY_LIMIT_K + 2);
+    return { data, maxK };
+  }, [history, baselineHistory]);
+
   if (history.length === 0) {
     return <div className="chart-placeholder">No bytecode yet</div>;
   }
 
-  // Build data array; baseline may have different length so pad with undefined
-  const maxLen = Math.max(history.length, baselineHistory?.length ?? 0);
-  const data = Array.from({ length: maxLen }, (_, i) => ({
-    pc: i,
-    k: i < history.length ? history[i] : undefined,
-    baseline: baselineHistory && i < baselineHistory.length ? baselineHistory[i] : undefined,
-  }));
+  const hasBaseline = !!baselineHistory && baselineHistory.length > 0;
 
-  const allVals = [...history, ...(baselineHistory ?? [])];
-  const maxK = Math.max(...allVals, MEMORY_LIMIT_K + 2);
+  // Cursor annotation. Replaces the prior in-chart ReferenceLine: pulling
+  // the highlightPC out of the AreaChart subtree means recharts no longer
+  // re-measures every axis tick on click, which is the dominant cost in
+  // the playground click latency at large circuit sizes.
+  const cursorK =
+    highlightPC !== null && highlightPC >= 0 && highlightPC < history.length
+      ? history[highlightPC]
+      : null;
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <AreaChart data={data} margin={{ top: 8, right: 16, bottom: 24, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} />
-        <XAxis
-          dataKey="pc"
-          stroke={colors.axis}
-          fontSize={11}
-          label={{ value: "Bytecode PC", position: "insideBottom", offset: -12, fill: colors.axis, fontSize: 11 }}
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BaseChart
+          data={chartData.data}
+          maxK={chartData.maxK}
+          hasBaseline={hasBaseline}
+          colors={colors}
         />
-        <YAxis
-          domain={[0, maxK]}
-          stroke={colors.axis}
-          fontSize={11}
-          label={{ value: "Active k", angle: -90, position: "insideLeft", fill: colors.axis, fontSize: 11 }}
-        />
-        <Tooltip
-          contentStyle={{ background: colors.tooltipBg, border: `1px solid ${colors.tooltipBorder}`, fontSize: 12 }}
-          labelStyle={{ color: colors.tooltipText }}
-          itemStyle={{ color: colors.tooltipText }}
-          labelFormatter={(pc) => `PC: ${pc}`}
-        />
-        {baselineHistory && baselineHistory.length > 0 && (
-          <Line
-            type="stepAfter"
-            dataKey="baseline"
-            stroke={colors.axis}
-            strokeWidth={1.5}
-            strokeDasharray="6 3"
-            dot={false}
-            isAnimationActive={false}
-            name="Baseline k"
-            connectNulls={false}
-          />
-        )}
-        <Area
-          type="stepAfter"
-          dataKey="k"
-          stroke={colors.accent}
-          fill={colors.accentFill}
-          fillOpacity={0.15}
-          strokeWidth={2}
-          dot={false}
-          isAnimationActive={false}
-          name="Optimized k"
-        />
-        <ReferenceLine
-          y={MEMORY_LIMIT_K}
-          stroke={colors.error}
-          strokeDasharray="6 3"
-          label={{
-            value: "Browser Memory Limit (~256 MB)",
-            position: "right",
-            fill: colors.error,
-            fontSize: 10,
+      </ResponsiveContainer>
+      {highlightPC !== null && (
+        <div
+          style={{
+            position: "absolute",
+            top: 4,
+            right: 16,
+            padding: "2px 6px",
+            borderRadius: 3,
+            background: colors.tooltipBg,
+            border: `1px solid ${colors.tooltipBorder}`,
+            color: colors.tooltipText,
+            fontSize: 11,
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            pointerEvents: "none",
           }}
-        />
-        {highlightPC !== null && (
-          <ReferenceLine x={highlightPC} stroke="#ffd54f" strokeDasharray="3 3" />
-        )}
-      </AreaChart>
-    </ResponsiveContainer>
+        >
+          {`PC ${highlightPC}${cursorK !== undefined && cursorK !== null ? ` · k=${cursorK}` : ""}`}
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The playground hangs (~700-3000 ms) on every click in the source / HIR / bytecode panes for large circuits. Profiling the SHYPS r=3 circuit showed **56% of per-click CPU was inside `getBoundingClientRect`**, called recursively from React commit during a full recharts re-render on every cursor move.

The driver was `<ReferenceLine x={highlightPC}>` sitting inside `<AreaChart>`: any change to `highlightPC` triggered recharts' full measurement pass over every axis tick and SVG element.

## Fix

Two-part change in `playground/src/components/KHistoryChart.tsx`:

1. **Memoize the chart body.** Extract everything inside `<AreaChart>` (axes, area, baseline line, memory-limit reference line) into a `BaseChart = memo(...)` depending only on the data, baseline flag, and theme colors. The `data` + `maxK` arrays are built in a `useMemo` at the parent keyed on `history` / `baselineHistory`. Cursor moves no longer touch this subtree.
2. **Replace the cursor highlight ReferenceLine with a text annotation** rendered in the chart's top-right corner: `PC 1505 · k=0`. Updates cheaply on every click, conveys *more* information than a vertical line on a possibly-flat trajectory, and — critically — does not re-enter recharts.

## Bench (headless Chromium, SHYPS r=3, 10 clicks)

| metric | before (main) | after | Δ |
|---|---:|---:|---:|
| per-click rAF latency median | 725 ms | 16 ms | **45× faster** |
| per-click rAF latency p95 | 3047 ms | 33 ms | **92× faster** |
| long-tasks (≥50 ms) | 18 | **0** | — |
| long-tasks total | 25,967 ms | 0 ms | — |

User-perceived hang gone.

## Visual

`PC 1505 · k=0` annotation lives in the top-right of the chart; the rest of the chart is unchanged. For Clifford-only circuits (where the trajectory is flat at k=0) the annotation is the only useful per-cursor signal anyway. For T-gate-heavy circuits with non-trivial `k(PC)`, the chart's existing area trace remains visible and the annotation calls out the cursor's specific PC and k value.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] Playwright bench: 0 long-tasks, 16 ms median per-click
- [ ] Manual verification by reviewer in real Chrome on the SHYPS r=3 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)