### PR TITLE
feat!: rename probability APIs and unify strong-simulation docs

### DIFF
--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -4,7 +4,7 @@ Clifft's Schrödinger Virtual Machine (SVM) executes compiled programs. The main
 
 - `sample()` for ordinary shot-based sampling
 - `sample_survivors()` for post-selected sampling
-- `basis_probabilities()` for exact computational-basis amplitudes of a unitary program
+- `basis_probabilities()` for exact computational-basis probabilities of a unitary program
 - `record_probabilities()` for exact joint probabilities of measurement records
 - `execute()` and `get_statevector()` for inspecting small final states
 - `sample_k()` and `sample_k_survivors()` for stratified importance sampling
@@ -104,10 +104,14 @@ qs = clifft.record_probabilities(measured, ["00", "01", "10", "11"])
 print(qs)  # [0.5, 0.0, 0.0, 0.5]
 ```
 
-On terminal `M`-all circuits the two return the same numbers, but their
-algorithms differ in important ways covered in
-[Strong Simulation: Exact Probabilities](strong-simulation.md), including
-when one is meaningfully faster than the other.
+Each program goes to exactly one API — `basis_probabilities()` rejects any
+measurement, including terminal `M`-all. To compare them on the same
+circuit, compile two variants (unitary into `basis_probabilities()`,
+unitary + terminal `M`-all into `record_probabilities()`); the returned
+distributions match on the bitstrings the records encode. Their execution
+costs can differ by 100× either way, depending on circuit structure; see
+[Strong Simulation: Exact Probabilities](strong-simulation.md) for the
+tradeoff and when one is meaningfully faster.
 
 If you intentionally want to query the unitary skeleton of a mixed circuit
 with `basis_probabilities()`, compile with a custom HIR pass manager:

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -85,7 +85,8 @@ Clifft offers two exact-probability APIs:
 - **`clifft.basis_probabilities(program, bitstrings)`** — computational-basis
   probabilities for a unitary program.
 - **`clifft.record_probabilities(program, records)`** — joint probabilities
-  of measurement records for a circuit that has measurements.
+  of measurement records for a unitary circuit that has measurements (no
+  noise).
 
 ```python
 import clifft

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -80,17 +80,12 @@ print(sv)  # [0.707+0j, 0+0j, 0+0j, 0.707+0j]
 
 ## Exact Probabilities
 
-Clifft offers two exact-probability APIs sitting on either side of one
-question: *is the final state pure?*
+Clifft offers two exact-probability APIs:
 
-- **`clifft.basis_probabilities(program, bitstrings)`** — for **unitary**
-  programs only. Returns $|\langle x | U | 0 \rangle|^2$ for each queried
-  bitstring. Rejects any measurement, feedback, noise, detector, observable,
-  or post-selection (`EXP_VAL` probes are allowed but ignored).
-
-- **`clifft.record_probabilities(program, records)`** — for programs **with
-  measurements** (and, optionally, classical feedback). Returns the exact
-  joint probability that `sample()` would assign to each measurement record.
+- **`clifft.basis_probabilities(program, bitstrings)`** — computational-basis
+  probabilities for a unitary program.
+- **`clifft.record_probabilities(program, records)`** — joint probabilities
+  of measurement records for a circuit that has measurements.
 
 ```python
 import clifft
@@ -104,38 +99,9 @@ qs = clifft.record_probabilities(measured, ["00", "01", "10", "11"])
 print(qs)  # [0.5, 0.0, 0.0, 0.5]
 ```
 
-Each program goes to exactly one API — `basis_probabilities()` rejects any
-measurement, including terminal `M`-all. To compare them on the same
-circuit, compile two variants (unitary into `basis_probabilities()`,
-unitary + terminal `M`-all into `record_probabilities()`); the returned
-distributions match on the bitstrings the records encode. Their execution
-costs can differ by 100× either way, depending on circuit structure; see
-[Strong Simulation: Exact Probabilities](strong-simulation.md) for the
-tradeoff and when one is meaningfully faster.
-
-If you intentionally want to query the unitary skeleton of a mixed circuit
-with `basis_probabilities()`, compile with a custom HIR pass manager:
-
-```python
-import clifft
-
-circuit_text = """
-H 0
-M 0
-"""
-
-pm = clifft.HirPassManager()
-pm.add(clifft.DropNonUnitaryPass())
-
-program = clifft.compile(circuit_text, hir_passes=pm)
-ps = clifft.basis_probabilities(program, ["0", "1"])
-```
-
-!!! warning "DropNonUnitaryPass changes circuit semantics"
-    `DropNonUnitaryPass` drops non-evolution HIR operations, including
-    measurements, feedback, noise, annotations, and read-only probes. It is
-    useful when a user explicitly wants the unitary-only skeleton, but it is
-    not equivalent to sampling or marginalizing the original mixed circuit.
+See [Strong Simulation: Exact Probabilities](strong-simulation.md) for
+walkthroughs of both APIs, their limitations, and how their runtime cost
+depends on the circuit.
 
 ## Detectors, Observables, and Post-Selection
 

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -4,7 +4,8 @@ Clifft's Schrödinger Virtual Machine (SVM) executes compiled programs. The main
 
 - `sample()` for ordinary shot-based sampling
 - `sample_survivors()` for post-selected sampling
-- `probabilities()` for exact full-bitstring computational-basis probabilities
+- `basis_probabilities()` for exact computational-basis amplitudes of a unitary program
+- `record_probabilities()` for exact joint probabilities of measurement records
 - `execute()` and `get_statevector()` for inspecting small final states
 - `sample_k()` and `sample_k_survivors()` for stratified importance sampling
 
@@ -77,36 +78,39 @@ print(sv)  # [0.707+0j, 0+0j, 0+0j, 0.707+0j]
     $2^n$ state vector over all physical qubits. This is useful for debugging
     and validation, but it is not the scalable simulation path.
 
-## Basis-State Probabilities
+## Exact Probabilities
 
-For unitary circuits, `clifft.probabilities()` returns exact probabilities for
-full computational-basis bitstrings:
+Clifft offers two exact-probability APIs sitting on either side of one
+question: *is the final state pure?*
+
+- **`clifft.basis_probabilities(program, bitstrings)`** — for **unitary**
+  programs only. Returns $|\langle x | U | 0 \rangle|^2$ for each queried
+  bitstring. Rejects any measurement, feedback, noise, detector, observable,
+  or post-selection (`EXP_VAL` probes are allowed but ignored).
+
+- **`clifft.record_probabilities(program, records)`** — for programs **with
+  measurements** (and, optionally, classical feedback). Returns the exact
+  joint probability that `sample()` would assign to each measurement record.
 
 ```python
 import clifft
 
-program = clifft.compile("""
-    H 0
-    CNOT 0 1
-""")
-
-ps = clifft.probabilities(program, ["00", "01", "10", "11"])
+unitary = clifft.compile("H 0\nCNOT 0 1")
+ps = clifft.basis_probabilities(unitary, ["00", "01", "10", "11"])
 print(ps)  # [0.5, 0.0, 0.0, 0.5]
+
+measured = clifft.compile("H 0\nCNOT 0 1\nM 0 1")
+qs = clifft.record_probabilities(measured, ["00", "01", "10", "11"])
+print(qs)  # [0.5, 0.0, 0.0, 0.5]
 ```
 
-Bitstrings must cover all `program.num_qubits` qubits. By default,
-`bit_order="big"` maps the first character, or first column of a 2D NumPy
-`bool`/`uint8` array, to qubit 0. With `bit_order="little"`, the last character
-or column maps to qubit 0. The practical cost is driven by the number of queried
-bitstrings, the circuit size, and the final active rank rather than by dense
-state-vector expansion. Each call re-executes the program once, so pass all
-bitstrings you want to query in one batch.
+On terminal `M`-all circuits the two return the same numbers, but their
+algorithms differ in important ways covered in
+[Strong Simulation: Exact Probabilities](strong-simulation.md), including
+when one is meaningfully faster than the other.
 
-`probabilities()` rejects programs containing measurements, feedback, noise,
-readout noise, detectors, post-selection, or observables. `EXP_VAL` probes are
-allowed, but their stored outputs are ignored by `probabilities()`.
-If you intentionally want to query the unitary skeleton of a mixed circuit,
-compile with a custom HIR pass manager:
+If you intentionally want to query the unitary skeleton of a mixed circuit
+with `basis_probabilities()`, compile with a custom HIR pass manager:
 
 ```python
 import clifft
@@ -120,7 +124,7 @@ pm = clifft.HirPassManager()
 pm.add(clifft.DropNonUnitaryPass())
 
 program = clifft.compile(circuit_text, hir_passes=pm)
-ps = clifft.probabilities(program, ["0", "1"])
+ps = clifft.basis_probabilities(program, ["0", "1"])
 ```
 
 !!! warning "DropNonUnitaryPass changes circuit semantics"
@@ -128,9 +132,6 @@ ps = clifft.probabilities(program, ["0", "1"])
     measurements, feedback, noise, annotations, and read-only probes. It is
     useful when a user explicitly wants the unitary-only skeleton, but it is
     not equivalent to sampling or marginalizing the original mixed circuit.
-
-See [Strong Simulation with Exact Probabilities](strong-simulation.md) for a
-walkthrough focused on sparse exact probability queries.
 
 ## Detectors, Observables, and Post-Selection
 

--- a/docs/guide/strong-simulation.md
+++ b/docs/guide/strong-simulation.md
@@ -23,12 +23,21 @@ even there the two strategies have meaningfully different execution costs.
 | Your circuit… | Use |
 |---|---|
 | has no measurements | `basis_probabilities()` |
-| ends in `M`-all and has no feedback or noise | either; see [performance](#performance-on-overlapping-circuits) |
-| has any measurement, intermediate or terminal | `record_probabilities()` |
+| has any measurement (terminal or intermediate) | `record_probabilities()` |
 | has classical feedback (`CX rec[-1] q`, etc.) | `record_probabilities()` |
 | has noise, detectors, observables, or post-selection | neither — use `sample()` |
 
-## `basis_probabilities()`: amplitudes of a unitary state
+Each program goes through exactly one API: `basis_probabilities()` rejects
+any measurement, and `record_probabilities()` requires at least one. If
+you have a unitary circuit that you'd also like to query as a measured
+circuit, compile two variants — unitary into `basis_probabilities()`,
+unitary + terminal `M`-all into `record_probabilities()`. The returned
+distributions match on the bitstrings the records encode, but the two
+compile flows can lower the program differently and the runtime cost can
+differ by 100× either way; see
+[Performance on overlapping circuits](#performance-on-overlapping-circuits).
+
+## `basis_probabilities()`: probabilities of a unitary state
 
 The smallest example is a Bell state. The circuit has four possible two-bit
 outputs, but only `00` and `11` have nonzero probability:

--- a/docs/guide/strong-simulation.md
+++ b/docs/guide/strong-simulation.md
@@ -5,8 +5,9 @@ Clifft provides two exact-probability APIs covering complementary regimes:
 - **`clifft.basis_probabilities(unitary_program, bitstrings)`** — exact
   computational-basis probabilities for a unitary program.
 - **`clifft.record_probabilities(measured_program, records)`** — exact
-  joint probabilities of measurement records for a circuit that contains
-  measurements (with or without classical feedback).
+  joint probabilities of measurement records for a unitary circuit that
+  contains measurements (with or without classical feedback). Noise is
+  not supported.
 
 You can convert the former problem into the latter by adding explicit
 terminal measurements to a unitary program, and the two distributions match

--- a/docs/guide/strong-simulation.md
+++ b/docs/guide/strong-simulation.md
@@ -1,22 +1,18 @@
 # Strong Simulation: Exact Probabilities
 
-Clifft provides two exact-probability APIs. They sit on opposite sides of a
-single question: *is the final state of the program a single pure state?*
+Clifft provides two exact-probability APIs covering complementary regimes:
 
-- **`clifft.basis_probabilities(unitary_program, bitstrings)`** — for
-  unitary programs. Returns the Born probability
-  $|\langle x | U | 0 \rangle|^2$ of each queried computational-basis
-  bitstring.
-- **`clifft.record_probabilities(measured_program, records)`** — for
-  programs that contain at least one measurement (with or without classical
-  feedback). Returns the exact joint probability that `sample()` would
-  assign to each measurement record.
+- **`clifft.basis_probabilities(unitary_program, bitstrings)`** — exact
+  computational-basis probabilities for a unitary program.
+- **`clifft.record_probabilities(measured_program, records)`** — exact
+  joint probabilities of measurement records for a circuit that contains
+  measurements (with or without classical feedback).
 
-Any measurement breaks the pure-state assumption, so the two APIs cover
-disjoint regions of program-space. They overlap mathematically when the
-circuit is a unitary prefix followed by terminal `M`-all — but, as the
-[performance section below](#performance-on-overlapping-circuits) explains,
-even there the two strategies have meaningfully different execution costs.
+You can convert the former problem into the latter by adding explicit
+terminal measurements to a unitary program, and the two distributions match
+on the bitstrings the records encode. The runtime cost can differ
+substantially — see
+[Performance on overlapping circuits](#performance-on-overlapping-circuits).
 
 ## When to use which
 
@@ -26,16 +22,6 @@ even there the two strategies have meaningfully different execution costs.
 | has any measurement (terminal or intermediate) | `record_probabilities()` |
 | has classical feedback (`CX rec[-1] q`, etc.) | `record_probabilities()` |
 | has noise, detectors, observables, or post-selection | neither — use `sample()` |
-
-Each program goes through exactly one API: `basis_probabilities()` rejects
-any measurement, and `record_probabilities()` requires at least one. If
-you have a unitary circuit that you'd also like to query as a measured
-circuit, compile two variants — unitary into `basis_probabilities()`,
-unitary + terminal `M`-all into `record_probabilities()`. The returned
-distributions match on the bitstrings the records encode, but the two
-compile flows can lower the program differently and the runtime cost can
-differ by 100× either way; see
-[Performance on overlapping circuits](#performance-on-overlapping-circuits).
 
 ## `basis_probabilities()`: probabilities of a unitary state
 

--- a/docs/guide/strong-simulation.md
+++ b/docs/guide/strong-simulation.md
@@ -1,17 +1,34 @@
-# Strong Simulation with Exact Probabilities
+# Strong Simulation: Exact Probabilities
 
-Strong simulation asks for exact output probabilities, not sampled shots.
-For unitary circuits, `clifft.probabilities()` computes exact probabilities
-for selected full-register bitstrings without expanding the full statevector.
+Clifft provides two exact-probability APIs. They sit on opposite sides of a
+single question: *is the final state of the program a single pure state?*
 
-This is useful when:
+- **`clifft.basis_probabilities(unitary_program, bitstrings)`** — for
+  unitary programs. Returns the Born probability
+  $|\langle x | U | 0 \rangle|^2$ of each queried computational-basis
+  bitstring.
+- **`clifft.record_probabilities(measured_program, records)`** — for
+  programs that contain at least one measurement (with or without classical
+  feedback). Returns the exact joint probability that `sample()` would
+  assign to each measurement record.
 
-- You care about a sparse set of output bitstrings.
-- The circuit is wider than is convenient for dense statevector extraction.
-- The active rank stays small, so exact sparse queries are cheap.
-- You want deterministic checks for compiled circuits.
+Any measurement breaks the pure-state assumption, so the two APIs cover
+disjoint regions of program-space. They overlap mathematically when the
+circuit is a unitary prefix followed by terminal `M`-all — but, as the
+[performance section below](#performance-on-overlapping-circuits) explains,
+even there the two strategies have meaningfully different execution costs.
 
-## Warm-up: Bell State
+## When to use which
+
+| Your circuit… | Use |
+|---|---|
+| has no measurements | `basis_probabilities()` |
+| ends in `M`-all and has no feedback or noise | either; see [performance](#performance-on-overlapping-circuits) |
+| has any measurement, intermediate or terminal | `record_probabilities()` |
+| has classical feedback (`CX rec[-1] q`, etc.) | `record_probabilities()` |
+| has noise, detectors, observables, or post-selection | neither — use `sample()` |
+
+## `basis_probabilities()`: amplitudes of a unitary state
 
 The smallest example is a Bell state. The circuit has four possible two-bit
 outputs, but only `00` and `11` have nonzero probability:
@@ -25,7 +42,7 @@ program = clifft.compile("""
 """)
 
 bitstrings = ["00", "01", "10", "11"]
-ps = clifft.probabilities(program, bitstrings)
+ps = clifft.basis_probabilities(program, bitstrings)
 
 for bitstring, probability in zip(bitstrings, ps):
     print(f"{bitstring}: {probability:.1f}")
@@ -43,11 +60,11 @@ Output:
 By default, `bit_order="big"` maps the first bitstring character to qubit 0.
 Each queried bitstring must include every qubit in the program.
 
-## Sparse Queries on a Wider Circuit
+### Sparse queries on a wider circuit
 
-For small circuits, `get_statevector()` is often the simplest way to inspect a
-state. It returns all $2^n$ amplitudes, so it is not the right interface when
-you only need a few exact probabilities from a wider output space.
+For small circuits, `get_statevector()` is often the simplest way to inspect
+a state. It returns all $2^n$ amplitudes, so it is not the right interface
+when you only need a few exact probabilities from a wider output space.
 
 The following circuit creates a small rare branch on qubit 0, then fans that
 branch out across the rest of the register:
@@ -73,7 +90,7 @@ bitstrings = [
     "0" * (n - 1) + "1",
 ]
 
-ps = clifft.probabilities(program, bitstrings)
+ps = clifft.basis_probabilities(program, bitstrings)
 
 print(f"qubits: {program.num_qubits}")
 print(f"peak active rank: {program.peak_rank}")
@@ -95,27 +112,28 @@ peak active rank: 1
 The full output space has 4096 bitstrings, but the query asks for only four.
 The non-Clifford work is localized to one active qubit, so the exact query
 scales with the active rank rather than by constructing a 4096-entry
-statevector. The same pattern is useful at larger widths when the active rank
-remains small and the set of target outputs stays sparse.
+statevector. The same pattern is useful at larger widths when the active
+rank remains small and the set of target outputs stays sparse.
 
-## Batch Related Queries
+### Batch related queries
 
 Pass all target bitstrings in one call:
 
 <!--pytest-codeblocks:cont-->
 
 ```python
-ps = clifft.probabilities(program, bitstrings)
+ps = clifft.basis_probabilities(program, bitstrings)
 ```
 
 Clifft shares circuit-dependent stabilizer work across the batch. Repeated
-single-bitstring calls are correct, but they rebuild work that one batched call
-can reuse.
+single-bitstring calls are correct, but they rebuild work that one batched
+call can reuse.
 
-## Programmatic Bitstring Arrays
+### Programmatic bitstring arrays
 
-String bitstrings are convenient in examples and tests. For generated queries,
-pass a 2D NumPy array with one row per bitstring and one column per qubit:
+String bitstrings are convenient in examples and tests. For generated
+queries, pass a 2D NumPy array with one row per bitstring and one column per
+qubit:
 
 <!--pytest-codeblocks:cont-->
 
@@ -131,7 +149,7 @@ query_bits = np.array(
     dtype=np.uint8,
 )
 
-ps = clifft.probabilities(program, query_bits)
+ps = clifft.basis_probabilities(program, query_bits)
 print(ps)
 ```
 
@@ -145,44 +163,216 @@ Output:
 `bit_order="big"` maps the first column to qubit 0; use
 `bit_order="little"` if the last column should map to qubit 0.
 
-## Compare with Sampling
+## `record_probabilities()`: probabilities of measurement records
 
-Sampling estimates probabilities from repeated shots. Exact probability queries
-return deterministic values:
-
-<!--pytest-codeblocks:cont-->
+`record_probabilities()` is the analytical counterpart of `sample()`: same
+trajectory model, but exact rather than estimated. The smallest example
+again is a Bell measurement, this time with the measurement included:
 
 ```python
-measurement = "M " + " ".join(str(q) for q in range(n))
-sample_program = clifft.compile("\n".join([*lines, measurement]))
+import clifft
 
-samples = clifft.sample(sample_program, shots=1000, seed=5)
-rare_hits = samples.measurements.all(axis=1).sum()
-print(rare_hits)
+program = clifft.compile("""
+    H 0
+    CNOT 0 1
+    M 0 1
+""")
+
+records = ["00", "01", "10", "11"]
+ps = clifft.record_probabilities(program, records)
+
+for record, probability in zip(records, ps):
+    print(f"{record}: {probability:.1f}")
 ```
 
-For a branch with probability around $10^{-3}$, a 1000-shot sample may see the
-rare outcome zero, one, or a few times. `probabilities()` reports the exact
-value directly.
+Output:
+
+```text
+00: 0.5
+01: 0.0
+10: 0.0
+11: 0.5
+```
+
+Each record is interpreted in measurement order: position `i` is the `i`-th
+entry `sample().measurements` would emit for that shot. A single record
+string is also accepted and returns a length-one array.
+
+### Joint probabilities under feedback
+
+`record_probabilities()` handles classical feedback (`CX rec[-1] ...` and
+related conditional gates). For trajectories where later operations depend
+on earlier outcomes, it returns the exact joint probability of the full
+record:
+
+```python
+import clifft
+
+program = clifft.compile("""
+    H 0
+    M 0
+    CX rec[-1] 1
+    M 1
+""")
+
+records = ["00", "01", "10", "11"]
+ps = clifft.record_probabilities(program, records)
+
+for record, probability in zip(records, ps):
+    print(f"{record}: {probability:.2f}")
+```
+
+Output:
+
+```text
+00: 0.50
+01: 0.00
+10: 0.00
+11: 0.50
+```
+
+Qubit 1 is flipped exactly when the first measurement returned 1, so
+records `01` and `10` are unreachable.
+
+### Cross-check against sampling
+
+For circuits ending in `M ...`, `sample()` produces an empirical
+distribution and `record_probabilities()` produces the exact distribution
+they should converge to. The two should agree up to the usual binomial
+sampling error:
+
+```python
+import clifft
+
+program = clifft.compile("H 0\nT 0\nH 0\nM 0")
+
+probs = clifft.record_probabilities(program, ["0", "1"])
+
+shots = 200_000
+samples = clifft.sample(program, shots=shots, seed=42).measurements
+freq_1 = float(samples.sum()) / shots
+freq_0 = 1.0 - freq_1
+
+print(f"exact: {probs[0]:.4f} {probs[1]:.4f}")
+print(f"freq:  {freq_0:.4f} {freq_1:.4f}")
+```
+
+Probabilities here are around 0.85 and 0.15 (the
+$(2 \pm \sqrt{2})/4$ outcomes of an $HTH$ rotation), and 200,000 shots
+resolve them to within a few thousandths.
+
+### Log probabilities for deep circuits
+
+For circuits with many measurements, joint probabilities can underflow
+float64. Pass `return_log=True` to get natural-log values instead:
+
+```python
+import clifft
+
+program = clifft.compile("H 0\nM 0")
+
+log_ps = clifft.record_probabilities(program, ["0", "1"], return_log=True)
+print(log_ps)
+```
+
+Output:
+
+```text
+[-0.69314718 -0.69314718]
+```
+
+Unreachable records are reported as `0.0` in linear output and `-inf` in
+log output.
+
+## Performance on overlapping circuits
+
+When the circuit is a unitary prefix followed by terminal `M`-all, either
+API mathematically applies. They use very different execution strategies,
+though, and the difference can be 100×+ in either direction:
+
+- `basis_probabilities()` evolves the program once, then walks
+  active-state amplitudes per queried bitstring. The up-front cost is
+  amortized across the batch.
+- `record_probabilities()` rewrites measurement opcodes to force the
+  requested outcome and replays the bytecode once per record. No
+  amortization, but the compiler's `StatevectorSqueezePass` can reorder
+  measurements next to their non-Clifford gates to free active dimensions
+  early — which lowers the effective active rank.
+
+A practical way to choose: compile both forms and read off
+`program.peak_rank`. When the *measured* form has a noticeably lower peak
+rank than the unitary form, `record_probabilities()` is typically faster
+per query. When the two peak ranks match, `basis_probabilities()` wins
+because it amortizes the bytecode execution across queries.
+
+```python
+import clifft
+
+# A circuit with a final H sandwich on every qubit: the squeeze pass can
+# pair each terminal H-T-H with an M and free that qubit's active dim early.
+circuit = """
+H 0 1 2 3 4
+CX 0 1
+CX 2 3
+CX 1 4
+H 0 1 2 3 4
+T 0 1 2 3 4
+H 0 1 2 3 4
+"""
+
+unitary = clifft.compile(circuit)
+measured = clifft.compile(circuit + "\nM 0 1 2 3 4")
+
+print(f"basis_probabilities()  peak_rank: {unitary.peak_rank}")
+print(f"record_probabilities() peak_rank: {measured.peak_rank}")
+```
+
+A gap in `peak_rank` indicates roughly a
+$2^{(k_{\text{unitary}} - k_{\text{measured}})}$ speedup ceiling for
+`record_probabilities()` over `basis_probabilities()` on this circuit,
+independent of batch size. At equal peak rank,
+`basis_probabilities()` wins by roughly the bytecode-to-amplitude-walk
+cost ratio for any moderately sized batch.
+
+If neither performance regime dominates your workload, picking by the
+table at the top — does the circuit have measurements? — is the right
+default.
 
 ## Limitations
 
-`probabilities()` applies to unitary programs. It rejects programs containing
-measurements, feedback, noise, readout noise, detectors, observables, or
-post-selection. Use `sample()` or `sample_survivors()` for mixed-circuit
-workflows.
+Both APIs reject programs that include noise, readout noise, detectors,
+observables, or post-selection. These constructs make the trajectory
+multi-valued or signal-conditioned in a way neither API models. Use
+[`sample()`](simulation.md#sampling) or
+[`sample_survivors()`](simulation.md) for those workflows.
 
-If you intentionally want to query the unitary skeleton of a mixed circuit,
-compile with [`DropNonUnitaryPass`](../reference/passes.md). That changes the
-circuit semantics by dropping non-unitary operations; it is not equivalent to
-sampling or marginalizing the original circuit.
+`basis_probabilities()` additionally rejects programs that contain any
+measurement, including terminal `M`-all. The rejection criterion is sharp:
+any measurement breaks the single-pure-final-state assumption that the
+amplitude-walk algorithm relies on. If you intentionally want the unitary
+skeleton of a mixed circuit, compile with
+[`DropNonUnitaryPass`](../reference/passes.md) — but note that this
+changes the circuit's semantics; it is not equivalent to marginalizing the
+original circuit.
 
-## How It Works
+`record_probabilities()` requires at least one measurement. Programs with
+hidden measurement slots (from `R` / reset gates lowered to
+measure-then-feedback) are also rejected. Recompile without resets, or use
+`sample()` to marginalize over the hidden outcomes.
 
-Clifft combines the active state vector with the final Clifford frame. For each
-queried physical bitstring, it sums over the active basis states and evaluates
-the remaining Clifford matrix elements as stabilizer amplitudes. The result is
-an exact full-register probability without expanding the entire physical
-statevector.
+## How it works
 
-See [Basis-State Probabilities](../theory/probabilities.md) for the algorithm.
+`basis_probabilities()` combines the active state vector with the final
+Clifford frame. For each queried physical bitstring, it sums over the
+active basis states and evaluates the remaining Clifford matrix elements as
+stabilizer amplitudes. The result is an exact full-register probability
+without expanding the entire physical statevector. See
+[Basis-State Probabilities](../theory/basis_probabilities.md) for the
+algorithm.
+
+`record_probabilities()` rewrites each sampling measurement opcode to a
+forced-outcome sibling and runs the program once per record. The forced
+kernels replace the PRNG draw with the user-supplied outcome and accumulate
+the log-probability of that choice into a running scalar, using the same
+dust-clamping convention as the sampler. The original `CompiledModule` is
+not mutated; the rewrite runs on a private shallow copy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,9 +87,10 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 ## What's New in 0.3.0
 
 Clifft 0.3.0 adds strong simulation for unitary circuits with
-`clifft.basis_probabilities()`, which computes exact probabilities for selected
+`clifft.probabilities()`, which computes exact probabilities for selected
 full-register computational-basis bitstrings without materializing the full
-statevector.
+statevector. (This API is renamed to `clifft.basis_probabilities()` in the
+next release.)
 
 It also removes the old compile-time qubit ceiling by moving Pauli mask storage
 to runtime-width arenas, and improves playground responsiveness on larger

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 ## What's New in 0.3.0
 
 Clifft 0.3.0 adds strong simulation for unitary circuits with
-`clifft.probabilities()`, which computes exact probabilities for selected
+`clifft.basis_probabilities()`, which computes exact probabilities for selected
 full-register computational-basis bitstrings without materializing the full
 statevector.
 

--- a/docs/theory/basis_probabilities.md
+++ b/docs/theory/basis_probabilities.md
@@ -1,6 +1,6 @@
 # Basis-State Probabilities
 
-For unitary programs, `clifft.probabilities()` computes exact probabilities for
+For unitary programs, `clifft.basis_probabilities()` computes exact probabilities for
 full-register computational-basis bitstrings without materializing the full
 $2^n$ statevector. This page summarizes the algorithm behind that API. For
 usage examples, see [Strong Simulation with Exact Probabilities](../guide/strong-simulation.md).
@@ -168,7 +168,7 @@ walk over the $2^k$ active basis states.
 
 ## Complexity
 
-Per `clifft.probabilities()` call, with $M$ queried bitstrings, $n$ qubits,
+Per `clifft.basis_probabilities()` call, with $M$ queried bitstrings, $n$ qubits,
 active rank $k$, and total X-rank $r_X$:
 
 | Step | Cost | Frequency |
@@ -201,7 +201,7 @@ speedup on Clifford+T workloads.
 For very small circuits ($n \lesssim 10$),
 [`clifft.get_statevector()`](../guide/simulation.md) returns the full
 $2^n$-amplitude vector and squaring its absolute value is the fastest
-path to a probability table. `probabilities()` shines when:
+path to a probability table. `basis_probabilities()` shines when:
 
 - $n$ is large enough that materializing the full $2^n$ statevector is
   impractical, but you only care about a sparse set of bitstrings.
@@ -210,8 +210,10 @@ path to a probability table. `probabilities()` shines when:
 - You want to query many bitstrings against the same circuit (the
   structure is shared across the batch).
 
-For mixed circuits, including measurements, noise, and observables,
-`probabilities()` is not applicable, since the state is no longer a single pure
-vector. Use [sampling](../guide/simulation.md#sampling) for those workflows, or
+For circuits ending in measurements (with or without classical feedback),
+[`clifft.record_probabilities()`](../guide/strong-simulation.md)
+returns the exact joint probability of a given measurement record. For
+broader workflows that include noise or post-selection, use
+[sampling](../guide/simulation.md#sampling), or
 [`DropNonUnitaryPass`](../reference/passes.md) if you intentionally want
 to query the unitary skeleton of a mixed circuit.

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -87,12 +87,12 @@ The Schrodinger Virtual Machine executes the localized bytecode using the factor
 
 ## Exact Basis-State Probabilities
 
-For unitary programs, `clifft.probabilities()` computes exact full-register
+For unitary programs, `clifft.basis_probabilities()` computes exact full-register
 computational-basis probabilities from the same factored state representation,
 without expanding the full $2^n$ statevector. The exponential part still scales
 with the active dimension $k$, so the API is useful when you need exact
 probabilities for a sparse set of output bitstrings.
 
-See [Basis-State Probabilities](probabilities.md) for the algorithm and
+See [Basis-State Probabilities](basis_probabilities.md) for the algorithm and
 [Strong Simulation with Exact Probabilities](../guide/strong-simulation.md) for
 a practical tutorial.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
   - Theory:
     - Overview: theory/overview.md
     - Architecture: theory/architecture.md
-    - Basis-State Probabilities: theory/probabilities.md
+    - Basis-State Probabilities: theory/basis_probabilities.md
   - Reference:
     - Supported Gates: reference/gates.md
     - Instruction Reference: reference/instructions.md

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -19,8 +19,8 @@ add_library(clifft_core STATIC
     optimizer/remove_noise_pass.cc
     optimizer/statevector_squeeze_pass.cc
     backend/backend.cc
-    api/probabilities.cc
-    api/probability_of.cc
+    api/basis_probabilities.cc
+    api/record_probabilities.cc
     api/reference_syndrome.cc
     svm/svm.cc
     svm/svm_forced_kernels.cc

--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -1,6 +1,6 @@
 // Exact basis-state probability queries. The Gaussian elimination over the
 // inverse Clifford tableau and the per-bitstring amplitude lookup are the
-// implementation of the algorithm derived in docs/theory/probabilities.md.
+// implementation of the algorithm derived in docs/theory/basis_probabilities.md.
 
 #include "clifft/svm/svm.h"
 #include "clifft/svm/svm_math.h"

--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -455,7 +455,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
         case Opcode::NUM_OPCODES:
             return true;
     }
-    throw std::invalid_argument("probabilities() encountered an unknown bytecode opcode");
+    throw std::invalid_argument("basis_probabilities() encountered an unknown bytecode opcode");
 }
 
 void assert_probability_program_is_supported(const CompiledModule& program) {
@@ -464,7 +464,8 @@ void assert_probability_program_is_supported(const CompiledModule& program) {
     for (const auto& instr : program.bytecode) {
         if (is_unsupported_probability_opcode(instr.opcode)) {
             throw std::invalid_argument(
-                "probabilities() requires pure-state evolution: measurements, feedback, noise, "
+                "basis_probabilities() requires pure-state evolution: measurements, feedback, "
+                "noise, "
                 "readout noise, detectors, postselection, and observables are not supported. "
                 "EXP_VAL probes are allowed but their outputs are ignored. Use "
                 "DropNonUnitaryPass only if you intentionally want to query the unitary "
@@ -475,13 +476,14 @@ void assert_probability_program_is_supported(const CompiledModule& program) {
 
 }  // namespace
 
-std::vector<double> probabilities(const CompiledModule& program,
-                                  std::span<const uint64_t> basis_masks, size_t num_basis_masks,
-                                  size_t words_per_basis_mask) {
+std::vector<double> basis_probabilities(const CompiledModule& program,
+                                        std::span<const uint64_t> basis_masks,
+                                        size_t num_basis_masks, size_t words_per_basis_mask) {
     assert_probability_program_is_supported(program);
     if (!program.constant_pool.final_tableau.has_value()) {
         throw std::invalid_argument(
-            "probabilities() requires final Clifford tableau metadata; compile programs through "
+            "basis_probabilities() requires final Clifford tableau metadata; compile programs "
+            "through "
             "clifft.compile() or preserve ConstantPool::final_tableau.");
     }
     assert_arena_widths_match(program.num_qubits, program.constant_pool);

--- a/src/clifft/api/record_probabilities.cc
+++ b/src/clifft/api/record_probabilities.cc
@@ -137,7 +137,11 @@ std::vector<double> record_probabilities(const CompiledModule& program,
             "record_probabilities() does not yet support programs with hidden measurement slots "
             "(e.g. R / reset gates). Compile without resets, or use sample() to marginalize.");
     }
-    if (records.size() != num_records * program.num_measurements) {
+    // Validate buffer length without forming the product, which can wrap
+    // size_t when num_records is attacker-controlled at the C++ entry point.
+    // After the early-out above we know num_measurements > 0.
+    if (records.size() % program.num_measurements != 0 ||
+        records.size() / program.num_measurements != num_records) {
         throw std::invalid_argument(
             "record_probabilities() record buffer length must equal "
             "num_records * program.num_measurements");

--- a/src/clifft/api/record_probabilities.cc
+++ b/src/clifft/api/record_probabilities.cc
@@ -1,6 +1,6 @@
 // Exact measurement-record probability queries.
 //
-// probability_of() runs the compiled program once per requested record,
+// record_probabilities() runs the compiled program once per requested record,
 // forcing each measurement to the user-supplied outcome and accumulating
 // log(prob_b / total) into state.forced_log_probability under the same
 // dust-clamping policy sample_branch() uses. A bytecode rewrite swaps
@@ -22,7 +22,7 @@
 namespace clifft {
 namespace {
 
-[[nodiscard]] bool is_unsupported_probability_of_opcode(Opcode opcode) {
+[[nodiscard]] bool is_unsupported_record_probabilities_opcode(Opcode opcode) {
     // Allowed: all gate / expand / array opcodes, EXP_VAL probes, feedback
     // (OP_APPLY_PAULI), and any sampling-mode measurement opcode (rewritten
     // to its FORCED sibling before execution). Forced opcodes shouldn't
@@ -75,14 +75,14 @@ namespace {
         case Opcode::NUM_OPCODES:
             return true;
     }
-    throw std::invalid_argument("probability_of() encountered an unknown bytecode opcode");
+    throw std::invalid_argument("record_probabilities() encountered an unknown bytecode opcode");
 }
 
-void assert_probability_of_program_is_supported(const CompiledModule& program) {
+void assert_record_probabilities_program_is_supported(const CompiledModule& program) {
     for (const auto& instr : program.bytecode) {
-        if (is_unsupported_probability_of_opcode(instr.opcode)) {
+        if (is_unsupported_record_probabilities_opcode(instr.opcode)) {
             throw std::invalid_argument(
-                "probability_of() requires pure-state evolution with measurements: noise, "
+                "record_probabilities() requires pure-state evolution with measurements: noise, "
                 "feedback-free detectors, observables, and post-selection are not supported. "
                 "Forced-measurement opcodes are reserved for the internal rewrite and must not "
                 "appear in user-compiled programs.");
@@ -119,13 +119,13 @@ void rewrite_for_forced_execution(std::vector<Instruction>& bytecode) {
 
 }  // namespace
 
-std::vector<double> probability_of(const CompiledModule& program, std::span<const uint8_t> records,
-                                   size_t num_records) {
-    assert_probability_of_program_is_supported(program);
+std::vector<double> record_probabilities(const CompiledModule& program,
+                                         std::span<const uint8_t> records, size_t num_records) {
+    assert_record_probabilities_program_is_supported(program);
     if (program.num_measurements == 0) {
         throw std::invalid_argument(
-            "probability_of() requires a program with at least one measurement; use "
-            "clifft::probabilities() for unitary circuits.");
+            "record_probabilities() requires a program with at least one measurement; use "
+            "clifft::basis_probabilities() for unitary circuits.");
     }
     // Hidden measurement slots (e.g. from R / reset gates lowered to
     // measure + classical-feedback Pauli) would be indexed past the
@@ -134,12 +134,12 @@ std::vector<double> probability_of(const CompiledModule& program, std::span<cons
     // now, so reject programs that have any.
     if (program.total_meas_slots != program.num_measurements) {
         throw std::invalid_argument(
-            "probability_of() does not yet support programs with hidden measurement slots "
+            "record_probabilities() does not yet support programs with hidden measurement slots "
             "(e.g. R / reset gates). Compile without resets, or use sample() to marginalize.");
     }
     if (records.size() != num_records * program.num_measurements) {
         throw std::invalid_argument(
-            "probability_of() record buffer length must equal "
+            "record_probabilities() record buffer length must equal "
             "num_records * program.num_measurements");
     }
     // Each record byte represents one measurement outcome and must be 0 or 1.
@@ -148,7 +148,7 @@ std::vector<double> probability_of(const CompiledModule& program, std::span<cons
     for (uint8_t byte : records) {
         if (byte != 0 && byte != 1) {
             throw std::invalid_argument(
-                "probability_of() record bytes must be 0 or 1; each represents one "
+                "record_probabilities() record bytes must be 0 or 1; each represents one "
                 "measurement outcome.");
         }
     }

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -60,7 +60,7 @@ enum class Opcode : uint8_t {
     OP_SWAP_MEAS_INTERFERE,    // Fused ARRAY_SWAP + MEAS_ACTIVE_INTERFERE
 
     // Forced-outcome measurement variants. Synthesized at runtime by
-    // probability_of() via a bytecode rewrite; never emitted by the
+    // record_probabilities() via a bytecode rewrite; never emitted by the
     // compiler. Each forced variant reads the desired outcome from a
     // side buffer (one byte per record slot) instead of sampling from
     // the PRNG, and accumulates the log-probability of that outcome

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -364,13 +364,13 @@ std::vector<double> noise_site_probabilities(const CompiledModule& program);
 /// full-register basis states. EXP_VAL probes are ignored; measurement,
 /// feedback, noise, detector, postselection, and observable opcodes are
 /// rejected. Each basis mask is word-packed little-endian by qubit index.
-std::vector<double> probabilities(const CompiledModule& program,
-                                  std::span<const uint64_t> basis_masks, size_t num_basis_masks,
-                                  size_t words_per_basis_mask);
+std::vector<double> basis_probabilities(const CompiledModule& program,
+                                        std::span<const uint64_t> basis_masks,
+                                        size_t num_basis_masks, size_t words_per_basis_mask);
 
-/// Sentinel returned by `probability_of()` for records the program cannot
-/// emit. Equal to `std::numeric_limits<double>::lowest()` (-DBL_MAX). A
-/// finite value is used (rather than `-infinity`) so the contract survives
+/// Sentinel returned by `record_probabilities()` for records the program
+/// cannot emit. Equal to `std::numeric_limits<double>::lowest()` (-DBL_MAX).
+/// A finite value is used (rather than `-infinity`) so the contract survives
 /// `-ffast-math` builds, which assume infinities cannot occur and fold
 /// away `std::isinf`/`std::isfinite`. Exponentiating it underflows to 0.
 inline constexpr double kUnreachableLogProb = std::numeric_limits<double>::lowest();
@@ -386,8 +386,8 @@ inline constexpr double kUnreachableLogProb = std::numeric_limits<double>::lowes
 /// bytes (0 or 1 per slot, in execution order -- the same order
 /// sample().measurements uses). Records the program cannot emit return
 /// `kUnreachableLogProb`; other entries are natural-log probabilities.
-std::vector<double> probability_of(const CompiledModule& program, std::span<const uint8_t> records,
-                                   size_t num_records);
+std::vector<double> record_probabilities(const CompiledModule& program,
+                                         std::span<const uint8_t> records, size_t num_records);
 
 // =============================================================================
 // Statevector Expansion

--- a/src/clifft/svm/svm_forced_kernels.cc
+++ b/src/clifft/svm/svm_forced_kernels.cc
@@ -29,7 +29,7 @@ namespace {
 // log-probability of a forced outcome b in {0, 1}. The sampling path
 // treats any branch with prob <= kDustEpsilon * total as exactly zero,
 // so records containing such an outcome are never emitted by sample().
-// probability_of() must agree:
+// record_probabilities() must agree:
 //   - The dust branch is unreachable.
 //   - When the other branch is dust, the surviving branch is
 //     deterministic and its log-increment is 0 (not log(prob/total)).

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -2226,7 +2226,7 @@ void execute_internal(const CompiledModule& program, SchrodingerState& state) {
         [static_cast<uint8_t>(Opcode::OP_MEAS_ACTIVE_INTERFERE)] = &&L_OP_MEAS_ACTIVE_INTERFERE,
         [static_cast<uint8_t>(Opcode::OP_SWAP_MEAS_INTERFERE)] = &&L_OP_SWAP_MEAS_INTERFERE,
 
-        // Forced-measurement opcodes are synthesized by probability_of()'s
+        // Forced-measurement opcodes are synthesized by record_probabilities()'s
         // bytecode rewrite. The kernels read each outcome from
         // state.forced_record[classical_idx] and accumulate the log-
         // probability into state.forced_log_probability. They return false

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1084,29 +1084,30 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("program"), nb::arg("state"), "Expand the SVM state into a dense statevector.");
 
     m.def(
-        "_probabilities_from_bitmasks",
+        "_basis_probabilities_from_bitmasks",
         [](const clifft::CompiledModule& program,
            nb::ndarray<nb::numpy, const uint64_t, nb::shape<-1, -1>, nb::c_contig> basis_masks) {
             std::vector<double> probs;
             {
                 nb::gil_scoped_release release;
-                probs = clifft::probabilities(
+                probs = clifft::basis_probabilities(
                     program, std::span<const uint64_t>(basis_masks.data(), basis_masks.size()),
                     basis_masks.shape(0), basis_masks.shape(1));
             }
             size_t n = probs.size();
             return vec_to_numpy(std::move(probs), {n});
         },
-        nb::arg("program"), nb::arg("basis_masks"), "Internal helper for clifft.probabilities().");
+        nb::arg("program"), nb::arg("basis_masks"),
+        "Internal helper for clifft.basis_probabilities().");
 
     m.def(
-        "_probability_of_from_records",
+        "_record_probabilities_from_records",
         [](const clifft::CompiledModule& program,
            nb::ndarray<nb::numpy, const uint8_t, nb::shape<-1, -1>, nb::c_contig> records) {
             std::vector<double> log_probs;
             {
                 nb::gil_scoped_release release;
-                log_probs = clifft::probability_of(
+                log_probs = clifft::record_probabilities(
                     program, std::span<const uint8_t>(records.data(), records.size()),
                     records.shape(0));
             }
@@ -1114,6 +1115,6 @@ NB_MODULE(_clifft_core, m) {
             return vec_to_numpy(std::move(log_probs), {n});
         },
         nb::arg("program"), nb::arg("records"),
-        "Internal helper for clifft.probability_of(). Returns log-probabilities; "
+        "Internal helper for clifft.record_probabilities(). Returns log-probabilities; "
         "the Python wrapper exponentiates to linear unless return_log=True.");
 }

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -81,8 +81,8 @@ from clifft._clifft_core import (
     StatevectorSqueezePass,
     SwapMeasPass,
     Target,
-    _probabilities_from_bitmasks,
-    _probability_of_from_records,
+    _basis_probabilities_from_bitmasks,
+    _record_probabilities_from_records,
     compute_reference_syndrome,
     default_bytecode_pass_manager,
     default_hir_pass_manager,
@@ -180,20 +180,24 @@ def _basis_masks_from_bitstrings(
     )
 
 
-def probabilities(
+def basis_probabilities(
     program: Program,
     bitstrings: BasisBitstrings,
     *,
     bit_order: str = "big",
 ) -> npt.NDArray[np.float64]:
-    """Return exact probabilities for full computational-basis bitstrings.
+    """Exact Born probabilities of computational-basis bitstrings.
+
+    Requires a unitary program (no measurements, feedback, noise, detectors,
+    observables, or post-selection). For circuits with measurements, use
+    :func:`record_probabilities` instead.
 
     ``bit_order="big"`` maps the first character or array column to qubit 0.
     ``bit_order="little"`` maps the last character or array column to qubit 0.
     """
     return cast(
         npt.NDArray[np.float64],
-        _probabilities_from_bitmasks(
+        _basis_probabilities_from_bitmasks(
             program, _basis_masks_from_bitstrings(program, bitstrings, bit_order)
         ),
     )
@@ -252,13 +256,16 @@ def _records_from_outcomes(
     return np.ascontiguousarray(bit_array.astype(np.uint8, copy=False))
 
 
-def probability_of(
+def record_probabilities(
     program: Program,
     records: MeasurementRecords,
     *,
     return_log: bool = False,
 ) -> npt.NDArray[np.float64]:
-    """Return the exact probability sample() would assign to each record.
+    """Exact joint probabilities of measurement records under ``sample()``.
+
+    Requires at least one measurement. For a purely unitary program with no
+    measurements, use :func:`basis_probabilities` instead.
 
     ``records`` is one of: a single record string (e.g. ``"010"``), a
     sequence of record strings, or a 2D ``bool`` / ``uint8`` array of
@@ -274,7 +281,7 @@ def probability_of(
     record_array = _records_from_outcomes(program, records)
     log_probs = cast(
         npt.NDArray[np.float64],
-        _probability_of_from_records(program, record_array),
+        _record_probabilities_from_records(program, record_array),
     )
     # C++ marks unreachable records with the finite sentinel
     # numpy.finfo(float64).min (-DBL_MAX). Translate it back to the
@@ -375,6 +382,7 @@ __all__ = [
     "StatevectorSqueezePass",
     "SwapMeasPass",
     "Target",
+    "basis_probabilities",
     "compile",
     "compute_reference_syndrome",
     "default_bytecode_pass_manager",
@@ -385,8 +393,7 @@ __all__ = [
     "lower",
     "parse",
     "parse_file",
-    "probabilities",
-    "probability_of",
+    "record_probabilities",
     "sample",
     "sample_k",
     "sample_k_survivors",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -206,6 +206,12 @@ def basis_probabilities(
         ),
     )
     if return_log:
+        # TODO: move logspace accumulation into the C++ amplitude walk so
+        # very-rare-bitstring queries don't lose precision through the
+        # linear->log conversion. Current path is symmetric with
+        # record_probabilities() at the API surface but does not give the
+        # precision benefit; that benefit only kicks in once the underlying
+        # |amplitude|^2 sum is itself tracked in logspace.
         with np.errstate(divide="ignore"):
             return np.log(probs)
     return probs

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -185,6 +185,7 @@ def basis_probabilities(
     bitstrings: BasisBitstrings,
     *,
     bit_order: str = "big",
+    return_log: bool = False,
 ) -> npt.NDArray[np.float64]:
     """Exact Born probabilities of computational-basis bitstrings.
 
@@ -194,13 +195,20 @@ def basis_probabilities(
 
     ``bit_order="big"`` maps the first character or array column to qubit 0.
     ``bit_order="little"`` maps the last character or array column to qubit 0.
+
+    Pass ``return_log=True`` to get natural-log probabilities. Zero
+    probabilities map to ``-inf`` in log output.
     """
-    return cast(
+    probs = cast(
         npt.NDArray[np.float64],
         _basis_probabilities_from_bitmasks(
             program, _basis_masks_from_bitstrings(program, bitstrings, bit_order)
         ),
     )
+    if return_log:
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
+    return probs
 
 
 def _records_from_outcomes(
@@ -278,6 +286,14 @@ def record_probabilities(
     underflow float64, pass ``return_log=True`` so the log-domain values
     survive.
     """
+    # Reject zero-measurement programs up front so a user who passes a real
+    # record string against a unitary program gets the right hint rather
+    # than the wrapper's record-length mismatch error.
+    if program.num_measurements == 0:
+        raise ValueError(
+            "record_probabilities() requires a program with at least one "
+            "measurement; use clifft.basis_probabilities() for unitary circuits."
+        )
     record_array = _records_from_outcomes(program, records)
     log_probs = cast(
         npt.NDArray[np.float64],

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -42,8 +42,8 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/single_axis_fusion_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/backend/backend.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/probabilities.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/probability_of.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/basis_probabilities.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/record_probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_forced_kernels.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_scalar.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,8 +26,8 @@ add_executable(clifft_tests
     test_source_map.cc
     test_importance_sampling.cc
     test_introspection.cc
-    test_probabilities.cc
-    test_probability_of.cc
+    test_basis_probabilities.cc
+    test_record_probabilities.cc
     test_exp_value.cc
     test_openmp.cc
     test_fuzz.cc

--- a/tests/python/test_basis_probabilities.py
+++ b/tests/python/test_basis_probabilities.py
@@ -405,3 +405,18 @@ def test_probabilities_fast_path_multiword_dormant_block() -> None:
         [2.0**-n] * len(bitstrings),
         atol=1e-15,
     )
+
+
+def test_basis_probabilities_return_log() -> None:
+    prog = clifft.compile("H 0\nCX 0 1")
+    log_probs = clifft.basis_probabilities(prog, ["00", "01", "10", "11"], return_log=True)
+    assert np.isclose(log_probs[0], np.log(0.5))
+    assert log_probs[1] == -np.inf
+    assert log_probs[2] == -np.inf
+    assert np.isclose(log_probs[3], np.log(0.5))
+
+
+def test_basis_probabilities_return_log_default_false() -> None:
+    prog = clifft.compile("H 0")
+    probs = clifft.basis_probabilities(prog, ["0"])
+    np.testing.assert_allclose(probs, [0.5], atol=1e-12)

--- a/tests/python/test_basis_probabilities.py
+++ b/tests/python/test_basis_probabilities.py
@@ -360,7 +360,7 @@ def test_probabilities_rank_deficient_fallback_matches_statevector() -> None:
     # Untouched qubits leave the inverse tableau's Z-row at Z_q, which has no
     # X support. With an active subspace formed by T-gates on other qubits,
     # the X-rank restricted to dormant columns drops below (n - active_k),
-    # which forces the can_use_gray_code = false fallback in basis_basis_probabilities().
+    # which forces the can_use_gray_code = false fallback in basis_probabilities().
     # If the fallback regresses we will see a mismatch here.
     prog = clifft.compile("H 0\nT 0\nH 0\nH 2")
     assert prog.num_qubits == 3

--- a/tests/python/test_basis_probabilities.py
+++ b/tests/python/test_basis_probabilities.py
@@ -18,10 +18,10 @@ def test_program_num_qubits_property() -> None:
     assert prog.num_qubits == 3
 
 
-def test_bell_state_probabilities() -> None:
+def test_bell_state_basis_probabilities() -> None:
     prog = clifft.compile("H 0\nCX 0 1")
 
-    probs = clifft.probabilities(prog, ["00", "01", "10", "11"])
+    probs = clifft.basis_probabilities(prog, ["00", "01", "10", "11"])
 
     np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
     assert probs.dtype == np.float64
@@ -32,8 +32,8 @@ def test_bit_order_big_maps_first_position_to_qubit_zero() -> None:
     prog_x0 = clifft.compile("X 0\nH 1\nH 1")
     prog_x1 = clifft.compile("X 1")
 
-    np.testing.assert_allclose(clifft.probabilities(prog_x0, ["10", "01"]), [1.0, 0.0])
-    np.testing.assert_allclose(clifft.probabilities(prog_x1, ["10", "01"]), [0.0, 1.0])
+    np.testing.assert_allclose(clifft.basis_probabilities(prog_x0, ["10", "01"]), [1.0, 0.0])
+    np.testing.assert_allclose(clifft.basis_probabilities(prog_x1, ["10", "01"]), [0.0, 1.0])
 
 
 def test_bit_order_little_maps_last_position_to_qubit_zero() -> None:
@@ -41,10 +41,10 @@ def test_bit_order_little_maps_last_position_to_qubit_zero() -> None:
     prog_x1 = clifft.compile("X 1")
 
     np.testing.assert_allclose(
-        clifft.probabilities(prog_x0, ["01", "10"], bit_order="little"), [1.0, 0.0]
+        clifft.basis_probabilities(prog_x0, ["01", "10"], bit_order="little"), [1.0, 0.0]
     )
     np.testing.assert_allclose(
-        clifft.probabilities(prog_x1, ["01", "10"], bit_order="little"), [0.0, 1.0]
+        clifft.basis_probabilities(prog_x1, ["01", "10"], bit_order="little"), [0.0, 1.0]
     )
 
 
@@ -54,12 +54,12 @@ def test_array_input_matches_string_input(dtype: np.dtype) -> None:
     bits = np.array([[1, 0], [0, 1]], dtype=dtype)
 
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bits),
-        clifft.probabilities(prog, ["10", "01"]),
+        clifft.basis_probabilities(prog, bits),
+        clifft.basis_probabilities(prog, ["10", "01"]),
     )
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bits, bit_order="little"),
-        clifft.probabilities(prog, ["10", "01"], bit_order="little"),
+        clifft.basis_probabilities(prog, bits, bit_order="little"),
+        clifft.basis_probabilities(prog, ["10", "01"], bit_order="little"),
     )
 
 
@@ -70,12 +70,12 @@ def test_probabilities_supports_high_qubit_string_bitstrings() -> None:
     one_q70_little = "1" + ("0" * 70)
 
     np.testing.assert_allclose(
-        clifft.probabilities(prog, [zero, one_q70_big]),
+        clifft.basis_probabilities(prog, [zero, one_q70_big]),
         [0.5, 0.5],
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        clifft.probabilities(prog, [zero, one_q70_little], bit_order="little"),
+        clifft.basis_probabilities(prog, [zero, one_q70_little], bit_order="little"),
         [0.5, 0.5],
         atol=1e-12,
     )
@@ -89,9 +89,9 @@ def test_probabilities_supports_high_qubit_array_bitstrings(dtype: np.dtype) -> 
     little_bits = np.zeros((2, 71), dtype=dtype)
     little_bits[1, 0] = 1
 
-    np.testing.assert_allclose(clifft.probabilities(prog, bits), [0.0, 1.0])
+    np.testing.assert_allclose(clifft.basis_probabilities(prog, bits), [0.0, 1.0])
     np.testing.assert_allclose(
-        clifft.probabilities(prog, little_bits, bit_order="little"), [0.0, 1.0]
+        clifft.basis_probabilities(prog, little_bits, bit_order="little"), [0.0, 1.0]
     )
 
 
@@ -104,9 +104,9 @@ def test_probabilities_supports_multiword_array_bitstrings() -> None:
     little_bits[1, 199] = 1
     little_bits[2, 0] = 1
 
-    np.testing.assert_allclose(clifft.probabilities(prog, bits), [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(clifft.basis_probabilities(prog, bits), [1.0, 0.0, 0.0])
     np.testing.assert_allclose(
-        clifft.probabilities(prog, little_bits, bit_order="little"),
+        clifft.basis_probabilities(prog, little_bits, bit_order="little"),
         [1.0, 0.0, 0.0],
     )
 
@@ -115,23 +115,23 @@ def test_probability_input_validation() -> None:
     prog = clifft.compile("H 0\nCX 0 1")
 
     with pytest.raises(ValueError, match="length 1, expected 2"):
-        clifft.probabilities(prog, ["0"])
+        clifft.basis_probabilities(prog, ["0"])
     with pytest.raises(ValueError, match="expected only '0' and '1'"):
-        clifft.probabilities(prog, ["0x"])
+        clifft.basis_probabilities(prog, ["0x"])
     with pytest.raises(ValueError, match="bit_order"):
-        clifft.probabilities(prog, ["00"], bit_order="middle")
+        clifft.basis_probabilities(prog, ["00"], bit_order="middle")
     with pytest.raises(TypeError, match="strings or a 2D"):
         invalid_sequence: Any = [[0, 0]]
-        clifft.probabilities(prog, invalid_sequence)
+        clifft.basis_probabilities(prog, invalid_sequence)
     with pytest.raises(ValueError, match="array must be 2D"):
-        clifft.probabilities(prog, np.array([0, 1], dtype=np.uint8))
+        clifft.basis_probabilities(prog, np.array([0, 1], dtype=np.uint8))
     with pytest.raises(ValueError, match="3 columns, expected 2"):
-        clifft.probabilities(prog, np.array([[0, 1, 0]], dtype=np.uint8))
+        clifft.basis_probabilities(prog, np.array([[0, 1, 0]], dtype=np.uint8))
     with pytest.raises(TypeError, match="dtype must be bool or uint8"):
         invalid_dtype: Any = np.array([[0, 1]], dtype=np.int64)
-        clifft.probabilities(prog, invalid_dtype)
+        clifft.basis_probabilities(prog, invalid_dtype)
     with pytest.raises(ValueError, match="contain only 0 and 1"):
-        clifft.probabilities(prog, np.array([[0, 2]], dtype=np.uint8))
+        clifft.basis_probabilities(prog, np.array([[0, 2]], dtype=np.uint8))
 
 
 @pytest.mark.parametrize(
@@ -150,7 +150,7 @@ def test_probabilities_rejects_non_unitary_programs(circuit: str, kwargs: dict[s
     prog = clifft.compile(circuit, **kwargs)
 
     with pytest.raises(ValueError, match="requires pure-state evolution"):
-        clifft.probabilities(prog, ["0" * prog.num_qubits])
+        clifft.basis_probabilities(prog, ["0" * prog.num_qubits])
 
 
 def test_probabilities_allows_exp_val_probes() -> None:
@@ -158,8 +158,8 @@ def test_probabilities_allows_exp_val_probes() -> None:
     without_probe = clifft.compile("H 0")
 
     np.testing.assert_allclose(
-        clifft.probabilities(with_probe, ["0", "1"]),
-        clifft.probabilities(without_probe, ["0", "1"]),
+        clifft.basis_probabilities(with_probe, ["0", "1"]),
+        clifft.basis_probabilities(without_probe, ["0", "1"]),
         atol=1e-12,
     )
 
@@ -183,7 +183,7 @@ def test_drop_non_unitary_pass_enables_querying_unitary_skeleton() -> None:
     assert prog.num_detectors == 0
     assert prog.num_observables == 0
     assert prog.num_exp_vals == 0
-    np.testing.assert_allclose(clifft.probabilities(prog, ["0", "1"]), [0.5, 0.5], atol=1e-12)
+    np.testing.assert_allclose(clifft.basis_probabilities(prog, ["0", "1"]), [0.5, 0.5], atol=1e-12)
 
 
 def test_probabilities_match_dense_statevector_for_small_circuit() -> None:
@@ -201,7 +201,7 @@ def test_probabilities_match_dense_statevector_for_small_circuit() -> None:
     expected = np.abs(clifft.get_statevector(prog, state)) ** 2
     bitstrings = [format(i, f"0{prog.num_qubits}b")[::-1] for i in range(1 << prog.num_qubits)]
 
-    np.testing.assert_allclose(clifft.probabilities(prog, bitstrings), expected, atol=1e-12)
+    np.testing.assert_allclose(clifft.basis_probabilities(prog, bitstrings), expected, atol=1e-12)
 
 
 @pytest.mark.parametrize("num_qubits,seed", [(2, 101), (3, 202), (4, 303)])
@@ -218,7 +218,7 @@ def test_probabilities_match_qiskit_for_random_small_circuits(num_qubits: int, s
     ).astype(np.uint8)
 
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bitstrings),
+        clifft.basis_probabilities(prog, bitstrings),
         np.abs(qiskit_sv) ** 2,
         atol=1e-12,
     )
@@ -236,7 +236,7 @@ def test_probabilities_supports_active_rank_beyond_dense_statevector_limit() -> 
         clifft.get_statevector(prog, state)
 
     np.testing.assert_allclose(
-        clifft.probabilities(prog, ["0" * 12, "1" * 12]),
+        clifft.basis_probabilities(prog, ["0" * 12, "1" * 12]),
         [2**-12, 2**-12],
         atol=1e-15,
     )
@@ -250,7 +250,7 @@ def test_probabilities_match_formula_for_continuous_z_rotation() -> None:
     prog = clifft.compile(f"H 0\nR_Z({alpha}) 0\nH 0")
     half_angle = math.pi * alpha / 2.0
     np.testing.assert_allclose(
-        clifft.probabilities(prog, ["0", "1"]),
+        clifft.basis_probabilities(prog, ["0", "1"]),
         [math.cos(half_angle) ** 2, math.sin(half_angle) ** 2],
         atol=1e-12,
     )
@@ -264,20 +264,20 @@ def test_probabilities_sum_to_one_at_high_active_rank() -> None:
     assert prog.peak_rank > 10
     n = prog.num_qubits
     bitstrings = [format(i, f"0{n}b") for i in range(1 << n)]
-    np.testing.assert_allclose(clifft.probabilities(prog, bitstrings).sum(), 1.0, atol=1e-10)
+    np.testing.assert_allclose(clifft.basis_probabilities(prog, bitstrings).sum(), 1.0, atol=1e-10)
 
 
 def test_probabilities_handles_empty_and_singleton_inputs() -> None:
     prog = clifft.compile("H 0")
 
-    empty_list = clifft.probabilities(prog, [])
+    empty_list = clifft.basis_probabilities(prog, [])
     assert empty_list.shape == (0,)
     assert empty_list.dtype == np.float64
 
-    empty_arr = clifft.probabilities(prog, np.zeros((0, 1), dtype=np.uint8))
+    empty_arr = clifft.basis_probabilities(prog, np.zeros((0, 1), dtype=np.uint8))
     assert empty_arr.shape == (0,)
 
-    single = clifft.probabilities(prog, "0")
+    single = clifft.basis_probabilities(prog, "0")
     assert single.shape == (1,)
     np.testing.assert_allclose(single, [0.5], atol=1e-12)
 
@@ -301,7 +301,7 @@ def test_probabilities_match_statevector_for_fused_unitaries() -> None:
     expected = np.abs(clifft.get_statevector(prog, state)) ** 2
     n = prog.num_qubits
     bitstrings = [format(i, f"0{n}b")[::-1] for i in range(1 << n)]
-    np.testing.assert_allclose(clifft.probabilities(prog, bitstrings), expected, atol=1e-12)
+    np.testing.assert_allclose(clifft.basis_probabilities(prog, bitstrings), expected, atol=1e-12)
 
 
 def _all_bitstrings(num_qubits: int) -> list[str]:
@@ -328,7 +328,7 @@ def test_probabilities_pure_clifford_zero_active_rank() -> None:
 
     bitstrings = _all_bitstrings(prog.num_qubits)
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
     )
 
 
@@ -352,7 +352,7 @@ def test_probabilities_full_rank_clifford_t_matches_statevector() -> None:
 
     bitstrings = _all_bitstrings(n)
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
     )
 
 
@@ -360,13 +360,13 @@ def test_probabilities_rank_deficient_fallback_matches_statevector() -> None:
     # Untouched qubits leave the inverse tableau's Z-row at Z_q, which has no
     # X support. With an active subspace formed by T-gates on other qubits,
     # the X-rank restricted to dormant columns drops below (n - active_k),
-    # which forces the can_use_gray_code = false fallback in probabilities().
+    # which forces the can_use_gray_code = false fallback in basis_basis_probabilities().
     # If the fallback regresses we will see a mismatch here.
     prog = clifft.compile("H 0\nT 0\nH 0\nH 2")
     assert prog.num_qubits == 3
     bitstrings = _all_bitstrings(3)
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
     )
 
 
@@ -380,7 +380,7 @@ def test_probabilities_random_clifford_t_matches_statevector(seed: int) -> None:
     prog = clifft.compile(circuit)
     bitstrings = _all_bitstrings(prog.num_qubits)
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
     )
 
 
@@ -401,7 +401,7 @@ def test_probabilities_fast_path_multiword_dormant_block() -> None:
     bitstrings = [zero, one_q0, one_q63, one_q69]
 
     np.testing.assert_allclose(
-        clifft.probabilities(prog, bitstrings),
+        clifft.basis_probabilities(prog, bitstrings),
         [2.0**-n] * len(bitstrings),
         atol=1e-15,
     )

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -1,9 +1,9 @@
-"""Tests for clifft.record_basis_probabilities(): exact measurement-record probabilities.
+"""Tests for clifft.record_probabilities(): exact measurement-record probabilities.
 
-record_basis_probabilities() returns the probability sample() would assign to each
+record_probabilities() returns the probability sample() would assign to each
 measurement record under a compiled program with measurements. This module
 covers the Python wrapper's contract: input polymorphism, return shapes,
-return_log behavior, cross-checks against basis_basis_probabilities() and qiskit,
+return_log behavior, cross-checks against basis_probabilities() and qiskit,
 sampling consistency, and rejection paths.
 """
 
@@ -104,7 +104,7 @@ def test_return_log_default_false() -> None:
 
 
 # =============================================================================
-# Cross-check against basis_basis_probabilities() on terminal-M-all circuits.
+# Cross-check against basis_probabilities() on terminal-M-all circuits.
 # =============================================================================
 
 

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -1,9 +1,9 @@
-"""Tests for clifft.probability_of(): exact measurement-record probabilities.
+"""Tests for clifft.record_basis_probabilities(): exact measurement-record probabilities.
 
-probability_of() returns the probability sample() would assign to each
+record_basis_probabilities() returns the probability sample() would assign to each
 measurement record under a compiled program with measurements. This module
 covers the Python wrapper's contract: input polymorphism, return shapes,
-return_log behavior, cross-checks against probabilities() and qiskit,
+return_log behavior, cross-checks against basis_basis_probabilities() and qiskit,
 sampling consistency, and rejection paths.
 """
 
@@ -21,9 +21,9 @@ import clifft
 # =============================================================================
 
 
-def test_bell_state_probabilities() -> None:
+def test_bell_state_basis_probabilities() -> None:
     prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-    probs = clifft.probability_of(prog, ["00", "01", "10", "11"])
+    probs = clifft.record_probabilities(prog, ["00", "01", "10", "11"])
     np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
     assert probs.dtype == np.float64
     assert probs.shape == (4,)
@@ -31,19 +31,19 @@ def test_bell_state_probabilities() -> None:
 
 def test_single_qubit_plus_state() -> None:
     prog = clifft.compile("H 0\nM 0")
-    probs = clifft.probability_of(prog, ["0", "1"])
+    probs = clifft.record_probabilities(prog, ["0", "1"])
     np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
 
 
 def test_unreachable_records_are_zero() -> None:
     prog = clifft.compile("M 0")
-    probs = clifft.probability_of(prog, ["0", "1"])
+    probs = clifft.record_probabilities(prog, ["0", "1"])
     np.testing.assert_allclose(probs, [1.0, 0.0], atol=1e-12)
 
 
 def test_feedback_circuit_returns_joint_trajectory_probability() -> None:
     prog = clifft.compile("H 0\n" "M 0\n" "CX rec[-1] 1\n" "M 1\n")
-    probs = clifft.probability_of(prog, ["00", "01", "10", "11"])
+    probs = clifft.record_probabilities(prog, ["00", "01", "10", "11"])
     np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
 
 
@@ -54,14 +54,14 @@ def test_feedback_circuit_returns_joint_trajectory_probability() -> None:
 
 def test_single_string_returns_length_one_array() -> None:
     prog = clifft.compile("H 0\nM 0")
-    probs = clifft.probability_of(prog, "0")
+    probs = clifft.record_probabilities(prog, "0")
     assert probs.shape == (1,)
     np.testing.assert_allclose(probs, [0.5], atol=1e-12)
 
 
 def test_sequence_of_strings() -> None:
     prog = clifft.compile("H 0\nM 0")
-    probs = clifft.probability_of(prog, ("0", "1"))
+    probs = clifft.record_probabilities(prog, ("0", "1"))
     np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
 
 
@@ -70,14 +70,14 @@ def test_array_input_matches_string_input(dtype: np.dtype) -> None:
     prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
     records = np.array([[0, 0], [1, 1]], dtype=dtype)
     np.testing.assert_allclose(
-        clifft.probability_of(prog, records),
-        clifft.probability_of(prog, ["00", "11"]),
+        clifft.record_probabilities(prog, records),
+        clifft.record_probabilities(prog, ["00", "11"]),
     )
 
 
 def test_empty_record_batch() -> None:
     prog = clifft.compile("H 0\nM 0")
-    probs = clifft.probability_of(prog, [])
+    probs = clifft.record_probabilities(prog, [])
     assert probs.shape == (0,)
     assert probs.dtype == np.float64
 
@@ -89,7 +89,7 @@ def test_empty_record_batch() -> None:
 
 def test_return_log_returns_natural_log() -> None:
     prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-    log_probs = clifft.probability_of(prog, ["00", "01", "10", "11"], return_log=True)
+    log_probs = clifft.record_probabilities(prog, ["00", "01", "10", "11"], return_log=True)
     assert np.isclose(log_probs[0], np.log(0.5))
     assert log_probs[1] == -np.inf
     assert log_probs[2] == -np.inf
@@ -98,13 +98,13 @@ def test_return_log_returns_natural_log() -> None:
 
 def test_return_log_default_false() -> None:
     prog = clifft.compile("H 0\nM 0")
-    probs = clifft.probability_of(prog, ["0"])
+    probs = clifft.record_probabilities(prog, ["0"])
     # 0.5 (linear), not log(0.5).
     np.testing.assert_allclose(probs, [0.5], atol=1e-12)
 
 
 # =============================================================================
-# Cross-check against probabilities() on terminal-M-all circuits.
+# Cross-check against basis_basis_probabilities() on terminal-M-all circuits.
 # =============================================================================
 
 
@@ -113,8 +113,8 @@ def test_matches_probabilities_on_clifford_circuit() -> None:
     unitary = clifft.compile("H 0\nCX 0 1")
     measured = clifft.compile("H 0\nCX 0 1\nM 0 1")
 
-    expected = clifft.probabilities(unitary, bitstrings)
-    actual = clifft.probability_of(measured, bitstrings)
+    expected = clifft.basis_probabilities(unitary, bitstrings)
+    actual = clifft.record_probabilities(measured, bitstrings)
     np.testing.assert_allclose(actual, expected, atol=1e-12)
 
 
@@ -123,8 +123,8 @@ def test_matches_probabilities_on_clifford_t_circuit() -> None:
     unitary = clifft.compile("H 0\nT 0\nH 0")
     measured = clifft.compile("H 0\nT 0\nH 0\nM 0")
 
-    expected = clifft.probabilities(unitary, bitstrings)
-    actual = clifft.probability_of(measured, bitstrings)
+    expected = clifft.basis_probabilities(unitary, bitstrings)
+    actual = clifft.record_probabilities(measured, bitstrings)
     np.testing.assert_allclose(actual, expected, atol=1e-12)
 
 
@@ -137,7 +137,7 @@ def test_matches_qiskit_for_random_small_circuits(num_qubits: int, seed: int) ->
     bitstrings = [
         "".join(str((i >> q) & 1) for q in range(num_qubits)) for i in range(1 << num_qubits)
     ]
-    actual = clifft.probability_of(measured, bitstrings)
+    actual = clifft.record_probabilities(measured, bitstrings)
     np.testing.assert_allclose(actual, np.abs(qiskit_sv) ** 2, atol=1e-12)
 
 
@@ -146,8 +146,8 @@ def test_matches_qiskit_for_random_small_circuits(num_qubits: int, seed: int) ->
 # =============================================================================
 
 
-def test_sample_frequencies_match_probability_of() -> None:
-    # Run sample() many shots, count frequencies, compare to probability_of().
+def test_sample_frequencies_match_record_probabilities() -> None:
+    # Run sample() many shots, count frequencies, compare to record_probabilities().
     # Chi-squared style sanity check; not a deep statistical test.
     prog = clifft.compile("H 0\nT 0\nH 0\nM 0")
 
@@ -156,7 +156,7 @@ def test_sample_frequencies_match_probability_of() -> None:
     freq_1 = float(measurements.sum()) / shots
     freq_0 = 1.0 - freq_1
 
-    probs = clifft.probability_of(prog, ["0", "1"])
+    probs = clifft.record_probabilities(prog, ["0", "1"])
     # 5 sigma binomial half-width on shots=2e5, p~0.85 is ~0.004.
     assert abs(freq_0 - probs[0]) < 0.01
     assert abs(freq_1 - probs[1]) < 0.01
@@ -170,75 +170,75 @@ def test_sample_frequencies_match_probability_of() -> None:
 def test_rejects_zero_measurement_program() -> None:
     prog = clifft.compile("H 0\nT 0")
     with pytest.raises(ValueError, match="at least one measurement"):
-        clifft.probability_of(prog, [])
+        clifft.record_probabilities(prog, [])
 
 
 def test_rejects_hidden_measurement_slots() -> None:
     prog = clifft.compile("M 0\nR 1\nM 1")
     assert prog.num_measurements == 2
     with pytest.raises(ValueError, match="hidden measurement slots"):
-        clifft.probability_of(prog, ["00", "11"])
+        clifft.record_probabilities(prog, ["00", "11"])
 
 
 def test_rejects_noise_opcodes() -> None:
     prog = clifft.compile("X_ERROR(0.1) 0\nM 0")
     with pytest.raises(ValueError, match="pure-state evolution"):
-        clifft.probability_of(prog, ["0"])
+        clifft.record_probabilities(prog, ["0"])
 
 
 def test_rejects_detector_opcodes() -> None:
     prog = clifft.compile("M 0\nDETECTOR rec[-1]")
     with pytest.raises(ValueError, match="pure-state evolution"):
-        clifft.probability_of(prog, ["0"])
+        clifft.record_probabilities(prog, ["0"])
 
 
 def test_rejects_observable_opcodes() -> None:
     prog = clifft.compile("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
     with pytest.raises(ValueError, match="pure-state evolution"):
-        clifft.probability_of(prog, ["0"])
+        clifft.record_probabilities(prog, ["0"])
 
 
 def test_rejects_record_string_with_wrong_length() -> None:
     prog = clifft.compile("M 0 1")
     with pytest.raises(ValueError, match="length 1, expected 2"):
-        clifft.probability_of(prog, "0")
+        clifft.record_probabilities(prog, "0")
 
 
 def test_rejects_record_string_with_invalid_chars() -> None:
     prog = clifft.compile("M 0")
     with pytest.raises(ValueError, match="expected only '0' and '1'"):
-        clifft.probability_of(prog, ["x"])
+        clifft.record_probabilities(prog, ["x"])
 
 
 def test_rejects_array_with_wrong_columns() -> None:
     prog = clifft.compile("M 0 1")
     arr = np.array([[0, 0, 0]], dtype=np.uint8)
     with pytest.raises(ValueError, match="3 columns, expected 2"):
-        clifft.probability_of(prog, arr)
+        clifft.record_probabilities(prog, arr)
 
 
 def test_rejects_array_with_non_bit_values() -> None:
     prog = clifft.compile("M 0")
     arr = np.array([[2]], dtype=np.uint8)
     with pytest.raises(ValueError, match="contain only 0 and 1"):
-        clifft.probability_of(prog, arr)
+        clifft.record_probabilities(prog, arr)
 
 
 def test_rejects_invalid_array_dtype() -> None:
     prog = clifft.compile("M 0")
     invalid: Any = np.array([[0]], dtype=np.int64)
     with pytest.raises(TypeError, match="dtype must be bool or uint8"):
-        clifft.probability_of(prog, invalid)
+        clifft.record_probabilities(prog, invalid)
 
 
 def test_rejects_invalid_array_dim() -> None:
     prog = clifft.compile("M 0")
     with pytest.raises(ValueError, match="must be 2D"):
-        clifft.probability_of(prog, np.array([0, 1], dtype=np.uint8))
+        clifft.record_probabilities(prog, np.array([0, 1], dtype=np.uint8))
 
 
 def test_rejects_invalid_input_type() -> None:
     prog = clifft.compile("M 0")
     bad: Any = 42
     with pytest.raises(TypeError, match="strings or a 2D"):
-        clifft.probability_of(prog, bad)
+        clifft.record_probabilities(prog, bad)

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -173,6 +173,16 @@ def test_rejects_zero_measurement_program() -> None:
         clifft.record_probabilities(prog, [])
 
 
+def test_rejects_zero_measurement_program_with_real_records() -> None:
+    # The wrapper formats records against program.num_measurements before
+    # calling into C++. Without an explicit zero-measurement guard, this
+    # surfaces as a confusing record-length mismatch ("expected 0") instead
+    # of pointing the user at basis_probabilities().
+    prog = clifft.compile("H 0")
+    with pytest.raises(ValueError, match="use clifft.basis_probabilities"):
+        clifft.record_probabilities(prog, ["0"])
+
+
 def test_rejects_hidden_measurement_slots() -> None:
     prog = clifft.compile("M 0\nR 1\nM 1")
     assert prog.num_measurements == 2

--- a/tests/test_basis_probabilities.cc
+++ b/tests/test_basis_probabilities.cc
@@ -20,7 +20,7 @@ TEST_CASE("Probabilities missing final tableau is rejected") {
     bool threw = false;
     try {
         std::vector<uint64_t> masks{0};
-        (void)probabilities(mod, masks, 1, 1);
+        (void)basis_probabilities(mod, masks, 1, 1);
     } catch (const std::invalid_argument& ex) {
         threw = true;
         REQUIRE(std::string(ex.what()).find("final Clifford tableau") != std::string::npos);

--- a/tests/test_forced_kernels.cc
+++ b/tests/test_forced_kernels.cc
@@ -157,7 +157,7 @@ TEST_CASE("forced active_diagonal: non-trivial probabilities accumulate the righ
 TEST_CASE("forced active_diagonal: dust-clamped branch is treated as unreachable") {
     // The sampling kernel routes branch selection through sample_branch(),
     // which clamps any prob <= kDustEpsilon * total to zero so that
-    // sample() never emits the dust outcome. probability_of() must match:
+    // sample() never emits the dust outcome. record_probabilities() must match:
     // forcing the dust outcome is unreachable, and forcing the surviving
     // outcome is deterministic (log_inc = 0, not log(prob/total)).
     const double dust_amp = 1e-11;  // |amp|^2 = 1e-22 < kDustEpsilon (1e-18)
@@ -182,7 +182,7 @@ TEST_CASE("forced active_diagonal: dust-clamped branch is treated as unreachable
         state.v()[1] = {dust_amp, 0.0};
         bool ok = exec_meas_active_diagonal_forced(state, 0, 0, false);
         // outcome 1 has dust probability -- sample() never emits it, so
-        // probability_of() must report it as unreachable.
+        // record_probabilities() must report it as unreachable.
         REQUIRE(ok == false);
         REQUIRE(state.forced_reachable == false);
     }

--- a/tests/test_introspection.cc
+++ b/tests/test_introspection.cc
@@ -130,7 +130,7 @@ TEST_CASE("introspection formats every VM opcode") {
     signed_meas.flags |= Instruction::FLAG_IDENTITY;
 
     // Forced-mode SWAP measurement: reuse the existing factory and patch
-    // the opcode. The forced variants are synthesized by probability_of()
+    // the opcode. The forced variants are synthesized by record_probabilities()
     // at runtime via the same rewrite, so this mirrors the production path.
     Instruction forced_swap_meas = make_swap_meas_interfere(58, 59, 60, false);
     forced_swap_meas.opcode = Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;

--- a/tests/test_record_probabilities.cc
+++ b/tests/test_record_probabilities.cc
@@ -1,6 +1,6 @@
-// Tests for the C++ record_basis_probabilities() entry point.
+// Tests for the C++ record_probabilities() entry point.
 //
-// record_basis_probabilities() computes exact log-probabilities for a batch of
+// record_probabilities() computes exact log-probabilities for a batch of
 // measurement records against a compiled circuit. It mirrors what
 // sample() would emit, modulo dust-clamping, via a bytecode rewrite that
 // turns OP_MEAS_* into their OP_MEAS_*_FORCED siblings and replays each
@@ -11,7 +11,7 @@
 // records, EXP_VAL pass-through, and that the input CompiledModule is
 // not mutated. Deeper algorithmic correctness is covered by the
 // per-kernel and dispatcher tests in earlier steps, and Python-level
-// equivalence with basis_basis_probabilities() is covered separately.
+// equivalence with basis_probabilities() is covered separately.
 
 #include "clifft/backend/backend.h"
 #include "clifft/circuit/parser.h"
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -150,6 +151,20 @@ TEST_CASE("record_probabilities: rejects record buffer with inconsistent length"
     REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/2), std::invalid_argument);
 }
 
+TEST_CASE("record_probabilities: rejects num_records that would overflow the buffer length") {
+    // num_records * num_measurements must not wrap size_t and silently match
+    // a small records.size(). The validation should compare via division so
+    // the overflowed product cannot bypass it.
+    auto mod = compile_circuit("M 0 1");
+    REQUIRE(mod.num_measurements == 2);
+
+    std::vector<uint8_t> records(4, 0);  // would match num_records=2 honestly
+    constexpr size_t kHuge = (std::numeric_limits<size_t>::max() / 2) + 1;
+    // With overflow, kHuge * 2 wraps to 0 and a naive length check passes;
+    // with the modulo/division check, this is rejected.
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, kHuge), std::invalid_argument);
+}
+
 TEST_CASE("record_probabilities: rejects programs with hidden measurement slots") {
     // R q lowers to a hidden measurement + conditional Pauli. The forced
     // execution path doesn't currently marginalize over hidden outcomes,
@@ -180,7 +195,7 @@ TEST_CASE("record_probabilities: rejects postselection opcodes") {
 
 TEST_CASE("record_probabilities: rejects hand-built bytecode containing forced opcodes") {
     // The validator must reject user-supplied forced opcodes so the
-    // rewrite step in record_basis_probabilities() is the only source of them.
+    // rewrite step in record_probabilities() is the only source of them.
     auto mod = compile_circuit("M 0");
     // Hand-patch the user-visible bytecode to its FORCED variant.
     mod.bytecode[0].opcode = Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
@@ -239,27 +254,27 @@ TEST_CASE("record_probabilities: does not mutate the input CompiledModule") {
 }
 
 // =============================================================================
-// Cross-check against basis_basis_probabilities() on terminal-M-all circuits.
+// Cross-check against basis_probabilities() on terminal-M-all circuits.
 // =============================================================================
 //
-// For a unitary circuit followed by M on every qubit, record_basis_probabilities()
-// computes the same value basis_basis_probabilities() does (the latter via the
+// For a unitary circuit followed by M on every qubit, record_probabilities()
+// computes the same value basis_probabilities() does (the latter via the
 // stabilizer-amplitude path on the unitary-stripped program). This is
 // the load-bearing equivalence: any drift between the two paths shows
 // up here.
 
-TEST_CASE("record_probabilities: matches basis_basis_probabilities() on a Clifford circuit") {
+TEST_CASE("record_probabilities: matches basis_probabilities() on a Clifford circuit") {
     auto unitary = compile_circuit("H 0\nCX 0 1");
     auto measured = compile_circuit("H 0\nCX 0 1\nM 0 1");
     REQUIRE(measured.num_measurements == 2);
 
-    // basis_basis_probabilities() takes word-packed bitmasks. For 2 qubits, each mask
+    // basis_probabilities() takes word-packed bitmasks. For 2 qubits, each mask
     // fits in one 64-bit word; bit i = qubit i.
     std::vector<uint64_t> masks{0b00, 0b01, 0b10, 0b11};
     auto probs = basis_probabilities(unitary, masks, /*num_basis_masks=*/4,
                                      /*words_per_basis_mask=*/1);
 
-    // record_basis_probabilities() takes byte-packed records in measurement order.
+    // record_probabilities() takes byte-packed records in measurement order.
     // M 0 1 records qubit 0 first, qubit 1 second, so record byte 0
     // corresponds to mask bit 0.
     std::vector<uint8_t> records{0, 0, 1, 0, 0, 1, 1, 1};
@@ -277,7 +292,7 @@ TEST_CASE("record_probabilities: matches basis_basis_probabilities() on a Cliffo
 }
 
 TEST_CASE(
-    "record_probabilities: matches basis_basis_probabilities() on a Clifford+T circuit (active "
+    "record_probabilities: matches basis_probabilities() on a Clifford+T circuit (active "
     "kernel)") {
     // H T H on |0> takes the qubit through a non-Clifford rotation that
     // forces the SVM to keep the qubit active at measurement time. The

--- a/tests/test_record_probabilities.cc
+++ b/tests/test_record_probabilities.cc
@@ -1,6 +1,6 @@
-// Tests for the C++ probability_of() entry point.
+// Tests for the C++ record_basis_probabilities() entry point.
 //
-// probability_of() computes exact log-probabilities for a batch of
+// record_basis_probabilities() computes exact log-probabilities for a batch of
 // measurement records against a compiled circuit. It mirrors what
 // sample() would emit, modulo dust-clamping, via a bytecode rewrite that
 // turns OP_MEAS_* into their OP_MEAS_*_FORCED siblings and replays each
@@ -11,7 +11,7 @@
 // records, EXP_VAL pass-through, and that the input CompiledModule is
 // not mutated. Deeper algorithmic correctness is covered by the
 // per-kernel and dispatcher tests in earlier steps, and Python-level
-// equivalence with probabilities() is covered separately.
+// equivalence with basis_basis_probabilities() is covered separately.
 
 #include "clifft/backend/backend.h"
 #include "clifft/circuit/parser.h"
@@ -46,13 +46,13 @@ CompiledModule compile_circuit(const std::string& text) {
 // Basic correctness: small circuits with known closed-form probabilities.
 // =============================================================================
 
-TEST_CASE("probability_of: Bell state probabilities") {
+TEST_CASE("record_probabilities: Bell state probabilities") {
     auto mod = compile_circuit("H 0\nCX 0 1\nM 0 1");
     REQUIRE(mod.num_measurements == 2);
 
     // Records "00", "01", "10", "11" in measurement-record order.
     std::vector<uint8_t> records{0, 0, 0, 1, 1, 0, 1, 1};
-    auto log_probs = probability_of(mod, records, /*num_records=*/4);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/4);
     REQUIRE(log_probs.size() == 4);
 
     // Bell state: only 00 and 11 are emitted, each with probability 0.5.
@@ -62,23 +62,23 @@ TEST_CASE("probability_of: Bell state probabilities") {
     CHECK_THAT(std::exp(log_probs[3]), WithinAbs(0.5, 1e-12));
 }
 
-TEST_CASE("probability_of: |+> single-qubit measurements are 1/2 each") {
+TEST_CASE("record_probabilities: |+> single-qubit measurements are 1/2 each") {
     auto mod = compile_circuit("H 0\nM 0");
     REQUIRE(mod.num_measurements == 1);
 
     std::vector<uint8_t> records{0, 1};
-    auto log_probs = probability_of(mod, records, /*num_records=*/2);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/2);
     REQUIRE(log_probs.size() == 2);
     CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
     CHECK_THAT(log_probs[1], WithinAbs(std::log(0.5), 1e-12));
 }
 
-TEST_CASE("probability_of: |0> deterministic measurement") {
+TEST_CASE("record_probabilities: |0> deterministic measurement") {
     auto mod = compile_circuit("M 0");
     REQUIRE(mod.num_measurements == 1);
 
     std::vector<uint8_t> records{0, 1};
-    auto log_probs = probability_of(mod, records, /*num_records=*/2);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/2);
     REQUIRE(log_probs.size() == 2);
     CHECK_THAT(log_probs[0], WithinAbs(0.0, 1e-12));  // log(1)
     REQUIRE(log_probs[1] == kUnreachableLogProb);
@@ -88,7 +88,7 @@ TEST_CASE("probability_of: |0> deterministic measurement") {
 // Feedback (OP_APPLY_PAULI) is supported.
 // =============================================================================
 
-TEST_CASE("probability_of: feedback circuit produces joint trajectory probability") {
+TEST_CASE("record_probabilities: feedback circuit produces joint trajectory probability") {
     // Measure qubit 0 (random 0/1), apply X to qubit 1 conditional on the
     // outcome, then measure qubit 1. Joint probability of (m0, m1):
     //   (0, ?): qubit 1 stayed in |0>, so m1=0 deterministically.
@@ -103,7 +103,7 @@ TEST_CASE("probability_of: feedback circuit produces joint trajectory probabilit
     REQUIRE(mod.num_measurements == 2);
 
     std::vector<uint8_t> records{0, 0, 0, 1, 1, 0, 1, 1};
-    auto log_probs = probability_of(mod, records, /*num_records=*/4);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/4);
     REQUIRE(log_probs.size() == 4);
 
     CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
@@ -116,41 +116,41 @@ TEST_CASE("probability_of: feedback circuit produces joint trajectory probabilit
 // Pre-flight validation.
 // =============================================================================
 
-TEST_CASE("probability_of: rejects zero-measurement programs") {
+TEST_CASE("record_probabilities: rejects zero-measurement programs") {
     auto mod = compile_circuit("H 0\nT 0");
     REQUIRE(mod.num_measurements == 0);
 
     std::vector<uint8_t> records{};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/0), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/0), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects noise opcodes") {
+TEST_CASE("record_probabilities: rejects noise opcodes") {
     auto mod = compile_circuit("X_ERROR(0.1) 0\nM 0");
     std::vector<uint8_t> records{0};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/1), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects detector opcodes") {
+TEST_CASE("record_probabilities: rejects detector opcodes") {
     auto mod = compile_circuit("M 0\nDETECTOR rec[-1]");
     std::vector<uint8_t> records{0};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/1), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects observable opcodes") {
+TEST_CASE("record_probabilities: rejects observable opcodes") {
     auto mod = compile_circuit("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]");
     std::vector<uint8_t> records{0};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/1), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects record buffer with inconsistent length") {
+TEST_CASE("record_probabilities: rejects record buffer with inconsistent length") {
     auto mod = compile_circuit("M 0 1");
     REQUIRE(mod.num_measurements == 2);
 
     std::vector<uint8_t> records{0, 0, 1};  // 3 bytes is not a multiple of 2.
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/2), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/2), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects programs with hidden measurement slots") {
+TEST_CASE("record_probabilities: rejects programs with hidden measurement slots") {
     // R q lowers to a hidden measurement + conditional Pauli. The forced
     // execution path doesn't currently marginalize over hidden outcomes,
     // so any program with hidden slots is rejected up front.
@@ -159,44 +159,44 @@ TEST_CASE("probability_of: rejects programs with hidden measurement slots") {
     REQUIRE(mod.total_meas_slots > mod.num_measurements);
 
     std::vector<uint8_t> records{0, 0, 1, 1};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/2), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/2), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects non-bit record bytes") {
+TEST_CASE("record_probabilities: rejects non-bit record bytes") {
     auto mod = compile_circuit("H 0\nM 0");
     REQUIRE(mod.num_measurements == 1);
 
     std::vector<uint8_t> records{0, 1, 2};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/3), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/3), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects postselection opcodes") {
+TEST_CASE("record_probabilities: rejects postselection opcodes") {
     auto mod = clifft::lower(clifft::trace(clifft::parse("M 0\nDETECTOR rec[-1]")),
                              /*postselection_mask=*/std::array<uint8_t, 1>{1});
 
     std::vector<uint8_t> records{0};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/1), std::invalid_argument);
 }
 
-TEST_CASE("probability_of: rejects hand-built bytecode containing forced opcodes") {
+TEST_CASE("record_probabilities: rejects hand-built bytecode containing forced opcodes") {
     // The validator must reject user-supplied forced opcodes so the
-    // rewrite step in probability_of() is the only source of them.
+    // rewrite step in record_basis_probabilities() is the only source of them.
     auto mod = compile_circuit("M 0");
     // Hand-patch the user-visible bytecode to its FORCED variant.
     mod.bytecode[0].opcode = Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
 
     std::vector<uint8_t> records{0};
-    REQUIRE_THROWS_AS(probability_of(mod, records, /*num_records=*/1), std::invalid_argument);
+    REQUIRE_THROWS_AS(record_probabilities(mod, records, /*num_records=*/1), std::invalid_argument);
 }
 
 // =============================================================================
 // EXP_VAL is allowed (probes are ignored).
 // =============================================================================
 
-TEST_CASE("probability_of: tolerates EXP_VAL probes") {
+TEST_CASE("record_probabilities: tolerates EXP_VAL probes") {
     auto mod = compile_circuit("H 0\nEXP_VAL X0\nM 0");
     std::vector<uint8_t> records{0, 1};
-    auto log_probs = probability_of(mod, records, /*num_records=*/2);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/2);
     REQUIRE(log_probs.size() == 2);
     CHECK_THAT(log_probs[0], WithinAbs(std::log(0.5), 1e-12));
     CHECK_THAT(log_probs[1], WithinAbs(std::log(0.5), 1e-12));
@@ -206,14 +206,14 @@ TEST_CASE("probability_of: tolerates EXP_VAL probes") {
 // Edge cases.
 // =============================================================================
 
-TEST_CASE("probability_of: empty record batch returns empty vector") {
+TEST_CASE("record_probabilities: empty record batch returns empty vector") {
     auto mod = compile_circuit("H 0\nM 0");
     std::vector<uint8_t> records{};
-    auto log_probs = probability_of(mod, records, /*num_records=*/0);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/0);
     REQUIRE(log_probs.empty());
 }
 
-TEST_CASE("probability_of: does not mutate the input CompiledModule") {
+TEST_CASE("record_probabilities: does not mutate the input CompiledModule") {
     auto mod = compile_circuit("H 0\nM 0");
     REQUIRE(mod.bytecode.size() > 0);
 
@@ -228,7 +228,7 @@ TEST_CASE("probability_of: does not mutate the input CompiledModule") {
     }
 
     std::vector<uint8_t> records{0, 1};
-    (void)probability_of(mod, records, /*num_records=*/2);
+    (void)record_probabilities(mod, records, /*num_records=*/2);
 
     REQUIRE(mod.bytecode.size() == snapshot.size());
     for (size_t i = 0; i < mod.bytecode.size(); ++i) {
@@ -239,31 +239,31 @@ TEST_CASE("probability_of: does not mutate the input CompiledModule") {
 }
 
 // =============================================================================
-// Cross-check against probabilities() on terminal-M-all circuits.
+// Cross-check against basis_basis_probabilities() on terminal-M-all circuits.
 // =============================================================================
 //
-// For a unitary circuit followed by M on every qubit, probability_of()
-// computes the same value probabilities() does (the latter via the
+// For a unitary circuit followed by M on every qubit, record_basis_probabilities()
+// computes the same value basis_basis_probabilities() does (the latter via the
 // stabilizer-amplitude path on the unitary-stripped program). This is
 // the load-bearing equivalence: any drift between the two paths shows
 // up here.
 
-TEST_CASE("probability_of: matches probabilities() on a Clifford circuit") {
+TEST_CASE("record_probabilities: matches basis_basis_probabilities() on a Clifford circuit") {
     auto unitary = compile_circuit("H 0\nCX 0 1");
     auto measured = compile_circuit("H 0\nCX 0 1\nM 0 1");
     REQUIRE(measured.num_measurements == 2);
 
-    // probabilities() takes word-packed bitmasks. For 2 qubits, each mask
+    // basis_basis_probabilities() takes word-packed bitmasks. For 2 qubits, each mask
     // fits in one 64-bit word; bit i = qubit i.
     std::vector<uint64_t> masks{0b00, 0b01, 0b10, 0b11};
-    auto probs = probabilities(unitary, masks, /*num_basis_masks=*/4,
-                               /*words_per_basis_mask=*/1);
+    auto probs = basis_probabilities(unitary, masks, /*num_basis_masks=*/4,
+                                     /*words_per_basis_mask=*/1);
 
-    // probability_of() takes byte-packed records in measurement order.
+    // record_basis_probabilities() takes byte-packed records in measurement order.
     // M 0 1 records qubit 0 first, qubit 1 second, so record byte 0
     // corresponds to mask bit 0.
     std::vector<uint8_t> records{0, 0, 1, 0, 0, 1, 1, 1};
-    auto log_probs = probability_of(measured, records, /*num_records=*/4);
+    auto log_probs = record_probabilities(measured, records, /*num_records=*/4);
 
     REQUIRE(probs.size() == 4);
     REQUIRE(log_probs.size() == 4);
@@ -276,7 +276,9 @@ TEST_CASE("probability_of: matches probabilities() on a Clifford circuit") {
     }
 }
 
-TEST_CASE("probability_of: matches probabilities() on a Clifford+T circuit (active kernel)") {
+TEST_CASE(
+    "record_probabilities: matches basis_basis_probabilities() on a Clifford+T circuit (active "
+    "kernel)") {
     // H T H on |0> takes the qubit through a non-Clifford rotation that
     // forces the SVM to keep the qubit active at measurement time. The
     // resulting measurement opcode hits the active forced kernels via
@@ -288,11 +290,11 @@ TEST_CASE("probability_of: matches probabilities() on a Clifford+T circuit (acti
     REQUIRE(measured.peak_rank > 0);  // T gate forces a non-zero active rank.
 
     std::vector<uint64_t> masks{0, 1};
-    auto probs = probabilities(unitary, masks, /*num_basis_masks=*/2,
-                               /*words_per_basis_mask=*/1);
+    auto probs = basis_probabilities(unitary, masks, /*num_basis_masks=*/2,
+                                     /*words_per_basis_mask=*/1);
 
     std::vector<uint8_t> records{0, 1};
-    auto log_probs = probability_of(measured, records, /*num_records=*/2);
+    auto log_probs = record_probabilities(measured, records, /*num_records=*/2);
 
     REQUIRE(probs.size() == 2);
     REQUIRE(log_probs.size() == 2);
@@ -307,14 +309,14 @@ TEST_CASE("probability_of: matches probabilities() on a Clifford+T circuit (acti
     CHECK_THAT(probs[1], WithinAbs((2.0 - sqrt2) / 4.0, 1e-12));
 }
 
-TEST_CASE("probability_of: multi-record probabilities sum to 1 for a small circuit") {
+TEST_CASE("record_probabilities: multi-record probabilities sum to 1 for a small circuit") {
     // Unitarity check: enumerate all 2^n measurement records for a circuit
     // ending in M-all and confirm probabilities sum to 1.
     auto mod = compile_circuit("H 0\nCX 0 1\nH 1\nM 0 1");
     REQUIRE(mod.num_measurements == 2);
 
     std::vector<uint8_t> records{0, 0, 0, 1, 1, 0, 1, 1};
-    auto log_probs = probability_of(mod, records, /*num_records=*/4);
+    auto log_probs = record_probabilities(mod, records, /*num_records=*/4);
 
     double total = 0.0;
     for (double lp : log_probs) {

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -10,10 +10,10 @@ sampling profilers:
   rather than the sampling loop. Useful for workflows that recompile
   often (e.g. stratified loss-topology sampling).
 - `profile_probability` compiles a unitary circuit and calls
-  `clifft::probabilities()` over a batch of bitstrings, so a `perf record`
+  `clifft::basis_probabilities()` over a batch of bitstrings, so a `perf record`
   run captures the strong-simulation hot path (basis-state probability
   query). Measurement/feedback/noise opcodes are unsupported by
-  `probabilities()`, so this harness emits a unitary-only circuit.
+  `basis_probabilities()`, so this harness emits a unitary-only circuit.
 
 ## Build
 
@@ -89,7 +89,7 @@ CLIFFT_COMPILE_ITERATIONS=200 \
 ## Probability-query profiling
 
 `profile_probability` compiles a unitary circuit (no terminal `M`) and calls
-`clifft::probabilities()` on `CLIFFT_QUERIES` random bitstrings. Use it to
+`clifft::basis_probabilities()` on `CLIFFT_QUERIES` random bitstrings. Use it to
 profile the strong-simulation path:
 
 ```bash

--- a/tools/profile/profile_probability.cpp
+++ b/tools/profile/profile_probability.cpp
@@ -1,11 +1,11 @@
 // Clifft Strong-Simulation Profiling Tool
 //
 // Generates or loads a unitary quantum circuit, compiles it, and calls
-// clifft::probabilities() on a batch of computational-basis bitstrings.
+// clifft::basis_probabilities() on a batch of computational-basis bitstrings.
 // Used with Linux perf or other sampling profilers to investigate the
 // hot path of the basis-state probability query.
 //
-// probabilities() rejects measurement/feedback/noise/detector/observable
+// basis_probabilities() rejects measurement/feedback/noise/detector/observable
 // opcodes, so this harness emits a unitary-only circuit (no trailing M).
 //
 // See tools/profile/README.md for full usage instructions.
@@ -196,7 +196,7 @@ int main() {
     auto trace_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
     std::cout << " done (" << trace_ms << " ms)\n";
 
-    // Backend (no postselection - probabilities() requires pure-state evolution)
+    // Backend (no postselection - basis_probabilities() requires pure-state evolution)
     std::cout << "Backend (bytecode generation)..." << std::flush;
     t0 = std::chrono::high_resolution_clock::now();
     clifft::CompiledModule program = clifft::lower(hir, {});
@@ -231,11 +231,11 @@ int main() {
     auto masks_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
     std::cout << " done (" << masks_ms << " ms)\n";
 
-    // Run probabilities()
+    // Run basis_probabilities()
     std::cout << "Running " << queries << " probability queries..." << std::flush;
     t0 = std::chrono::high_resolution_clock::now();
-    std::vector<double> probs = clifft::probabilities(program, std::span<const uint64_t>(bitmasks),
-                                                      queries, words_per_mask);
+    std::vector<double> probs = clifft::basis_probabilities(
+        program, std::span<const uint64_t>(bitmasks), queries, words_per_mask);
     t1 = std::chrono::high_resolution_clock::now();
     auto prob_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 


### PR DESCRIPTION
## Summary

Breaking rename of the two strong-simulation entry points, plus a documentation restructure that surfaces both side-by-side with their performance tradeoff.

\`\`\`
clifft.probabilities()  -> clifft.basis_probabilities()
clifft.probability_of() -> clifft.record_probabilities()
\`\`\`

The new names make the *object being assigned probability* explicit and put the two APIs on a sharp shared criterion: **is the program's final state pure?** Any measurement breaks that, so:

- \`basis_probabilities()\` — Born amplitudes of computational-basis bitstrings. Requires a unitary program; rejects any measurement (terminal or otherwise).
- \`record_probabilities()\` — exact joint probabilities of measurement records (with optional classical feedback). Requires at least one measurement.

C++ symbols, Python wrappers, internal helpers, source filenames, test filenames, and all doc references renamed in lockstep. No compatibility aliases.

## Documentation restructure

- **\`docs/guide/strong-simulation.md\`** now covers both APIs as one tutorial. New \"When to use which\" decision table at the top, then walkthroughs for each API, then a \"Performance on overlapping circuits\" section explaining when one beats the other on terminal-\`M\`-all circuits (StatevectorSqueezePass lowers active rank for the measured form; \`basis_probabilities()\` amortizes evolve cost across queries).
- **\`docs/guide/simulation.md\`** now lists both in the API summary and the \"Exact Probabilities\" subsection states the pure-state / records distinction up front.
- **\`docs/theory/probabilities.md\` -> \`docs/theory/basis_probabilities.md\`** rename plus cross-link to \`record_probabilities()\` for the measurement-bearing side.

## Why this rename

The previous \`probability_of()\` was grammatically incomplete (\"probability of *what*?\") and the previous \`probabilities()\` didn't signal that it requires a unitary program. The pair \`basis_probabilities\` / \`record_probabilities\` names the queried object and lines up directly with the \"is the final state pure?\" decision.

## Test plan

- [x] All 768 C++ tests pass under Release
- [x] All 664 Python tests pass
- [x] \`uv run pytest --codeblocks docs/\` clean (only preexisting README \`pip install\` failure unrelated to this PR)
- [x] \`uv run mkdocs build --strict\` clean
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)