### PR TITLE
perf(playground): decouple K-history highlight via recharts hooks

### DIFF
--- a/playground/src/components/KHistoryChart.tsx
+++ b/playground/src/components/KHistoryChart.tsx
@@ -1,3 +1,4 @@
+import { createContext, memo, useContext, useMemo } from "react";
 import {
   AreaChart,
   Area,
@@ -8,6 +9,8 @@ import {
   ReferenceLine,
   ResponsiveContainer,
   Line,
+  usePlotArea,
+  useXAxisScale,
 } from "recharts";
 import type { ChartColors } from "../hooks/useTheme";
 
@@ -19,84 +22,168 @@ interface Props {
 }
 
 const MEMORY_LIMIT_K = 24;
+const CHART_MARGIN = { top: 8, right: 16, bottom: 24, left: 8 };
+
+type ChartDatum = { pc: number; k?: number; baseline?: number };
+
+// Cursor highlight delivered through context rather than as a prop on the
+// memoized chart, so changes don't invalidate BaseChart's React.memo.
+// HighlightLine consumes the context and re-renders independently when
+// the cursor moves; the chart body stays untouched.
+const HighlightPCContext = createContext<number | null>(null);
+
+const HighlightLine = memo(function HighlightLine() {
+  const highlightPC = useContext(HighlightPCContext);
+  const plotArea = usePlotArea();
+  const xScale = useXAxisScale();
+
+  if (highlightPC === null || !plotArea || !xScale) return null;
+  const raw = xScale(highlightPC);
+  const x = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(x)) return null;
+  if (x < plotArea.x || x > plotArea.x + plotArea.width) return null;
+
+  return (
+    <line
+      x1={x}
+      x2={x}
+      y1={plotArea.y}
+      y2={plotArea.y + plotArea.height}
+      stroke="#ffd54f"
+      strokeDasharray="3 3"
+      pointerEvents="none"
+    />
+  );
+});
+
+interface BaseChartProps {
+  data: ChartDatum[];
+  maxK: number;
+  hasBaseline: boolean;
+  colors: ChartColors;
+}
+
+// Heavy chart body. Memoized so the recharts axis/area measurement pass
+// only re-runs when the underlying data, baseline flag, or theme colors
+// change -- not on cursor moves. The cursor highlight is rendered by
+// HighlightLine, which subscribes to HighlightPCContext and lives inside
+// AreaChart so it can pull the chart's plot area + x scale from the
+// recharts hooks.
+const BaseChart = memo(function BaseChart({ data, maxK, hasBaseline, colors }: BaseChartProps) {
+  return (
+    <AreaChart data={data} margin={CHART_MARGIN}>
+      <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} />
+      <XAxis
+        dataKey="pc"
+        stroke={colors.axis}
+        fontSize={11}
+        label={{
+          value: "Bytecode PC",
+          position: "insideBottom",
+          offset: -12,
+          fill: colors.axis,
+          fontSize: 11,
+        }}
+      />
+      <YAxis
+        domain={[0, maxK]}
+        stroke={colors.axis}
+        fontSize={11}
+        label={{
+          value: "Active k",
+          angle: -90,
+          position: "insideLeft",
+          fill: colors.axis,
+          fontSize: 11,
+        }}
+      />
+      <Tooltip
+        contentStyle={{
+          background: colors.tooltipBg,
+          border: `1px solid ${colors.tooltipBorder}`,
+          fontSize: 12,
+        }}
+        labelStyle={{ color: colors.tooltipText }}
+        itemStyle={{ color: colors.tooltipText }}
+        labelFormatter={(pc) => `PC: ${pc}`}
+      />
+      {hasBaseline && (
+        <Line
+          type="stepAfter"
+          dataKey="baseline"
+          stroke={colors.axis}
+          strokeWidth={1.5}
+          strokeDasharray="6 3"
+          dot={false}
+          isAnimationActive={false}
+          name="Baseline k"
+          connectNulls={false}
+        />
+      )}
+      <Area
+        type="stepAfter"
+        dataKey="k"
+        stroke={colors.accent}
+        fill={colors.accentFill}
+        fillOpacity={0.15}
+        strokeWidth={2}
+        dot={false}
+        isAnimationActive={false}
+        name="Optimized k"
+      />
+      <ReferenceLine
+        y={MEMORY_LIMIT_K}
+        stroke={colors.error}
+        strokeDasharray="6 3"
+        label={{
+          value: "Browser Memory Limit (~256 MB)",
+          position: "right",
+          fill: colors.error,
+          fontSize: 10,
+        }}
+      />
+      <HighlightLine />
+    </AreaChart>
+  );
+});
 
 export function KHistoryChart({ history, baselineHistory, highlightPC, colors }: Props) {
+  // Build the data array and y-axis upper bound once per
+  // (history, baselineHistory) pair. Single-pass scan avoids the
+  // [...history, ...baselineHistory] allocation and the Math.max(...)
+  // function-argument spread, which can hit V8's argument count limit
+  // on multi-tens-of-thousands of entries.
+  const chartData = useMemo(() => {
+    const maxLen = Math.max(history.length, baselineHistory?.length ?? 0);
+    let maxVal = MEMORY_LIMIT_K + 2;
+    const data: ChartDatum[] = new Array(maxLen);
+    for (let i = 0; i < maxLen; i++) {
+      const k = i < history.length ? history[i] : undefined;
+      const baseline =
+        baselineHistory && i < baselineHistory.length ? baselineHistory[i] : undefined;
+      if (k !== undefined && k > maxVal) maxVal = k;
+      if (baseline !== undefined && baseline > maxVal) maxVal = baseline;
+      data[i] = { pc: i, k, baseline };
+    }
+    return { data, maxK: maxVal };
+  }, [history, baselineHistory]);
+
   if (history.length === 0) {
     return <div className="chart-placeholder">No bytecode yet</div>;
   }
 
-  // Build data array; baseline may have different length so pad with undefined
-  const maxLen = Math.max(history.length, baselineHistory?.length ?? 0);
-  const data = Array.from({ length: maxLen }, (_, i) => ({
-    pc: i,
-    k: i < history.length ? history[i] : undefined,
-    baseline: baselineHistory && i < baselineHistory.length ? baselineHistory[i] : undefined,
-  }));
-
-  const allVals = [...history, ...(baselineHistory ?? [])];
-  const maxK = Math.max(...allVals, MEMORY_LIMIT_K + 2);
+  const hasBaseline = !!baselineHistory && baselineHistory.length > 0;
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <AreaChart data={data} margin={{ top: 8, right: 16, bottom: 24, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} />
-        <XAxis
-          dataKey="pc"
-          stroke={colors.axis}
-          fontSize={11}
-          label={{ value: "Bytecode PC", position: "insideBottom", offset: -12, fill: colors.axis, fontSize: 11 }}
+    <HighlightPCContext.Provider value={highlightPC}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BaseChart
+          data={chartData.data}
+          maxK={chartData.maxK}
+          hasBaseline={hasBaseline}
+          colors={colors}
         />
-        <YAxis
-          domain={[0, maxK]}
-          stroke={colors.axis}
-          fontSize={11}
-          label={{ value: "Active k", angle: -90, position: "insideLeft", fill: colors.axis, fontSize: 11 }}
-        />
-        <Tooltip
-          contentStyle={{ background: colors.tooltipBg, border: `1px solid ${colors.tooltipBorder}`, fontSize: 12 }}
-          labelStyle={{ color: colors.tooltipText }}
-          itemStyle={{ color: colors.tooltipText }}
-          labelFormatter={(pc) => `PC: ${pc}`}
-        />
-        {baselineHistory && baselineHistory.length > 0 && (
-          <Line
-            type="stepAfter"
-            dataKey="baseline"
-            stroke={colors.axis}
-            strokeWidth={1.5}
-            strokeDasharray="6 3"
-            dot={false}
-            isAnimationActive={false}
-            name="Baseline k"
-            connectNulls={false}
-          />
-        )}
-        <Area
-          type="stepAfter"
-          dataKey="k"
-          stroke={colors.accent}
-          fill={colors.accentFill}
-          fillOpacity={0.15}
-          strokeWidth={2}
-          dot={false}
-          isAnimationActive={false}
-          name="Optimized k"
-        />
-        <ReferenceLine
-          y={MEMORY_LIMIT_K}
-          stroke={colors.error}
-          strokeDasharray="6 3"
-          label={{
-            value: "Browser Memory Limit (~256 MB)",
-            position: "right",
-            fill: colors.error,
-            fontSize: 10,
-          }}
-        />
-        {highlightPC !== null && (
-          <ReferenceLine x={highlightPC} stroke="#ffd54f" strokeDasharray="3 3" />
-        )}
-      </AreaChart>
-    </ResponsiveContainer>
+      </ResponsiveContainer>
+    </HighlightPCContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary

Replaces #58. Same problem (playground hangs ~700-3000 ms per click on large circuits because `<ReferenceLine x={highlightPC}>` in `<AreaChart>` triggers a full recharts measurement pass), but a cleaner fix using recharts 3 public hooks instead of the in-corner text label.

## Fix

Three changes in `playground/src/components/KHistoryChart.tsx`:

1. **Memoize the chart body.** `BaseChart = memo(...)` depends only on `data` / `hasBaseline` / `colors`. Cursor moves no longer invalidate the memo, so recharts' axis-tick measurement pass doesn't re-run.
2. **Render the cursor highlight via recharts hooks.** A small `HighlightLine` component sits inside `<AreaChart>`, pulls `highlightPC` from a React context, and reads the chart's plot area + x scale via `usePlotArea` / `useXAxisScale` (both publicly exported from recharts 3). When the cursor moves, the context value changes and only `HighlightLine` re-renders — `BaseChart` doesn't, because the context plumbing is outside its props. The line is drawn as a single SVG `<line>` element at the right pixel position.
3. **Single-pass `data` + `maxK` build.** The old `[...history, ...(baselineHistory ?? [])]` + `Math.max(...allVals, ...)` pattern allocated a transient n+m array and spread it as function arguments, which can hit V8's argument-count limit on circuits with tens of thousands of instructions. Replaced with a single `for` loop that computes both in one pass.

## Validation

Highlight line renders at the correct pixel position. For `highlightPC = 1505` of `maxLen = 8208` with plot area starting at `x=68` width `708`, expected `x ≈ 197.85`; actual rendered SVG `<line x1="197.83">`. Within sub-pixel.

## Bench (headless Chromium, SHYPS r=3, 10 clicks)

| metric | before (main) | after | Δ |
|---|---:|---:|---:|
| per-click rAF latency median | 725 ms | 16 ms | **45× faster** |
| per-click rAF latency p95 | 3047 ms | 34 ms | **90× faster** |
| long-tasks (≥50 ms) | 18 | **0** | — |
| long-tasks total | 25,967 ms | 0 ms | — |

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] Playwright bench: 0 long-tasks, 16 ms median per-click
- [x] DOM check: yellow dashed `<line>` rendered inside `recharts-surface` at expected pixel x
- [ ] Manual verification by reviewer in real Chrome on the SHYPS r=3 URL

Closes #58 (replaces with this cleaner approach using public recharts APIs instead of the in-corner text label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)