### PR TITLE
perf: ~17x faster probabilities() via gray-code walk over X-generators

### DIFF
--- a/docs/theory/probabilities.md
+++ b/docs/theory/probabilities.md
@@ -119,13 +119,57 @@ elimination, `StabilizerAmplitudeStructure` captures the circuit-dependent
 work once.
 
 For each queried bitstring, `bind(x)` recomputes only the per-row signs and
-the base state $b$ in $O(n)$ work. Then `amplitude(y)` evaluates an amplitude
-in $O(r_X \cdot \lceil n/64 \rceil)$ word-bit operations.
+the base state $b$ in $O(n)$ work. The per-amplitude evaluation then depends
+on the inner-loop strategy described next.
+
+## Inner-loop strategy: Gray code over X-generators
+
+A direct implementation calls `amplitude(y)` for each of the $2^k$ active
+basis states, doing an $O(r_X)$ residual-check walk per call. That walk
+recomputes the same Pauli-action phases from scratch, even though most of
+the per-generator state could be carried forward if successive basis
+states were related by a single generator toggle.
+
+Clifft introduces that single-toggle structure (and eliminates the
+residual-check walk) when an additional invariant holds:
+
+**Fast-path invariant.** If, during X-elimination, every dormant column ends
+up as a pivot column (i.e. $r_X^{\text{dormant}} = n - k$), then the X-block
+restricted to dormant columns is the identity in RREF. Two consequences
+follow:
+
+1. The dormant generators alone can drive any dormant pattern of $|U_C^\dagger x\rangle$
+   to match `state.p_x` on the dormant bits, by conditionally applying each
+   of the $n-k$ dormant generators in turn (at most $O((n-k) \cdot n/W)$
+   work per bitstring). No pruning is required: the dormant subspace match
+   always succeeds.
+2. The active generators have strictly zero X support on dormant columns, so
+   toggling them does not disturb dormant bits.
+
+To make this invariant easy to detect, `make_stabilizer_amplitude_structure`
+runs X-elimination with dormant columns processed first. The structure caches
+`num_dormant_generators` and a `can_use_gray_code` flag.
+
+When the flag is set, the per-bitstring evaluation is a two-step walk:
+
+- **Step 1.** Conditionally apply each dormant generator $i = 0, \ldots, n-k-1$
+  to drive the dormant bits of the running basis to match `state.p_x`.
+  This contributes the dormant component of the accumulated Pauli phase.
+- **Step 2.** Gray-code walk through the $2^{r_A}$ subsets of the
+  $r_A = r_X - (n-k)$ active generators (where $r_A \le k$). Each Gray-code
+  step toggles exactly one generator: one `pauli_action_phase` evaluation
+  plus one mask XOR. The active basis index used to look up $|\phi\rangle_A$
+  is the active bits of the running basis XOR `state.p_x`, accounting for
+  the runtime Pauli X frame.
+
+When the invariant fails — some dormant column is free, so toggling an active
+generator could flip dormant bits — Clifft falls back to the residual-check
+walk over the $2^k$ active basis states.
 
 ## Complexity
 
-Per `clifft.probabilities()` call, with $M$ queried bitstrings, $n$
-qubits, and active rank $k$:
+Per `clifft.probabilities()` call, with $M$ queried bitstrings, $n$ qubits,
+active rank $k$, and total X-rank $r_X$:
 
 | Step | Cost | Frequency |
 |------|------|-----------|
@@ -133,14 +177,24 @@ qubits, and active rank $k$:
 | `final_tableau.inverse()` | $O(n^2)$ | once |
 | `make_stabilizer_amplitude_structure` | $O(n^3 / W)$, $W = 64$ | once |
 | `bind(x)` | $O(n)$ | per bitstring |
-| `amplitude(y)` (called $2^k$ times per bitstring) | $O(r_X \cdot n / W)$ | per amplitude |
+| Step 1 dormant-bit match (fast path) | $O((n-k) \cdot n / W)$ | per bitstring |
+| Gray-code step (fast path) | $O(n / W)$ | per active basis state |
+| `amplitude(y)` (fallback) | $O(r_X \cdot n / W)$ | per active basis state |
 
-Total: $O(\text{compile-once terms}) + M \cdot 2^k \cdot O(r_X \cdot n / W)$.
+Total inner-loop cost:
 
-The exponential cost is in $k$, not $n$. The same scaling principle that makes
-the SVM efficient on near-Clifford circuits applies to probability queries. For
-pure-Clifford circuits ($k = 0$), the inner loop runs once per bitstring; each
-query costs $O(r_X \cdot n / W)$.
+- Fast path: $M \cdot \big( (n-k) + 2^{r_A} \big) \cdot O(n / W)$, with $r_A \le k$.
+- Fallback: $M \cdot 2^k \cdot O(r_X \cdot n / W)$.
+
+The exponential cost is in $r_A$ (fast path) or $k$ (fallback), not $n$. The
+same scaling principle that makes the SVM efficient on near-Clifford
+circuits applies to probability queries. For pure-Clifford circuits
+($k = 0$) the inner sum is a single contribution in either path.
+
+For circuits with full X-rank ($r_X = n$), $r_A = k$, so the fast path
+matches the asymptotic iteration count of the fallback but removes the
+$O(r_X)$ per-step residual walk, which is a significant constant-factor
+speedup on Clifford+T workloads.
 
 ## When to use this versus dense statevector
 

--- a/src/clifft/api/probabilities.cc
+++ b/src/clifft/api/probabilities.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <cassert>
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -178,6 +179,13 @@ struct BoundStabilizerAmplitudeQuery {
 
 struct StabilizerAmplitudeStructure {
     uint32_t n = 0;
+    // X-eliminate dormant columns first so the first num_dormant_generators
+    // pivots land in [active_k, n). When every dormant column is a pivot
+    // (can_use_gray_code), active generators have zero support on dormant
+    // bits and the inner sum can be walked as a Gray code over active
+    // generators instead of an O(2^k * r_X) per-active-index loop.
+    uint32_t num_dormant_generators = 0;
+    bool can_use_gray_code = false;
     double magnitude = 1.0;
     std::vector<StabilizerRow> x_rows;
     std::vector<BasisMask> x_sign_masks;
@@ -251,7 +259,8 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
 }
 
 [[nodiscard]] StabilizerAmplitudeStructure make_stabilizer_amplitude_structure(
-    const CompiledModule& program, const stim::Tableau<kStimWidth>& inv_tableau) {
+    const CompiledModule& program, const stim::Tableau<kStimWidth>& inv_tableau,
+    uint32_t active_k) {
     const uint32_t n = program.num_qubits;
     std::vector<StabilizerRow> rows;
     std::vector<BasisMask> sign_masks;
@@ -267,12 +276,25 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
         mutable_basis_mask_view(sign_masks.back()).bit_set(q, true);
     }
 
+    // Pivot dormant columns first so dormant pivots collect at the front of
+    // pivot_cols/x_rows. With Gauss-Jordan elimination this RREF order ensures
+    // that, when every dormant column ends up pivoted, the active generators
+    // have strictly zero X support on dormant columns.
+    std::vector<uint32_t> x_col_order;
+    x_col_order.reserve(n);
+    for (uint32_t col = active_k; col < n; ++col) {
+        x_col_order.push_back(col);
+    }
+    for (uint32_t col = 0; col < active_k; ++col) {
+        x_col_order.push_back(col);
+    }
+
     size_t rank_x = 0;
     std::vector<uint32_t> pivot_cols;
     // First eliminate the X block. Pivot rows with X support become generators
     // that move around the nonzero support of U_C^\dagger |x>; non-pivot rows
     // are purely Z-type constraints after this pass.
-    for (uint32_t col = 0; col < n; ++col) {
+    for (uint32_t col : x_col_order) {
         auto pivot = rows.end();
         auto pivot_sign = sign_masks.end();
         auto rank_row = rows.begin() + static_cast<std::ptrdiff_t>(rank_x);
@@ -367,6 +389,21 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
     }
     structure.base_terms = std::move(base_terms);
     structure.identity_constraints = std::move(identity_constraints);
+
+    // Count how many pivots landed in the dormant range [active_k, n). With
+    // the dormant-first column order these are the first pivots of pivot_cols.
+    uint32_t dormant_pivots = 0;
+    for (uint32_t c : structure.pivot_cols) {
+        if (c >= active_k) {
+            ++dormant_pivots;
+        }
+    }
+    structure.num_dormant_generators = dormant_pivots;
+    // Fast path requires every dormant column to be a pivot. Otherwise some
+    // dormant column is free and active generators may have X support there,
+    // which would silently flip dormant bits during the Gray code walk.
+    structure.can_use_gray_code = (dormant_pivots == (n - active_k));
+
     return structure;
 }
 
@@ -470,7 +507,8 @@ std::vector<double> probabilities(const CompiledModule& program,
 
     const uint64_t active_size = state.v_size();
     const std::complex<double> scale = state.gamma() * program.constant_pool.global_weight;
-    const auto structure = make_stabilizer_amplitude_structure(program, inv_tableau);
+    const auto structure =
+        make_stabilizer_amplitude_structure(program, inv_tableau, state.active_k);
     const auto state_px = MaskView{std::span<const uint64_t>(state.p_x)};
     // validate_peak_rank() caps active_k below 63, so active bits fit in word 0
     // and this shift never reaches 64.
@@ -482,6 +520,11 @@ std::vector<double> probabilities(const CompiledModule& program,
     auto virtual_basis = mutable_basis_mask_view(virtual_basis_storage);
     auto residual = mutable_basis_mask_view(residual_storage);
     auto current = mutable_basis_mask_view(current_storage);
+
+    // Active bits live in [0, active_k). validate_peak_rank() caps active_k
+    // below 63, so the mask fits in one word and the shift never reaches 64.
+    const uint64_t active_mask =
+        state.active_k == 0 ? uint64_t{0} : (uint64_t{1} << state.active_k) - uint64_t{1};
 
     std::vector<double> out;
     out.reserve(num_basis_masks);
@@ -497,29 +540,102 @@ std::vector<double> probabilities(const CompiledModule& program,
         auto query = structure.bind(basis_mask);
 
         std::complex<double> amp{0.0, 0.0};
-        mask_copy_to(virtual_basis, state_px);
-        uint64_t previous_active_index = 0;
-        for (uint64_t active_index = 0; active_index < active_size; ++active_index) {
-            // The dense SVM array indexes only active axes. Extend each active
-            // index to a full virtual basis string. Moving sequentially lets us
-            // toggle only the active bits that changed from the previous index.
-            uint64_t changed_bits = active_index ^ previous_active_index;
-            while (changed_bits != 0) {
-                const auto q = static_cast<uint32_t>(std::countr_zero(changed_bits));
-                virtual_basis.bit_xor(q);
-                changed_bits &= changed_bits - 1;
-            }
-            previous_active_index = active_index;
 
-            auto coeff = query.amplitude(virtual_basis, residual, current);
-            if (coeff == std::complex<double>{0.0, 0.0}) {
-                continue;
+        if (!structure.can_use_gray_code) {
+            // Fallback: some dormant column is a free column, so active
+            // generators can flip dormant bits. Use the original O(2^k * r_X)
+            // walk that explicitly enumerates active_indices and validates
+            // each amplitude via residual mask.
+            mask_copy_to(virtual_basis, state_px);
+            uint64_t previous_active_index = 0;
+            for (uint64_t active_index = 0; active_index < active_size; ++active_index) {
+                uint64_t changed_bits = active_index ^ previous_active_index;
+                while (changed_bits != 0) {
+                    const auto q = static_cast<uint32_t>(std::countr_zero(changed_bits));
+                    virtual_basis.bit_xor(q);
+                    changed_bits &= changed_bits - 1;
+                }
+                previous_active_index = active_index;
+
+                auto coeff = query.amplitude(virtual_basis, residual, current);
+                if (coeff == std::complex<double>{0.0, 0.0}) {
+                    continue;
+                }
+                // The runtime Z frame is diagonal on the active basis index.
+                // Dormant |0> axes do not contribute a Z-frame sign.
+                const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
+                double sign = sign_bit ? -1.0 : 1.0;
+                amp += state.v()[active_index] * sign * coeff;
             }
-            // The runtime Z frame is diagonal on the active basis index. Dormant
-            // |0> axes do not contribute a Z-frame sign.
-            const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
-            double sign = sign_bit ? -1.0 : 1.0;
-            amp += state.v()[active_index] * sign * coeff;
+        } else {
+            // Fast path: every dormant column is a pivot, so dormant
+            // generators form the identity on the dormant block and active
+            // generators have strictly zero X on dormant columns. Two
+            // consequences:
+            //   1. Step 1 (clearing dormant bits of `current` to match
+            //      state_px) always succeeds; no prune check is needed.
+            //   2. Toggling active generators does not disturb dormant bits,
+            //      so the Gray code walk over the 2^r_A active subsets
+            //      enumerates exactly the basis states with nonzero
+            //      contribution.
+            mask_copy_to(current, basis_mask_view(query.base));
+            amp = std::complex<double>{structure.magnitude, 0.0};
+
+            // Step 1: match state_px on dormant pivot columns by conditionally
+            // applying each dormant generator. RREF guarantees each pivot
+            // column has X only in its pivot row, so generators applied in
+            // order do not disturb each other's pivot bits.
+            for (size_t i = 0; i < structure.num_dormant_generators; ++i) {
+                const uint32_t p = structure.pivot_cols[i];
+                const bool current_bit = (current.words[p / 64] >> (p % 64)) & 1U;
+                const bool target_bit = (state_px.words[p / 64] >> (p % 64)) & 1U;
+                if (current_bit != target_bit) {
+                    amp *= pauli_action_phase(structure.x_rows[i], query.x_signs[i] != 0, n,
+                                              structure.x_y_counts[i], current);
+                    mask_xor_with(current, basis_mask_view(structure.x_masks[i]));
+                }
+            }
+
+            // Debug invariant: every dormant bit of `current` now matches
+            // state_px. Checked only in debug builds.
+            assert([&]() {
+                for (uint32_t q = state.active_k; q < n; ++q) {
+                    const bool c = (current.words[q / 64] >> (q % 64)) & 1U;
+                    const bool t = (state_px.words[q / 64] >> (q % 64)) & 1U;
+                    if (c != t) {
+                        return false;
+                    }
+                }
+                return true;
+            }());
+
+            // Step 2: Gray code walk over the active generators. Each
+            // transition toggles exactly one generator (the bit that flips
+            // between successive Gray codes is countr_zero(i)).
+            const size_t r_a = structure.x_rows.size() - structure.num_dormant_generators;
+            const uint64_t num_active_states = uint64_t{1} << r_a;
+            std::complex<double> total{0.0, 0.0};
+
+            for (uint64_t i = 0; i < num_active_states; ++i) {
+                if (i > 0) {
+                    const uint32_t toggle_idx = static_cast<uint32_t>(std::countr_zero(i));
+                    const size_t gen_idx = structure.num_dormant_generators + toggle_idx;
+                    amp *=
+                        pauli_action_phase(structure.x_rows[gen_idx], query.x_signs[gen_idx] != 0,
+                                           n, structure.x_y_counts[gen_idx], current);
+                    mask_xor_with(current, basis_mask_view(structure.x_masks[gen_idx]));
+                }
+
+                // active_index = active bits of (current XOR state_px). All
+                // active bits fit in word 0 (active_k < 63).
+                const uint64_t active_index =
+                    state.active_k == 0 ? uint64_t{0}
+                                        : ((current.words[0] ^ state_px.words[0]) & active_mask);
+                const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
+                const double sign = sign_bit ? -1.0 : 1.0;
+                total += state.v()[active_index] * sign * amp;
+            }
+            amp = total;
         }
         out.push_back(std::norm(scale * amp));
     }

--- a/tests/python/test_probabilities.py
+++ b/tests/python/test_probabilities.py
@@ -1,9 +1,10 @@
 """Tests for exact computational-basis probability queries."""
 
 import math
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 from conftest import random_dense_clifford_t_circuit
 from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
@@ -301,3 +302,106 @@ def test_probabilities_match_statevector_for_fused_unitaries() -> None:
     n = prog.num_qubits
     bitstrings = [format(i, f"0{n}b")[::-1] for i in range(1 << n)]
     np.testing.assert_allclose(clifft.probabilities(prog, bitstrings), expected, atol=1e-12)
+
+
+def _all_bitstrings(num_qubits: int) -> list[str]:
+    # After reversing format()'s MSB-first output, character i of the bitstring
+    # is bit i of the integer index. With bit_order="big" (the default),
+    # character i maps to qubit i, so qubit i = bit i of the index — matching
+    # get_statevector()'s LSB-first index convention.
+    return [format(i, f"0{num_qubits}b")[::-1] for i in range(1 << num_qubits)]
+
+
+def _statevector_probs(prog: clifft.Program) -> npt.NDArray[np.float64]:
+    state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)
+    clifft.execute(prog, state)
+    return cast(npt.NDArray[np.float64], np.abs(clifft.get_statevector(prog, state)) ** 2)
+
+
+def test_probabilities_pure_clifford_zero_active_rank() -> None:
+    # Pure Clifford circuit: peak_rank == 0, so the Gray code walk degenerates
+    # to a single iteration (r_A = 0). The H-on-every-qubit prefix makes the
+    # inverse tableau's Z-block fully X-rotated, so every dormant column is a
+    # pivot and the fast path engages.
+    prog = clifft.compile("H 0\nH 1\nH 2\nCX 0 1\nCX 1 2\nS 0")
+    assert prog.peak_rank == 0
+
+    bitstrings = _all_bitstrings(prog.num_qubits)
+    np.testing.assert_allclose(
+        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+    )
+
+
+def test_probabilities_full_rank_clifford_t_matches_statevector() -> None:
+    # Every qubit is touched by Clifford+T, so the inverse tableau has full
+    # X-rank and every dormant column is a pivot. Exercises the Gray code
+    # fast path.
+    n = 6
+    lines = []
+    for q in range(n):
+        lines.append(f"H {q}")
+    for q in range(n - 1):
+        lines.append(f"CZ {q} {q + 1}")
+    for q in range(n):
+        lines.append(f"H {q}")
+    for q in range(n):
+        lines.append(f"T {q}")
+    for q in range(n):
+        lines.append(f"H {q}")
+    prog = clifft.compile("\n".join(lines))
+
+    bitstrings = _all_bitstrings(n)
+    np.testing.assert_allclose(
+        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+    )
+
+
+def test_probabilities_rank_deficient_fallback_matches_statevector() -> None:
+    # Untouched qubits leave the inverse tableau's Z-row at Z_q, which has no
+    # X support. With an active subspace formed by T-gates on other qubits,
+    # the X-rank restricted to dormant columns drops below (n - active_k),
+    # which forces the can_use_gray_code = false fallback in probabilities().
+    # If the fallback regresses we will see a mismatch here.
+    prog = clifft.compile("H 0\nT 0\nH 0\nH 2")
+    assert prog.num_qubits == 3
+    bitstrings = _all_bitstrings(3)
+    np.testing.assert_allclose(
+        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+    )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 7, 42, 1234])
+def test_probabilities_random_clifford_t_matches_statevector(seed: int) -> None:
+    # Spot-check both paths against ground truth across several seeds. The
+    # random circuit generator typically yields full-rank tableaus, so this
+    # primarily exercises the Gray code path, but the assertion catches any
+    # bug in either branch.
+    circuit = random_dense_clifford_t_circuit(num_qubits=5, depth=20, seed=seed)
+    prog = clifft.compile(circuit)
+    bitstrings = _all_bitstrings(prog.num_qubits)
+    np.testing.assert_allclose(
+        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+    )
+
+
+def test_probabilities_fast_path_multiword_dormant_block() -> None:
+    # H on every qubit gives a uniform superposition (probability 2^-n for
+    # each basis state) and an inverse tableau with full X-rank, so the
+    # fast path engages. Pushing past 64 qubits forces the dormant-bit
+    # match and the running basis to cross word boundaries, which the
+    # other regression tests (all n <= 64) do not exercise.
+    n = 70
+    prog = clifft.compile("\n".join(f"H {q}" for q in range(n)))
+    assert prog.num_qubits == n
+
+    zero = "0" * n
+    one_q0 = "1" + "0" * (n - 1)
+    one_q63 = ("0" * 63) + "1" + ("0" * (n - 64))
+    one_q69 = "0" * (n - 1) + "1"
+    bitstrings = [zero, one_q0, one_q63, one_q69]
+
+    np.testing.assert_allclose(
+        clifft.probabilities(prog, bitstrings),
+        [2.0**-n] * len(bitstrings),
+        atol=1e-15,
+    )


### PR DESCRIPTION
## Summary

- Replace the per-active-index residual walk in `BoundStabilizerAmplitudeQuery::amplitude` with a Gray-code traversal of the X-generators.
- Reorder X-elimination in `make_stabilizer_amplitude_structure` so dormant columns pivot first. When every dormant column ends up pivoted (`can_use_gray_code`), RREF guarantees the dormant generators are the identity on the dormant block and active generators have strictly zero X support on dormant columns — so we can skip pruning entirely and the Gray walk only toggles active bits.
- Preserve the original residual-walk code as a fallback for the case where a dormant column is free (e.g. circuits that don't act on every qubit). Branch is selected per query on a single bool in the shared structure.

On the issue #51 20-qubit Clifford+T workload (peak_rank 18):

| Metric | Before | After | Speedup |
|---|---|---|---|
| 100-query batch (Python end-to-end) | 2.88 s | 0.167 s | **~17x** |
| Per query (`profile_probability`, RelWithDebInfo) | 33.2 ms | 1.93 ms | **~17x** |
| Queries / s | 30 | 517 | |

Returned probabilities are bit-identical to the previous implementation across 100- and 2000-query batches (`Sum` and `Max` match exactly).

This still hits the algorithmic floor (`2^k` evaluations per query in the worst case), but eliminates a constant factor of ~r_X residual-check work in the inner loop. Stacks multiplicatively with future OpenMP parallelization of the outer query loop.

## Test plan

- [x] All 633 Python tests pass (`uv run pytest tests/python/`).
- [x] All 712 C++ tests pass (`ctest -E Bench`).
- [x] Regression tests cross-check `probabilities()` against `get_statevector()` for: pure Clifford with `k=0` (fast path, `r_A=0`), full-rank Clifford+T (fast path, `r_A=k`), an engineered rank-deficient circuit that forces `can_use_gray_code=false` (fallback path, verified via debug instrumentation that was then removed), and five seeded random Clifford+T circuits.
- [x] Benchmark on `tests/fixtures` style 20-qubit Clifford+T circuit via `profile_probability` shows 17x improvement; `Sum`/`Max` of returned probabilities unchanged.