### PR TITLE
perf: cut compile time on QEC circuits via heap-alloc fix and eager V_cum flush

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,5 +155,11 @@ else()
             ${CMAKE_CURRENT_SOURCE_DIR}/src
             ${CMAKE_CURRENT_BINARY_DIR}/generated
         )
+        add_executable(profile_compile tools/profile/profile_compile.cpp)
+        target_link_libraries(profile_compile PRIVATE clifft_core)
+        target_include_directories(profile_compile PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_BINARY_DIR}/generated
+        )
     endif()
 endif()

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -420,10 +420,13 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
     const uint32_t n = ctx.reg_manager.num_qubits();
     const uint32_t words = (n + 63) / 64;
 
-    std::vector<uint64_t> x_bits(words, 0);
-    std::vector<uint64_t> z_bits(words, 0);
-    MutableMaskView x_view{std::span<uint64_t>(x_bits)};
-    MutableMaskView z_view{std::span<uint64_t>(z_bits)};
+    // Reuse context-owned scratch so this function does not allocate per
+    // call. localize_pauli runs hundreds of times per compile on QEC
+    // circuits.
+    ctx.localize_x_bits.assign(words, 0);
+    ctx.localize_z_bits.assign(words, 0);
+    MutableMaskView x_view{std::span<uint64_t>(ctx.localize_x_bits)};
+    MutableMaskView z_view{std::span<uint64_t>(ctx.localize_z_bits)};
     for (uint32_t w = 0; w < words; ++w) {
         x_view.words[w] = pauli.xs.u64[w];
         z_view.words[w] = pauli.zs.u64[w];
@@ -452,8 +455,8 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
         // Z propagation: Z_t -> Z_c Z_t, so z_pivot ^= z_q.
         // Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1).
         // Here x_pivot=1, x_q=1, so: sign ^= z_q & z_pivot.
-        std::vector<uint64_t> to_clear_x_buf(x_bits);
-        MutableMaskView to_clear_x{std::span<uint64_t>(to_clear_x_buf)};
+        ctx.localize_to_clear.assign(ctx.localize_x_bits.begin(), ctx.localize_x_bits.end());
+        MutableMaskView to_clear_x{std::span<uint64_t>(ctx.localize_to_clear)};
         to_clear_x.bit_set(pivot, false);
         while (!to_clear_x.is_zero()) {
             uint32_t q = to_clear_x.lowest_bit();
@@ -469,8 +472,8 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
         // Z-localization: CZ(pivot, q) clears residual Z_q.
         // Sign rule: CZ(a,b) flips sign iff x_a & x_b & (z_a ^ z_b).
         // Here x_q=0 (already cleared), so sign NEVER flips.
-        std::vector<uint64_t> to_clear_z_buf(z_bits);
-        MutableMaskView to_clear_z{std::span<uint64_t>(to_clear_z_buf)};
+        ctx.localize_to_clear.assign(ctx.localize_z_bits.begin(), ctx.localize_z_bits.end());
+        MutableMaskView to_clear_z{std::span<uint64_t>(ctx.localize_to_clear)};
         to_clear_z.bit_set(pivot, false);
         while (!to_clear_z.is_zero()) {
             uint32_t q = to_clear_z.lowest_bit();
@@ -498,8 +501,8 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
         // Z-localization: CNOT(q -> pivot) folds Z_q onto pivot.
         // Sign rule: CNOT(c,t) flips sign iff x_c & z_t & (x_t ^ z_c ^ 1).
         // Here x_c=x_q=0, so sign NEVER flips.
-        std::vector<uint64_t> to_clear_z_buf(z_bits);
-        MutableMaskView to_clear_z{std::span<uint64_t>(to_clear_z_buf)};
+        ctx.localize_to_clear.assign(ctx.localize_z_bits.begin(), ctx.localize_z_bits.end());
+        MutableMaskView to_clear_z{std::span<uint64_t>(ctx.localize_to_clear)};
         to_clear_z.bit_set(pivot, false);
         while (!to_clear_z.is_zero()) {
             uint32_t q = to_clear_z.lowest_bit();

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -159,6 +159,12 @@ class VirtualFrame {
 
     [[nodiscard]] stim::PauliString<kStimWidth> map_pauli(MaskView destab_mask, MaskView stab_mask,
                                                           bool sign, uint32_t n) {
+        // Note: do not eager-flush here. map_pauli is called once per
+        // mask-carrying HIR op (T_GATE, MEASURE, etc.) and the queue
+        // between consecutive calls is short (the gates emitted by the
+        // previous localize_pauli). Replaying a short queue inline beats
+        // paying a fixed tableau-transpose-scope per op; eager flushing
+        // here regresses T-heavy circuits like QV-20 by ~40%.
         maybe_flush();
 
         stim::PauliString<kStimWidth> p(n);
@@ -189,7 +195,14 @@ class VirtualFrame {
     /// noise channels.
     void map_noise_channel(MaskView in_x, MaskView in_z, MutableMaskView out_x,
                            MutableMaskView out_z, uint32_t n) {
-        maybe_flush();
+        // Flush eagerly here. A noise op typically maps several channels
+        // back to back (e.g. DEPOLARIZE2 has 15) and the lower() loop
+        // visits thousands of noise sites on surface QEC circuits. Each
+        // channel mapping that runs against a non-empty pending queue pays
+        // O(queue_size * n_words) replay cost; flushing once amortizes
+        // that into one tableau update and lets all subsequent channel
+        // mappings see an empty queue (cheap early-out).
+        flush();
 
         out_x.zero_out();
         out_z.zero_out();

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -195,23 +195,30 @@ class VirtualFrame {
         out_z.zero_out();
         const uint32_t words = (n + 63) / 64;
 
-        auto xor_row = [&](const stim::PauliString<kStimWidth>& row) {
+        // Take the tableau row by view, not by value: materialized_.xs[q]
+        // returns a PauliStringRef (non-owning), and binding it to
+        // `const PauliString<W>&` would copy-construct a fresh PauliString
+        // per call. On QEC circuits this lambda is invoked ~10^5 times per
+        // compile, so the copies were the dominant heap allocator load.
+        auto xor_row = [&](stim::PauliStringRef<kStimWidth> row) {
             for (uint32_t w = 0; w < words && w < out_x.num_words(); ++w) {
                 out_x.words[w] ^= row.xs.u64[w];
                 out_z.words[w] ^= row.zs.u64[w];
             }
         };
 
-        // Iterate set X-bits via a local copy.
-        std::vector<uint64_t> x_scratch(in_x.words.begin(), in_x.words.end());
-        MutableMaskView x_iter{std::span<uint64_t>(x_scratch)};
+        // Iterate set X-bits via a working copy. Reuses member-owned scratch
+        // storage so QEC circuits that map thousands of noise channels per
+        // compile don't pay a heap round-trip per channel.
+        noise_x_scratch_.assign(in_x.words.begin(), in_x.words.end());
+        MutableMaskView x_iter{std::span<uint64_t>(noise_x_scratch_)};
         while (!x_iter.is_zero()) {
             uint32_t q = x_iter.lowest_bit();
             xor_row(materialized_.xs[q]);
             x_iter.clear_lowest_bit();
         }
-        std::vector<uint64_t> z_scratch(in_z.words.begin(), in_z.words.end());
-        MutableMaskView z_iter{std::span<uint64_t>(z_scratch)};
+        noise_z_scratch_.assign(in_z.words.begin(), in_z.words.end());
+        MutableMaskView z_iter{std::span<uint64_t>(noise_z_scratch_)};
         while (!z_iter.is_zero()) {
             uint32_t q = z_iter.lowest_bit();
             xor_row(materialized_.zs[q]);
@@ -297,6 +304,12 @@ class VirtualFrame {
     stim::Tableau<kStimWidth> materialized_;
     std::vector<PendingGate> pending_gates_;
     size_t flush_threshold_;
+
+    // Per-instance scratch buffers reused across calls to map_noise_channel.
+    // QEC circuits with thousands of noise channels per compile would
+    // otherwise allocate and free two std::vector<uint64_t> per call.
+    std::vector<uint64_t> noise_x_scratch_;
+    std::vector<uint64_t> noise_z_scratch_;
 };
 
 struct CompilerContext {
@@ -309,6 +322,13 @@ struct CompilerContext {
     // Playground telemetry (populated by lower(), parallel to bytecode)
     SourceMap source_map;
     std::vector<uint32_t> emit_k_history;  // per-instruction k captured at emit time
+
+    // Scratch buffers reused across calls to localize_pauli. The greedy
+    // CNOT/CZ loop walks per-bit working copies of the X and Z masks; on
+    // QEC circuits localize_pauli runs hundreds of times per compile.
+    std::vector<uint64_t> localize_x_bits;
+    std::vector<uint64_t> localize_z_bits;
+    std::vector<uint64_t> localize_to_clear;
 
     explicit CompilerContext(uint32_t num_qubits, size_t flush_threshold = 128)
         : virtual_frame(num_qubits, flush_threshold), reg_manager(num_qubits) {}

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -1,8 +1,14 @@
-# SVM Profiling Tool
+# SVM and Compile Profiling Tools
 
-A native C++ harness for profiling Clifft's Schrödinger Virtual Machine with
-`perf` (Linux) or other sampling profilers. It compiles a circuit and runs
-many shots so the hot loops accumulate enough samples for meaningful analysis.
+Two native C++ harnesses for profiling Clifft with `perf` (Linux) or other
+sampling profilers:
+
+- `profile_svm` compiles a circuit once and runs many shots, so the SVM hot
+  loops accumulate enough samples for meaningful analysis.
+- `profile_compile` loops parse → trace → lower → bytecode passes many
+  times with no shots, so a `perf record` run captures the compile path
+  rather than the sampling loop. Useful for workflows that recompile
+  often (e.g. stratified loss-topology sampling).
 
 ## Build
 
@@ -45,7 +51,30 @@ CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim CLIFFT_SHOTS=10 ./buil
 | `CLIFFT_NUM_QUBITS` | 50 | Number of qubits for random circuit |
 | `CLIFFT_CLIFFORD_DEPTH` | 5000 | Number of random Clifford gates |
 | `CLIFFT_T_GATES` | 0 | Number of T-gates to append |
-| `CLIFFT_SHOTS` | 100000 | Number of shots to sample |
+| `CLIFFT_SHOTS` | 100000 | Number of shots to sample (`profile_svm`) |
+| `CLIFFT_COMPILE_ITERATIONS` | 20 | Number of compile iterations (`profile_compile`) |
+| `CLIFFT_POSTSELECT_ALL` | *(unset)* | If set, all detectors become postselects |
+
+## Compile-only profiling
+
+`profile_compile` re-runs the full compile pipeline `CLIFFT_COMPILE_ITERATIONS`
+times on the same circuit and reports per-stage min/median/mean/p95/max plus
+implied compiles-per-second. Uses the production
+`default_hir_pass_manager()` and `default_bytecode_pass_manager()`, so
+timings match what `clifft.compile()` would actually pay.
+
+```bash
+# Per-stage timings only
+CLIFFT_COMPILE_ITERATIONS=20 \
+  CLIFFT_CIRCUIT_FILE=tests/fixtures/target_qec.stim \
+  ./build/profile_compile
+
+# perf record on the compile path
+CLIFFT_COMPILE_ITERATIONS=200 \
+  CLIFFT_CIRCUIT_FILE=tests/fixtures/target_qec.stim \
+  perf record -F 9999 -g --call-graph dwarf -o perf-compile.data \
+  ./build/profile_compile
+```
 
 ## Profiling with `perf`
 

--- a/tools/profile/profile_compile.cpp
+++ b/tools/profile/profile_compile.cpp
@@ -1,0 +1,259 @@
+// Clifft compilation profiler
+//
+// Sibling to profile_svm.cpp, but biased toward compilation rather than
+// sampling. Loops parse -> trace -> HirPassManager -> lower ->
+// BytecodePassManager many times so a `perf record` run captures the
+// compile path instead of the sample loop.
+//
+// See tools/profile/README.md for build instructions.
+
+#include "clifft/backend/backend.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/optimizer/bytecode_pass.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/svm/svm.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kDefaultIterations = 20;
+constexpr int kDefaultNumQubits = 50;
+constexpr int kDefaultCliffordDepth = 5000;
+constexpr int kDefaultTGates = 0;
+constexpr uint64_t kSeed = 42;
+
+std::string generate_circuit(int num_qubits, int clifford_depth, int t_gates, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::ostringstream ss;
+    for (int i = 0; i < clifford_depth; ++i) {
+        int gate_type = rng() % 3;
+        if (gate_type == 0) {
+            ss << "H " << (rng() % num_qubits) << "\n";
+        } else if (gate_type == 1) {
+            ss << "S " << (rng() % num_qubits) << "\n";
+        } else {
+            int q1 = rng() % num_qubits;
+            int q2 = rng() % num_qubits;
+            while (q2 == q1)
+                q2 = rng() % num_qubits;
+            ss << "CX " << q1 << " " << q2 << "\n";
+        }
+    }
+    for (int i = 0; i < t_gates; ++i) {
+        ss << "T " << (rng() % num_qubits) << "\n";
+        if (i < t_gates - 1)
+            ss << "H " << (rng() % num_qubits) << "\n";
+    }
+    ss << "M";
+    for (int i = 0; i < num_qubits; ++i)
+        ss << " " << i;
+    ss << "\n";
+    return ss.str();
+}
+
+int get_env_int(const char* name, int default_val) {
+    const char* val = std::getenv(name);
+    return val ? std::stoi(val) : default_val;
+}
+
+bool get_env_bool(const char* name) {
+    const char* val = std::getenv(name);
+    return val != nullptr && std::string(val) != "0" && std::string(val) != "";
+}
+
+std::string read_file(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        std::cerr << "Error: cannot open file: " << path << "\n";
+        std::exit(1);
+    }
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+struct StageTimings {
+    double parse_ms = 0.0;
+    double trace_ms = 0.0;  // includes HirPassManager
+    double lower_ms = 0.0;
+    double bpm_ms = 0.0;
+};
+
+double total_ms(const StageTimings& t) {
+    return t.parse_ms + t.trace_ms + t.lower_ms + t.bpm_ms;
+}
+
+void summarize(const std::string& label, std::vector<double> samples) {
+    if (samples.empty()) {
+        std::cout << "  " << label << ": (no samples)\n";
+        return;
+    }
+    std::sort(samples.begin(), samples.end());
+    double sum = 0;
+    for (double v : samples)
+        sum += v;
+    double mean = sum / samples.size();
+    double median = samples[samples.size() / 2];
+    double p95 = samples[(samples.size() * 95) / 100];
+    double min_v = samples.front();
+    double max_v = samples.back();
+    std::cout << "  " << label << ": min " << min_v << " ms, median " << median << " ms, mean "
+              << mean << " ms, p95 " << p95 << " ms, max " << max_v << " ms\n";
+}
+
+}  // namespace
+
+int main() {
+    int iterations = get_env_int("CLIFFT_COMPILE_ITERATIONS", kDefaultIterations);
+    int num_qubits = get_env_int("CLIFFT_NUM_QUBITS", kDefaultNumQubits);
+    int clifford_depth = get_env_int("CLIFFT_CLIFFORD_DEPTH", kDefaultCliffordDepth);
+    int t_gates = get_env_int("CLIFFT_T_GATES", kDefaultTGates);
+    const char* circuit_file = std::getenv("CLIFFT_CIRCUIT_FILE");
+    bool postselect_all = get_env_bool("CLIFFT_POSTSELECT_ALL");
+
+    std::cout << "Clifft Compile Profiler\n";
+    std::cout << "================\n";
+
+    // Generate or load the circuit text once; we want to time compilation,
+    // not file IO.
+    std::string circuit_text;
+    if (circuit_file) {
+        std::cout << "Circuit: " << circuit_file << "\n";
+        circuit_text = read_file(circuit_file);
+        std::cout << "Loaded:  " << circuit_text.size() << " bytes\n";
+    } else {
+        std::cout << "Circuit: " << num_qubits << " qubits, " << clifford_depth
+                  << " Clifford gates";
+        if (t_gates > 0) {
+            std::cout << ", " << t_gates << " T-gates";
+        }
+        std::cout << " (generated)\n";
+        circuit_text = generate_circuit(num_qubits, clifford_depth, t_gates, kSeed);
+    }
+    std::cout << "Iterations:     " << iterations << "\n";
+    std::cout << "Postselect all: " << (postselect_all ? "yes" : "no") << "\n";
+    std::cout << "(Set CLIFFT_COMPILE_ITERATIONS, CLIFFT_CIRCUIT_FILE, CLIFFT_NUM_QUBITS, "
+                 "CLIFFT_CLIFFORD_DEPTH, CLIFFT_T_GATES, CLIFFT_POSTSELECT_ALL)\n\n";
+
+    std::vector<StageTimings> samples;
+    samples.reserve(iterations);
+
+    size_t parsed_ops = 0;
+    size_t bytecode_size_pre = 0;
+    size_t bytecode_size_post = 0;
+    uint32_t peak_rank = 0;
+    uint32_t total_qubits = 0;
+
+    auto outer_start = std::chrono::high_resolution_clock::now();
+
+    for (int iter = 0; iter < iterations; ++iter) {
+        StageTimings t{};
+
+        // Parse
+        auto t0 = std::chrono::high_resolution_clock::now();
+        clifft::Circuit circuit = clifft::parse(circuit_text);
+        auto t1 = std::chrono::high_resolution_clock::now();
+        t.parse_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        if (iter == 0)
+            parsed_ops = circuit.nodes.size();
+
+        // Frontend (trace + default HIR passes)
+        t0 = std::chrono::high_resolution_clock::now();
+        clifft::HirModule hir = clifft::trace(circuit);
+        auto pm = clifft::default_hir_pass_manager();
+        pm.run(hir);
+        t1 = std::chrono::high_resolution_clock::now();
+        t.trace_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+
+        // Build postselection mask if requested.
+        std::vector<uint8_t> postselection_mask;
+        if (postselect_all) {
+            uint32_t num_det = 0;
+            for (const auto& op : hir.ops) {
+                if (op.op_type() == clifft::OpType::DETECTOR) {
+                    ++num_det;
+                }
+            }
+            postselection_mask.assign(num_det, 1);
+        }
+
+        // Backend lower()
+        t0 = std::chrono::high_resolution_clock::now();
+        clifft::CompiledModule program = clifft::lower(hir, postselection_mask);
+        t1 = std::chrono::high_resolution_clock::now();
+        t.lower_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        if (iter == 0) {
+            bytecode_size_pre = program.bytecode.size();
+            peak_rank = program.peak_rank;
+            total_qubits = program.num_qubits;
+        }
+
+        // Bytecode pass manager (production default set).
+        t0 = std::chrono::high_resolution_clock::now();
+        auto bpm = clifft::default_bytecode_pass_manager();
+        bpm.run(program);
+        t1 = std::chrono::high_resolution_clock::now();
+        t.bpm_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        if (iter == 0)
+            bytecode_size_post = program.bytecode.size();
+
+        samples.push_back(t);
+
+        // Drop into ostream once at the start to give a "first-run" baseline; the
+        // rest of the iterations are the perf-record budget.
+        if (iter == 0) {
+            std::cout << "First-iteration timings (warmup):\n";
+            std::cout << "  parse:  " << t.parse_ms << " ms\n";
+            std::cout << "  trace:  " << t.trace_ms << " ms\n";
+            std::cout << "  lower:  " << t.lower_ms << " ms\n";
+            std::cout << "  bpm:    " << t.bpm_ms << " ms\n";
+            std::cout << "  total:  " << total_ms(t) << " ms\n";
+            std::cout << "Module: " << total_qubits << " qubits, peak_rank " << peak_rank << ", "
+                      << parsed_ops << " parsed ops, " << bytecode_size_pre << " -> "
+                      << bytecode_size_post << " bytecode instructions\n\n";
+        }
+    }
+
+    auto outer_end = std::chrono::high_resolution_clock::now();
+    double outer_ms = std::chrono::duration<double, std::milli>(outer_end - outer_start).count();
+
+    std::vector<double> parse_v, trace_v, lower_v, bpm_v, total_v;
+    for (const auto& s : samples) {
+        parse_v.push_back(s.parse_ms);
+        trace_v.push_back(s.trace_ms);
+        lower_v.push_back(s.lower_ms);
+        bpm_v.push_back(s.bpm_ms);
+        total_v.push_back(total_ms(s));
+    }
+
+    std::cout << "Per-stage distribution across " << iterations << " iterations:\n";
+    summarize("parse  ", parse_v);
+    summarize("trace  ", trace_v);
+    summarize("lower  ", lower_v);
+    summarize("bpm    ", bpm_v);
+    summarize("total  ", total_v);
+
+    double mean_total = 0;
+    for (double v : total_v)
+        mean_total += v;
+    mean_total /= iterations;
+    double compiles_per_sec = mean_total > 0 ? 1000.0 / mean_total : 0.0;
+
+    std::cout << "\nThroughput:\n";
+    std::cout << "  Wall-clock for all " << iterations << " compiles: " << outer_ms << " ms\n";
+    std::cout << "  Compiles/sec (mean total):                " << compiles_per_sec << "\n";
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add `profile_compile`, a sibling to `profile_svm` that loops the full compile pipeline so `perf record` runs capture the compile path. Uses production `default_hir_pass_manager()` / `default_bytecode_pass_manager()`, so timings match what `clifft.compile()` actually pays.
- Eliminate the largest heap-allocator hot spot in `lower()`: `VirtualFrame::map_noise_channel`'s `xor_row` lambda took its argument as `const PauliString<W>&`, but the call site passed a `PauliStringRef<W>`. That triggered a full aligned-heap PauliString copy per inner-loop iteration (~10⁵ per compile on surface_d7_r7). Switching the lambda to take the row by view fixes it. Also hoist `std::vector<uint64_t>` scratch buffers in `map_noise_channel` and `localize_pauli` onto VirtualFrame / CompilerContext members so they don't allocate per call.
- Eager-flush V_cum at the start of `map_noise_channel`. Each noise op typically maps multiple channels back to back; without flushing, every channel mapping replays the entire pending-gate queue (up to `flush_threshold=128` gates). After flushing once at the start of a noise burst, subsequent channel mappings see an empty queue and short-circuit. Tried the same in `map_pauli` and reverted — `map_pauli` is followed by queue writes via `localize_pauli`, so eager flush there regresses T-heavy QV-20 by ~40%.

The two backend fixes were each guided by perf data captured via `profile_compile`. Together they cut compile time on the LOSS-relevant QEC circuits roughly in half.

## Measured (median, 20 iterations on RelWithDebInfo)

| Circuit | n | k_max | gates | total before | total after | speedup | compiles/sec |
|---|---|---|---|---|---|---|---|
| `surface_d7_r7` | 118 | 0 | 5053 | 14.3 ms | **6.4 ms** | 2.2× | 70 → **147** |
| `cultivation_d5` | 42 | 10 | 4582 | 12.5 ms | **3.7 ms** | 3.4× | 80 → **263** |
| `cultivation_d3` | 15 | 4 | 737 | 2.85 ms | **0.61 ms** | 4.7× | 351 → **1623** |
| `qv20_seed42` | 20 | 20 | 2220 | 14.0 ms | 13.9 ms | (unchanged) | 71 → 62 |

QV-20 has no noise channels in the circuit, so neither fix engages. `lower()` itself dropped 70–87% on the QEC and cultivation circuits.

For loss workflows that compile many topologies per shot batch (Discussion #62's stratified topology sampling), this is the win that lets compile cost hide inside Pauli-shot variance.

## Test plan

- [x] `cmake --build build-debug -j` (Debug)
- [x] `ctest --test-dir build-debug --output-on-failure -E Bench` — all 712 tests pass
- [x] `cmake --build build-profile -j` (RelWithDebInfo, profiler enabled)
- [x] `profile_compile` sweep against four representative circuits (surface_d7_r7, cultivation_d5/d3, qv20)
- [x] perf record + report on surface_d7_r7 confirms `apply_gate_to_pauli` (38.5% in baseline, 46% after #1) is no longer in the top of the flat profile after #2
- [x] `uv tool run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)