### PR TITLE
ci: serialize docs preview deployments

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -73,6 +73,9 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     if: github.event.pull_request.head.repo.fork == false
+    concurrency:
+      group: docs-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write
@@ -98,6 +101,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-24.04
     if: github.event.action == 'closed'
+    concurrency:
+      group: docs-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Put PR preview deploy and cleanup jobs in the same docs-deploy concurrency group used by main/release docs.
- Prevent concurrent gh-pages writers from racing and causing non-fast-forward mike deploy failures.

## Test plan

- [x] Workflow YAML parses
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.