### PR TITLE
chore(bench): probe runner CPU and skip bench-cpp on unsupported hardware

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,37 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
+      - name: Print runner CPU info
+        # GitHub-hosted runners draw from a heterogeneous pool. Surface
+        # the actual CPU and feature flags before the build so nightly
+        # failures are diagnosable from the log alone.
+        run: |
+          echo "--- lscpu ---"
+          lscpu
+          echo "--- /proc/cpuinfo flags ---"
+          grep -m1 ^flags /proc/cpuinfo | tr ' ' '\n' | sort -u | tr '\n' ' '
+          echo
+
+      - name: Verify runner CPU meets x86-64-v3 baseline
+        # The build pins -march=x86-64-v3 (AVX2 + BMI2 + FMA + SSE4.2).
+        # If the runner CPU lacks any of those, GCC emits instructions
+        # the loader can't execute and the freshly-linked binary SIGILLs
+        # during catch_discover_tests, producing an opaque "Illegal
+        # instruction" error. Detect that up front and skip the rest of
+        # the job (with a warning annotation) instead of failing red.
+        id: cpu_check
+        run: |
+          missing=()
+          for flag in avx2 bmi2 fma sse4_2; do
+            grep -qw "$flag" /proc/cpuinfo || missing+=("$flag")
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::warning::Runner CPU lacks x86-64-v3 feature(s): ${missing[*]}. Skipping bench-cpp."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup ccache
+        if: steps.cpu_check.outputs.skip != 'true'
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-ccache-bench-${{ env.CMAKE_BUILD_TYPE }}
@@ -50,23 +80,27 @@ jobs:
         # heterogeneous pool; native tuning on one host can emit
         # instructions the next runner's CPU rejects (SIGILL). A fixed
         # baseline also makes day-to-day timings more comparable.
+        if: steps.cpu_check.outputs.skip != 'true'
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
             -DCLIFFT_CPU_BASELINE=x86-64-v3
 
       - name: Build benchmark binary
+        if: steps.cpu_check.outputs.skip != 'true'
         run: cmake --build build --target clifft_tests --parallel
 
       - name: Run Catch2 benchmarks
         # Action parser requires the console reporter (XML is not yet
         # supported by benchmark-action/github-action-benchmark@v1).
+        if: steps.cpu_check.outputs.skip != 'true'
         run: |
           build/tests/clifft_tests "[bench]" \
             --reporter console \
             --out cpp-bench.txt
 
       - name: Publish to gh-pages
+        if: steps.cpu_check.outputs.skip != 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: C++ Catch2 benchmarks


### PR DESCRIPTION
## Summary

Nightly \`bench-cpp\` keeps SIGILLing during \`catch_discover_tests\` (latest example: [run 25906049343](https://github.com/unitaryfoundation/clifft/actions/runs/25906049343)). With \`-march=x86-64-v3\` pinned globally, GCC emits AVX-2 / BMI2 / FMA / SSE4.2 instructions throughout the binary; if the assigned runner's CPU is missing any of those, the loader faults before any test runs and the failure surfaces as an opaque \"Illegal instruction.\"

Two new steps in \`bench-cpp\`:

- **Print runner CPU info** — dumps \`lscpu\` and \`/proc/cpuinfo\` flags before the build, so every job log shows the CPU it ran on (diagnoses both this issue and future surprises).
- **Verify runner CPU meets x86-64-v3 baseline** — greps for the required flags. If any are missing, emits a \`::warning::\` listing the missing features and sets an output flag that gates the rest of the job. Result: green-with-warning instead of red.

\`bench-python\` is unaffected: it builds the package via \`uv pip install\` without setting \`CLIFFT_CPU_BASELINE\`, so it uses the default native tuning and only emits ISA the same runner already supports.

## Why not just lower the baseline to x86-64-v2?

Considered but deferred. \`x86-64-v3\` is the project's baseline for release wheels; running benchmarks under a different baseline would be measuring a different binary than what users actually install. The runner-pool incompatibility is rare enough that skipping affected runs is preferable to globally regressing the bench-binary perf profile.

## Test plan

- [x] \`pre-commit run --files .github/workflows/bench.yml\` clean
- [x] YAML parses
- [ ] Next manual dispatch shows the lscpu output in the job log
- [ ] If a future run lands on an incompatible runner, the job ends green with a clear warning rather than red

🤖 Generated with [Claude Code](https://claude.com/claude-code)