### PR TITLE
ci: fix Windows configure command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,10 +285,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure C++ build
-        run: |
-          cmake -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
-            -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Build C++
         run: cmake --build build --config ${{ env.CMAKE_BUILD_TYPE }} --parallel


### PR DESCRIPTION
## Summary

- Fix the cross-platform CMake configure step on Windows by avoiding bash-style `\` line continuations under PowerShell.
- Keeps the Linux-only configure steps unchanged.

## Why

The post-#97 `main` CI failure configured once with the default `CLIFFT_CPU_BASELINE=native`, then PowerShell tried to execute `-DCMAKE_BUILD_TYPE=Debug` as a separate command. This restores the intended `-DCLIFFT_CPU_BASELINE=generic` argument on Windows.

## Testing

- `uv run pre-commit run --all-files`
