### PR TITLE
fix(svm): tighten AVX-2 dispatch and trap CLIFFT_FORCE_ISA misconfig

### DIFF
--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -5,9 +5,11 @@
 
 #include <algorithm>
 #include <bit>
+#include <cctype>
 #include <cstdlib>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 
 namespace clifft {
 
@@ -36,28 +38,109 @@ using DispatchFn = void (*)(const CompiledModule&, SchrodingerState&);
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
 
+// Each per-ISA kernel TU is compiled with a specific set of -m flags
+// (see src/clifft/CMakeLists.txt). The runtime dispatcher must match
+// that exact set or risk emitting an instruction the host CPU cannot
+// execute. The helpers below are the one place where each kernel's
+// compile-time feature requirements are declared, so the auto-detect
+// path and the CLIFFT_FORCE_ISA override path stay in sync.
+
+static bool host_supports_avx2_kernel() {
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
+    // svm_avx2.cc is compiled with -mavx2 -mbmi2 -mfma. All three must
+    // be present at runtime, not just avx2+bmi2 -- a CPU with AVX2+BMI2
+    // but no FMA (Excavator-gen AMD, some VIA Eden-X4) will SIGILL on
+    // an FMA instruction otherwise.
+    return __builtin_cpu_supports("avx2") && __builtin_cpu_supports("bmi2") &&
+           __builtin_cpu_supports("fma");
+#else
+    return false;
+#endif
+}
+
+static bool host_supports_avx512_kernel() {
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
+    // svm_avx512.cc is compiled with -mavx2 -mbmi2 -mfma -mavx512f
+    // -mavx512dq, so all five features must be present at runtime.
+    return host_supports_avx2_kernel() && __builtin_cpu_supports("avx512f") &&
+           __builtin_cpu_supports("avx512dq");
+#else
+    return false;
+#endif
+}
+
+// Trap functions installed when the user explicitly requests an ISA via
+// CLIFFT_FORCE_ISA that the host CPU cannot actually execute. We install
+// these at static-initialization time and let the throw fire on the
+// first execute() call -- throwing during static init would terminate
+// the entire process (no Python catch is in scope yet) and turn a clear
+// runtime error into a hard crash at import.
+[[noreturn]] static void trap_force_isa_avx2(const CompiledModule&, SchrodingerState&) {
+    throw std::runtime_error(
+        "CLIFFT_FORCE_ISA=avx2 requested but host CPU lacks one or more required "
+        "features (avx2, bmi2, fma). Unset CLIFFT_FORCE_ISA to use the auto-detected "
+        "fallback, or set it to 'scalar' explicitly.");
+}
+
+[[noreturn]] static void trap_force_isa_avx512(const CompiledModule&, SchrodingerState&) {
+    throw std::runtime_error(
+        "CLIFFT_FORCE_ISA=avx512 requested but host CPU lacks one or more required "
+        "features (avx2, bmi2, fma, avx512f, avx512dq). Unset CLIFFT_FORCE_ISA to use "
+        "the auto-detected fallback, or set it to 'avx2' or 'scalar' explicitly.");
+}
+
+[[noreturn]] static void trap_force_isa_unknown(const CompiledModule&, SchrodingerState&) {
+    throw std::runtime_error(
+        "CLIFFT_FORCE_ISA is set to an unrecognized value. Accepted values are "
+        "'avx512', 'avx2', 'scalar' (case-insensitive). Unset CLIFFT_FORCE_ISA to "
+        "use the auto-detected fallback.");
+}
+
+// Lowercase a copy of the env var and strip surrounding whitespace so the
+// parser stays case-insensitive without mutating the host environment.
+static std::string normalize_force_isa(const char* env) {
+    std::string s(env);
+    auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+    return s;
+}
+
 static DispatchFn resolve_dispatcher() {
     // Allow environment override for testing.
     if (const char* env = std::getenv("CLIFFT_FORCE_ISA")) {
-        if (env[0] == '5' || (env[0] == 'a' && env[3] == '5')) {
-            // "avx512" or "512"
-            return avx512::execute_internal;
+        std::string name = normalize_force_isa(env);
+        if (name == "avx512") {
+            return host_supports_avx512_kernel() ? avx512::execute_internal : trap_force_isa_avx512;
         }
-        if (env[0] == 'a' || env[0] == 'A') {
-            return avx2::execute_internal;
+        if (name == "avx2") {
+            return host_supports_avx2_kernel() ? avx2::execute_internal : trap_force_isa_avx2;
         }
-        return scalar::execute_internal;
+        if (name == "scalar") {
+            return scalar::execute_internal;
+        }
+        // An empty CLIFFT_FORCE_ISA (e.g. `CLIFFT_FORCE_ISA= python ...`)
+        // falls back to auto-detect rather than reporting an error: bash
+        // sets the var to empty when written that way, and the previous
+        // dispatcher treated empty as scalar. Allow it to behave like
+        // "unset" so callers don't have to special-case shell quirks.
+        if (name.empty()) {
+            // Fall through to auto-detect below.
+        } else {
+            return trap_force_isa_unknown;
+        }
     }
 
-#if (defined(__GNUC__) || defined(__clang__)) && \
-    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
-    if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512dq")) {
+    // Auto-detect: walk down to the highest kernel the host can run.
+    if (host_supports_avx512_kernel()) {
         return avx512::execute_internal;
     }
-    if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("bmi2")) {
+    if (host_supports_avx2_kernel()) {
         return avx2::execute_internal;
     }
-#endif
     return scalar::execute_internal;
 }
 
@@ -86,6 +169,17 @@ const char* svm_backend() {
         return "avx512";
     if (resolved_fn == avx2::execute_internal)
         return "avx2";
+    // Trap states surface a CLIFFT_FORCE_ISA misconfig: the user asked
+    // for an ISA the host can't run, or set the variable to a value the
+    // dispatcher doesn't recognize. Reporting these distinctly (rather
+    // than masquerading as "scalar") lets tests and tooling notice the
+    // misconfig before execute() actually throws.
+    if (resolved_fn == trap_force_isa_avx512)
+        return "trap:avx512";
+    if (resolved_fn == trap_force_isa_avx2)
+        return "trap:avx2";
+    if (resolved_fn == trap_force_isa_unknown)
+        return "trap:unknown";
 #endif
     return "scalar";
 }

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -295,8 +295,24 @@ class SchrodingerState {
 /// Execute a compiled program for one shot, populating state with results.
 void execute(const CompiledModule& program, SchrodingerState& state);
 
-/// Return the name of the active SVM dispatch backend ("avx512", "avx2", or "scalar").
-/// Reflects the resolved CPUID path or CLIFFT_FORCE_ISA override.
+/// Return the name of the active SVM dispatch backend. Reflects the
+/// resolved CPUID path or the CLIFFT_FORCE_ISA environment override.
+///
+/// In normal operation returns one of:
+///   - "avx512" — the AVX-512 kernel is active.
+///   - "avx2"   — the AVX-2 kernel is active.
+///   - "scalar" — the portable scalar fallback is active.
+///
+/// If CLIFFT_FORCE_ISA names an ISA the host CPU cannot execute, or is
+/// set to an unrecognized value, the backend reports one of:
+///   - "trap:avx512"  — CLIFFT_FORCE_ISA=avx512 but host lacks
+///                      avx2/bmi2/fma/avx512f/avx512dq.
+///   - "trap:avx2"    — CLIFFT_FORCE_ISA=avx2 but host lacks
+///                      avx2/bmi2/fma.
+///   - "trap:unknown" — CLIFFT_FORCE_ISA is set to a value other than
+///                      avx512/avx2/scalar (case-insensitive).
+/// In each trap case the next execute() call throws std::runtime_error
+/// with a message naming the missing features or accepted values.
 const char* svm_backend();
 
 /// Results from sampling a circuit.

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -60,9 +60,14 @@ NB_MODULE(_clifft_core, m) {
 
     m.def(
         "svm_backend", []() { return clifft::svm_backend(); },
-        "Return the active SVM dispatch backend: 'avx512', 'avx2', or 'scalar'.\n\n"
-        "Reflects the resolved runtime kernel path or CLIFFT_FORCE_ISA environment override. "
-        "'scalar' names the generic/base SVM path.");
+        "Return the active SVM dispatch backend.\n\n"
+        "Reflects the resolved runtime kernel path or the CLIFFT_FORCE_ISA environment "
+        "override. In normal operation returns one of 'avx512', 'avx2', or 'scalar' "
+        "('scalar' names the generic/base SVM path).\n\n"
+        "If CLIFFT_FORCE_ISA names an ISA the host CPU cannot execute, or is set to "
+        "an unrecognized value, the backend instead reports one of 'trap:avx512', "
+        "'trap:avx2', or 'trap:unknown'. The next execute() call throws RuntimeError "
+        "with a message naming the missing features or accepted values.");
 
     m.def(
         "set_num_threads",


### PR DESCRIPTION
Closes #93 (sub-task of #92).

## Two dispatch-correctness bugs

### 1. AVX-2 dispatch was missing the FMA check

\`svm_avx2.cc\` is compiled with \`-mavx2 -mbmi2 -mfma\` per the per-TU flags in \`src/clifft/CMakeLists.txt\`. \`resolve_dispatcher()\` only checked \`avx2\` + \`bmi2\`, so a CPU with AVX-2 + BMI2 but no FMA (Excavator-gen AMD, some VIA Eden-X4) would dispatch to the AVX-2 kernel and SIGILL on the first FMA instruction. The AVX-512 path correctly checked both \`avx512f\` and \`avx512dq\`; the AVX-2 path now likewise gates on all three of its compile-time features.

### 2. \`CLIFFT_FORCE_ISA\` SIGILLed on hosts that can't run the requested ISA

The override path accepted any value and returned the requested function pointer without verifying the host could actually execute it. A user (or CI step) setting \`CLIFFT_FORCE_ISA=avx2\` on a sub-AVX-2 host got a bare SIGILL on first \`execute()\`. The override path now checks the host's actual feature set and installs a small trap function on mismatch:

\`\`\`cpp
[[noreturn]] static void trap_force_isa_avx2(const CompiledModule&, SchrodingerState&) {
    throw std::runtime_error(
        \"CLIFFT_FORCE_ISA=avx2 requested but host CPU lacks one or more required \"
        \"features (avx2, bmi2, fma). Unset CLIFFT_FORCE_ISA to use the auto-detected \"
        \"fallback, or set it to 'scalar' explicitly.\");
}
\`\`\`

The trap is installed at static-init time but the throw only fires on the first \`execute()\` call -- throwing during static init would terminate the entire process before Python's exception machinery is in scope, turning a clear runtime error into a hard crash at import.

## Single source of truth for kernel feature requirements

Both fixes are co-located in two small helpers:

\`\`\`cpp
static bool host_supports_avx2_kernel();    // avx2 + bmi2 + fma
static bool host_supports_avx512_kernel();  // (avx2 kernel set) + avx512f + avx512dq
\`\`\`

The auto-detect path and the \`FORCE_ISA\` override path both call these, so each kernel TU's compile-time flag set is declared exactly once.

## \`svm_backend()\` reporting

Reports \`trap:avx2\` / \`trap:avx512\` when a trap is installed instead of masquerading as \`scalar\`. The existing \`test_svm_backend_returns_valid_isa\` Python test asserts the backend is in \`{avx512, avx2, scalar}\`, so any future CI run that lands a \`CLIFFT_FORCE_ISA\` misconfig will fail loudly there.

## Test plan

- [x] All 769 C++ tests pass (unchanged behavior on the host since it has all v3 + AVX-512 features).
- [x] All 667 Python tests pass.
- [x] Manual smoke: \`CLIFFT_FORCE_ISA={unset,scalar,avx2,avx512}\` each report the expected backend on this host.
- [ ] Trap path coverage: hard to test in CI without a sub-AVX-2 runner. The existing assertion in \`test_svm_backend_returns_valid_isa\` will catch the misconfig if it ever lands in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)