### PR TITLE
feat: add probability_of C++ entry point

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(clifft_core STATIC
     optimizer/statevector_squeeze_pass.cc
     backend/backend.cc
     api/probabilities.cc
+    api/probability_of.cc
     api/reference_syndrome.cc
     svm/svm.cc
     svm/svm_forced_kernels.cc

--- a/src/clifft/api/probability_of.cc
+++ b/src/clifft/api/probability_of.cc
@@ -1,0 +1,190 @@
+// Exact measurement-record probability queries.
+//
+// probability_of() runs the compiled program once per requested record,
+// forcing each measurement to the user-supplied outcome and accumulating
+// log(prob_b / total) into state.forced_log_probability under the same
+// dust-clamping policy sample_branch() uses. A bytecode rewrite swaps
+// each OP_MEAS_* opcode for its OP_MEAS_*_FORCED sibling; the rewrite
+// runs on a private shallow copy so the user's CompiledModule is
+// untouched.
+//
+// See svm_forced_kernels.h for the forced-kernel contract and
+// svm_kernels.inl for the dispatcher wiring.
+
+#include "clifft/svm/svm.h"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace clifft {
+namespace {
+
+[[nodiscard]] bool is_unsupported_probability_of_opcode(Opcode opcode) {
+    // Allowed: all gate / expand / array opcodes, EXP_VAL probes, feedback
+    // (OP_APPLY_PAULI), and any sampling-mode measurement opcode (rewritten
+    // to its FORCED sibling before execution). Forced opcodes shouldn't
+    // appear in user-compiled programs; reject defensively so the rewrite
+    // is the only path that produces them.
+    switch (opcode) {
+        case Opcode::OP_FRAME_CNOT:
+        case Opcode::OP_FRAME_CZ:
+        case Opcode::OP_FRAME_H:
+        case Opcode::OP_FRAME_S:
+        case Opcode::OP_FRAME_S_DAG:
+        case Opcode::OP_FRAME_SWAP:
+        case Opcode::OP_ARRAY_CNOT:
+        case Opcode::OP_ARRAY_CZ:
+        case Opcode::OP_ARRAY_SWAP:
+        case Opcode::OP_ARRAY_MULTI_CNOT:
+        case Opcode::OP_ARRAY_MULTI_CZ:
+        case Opcode::OP_ARRAY_H:
+        case Opcode::OP_ARRAY_S:
+        case Opcode::OP_ARRAY_S_DAG:
+        case Opcode::OP_ARRAY_T:
+        case Opcode::OP_ARRAY_T_DAG:
+        case Opcode::OP_ARRAY_ROT:
+        case Opcode::OP_ARRAY_U2:
+        case Opcode::OP_ARRAY_U4:
+        case Opcode::OP_EXPAND:
+        case Opcode::OP_EXPAND_T:
+        case Opcode::OP_EXPAND_T_DAG:
+        case Opcode::OP_EXPAND_ROT:
+        case Opcode::OP_EXP_VAL:
+        case Opcode::OP_APPLY_PAULI:
+        case Opcode::OP_MEAS_DORMANT_STATIC:
+        case Opcode::OP_MEAS_DORMANT_RANDOM:
+        case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
+        case Opcode::OP_MEAS_ACTIVE_INTERFERE:
+        case Opcode::OP_SWAP_MEAS_INTERFERE:
+            return false;
+
+        case Opcode::OP_MEAS_DORMANT_STATIC_FORCED:
+        case Opcode::OP_MEAS_DORMANT_RANDOM_FORCED:
+        case Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED:
+        case Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED:
+        case Opcode::OP_SWAP_MEAS_INTERFERE_FORCED:
+        case Opcode::OP_NOISE:
+        case Opcode::OP_NOISE_BLOCK:
+        case Opcode::OP_READOUT_NOISE:
+        case Opcode::OP_DETECTOR:
+        case Opcode::OP_POSTSELECT:
+        case Opcode::OP_OBSERVABLE:
+        case Opcode::NUM_OPCODES:
+            return true;
+    }
+    throw std::invalid_argument("probability_of() encountered an unknown bytecode opcode");
+}
+
+void assert_probability_of_program_is_supported(const CompiledModule& program) {
+    for (const auto& instr : program.bytecode) {
+        if (is_unsupported_probability_of_opcode(instr.opcode)) {
+            throw std::invalid_argument(
+                "probability_of() requires pure-state evolution with measurements: noise, "
+                "feedback-free detectors, observables, and post-selection are not supported. "
+                "Forced-measurement opcodes are reserved for the internal rewrite and must not "
+                "appear in user-compiled programs.");
+        }
+    }
+}
+
+// Replace each sampling-mode measurement opcode with its FORCED sibling.
+// The bytecode otherwise stays identical; classical_idx, axes, sign flag,
+// and FLAG_IDENTITY are preserved.
+void rewrite_for_forced_execution(std::vector<Instruction>& bytecode) {
+    for (auto& instr : bytecode) {
+        switch (instr.opcode) {
+            case Opcode::OP_MEAS_DORMANT_STATIC:
+                instr.opcode = Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
+                break;
+            case Opcode::OP_MEAS_DORMANT_RANDOM:
+                instr.opcode = Opcode::OP_MEAS_DORMANT_RANDOM_FORCED;
+                break;
+            case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
+                instr.opcode = Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED;
+                break;
+            case Opcode::OP_MEAS_ACTIVE_INTERFERE:
+                instr.opcode = Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED;
+                break;
+            case Opcode::OP_SWAP_MEAS_INTERFERE:
+                instr.opcode = Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+}  // namespace
+
+std::vector<double> probability_of(const CompiledModule& program, std::span<const uint8_t> records,
+                                   size_t num_records) {
+    assert_probability_of_program_is_supported(program);
+    if (program.num_measurements == 0) {
+        throw std::invalid_argument(
+            "probability_of() requires a program with at least one measurement; use "
+            "clifft::probabilities() for unitary circuits.");
+    }
+    // Hidden measurement slots (e.g. from R / reset gates lowered to
+    // measure + classical-feedback Pauli) would be indexed past the
+    // user-visible portion of the forced record. Supporting them would
+    // require marginalizing over the hidden outcomes; out of scope for
+    // now, so reject programs that have any.
+    if (program.total_meas_slots != program.num_measurements) {
+        throw std::invalid_argument(
+            "probability_of() does not yet support programs with hidden measurement slots "
+            "(e.g. R / reset gates). Compile without resets, or use sample() to marginalize.");
+    }
+    if (records.size() != num_records * program.num_measurements) {
+        throw std::invalid_argument(
+            "probability_of() record buffer length must equal "
+            "num_records * program.num_measurements");
+    }
+    // Each record byte represents one measurement outcome and must be 0 or 1.
+    // The forced kernels would otherwise XOR the byte into the abstract
+    // branch index and produce garbage probabilities for out-of-range values.
+    for (uint8_t byte : records) {
+        if (byte != 0 && byte != 1) {
+            throw std::invalid_argument(
+                "probability_of() record bytes must be 0 or 1; each represents one "
+                "measurement outcome.");
+        }
+    }
+
+    // Private shallow copy of the program. Only the bytecode vector is
+    // rewritten; the constant pool and metadata are shared by value-copy
+    // of POD members. The user's CompiledModule is unmodified.
+    CompiledModule patched = program;
+    rewrite_for_forced_execution(patched.bytecode);
+
+    SchrodingerState state({.peak_rank = patched.peak_rank,
+                            .num_measurements = patched.total_meas_slots,
+                            .num_qubits = patched.num_qubits,
+                            .num_detectors = patched.num_detectors,
+                            .num_observables = patched.num_observables,
+                            .num_exp_vals = patched.num_exp_vals,
+                            .seed = uint64_t{0}});
+
+    const size_t record_stride = program.num_measurements;
+    std::vector<double> log_probs;
+    log_probs.reserve(num_records);
+
+    for (size_t i = 0; i < num_records; ++i) {
+        state.reset();
+        state.forced_record = records.subspan(i * record_stride, record_stride);
+        // reset() restored forced_log_probability and forced_reachable to
+        // their defaults; no need to clear them again.
+        execute(patched, state);
+        if (state.forced_reachable) {
+            log_probs.push_back(state.forced_log_probability);
+        } else {
+            log_probs.push_back(-std::numeric_limits<double>::infinity());
+        }
+    }
+    return log_probs;
+}
+
+}  // namespace clifft

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -367,6 +367,20 @@ std::vector<double> probabilities(const CompiledModule& program,
                                   std::span<const uint64_t> basis_masks, size_t num_basis_masks,
                                   size_t words_per_basis_mask);
 
+/// Return exact log-probabilities for a batch of measurement records under
+/// the compiled program. Computes the probability that sample() would emit
+/// each record, modulo dust-clamping. The program must contain at least one
+/// measurement and may include any unitary gate, EXP_VAL probe, or
+/// classical feedback (OP_APPLY_PAULI); noise, detectors, observables, and
+/// post-selection are rejected.
+///
+/// `records` is a packed buffer of `num_records * program.num_measurements`
+/// bytes (0 or 1 per slot, in execution order -- the same order
+/// sample().measurements uses). Records the program cannot emit return
+/// `-infinity`; finite values are natural-log probabilities.
+std::vector<double> probability_of(const CompiledModule& program, std::span<const uint8_t> records,
+                                   size_t num_records);
+
 // =============================================================================
 // Statevector Expansion
 // =============================================================================

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/backend/backend.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/probabilities.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/probability_of.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_forced_kernels.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_scalar.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(clifft_tests
     test_importance_sampling.cc
     test_introspection.cc
     test_probabilities.cc
+    test_probability_of.cc
     test_exp_value.cc
     test_openmp.cc
     test_fuzz.cc

--- a/tests/test_probability_of.cc
+++ b/tests/test_probability_of.cc
@@ -1,0 +1,331 @@
+// Tests for the C++ probability_of() entry point.
+//
+// probability_of() computes exact log-probabilities for a batch of
+// measurement records against a compiled circuit. It mirrors what
+// sample() would emit, modulo dust-clamping, via a bytecode rewrite that
+// turns OP_MEAS_* into their OP_MEAS_*_FORCED siblings and replays each
+// record through execute().
+//
+// These tests cover the entry-point contract: pre-flight validation,
+// correct handling of the rewrite + per-record loop, unreachable
+// records, EXP_VAL pass-through, and that the input CompiledModule is
+// not mutated. Deeper algorithmic correctness is covered by the
+// per-kernel and dispatcher tests in earlier steps, and Python-level
+// equivalence with probabilities() is covered separately.
+
+#include "clifft/backend/backend.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/svm/svm.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+CompiledModule compile_circuit(const std::string& text) {
+    auto circuit = clifft::parse(text);
+    auto hir = clifft::trace(circuit);
+    return clifft::lower(hir);
+}
+
+}  // namespace
+
+// =============================================================================
+// Basic correctness: small circuits with known closed-form probabilities.
+// =============================================================================
+
+TEST_CASE("probability_of: Bell state probabilities") {
+    auto mod = compile_circuit("H 0\nCX 0 1\nM 0 1");
+    REQUIRE(mod.num_measurements == 2);
+
+    // Records "00", "01", "10", "11" in measurement-record order.
+    std::vector<uint8_t> records{0, 0, 0, 1, 1, 0, 1, 1};
+    auto log_probs = probability_of(mod, records, /*num_records=*/4);
+    REQUIRE(log_probs.size() == 4);
+
+    // Bell state: only 00 and 11 are emitted, each with probability 0.5.
+    CHECK_THAT(std::exp(log_probs[0]), WithinAbs(0.5, 1e-12));
+    REQUIRE(std::isinf(log_probs[1]));
+    REQUIRE(log_probs[1] < 0);  // -inf for unreachable
+    REQUIRE(std::isinf(log_probs[2]));
+    REQUIRE(log_probs[2] < 0);
+    CHECK_THAT(std::exp(log_probs[3]), WithinAbs(0.5, 1e-12));
+}
+
+TEST_CASE("probability_of: |+> single-qubit measurements are 1/2 each") {
+    auto mod = compile_circuit("H 0\nM 0");
+    REQUIRE(mod.num_measurements == 1);
+
+    std::vector<uint8_t> records{0, 1};
+    auto log_probs = probability_of(mod, records, /*num_records=*/2);
+    REQUIRE(log_probs.size() == 2);
+    CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
+    CHECK_THAT(log_probs[1], WithinAbs(std::log(0.5), 1e-12));
+}
+
+TEST_CASE("probability_of: |0> deterministic measurement") {
+    auto mod = compile_circuit("M 0");
+    REQUIRE(mod.num_measurements == 1);
+
+    std::vector<uint8_t> records{0, 1};
+    auto log_probs = probability_of(mod, records, /*num_records=*/2);
+    REQUIRE(log_probs.size() == 2);
+    CHECK_THAT(log_probs[0], WithinAbs(0.0, 1e-12));  // log(1)
+    REQUIRE(std::isinf(log_probs[1]));
+    REQUIRE(log_probs[1] < 0);
+}
+
+// =============================================================================
+// Feedback (OP_APPLY_PAULI) is supported.
+// =============================================================================
+
+TEST_CASE("probability_of: feedback circuit produces joint trajectory probability") {
+    // Measure qubit 0 (random 0/1), apply X to qubit 1 conditional on the
+    // outcome, then measure qubit 1. Joint probability of (m0, m1):
+    //   (0, ?): qubit 1 stayed in |0>, so m1=0 deterministically.
+    //   (1, ?): qubit 1 was flipped to |1>, so m1=1 deterministically.
+    // So records (0,0) and (1,1) each have probability 1/2; (0,1) and (1,0)
+    // are unreachable.
+    auto mod = compile_circuit(
+        "H 0\n"
+        "M 0\n"
+        "CX rec[-1] 1\n"
+        "M 1\n");
+    REQUIRE(mod.num_measurements == 2);
+
+    std::vector<uint8_t> records{0, 0, 0, 1, 1, 0, 1, 1};
+    auto log_probs = probability_of(mod, records, /*num_records=*/4);
+    REQUIRE(log_probs.size() == 4);
+
+    CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
+    REQUIRE(std::isinf(log_probs[1]));
+    REQUIRE(log_probs[1] < 0);
+    REQUIRE(std::isinf(log_probs[2]));
+    REQUIRE(log_probs[2] < 0);
+    CHECK_THAT(log_probs[3], WithinAbs(std::log(0.5), 1e-12));
+}
+
+// =============================================================================
+// Pre-flight validation.
+// =============================================================================
+
+TEST_CASE("probability_of: rejects zero-measurement programs") {
+    auto mod = compile_circuit("H 0\nT 0");
+    REQUIRE(mod.num_measurements == 0);
+
+    std::vector<uint8_t> records{};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/0), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects noise opcodes") {
+    auto mod = compile_circuit("X_ERROR(0.1) 0\nM 0");
+    std::vector<uint8_t> records{0};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects detector opcodes") {
+    auto mod = compile_circuit("M 0\nDETECTOR rec[-1]");
+    std::vector<uint8_t> records{0};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects observable opcodes") {
+    auto mod = compile_circuit("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]");
+    std::vector<uint8_t> records{0};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects record buffer with inconsistent length") {
+    auto mod = compile_circuit("M 0 1");
+    REQUIRE(mod.num_measurements == 2);
+
+    std::vector<uint8_t> records{0, 0, 1};  // 3 bytes is not a multiple of 2.
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/2), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects programs with hidden measurement slots") {
+    // R q lowers to a hidden measurement + conditional Pauli. The forced
+    // execution path doesn't currently marginalize over hidden outcomes,
+    // so any program with hidden slots is rejected up front.
+    auto mod = compile_circuit("M 0\nR 1\nM 1");
+    REQUIRE(mod.num_measurements == 2);
+    REQUIRE(mod.total_meas_slots > mod.num_measurements);
+
+    std::vector<uint8_t> records{0, 0, 1, 1};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/2), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects non-bit record bytes") {
+    auto mod = compile_circuit("H 0\nM 0");
+    REQUIRE(mod.num_measurements == 1);
+
+    std::vector<uint8_t> records{0, 1, 2};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/3), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects postselection opcodes") {
+    auto mod = clifft::lower(clifft::trace(clifft::parse("M 0\nDETECTOR rec[-1]")),
+                             /*postselection_mask=*/std::array<uint8_t, 1>{1});
+
+    std::vector<uint8_t> records{0};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+}
+
+TEST_CASE("probability_of: rejects hand-built bytecode containing forced opcodes") {
+    // The validator must reject user-supplied forced opcodes so the
+    // rewrite step in probability_of() is the only source of them.
+    auto mod = compile_circuit("M 0");
+    // Hand-patch the user-visible bytecode to its FORCED variant.
+    mod.bytecode[0].opcode = Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
+
+    std::vector<uint8_t> records{0};
+    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+}
+
+// =============================================================================
+// EXP_VAL is allowed (probes are ignored).
+// =============================================================================
+
+TEST_CASE("probability_of: tolerates EXP_VAL probes") {
+    auto mod = compile_circuit("H 0\nEXP_VAL X0\nM 0");
+    std::vector<uint8_t> records{0, 1};
+    auto log_probs = probability_of(mod, records, /*num_records=*/2);
+    REQUIRE(log_probs.size() == 2);
+    CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
+    CHECK_THAT(log_probs[1], WithinAbs(std::log(0.5), 1e-12));
+}
+
+// =============================================================================
+// Edge cases.
+// =============================================================================
+
+TEST_CASE("probability_of: empty record batch returns empty vector") {
+    auto mod = compile_circuit("H 0\nM 0");
+    std::vector<uint8_t> records{};
+    auto log_probs = probability_of(mod, records, /*num_records=*/0);
+    REQUIRE(log_probs.empty());
+}
+
+TEST_CASE("probability_of: does not mutate the input CompiledModule") {
+    auto mod = compile_circuit("H 0\nM 0");
+    REQUIRE(mod.bytecode.size() > 0);
+
+    // Byte-level snapshot of the full bytecode. The rewrite touches
+    // opcode bytes, but any field shifting would be caught here too.
+    std::vector<std::array<uint8_t, sizeof(Instruction)>> snapshot;
+    snapshot.reserve(mod.bytecode.size());
+    for (const auto& instr : mod.bytecode) {
+        std::array<uint8_t, sizeof(Instruction)> bytes{};
+        std::memcpy(bytes.data(), &instr, sizeof(Instruction));
+        snapshot.push_back(bytes);
+    }
+
+    std::vector<uint8_t> records{0, 1};
+    (void)probability_of(mod, records, /*num_records=*/2);
+
+    REQUIRE(mod.bytecode.size() == snapshot.size());
+    for (size_t i = 0; i < mod.bytecode.size(); ++i) {
+        std::array<uint8_t, sizeof(Instruction)> after_bytes{};
+        std::memcpy(after_bytes.data(), &mod.bytecode[i], sizeof(Instruction));
+        REQUIRE(after_bytes == snapshot[i]);
+    }
+}
+
+// =============================================================================
+// Cross-check against probabilities() on terminal-M-all circuits.
+// =============================================================================
+//
+// For a unitary circuit followed by M on every qubit, probability_of()
+// computes the same value probabilities() does (the latter via the
+// stabilizer-amplitude path on the unitary-stripped program). This is
+// the load-bearing equivalence: any drift between the two paths shows
+// up here.
+
+TEST_CASE("probability_of: matches probabilities() on a Clifford circuit") {
+    auto unitary = compile_circuit("H 0\nCX 0 1");
+    auto measured = compile_circuit("H 0\nCX 0 1\nM 0 1");
+    REQUIRE(measured.num_measurements == 2);
+
+    // probabilities() takes word-packed bitmasks. For 2 qubits, each mask
+    // fits in one 64-bit word; bit i = qubit i.
+    std::vector<uint64_t> masks{0b00, 0b01, 0b10, 0b11};
+    auto probs = probabilities(unitary, masks, /*num_basis_masks=*/4,
+                               /*words_per_basis_mask=*/1);
+
+    // probability_of() takes byte-packed records in measurement order.
+    // M 0 1 records qubit 0 first, qubit 1 second, so record byte 0
+    // corresponds to mask bit 0.
+    std::vector<uint8_t> records{0, 0, 1, 0, 0, 1, 1, 1};
+    auto log_probs = probability_of(measured, records, /*num_records=*/4);
+
+    REQUIRE(probs.size() == 4);
+    REQUIRE(log_probs.size() == 4);
+    for (size_t i = 0; i < 4; ++i) {
+        if (std::isfinite(log_probs[i])) {
+            CHECK_THAT(std::exp(log_probs[i]), WithinAbs(probs[i], 1e-12));
+        } else {
+            CHECK_THAT(probs[i], WithinAbs(0.0, 1e-12));
+        }
+    }
+}
+
+TEST_CASE("probability_of: matches probabilities() on a Clifford+T circuit (active kernel)") {
+    // H T H on |0> takes the qubit through a non-Clifford rotation that
+    // forces the SVM to keep the qubit active at measurement time. The
+    // resulting measurement opcode hits the active forced kernels via
+    // the dispatcher, which the smaller closed-form tests above don't
+    // exercise through the full compile pipeline.
+    auto unitary = compile_circuit("H 0\nT 0\nH 0");
+    auto measured = compile_circuit("H 0\nT 0\nH 0\nM 0");
+    REQUIRE(measured.num_measurements == 1);
+    REQUIRE(measured.peak_rank > 0);  // T gate forces a non-zero active rank.
+
+    std::vector<uint64_t> masks{0, 1};
+    auto probs = probabilities(unitary, masks, /*num_basis_masks=*/2,
+                               /*words_per_basis_mask=*/1);
+
+    std::vector<uint8_t> records{0, 1};
+    auto log_probs = probability_of(measured, records, /*num_records=*/2);
+
+    REQUIRE(probs.size() == 2);
+    REQUIRE(log_probs.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        REQUIRE(std::isfinite(log_probs[i]));
+        CHECK_THAT(std::exp(log_probs[i]), WithinAbs(probs[i], 1e-12));
+    }
+
+    // Sanity: analytic outcome probabilities are (2 +/- sqrt(2)) / 4.
+    const double sqrt2 = std::sqrt(2.0);
+    CHECK_THAT(probs[0], WithinAbs((2.0 + sqrt2) / 4.0, 1e-12));
+    CHECK_THAT(probs[1], WithinAbs((2.0 - sqrt2) / 4.0, 1e-12));
+}
+
+TEST_CASE("probability_of: multi-record probabilities sum to 1 for a small circuit") {
+    // Unitarity check: enumerate all 2^n measurement records for a circuit
+    // ending in M-all and confirm probabilities sum to 1.
+    auto mod = compile_circuit("H 0\nCX 0 1\nH 1\nM 0 1");
+    REQUIRE(mod.num_measurements == 2);
+
+    std::vector<uint8_t> records{0, 0, 0, 1, 1, 0, 1, 1};
+    auto log_probs = probability_of(mod, records, /*num_records=*/4);
+
+    double total = 0.0;
+    for (double lp : log_probs) {
+        if (std::isfinite(lp)) {
+            total += std::exp(lp);
+        }
+    }
+    CHECK_THAT(total, WithinAbs(1.0, 1e-12));
+}


### PR DESCRIPTION
## Summary

Adds \`clifft::probability_of(program, records, num_records)\` — a strong-simulation API that returns the exact log-probability \`sample()\` would assign to each of N measurement records.

### Implementation

Per record: a private shallow copy of the \`CompiledModule\` has its \`OP_MEAS_*\` opcodes rewritten to their \`OP_MEAS_*_FORCED\` siblings; \`execute()\` then runs the patched bytecode with \`state.forced_record\` pointed at that record's bytes, and the harvested \`state.forced_log_probability\` is appended to the result. The user's \`CompiledModule\` is byte-identical after the call.

### Contract

| Input | Behavior |
|---|---|
| Unitary circuit (no \`M\`) | Rejected with \`std::invalid_argument\`; recommend \`probabilities()\` |
| Noise / detectors / observables / postselection | Rejected with \`std::invalid_argument\` |
| EXP_VAL probes | Allowed; outputs ignored |
| Feedback (\`OP_APPLY_PAULI\`) | Allowed; returns joint trajectory probability |
| \`records.size() != num_records * num_measurements\` | Rejected |
| Record unreachable | Result is \`-infinity\` |

### Tests

13 directed C++ tests covering:
- Closed-form correctness: Bell state, \`H 0; M 0\`, deterministic \`M 0\`, feedback (\`H 0; M 0; CX rec[-1] 1; M 1\`).
- Pre-flight: zero-measurement, noise, detectors, observables, inconsistent buffer length.
- Edge cases: empty batch, EXP_VAL tolerance, unitarity (probabilities sum to 1).
- Non-mutation: input bytecode opcode sequence is identical pre- and post-call.

Python-level cross-equivalence with \`probabilities()\` lands in the next PR (step 7).

## Test plan

- [x] \`ctest --test-dir build -E Bench\` — 756/756 pass.
- [x] \`uv run pytest tests/python/\` — 635/635 pass.
- [x] Pre-commit clean.