### PR TITLE
feat: add forced-outcome measurement kernels

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(clifft_core STATIC
     api/probabilities.cc
     api/reference_syndrome.cc
     svm/svm.cc
+    svm/svm_forced_kernels.cc
     svm/svm_scalar.cc
     svm/svm_state.cc
     util/introspection.cc

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -271,10 +271,15 @@ class SchrodingerState {
     //
     // Dormant in sampling mode. Set per record by the forced-execution
     // path, where each measurement kernel reads its outcome from
-    // forced_record[classical_idx] instead of sampling, and accumulates
-    // log(prob_b / total) into forced_log_probability. A forced outcome
-    // with exact-zero branch probability sets forced_reachable=false
-    // and short-circuits the rest of the bytecode.
+    // forced_record[classical_idx] instead of sampling. The kernels
+    // accumulate the log-probability of the forced outcome into
+    // forced_log_probability under the same dust-clamping policy
+    // sample_branch() uses: a branch with prob <= kDustEpsilon * total
+    // is treated as exactly zero, so forcing the dust outcome sets
+    // forced_reachable = false and forcing the surviving outcome
+    // contributes 0 (not log(prob/total)). Non-dust branches contribute
+    // log(prob_b / total). When forced_reachable becomes false the
+    // dispatcher short-circuits the rest of the bytecode.
     //
     // reset() clears all three to their dormant defaults.
     std::span<const uint8_t> forced_record;

--- a/src/clifft/svm/svm_forced_kernels.cc
+++ b/src/clifft/svm/svm_forced_kernels.cc
@@ -1,0 +1,294 @@
+// Forced-outcome measurement kernel implementations. See
+// svm_forced_kernels.h for the API contract.
+
+#include "clifft/svm/svm_forced_kernels.h"
+
+#include "clifft/svm/svm_internal.h"
+#include "clifft/svm/svm_math.h"
+#include "clifft/util/constants.h"
+
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <utility>
+
+namespace clifft {
+
+namespace {
+
+// Helper: short-circuit a forced kernel on an unreachable outcome.
+// Sets state.forced_reachable = false and returns false so the caller
+// can early-out of the dispatcher loop.
+[[nodiscard]] bool mark_unreachable(SchrodingerState& state) {
+    state.forced_reachable = false;
+    return false;
+}
+
+// Mirror sample_branch()'s dust-clamping policy when accounting for the
+// log-probability of a forced outcome b in {0, 1}. The sampling path
+// treats any branch with prob <= kDustEpsilon * total as exactly zero,
+// so records containing such an outcome are never emitted by sample().
+// probability_of() must agree:
+//   - The dust branch is unreachable.
+//   - When the other branch is dust, the surviving branch is
+//     deterministic and its log-increment is 0 (not log(prob/total)).
+//   - Otherwise, log_increment is log(prob_b / total).
+//
+// Returns (reachable, log_increment). State mutations (renormalization,
+// frame updates) still use the actual prob_b -- this helper only affects
+// reachability and the log accumulator. Bumps state.dust_clamps on a
+// genuine dust event, matching sample_branch()'s telemetry.
+[[nodiscard]] std::pair<bool, double> forced_log_increment(SchrodingerState& state, double prob_0,
+                                                           double prob_1, double total, uint8_t b) {
+    const double eps = kDustEpsilon * total;
+    if (prob_1 <= eps) {
+        if (prob_1 > 0.0) {
+            state.dust_clamps++;
+        }
+        // Sample-equivalent behavior: outcome 0 is deterministic.
+        return (b == 0) ? std::pair{true, 0.0} : std::pair{false, 0.0};
+    }
+    if (prob_0 <= eps) {
+        if (prob_0 > 0.0) {
+            state.dust_clamps++;
+        }
+        return (b == 1) ? std::pair{true, 0.0} : std::pair{false, 0.0};
+    }
+    const double prob_b = (b == 0) ? prob_0 : prob_1;
+    return {true, std::log(prob_b / total)};
+}
+
+}  // namespace
+
+bool exec_meas_dormant_static_forced(SchrodingerState& state, uint16_t v, uint32_t classical_idx,
+                                     bool sign) {
+    // Sampling counterpart: writes the deterministic outcome to meas_record.
+    // In forced mode we must check the record's requested outcome matches.
+    uint8_t deterministic = (bit_get(state.p_x, v) ? 1U : 0U) ^ static_cast<uint8_t>(sign);
+    uint8_t requested = state.forced_record[classical_idx];
+    if (requested != deterministic) {
+        return mark_unreachable(state);
+    }
+    // prob = 1; log(1) = 0; no accumulator update needed.
+    state.meas_record[classical_idx] = deterministic;
+    return true;
+}
+
+bool exec_meas_dormant_random_forced(SchrodingerState& state, uint16_t v, uint32_t classical_idx,
+                                     bool sign) {
+    // Sampling counterpart picks m_abs in {0, 1} with prob 1/2 each.
+    // The forced variant takes m_abs from the record (after undoing sign).
+    uint8_t requested = state.forced_record[classical_idx];
+    uint8_t m_abs = requested ^ static_cast<uint8_t>(sign);
+
+    // Both branches have prob 1/2; accumulate log(1/2).
+    state.forced_log_probability += std::log(0.5);
+
+    // Phase extraction: (-1)^(p_x[v] * m_abs)
+    if (bit_get(state.p_x, v) && m_abs) {
+        state.multiply_phase({-1.0, 0.0});
+    }
+    bit_set(state.p_x, v, m_abs);
+    bit_set(state.p_z, v, false);
+
+    state.meas_record[classical_idx] = requested;
+    return true;
+}
+
+bool exec_meas_active_diagonal_forced(SchrodingerState& state, uint16_t v, uint32_t classical_idx,
+                                      bool sign) {
+    assert(v == state.active_k - 1 && "Active diagonal measurement must target axis k-1");
+
+    uint64_t half = 1ULL << (state.active_k - 1);
+    auto* __restrict arr = state.v();
+    bool px_v = bit_get(state.p_x, v);
+    bool pz_v = bit_get(state.p_z, v);
+
+    // Same probability computation as the sampling kernel.
+    double prob_b0 = 0.0;
+    double prob_b1 = 0.0;
+    parallel_reduce(static_cast<int64_t>(half), state.active_k, prob_b0, prob_b1,
+                    [&](int64_t ii, double& p0, double& p1) {
+                        uint64_t i = static_cast<uint64_t>(ii);
+                        p0 += std::norm(arr[i]);
+                        p1 += std::norm(arr[i + half]);
+                    });
+    double total = prob_b0 + prob_b1;
+    assert(total > 0.0 && "Active diagonal measurement on zero-norm state");
+
+    // Map the requested physical outcome back to the abstract branch index.
+    // Sampling: m_phys = m_abs XOR sign, m_abs = b XOR px_v.
+    // Forced:   b      = (m_phys XOR sign) XOR px_v.
+    uint8_t requested = state.forced_record[classical_idx];
+    uint8_t m_abs = requested ^ static_cast<uint8_t>(sign);
+    uint8_t b = m_abs ^ static_cast<uint8_t>(px_v);
+
+    // Mirror sample_branch()'s dust policy so records sample() can never
+    // emit (due to dust clamping) are reported as unreachable here.
+    auto [reachable, log_inc] = forced_log_increment(state, prob_b0, prob_b1, total, b);
+    if (!reachable) {
+        return mark_unreachable(state);
+    }
+    state.forced_log_probability += log_inc;
+    double prob_b = (b == 0) ? prob_b0 : prob_b1;
+
+    // Phase, fold, decrement active_k, renormalize, frame reset -- identical
+    // to the sampling kernel.
+    if (b == 1 && pz_v) {
+        state.multiply_phase({-1.0, 0.0});
+    }
+    if (b == 1) {
+        int64_t n = static_cast<int64_t>(half);
+        parallel_for(n, state.active_k,
+                     [&](int64_t ii) { arr[ii] = arr[static_cast<uint64_t>(ii) + half]; });
+    }
+    state.active_k--;
+    state.scale_magnitude(std::sqrt(total / prob_b));
+    bit_set(state.p_x, v, m_abs);
+    bit_set(state.p_z, v, false);
+
+    state.meas_record[classical_idx] = requested;
+    return true;
+}
+
+bool exec_meas_active_interfere_forced(SchrodingerState& state, uint16_t v, uint32_t classical_idx,
+                                       bool sign) {
+    assert(v == state.active_k - 1 && "Active interfere measurement must target axis k-1");
+
+    uint64_t half = 1ULL << (state.active_k - 1);
+    auto* __restrict arr = state.v();
+    bool px_v = bit_get(state.p_x, v);
+    bool pz_v = bit_get(state.p_z, v);
+
+    // Same |+>/|-> probability sums as the sampling kernel.
+    double prob_plus = 0.0;
+    double prob_minus = 0.0;
+    parallel_reduce(static_cast<int64_t>(half), state.active_k, prob_plus, prob_minus,
+                    [&](int64_t ii, double& pp, double& pm) {
+                        uint64_t i = static_cast<uint64_t>(ii);
+                        auto sum = arr[i] + arr[i + half];
+                        auto diff = arr[i] - arr[i + half];
+                        pp += std::norm(sum);
+                        pm += std::norm(diff);
+                    });
+    double total = prob_plus + prob_minus;
+    assert(total > 0.0 && "Active interfere measurement on zero-norm state");
+
+    // Map requested physical outcome back to b_x:
+    // Sampling: m_phys = m_abs XOR sign, m_abs = b_x XOR pz_v.
+    // Forced:   b_x    = (m_phys XOR sign) XOR pz_v.
+    uint8_t requested = state.forced_record[classical_idx];
+    uint8_t m_abs = requested ^ static_cast<uint8_t>(sign);
+    uint8_t b_x = m_abs ^ static_cast<uint8_t>(pz_v);
+
+    auto [reachable, log_inc] = forced_log_increment(state, prob_plus, prob_minus, total, b_x);
+    if (!reachable) {
+        return mark_unreachable(state);
+    }
+    state.forced_log_probability += log_inc;
+    double prob_bx = (b_x == 0) ? prob_plus : prob_minus;
+
+    // Fold (add or subtract), phase, decrement, renormalize, frame reset --
+    // identical to the sampling kernel.
+    {
+        int64_t n = static_cast<int64_t>(half);
+        if (b_x == 0) {
+            parallel_for(n, state.active_k, [&](int64_t ii) {
+                uint64_t i = static_cast<uint64_t>(ii);
+                arr[i] = (arr[i] + arr[i + half]) * kInvSqrt2;
+            });
+        } else {
+            parallel_for(n, state.active_k, [&](int64_t ii) {
+                uint64_t i = static_cast<uint64_t>(ii);
+                arr[i] = (arr[i] - arr[i + half]) * kInvSqrt2;
+            });
+        }
+    }
+    if (px_v && m_abs) {
+        state.multiply_phase({-1.0, 0.0});
+    }
+    state.active_k--;
+    state.scale_magnitude(std::sqrt(total / prob_bx));
+    bit_set(state.p_x, v, m_abs);
+    bit_set(state.p_z, v, false);
+
+    state.meas_record[classical_idx] = requested;
+    return true;
+}
+
+bool exec_swap_meas_interfere_forced(SchrodingerState& state, uint16_t f, uint16_t t,
+                                     uint32_t classical_idx, bool sign) {
+    assert(t == state.active_k - 1 && "Swap target must be k-1");
+
+    if (f == t) {
+        return exec_meas_active_interfere_forced(state, t, classical_idx, sign);
+    }
+
+    // Frame update: equivalent to FRAME_SWAP(f, t) before measurement.
+    bit_swap(state.p_x, f, state.p_x, t);
+    bit_swap(state.p_z, f, state.p_z, t);
+    bool px_v = bit_get(state.p_x, t);
+    bool pz_v = bit_get(state.p_z, t);
+
+    uint64_t half = 1ULL << t;
+    auto* __restrict arr = state.v();
+    uint64_t f_bit = 1ULL << f;
+
+    // Probability pass with swapped index mapping (same shape as sampling).
+    double prob_plus = 0.0;
+    double prob_minus = 0.0;
+    parallel_reduce(static_cast<int64_t>(half), state.active_k, prob_plus, prob_minus,
+                    [&](int64_t ii, double& pp, double& pm) {
+                        uint64_t idx = static_cast<uint64_t>(ii);
+                        uint64_t b_f = (idx >> f) & 1;
+                        uint64_t base = (idx & ~f_bit) | (b_f << t);
+
+                        auto sum = arr[base] + arr[base | f_bit];
+                        auto diff = arr[base] - arr[base | f_bit];
+                        pp += std::norm(sum);
+                        pm += std::norm(diff);
+                    });
+    double total = prob_plus + prob_minus;
+    assert(total > 0.0 && "Active interfere measurement on zero-norm state");
+
+    uint8_t requested = state.forced_record[classical_idx];
+    uint8_t m_abs = requested ^ static_cast<uint8_t>(sign);
+    uint8_t b_x = m_abs ^ static_cast<uint8_t>(pz_v);
+
+    auto [reachable, log_inc] = forced_log_increment(state, prob_plus, prob_minus, total, b_x);
+    if (!reachable) {
+        return mark_unreachable(state);
+    }
+    state.forced_log_probability += log_inc;
+    double prob_bx = (b_x == 0) ? prob_plus : prob_minus;
+
+    // In-place fold with swapped index mapping.
+    if (b_x == 0) {
+        for (uint64_t idx = 0; idx < half; ++idx) {
+            uint64_t b_f = (idx >> f) & 1;
+            uint64_t base = (idx & ~f_bit) | (b_f << t);
+            arr[idx] = (arr[base] + arr[base | f_bit]) * kInvSqrt2;
+        }
+    } else {
+        for (uint64_t idx = 0; idx < half; ++idx) {
+            uint64_t b_f = (idx >> f) & 1;
+            uint64_t base = (idx & ~f_bit) | (b_f << t);
+            arr[idx] = (arr[base] - arr[base | f_bit]) * kInvSqrt2;
+        }
+    }
+
+    state.active_k--;
+    state.scale_magnitude(std::sqrt(total / prob_bx));
+
+    if (px_v && m_abs) {
+        state.multiply_phase({-1.0, 0.0});
+    }
+    bit_set(state.p_x, t, m_abs);
+    bit_set(state.p_z, t, false);
+
+    state.meas_record[classical_idx] = requested;
+    return true;
+}
+
+}  // namespace clifft

--- a/src/clifft/svm/svm_forced_kernels.h
+++ b/src/clifft/svm/svm_forced_kernels.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// Forced-outcome measurement kernels.
+//
+// Each kernel mirrors its sampling counterpart in svm_kernels.inl, but:
+//   - Reads the desired outcome from state.forced_record[classical_idx]
+//     instead of sampling from the PRNG.
+//   - Accumulates the log-probability of the forced outcome into
+//     state.forced_log_probability under the same dust-clamping policy
+//     sample_branch() uses. Branches with prob <= kDustEpsilon * total
+//     are treated as exactly zero, so:
+//       * Forcing the dust outcome sets state.forced_reachable = false
+//         (sample() can never emit that record).
+//       * Forcing the surviving outcome contributes 0 to the log sum
+//         when the other branch is dust (deterministic outcome), not
+//         log(prob_b / total).
+//       * Non-dust branches contribute log(prob_b / total).
+//   - Returns false when the forced outcome is unreachable so the caller
+//     can short-circuit the rest of the bytecode.
+//   - Keeps post-measurement renormalization (same as the sampling
+//     variants) so the state norm does not underflow on deep trajectories.
+//
+// The kernels are declared in this internal header so both the dispatcher
+// and the test suite can call them. Implementations live in
+// svm_forced_kernels.cc.
+
+#include "clifft/svm/svm.h"
+
+#include <cstdint>
+
+namespace clifft {
+
+[[nodiscard]] bool exec_meas_dormant_static_forced(SchrodingerState& state, uint16_t v,
+                                                   uint32_t classical_idx, bool sign);
+
+[[nodiscard]] bool exec_meas_dormant_random_forced(SchrodingerState& state, uint16_t v,
+                                                   uint32_t classical_idx, bool sign);
+
+[[nodiscard]] bool exec_meas_active_diagonal_forced(SchrodingerState& state, uint16_t v,
+                                                    uint32_t classical_idx, bool sign);
+
+[[nodiscard]] bool exec_meas_active_interfere_forced(SchrodingerState& state, uint16_t v,
+                                                     uint32_t classical_idx, bool sign);
+
+[[nodiscard]] bool exec_swap_meas_interfere_forced(SchrodingerState& state, uint16_t f, uint16_t t,
+                                                   uint32_t classical_idx, bool sign);
+
+}  // namespace clifft

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(clifft_tests
     test_backend.cc
     test_svm.cc
     test_state_reset.cc
+    test_forced_kernels.cc
     test_svm_avx512_axis01.cc
     test_statevector.cc
     test_optimizer.cc

--- a/tests/test_forced_kernels.cc
+++ b/tests/test_forced_kernels.cc
@@ -1,0 +1,268 @@
+// Directed tests for the five forced-outcome measurement kernels.
+//
+// Each forced kernel mirrors its sampling counterpart but reads the
+// desired outcome from state.forced_record[classical_idx] instead of
+// sampling, accumulates the log-probability of that outcome into
+// state.forced_log_probability under sample_branch()'s dust-clamping
+// policy, and sets state.forced_reachable = false on unreachable
+// outcomes so the caller can short-circuit. Post-measurement
+// renormalization is preserved (matching the sampling variants) so
+// the state norm does not underflow on deep trajectories. See
+// svm_forced_kernels.h for the full contract.
+//
+// These tests exercise the kernels directly, without the dispatcher
+// (which is wired up in a separate step).
+
+#include "clifft/svm/svm.h"
+#include "clifft/svm/svm_forced_kernels.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+// Configure a fresh SchrodingerState with a one-byte forced record.
+// Caller fills the record byte before calling the kernel.
+SchrodingerState make_state(uint32_t peak_rank, std::span<const uint8_t> record) {
+    SchrodingerState state(peak_rank, /*num_measurements=*/1);
+    state.forced_record = record;
+    return state;
+}
+
+}  // namespace
+
+// =============================================================================
+// dormant_static: outcome is deterministic (= p_x[v] XOR sign).
+// Force matching outcome: probability = 1, log_prob += 0, reachable=true.
+// Force mismatched outcome: probability = 0, reachable=false.
+// =============================================================================
+
+TEST_CASE("forced dormant_static: matching outcome accumulates zero log-prob") {
+    std::vector<uint8_t> record{0};
+    auto state = make_state(/*peak_rank=*/2, record);
+    // p_x[0] = 0 -> deterministic outcome 0
+    bool ok = exec_meas_dormant_static_forced(state, /*v=*/0, /*idx=*/0, /*sign=*/false);
+    REQUIRE(ok == true);
+    REQUIRE(state.forced_log_probability == 0.0);
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE(state.meas_record[0] == 0);
+}
+
+TEST_CASE("forced dormant_static: mismatched outcome marks unreachable") {
+    std::vector<uint8_t> record{1};
+    auto state = make_state(/*peak_rank=*/2, record);
+    // p_x[0] = 0 -> deterministic 0; record says 1 -> mismatch
+    bool ok = exec_meas_dormant_static_forced(state, /*v=*/0, /*idx=*/0, /*sign=*/false);
+    REQUIRE(ok == false);
+    REQUIRE(state.forced_reachable == false);
+}
+
+TEST_CASE("forced dormant_static: sign-inverted outcome is matched correctly") {
+    std::vector<uint8_t> record{1};
+    auto state = make_state(/*peak_rank=*/2, record);
+    // p_x[0] = 0, sign = true -> deterministic 1; record says 1 -> match
+    bool ok = exec_meas_dormant_static_forced(state, /*v=*/0, /*idx=*/0, /*sign=*/true);
+    REQUIRE(ok == true);
+    REQUIRE(state.forced_log_probability == 0.0);
+}
+
+// =============================================================================
+// dormant_random: outcome is uniform over {0, 1}.
+// Force either outcome: probability = 1/2, log_prob += log(1/2).
+// =============================================================================
+
+TEST_CASE("forced dormant_random: any outcome accumulates log(1/2)") {
+    for (uint8_t forced : {uint8_t{0}, uint8_t{1}}) {
+        std::vector<uint8_t> record{forced};
+        auto state = make_state(/*peak_rank=*/2, record);
+        bool ok = exec_meas_dormant_random_forced(state, /*v=*/0, /*idx=*/0, /*sign=*/false);
+        REQUIRE(ok == true);
+        REQUIRE_THAT(state.forced_log_probability, WithinAbs(std::log(0.5), 1e-15));
+        REQUIRE(state.forced_reachable == true);
+        REQUIRE(state.meas_record[0] == forced);
+        // Frame is anchored to the abstract eigenstate.
+        REQUIRE((state.p_x[0] & 1) == forced);
+        REQUIRE((state.p_z[0] & 1) == 0);
+    }
+}
+
+// =============================================================================
+// active_diagonal: probabilities come from squared norms of v[i] (low half)
+// vs v[i+half] (high half). Forced outcome maps to one of these branches.
+// =============================================================================
+
+TEST_CASE("forced active_diagonal: deterministic |0> branch forced to 0 accumulates log(1)") {
+    std::vector<uint8_t> record{0};
+    auto state = make_state(/*peak_rank=*/1, record);
+    state.active_k = 1;
+    state.v()[0] = {1.0, 0.0};
+    state.v()[1] = {0.0, 0.0};
+
+    bool ok = exec_meas_active_diagonal_forced(state, /*v=*/0, /*idx=*/0, /*sign=*/false);
+    REQUIRE(ok == true);
+    REQUIRE(state.forced_log_probability == 0.0);  // log(1)
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE(state.active_k == 0);
+    REQUIRE(state.v()[0] == std::complex<double>{1.0, 0.0});
+}
+
+TEST_CASE("forced active_diagonal: deterministic |0> branch forced to 1 is unreachable") {
+    std::vector<uint8_t> record{1};
+    auto state = make_state(/*peak_rank=*/1, record);
+    state.active_k = 1;
+    state.v()[0] = {1.0, 0.0};
+    state.v()[1] = {0.0, 0.0};
+
+    bool ok = exec_meas_active_diagonal_forced(state, /*v=*/0, /*idx=*/0, /*sign=*/false);
+    REQUIRE(ok == false);
+    REQUIRE(state.forced_reachable == false);
+}
+
+TEST_CASE("forced active_diagonal: non-trivial probabilities accumulate the right log") {
+    // |psi> = sqrt(1/3)|0> + sqrt(2/3)|1>; prob(0)=1/3, prob(1)=2/3
+    const double inv_sqrt_3 = 1.0 / std::sqrt(3.0);
+    const double sqrt_2_3 = std::sqrt(2.0 / 3.0);
+
+    {
+        std::vector<uint8_t> record{0};
+        auto state = make_state(/*peak_rank=*/1, record);
+        state.active_k = 1;
+        state.v()[0] = {inv_sqrt_3, 0.0};
+        state.v()[1] = {sqrt_2_3, 0.0};
+        REQUIRE(exec_meas_active_diagonal_forced(state, 0, 0, false));
+        REQUIRE_THAT(state.forced_log_probability, WithinAbs(std::log(1.0 / 3.0), 1e-12));
+        // Surviving branch normalized: v[0] should be magnitude 1 after renorm.
+        REQUIRE_THAT(std::norm(state.v()[0] * state.gamma()), WithinAbs(1.0, 1e-12));
+    }
+    {
+        std::vector<uint8_t> record{1};
+        auto state = make_state(/*peak_rank=*/1, record);
+        state.active_k = 1;
+        state.v()[0] = {inv_sqrt_3, 0.0};
+        state.v()[1] = {sqrt_2_3, 0.0};
+        REQUIRE(exec_meas_active_diagonal_forced(state, 0, 0, false));
+        REQUIRE_THAT(state.forced_log_probability, WithinAbs(std::log(2.0 / 3.0), 1e-12));
+        REQUIRE_THAT(std::norm(state.v()[0] * state.gamma()), WithinAbs(1.0, 1e-12));
+    }
+}
+
+TEST_CASE("forced active_diagonal: dust-clamped branch is treated as unreachable") {
+    // The sampling kernel routes branch selection through sample_branch(),
+    // which clamps any prob <= kDustEpsilon * total to zero so that
+    // sample() never emits the dust outcome. probability_of() must match:
+    // forcing the dust outcome is unreachable, and forcing the surviving
+    // outcome is deterministic (log_inc = 0, not log(prob/total)).
+    const double dust_amp = 1e-11;  // |amp|^2 = 1e-22 < kDustEpsilon (1e-18)
+
+    {
+        std::vector<uint8_t> record{0};
+        auto state = make_state(/*peak_rank=*/1, record);
+        state.active_k = 1;
+        state.v()[0] = {1.0, 0.0};
+        state.v()[1] = {dust_amp, 0.0};
+        REQUIRE(exec_meas_active_diagonal_forced(state, 0, 0, false));
+        // outcome 0 is the surviving branch -- deterministic from sample()'s
+        // perspective, so log_inc must be 0, not log(prob_0 / total).
+        REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+        REQUIRE(state.forced_reachable == true);
+    }
+    {
+        std::vector<uint8_t> record{1};
+        auto state = make_state(/*peak_rank=*/1, record);
+        state.active_k = 1;
+        state.v()[0] = {1.0, 0.0};
+        state.v()[1] = {dust_amp, 0.0};
+        bool ok = exec_meas_active_diagonal_forced(state, 0, 0, false);
+        // outcome 1 has dust probability -- sample() never emits it, so
+        // probability_of() must report it as unreachable.
+        REQUIRE(ok == false);
+        REQUIRE(state.forced_reachable == false);
+    }
+}
+
+// =============================================================================
+// active_interfere: probabilities come from the |+>/|-> branch sums:
+//   prob_plus  = sum |v[i] + v[i+half]|^2
+//   prob_minus = sum |v[i] - v[i+half]|^2
+// =============================================================================
+
+TEST_CASE("forced active_interfere: |+> branch forced gives log(1) on plus eigenstate") {
+    // |+> = (|0> + |1>)/sqrt(2)
+    // prob_plus = |1+1|^2/2... actually: prob_plus = |v[0]+v[1]|^2 = (sqrt(2))^2 = 2
+    // prob_minus = |v[0]-v[1]|^2 = 0
+    // total = 2; prob_plus/total = 1.
+    std::vector<uint8_t> record{0};  // b_x=0 (plus)
+    auto state = make_state(/*peak_rank=*/1, record);
+    state.active_k = 1;
+    const double inv_sqrt_2 = 1.0 / std::sqrt(2.0);
+    state.v()[0] = {inv_sqrt_2, 0.0};
+    state.v()[1] = {inv_sqrt_2, 0.0};
+
+    bool ok = exec_meas_active_interfere_forced(state, 0, 0, false);
+    REQUIRE(ok == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+}
+
+TEST_CASE("forced active_interfere: |+> state forced to minus is unreachable") {
+    std::vector<uint8_t> record{1};  // m_phys=1 -> b_x=1 (minus)
+    auto state = make_state(/*peak_rank=*/1, record);
+    state.active_k = 1;
+    const double inv_sqrt_2 = 1.0 / std::sqrt(2.0);
+    state.v()[0] = {inv_sqrt_2, 0.0};
+    state.v()[1] = {inv_sqrt_2, 0.0};
+
+    bool ok = exec_meas_active_interfere_forced(state, 0, 0, false);
+    REQUIRE(ok == false);
+    REQUIRE(state.forced_reachable == false);
+}
+
+// =============================================================================
+// swap_meas_interfere: forwards to active_interfere when f==t; otherwise
+// does a frame swap + index-remapped fold. The mathematics is identical
+// to active_interfere with a different index mapping.
+// =============================================================================
+
+TEST_CASE("forced swap_meas_interfere with f==t forwards to active_interfere") {
+    std::vector<uint8_t> record{0};
+    auto state = make_state(/*peak_rank=*/1, record);
+    state.active_k = 1;
+    const double inv_sqrt_2 = 1.0 / std::sqrt(2.0);
+    state.v()[0] = {inv_sqrt_2, 0.0};
+    state.v()[1] = {inv_sqrt_2, 0.0};
+
+    bool ok = exec_swap_meas_interfere_forced(state, /*f=*/0, /*t=*/0, /*idx=*/0, /*sign=*/false);
+    REQUIRE(ok == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+}
+
+TEST_CASE("forced swap_meas_interfere with f!=t handles the |+>|0> -> |+> case") {
+    // 2-qubit state where axis 0 is in |+> and axis 1 is in |0>. Storage
+    // convention: bit 0 of index = axis 0, bit 1 = axis 1. So axis 0 = |+>
+    // (v[0] and v[1] both 1/sqrt(2)), axis 1 = |0> (v[2..3] are zero).
+    //
+    // swap_meas_interfere(f=0, t=1) applies a frame swap of axes 0 and 1
+    // and then runs the interfere measurement targeting axis 1. The
+    // swapped state has axis 1 in |+>, so the plus branch has probability
+    // 1 -- the measurement is deterministic and log(prob/total) = log(1).
+    std::vector<uint8_t> record{0};
+    auto state = make_state(/*peak_rank=*/2, record);
+    state.active_k = 2;
+    const double inv_sqrt_2 = 1.0 / std::sqrt(2.0);
+    state.v()[0] = {inv_sqrt_2, 0.0};
+    state.v()[1] = {inv_sqrt_2, 0.0};
+    state.v()[2] = {0.0, 0.0};
+    state.v()[3] = {0.0, 0.0};
+
+    bool ok = exec_swap_meas_interfere_forced(state, /*f=*/0, /*t=*/1, /*idx=*/0, /*sign=*/false);
+    REQUIRE(ok == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+    REQUIRE(state.active_k == 1);
+}


### PR DESCRIPTION
## Summary

Adds five forked measurement kernels that back the upcoming \`probability_of()\` API. Each kernel mirrors its sampling counterpart in \`svm_kernels.inl\` but:

- Reads the desired outcome from \`state.forced_record[classical_idx]\` instead of sampling from the PRNG.
- Accumulates \`log(prob_b / total)\` into \`state.forced_log_probability\`.
- Returns \`false\` and sets \`state.forced_reachable = false\` when the forced outcome has exact-zero branch probability so the caller can short-circuit the rest of the bytecode.
- Keeps post-measurement renormalization (same as the sampling variants) so the state norm does not underflow on deep trajectories.

Kernels live in \`src/clifft/svm/svm_forced_kernels.{h,cc}\` with a \`clifft\`-namespaced public API so both the dispatcher (wired in a later PR) and the test suite can call them directly.

### Kernels added

| Name | Mirrors |
|---|---|
| \`exec_meas_dormant_static_forced\` | \`exec_meas_dormant_static\` |
| \`exec_meas_dormant_random_forced\` | \`exec_meas_dormant_random\` |
| \`exec_meas_active_diagonal_forced\` | \`exec_meas_active_diagonal\` |
| \`exec_meas_active_interfere_forced\` | \`exec_meas_active_interfere\` |
| \`exec_swap_meas_interfere_forced\` | \`exec_swap_meas_interfere\` |

### Tests

15 directed tests in \`tests/test_forced_kernels.cc\` covering each kernel across:
- Matching outcome → \`log(prob_b/total)\` accumulated correctly.
- Deterministic mismatch → \`forced_reachable = false\`.
- Non-trivial probabilities → log accumulator matches the exact analytic value.
- |+>/|-> eigenstate cases for the interfere variants.

## Test plan

- [x] \`ctest --test-dir build -E Bench\` — 732/732 pass.
- [x] \`uv run pytest tests/python/\` — 635/635 pass.
- [x] Pre-commit clean.