### PR TITLE
feat: add probability_of Python API

### DIFF
--- a/src/clifft/api/probability_of.cc
+++ b/src/clifft/api/probability_of.cc
@@ -15,7 +15,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <limits>
 #include <span>
 #include <stdexcept>
 #include <vector>
@@ -181,7 +180,7 @@ std::vector<double> probability_of(const CompiledModule& program, std::span<cons
         if (state.forced_reachable) {
             log_probs.push_back(state.forced_log_probability);
         } else {
-            log_probs.push_back(-std::numeric_limits<double>::infinity());
+            log_probs.push_back(kUnreachableLogProb);
         }
     }
     return log_probs;

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <span>
 #include <string>
@@ -367,6 +368,13 @@ std::vector<double> probabilities(const CompiledModule& program,
                                   std::span<const uint64_t> basis_masks, size_t num_basis_masks,
                                   size_t words_per_basis_mask);
 
+/// Sentinel returned by `probability_of()` for records the program cannot
+/// emit. Equal to `std::numeric_limits<double>::lowest()` (-DBL_MAX). A
+/// finite value is used (rather than `-infinity`) so the contract survives
+/// `-ffast-math` builds, which assume infinities cannot occur and fold
+/// away `std::isinf`/`std::isfinite`. Exponentiating it underflows to 0.
+inline constexpr double kUnreachableLogProb = std::numeric_limits<double>::lowest();
+
 /// Return exact log-probabilities for a batch of measurement records under
 /// the compiled program. Computes the probability that sample() would emit
 /// each record, modulo dust-clamping. The program must contain at least one
@@ -377,7 +385,7 @@ std::vector<double> probabilities(const CompiledModule& program,
 /// `records` is a packed buffer of `num_records * program.num_measurements`
 /// bytes (0 or 1 per slot, in execution order -- the same order
 /// sample().measurements uses). Records the program cannot emit return
-/// `-infinity`; finite values are natural-log probabilities.
+/// `kUnreachableLogProb`; other entries are natural-log probabilities.
 std::vector<double> probability_of(const CompiledModule& program, std::span<const uint8_t> records,
                                    size_t num_records);
 

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1098,4 +1098,22 @@ NB_MODULE(_clifft_core, m) {
             return vec_to_numpy(std::move(probs), {n});
         },
         nb::arg("program"), nb::arg("basis_masks"), "Internal helper for clifft.probabilities().");
+
+    m.def(
+        "_probability_of_from_records",
+        [](const clifft::CompiledModule& program,
+           nb::ndarray<nb::numpy, const uint8_t, nb::shape<-1, -1>, nb::c_contig> records) {
+            std::vector<double> log_probs;
+            {
+                nb::gil_scoped_release release;
+                log_probs = clifft::probability_of(
+                    program, std::span<const uint8_t>(records.data(), records.size()),
+                    records.shape(0));
+            }
+            size_t n = log_probs.size();
+            return vec_to_numpy(std::move(log_probs), {n});
+        },
+        nb::arg("program"), nb::arg("records"),
+        "Internal helper for clifft.probability_of(). Returns log-probabilities; "
+        "the Python wrapper exponentiates to linear unless return_log=True.");
 }

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -82,6 +82,7 @@ from clifft._clifft_core import (
     SwapMeasPass,
     Target,
     _probabilities_from_bitmasks,
+    _probability_of_from_records,
     compute_reference_syndrome,
     default_bytecode_pass_manager,
     default_hir_pass_manager,
@@ -106,6 +107,7 @@ from clifft._clifft_core import (
 from clifft._sample_result import SampleResult
 
 BasisBitstrings: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
+MeasurementRecords: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
 
 
 def _basis_masks_from_bitstrings(
@@ -197,6 +199,92 @@ def probabilities(
     )
 
 
+def _records_from_outcomes(
+    program: Program,
+    records: MeasurementRecords,
+) -> npt.NDArray[np.uint8]:
+    """Convert string or array measurement records into a 2D uint8 array.
+
+    The output has shape ``(num_records, program.num_measurements)`` and
+    contains only 0/1 entries. Each row is a single measurement record in
+    record-position order (matching ``sample().measurements``).
+    """
+    num_meas = program.num_measurements
+
+    def fill_string_record(out: npt.NDArray[np.uint8], record: str, row: int) -> None:
+        if len(record) != num_meas:
+            raise ValueError(f"record at index {row} has length {len(record)}, expected {num_meas}")
+        for col, char in enumerate(record):
+            if char == "0":
+                out[row, col] = 0
+            elif char == "1":
+                out[row, col] = 1
+            else:
+                raise ValueError(
+                    f"record at index {row} contains {char!r}; expected only '0' and '1'"
+                )
+
+    if isinstance(records, str):
+        out = np.zeros((1, num_meas), dtype=np.uint8)
+        fill_string_record(out, records, 0)
+        return out
+
+    if isinstance(records, np.ndarray):
+        bit_array = records
+    elif isinstance(records, Sequence):
+        if all(isinstance(record, str) for record in records):
+            out = np.zeros((len(records), num_meas), dtype=np.uint8)
+            for row, record in enumerate(records):
+                fill_string_record(out, record, row)
+            return out
+        raise TypeError("records must be strings or a 2D bool/uint8 NumPy array")
+    else:
+        raise TypeError("records must be strings or a 2D bool/uint8 NumPy array")
+
+    if bit_array.ndim != 2:
+        raise ValueError("records array must be 2D with shape (num_records, num_measurements)")
+    if bit_array.shape[1] != num_meas:
+        raise ValueError(f"records array has {bit_array.shape[1]} columns, expected {num_meas}")
+    if bit_array.dtype not in (np.dtype("bool"), np.dtype("uint8")):
+        raise TypeError("records array dtype must be bool or uint8")
+    if bit_array.dtype == np.dtype("uint8") and np.any((bit_array != 0) & (bit_array != 1)):
+        raise ValueError("uint8 records array must contain only 0 and 1")
+    return np.ascontiguousarray(bit_array.astype(np.uint8, copy=False))
+
+
+def probability_of(
+    program: Program,
+    records: MeasurementRecords,
+    *,
+    return_log: bool = False,
+) -> npt.NDArray[np.float64]:
+    """Return the exact probability sample() would assign to each record.
+
+    ``records`` is one of: a single record string (e.g. ``"010"``), a
+    sequence of record strings, or a 2D ``bool`` / ``uint8`` array of
+    shape ``(num_records, program.num_measurements)``. Each record is
+    interpreted in measurement order -- position ``i`` is the i-th entry
+    sample().measurements would emit.
+
+    Records the program cannot emit are reported as ``0.0`` (or ``-inf``
+    when ``return_log=True``). For deep circuits whose probabilities
+    underflow float64, pass ``return_log=True`` so the log-domain values
+    survive.
+    """
+    record_array = _records_from_outcomes(program, records)
+    log_probs = cast(
+        npt.NDArray[np.float64],
+        _probability_of_from_records(program, record_array),
+    )
+    # C++ marks unreachable records with the finite sentinel
+    # numpy.finfo(float64).min (-DBL_MAX). Translate it back to the
+    # Pythonic -inf for log output, and rely on the natural underflow
+    # to 0.0 under np.exp for the linear case.
+    if return_log:
+        return np.where(log_probs == np.finfo(np.float64).min, -np.inf, log_probs)
+    return np.exp(log_probs)
+
+
 class _DefaultPasses:
     """Sentinel marker for compile()'s default optimization passes."""
 
@@ -260,6 +348,7 @@ def compile(
 __all__ = [
     "AstNode",
     "BasisBitstrings",
+    "MeasurementRecords",
     "BytecodePass",
     "BytecodePassManager",
     "Circuit",
@@ -297,6 +386,7 @@ __all__ = [
     "parse",
     "parse_file",
     "probabilities",
+    "probability_of",
     "sample",
     "sample_k",
     "sample_k_survivors",

--- a/tests/python/test_probability_of.py
+++ b/tests/python/test_probability_of.py
@@ -1,0 +1,244 @@
+"""Tests for clifft.probability_of(): exact measurement-record probabilities.
+
+probability_of() returns the probability sample() would assign to each
+measurement record under a compiled program with measurements. This module
+covers the Python wrapper's contract: input polymorphism, return shapes,
+return_log behavior, cross-checks against probabilities() and qiskit,
+sampling consistency, and rejection paths.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+from conftest import random_dense_clifford_t_circuit
+from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
+
+import clifft
+
+# =============================================================================
+# Basic correctness: closed-form probabilities.
+# =============================================================================
+
+
+def test_bell_state_probabilities() -> None:
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    probs = clifft.probability_of(prog, ["00", "01", "10", "11"])
+    np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
+    assert probs.dtype == np.float64
+    assert probs.shape == (4,)
+
+
+def test_single_qubit_plus_state() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, ["0", "1"])
+    np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
+
+
+def test_unreachable_records_are_zero() -> None:
+    prog = clifft.compile("M 0")
+    probs = clifft.probability_of(prog, ["0", "1"])
+    np.testing.assert_allclose(probs, [1.0, 0.0], atol=1e-12)
+
+
+def test_feedback_circuit_returns_joint_trajectory_probability() -> None:
+    prog = clifft.compile("H 0\n" "M 0\n" "CX rec[-1] 1\n" "M 1\n")
+    probs = clifft.probability_of(prog, ["00", "01", "10", "11"])
+    np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
+
+
+# =============================================================================
+# Input polymorphism.
+# =============================================================================
+
+
+def test_single_string_returns_length_one_array() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, "0")
+    assert probs.shape == (1,)
+    np.testing.assert_allclose(probs, [0.5], atol=1e-12)
+
+
+def test_sequence_of_strings() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, ("0", "1"))
+    np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
+
+
+@pytest.mark.parametrize("dtype", [np.bool_, np.uint8])
+def test_array_input_matches_string_input(dtype: np.dtype) -> None:
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    records = np.array([[0, 0], [1, 1]], dtype=dtype)
+    np.testing.assert_allclose(
+        clifft.probability_of(prog, records),
+        clifft.probability_of(prog, ["00", "11"]),
+    )
+
+
+def test_empty_record_batch() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, [])
+    assert probs.shape == (0,)
+    assert probs.dtype == np.float64
+
+
+# =============================================================================
+# return_log option.
+# =============================================================================
+
+
+def test_return_log_returns_natural_log() -> None:
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    log_probs = clifft.probability_of(prog, ["00", "01", "10", "11"], return_log=True)
+    assert np.isclose(log_probs[0], np.log(0.5))
+    assert log_probs[1] == -np.inf
+    assert log_probs[2] == -np.inf
+    assert np.isclose(log_probs[3], np.log(0.5))
+
+
+def test_return_log_default_false() -> None:
+    prog = clifft.compile("H 0\nM 0")
+    probs = clifft.probability_of(prog, ["0"])
+    # 0.5 (linear), not log(0.5).
+    np.testing.assert_allclose(probs, [0.5], atol=1e-12)
+
+
+# =============================================================================
+# Cross-check against probabilities() on terminal-M-all circuits.
+# =============================================================================
+
+
+def test_matches_probabilities_on_clifford_circuit() -> None:
+    bitstrings = ["00", "01", "10", "11"]
+    unitary = clifft.compile("H 0\nCX 0 1")
+    measured = clifft.compile("H 0\nCX 0 1\nM 0 1")
+
+    expected = clifft.probabilities(unitary, bitstrings)
+    actual = clifft.probability_of(measured, bitstrings)
+    np.testing.assert_allclose(actual, expected, atol=1e-12)
+
+
+def test_matches_probabilities_on_clifford_t_circuit() -> None:
+    bitstrings = ["0", "1"]
+    unitary = clifft.compile("H 0\nT 0\nH 0")
+    measured = clifft.compile("H 0\nT 0\nH 0\nM 0")
+
+    expected = clifft.probabilities(unitary, bitstrings)
+    actual = clifft.probability_of(measured, bitstrings)
+    np.testing.assert_allclose(actual, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("num_qubits,seed", [(2, 101), (3, 202), (4, 303)])
+def test_matches_qiskit_for_random_small_circuits(num_qubits: int, seed: int) -> None:
+    circuit = random_dense_clifford_t_circuit(num_qubits, depth=18, seed=seed)
+    measured = clifft.compile(circuit + "\nM " + " ".join(str(q) for q in range(num_qubits)))
+    qiskit_sv = qiskit_statevector(stim_to_qiskit_noiseless(circuit))
+
+    bitstrings = [
+        "".join(str((i >> q) & 1) for q in range(num_qubits)) for i in range(1 << num_qubits)
+    ]
+    actual = clifft.probability_of(measured, bitstrings)
+    np.testing.assert_allclose(actual, np.abs(qiskit_sv) ** 2, atol=1e-12)
+
+
+# =============================================================================
+# Empirical sampling consistency.
+# =============================================================================
+
+
+def test_sample_frequencies_match_probability_of() -> None:
+    # Run sample() many shots, count frequencies, compare to probability_of().
+    # Chi-squared style sanity check; not a deep statistical test.
+    prog = clifft.compile("H 0\nT 0\nH 0\nM 0")
+
+    shots = 200_000
+    measurements = clifft.sample(prog, shots=shots, seed=42).measurements
+    freq_1 = float(measurements.sum()) / shots
+    freq_0 = 1.0 - freq_1
+
+    probs = clifft.probability_of(prog, ["0", "1"])
+    # 5 sigma binomial half-width on shots=2e5, p~0.85 is ~0.004.
+    assert abs(freq_0 - probs[0]) < 0.01
+    assert abs(freq_1 - probs[1]) < 0.01
+
+
+# =============================================================================
+# Rejection paths.
+# =============================================================================
+
+
+def test_rejects_zero_measurement_program() -> None:
+    prog = clifft.compile("H 0\nT 0")
+    with pytest.raises(ValueError, match="at least one measurement"):
+        clifft.probability_of(prog, [])
+
+
+def test_rejects_hidden_measurement_slots() -> None:
+    prog = clifft.compile("M 0\nR 1\nM 1")
+    assert prog.num_measurements == 2
+    with pytest.raises(ValueError, match="hidden measurement slots"):
+        clifft.probability_of(prog, ["00", "11"])
+
+
+def test_rejects_noise_opcodes() -> None:
+    prog = clifft.compile("X_ERROR(0.1) 0\nM 0")
+    with pytest.raises(ValueError, match="pure-state evolution"):
+        clifft.probability_of(prog, ["0"])
+
+
+def test_rejects_detector_opcodes() -> None:
+    prog = clifft.compile("M 0\nDETECTOR rec[-1]")
+    with pytest.raises(ValueError, match="pure-state evolution"):
+        clifft.probability_of(prog, ["0"])
+
+
+def test_rejects_observable_opcodes() -> None:
+    prog = clifft.compile("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
+    with pytest.raises(ValueError, match="pure-state evolution"):
+        clifft.probability_of(prog, ["0"])
+
+
+def test_rejects_record_string_with_wrong_length() -> None:
+    prog = clifft.compile("M 0 1")
+    with pytest.raises(ValueError, match="length 1, expected 2"):
+        clifft.probability_of(prog, "0")
+
+
+def test_rejects_record_string_with_invalid_chars() -> None:
+    prog = clifft.compile("M 0")
+    with pytest.raises(ValueError, match="expected only '0' and '1'"):
+        clifft.probability_of(prog, ["x"])
+
+
+def test_rejects_array_with_wrong_columns() -> None:
+    prog = clifft.compile("M 0 1")
+    arr = np.array([[0, 0, 0]], dtype=np.uint8)
+    with pytest.raises(ValueError, match="3 columns, expected 2"):
+        clifft.probability_of(prog, arr)
+
+
+def test_rejects_array_with_non_bit_values() -> None:
+    prog = clifft.compile("M 0")
+    arr = np.array([[2]], dtype=np.uint8)
+    with pytest.raises(ValueError, match="contain only 0 and 1"):
+        clifft.probability_of(prog, arr)
+
+
+def test_rejects_invalid_array_dtype() -> None:
+    prog = clifft.compile("M 0")
+    invalid: Any = np.array([[0]], dtype=np.int64)
+    with pytest.raises(TypeError, match="dtype must be bool or uint8"):
+        clifft.probability_of(prog, invalid)
+
+
+def test_rejects_invalid_array_dim() -> None:
+    prog = clifft.compile("M 0")
+    with pytest.raises(ValueError, match="must be 2D"):
+        clifft.probability_of(prog, np.array([0, 1], dtype=np.uint8))
+
+
+def test_rejects_invalid_input_type() -> None:
+    prog = clifft.compile("M 0")
+    bad: Any = 42
+    with pytest.raises(TypeError, match="strings or a 2D"):
+        clifft.probability_of(prog, bad)

--- a/tests/test_probability_of.cc
+++ b/tests/test_probability_of.cc
@@ -57,10 +57,8 @@ TEST_CASE("probability_of: Bell state probabilities") {
 
     // Bell state: only 00 and 11 are emitted, each with probability 0.5.
     CHECK_THAT(std::exp(log_probs[0]), WithinAbs(0.5, 1e-12));
-    REQUIRE(std::isinf(log_probs[1]));
-    REQUIRE(log_probs[1] < 0);  // -inf for unreachable
-    REQUIRE(std::isinf(log_probs[2]));
-    REQUIRE(log_probs[2] < 0);
+    REQUIRE(log_probs[1] == kUnreachableLogProb);
+    REQUIRE(log_probs[2] == kUnreachableLogProb);
     CHECK_THAT(std::exp(log_probs[3]), WithinAbs(0.5, 1e-12));
 }
 
@@ -83,8 +81,7 @@ TEST_CASE("probability_of: |0> deterministic measurement") {
     auto log_probs = probability_of(mod, records, /*num_records=*/2);
     REQUIRE(log_probs.size() == 2);
     CHECK_THAT(log_probs[0], WithinAbs(0.0, 1e-12));  // log(1)
-    REQUIRE(std::isinf(log_probs[1]));
-    REQUIRE(log_probs[1] < 0);
+    REQUIRE(log_probs[1] == kUnreachableLogProb);
 }
 
 // =============================================================================
@@ -110,10 +107,8 @@ TEST_CASE("probability_of: feedback circuit produces joint trajectory probabilit
     REQUIRE(log_probs.size() == 4);
 
     CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
-    REQUIRE(std::isinf(log_probs[1]));
-    REQUIRE(log_probs[1] < 0);
-    REQUIRE(std::isinf(log_probs[2]));
-    REQUIRE(log_probs[2] < 0);
+    REQUIRE(log_probs[1] == kUnreachableLogProb);
+    REQUIRE(log_probs[2] == kUnreachableLogProb);
     CHECK_THAT(log_probs[3], WithinAbs(std::log(0.5), 1e-12));
 }
 
@@ -273,10 +268,10 @@ TEST_CASE("probability_of: matches probabilities() on a Clifford circuit") {
     REQUIRE(probs.size() == 4);
     REQUIRE(log_probs.size() == 4);
     for (size_t i = 0; i < 4; ++i) {
-        if (std::isfinite(log_probs[i])) {
-            CHECK_THAT(std::exp(log_probs[i]), WithinAbs(probs[i], 1e-12));
-        } else {
+        if (log_probs[i] == kUnreachableLogProb) {
             CHECK_THAT(probs[i], WithinAbs(0.0, 1e-12));
+        } else {
+            CHECK_THAT(std::exp(log_probs[i]), WithinAbs(probs[i], 1e-12));
         }
     }
 }
@@ -302,7 +297,7 @@ TEST_CASE("probability_of: matches probabilities() on a Clifford+T circuit (acti
     REQUIRE(probs.size() == 2);
     REQUIRE(log_probs.size() == 2);
     for (size_t i = 0; i < 2; ++i) {
-        REQUIRE(std::isfinite(log_probs[i]));
+        REQUIRE(log_probs[i] != kUnreachableLogProb);
         CHECK_THAT(std::exp(log_probs[i]), WithinAbs(probs[i], 1e-12));
     }
 
@@ -323,7 +318,7 @@ TEST_CASE("probability_of: multi-record probabilities sum to 1 for a small circu
 
     double total = 0.0;
     for (double lp : log_probs) {
-        if (std::isfinite(lp)) {
+        if (lp != kUnreachableLogProb) {
             total += std::exp(lp);
         }
     }


### PR DESCRIPTION
## Summary

- Adds `clifft.probability_of(program, records, *, return_log=False)` — the deterministic-record counterpart to `sample()`. Accepts a single record string, a sequence of strings, or a 2D `bool`/`uint8` array; returns linear probabilities by default, log when `return_log=True`.
- Changes the C++ unreachable-record sentinel from `-infinity` to a finite value (`std::numeric_limits<double>::lowest()`, exposed as `clifft::kUnreachableLogProb`). The new sentinel survives Release `-ffast-math` builds (which imply `-ffinite-math-only` and fold away `std::isinf`/`std::isfinite`). The Python wrapper translates the sentinel back to `-inf` when `return_log=True`; `np.exp` underflows it to `0.0` for the linear case.

## Notes for review

- Supersedes #81. This branch is a clean rebase off `main` with no `measurement_qubits` accessor and no `-fno-fast-math` carve-outs — both are removed in favor of the finite sentinel.
- All validation/rejection paths and qiskit/`probabilities()` cross-checks live in `tests/python/test_probability_of.py`. The C++ tests for the entry point now compare against `kUnreachableLogProb` directly.

## Test plan

- [x] `./build-release/tests/clifft_tests` (768 cases, all pass)
- [x] `uv run pytest tests/python` (664 tests, all pass)
- [x] `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)