### PR TITLE
feat: add probability_of Python API and measurement_qubits accessor

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -29,6 +29,17 @@ add_library(clifft_core STATIC
     util/introspection.cc
 )
 
+# probability_of() uses -inf as an in-band sentinel for unreachable records
+# and surfaces it through the Python API. The Release-only -ffast-math (set
+# in the top-level CMakeLists.txt) implies -ffinite-math-only, which lets
+# the compiler assume infinities never occur and folds away the sentinel.
+# Undo fast-math for just this TU to preserve the contract.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set_source_files_properties(api/probability_of.cc
+        PROPERTIES COMPILE_OPTIONS "-fno-fast-math"
+    )
+endif()
+
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)") AND NOT MSVC)
     target_sources(clifft_core PRIVATE svm/svm_avx2.cc svm/svm_avx512.cc)

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -864,6 +864,7 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
     result.peak_rank = peak;
     result.num_measurements = hir.num_measurements;
     result.total_meas_slots = total_meas_slots;
+    result.measurement_qubits = hir.measurement_qubits;
     result.num_detectors = hir.num_detectors;
     result.num_observables = hir.num_observables;
     result.num_exp_vals = hir.num_exp_vals;

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -336,6 +336,10 @@ struct CompiledModule {
     /// Per visible measurement record slot, the qubit that was measured.
     /// Indexed by classical_idx for indices in [0, num_measurements). Lets
     /// callers map a measurement record entry back to a physical qubit.
+    ///
+    /// Slots for measurements that do not target a single qubit -- MPP
+    /// (joint Pauli) and MPAD (deterministic padding) -- are set to
+    /// `HirModule::kNoSingleMeasurementQubit` (UINT32_MAX).
     std::vector<uint32_t> measurement_qubits;
 
     // Expected noiseless observable parities for syndrome normalization.

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -333,6 +333,11 @@ struct CompiledModule {
     uint32_t num_exp_vals = 0;       // Total expectation value probes
     bool has_postselection = false;  // True if any detector uses OP_POSTSELECT
 
+    /// Per visible measurement record slot, the qubit that was measured.
+    /// Indexed by classical_idx for indices in [0, num_measurements). Lets
+    /// callers map a measurement record entry back to a physical qubit.
+    std::vector<uint32_t> measurement_qubits;
+
     // Expected noiseless observable parities for syndrome normalization.
     // When non-empty, sample()/sample_survivors() XOR obs_record[i] with
     // expected_observables[i] before writing output.

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -367,8 +367,7 @@ HirModule trace(const Circuit& circuit) {
     // represented; their record slots are not user-visible. Slots default
     // to kNoSingleMeasurementQubit; MPP and MPAD leave the sentinel since
     // they do not target a single qubit.
-    hir.measurement_qubits.assign(circuit.num_measurements,
-                                  HirModule::kNoSingleMeasurementQubit);
+    hir.measurement_qubits.assign(circuit.num_measurements, HirModule::kNoSingleMeasurementQubit);
 
     std::mt19937_64 rng(0);
     stim::TableauSimulator<kStimWidth> sim(std::move(rng), circuit.num_qubits);

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -362,6 +362,10 @@ HirModule trace(const Circuit& circuit) {
     hir.num_detectors = circuit.num_detectors;
     hir.num_observables = circuit.num_observables;
     hir.num_exp_vals = circuit.num_exp_vals;
+    // Per-slot qubit assignment for visible measurements, filled in as each
+    // M target is traced. Hidden measurements (from R / reset) are not
+    // represented; their record slots are not user-visible.
+    hir.measurement_qubits.assign(circuit.num_measurements, 0);
 
     std::mt19937_64 rng(0);
     stim::TableauSimulator<kStimWidth> sim(std::move(rng), circuit.num_qubits);
@@ -559,6 +563,7 @@ HirModule trace(const Circuit& circuit) {
 
             case GateType::M: {
                 for (const auto& target : node.targets) {
+                    hir.measurement_qubits[static_cast<uint32_t>(meas_idx)] = target.value();
                     hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
                         bool sign;
                         extract_rewound_z_into(sim, target.value(), slot.x(), slot.z(), sign);
@@ -571,6 +576,7 @@ HirModule trace(const Circuit& circuit) {
 
             case GateType::MX: {
                 for (const auto& target : node.targets) {
+                    hir.measurement_qubits[static_cast<uint32_t>(meas_idx)] = target.value();
                     hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
                         bool sign;
                         extract_rewound_x_into(sim, target.value(), slot.x(), slot.z(), sign);
@@ -583,6 +589,7 @@ HirModule trace(const Circuit& circuit) {
 
             case GateType::MY: {
                 for (const auto& target : node.targets) {
+                    hir.measurement_qubits[static_cast<uint32_t>(meas_idx)] = target.value();
                     hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {
                         bool sign;
                         extract_rewound_y_into(sim, target.value(), slot.x(), slot.z(), sign);
@@ -676,6 +683,7 @@ HirModule trace(const Circuit& circuit) {
                             extract_meas(qubit, slot.x(), slot.z(), sign);
                             slot.set_sign(sign);
                         });
+                        hir.measurement_qubits[this_meas] = qubit;
                         ++meas_idx;
                     }
 

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -364,8 +364,11 @@ HirModule trace(const Circuit& circuit) {
     hir.num_exp_vals = circuit.num_exp_vals;
     // Per-slot qubit assignment for visible measurements, filled in as each
     // M target is traced. Hidden measurements (from R / reset) are not
-    // represented; their record slots are not user-visible.
-    hir.measurement_qubits.assign(circuit.num_measurements, 0);
+    // represented; their record slots are not user-visible. Slots default
+    // to kNoSingleMeasurementQubit; MPP and MPAD leave the sentinel since
+    // they do not target a single qubit.
+    hir.measurement_qubits.assign(circuit.num_measurements,
+                                  HirModule::kNoSingleMeasurementQubit);
 
     std::mt19937_64 rng(0);
     stim::TableauSimulator<kStimWidth> sim(std::move(rng), circuit.num_qubits);

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -348,7 +349,17 @@ struct HirModule {
     /// Per visible measurement record slot, the qubit that was measured.
     /// Indexed by MeasRecordIdx for indices in [0, num_measurements).
     /// Hidden measurements (from R / reset gates) are not represented.
+    ///
+    /// For measurements that do not target a single qubit -- MPP (joint
+    /// Pauli) and MPAD (deterministic padding) -- the slot is set to
+    /// `kNoSingleMeasurementQubit` (UINT32_MAX). Callers that need a
+    /// single qubit index must check for this sentinel.
     std::vector<uint32_t> measurement_qubits;
+
+    /// Sentinel value in `measurement_qubits` for record slots that do
+    /// not correspond to a single-qubit measurement (MPP, MPAD).
+    static constexpr uint32_t kNoSingleMeasurementQubit =
+        std::numeric_limits<uint32_t>::max();
 
     std::complex<double> global_weight = {1.0, 0.0};
 

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -358,8 +358,7 @@ struct HirModule {
 
     /// Sentinel value in `measurement_qubits` for record slots that do
     /// not correspond to a single-qubit measurement (MPP, MPAD).
-    static constexpr uint32_t kNoSingleMeasurementQubit =
-        std::numeric_limits<uint32_t>::max();
+    static constexpr uint32_t kNoSingleMeasurementQubit = std::numeric_limits<uint32_t>::max();
 
     std::complex<double> global_weight = {1.0, 0.0};
 

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -345,6 +345,11 @@ struct HirModule {
     uint32_t num_observables = 0;
     uint32_t num_exp_vals = 0;
 
+    /// Per visible measurement record slot, the qubit that was measured.
+    /// Indexed by MeasRecordIdx for indices in [0, num_measurements).
+    /// Hidden measurements (from R / reset gates) are not represented.
+    std::vector<uint32_t> measurement_qubits;
+
     std::complex<double> global_weight = {1.0, 0.0};
 
     /// Parallel to ops: source_map[i] lists the source line(s) that

--- a/src/clifft/optimizer/drop_non_unitary_pass.cc
+++ b/src/clifft/optimizer/drop_non_unitary_pass.cc
@@ -38,6 +38,7 @@ void DropNonUnitaryPass::run(HirModule& hir) {
     hir.num_detectors = 0;
     hir.num_observables = 0;
     hir.num_exp_vals = 0;
+    hir.measurement_qubits.clear();
     hir.source_map.clear();
 }
 

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -715,6 +715,13 @@ NB_MODULE(_clifft_core, m) {
             "has_postselection",
             [](const clifft::CompiledModule& p) { return p.has_postselection; },
             "True if the program contains OP_POSTSELECT instructions.")
+        .def_prop_ro(
+            "measurement_qubits",
+            [](const clifft::CompiledModule& p) { return p.measurement_qubits; },
+            "Per visible measurement record slot, the qubit that was measured. "
+            "Indexed [0, num_measurements). Use to map a record entry back to a "
+            "physical qubit -- e.g. record_index = "
+            "list(program.measurement_qubits).index(qubit).")
         .def_prop_ro("num_instructions",
                      [](const clifft::CompiledModule& p) { return p.bytecode.size(); })
         .def_prop_ro(
@@ -1098,4 +1105,22 @@ NB_MODULE(_clifft_core, m) {
             return vec_to_numpy(std::move(probs), {n});
         },
         nb::arg("program"), nb::arg("basis_masks"), "Internal helper for clifft.probabilities().");
+
+    m.def(
+        "_probability_of_from_records",
+        [](const clifft::CompiledModule& program,
+           nb::ndarray<nb::numpy, const uint8_t, nb::shape<-1, -1>, nb::c_contig> records) {
+            std::vector<double> log_probs;
+            {
+                nb::gil_scoped_release release;
+                log_probs = clifft::probability_of(
+                    program, std::span<const uint8_t>(records.data(), records.size()),
+                    records.shape(0));
+            }
+            size_t n = log_probs.size();
+            return vec_to_numpy(std::move(log_probs), {n});
+        },
+        nb::arg("program"), nb::arg("records"),
+        "Internal helper for clifft.probability_of(). Returns log-probabilities; "
+        "the Python wrapper exponentiates to linear unless return_log=True.");
 }

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -721,7 +721,10 @@ NB_MODULE(_clifft_core, m) {
             "Per visible measurement record slot, the qubit that was measured. "
             "Indexed [0, num_measurements). Use to map a record entry back to a "
             "physical qubit -- e.g. record_index = "
-            "list(program.measurement_qubits).index(qubit).")
+            "list(program.measurement_qubits).index(qubit). "
+            "Slots for measurements that do not target a single qubit -- MPP "
+            "(joint Pauli) and MPAD (deterministic padding) -- hold UINT32_MAX "
+            "(2**32 - 1) as a sentinel.")
         .def_prop_ro("num_instructions",
                      [](const clifft::CompiledModule& p) { return p.bytecode.size(); })
         .def_prop_ro(

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -109,6 +109,11 @@ from clifft._sample_result import SampleResult
 BasisBitstrings: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
 MeasurementRecords: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
 
+#: Sentinel stored in :attr:`Program.measurement_qubits` for record slots
+#: that do not correspond to a single-qubit measurement (MPP joint Pauli,
+#: MPAD deterministic padding). Equal to ``2**32 - 1``.
+NO_SINGLE_MEASUREMENT_QUBIT: int = (1 << 32) - 1
+
 
 def _basis_masks_from_bitstrings(
     program: Program,
@@ -359,6 +364,7 @@ __all__ = [
     "Instruction",
     "DropNonUnitaryPass",
     "MultiGatePass",
+    "NO_SINGLE_MEASUREMENT_QUBIT",
     "NoiseBlockPass",
     "Opcode",
     "OpType",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -82,6 +82,7 @@ from clifft._clifft_core import (
     SwapMeasPass,
     Target,
     _probabilities_from_bitmasks,
+    _probability_of_from_records,
     compute_reference_syndrome,
     default_bytecode_pass_manager,
     default_hir_pass_manager,
@@ -106,6 +107,7 @@ from clifft._clifft_core import (
 from clifft._sample_result import SampleResult
 
 BasisBitstrings: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
+MeasurementRecords: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
 
 
 def _basis_masks_from_bitstrings(
@@ -197,6 +199,89 @@ def probabilities(
     )
 
 
+def _records_from_outcomes(
+    program: Program,
+    records: MeasurementRecords,
+) -> npt.NDArray[np.uint8]:
+    """Convert string or array measurement records into a 2D uint8 array.
+
+    The output has shape ``(num_records, program.num_measurements)`` and
+    contains only 0/1 entries. Each row is a single measurement record in
+    record-position order (matching ``sample().measurements``).
+    """
+    num_meas = program.num_measurements
+
+    def fill_string_record(out: npt.NDArray[np.uint8], record: str, row: int) -> None:
+        if len(record) != num_meas:
+            raise ValueError(f"record at index {row} has length {len(record)}, expected {num_meas}")
+        for col, char in enumerate(record):
+            if char == "0":
+                out[row, col] = 0
+            elif char == "1":
+                out[row, col] = 1
+            else:
+                raise ValueError(
+                    f"record at index {row} contains {char!r}; expected only '0' and '1'"
+                )
+
+    if isinstance(records, str):
+        out = np.zeros((1, num_meas), dtype=np.uint8)
+        fill_string_record(out, records, 0)
+        return out
+
+    if isinstance(records, np.ndarray):
+        bit_array = records
+    elif isinstance(records, Sequence):
+        if all(isinstance(record, str) for record in records):
+            out = np.zeros((len(records), num_meas), dtype=np.uint8)
+            for row, record in enumerate(records):
+                fill_string_record(out, record, row)
+            return out
+        raise TypeError("records must be strings or a 2D bool/uint8 NumPy array")
+    else:
+        raise TypeError("records must be strings or a 2D bool/uint8 NumPy array")
+
+    if bit_array.ndim != 2:
+        raise ValueError("records array must be 2D with shape (num_records, num_measurements)")
+    if bit_array.shape[1] != num_meas:
+        raise ValueError(f"records array has {bit_array.shape[1]} columns, expected {num_meas}")
+    if bit_array.dtype not in (np.dtype("bool"), np.dtype("uint8")):
+        raise TypeError("records array dtype must be bool or uint8")
+    if bit_array.dtype == np.dtype("uint8") and np.any((bit_array != 0) & (bit_array != 1)):
+        raise ValueError("uint8 records array must contain only 0 and 1")
+    return np.ascontiguousarray(bit_array.astype(np.uint8, copy=False))
+
+
+def probability_of(
+    program: Program,
+    records: MeasurementRecords,
+    *,
+    return_log: bool = False,
+) -> npt.NDArray[np.float64]:
+    """Return the exact probability sample() would assign to each record.
+
+    ``records`` is one of: a single record string (e.g. ``"010"``), a
+    sequence of record strings, or a 2D ``bool`` / ``uint8`` array of
+    shape ``(num_records, program.num_measurements)``. Each record is
+    interpreted in measurement order -- position ``i`` is the i-th entry
+    sample().measurements would emit. Use ``program.measurement_qubits``
+    to map record positions to physical qubit indices.
+
+    Records the program cannot emit are reported as ``0.0`` (or ``-inf``
+    when ``return_log=True``). For deep circuits whose probabilities
+    underflow float64, pass ``return_log=True`` so the log-domain values
+    survive.
+    """
+    record_array = _records_from_outcomes(program, records)
+    log_probs = cast(
+        npt.NDArray[np.float64],
+        _probability_of_from_records(program, record_array),
+    )
+    if return_log:
+        return log_probs
+    return np.exp(log_probs)
+
+
 class _DefaultPasses:
     """Sentinel marker for compile()'s default optimization passes."""
 
@@ -260,6 +345,7 @@ def compile(
 __all__ = [
     "AstNode",
     "BasisBitstrings",
+    "MeasurementRecords",
     "BytecodePass",
     "BytecodePassManager",
     "Circuit",
@@ -297,6 +383,7 @@ __all__ = [
     "parse",
     "parse_file",
     "probabilities",
+    "probability_of",
     "sample",
     "sample_k",
     "sample_k_survivors",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,17 @@ target_compile_definitions(clifft_tests PRIVATE
     CLIFFT_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures"
 )
 
+# probability_of() returns -inf for unreachable records. Under the Release-
+# only -ffast-math (which implies -ffinite-math-only), std::isinf and
+# std::isfinite are constant-folded to false because the compiler assumes
+# infinities cannot occur. Compile this test in finite-math-aware mode so
+# the predicates exercise the API contract.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set_source_files_properties(test_probability_of.cc
+        PROPERTIES COMPILE_OPTIONS "-fno-fast-math"
+    )
+endif()
+
 # Code coverage instrumentation for test executable
 if(CLIFFT_COVERAGE)
     target_compile_options(clifft_tests PRIVATE --coverage)

--- a/tests/python/test_probability_of.py
+++ b/tests/python/test_probability_of.py
@@ -33,6 +33,24 @@ def test_measurement_qubits_is_empty_for_unitary_circuit() -> None:
     assert list(prog.measurement_qubits) == []
 
 
+def test_measurement_qubits_uses_sentinel_for_mpp() -> None:
+    prog = clifft.compile("MPP X0*X1")
+    assert prog.num_measurements == 1
+    assert list(prog.measurement_qubits) == [clifft.NO_SINGLE_MEASUREMENT_QUBIT]
+
+
+def test_measurement_qubits_uses_sentinel_for_mpad() -> None:
+    prog = clifft.compile("MPAD 1")
+    assert prog.num_measurements == 1
+    assert list(prog.measurement_qubits) == [clifft.NO_SINGLE_MEASUREMENT_QUBIT]
+
+
+def test_measurement_qubits_mixes_qubits_and_sentinels() -> None:
+    prog = clifft.compile("M 2\nMPP X0*X1\nMPAD 0\nM 1")
+    sentinel = clifft.NO_SINGLE_MEASUREMENT_QUBIT
+    assert list(prog.measurement_qubits) == [2, sentinel, sentinel, 1]
+
+
 # =============================================================================
 # Basic correctness: closed-form probabilities.
 # =============================================================================

--- a/tests/python/test_probability_of.py
+++ b/tests/python/test_probability_of.py
@@ -1,0 +1,261 @@
+"""Tests for clifft.probability_of(): exact measurement-record probabilities.
+
+probability_of() returns the probability sample() would assign to each
+measurement record under a compiled program with measurements. This module
+covers the Python wrapper's contract: input polymorphism, return shapes,
+return_log behavior, the measurement_qubits accessor, cross-checks against
+probabilities() and qiskit, sampling consistency, and rejection paths.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+from conftest import random_dense_clifford_t_circuit
+from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
+
+import clifft
+
+# =============================================================================
+# measurement_qubits accessor
+# =============================================================================
+
+
+def test_measurement_qubits_records_qubit_per_slot() -> None:
+    prog = clifft.compile("H 0\nH 3\nM 3 0")
+    assert prog.num_measurements == 2
+    assert list(prog.measurement_qubits) == [3, 0]
+
+
+def test_measurement_qubits_is_empty_for_unitary_circuit() -> None:
+    prog = clifft.compile("H 0\nT 0")
+    assert prog.num_measurements == 0
+    assert list(prog.measurement_qubits) == []
+
+
+# =============================================================================
+# Basic correctness: closed-form probabilities.
+# =============================================================================
+
+
+def test_bell_state_probabilities() -> None:
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    probs = clifft.probability_of(prog, ["00", "01", "10", "11"])
+    np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
+    assert probs.dtype == np.float64
+    assert probs.shape == (4,)
+
+
+def test_single_qubit_plus_state() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, ["0", "1"])
+    np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
+
+
+def test_unreachable_records_are_zero() -> None:
+    prog = clifft.compile("M 0")
+    probs = clifft.probability_of(prog, ["0", "1"])
+    np.testing.assert_allclose(probs, [1.0, 0.0], atol=1e-12)
+
+
+def test_feedback_circuit_returns_joint_trajectory_probability() -> None:
+    prog = clifft.compile("H 0\n" "M 0\n" "CX rec[-1] 1\n" "M 1\n")
+    probs = clifft.probability_of(prog, ["00", "01", "10", "11"])
+    np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
+
+
+# =============================================================================
+# Input polymorphism.
+# =============================================================================
+
+
+def test_single_string_returns_length_one_array() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, "0")
+    assert probs.shape == (1,)
+    np.testing.assert_allclose(probs, [0.5], atol=1e-12)
+
+
+def test_sequence_of_strings() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, ("0", "1"))
+    np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
+
+
+@pytest.mark.parametrize("dtype", [np.bool_, np.uint8])
+def test_array_input_matches_string_input(dtype: np.dtype) -> None:
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    records = np.array([[0, 0], [1, 1]], dtype=dtype)
+    np.testing.assert_allclose(
+        clifft.probability_of(prog, records),
+        clifft.probability_of(prog, ["00", "11"]),
+    )
+
+
+def test_empty_record_batch() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, [])
+    assert probs.shape == (0,)
+    assert probs.dtype == np.float64
+
+
+# =============================================================================
+# return_log option.
+# =============================================================================
+
+
+def test_return_log_returns_natural_log() -> None:
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    log_probs = clifft.probability_of(prog, ["00", "01", "10", "11"], return_log=True)
+    assert np.isclose(log_probs[0], np.log(0.5))
+    assert log_probs[1] == -np.inf
+    assert log_probs[2] == -np.inf
+    assert np.isclose(log_probs[3], np.log(0.5))
+
+
+def test_return_log_default_false() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, ["0"])
+    # 0.5 (linear), not log(0.5).
+    np.testing.assert_allclose(probs, [0.5], atol=1e-12)
+
+
+# =============================================================================
+# Cross-check against probabilities() on terminal-M-all circuits.
+# =============================================================================
+
+
+def test_matches_probabilities_on_clifford_circuit() -> None:
+    bitstrings = ["00", "01", "10", "11"]
+    unitary = clifft.compile("H 0\nCX 0 1")
+    measured = clifft.compile("H 0\nCX 0 1\nM 0 1")
+
+    expected = clifft.probabilities(unitary, bitstrings)
+    actual = clifft.probability_of(measured, bitstrings)
+    np.testing.assert_allclose(actual, expected, atol=1e-12)
+
+
+def test_matches_probabilities_on_clifford_t_circuit() -> None:
+    bitstrings = ["0", "1"]
+    unitary = clifft.compile("H 0\nT 0\nH 0")
+    measured = clifft.compile("H 0\nT 0\nH 0\nM 0")
+
+    expected = clifft.probabilities(unitary, bitstrings)
+    actual = clifft.probability_of(measured, bitstrings)
+    np.testing.assert_allclose(actual, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("num_qubits,seed", [(2, 101), (3, 202), (4, 303)])
+def test_matches_qiskit_for_random_small_circuits(num_qubits: int, seed: int) -> None:
+    circuit = random_dense_clifford_t_circuit(num_qubits, depth=18, seed=seed)
+    measured = clifft.compile(circuit + "\nM " + " ".join(str(q) for q in range(num_qubits)))
+    qiskit_sv = qiskit_statevector(stim_to_qiskit_noiseless(circuit))
+
+    bitstrings = [
+        "".join(str((i >> q) & 1) for q in range(num_qubits)) for i in range(1 << num_qubits)
+    ]
+    actual = clifft.probability_of(measured, bitstrings)
+    np.testing.assert_allclose(actual, np.abs(qiskit_sv) ** 2, atol=1e-12)
+
+
+# =============================================================================
+# Empirical sampling consistency.
+# =============================================================================
+
+
+def test_sample_frequencies_match_probability_of() -> None:
+    # Run sample() many shots, count frequencies, compare to probability_of().
+    # Chi-squared style sanity check; not a deep statistical test.
+    prog = clifft.compile("H 0\nT 0\nH 0\nM 0")
+
+    shots = 200_000
+    measurements = clifft.sample(prog, shots=shots, seed=42).measurements
+    freq_1 = float(measurements.sum()) / shots
+    freq_0 = 1.0 - freq_1
+
+    probs = clifft.probability_of(prog, ["0", "1"])
+    # 5 sigma binomial half-width on shots=2e5, p~0.85 is ~0.004.
+    assert abs(freq_0 - probs[0]) < 0.01
+    assert abs(freq_1 - probs[1]) < 0.01
+
+
+# =============================================================================
+# Rejection paths.
+# =============================================================================
+
+
+def test_rejects_zero_measurement_program() -> None:
+    prog = clifft.compile("H 0\nT 0")
+    with pytest.raises(ValueError, match="at least one measurement"):
+        clifft.probability_of(prog, [])
+
+
+def test_rejects_hidden_measurement_slots() -> None:
+    prog = clifft.compile("M 0\nR 1\nM 1")
+    assert prog.num_measurements == 2
+    with pytest.raises(ValueError, match="hidden measurement slots"):
+        clifft.probability_of(prog, ["00", "11"])
+
+
+def test_rejects_noise_opcodes() -> None:
+    prog = clifft.compile("X_ERROR(0.1) 0\nM 0")
+    with pytest.raises(ValueError, match="pure-state evolution"):
+        clifft.probability_of(prog, ["0"])
+
+
+def test_rejects_detector_opcodes() -> None:
+    prog = clifft.compile("M 0\nDETECTOR rec[-1]")
+    with pytest.raises(ValueError, match="pure-state evolution"):
+        clifft.probability_of(prog, ["0"])
+
+
+def test_rejects_observable_opcodes() -> None:
+    prog = clifft.compile("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
+    with pytest.raises(ValueError, match="pure-state evolution"):
+        clifft.probability_of(prog, ["0"])
+
+
+def test_rejects_record_string_with_wrong_length() -> None:
+    prog = clifft.compile("M 0 1")
+    with pytest.raises(ValueError, match="length 1, expected 2"):
+        clifft.probability_of(prog, "0")
+
+
+def test_rejects_record_string_with_invalid_chars() -> None:
+    prog = clifft.compile("M 0")
+    with pytest.raises(ValueError, match="expected only '0' and '1'"):
+        clifft.probability_of(prog, ["x"])
+
+
+def test_rejects_array_with_wrong_columns() -> None:
+    prog = clifft.compile("M 0 1")
+    arr = np.array([[0, 0, 0]], dtype=np.uint8)
+    with pytest.raises(ValueError, match="3 columns, expected 2"):
+        clifft.probability_of(prog, arr)
+
+
+def test_rejects_array_with_non_bit_values() -> None:
+    prog = clifft.compile("M 0")
+    arr = np.array([[2]], dtype=np.uint8)
+    with pytest.raises(ValueError, match="contain only 0 and 1"):
+        clifft.probability_of(prog, arr)
+
+
+def test_rejects_invalid_array_dtype() -> None:
+    prog = clifft.compile("M 0")
+    invalid: Any = np.array([[0]], dtype=np.int64)
+    with pytest.raises(TypeError, match="dtype must be bool or uint8"):
+        clifft.probability_of(prog, invalid)
+
+
+def test_rejects_invalid_array_dim() -> None:
+    prog = clifft.compile("M 0")
+    with pytest.raises(ValueError, match="must be 2D"):
+        clifft.probability_of(prog, np.array([0, 1], dtype=np.uint8))
+
+
+def test_rejects_invalid_input_type() -> None:
+    prog = clifft.compile("M 0")
+    bad: Any = 42
+    with pytest.raises(TypeError, match="strings or a 2D"):
+        clifft.probability_of(prog, bad)

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1406,6 +1406,7 @@ TEST_CASE("DropNonUnitaryPass strips non-unitary ops and metadata") {
     REQUIRE(hir.num_observables > 0);
     REQUIRE(hir.num_exp_vals > 0);
     REQUIRE(!hir.noise_sites.empty());
+    REQUIRE(!hir.measurement_qubits.empty());
 
     DropNonUnitaryPass pass;
     pass.run(hir);
@@ -1421,6 +1422,10 @@ TEST_CASE("DropNonUnitaryPass strips non-unitary ops and metadata") {
     CHECK(hir.observable_targets.empty());
     CHECK(hir.noise_channel_masks.size() == 0);
     CHECK(hir.source_map.empty());
+    // After dropping measurements, the per-slot qubit metadata must be
+    // cleared so a follow-on lower() does not surface stale entries with
+    // num_measurements == 0.
+    CHECK(hir.measurement_qubits.empty());
 
     for (const auto& op : hir.ops) {
         CHECK((op.op_type() == OpType::T_GATE || op.op_type() == OpType::PHASE_ROTATION));

--- a/tests/test_probability_of.cc
+++ b/tests/test_probability_of.cc
@@ -136,6 +136,30 @@ TEST_CASE("measurement_qubits is empty for unitary programs") {
     REQUIRE(mod.measurement_qubits.empty());
 }
 
+TEST_CASE("measurement_qubits uses sentinel for MPP joint-Pauli measurements") {
+    auto mod = compile_circuit("MPP X0*X1");
+    REQUIRE(mod.num_measurements == 1);
+    REQUIRE(mod.measurement_qubits.size() == 1);
+    REQUIRE(mod.measurement_qubits[0] == HirModule::kNoSingleMeasurementQubit);
+}
+
+TEST_CASE("measurement_qubits uses sentinel for MPAD padding records") {
+    auto mod = compile_circuit("MPAD 1");
+    REQUIRE(mod.num_measurements == 1);
+    REQUIRE(mod.measurement_qubits.size() == 1);
+    REQUIRE(mod.measurement_qubits[0] == HirModule::kNoSingleMeasurementQubit);
+}
+
+TEST_CASE("measurement_qubits mixes per-slot qubits with sentinels across gate types") {
+    auto mod = compile_circuit("M 2\nMPP X0*X1\nMPAD 0\nM 1");
+    REQUIRE(mod.num_measurements == 4);
+    REQUIRE(mod.measurement_qubits.size() == 4);
+    REQUIRE(mod.measurement_qubits[0] == 2);
+    REQUIRE(mod.measurement_qubits[1] == HirModule::kNoSingleMeasurementQubit);
+    REQUIRE(mod.measurement_qubits[2] == HirModule::kNoSingleMeasurementQubit);
+    REQUIRE(mod.measurement_qubits[3] == 1);
+}
+
 // =============================================================================
 // Pre-flight validation.
 // =============================================================================

--- a/tests/test_probability_of.cc
+++ b/tests/test_probability_of.cc
@@ -118,6 +118,25 @@ TEST_CASE("probability_of: feedback circuit produces joint trajectory probabilit
 }
 
 // =============================================================================
+// measurement_qubits accessor on CompiledModule.
+// =============================================================================
+
+TEST_CASE("measurement_qubits records the qubit per visible measurement slot") {
+    auto mod = compile_circuit("H 0\nH 3\nM 3 0");
+    REQUIRE(mod.num_measurements == 2);
+    REQUIRE(mod.measurement_qubits.size() == 2);
+    // M 3 0 records qubit 3 first, qubit 0 second.
+    REQUIRE(mod.measurement_qubits[0] == 3);
+    REQUIRE(mod.measurement_qubits[1] == 0);
+}
+
+TEST_CASE("measurement_qubits is empty for unitary programs") {
+    auto mod = compile_circuit("H 0\nT 0");
+    REQUIRE(mod.num_measurements == 0);
+    REQUIRE(mod.measurement_qubits.empty());
+}
+
+// =============================================================================
 // Pre-flight validation.
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Exposes \`probability_of\` to Python and adds a \`measurement_qubits\` accessor on \`Program\`, completing the user-facing surface for the strong-simulation API.

### Public API

\`\`\`python
clifft.probability_of(program, records, *, return_log=False)
\`\`\`

Returns the probability that \`sample()\` would emit each measurement record, with the same dust-clamping semantics as the sampling path. Polymorphic on input:

| Input shape | Output |
|---|---|
| Single string \`"010"\` | 1D array of length 1 |
| Sequence of strings | 1D array of length \`len(records)\` |
| 2D \`bool\` or \`uint8\` array \`(N, num_measurements)\` | 1D array of length \`N\` |

Returns linear probabilities by default; pass \`return_log=True\` to get natural-log values that survive underflow on deep circuits.

\`\`\`python
program.measurement_qubits  # list[int]
\`\`\`

For each visible measurement record slot \`i\`, the qubit \`measurement_qubits[i]\` that was measured. Lets users map record positions back to physical qubits without re-parsing the source.

### Wired in

- New \`_probability_of_from_records\` nanobind helper takes a 2D \`uint8\` array and returns a 1D \`float64\` array of log-probabilities.
- New \`_records_from_outcomes\` Python helper normalizes the polymorphic input into a row-major \`uint8\` array (parallel to the existing \`_basis_masks_from_bitstrings\`).
- \`measurement_qubits\` is populated in \`HirModule\` during \`trace()\` from the per-target qubit indices on \`M\` / \`MX\` / \`MY\` ops (hidden reset measurements are excluded by virtue of the existing reject in \`probability_of\`), then copied through \`lower()\` to \`CompiledModule\`, then exposed via nanobind.

### Tests

**31 new Python tests** in \`tests/python/test_probability_of.py\` covering:

- Closed-form correctness (Bell state, |+>, deterministic, feedback).
- Input polymorphism (string / sequence / bool array / uint8 array / empty).
- \`return_log\` toggle.
- Equivalence with \`probabilities()\` on terminal-M-all circuits, both Clifford and Clifford+T.
- Qiskit cross-check for seeded random circuits (\`n in {2, 3, 4}\`).
- Empirical \`sample()\` frequency match against \`probability_of\` predictions (200K shots).
- \`measurement_qubits\` accessor on a measured program and an empty list on a unitary one.
- Full rejection contract: zero-measurement programs, hidden slots, noise, detectors, observables, wrong record length, invalid characters, wrong array shape / dtype / contents, invalid input types.

**2 new C++ tests** in \`tests/test_probability_of.cc\` covering the underlying \`CompiledModule.measurement_qubits\` field directly.

## Test plan

- [x] \`ctest --test-dir build -E Bench\` — 764/764 pass.
- [x] \`uv run pytest tests/python/\` — 666/666 pass.
- [x] Pre-commit clean.