### PR TITLE
ci: make MSVC debug builds ccache-friendly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,10 @@ jobs:
       - name: Build C++
         run: cmake --build build --config ${{ env.CMAKE_BUILD_TYPE }} --parallel
 
+      - name: Show ccache verbose stats
+        if: runner.os == 'Windows'
+        run: ccache -sv
+
       - name: Run C++ tests (skip benchmarks on cross-platform)
         run: |
           ctest --test-dir build \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
+
+# Make MSVC Debug builds compatible with ccache. The default ProgramDatabase
+# format uses /Zi, which ccache treats as uncacheable; Embedded uses /Z7.
+if(POLICY CMP0141)
+    cmake_policy(SET CMP0141 NEW)
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+endif()
+
 project(clifft LANGUAGES CXX)
 
 # Version: derived from git tags (or VERSION file in sdists)


### PR DESCRIPTION
## Summary
- set CMake CMP0141 before project() and select embedded MSVC debug info for Debug/RelWithDebInfo
- this should switch Windows Debug builds from /Zi to /Z7 so ccache can cache MSVC object files
- add a Windows-only verbose ccache stats step after the C++ build to verify cacheability on the next main push

## Testing
- uv run pre-commit run --all-files
- cmake -S . -B /private/tmp/clifft-ccache-smoke -G Ninja -DCMAKE_BUILD_TYPE=Debug
- cmake --build /private/tmp/clifft-ccache-smoke --target clifft_core --parallel

Note: cross-platform Windows CI only runs on pushes to main, so the ccache effectiveness check will happen after merge.