### PR TITLE
chore(bench): accept abm as the AMD equivalent of lzcnt in CPU precheck

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,18 +49,38 @@ jobs:
 
       - name: Check x86-64-v3 benchmark CPU flags
         id: cpu_check
+        # The required-feature list has one vendor split: LZCNT is reported
+        # as `lzcnt` on Intel but as `abm` (Advanced Bit Manipulation) on
+        # AMD even though both provide the same instruction. Express each
+        # feature as a set of acceptable flag names so AMD runners (e.g.
+        # AMD EPYC 7763, which GitHub's hosted pool routinely assigns)
+        # don't get spuriously skipped.
         run: |
-          flags="$(grep -m1 '^flags' /proc/cpuinfo || true)"
-          missing=()
-          for flag in avx avx2 bmi1 bmi2 f16c fma lzcnt movbe sse4_2 xsave; do
-            if [[ " ${flags} " != *" ${flag} "* ]]; then
-              missing+=("${flag}")
-            fi
-          done
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::warning::Runner CPU lacks expected x86-64-v3 benchmark flag(s): ${missing[*]}. Skipping bench-cpp."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          fi
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          flags = set()
+          for line in Path("/proc/cpuinfo").read_text().splitlines():
+              if line.startswith("flags"):
+                  flags = set(line.split(":", 1)[1].split())
+                  break
+
+          required = [
+              {"avx"}, {"avx2"}, {"bmi1"}, {"bmi2"}, {"f16c"}, {"fma"},
+              {"lzcnt", "abm"},
+              {"movbe"}, {"sse4_2"}, {"xsave"},
+          ]
+          missing = ["|".join(sorted(g)) for g in required if not (g & flags)]
+          if missing:
+              names = " ".join(missing)
+              print(
+                  f"::warning::Runner CPU lacks expected x86-64-v3 benchmark "
+                  f"flag(s): {names}. Skipping bench-cpp."
+              )
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  fh.write("skip=true\n")
+          PY
 
       - name: Setup ccache
         if: steps.cpu_check.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Yesterday's nightly bench-cpp ([run 25984452087](https://github.com/unitaryfoundation/clifft/actions/runs/25984452087/job/76379113015)) got assigned an AMD EPYC 7763 (Zen 3) — a fully x86-64-v3-capable CPU — and the precheck still skipped the job. The LZCNT instruction is reported as \`lzcnt\` in \`/proc/cpuinfo\` on Intel and as \`abm\` (Advanced Bit Manipulation) on AMD, but our check only accepted \`lzcnt\`. Same hardware behavior, different vendor-flavored string.

Rewriting the precheck in a Python heredoc lets each required feature express acceptable flag names as a set:

\`\`\`python
required = [
    {\"avx\"}, {\"avx2\"}, {\"bmi1\"}, {\"bmi2\"}, {\"f16c\"}, {\"fma\"},
    {\"lzcnt\", \"abm\"},  # Intel: lzcnt; AMD: abm. Both provide LZCNT.
    {\"movbe\"}, {\"sse4_2\"}, {\"xsave\"},
]
\`\`\`

The other nine v3 features use the same string on both vendors and stay as single-element sets. The script is small enough that the extra Python dependency (already available on hosted ubuntu-24.04) doesn't cost anything, and the equivalence is far more readable as a data structure than as a multi-OR shell condition.

## Why CI doesn't see this

\`ci.yml\` doesn't pin \`CLIFFT_CPU_BASELINE\`, so its build uses \`-march=native\` and GCC only emits instructions the runner already supports. The bench workflow is the only one that hard-pins \`-march=x86-64-v3\`, so it's the only one that needs an up-front check that the runner can execute v3 code. Hence: AMD runners pass CI fine, only the bench precheck failed.

## Test plan

- [x] Verified the new check against the actual AMD EPYC 7763 flag list from the failing run: reports no missing features.
- [x] Verified against an Intel-style flag list (substitute \`abm\` → \`lzcnt\`): reports no missing features.
- [x] Verified an intentionally-broken flag list (missing \`avx2\` + both \`lzcnt\` and \`abm\`): correctly reports both \`avx2\` and \`abm|lzcnt\` missing.
- [x] \`pre-commit run --files .github/workflows/bench.yml\` clean.
- [x] YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)