### PR TITLE
feat: wire forced measurement opcodes into the SVM dispatcher

### DIFF
--- a/src/clifft/svm/svm_avx2.cc
+++ b/src/clifft/svm/svm_avx2.cc
@@ -5,6 +5,7 @@
 #define CLIFFT_SIMD_NAMESPACE avx2
 
 #include "clifft/svm/svm.h"
+#include "clifft/svm/svm_forced_kernels.h"
 #include "clifft/svm/svm_internal.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/constants.h"

--- a/src/clifft/svm/svm_avx512.cc
+++ b/src/clifft/svm/svm_avx512.cc
@@ -9,6 +9,7 @@
 #define CLIFFT_SIMD_NAMESPACE avx512
 
 #include "clifft/svm/svm.h"
+#include "clifft/svm/svm_forced_kernels.h"
 #include "clifft/svm/svm_internal.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/constants.h"

--- a/src/clifft/svm/svm_forced_kernels.cc
+++ b/src/clifft/svm/svm_forced_kernels.cc
@@ -61,6 +61,18 @@ namespace {
 
 }  // namespace
 
+bool exec_meas_dormant_static_identity_forced(SchrodingerState& state, uint32_t classical_idx,
+                                              bool sign) {
+    // Sampling counterpart in the dispatcher writes meas_record[idx] = sign.
+    // Forced variant checks the record matches the deterministic sign bit.
+    uint8_t expected = sign ? 1U : 0U;
+    if (state.forced_record[classical_idx] != expected) {
+        return mark_unreachable(state);
+    }
+    state.meas_record[classical_idx] = expected;
+    return true;
+}
+
 bool exec_meas_dormant_static_forced(SchrodingerState& state, uint16_t v, uint32_t classical_idx,
                                      bool sign) {
     // Sampling counterpart: writes the deterministic outcome to meas_record.

--- a/src/clifft/svm/svm_forced_kernels.h
+++ b/src/clifft/svm/svm_forced_kernels.h
@@ -33,6 +33,13 @@ namespace clifft {
 [[nodiscard]] bool exec_meas_dormant_static_forced(SchrodingerState& state, uint16_t v,
                                                    uint32_t classical_idx, bool sign);
 
+// FLAG_IDENTITY shortcut for OP_MEAS_DORMANT_STATIC_FORCED. Identity-Pauli
+// measurements bypass p_x: the deterministic outcome is just the sign bit.
+// The forced variant checks the requested outcome matches and marks the
+// state unreachable otherwise.
+[[nodiscard]] bool exec_meas_dormant_static_identity_forced(SchrodingerState& state,
+                                                            uint32_t classical_idx, bool sign);
+
 [[nodiscard]] bool exec_meas_dormant_random_forced(SchrodingerState& state, uint16_t v,
                                                    uint32_t classical_idx, bool sign);
 

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -8,6 +8,7 @@
 // Required before this file:
 //   #define CLIFFT_SIMD_NAMESPACE scalar  (or avx2, etc.)
 //   #include "clifft/svm/svm.h"
+//   #include "clifft/svm/svm_forced_kernels.h"
 //   #include "clifft/svm/svm_internal.h"
 //   #include "clifft/svm/svm_math.h"
 //   #include "clifft/util/constants.h"
@@ -2225,15 +2226,23 @@ void execute_internal(const CompiledModule& program, SchrodingerState& state) {
         [static_cast<uint8_t>(Opcode::OP_MEAS_ACTIVE_INTERFERE)] = &&L_OP_MEAS_ACTIVE_INTERFERE,
         [static_cast<uint8_t>(Opcode::OP_SWAP_MEAS_INTERFERE)] = &&L_OP_SWAP_MEAS_INTERFERE,
 
-        // Forced-measurement opcodes are synthesized only by probability_of()'s
-        // bytecode rewrite. They must never appear here; route to an explicit
-        // trap label so a hand-constructed bytecode that slips them past the
-        // pre-flight validator faults loudly instead of jumping to address 0.
-        [static_cast<uint8_t>(Opcode::OP_MEAS_DORMANT_STATIC_FORCED)] = &&L_OP_FORCED_TRAP,
-        [static_cast<uint8_t>(Opcode::OP_MEAS_DORMANT_RANDOM_FORCED)] = &&L_OP_FORCED_TRAP,
-        [static_cast<uint8_t>(Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED)] = &&L_OP_FORCED_TRAP,
-        [static_cast<uint8_t>(Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED)] = &&L_OP_FORCED_TRAP,
-        [static_cast<uint8_t>(Opcode::OP_SWAP_MEAS_INTERFERE_FORCED)] = &&L_OP_FORCED_TRAP,
+        // Forced-measurement opcodes are synthesized by probability_of()'s
+        // bytecode rewrite. The kernels read each outcome from
+        // state.forced_record[classical_idx] and accumulate the log-
+        // probability into state.forced_log_probability. They return false
+        // (and set state.forced_reachable = false) when the forced outcome
+        // is unreachable; the dispatcher labels turn that into an early
+        // return so the rest of the bytecode is skipped.
+        [static_cast<uint8_t>(Opcode::OP_MEAS_DORMANT_STATIC_FORCED)] =
+            &&L_OP_MEAS_DORMANT_STATIC_FORCED,
+        [static_cast<uint8_t>(Opcode::OP_MEAS_DORMANT_RANDOM_FORCED)] =
+            &&L_OP_MEAS_DORMANT_RANDOM_FORCED,
+        [static_cast<uint8_t>(Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED)] =
+            &&L_OP_MEAS_ACTIVE_DIAGONAL_FORCED,
+        [static_cast<uint8_t>(Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED)] =
+            &&L_OP_MEAS_ACTIVE_INTERFERE_FORCED,
+        [static_cast<uint8_t>(Opcode::OP_SWAP_MEAS_INTERFERE_FORCED)] =
+            &&L_OP_SWAP_MEAS_INTERFERE_FORCED,
 
         [static_cast<uint8_t>(Opcode::OP_APPLY_PAULI)] = &&L_OP_APPLY_PAULI,
         [static_cast<uint8_t>(Opcode::OP_NOISE)] = &&L_OP_NOISE,
@@ -2414,12 +2423,46 @@ L_OP_EXP_VAL:
     exec_exp_val(state, program.constant_pool, pc->exp_val.cp_exp_val_idx, pc->exp_val.exp_val_idx);
     DISPATCH();
 
-L_OP_FORCED_TRAP:
-    // Forced measurement opcodes are reserved for probability_of()'s
-    // bytecode rewrite. Reaching this label means a hand-built bytecode
-    // sent one through execute() directly; that's a programmer error.
-    assert(false && "forced measurement opcode reached sampling execute()");
-    throw std::logic_error("forced measurement opcode reached sampling execute()");
+L_OP_MEAS_DORMANT_STATIC_FORCED: {
+    const bool sign_flag = (pc->flags & Instruction::FLAG_SIGN) != 0;
+    const bool ok = (pc->flags & Instruction::FLAG_IDENTITY)
+                        ? exec_meas_dormant_static_identity_forced(
+                              state, pc->classical.classical_idx, sign_flag)
+                        : exec_meas_dormant_static_forced(state, pc->axis_1,
+                                                          pc->classical.classical_idx, sign_flag);
+    if (!ok) {
+        return;
+    }
+    DISPATCH();
+}
+
+L_OP_MEAS_DORMANT_RANDOM_FORCED:
+    if (!exec_meas_dormant_random_forced(state, pc->axis_1, pc->classical.classical_idx,
+                                         (pc->flags & Instruction::FLAG_SIGN) != 0)) {
+        return;
+    }
+    DISPATCH();
+
+L_OP_MEAS_ACTIVE_DIAGONAL_FORCED:
+    if (!exec_meas_active_diagonal_forced(state, pc->axis_1, pc->classical.classical_idx,
+                                          (pc->flags & Instruction::FLAG_SIGN) != 0)) {
+        return;
+    }
+    DISPATCH();
+
+L_OP_MEAS_ACTIVE_INTERFERE_FORCED:
+    if (!exec_meas_active_interfere_forced(state, pc->axis_1, pc->classical.classical_idx,
+                                           (pc->flags & Instruction::FLAG_SIGN) != 0)) {
+        return;
+    }
+    DISPATCH();
+
+L_OP_SWAP_MEAS_INTERFERE_FORCED:
+    if (!exec_swap_meas_interfere_forced(state, pc->axis_1, pc->axis_2, pc->classical.classical_idx,
+                                         (pc->flags & Instruction::FLAG_SIGN) != 0)) {
+        return;
+    }
+    DISPATCH();
 
 #pragma GCC diagnostic pop
 #undef DISPATCH
@@ -2523,16 +2566,47 @@ L_OP_FORCED_TRAP:
                                          instr.classical.classical_idx,
                                          (instr.flags & Instruction::FLAG_SIGN) != 0);
                 break;
-            // Forced measurement opcodes never reach sampling execute(); they're
-            // synthesized only by probability_of()'s rewrite. Fault loudly if
-            // a hand-built bytecode slipped one past the validator.
-            case Opcode::OP_MEAS_DORMANT_STATIC_FORCED:
+            case Opcode::OP_MEAS_DORMANT_STATIC_FORCED: {
+                const bool sign_flag = (instr.flags & Instruction::FLAG_SIGN) != 0;
+                const bool ok =
+                    (instr.flags & Instruction::FLAG_IDENTITY)
+                        ? exec_meas_dormant_static_identity_forced(
+                              state, instr.classical.classical_idx, sign_flag)
+                        : exec_meas_dormant_static_forced(state, instr.axis_1,
+                                                          instr.classical.classical_idx, sign_flag);
+                if (!ok) {
+                    return;
+                }
+                break;
+            }
             case Opcode::OP_MEAS_DORMANT_RANDOM_FORCED:
+                if (!exec_meas_dormant_random_forced(state, instr.axis_1,
+                                                     instr.classical.classical_idx,
+                                                     (instr.flags & Instruction::FLAG_SIGN) != 0)) {
+                    return;
+                }
+                break;
             case Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED:
+                if (!exec_meas_active_diagonal_forced(
+                        state, instr.axis_1, instr.classical.classical_idx,
+                        (instr.flags & Instruction::FLAG_SIGN) != 0)) {
+                    return;
+                }
+                break;
             case Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED:
+                if (!exec_meas_active_interfere_forced(
+                        state, instr.axis_1, instr.classical.classical_idx,
+                        (instr.flags & Instruction::FLAG_SIGN) != 0)) {
+                    return;
+                }
+                break;
             case Opcode::OP_SWAP_MEAS_INTERFERE_FORCED:
-                assert(false && "forced measurement opcode reached sampling execute()");
-                throw std::logic_error("forced measurement opcode reached sampling execute()");
+                if (!exec_swap_meas_interfere_forced(state, instr.axis_1, instr.axis_2,
+                                                     instr.classical.classical_idx,
+                                                     (instr.flags & Instruction::FLAG_SIGN) != 0)) {
+                    return;
+                }
+                break;
             case Opcode::OP_APPLY_PAULI:
                 exec_apply_pauli(state, program.constant_pool, instr.pauli.cp_mask_idx,
                                  instr.pauli.condition_idx);

--- a/src/clifft/svm/svm_scalar.cc
+++ b/src/clifft/svm/svm_scalar.cc
@@ -4,6 +4,7 @@
 #define CLIFFT_SIMD_NAMESPACE scalar
 
 #include "clifft/svm/svm.h"
+#include "clifft/svm/svm_forced_kernels.h"
 #include "clifft/svm/svm_internal.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/constants.h"

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/backend/backend.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_forced_kernels.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_scalar.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_state.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/util/introspection.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(clifft_tests
     test_svm.cc
     test_state_reset.cc
     test_forced_kernels.cc
+    test_execute_forced.cc
     test_svm_avx512_axis01.cc
     test_statevector.cc
     test_optimizer.cc

--- a/tests/test_execute_forced.cc
+++ b/tests/test_execute_forced.cc
@@ -1,0 +1,252 @@
+// Tests for execute()'s forced-mode dispatch labels.
+//
+// The forced measurement opcodes (OP_MEAS_*_FORCED, OP_SWAP_MEAS_INTERFERE_FORCED)
+// are wired into the same dispatcher that handles the sampling kernels. Each
+// label calls the corresponding forced kernel from svm_forced_kernels.h and
+// returns early from execute() when the kernel reports the record is
+// unreachable.
+//
+// These tests verify dispatcher-level behavior end-to-end: a hand-built
+// CompiledModule with forced opcodes runs through execute() and produces the
+// same state changes that the standalone kernel tests already cover.
+
+#include "clifft/backend/backend.h"
+#include "clifft/svm/svm.h"
+
+#include "test_helpers.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+CompiledModule make_module(std::vector<Instruction> bytecode, uint32_t peak_rank,
+                           uint32_t num_meas) {
+    CompiledModule mod;
+    mod.bytecode = std::move(bytecode);
+    mod.peak_rank = peak_rank;
+    mod.num_measurements = num_meas;
+    mod.total_meas_slots = num_meas;
+    return mod;
+}
+
+// Set up state.forced_record on a SchrodingerState. Caller owns the storage.
+void install_forced_record(SchrodingerState& state, std::span<const uint8_t> record) {
+    state.forced_record = record;
+}
+
+}  // namespace
+
+TEST_CASE("execute: dispatches OP_MEAS_DORMANT_STATIC_FORCED for matching outcome") {
+    auto mod = make_module(
+        {
+            make_meas(Opcode::OP_MEAS_DORMANT_STATIC_FORCED, /*axis=*/0,
+                      /*classical_idx=*/0, /*sign=*/false),
+        },
+        /*peak_rank=*/2, /*num_meas=*/1);
+    SchrodingerState state(2, 1);
+    std::vector<uint8_t> record{0};
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE(state.forced_log_probability == 0.0);
+    REQUIRE(state.meas_record[0] == 0);
+}
+
+TEST_CASE("execute: dispatches OP_MEAS_DORMANT_STATIC_FORCED for mismatched outcome") {
+    auto mod = make_module(
+        {
+            make_meas(Opcode::OP_MEAS_DORMANT_STATIC_FORCED, 0, 0, false),
+        },
+        /*peak_rank=*/2, /*num_meas=*/1);
+    SchrodingerState state(2, 1);
+    std::vector<uint8_t> record{1};  // p_x[0]=0 -> deterministic 0; record says 1.
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == false);
+}
+
+TEST_CASE("execute: dispatches OP_MEAS_DORMANT_STATIC_FORCED with FLAG_IDENTITY") {
+    // FLAG_IDENTITY measurements skip p_x and produce a deterministic outcome
+    // equal to the SIGN bit. Forcing a matching outcome is reachable;
+    // forcing the opposite is unreachable.
+    auto identity_meas = make_meas(Opcode::OP_MEAS_DORMANT_STATIC_FORCED, 0, 0, /*sign=*/true);
+    identity_meas.flags |= Instruction::FLAG_IDENTITY;
+
+    {
+        auto mod = make_module({identity_meas}, /*peak_rank=*/2, /*num_meas=*/1);
+        SchrodingerState state(2, 1);
+        std::vector<uint8_t> record{1};  // FLAG_IDENTITY + SIGN -> expected outcome 1.
+        install_forced_record(state, record);
+        execute(mod, state);
+        REQUIRE(state.forced_reachable == true);
+        REQUIRE(state.forced_log_probability == 0.0);
+        REQUIRE(state.meas_record[0] == 1);
+    }
+    {
+        auto mod = make_module({identity_meas}, /*peak_rank=*/2, /*num_meas=*/1);
+        SchrodingerState state(2, 1);
+        std::vector<uint8_t> record{0};  // mismatched.
+        install_forced_record(state, record);
+        execute(mod, state);
+        REQUIRE(state.forced_reachable == false);
+    }
+}
+
+TEST_CASE("execute: dispatches OP_MEAS_DORMANT_RANDOM_FORCED for either outcome") {
+    for (uint8_t forced : {uint8_t{0}, uint8_t{1}}) {
+        auto mod = make_module({make_meas(Opcode::OP_MEAS_DORMANT_RANDOM_FORCED, 0, 0, false)},
+                               /*peak_rank=*/2, /*num_meas=*/1);
+        SchrodingerState state(2, 1);
+        std::vector<uint8_t> record{forced};
+        install_forced_record(state, record);
+
+        execute(mod, state);
+
+        REQUIRE(state.forced_reachable == true);
+        REQUIRE_THAT(state.forced_log_probability, WithinAbs(std::log(0.5), 1e-15));
+        REQUIRE(state.meas_record[0] == forced);
+    }
+}
+
+TEST_CASE("execute: dispatches OP_MEAS_ACTIVE_DIAGONAL_FORCED") {
+    // EXPAND lifts k=0 -> k=1 with the active state in |+>. ARRAY_H then
+    // takes |+> -> |0>, so the diagonal (Z-basis) measurement is
+    // deterministic and the forced outcome 0 contributes log(1) = 0.
+    auto mod = make_module(
+        {
+            make_expand(0),
+            make_array_h(0),
+            make_meas(Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED, 0, 0, false),
+        },
+        /*peak_rank=*/1, /*num_meas=*/1);
+    SchrodingerState state(1, 1);
+    std::vector<uint8_t> record{0};
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+    REQUIRE(state.active_k == 0);
+    REQUIRE(state.meas_record[0] == 0);
+}
+
+TEST_CASE("execute: dispatches OP_MEAS_ACTIVE_INTERFERE_FORCED") {
+    // Start in |+>_active by going through EXPAND + virtual frame to put
+    // the active qubit in the |+> eigenstate of X. The simplest setup: do
+    // EXPAND, manually set v[] to |+>, then measure on X.
+    auto mod = make_module(
+        {
+            make_expand(0),
+            make_meas(Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED, 0, 0, false),
+        },
+        /*peak_rank=*/1, /*num_meas=*/1);
+    SchrodingerState state(1, 1);
+    // EXPAND on rank-0 state yields |+>_active (v[0]=v[1]=1/sqrt(2)).
+    std::vector<uint8_t> record{0};  // m_phys = 0 == plus branch.
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+    REQUIRE(state.active_k == 0);
+}
+
+TEST_CASE("execute: dispatches OP_SWAP_MEAS_INTERFERE_FORCED") {
+    // Same idea as above; just exercise the swap-fused opcode with f==t so
+    // the kernel forwards to active_interfere internally.
+    auto mod = make_module(
+        {
+            make_expand(0),
+            make_swap_meas_interfere(/*swap_from=*/0, /*swap_to=*/0, /*classical_idx=*/0,
+                                     /*sign=*/false),
+        },
+        /*peak_rank=*/1, /*num_meas=*/1);
+    // Patch the opcode to its FORCED variant (the make_ helper sets the
+    // sampling opcode; the dispatcher only sees what's in the bytecode).
+    mod.bytecode[1].opcode = Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;
+
+    SchrodingerState state(1, 1);
+    std::vector<uint8_t> record{0};
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(0.0, 1e-15));
+    REQUIRE(state.active_k == 0);
+}
+
+TEST_CASE("execute: unreachable forced record short-circuits the remaining bytecode") {
+    // Two measurements. Force the first to an outcome it can't satisfy
+    // (p_x[0]=0 deterministic 0, record says 1). The dispatcher must
+    // return immediately, leaving the second measurement's slot untouched.
+    auto mod = make_module(
+        {
+            make_meas(Opcode::OP_MEAS_DORMANT_STATIC_FORCED, 0, 0, false),
+            make_meas(Opcode::OP_MEAS_DORMANT_STATIC_FORCED, 1, 1, false),
+        },
+        /*peak_rank=*/2, /*num_meas=*/2);
+
+    SchrodingerState state(2, 2);
+    state.meas_record[1] = 99;          // sentinel
+    std::vector<uint8_t> record{1, 0};  // first record entry is unsatisfiable
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == false);
+    // Second measurement's slot must not have been written (sentinel preserved).
+    REQUIRE(state.meas_record[1] == 99);
+}
+
+TEST_CASE("execute: forced log-probabilities accumulate across multiple measurements") {
+    // Two random-dormant measurements. Each contributes log(1/2), so the
+    // running total should be 2*log(1/2) = log(1/4).
+    auto mod = make_module(
+        {
+            make_meas(Opcode::OP_MEAS_DORMANT_RANDOM_FORCED, 0, 0, false),
+            make_meas(Opcode::OP_MEAS_DORMANT_RANDOM_FORCED, 1, 1, false),
+        },
+        /*peak_rank=*/2, /*num_meas=*/2);
+
+    SchrodingerState state(2, 2);
+    std::vector<uint8_t> record{0, 1};
+    install_forced_record(state, record);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == true);
+    REQUIRE_THAT(state.forced_log_probability, WithinAbs(std::log(0.25), 1e-15));
+    REQUIRE(state.meas_record[0] == 0);
+    REQUIRE(state.meas_record[1] == 1);
+}
+
+TEST_CASE("execute: sampling-mode measurement opcodes are not disturbed by step 5") {
+    // Regression check that wiring forced opcodes in did not touch the
+    // sampling dispatch. Sampling a dormant_static still works.
+    auto mod = make_module({make_meas(Opcode::OP_MEAS_DORMANT_STATIC, 0, 0, /*sign=*/false)},
+                           /*peak_rank=*/2, /*num_meas=*/1);
+    SchrodingerState state(2, 1);
+
+    execute(mod, state);
+
+    REQUIRE(state.forced_reachable == true);  // unchanged from default
+    REQUIRE(state.forced_log_probability == 0.0);
+    // Deterministic outcome from p_x[0] = 0.
+    REQUIRE(state.meas_record[0] == 0);
+}


### PR DESCRIPTION
## Summary

Replaces the trap labels added in step 2 with real handlers in the SVM dispatcher. Each of the five forced opcodes now calls its corresponding kernel from \`svm_forced_kernels.h\` and returns early from \`execute()\` when the kernel reports the record is unreachable.

Special-cased: \`OP_MEAS_DORMANT_STATIC_FORCED\` with \`FLAG_IDENTITY\` skips the kernel (the deterministic outcome is just the SIGN bit, matching the sampling path's shortcut).

Both the computed-goto dispatcher and the switch-fallback (MSVC / non-GNU) are updated. The sampling path's labels and switch cases are unchanged.

### Dispatcher behavior

| Forced opcode | Kernel called | On \`false\` (unreachable) |
|---|---|---|
| \`OP_MEAS_DORMANT_STATIC_FORCED\` | \`exec_meas_dormant_static_forced\` (or FLAG_IDENTITY inline) | \`return\` from execute() |
| \`OP_MEAS_DORMANT_RANDOM_FORCED\` | \`exec_meas_dormant_random_forced\` | \`return\` from execute() |
| \`OP_MEAS_ACTIVE_DIAGONAL_FORCED\` | \`exec_meas_active_diagonal_forced\` | \`return\` from execute() |
| \`OP_MEAS_ACTIVE_INTERFERE_FORCED\` | \`exec_meas_active_interfere_forced\` | \`return\` from execute() |
| \`OP_SWAP_MEAS_INTERFERE_FORCED\` | \`exec_swap_meas_interfere_forced\` | \`return\` from execute() |

### Tests

Ten new tests in \`tests/test_execute_forced.cc\`:
- Each forced opcode dispatched through \`execute()\` produces the expected state.
- \`FLAG_IDENTITY\` shortcut for dormant_static, both matching and mismatched.
- Log-probability accumulator threads correctly across two measurements (asserting \`log(1/2) + log(1/2) = log(1/4)\`).
- Unreachable forced record short-circuits remaining bytecode (subsequent measurement slot untouched).
- Regression: sampling-mode \`OP_MEAS_DORMANT_STATIC\` still works.

## Test plan

- [x] \`ctest --test-dir build -E Bench\` — 743/743 pass.
- [x] \`uv run pytest tests/python/\` — 635/635 pass.
- [x] Pre-commit clean.