### PR TITLE
docs: update changelog for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - 2026-05-08
+
+This release adds strong simulation for unitary circuits through exact computational-basis probability queries of the factored state. The new `clifft.probabilities()` API evaluates selected bitstrings without materializing the full $2^n$ statevector, so sparse output queries can scale with active rank rather than output-space size. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/guide/strong-simulation/) for examples.
+
+Clifft 0.3.0 also removes the old compile-time qubit ceiling by moving Pauli mask storage to runtime-width arenas. That fixed-width limit kept the early implementation simple and fast; the new arena path keeps the overhead localized while supporting circuits above the former inline-width bound.
+
+The release also improves performance in the playground for larger circuits. The prior playground had some pauses when unnecessarily re-rendering the current program counter line in the active dimensions timeline.
+
+### Bug Fixes
+
+- version playground wasm assets (#57) to ensure users load the latest playground code by @bachase in [#57](https://github.com/unitaryfoundation/clifft/pull/57)
+
+
+### Features
+
+- add exact full-bitstring probabilities (#60) by @bachase in [#60](https://github.com/unitaryfoundation/clifft/pull/60)
+- runtime-width SVM Pauli frame, drop kMaxInlineQubits ceiling (#53) by @bachase in [#53](https://github.com/unitaryfoundation/clifft/pull/53)
+- migrate AOT-side Pauli mask storage to runtime-width arenas (#52) by @bachase in [#52](https://github.com/unitaryfoundation/clifft/pull/52)
+- add runtime-width Pauli mask views and arena (#49) by @bachase in [#49](https://github.com/unitaryfoundation/clifft/pull/49)
+
+### Performance
+
+- decouple K-history highlight via recharts hooks (#59) by @bachase in [#59](https://github.com/unitaryfoundation/clifft/pull/59)
+- O(1) cursor highlight via reverse source maps (#56) by @bachase in [#56](https://github.com/unitaryfoundation/clifft/pull/56)
+
+### Testing
+
+- cover introspection formatters (#61) by @bachase in [#61](https://github.com/unitaryfoundation/clifft/pull/61)
+- add baseline benchmarks for runtime-qubit migration (#47) by @bachase in [#47](https://github.com/unitaryfoundation/clifft/pull/47)
+
 ## [0.2.0] - 2026-05-01
 
 Version 0.2.0 of clifft is primarily a cleanup release to coincide with the release of the clifft [preprint](https://arxiv.org/abs/2604.27058) on the arXiv. There are no major functionality changes or fixes.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -35,27 +35,40 @@ Manual dispatch always publishes to TestPyPI only — it cannot publish to PyPI.
 
 ### 2. Update the changelog
 
-Generate the changelog using [git-cliff](https://git-cliff.org/):
+Generate the new release section using [git-cliff](https://git-cliff.org/):
 
 ```bash
-git cliff --tag v0.2.0 -o CHANGELOG.md
+git cliff --unreleased --tag v0.2.0 --prepend CHANGELOG.md
 ```
 
-Review, edit if needed (fix typos, clarify entries, remove noise), then commit:
+This prepends only the unreleased changes since the previous tag and preserves
+older hand-edited release sections. Do not use `-o CHANGELOG.md` for routine
+releases unless you intentionally want to regenerate the entire changelog.
+
+Review, edit if needed (add the release summary, fix typos, clarify entries,
+remove noise), then commit:
 
 ```bash
 git add CHANGELOG.md
 git commit -m "docs: update changelog for v0.2.0"
 ```
 
-### 3. Tag and push
+### 3. Update the docs home page
+
+Update the "What's New" section in `docs/index.md` with a short,
+editorial summary of the release. Keep this section user-facing and
+curated rather than generated directly from the changelog. Link to the
+most relevant new documentation or tutorial, and include a link to the
+full changelog.
+
+### 4. Tag and push
 
 ```bash
 git tag v0.2.0
 git push origin main v0.2.0
 ```
 
-### 4. CI runs automatically
+### 5. CI runs automatically
 
 The tag push triggers the release workflow:
 
@@ -66,7 +79,7 @@ The tag push triggers the release workflow:
 
 If any step fails, subsequent steps are skipped.
 
-### 5. Verify
+### 6. Verify
 
 ```bash
 pip install clifft==0.2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,3 +83,18 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 [Install Clifft](getting-started/installation.md){ .md-button .md-button--primary }
 
 [Try the Playground](playground/){ .md-button }
+
+## What's New in 0.3.0
+
+Clifft 0.3.0 adds strong simulation for unitary circuits with
+`clifft.probabilities()`, which computes exact probabilities for selected
+full-register computational-basis bitstrings without materializing the full
+statevector.
+
+It also removes the old compile-time qubit ceiling by moving Pauli mask storage
+to runtime-width arenas, and improves playground responsiveness on larger
+circuits.
+
+[Strong Simulation Tutorial](guide/strong-simulation.md){ .md-button .md-button--primary }
+
+[Full Changelog](https://github.com/unitaryfoundation/clifft/blob/main/CHANGELOG.md){ .md-button }

--- a/justfile
+++ b/justfile
@@ -220,5 +220,5 @@ changelog-preview version:
 
 # Generate CHANGELOG.md for the next release (pass version, e.g. just changelog v0.2.0)
 changelog version:
-  git cliff --tag {{version}} -o CHANGELOG.md
+  git cliff --unreleased --tag {{version}} --prepend CHANGELOG.md
   @echo "Updated CHANGELOG.md — review, edit, then commit."


### PR DESCRIPTION
## Summary

Updates the changelog for v0.3.0 and adds an excerpt and link to the main documentation page. Also fixes the uses of `git cliff` to only prepend new changes and not regenerate the entire CHANGELOG file.

## Test plan

<!-- How was this tested? Check all that apply. -->

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
