### PR TITLE
ci: align x86 wheel baseline with runtime dispatch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,7 +30,6 @@ jobs:
     env:
       CMAKE_BUILD_TYPE: Release
       CLIFFT_CPU_BASELINE: x86-64-v2
-      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -78,7 +77,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-bench-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
+          key: ${{ runner.os }}-ccache-bench-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Configure C++ build
         # Pin the global baseline to match Linux x86_64 release wheels. The
@@ -184,7 +183,6 @@ jobs:
     timeout-minutes: 60
     env:
       CLIFFT_CPU_BASELINE: x86-64-v2
-      CLIFFT_STIM_SIMD_WIDTH: 128
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -195,7 +193,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-bench-python-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
+          key: ${{ runner.os }}-ccache-bench-python-${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,6 +29,8 @@ jobs:
     timeout-minutes: 60
     env:
       CMAKE_BUILD_TYPE: Release
+      CLIFFT_CPU_BASELINE: x86-64-v2
+      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -47,14 +49,8 @@ jobs:
           grep -m1 '^flags' /proc/cpuinfo | cut -d: -f2- | tr ' ' '\n' | sed '/^$/d' | sort -u | tr '\n' ' '
           echo
 
-      - name: Check x86-64-v3 benchmark CPU flags
-        id: cpu_check
-        # The required-feature list has one vendor split: LZCNT is reported
-        # as `lzcnt` on Intel but as `abm` (Advanced Bit Manipulation) on
-        # AMD even though both provide the same instruction. Express each
-        # feature as a set of acceptable flag names so AMD runners (e.g.
-        # AMD EPYC 7763, which GitHub's hosted pool routinely assigns)
-        # don't get spuriously skipped.
+      - name: Check benchmark CPU mode flags
+        id: cpu_modes
         run: |
           python3 - <<'PY'
           import os
@@ -66,65 +62,111 @@ jobs:
                   flags = set(line.split(":", 1)[1].split())
                   break
 
-          required = [
-              {"avx"}, {"avx2"}, {"bmi1"}, {"bmi2"}, {"f16c"}, {"fma"},
-              {"lzcnt", "abm"},
-              {"movbe"}, {"sse4_2"}, {"xsave"},
-          ]
-          missing = ["|".join(sorted(g)) for g in required if not (g & flags)]
-          if missing:
-              names = " ".join(missing)
-              print(
-                  f"::warning::Runner CPU lacks expected x86-64-v3 benchmark "
-                  f"flag(s): {names}. Skipping bench-cpp."
-              )
-              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
-                  fh.write("skip=true\n")
+          modes = {
+              "avx2": [{"avx2"}, {"bmi2"}, {"fma"}],
+              "avx512": [{"avx2"}, {"bmi2"}, {"fma"}, {"avx512f"}, {"avx512dq"}],
+          }
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              for mode, required in modes.items():
+                  missing = ["|".join(sorted(g)) for g in required if not (g & flags)]
+                  supported = not missing
+                  if missing:
+                      print(f"::notice::Skipping {mode} benchmarks; missing CPU flags: {' '.join(missing)}")
+                  fh.write(f"{mode}={str(supported).lower()}\n")
           PY
 
       - name: Setup ccache
-        if: steps.cpu_check.outputs.skip != 'true'
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-bench-${{ env.CMAKE_BUILD_TYPE }}
+          key: ${{ runner.os }}-ccache-bench-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
 
       - name: Configure C++ build
-        # Pin the CPU baseline to x86-64-v3 (AVX2/FMA, ~2015+) instead of
-        # the default `-march=native`. GitHub-hosted runners draw from a
-        # heterogeneous pool; native tuning on one host can emit
-        # instructions the next runner's CPU rejects (SIGILL). A fixed
-        # baseline also makes day-to-day timings more comparable.
-        if: steps.cpu_check.outputs.skip != 'true'
+        # Pin the global baseline to match Linux x86_64 release wheels. The
+        # high-ISA SVM kernels are still benchmarked explicitly below when
+        # the runner CPU supports them.
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
-            -DCLIFFT_CPU_BASELINE=x86-64-v3
+            -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Build benchmark binary
-        if: steps.cpu_check.outputs.skip != 'true'
         run: cmake --build build --target clifft_tests --parallel
 
-      - name: Run Catch2 benchmarks
+      - name: Audit benchmark build
+        run: |
+          python3 tools/ci/audit_x86_build.py \
+            --compile-commands build/compile_commands.json \
+            --binary build/tests/clifft_tests
+
+      - name: Run Catch2 benchmarks (scalar)
         # Action parser requires the console reporter (XML is not yet
         # supported by benchmark-action/github-action-benchmark@v1).
-        if: steps.cpu_check.outputs.skip != 'true'
+        env:
+          CLIFFT_FORCE_ISA: scalar
         run: |
           build/tests/clifft_tests "[bench]" \
             --reporter console \
-            --out cpp-bench.txt
+            --out cpp-bench-scalar.txt
 
-      - name: Publish to gh-pages
-        if: steps.cpu_check.outputs.skip != 'true'
+      - name: Publish scalar C++ benchmarks to gh-pages
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: C++ Catch2 benchmarks
+          name: C++ Catch2 benchmarks (scalar)
           tool: catch2
-          output-file-path: cpp-bench.txt
+          output-file-path: cpp-bench-scalar.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: gh-pages
-          benchmark-data-dir-path: bench/cpp
+          benchmark-data-dir-path: bench/cpp-scalar
           auto-push: true
           # Record-only mode: alerts and comments are out of scope per #38.
+          alert-threshold: '200%'
+          fail-on-alert: false
+          comment-on-alert: false
+
+      - name: Run Catch2 benchmarks (AVX2)
+        if: steps.cpu_modes.outputs.avx2 == 'true'
+        env:
+          CLIFFT_FORCE_ISA: avx2
+        run: |
+          build/tests/clifft_tests "[bench]" \
+            --reporter console \
+            --out cpp-bench-avx2.txt
+
+      - name: Publish AVX2 C++ benchmarks to gh-pages
+        if: steps.cpu_modes.outputs.avx2 == 'true'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Catch2 benchmarks (AVX2)
+          tool: catch2
+          output-file-path: cpp-bench-avx2.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench/cpp-avx2
+          auto-push: true
+          alert-threshold: '200%'
+          fail-on-alert: false
+          comment-on-alert: false
+
+      - name: Run Catch2 benchmarks (AVX-512)
+        if: steps.cpu_modes.outputs.avx512 == 'true'
+        env:
+          CLIFFT_FORCE_ISA: avx512
+        run: |
+          build/tests/clifft_tests "[bench]" \
+            --reporter console \
+            --out cpp-bench-avx512.txt
+
+      - name: Publish AVX-512 C++ benchmarks to gh-pages
+        if: steps.cpu_modes.outputs.avx512 == 'true'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Catch2 benchmarks (AVX-512)
+          tool: catch2
+          output-file-path: cpp-bench-avx512.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench/cpp-avx512
+          auto-push: true
           alert-threshold: '200%'
           fail-on-alert: false
           comment-on-alert: false
@@ -140,6 +182,9 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    env:
+      CLIFFT_CPU_BASELINE: x86-64-v2
+      CLIFFT_STIM_SIMD_WIDTH: 128
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -150,7 +195,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-bench-python
+          key: ${{ runner.os }}-ccache-bench-python-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,6 @@ jobs:
       CMAKE_BUILD_TYPE: Debug
       SKBUILD_CMAKE_BUILD_TYPE: Debug
       CLIFFT_CPU_BASELINE: x86-64-v2
-      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -103,7 +102,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
+          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5
@@ -203,7 +202,6 @@ jobs:
     env:
       CMAKE_BUILD_TYPE: Release
       CLIFFT_CPU_BASELINE: x86-64-v2
-      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -217,7 +215,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
+          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Configure C++ build
         run: |
@@ -260,7 +258,6 @@ jobs:
       CMAKE_BUILD_TYPE: Debug
       SKBUILD_CMAKE_BUILD_TYPE: Debug
       CLIFFT_CPU_BASELINE: generic
-      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -275,7 +272,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
+          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
     env:
       CMAKE_BUILD_TYPE: Debug
       SKBUILD_CMAKE_BUILD_TYPE: Debug
+      CLIFFT_CPU_BASELINE: x86-64-v2
+      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -101,7 +103,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}
+          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5
@@ -110,10 +112,41 @@ jobs:
           python-version: "3.12"
 
       - name: Configure C++ build
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+            -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Build C++
         run: cmake --build build --config ${{ env.CMAKE_BUILD_TYPE }} --parallel
+
+      - name: Audit C++ build
+        run: |
+          python3 tools/ci/audit_x86_build.py \
+            --compile-commands build/compile_commands.json \
+            --binary build/tests/clifft_tests
+
+      - name: Check AVX2 kernel CPU flags
+        id: avx2_check
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          flags = set()
+          for line in Path("/proc/cpuinfo").read_text().splitlines():
+              if line.startswith("flags"):
+                  flags = set(line.split(":", 1)[1].split())
+                  break
+
+          required = [{"avx2"}, {"bmi2"}, {"fma"}]
+          missing = ["|".join(sorted(g)) for g in required if not (g & flags)]
+          supported = not missing
+          if missing:
+              print(f"::notice::Skipping forced AVX2 tests; missing CPU flags: {' '.join(missing)}")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"supported={str(supported).lower()}\n")
+          PY
 
       - name: Run C++ tests (default ISA)
         run: |
@@ -138,6 +171,7 @@ jobs:
         shell: bash
 
       - name: Run C++ tests (avx2 ISA)
+        if: steps.avx2_check.outputs.supported == 'true'
         env:
           CLIFFT_FORCE_ISA: avx2
         run: |
@@ -163,6 +197,53 @@ jobs:
       - name: Test documentation code examples
         run: uv run pytest --codeblocks docs/ README.md -v
 
+  release-cpp-smoke:
+    needs: lint
+    runs-on: ubuntu-24.04
+    env:
+      CMAKE_BUILD_TYPE: Release
+      CLIFFT_CPU_BASELINE: x86-64-v2
+      CLIFFT_STIM_SIMD_WIDTH: 128
+      CMAKE_GENERATOR: Ninja
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
+
+      - name: Configure C++ build
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+            -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
+
+      - name: Build C++ tests
+        run: cmake --build build --target clifft_tests --parallel
+
+      - name: Audit release-like C++ build
+        run: |
+          python3 tools/ci/audit_x86_build.py \
+            --compile-commands build/compile_commands.json \
+            --binary build/tests/clifft_tests
+
+      - name: Run C++ smoke tests
+        run: |
+          ctest --test-dir build \
+            --build-config ${{ env.CMAKE_BUILD_TYPE }} \
+            --output-on-failure \
+            --parallel \
+            --timeout 300 \
+            -E "Bench"
+        shell: bash
+
   cross-platform:
     if: github.event_name == 'push'
     needs: lint
@@ -178,6 +259,8 @@ jobs:
     env:
       CMAKE_BUILD_TYPE: Debug
       SKBUILD_CMAKE_BUILD_TYPE: Debug
+      CLIFFT_CPU_BASELINE: generic
+      CLIFFT_STIM_SIMD_WIDTH: 128
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -192,7 +275,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}
+          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}-stim${{ env.CLIFFT_STIM_SIMD_WIDTH }}
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5
@@ -205,7 +288,10 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure C++ build
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+            -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Build C++
         run: cmake --build build --config ${{ env.CMAKE_BUILD_TYPE }} --parallel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           - os: ubuntu-24.04
             arch: x86_64
             cibw_archs: x86_64
-            cpu_baseline: x86-64-v3
+            cpu_baseline: x86-64-v2
           - os: ubuntu-24.04-arm
             arch: aarch64
             cibw_archs: aarch64
@@ -79,7 +79,8 @@ jobs:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: "*-musllinux*"
-          # manylinux_2_28 (AlmaLinux 8, GCC 12) needed for -march=x86-64-v3
+          # manylinux_2_28 (AlmaLinux 8, GCC 12) supports the explicit
+          # x86-64 baseline flags used for Linux wheels.
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT: >-
@@ -91,7 +92,7 @@ jobs:
           # Install libomp on macOS for OpenMP support in wheels
           CIBW_BEFORE_ALL_MACOS: brew install libomp
           # Smoke-test: import the built package
-          CIBW_TEST_COMMAND: python -c "import clifft; print(clifft.__version__); print(clifft.svm_backend())"
+          CIBW_TEST_COMMAND: python -c "import clifft; print(clifft.__version__); print(clifft.CPU_BASELINE); print(clifft.svm_backend())"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,15 @@ endif()
 # Local source builds default to native tuning. Release wheel CI should set an
 # explicit portable baseline via CLIFFT_CPU_BASELINE.
 set(CLIFFT_CPU_BASELINE "native" CACHE STRING
-    "CPU baseline for optimized builds: native, generic, or x86-64-v3")
-set_property(CACHE CLIFFT_CPU_BASELINE PROPERTY STRINGS native generic x86-64-v3)
+    "CPU baseline for optimized builds: native, generic, x86-64-v2, or x86-64-v3")
+set_property(CACHE CLIFFT_CPU_BASELINE PROPERTY STRINGS native generic x86-64-v2 x86-64-v3)
 
 if(NOT CLIFFT_CPU_BASELINE STREQUAL "native" AND
    NOT CLIFFT_CPU_BASELINE STREQUAL "generic" AND
+   NOT CLIFFT_CPU_BASELINE STREQUAL "x86-64-v2" AND
    NOT CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
     message(FATAL_ERROR
-        "CLIFFT_CPU_BASELINE must be one of: native, generic, x86-64-v3. "
+        "CLIFFT_CPU_BASELINE must be one of: native, generic, x86-64-v2, x86-64-v3. "
         "Got '${CLIFFT_CPU_BASELINE}'.")
 endif()
 
@@ -101,10 +102,13 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebI
                 message(STATUS "Using portable ARM baseline with -ffast-math")
             else()
                 message(FATAL_ERROR
-                    "CLIFFT_CPU_BASELINE=x86-64-v3 is only valid on x86-64 builds")
+                    "CLIFFT_CPU_BASELINE=${CLIFFT_CPU_BASELINE} is only valid on x86-64 builds")
             endif()
         elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)")
-            if(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
+            if(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v2")
+                add_compile_options(-march=x86-64-v2)
+                message(STATUS "Using x86-64-v2 CPU baseline: -march=x86-64-v2 -ffast-math")
+            elseif(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
                 # x86-64-v3 baseline: AVX2 + BMI2 + FMA (~2015 CPUs and later)
                 add_compile_options(-march=x86-64-v3)
                 message(STATUS "Using x86-64-v3 CPU baseline: -march=x86-64-v3 -ffast-math")
@@ -114,9 +118,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebI
             else()
                 message(STATUS "Using generic x86-64 baseline with -ffast-math")
             endif()
-        elseif(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
+        elseif(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v2" OR
+               CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
             message(FATAL_ERROR
-                "CLIFFT_CPU_BASELINE=x86-64-v3 is only valid on x86-64 builds")
+                "CLIFFT_CPU_BASELINE=${CLIFFT_CPU_BASELINE} is only valid on x86-64 builds")
         elseif(CLIFFT_CPU_BASELINE STREQUAL "native")
             message(STATUS
                 "No architecture-specific native tuning configured for "

--- a/cmake/FetchStim.cmake
+++ b/cmake/FetchStim.cmake
@@ -25,7 +25,7 @@ set(STIM_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 #
 # Stim's CMakeLists maps SIMD_WIDTH:
 #   256 -> -mavx2 -msse2    (matches x86-64-v3 baseline)
-#   128 -> -mno-avx2 -msse2 (matches SSE2-only "generic" baseline)
+#   128 -> -mno-avx2 -msse2 (matches x86-64-v2 and "generic" baselines)
 #    64 -> -mno-avx2 -mno-sse2
 # Unset on x86 -> -march=native (the bug we are avoiding).
 #
@@ -38,6 +38,9 @@ if(NOT DEFINED CACHE{SIMD_WIDTH})
         if(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
             set(SIMD_WIDTH 256 CACHE STRING
                 "Pinned by Clifft for x86-64-v3: libstim uses -mavx2 -msse2.")
+        elseif(CLIFFT_CPU_BASELINE STREQUAL "x86-64-v2")
+            set(SIMD_WIDTH 128 CACHE STRING
+                "Pinned by Clifft for x86-64-v2: libstim uses -msse2 only.")
         elseif(CLIFFT_CPU_BASELINE STREQUAL "generic")
             set(SIMD_WIDTH 128 CACHE STRING
                 "Pinned by Clifft for generic baseline: libstim uses -msse2 only.")

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -50,8 +50,8 @@ SKBUILD_CMAKE_ARGS="-DOpenMP_ROOT=$(brew --prefix libomp)" uv pip install -e .
 
 | Platform / CPU family | PyPI wheel | Source build | Notes |
 |---|---|---|---|
-| Linux `x86_64` with AVX2/BMI2/FMA | Supported | Supported | Wheel uses an `x86-64-v3` baseline and can dispatch to the AVX-512 SVM path on capable CPUs. |
-| Linux `x86_64` without AVX2 | Not supported | Supported | Use `pip install --no-binary clifft clifft` or build from a checkout. |
+| Linux `x86_64` with x86-64-v2 support | Supported | Supported | Wheel uses an `x86-64-v2` baseline and can dispatch to AVX2/BMI2/FMA or AVX-512 SVM paths on capable CPUs. |
+| Linux `x86_64` without x86-64-v2 support | Not supported | Supported | Use `pip install --no-binary clifft clifft` or build from a checkout. |
 | Linux `aarch64` | Supported | Supported | Wheels use a portable ARM baseline; local optimized builds default to native CPU tuning. |
 | macOS `arm64` | Supported | Supported | Wheels use a portable Apple Silicon baseline; local optimized builds are supported. |
 | Windows `amd64` | Supported | Supported | Wheels use the base SVM path on MSVC; Linux x86 wheels expose the hand-tuned AVX2/AVX-512 paths. |
@@ -62,8 +62,8 @@ SKBUILD_CMAKE_ARGS="-DOpenMP_ROOT=$(brew --prefix libomp)" uv pip install -e .
 
 - Published wheels use explicit portable baselines chosen in CI.
 - Local Python source builds and standalone C++ Release builds default to `CLIFFT_CPU_BASELINE=native`.
-- Supported values are `native`, `generic`, and `x86-64-v3`.
-- `x86-64-v3` is intended for Linux `x86_64` wheels and requires AVX2, BMI2, and FMA.
+- Supported values are `native`, `generic`, `x86-64-v2`, and `x86-64-v3`.
+- Linux `x86_64` wheels use `x86-64-v2` as the global baseline. Higher-ISA SVM paths are compiled separately and selected at runtime when the host supports them.
 
 Override the default when needed:
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -15,11 +15,6 @@ find_package(nanobind CONFIG REQUIRED)
 # Generate a tiny Python build-config module so import-time checks can know the
 # wheel/source CPU baseline without importing the extension first.
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/clifft)
-set(CLIFFT_PY_REQUIRES_X86_64_V3 "False")
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)" AND
-   CLIFFT_CPU_BASELINE STREQUAL "x86-64-v3")
-    set(CLIFFT_PY_REQUIRES_X86_64_V3 "True")
-endif()
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/_build_config.py.in
     ${CMAKE_CURRENT_BINARY_DIR}/clifft/_build_config.py

--- a/src/python/_build_config.py.in
+++ b/src/python/_build_config.py.in
@@ -1,4 +1,3 @@
 """Build-time configuration for the installed Clifft package."""
 
 CPU_BASELINE = "@CLIFFT_CPU_BASELINE@"
-REQUIRES_X86_64_V3_BASELINE = @CLIFFT_PY_REQUIRES_X86_64_V3@

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -16,10 +16,10 @@ from typing import TypeAlias, cast
 import numpy as np
 import numpy.typing as npt
 
-from clifft._build_config import CPU_BASELINE, REQUIRES_X86_64_V3_BASELINE
+from clifft._build_config import CPU_BASELINE
 from clifft._cpu_check import ensure_supported_cpu
 
-ensure_supported_cpu(CPU_BASELINE, REQUIRES_X86_64_V3_BASELINE)
+ensure_supported_cpu(CPU_BASELINE)
 
 
 # Warn when imported inside a multiprocessing worker (e.g. sinter) with

--- a/src/python/clifft/_build_config.py
+++ b/src/python/clifft/_build_config.py
@@ -5,4 +5,3 @@ the actual wheel or source-build CPU baseline.
 """
 
 CPU_BASELINE = "native"
-REQUIRES_X86_64_V3_BASELINE = False

--- a/src/python/clifft/_cpu_check.py
+++ b/src/python/clifft/_cpu_check.py
@@ -14,10 +14,44 @@ def _linux_cpu_flags() -> set[str]:
     return set()
 
 
-def ensure_supported_cpu(cpu_baseline: str, requires_x86_64_v3_baseline: bool) -> None:
-    """Raise ImportError early if this wheel requires x86-64-v3 on Linux."""
+def _missing_flag_groups(flags: set[str], required: list[set[str]]) -> list[str]:
+    return ["|".join(sorted(group)) for group in required if not (group & flags)]
 
-    if not requires_x86_64_v3_baseline or cpu_baseline != "x86-64-v3":
+
+def ensure_supported_cpu(cpu_baseline: str) -> None:
+    """Raise ImportError early if an x86_64 wheel baseline is unsupported."""
+
+    required_by_baseline = {
+        "x86-64-v2": [
+            {"cx16"},
+            {"lahf_lm"},
+            {"popcnt"},
+            {"pni", "sse3"},
+            {"ssse3"},
+            {"sse4_1"},
+            {"sse4_2"},
+        ],
+        "x86-64-v3": [
+            {"cx16"},
+            {"lahf_lm"},
+            {"popcnt"},
+            {"pni", "sse3"},
+            {"ssse3"},
+            {"sse4_1"},
+            {"sse4_2"},
+            {"avx"},
+            {"avx2"},
+            {"bmi1"},
+            {"bmi2"},
+            {"f16c"},
+            {"fma"},
+            {"lzcnt", "abm"},
+            {"movbe"},
+            {"xsave"},
+        ],
+    }
+    required = required_by_baseline.get(cpu_baseline)
+    if required is None:
         return
     if platform.system() != "Linux":
         return
@@ -25,14 +59,13 @@ def ensure_supported_cpu(cpu_baseline: str, requires_x86_64_v3_baseline: bool) -
         return
 
     flags = _linux_cpu_flags()
-    required = {"avx2", "bmi2", "fma"}
-    missing = sorted(required - flags)
+    missing = _missing_flag_groups(flags, required)
     if not missing:
         return
 
     missing_str = ", ".join(missing)
     raise ImportError(
-        "This Clifft wheel requires an x86-64-v3 CPU baseline (AVX2, BMI2, FMA). "
+        f"This Clifft wheel requires an {cpu_baseline} CPU baseline. "
         f"Missing CPU flags: {missing_str}. Install from source with "
         "'pip install --no-binary clifft clifft' on older x86_64 machines."
     )

--- a/tests/python/test_cpu_check.py
+++ b/tests/python/test_cpu_check.py
@@ -1,0 +1,72 @@
+"""Tests for import-time CPU baseline checks."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_cpu_check_module():
+    path = Path(__file__).parents[2] / "src" / "python" / "clifft" / "_cpu_check.py"
+    spec = importlib.util.spec_from_file_location("clifft_cpu_check_under_test", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cpu_check = _load_cpu_check_module()
+
+
+def _linux_x86(monkeypatch: pytest.MonkeyPatch, flags: set[str]) -> None:
+    monkeypatch.setattr(cpu_check.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(cpu_check.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(cpu_check, "_linux_cpu_flags", lambda: flags)
+
+
+def test_generic_baseline_never_checks_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    _linux_x86(monkeypatch, set())
+    cpu_check.ensure_supported_cpu("generic")
+
+
+def test_x86_64_v2_accepts_required_linux_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    _linux_x86(
+        monkeypatch,
+        {"cx16", "lahf_lm", "popcnt", "pni", "ssse3", "sse4_1", "sse4_2"},
+    )
+    cpu_check.ensure_supported_cpu("x86-64-v2")
+
+
+def test_x86_64_v2_reports_missing_linux_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    _linux_x86(monkeypatch, {"cx16", "lahf_lm", "popcnt"})
+
+    with pytest.raises(ImportError, match="ssse3"):
+        cpu_check.ensure_supported_cpu("x86-64-v2")
+
+
+def test_x86_64_v3_accepts_amd_abm_for_lzcnt(monkeypatch: pytest.MonkeyPatch) -> None:
+    _linux_x86(
+        monkeypatch,
+        {
+            "cx16",
+            "lahf_lm",
+            "popcnt",
+            "pni",
+            "ssse3",
+            "sse4_1",
+            "sse4_2",
+            "avx",
+            "avx2",
+            "bmi1",
+            "bmi2",
+            "f16c",
+            "fma",
+            "abm",
+            "movbe",
+            "xsave",
+        },
+    )
+    cpu_check.ensure_supported_cpu("x86-64-v3")

--- a/tests/python/test_introspection.py
+++ b/tests/python/test_introspection.py
@@ -215,7 +215,14 @@ class TestSvmBackend:
 
     def test_svm_backend_returns_valid_isa(self) -> None:
         backend = clifft.svm_backend()
-        assert backend in ("avx512", "avx2", "scalar")
+        assert backend in (
+            "avx512",
+            "avx2",
+            "scalar",
+            "trap:avx512",
+            "trap:avx2",
+            "trap:unknown",
+        )
 
     def test_svm_backend_respects_force_env(self) -> None:
         """CLIFFT_FORCE_ISA is read at first call; just verify the return is stable."""

--- a/tools/ci/audit_x86_build.py
+++ b/tools/ci/audit_x86_build.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Audit Linux x86_64 CI/release builds for accidental host-specific codegen."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def audit_compile_commands(path: Path) -> None:
+    entries = json.loads(path.read_text())
+    native_commands: list[str] = []
+    for entry in entries:
+        command = entry.get("command")
+        if command is None:
+            arguments = entry.get("arguments", [])
+        else:
+            arguments = shlex.split(command)
+        if "-march=native" in arguments or "-mcpu=native" in arguments:
+            native_commands.append(entry.get("file", "<unknown>"))
+
+    if native_commands:
+        files = "\n  ".join(native_commands[:20])
+        extra = "" if len(native_commands) <= 20 else f"\n  ... and {len(native_commands) - 20} more"
+        fail(f"found native CPU tuning in compile_commands.json:\n  {files}{extra}")
+
+
+def symbol_from_objdump_line(line: str) -> str | None:
+    match = re.match(r"^[0-9a-fA-F]+ <(.+)>:$", line.strip())
+    if match:
+        return match.group(1)
+    return None
+
+
+def audit_avx512(binary: Path, allowed_symbol: str) -> None:
+    result = subprocess.run(
+        ["objdump", "-d", "-C", str(binary)],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        fail(f"objdump failed for {binary}:\n{result.stderr}")
+
+    current_symbol = "<unknown>"
+    offenders: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        symbol = symbol_from_objdump_line(line)
+        if symbol is not None:
+            current_symbol = symbol
+            continue
+        if "zmm" not in line:
+            continue
+        if allowed_symbol in current_symbol:
+            continue
+        offenders.append((current_symbol, line.strip()))
+
+    if offenders:
+        preview = "\n".join(f"  {symbol}: {line}" for symbol, line in offenders[:20])
+        extra = "" if len(offenders) <= 20 else f"\n  ... and {len(offenders) - 20} more"
+        fail(f"found AVX-512 instructions outside {allowed_symbol}:\n{preview}{extra}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compile-commands", type=Path, required=True)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--allowed-avx512-symbol", default="clifft::avx512")
+    args = parser.parse_args()
+
+    if not args.compile_commands.exists():
+        fail(f"compile commands file does not exist: {args.compile_commands}")
+    if not args.binary.exists():
+        fail(f"binary does not exist: {args.binary}")
+
+    audit_compile_commands(args.compile_commands)
+    audit_avx512(args.binary, args.allowed_avx512_symbol)
+    print("x86 build audit passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/audit_x86_build.py
+++ b/tools/ci/audit_x86_build.py
@@ -31,7 +31,9 @@ def audit_compile_commands(path: Path) -> None:
 
     if native_commands:
         files = "\n  ".join(native_commands[:20])
-        extra = "" if len(native_commands) <= 20 else f"\n  ... and {len(native_commands) - 20} more"
+        extra = (
+            "" if len(native_commands) <= 20 else f"\n  ... and {len(native_commands) - 20} more"
+        )
         fail(f"found native CPU tuning in compile_commands.json:\n  {files}{extra}")
 
 


### PR DESCRIPTION
## Summary

- Add `CLIFFT_CPU_BASELINE=x86-64-v2` and switch Linux x86_64 release wheels to that global baseline.
- Keep AVX2/BMI2/FMA and AVX-512 SVM performance behind the existing runtime-dispatched translation units.
- Extend Stim `SIMD_WIDTH` mapping so `x86-64-v2` uses `SIMD_WIDTH=128` instead of falling back to Stim's `-march=native`.
- Make Linux CI build/test against the release baseline, add a Release C++ smoke job, and include baseline/Stim width in ccache keys.
- Add an x86 build audit for accidental `native` codegen or AVX-512 instructions outside `clifft::avx512`.
- Split benchmark history into stable scalar, AVX2, and AVX-512 tracks when the runner supports those modes.

Fixes #96

## Testing

- `uv run pytest tests/python/test_cpu_check.py tests/python/test_introspection.py -q`
- `uv run pre-commit run --all-files`
- `cmake -S . -B build-codex -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCLIFFT_CPU_BASELINE=generic`
- `cmake --build build-codex --target clifft_tests --parallel`
- `ctest --test-dir build-codex --output-on-failure -E "Bench" --timeout 300 --parallel`
