### PR TITLE
feat: add forced-execution state fields to SchrodingerState

### DIFF
--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -266,6 +266,20 @@ class SchrodingerState {
   public:
     // Expectation value record: one double per EXP_VAL probe per shot.
     std::vector<double> exp_vals;
+
+    // --- Forced-execution state ---
+    //
+    // Dormant in sampling mode. Set per record by the forced-execution
+    // path, where each measurement kernel reads its outcome from
+    // forced_record[classical_idx] instead of sampling, and accumulates
+    // log(prob_b / total) into forced_log_probability. A forced outcome
+    // with exact-zero branch probability sets forced_reachable=false
+    // and short-circuits the rest of the bytecode.
+    //
+    // reset() clears all three to their dormant defaults.
+    std::span<const uint8_t> forced_record;
+    double forced_log_probability = 0.0;
+    bool forced_reachable = true;
 };
 
 // =============================================================================

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -155,13 +155,19 @@ SchrodingerState::SchrodingerState(SchrodingerState&& other) noexcept
       peak_rank_(other.peak_rank_),
       v_is_mmap_(other.v_is_mmap_),
       rng_(std::move(other.rng_)),
-      exp_vals(std::move(other.exp_vals)) {
+      exp_vals(std::move(other.exp_vals)),
+      forced_record(other.forced_record),
+      forced_log_probability(other.forced_log_probability),
+      forced_reachable(other.forced_reachable) {
     other.v_ = nullptr;
     other.array_size_ = 0;
     other.v_alloc_bytes_ = 0;
     other.v_is_mmap_ = false;
     other.active_k = 0;
     other.peak_rank_ = 0;
+    other.forced_record = {};
+    other.forced_log_probability = 0.0;
+    other.forced_reachable = true;
 }
 
 SchrodingerState& SchrodingerState::operator=(SchrodingerState&& other) noexcept {
@@ -195,12 +201,18 @@ SchrodingerState& SchrodingerState::operator=(SchrodingerState&& other) noexcept
         det_record = std::move(other.det_record);
         obs_record = std::move(other.obs_record);
         exp_vals = std::move(other.exp_vals);
+        forced_record = other.forced_record;
+        forced_log_probability = other.forced_log_probability;
+        forced_reachable = other.forced_reachable;
         other.v_ = nullptr;
         other.array_size_ = 0;
         other.v_alloc_bytes_ = 0;
         other.v_is_mmap_ = false;
         other.active_k = 0;
         other.peak_rank_ = 0;
+        other.forced_record = {};
+        other.forced_log_probability = 0.0;
+        other.forced_reachable = true;
     }
     return *this;
 }
@@ -243,6 +255,13 @@ void SchrodingerState::reset() {
     // Reset forced-fault cursors (vectors are refilled per shot externally).
     forced_faults.noise_pos = 0;
     forced_faults.readout_pos = 0;
+
+    // Forced-execution state: span cleared, accumulator zeroed, reachable
+    // back to true. Dormant in sampling mode; the forced path sets these
+    // per record before calling execute().
+    forced_record = {};
+    forced_log_probability = 0.0;
+    forced_reachable = true;
 
     // PRNG is NOT reseeded -- it streams forward naturally across shots.
 }

--- a/tests/test_state_reset.cc
+++ b/tests/test_state_reset.cc
@@ -17,6 +17,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <complex>
+#include <cstdint>
+#include <span>
 #include <vector>
 
 using namespace clifft;
@@ -208,4 +210,93 @@ TEST_CASE("reset() preserves p_x / p_z buffer sizing") {
     REQUIRE(state.p_z.size() == pz_size);
     REQUIRE(state.p_x[0] == 0);
     REQUIRE(state.p_z[1] == 0);
+}
+
+// =============================================================================
+// Forced-mode field tests
+// =============================================================================
+//
+// SchrodingerState carries three fields used by the forced-execution path:
+//   - forced_record: span of outcome bytes the forced kernels read.
+//   - forced_log_probability: running sum of log(prob_b / total).
+//   - forced_reachable: false once a forced outcome hits exact-zero
+//     probability, short-circuiting the rest of the bytecode.
+// These fields are dormant in sampling mode (empty span / 0.0 / true).
+// reset() must clear them so reuse across records is safe.
+
+TEST_CASE("forced-mode fields default to empty / 0.0 / true on a fresh state") {
+    SchrodingerState state(/*peak_rank=*/2, /*num_measurements=*/0);
+    REQUIRE(state.forced_record.empty());
+    REQUIRE(state.forced_log_probability == 0.0);
+    REQUIRE(state.forced_reachable == true);
+}
+
+TEST_CASE("reset() clears the forced-mode fields") {
+    SchrodingerState state(/*peak_rank=*/2, /*num_measurements=*/2);
+    std::vector<uint8_t> record{1, 0};
+    state.forced_record = std::span<const uint8_t>{record};
+    state.forced_log_probability = -1.234;
+    state.forced_reachable = false;
+
+    state.reset();
+
+    REQUIRE(state.forced_record.empty());
+    REQUIRE(state.forced_log_probability == 0.0);
+    REQUIRE(state.forced_reachable == true);
+}
+
+TEST_CASE("move construction and move assignment transfer the forced-mode fields") {
+    // SchrodingerState's move operators are hand-written and list every
+    // field by name. When a new field is added (as the forced-mode trio
+    // was), it's easy to forget to update both operators. This test
+    // catches that regression class for the three forced-mode fields.
+    StateConfig cfg{.peak_rank = 2, .num_measurements = 1, .num_qubits = 2, .seed = 0};
+
+    std::vector<uint8_t> record{1};
+
+    SchrodingerState src(cfg);
+    src.forced_record = std::span<const uint8_t>{record};
+    src.forced_log_probability = -2.5;
+    src.forced_reachable = false;
+
+    SchrodingerState moved(std::move(src));
+    REQUIRE(moved.forced_record.data() == record.data());
+    REQUIRE(moved.forced_record.size() == record.size());
+    REQUIRE(moved.forced_log_probability == -2.5);
+    REQUIRE(moved.forced_reachable == false);
+
+    SchrodingerState src2(cfg);
+    src2.forced_record = std::span<const uint8_t>{record};
+    src2.forced_log_probability = -7.0;
+    src2.forced_reachable = false;
+
+    SchrodingerState dst(cfg);
+    dst = std::move(src2);
+    REQUIRE(dst.forced_record.data() == record.data());
+    REQUIRE(dst.forced_log_probability == -7.0);
+    REQUIRE(dst.forced_reachable == false);
+}
+
+TEST_CASE("setting forced-mode fields does not disturb the active state") {
+    // The forced fields are independent state. Mutating them must not
+    // touch v_, the Pauli frame, gamma, or active_k.
+    SchrodingerState state(/*peak_rank=*/2, /*num_measurements=*/1);
+    state.active_k = 1;
+    state.v()[0] = {0.5, 0.0};
+    state.v()[1] = {0.5, 0.0};
+    state.p_x[0] = 0b10;
+    state.p_z[0] = 0b01;
+    state.set_gamma({0.7071067811865476, 0.0});
+
+    std::vector<uint8_t> record{1};
+    state.forced_record = std::span<const uint8_t>{record};
+    state.forced_log_probability = -0.5;
+    state.forced_reachable = false;
+
+    REQUIRE(state.active_k == 1);
+    REQUIRE(state.v()[0] == std::complex<double>{0.5, 0.0});
+    REQUIRE(state.v()[1] == std::complex<double>{0.5, 0.0});
+    REQUIRE(state.p_x[0] == 0b10);
+    REQUIRE(state.p_z[0] == 0b01);
+    REQUIRE(state.gamma() == std::complex<double>{0.7071067811865476, 0.0});
 }


### PR DESCRIPTION
## Summary

Adds three public fields to \`SchrodingerState\` that back the forced-execution path used by an upcoming \`probability_of()\` API:

- \`forced_record\` (\`std::span<const uint8_t>\`): outcome bytes the forced measurement kernels will read instead of sampling from the PRNG.
- \`forced_log_probability\` (\`double\`): running sum of \`log(prob_b / total)\` accumulated as each forced measurement runs.
- \`forced_reachable\` (\`bool\`): false once a forced outcome hits exact-zero branch probability, short-circuiting the rest of the bytecode.

All three are dormant in sampling mode (empty span / 0.0 / true). \`reset()\` clears them so per-record reuse stays correct. Overhead on the sampling path is three trivial stores per \`reset()\` call — microseconds-per-million-shots at most, dominated by the existing \`v[]\` zero pass.

This PR is state-layout only. The forced kernels that read and write these fields land in a subsequent PR.

### Tests

Three new test cases in \`tests/test_state_reset.cc\`:
- Fresh \`SchrodingerState\` defaults: empty span, 0.0, true.
- \`reset()\` clears the forced-mode fields.
- Setting forced-mode fields doesn't disturb the active state (\`v_\`, Pauli frame, \`gamma\`, \`active_k\`).

## Test plan

- [x] \`ctest --test-dir build -E Bench\` — 720/720 pass (was 717).
- [x] \`uv run pytest tests/python/\` — 635/635 pass.
- [x] Pre-commit clean.