### PR TITLE
docs(design): noncomputational MVP API and rewrite-policy contract

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -93,11 +93,14 @@ simulation:
   the energy basis demotes `Known → Unknown`, discarding the level id
   (Hadamard on `|0>` is the canonical example).
 - `(anything) → Leaked` or `Lost`: via a transition jump.
-- `Leaked / Lost → ComputationalKnown`: only via reset/reload, gated
-  by policy. `Leaked → Known` via `R`/`RX`/`RY` is allowed; `Lost →
-  Known` only when `policy.reset_restores_lost` is set. There is no
-  spontaneous coherent return from a leaked level back into a
-  superposition with `g`/`e`.
+- `Leaked / Lost → Computational`: only via reset/reload, gated by
+  policy. Z-basis reset (`R`) lands in `ComputationalKnown(g)`;
+  X/Y-basis reset (`RX`/`RY`) lands in `ComputationalUnknown` (the
+  post-reset state is in a non-energy basis). `Leaked → Computational`
+  via any of these is allowed; `Lost → Computational` only when
+  `policy.reset_restores_lost` is set. There is no spontaneous
+  coherent return from a leaked level back into a superposition with
+  `g`/`e`.
 
 A `Computational`-category level must also declare a `basis_bit`
 (0 or 1) identifying which computational basis state it represents.
@@ -434,8 +437,10 @@ the op runs unchanged but the qubit's status transitions
 | Single-qubit Pauli noise | apply                 | apply, demote to Unknown            | drop                                    | drop                                              |
 | Two-qubit gate           | apply                 | apply, demote to Unknown on both    | reject                                  | reject (policy override: drop)                    |
 | MPP / multi-target meas  | apply                 | apply, demote to Unknown on all     | reject                                  | reject                                            |
-| Visible Z-basis meas (`M`/`MR`) | apply, promote to Known | apply, outcome = current `level_id` | classifier; reject probability per `lost`/`leak` column | classifier; reject probability per `lost` column  |
-| Visible X/Y-basis meas (`MX`/`MY`/`MRX`/`MRY`) | apply, stays Unknown | apply, demote to Unknown | classifier; as above | classifier; as above |
+| Visible Z-basis meas `M`              | apply, promote to `ComputationalKnown(outcome)` | apply, visible outcome = current `level_id` (status unchanged) | classifier; reject probability per `leak_*` column | classifier; reject probability per `lost` column |
+| Visible Z-basis meas-and-reset `MR`   | apply, **post-op `ComputationalKnown(g)`**; visible outcome reflects sampled value | apply, visible outcome = current `level_id`; **post-op `ComputationalKnown(g)`** | classifier; post-op `ComputationalKnown(g)` if `reset_restores_lost` applies, else status preserved | classifier; reject unless `policy.reset_restores_lost`, then post-op `ComputationalKnown(g)` |
+| Visible X/Y-basis meas (`MX`/`MY`)    | apply, stays `ComputationalUnknown`  | apply, demote to Unknown | classifier; as above | classifier; as above |
+| Visible X/Y-basis meas-and-reset (`MRX`/`MRY`) | apply, stays `ComputationalUnknown`; **post-op also `ComputationalUnknown`** | apply, demote to Unknown | classifier; post-op `ComputationalUnknown` if `reset_restores_lost` applies, else preserved | classifier; reject unless `policy.reset_restores_lost`, then post-op `ComputationalUnknown` |
 | Z-basis reset `R`        | apply, promote to Known (`g`) | apply, set `level_id = g` | restore to ComputationalKnown (`g`) | reject unless `policy.reset_restores_lost` is set; then restore to ComputationalKnown (`g`) |
 | X/Y-basis reset `RX`/`RY` | apply, stays Unknown | apply, demote to Unknown | restore to ComputationalUnknown      | reject unless `policy.reset_restores_lost` is set; then restore to ComputationalUnknown |
 | Detector / Observable    | unchanged             | unchanged                            | unchanged                               | unchanged                                         |
@@ -471,7 +476,8 @@ sampling:
 | Initial-state sample (Leaked level)              | `Leaked(level_id)`                                                      |
 | Initial-state sample (Lost level)                | `Lost(level_id)`                                                        |
 | Any quantum gate touching qubit, kind == Known   | demote to `ComputationalUnknown`                                        |
-| Z-basis measurement (`M`/`MR`)                   | `ComputationalKnown(g)` or `ComputationalKnown(e)` per outcome          |
+| Z-basis measurement `M`                          | `ComputationalKnown(g)` or `ComputationalKnown(e)` per outcome          |
+| Z-basis measurement-and-reset `MR`               | `ComputationalKnown(g)` (post-op state is reset, regardless of outcome) |
 | X- or Y-basis measurement (`MX`/`MY`/`MRX`/`MRY`)| post-state is in X/Y basis, not energy basis: `ComputationalUnknown`    |
 | Z-basis reset `R`                                | `ComputationalKnown(g)`                                                 |
 | X- or Y-basis reset `RX`/`RY`                    | `ComputationalUnknown`                                                  |
@@ -488,21 +494,28 @@ basis (a superposition of `g` and `e`), so its kind is
 the §4.2 sample-time rejection unless the instrument is
 source-independent on Computational sources.
 
-### 5.3 Hidden trace-out at structural loss
+### 5.3 Hidden trace-out at noncomputational transitions
 
-When a qubit whose status is `ComputationalUnknown` transitions to
-`Lost`, theory requires a hidden Z-basis measurement to unravel the
-partial trace. clifft already has the infrastructure for this: the
-`R`/`RX`/`RY` reset ops are lowered by the frontend
+Whenever a qubit whose status is `ComputationalUnknown` transitions
+to a noncomputational kind (either `Leaked` or `Lost`), theory
+requires a hidden Z-basis measurement to unravel the partial trace.
+The qubit's computational amplitude is entangled with the rest of the
+state, and "removing" it from the coherent subspace — whether by
+hardware loss or by escape to a noncomputational level — must trace
+that amplitude out. The post-tag (`Leaked` vs `Lost`) only changes
+the metadata; the trace-out unraveling is identical.
+
+clifft already has the infrastructure for this: the `R`/`RX`/`RY`
+reset ops are lowered by the frontend
 (`src/clifft/frontend/frontend.cc:618-694`) to a *hidden* measurement
 slot — tracked on a separate `hidden_meas_idx` counter, marked with
 `meas_op.set_hidden(true)`, never exposed to the user-facing record,
 followed by a conditional Pauli correction so the residual state on
 survivors is the correct conditional state. This is exactly the
-trace-out unraveling the loss event needs.
+trace-out unraveling the noncomputational transition needs.
 
-The MVP rewriter takes advantage of this directly. At a structural
-loss event on a `ComputationalUnknown` qubit, the rewriter inserts a
+The MVP rewriter takes advantage of this directly. At a transition
+`ComputationalUnknown → (Leaked or Lost)`, the rewriter inserts a
 single `R` op on that qubit in the rewritten circuit. Concretely:
 
 1. **No new HIR op or circuit instruction is introduced.** The
@@ -526,17 +539,22 @@ single `R` op on that qubit in the rewritten circuit. Concretely:
    out of scope for MVP. The noncomputational sidecar therefore does
    not include trace-out outcomes in v1.
 
-After the inserted `R`, the rewriter marks the qubit `Lost` in the
-trajectory and drops every subsequent op on that qubit per the policy
+After the inserted `R`, the rewriter sets the qubit's status to the
+destination noncomputational kind (`Leaked(level)` or `Lost(level)`)
+in the trajectory and dispatches every subsequent op per the policy
 table. Note that `R` semantically leaves the qubit in `|0>`
-ComputationalKnown — that residual state is immediately reinterpreted
-as `Lost` by the trajectory; the SVM's own post-`R` state on that
-qubit is irrelevant because no later op reads from it.
+`ComputationalKnown` — that residual state is immediately
+reinterpreted as the noncomputational kind by the trajectory; the
+SVM's own post-`R` state on that qubit is irrelevant because no
+later op reads computational amplitude from it.
 
-If a qubit transitions to `Lost` while it is already
-`ComputationalKnown`, `Leaked`, or starting `Lost`, no quantum
-trace-out is needed — the destination is purely a status update with
-no `R` insertion required.
+If the source kind at the transition is already
+`ComputationalKnown`, `Leaked`, or `Lost`, no quantum trace-out is
+needed: there is no entangled computational amplitude to unravel.
+The transition is a pure status update with no `R` insertion.
+
+Summary rule: insert `R` iff source kind is `ComputationalUnknown`
+and destination kind is `Leaked` or `Lost`.
 
 ## 6. New C++ headers and dependency order
 
@@ -651,39 +669,17 @@ qubits + classical statuses. Bounded to ~4 qubits and ~10 events;
 fast enough for parameter sweeps. No sqale-sim dependency in the
 MVP.
 
-## 8. Open questions to settle before §6 step 7 (`rewriter`)
+## 8. Open question to settle before §6 step 7 (`rewriter`)
 
-These do not block the design note but should be settled before the
-rewriter PR:
+One remaining sidecar-shape question, not load-bearing for the
+contract:
 
-- **Surfacing trace-out outcomes in the sidecar.** Hidden-measurement
-  outcomes are available from the SVM's hidden-record buffer; whether
-  to expose them as part of the noncomputational metadata sidecar is
-  not load-bearing for correctness. Provisional: do not expose them in
-  MVP. Re-enable later if a decoder or debugging workflow needs them.
 - **Herald metadata transport.** The orchestrator sidecar shape is
   written above as "per-qubit final status + classifier output +
   herald bits". We may want a more structured sidecar (e.g., numpy
   structured array) for performance / decoder integration.
   Provisional: keep the sidecar a typed dict in Python for the MVP;
   convert to a structured array if/when a decoder consumer demands it.
-
-### Resolved during note revision
-
-- **`RL` (loss reload).** Closed: no new circuit op in MVP. Lost-qubit
-  reset rejects unless `policy.reset_restores_lost` is set, in which
-  case existing `R`/`RX`/`RY` ops restore the qubit to a known
-  computational state. The table in §5.2 reflects this.
-- **Initial-state correlation across qubits.** Closed: out of scope.
-  `initial_state` is an independent per-qubit distribution; a future
-  feature can add correlated initial states without breaking this
-  schema.
-- **Source-independence enforcement point.** Closed: not a
-  construction-time invariant. Source-dependent matrices construct
-  fine; the runtime sampler rejects only when a transition fires on a
-  qubit whose `QubitStatusKind` is `ComputationalUnknown` and the
-  instrument is not source-independent on `Computational` levels.
-  See §4.
 
 ## 9. Out of scope but planned-for
 

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -64,15 +64,22 @@ a freshly-sampled site holding that level. A `Computational` level can
 be promoted to `KnownComputational` at runtime (via a sampled
 Z-collapse); the reverse promotion (re-coherence) is not in MVP scope.
 
+A `Computational`-intrinsic level must also declare a `basis_bit`
+(0 or 1) identifying which computational basis state it represents.
+The rewriter uses this to prepend a preparation gate when an initial
+sample places the site in a `Computational` level whose `basis_bit`
+is not 0 (the SVM default initialization). `Leaked` and `Lost` levels
+have no `basis_bit`.
+
 Default level set for the MVP (sqale-aligned):
 
-| id | label    | intrinsic category | notes                          |
-|----|----------|--------------------|--------------------------------|
-| 0  | `g`      | Computational      | logical 0                      |
-| 1  | `e`      | Computational      | logical 1                      |
-| 2  | `leak_g` | Leaked             | metastable / Rydberg "leak g"  |
-| 3  | `leak_e` | Leaked             | metastable / Rydberg "leak e"  |
-| 4  | `lost`   | Lost               | empty trap / vacuum            |
+| id | label    | intrinsic category | basis_bit | notes                          |
+|----|----------|--------------------|-----------|--------------------------------|
+| 0  | `g`      | Computational      | 0         | logical 0                      |
+| 1  | `e`      | Computational      | 1         | logical 1                      |
+| 2  | `leak_g` | Leaked             | —         | metastable / Rydberg "leak g"  |
+| 3  | `leak_e` | Leaked             | —         | metastable / Rydberg "leak e"  |
+| 4  | `lost`   | Lost               | —         | empty trap / vacuum            |
 
 Users may construct a `NonComputationalModel` with a different level
 set, but the default ships unchanged.
@@ -105,8 +112,8 @@ import clifft
 model = clifft.NonComputationalModel(
     # Optional; defaults to the sqale-aligned 5-level set above.
     levels=[
-        clifft.Level("g",      category="computational"),
-        clifft.Level("e",      category="computational"),
+        clifft.Level("g",      category="computational", basis_bit=0),
+        clifft.Level("e",      category="computational", basis_bit=1),
         clifft.Level("leak_g", category="leaked"),
         clifft.Level("leak_e", category="leaked"),
         clifft.Level("lost",   category="lost"),
@@ -185,34 +192,64 @@ public:
 }  // namespace clifft
 ```
 
-## 4. Pre-sampleability validation
+## 4. Validation: construction-time vs. sample-time
 
-Validation runs once at `NonComputationalModel` construction. Failures
-throw with a message naming the offending field. Checks:
+Validation is split: model construction checks shape and self-consistency;
+the runtime sampler checks whether each transition's source-context is
+representable in the MVP.
+
+### 4.1 Construction-time checks (always run, throw on failure)
 
 1. **Level set well-formed.** Every level id in `[0, len(levels))`,
-   intrinsic categories all in the enum.
+   intrinsic categories all in the enum. Every `Computational`-intrinsic
+   level declares a `basis_bit` in `{0, 1}`; non-`Computational` levels
+   omit it.
 2. **Initial state is a probability vector** over `levels`. Sums to 1
    within tolerance.
 3. **Transition matrices are square**, of size `len(levels)`, entries
    in `[0, 1]`.
 4. **Column sums in [0, 1].** Implied no-jump weight per source is
    `1 - sum(col)`.
-5. **Source-independence for Computational sources.** For every
-   transition, every column whose source is a `Computational` level
-   must be identical. This is the "pre-sampleable" condition: no two
-   Computational source levels have distinguishable jump rates. If
-   violated, raise with a message naming the operation and the
-   differing columns. (This is exactly the cut between the MVP and the
-   later diagonal-filter work.)
-6. **Classifier sources cover the full level set** if provided.
-7. **Policy values are well-formed** (enum values, not free strings on
+5. **Classifier sources cover the full level set** if provided.
+6. **Policy values are well-formed** (enum values, not free strings on
    the C++ side; Python sugar translates).
-8. **Transition keys reference known gate names** in clifft's circuit
+7. **Transition keys reference known gate names** in clifft's circuit
    vocabulary; unknown keys reject.
 
-Sources that are intrinsic `Leaked` or `Lost` are not subject to (5) —
-their transitions are classical Markov updates by definition.
+Each `TransitionInstrument` also computes and caches a derived flag
+at construction:
+
+- `is_source_independent_on_computational`: true iff every column whose
+  source level is intrinsic `Computational` is bit-identical (within
+  tolerance) to the others.
+
+This flag is *not* a validation gate — source-dependent matrices are
+fine to declare. Whether they are applicable depends on the source
+context at sample time. The sqale-aligned `cz_transition_matrix` and
+`rz_transition_matrix` in §1's prior art have distinct `g` and `e`
+columns; they are valid `TransitionInstrument`s and will be accepted
+here.
+
+### 4.2 Sample-time check (per (transition, target-site) firing)
+
+When a transition fires on a target site at category `c`:
+
+- `c == KnownComputational`: use the column matching the known level
+  directly. Always allowed.
+- `c == Leaked` or `c == Lost`: use the column matching the level
+  directly. Classical Markov update. Always allowed.
+- `c == Computational` (coherent, unknown): require
+  `is_source_independent_on_computational` on this instrument. If
+  false, reject with an error naming the op index, the site, and the
+  instrument — pointing the user at the cut between MVP and the later
+  diagonal-filter extension. If true, the no-jump branch is scalar on
+  `H_C` and the jump branches are source-independent; sample without
+  consulting amplitudes.
+
+This is the "pre-sampleable" boundary, enforced where it actually
+matters (at the unknown-coherent-source point) rather than at model
+construction. It also means a model with a source-dependent instrument
+that only ever fires on known-or-classical sources runs fine in MVP.
 
 ## 5. Sampling, rewrite, and policy table
 
@@ -221,83 +258,131 @@ their transitions are classical Markov updates by definition.
 For each shot:
 
 1. **Sample initial statuses.** One draw from `initial_state` per
-   site. Initial `known` bit is 1 (the sampled level is, by
-   construction, a classical fact).
-2. **Walk the circuit ops in order, sampling transitions and updating
+   site. The sampled level is a classical fact, so the initial
+   `known` bit is 1 for every site (it is moot on `Leaked`/`Lost`).
+2. **Translate known computational initial levels into prep gates.**
+   For every site sampled to a `Computational` level whose
+   `basis_bit == 1`, the rewriter prepends an `X` on that site so the
+   SVM's `|0...0>` initial state matches the sampled known level.
+   `basis_bit == 0` requires no prep. `Leaked`/`Lost` initial sites
+   need no quantum prep (their computational amplitude is irrelevant);
+   the lost/leaked policy gates downstream ops on them from op 0.
+3. **Walk the circuit ops in order, sampling transitions and updating
    statuses.** For each op, consult the model's transitions and the
-   site statuses. Sample any per-target branches. Record the resulting
+   site statuses. Apply the §4.2 sample-time check on the source
+   context. Sample any per-target branches. Record the resulting
    `NonComputationalHistory` (sequence of (op-index, site, sampled
-   branch, status-update, optional herald)).
-3. **Rewrite the original circuit using the history.** Produce a new
+   branch, status-update, optional herald)). Update the `known` bit
+   per §5.2.1 below.
+4. **Rewrite the original circuit using the history.** Produce a new
    ordinary clifft circuit (no new instructions). Drop, keep, or
-   replace ops per the policy table. Insert hidden trace-out
-   measurements at structural loss points where the lost site was
-   coherent (see §5.3).
-4. **Compile the rewritten circuit** through the ordinary
+   replace ops per the policy table. Insert an `R` op at structural
+   loss points where the lost site was previously coherent (see §5.3).
+5. **Compile the rewritten circuit** through the ordinary
    trace/lower/bytecode pipeline.
-5. **Sample one shot** on the SVM.
-6. **Strip hidden record positions** from the measurement array (see
-   §5.3) and return the user-facing `(measurements, detectors,
-   observables)` plus the noncomputational metadata sidecar:
-   `(history, per-site final status, classifier output, herald bits)`.
+6. **Sample one shot** on the SVM.
+7. **Return** the user-facing `(measurements, detectors, observables)`
+   unchanged from the existing API, plus the noncomputational metadata
+   sidecar: `(history, per-site final status, classifier output, herald
+   bits)`.
 
-The C++ orchestrator owns steps 1-6. Caching of step 4 across shots is
-deferred (see §1, "Out").
+The C++ orchestrator owns steps 1-7. Caching of step 5 across shots
+is deferred (see §1, "Out").
 
 ### 5.2 Default rewrite-policy table
 
 Rows are (operation kind, site category at op time). "Reject" means
 the C++ rewrite raises with a clear message naming the op index and
-site; no silent approximation.
+site; no silent approximation. "Apply, clear known" means the op runs
+unchanged but the site's `known` bit is set to 0 afterward (per §5.2.1).
 
-| Operation                | Computational     | KnownComputational            | Leaked                          | Lost                            |
-|--------------------------|-------------------|-------------------------------|---------------------------------|---------------------------------|
-| Single-qubit gate        | apply             | apply (rehydrates known state) | reject (policy override allowed) | drop                            |
-| Single-qubit Pauli noise | apply             | apply                          | drop                            | drop                            |
-| Two-qubit gate           | apply             | apply                          | reject                          | reject (policy override: drop)  |
-| MPP / multi-target meas  | apply             | apply                          | reject                          | reject                          |
-| Visible single-q meas    | apply             | apply (sampled-known outcome)  | classifier → visible bit; default reject | policy: random / zero / one / reject |
-| Reset `R`                | apply             | apply                          | restore to known computational  | reject (use `RL` for reload)    |
-| Reload `RL`              | apply             | apply                          | restore                         | restore                         |
-| Detector / Observable    | unchanged         | unchanged                      | unchanged                       | unchanged                       |
+| Operation                | Computational         | KnownComputational                  | Leaked                                  | Lost                                              |
+|--------------------------|-----------------------|--------------------------------------|------------------------------------------|---------------------------------------------------|
+| Single-qubit gate        | apply                 | apply, clear known                  | reject (policy override allowed)        | drop                                              |
+| Single-qubit Pauli noise | apply                 | apply, clear known                  | drop                                    | drop                                              |
+| Two-qubit gate           | apply                 | apply, clear known on both           | reject                                  | reject (policy override: drop)                    |
+| MPP / multi-target meas  | apply                 | apply, clear known on all            | reject                                  | reject                                            |
+| Visible single-q meas    | apply                 | apply, outcome = sampled known value | classifier → visible bit; default reject | policy: random / zero / one / reject              |
+| Reset `R` (or `RX`/`RY`) | apply                 | apply                                | restore to known computational          | reject unless `policy.reset_restores_lost` is set |
+| Detector / Observable    | unchanged             | unchanged                            | unchanged                               | unchanged                                         |
 
 Notes:
 
 - "Policy override allowed" means the cell rejects by default but the
   user may set a `NonComputationalPolicy` field to flip it to a
   specific behavior. The MVP exposes overrides only where listed.
-- `RL` (reload) is the loss-restoration operation analog from the
-  prior LOSS design notes; it differs from `R` (computational reset)
-  in that it can promote a `Lost` site back to a known computational
-  state. If we do not want to add `RL` as a new HIR-level op in this
-  MVP, `RL` collapses to a model-config flag on existing `R` ops; that
-  decision is open (see §8).
+- There is no separate `RL` op in MVP. Lost-site reset rejects by
+  default; the `policy.reset_restores_lost` flag turns it into a
+  reload that restores the site to a known computational state. See
+  §8 for the rationale.
+- "Apply, clear known" is the conservative default: we drop knownness
+  on any quantum gate touching a `KnownComputational` site. This loses
+  some optimization opportunity (X on a known site could keep
+  knownness with a flipped value; Z/S/T preserve it as a phase), but
+  the conservative rule sidesteps gate-by-gate classification in MVP.
+  Refinement is a later pass once the trajectory infrastructure is in
+  place. The reviewer's framing applies: knownness is produced by
+  initial sampling, measurement/collapse, and reset/reload; ordinary
+  quantum gates clear it unless explicitly handled.
+
+### 5.2.1 Knownness transitions
+
+A site's `known` bit transitions as follows during history sampling:
+
+| Cause                                            | Effect                                                  |
+|--------------------------------------------------|---------------------------------------------------------|
+| Initial-state sample (any level)                 | `known = 1`                                             |
+| Any quantum gate touching site (single or multi) | `known = 0` on every touched site                       |
+| Visible measurement                              | `known = 1` after sampling the outcome                  |
+| Reset `R`/`RX`/`RY`                              | `known = 1` (reset is to a known computational state)   |
+| Reload via `policy.reset_restores_lost`          | `known = 1`                                             |
+| Transition jump to a new level                   | `known = 1` if destination level is `KnownComputational` after the transition; otherwise the bit is moot |
 
 ### 5.3 Hidden trace-out at structural loss
 
 When a site that is currently `Computational` (coherent) transitions
 to `Lost`, theory requires a hidden Z-basis measurement to unravel the
-partial trace. The rewriter inserts an ordinary `M` op at that point.
-Two consequences:
+partial trace. clifft already has the infrastructure for this: the
+`R`/`RX`/`RY` reset ops are lowered by the frontend
+(`src/clifft/frontend/frontend.cc:618-694`) to a *hidden* measurement
+slot — tracked on a separate `hidden_meas_idx` counter, marked with
+`meas_op.set_hidden(true)`, never exposed to the user-facing record,
+followed by a conditional Pauli correction so the residual state on
+survivors is the correct conditional state. This is exactly the
+trace-out unraveling the loss event needs.
 
-1. **The hidden M consumes a measurement slot** in the rewritten
-   circuit. The rewriter tracks the slot offset and **renumbers every
-   subsequent `rec[-k]` reference** in detectors, observables, and
-   classical feedback so visible record layout is unchanged. This is a
-   straightforward pre-compile pass over the rewritten ops.
-2. **The hidden slot is stripped from user output.** The orchestrator
-   carries a `std::vector<uint64_t> hidden_slot_indices` per
-   rewritten-circuit instance; after the SVM returns the full
-   measurement array it removes those indices before exposing the
-   `measurements` array. The hidden outcome is *not* discarded
-   internally — it becomes part of the noncomputational metadata
-   sidecar (under "trace-out outcomes") for debugging and validation.
+The MVP rewriter takes advantage of this directly. At a structural
+loss event on a previously-coherent site, the rewriter inserts a
+single `R` op on that site in the rewritten circuit. Concretely:
 
-This keeps the rewriter's output in ordinary clifft syntax (no new HIR
-op required) and isolates the hidden-record handling to two small
-helpers on the orchestrator path. It does mean every history pays one
-extra M per coherent-site loss in compile work; for the MVP that is
-acceptable.
+1. **No new HIR op or circuit instruction is introduced.** The
+   rewriter emits an existing `R` op; the existing frontend lowering
+   handles the hidden measurement, the corrective Pauli, and the
+   hidden-slot accounting.
+2. **No `rec[-k]` renumbering is needed.** Visible measurement counts
+   only advance on visible `M` slots; hidden-measurement slots live on
+   their own counter and never shift the user-facing record. Detectors,
+   observables, and feedback continue to reference the original
+   visible-record indices unchanged.
+3. **No output stripping pass is needed.** The SVM does not emit
+   hidden-measurement slots into the user-facing measurement array;
+   `compile()` / `sample()` already enforce that.
+4. **The trace-out outcome can still be surfaced for debugging** by
+   reading the SVM's hidden-record buffer after sampling. Whether to
+   expose it in the noncomputational sidecar is an open knob (see §8);
+   for MVP correctness it is not required.
+
+After the inserted `R`, the rewriter marks the site `Lost` in the
+trajectory and drops every subsequent op on that site per the policy
+table. Note that `R` semantically leaves the site in `|0>` known
+computational — that residual state is immediately reinterpreted as
+`Lost` by the trajectory; the SVM's own post-`R` state on that qubit
+is irrelevant because no later op reads from it.
+
+If a site transitions to `Lost` while it is already `KnownComputational`
+or already noncomputational (`Leaked` or starting `Lost`), no quantum
+trace-out is needed — the destination is purely a status update with
+no `R` insertion required.
 
 ## 6. New C++ headers and dependency order
 
@@ -379,24 +464,34 @@ MVP.
 These do not block the design note but should be settled before the
 rewriter PR:
 
-- **`RL` as a new HIR op vs. a config flag on existing `R`.** A new op
-  adds a parser/lower change (which we said we would not do in MVP),
-  but folding it into `R` via a policy flag makes the semantics
-  context-sensitive (same circuit text means different things
-  depending on the model). Provisional: config flag on the model
-  (`policy.reset_restores_lost = bool`), no new circuit op. If we
-  later add `LOSS(p)` syntax, `RL` rides with it.
+- **Surfacing trace-out outcomes in the sidecar.** Hidden-measurement
+  outcomes are available from the SVM's hidden-record buffer; whether
+  to expose them as part of the noncomputational metadata sidecar is
+  not load-bearing for correctness. Provisional: do not expose them in
+  MVP. Re-enable later if a decoder or debugging workflow needs them.
 - **Herald metadata transport.** The orchestrator sidecar shape is
   written above as "per-site final status + classifier output + herald
   bits". We may want a more structured sidecar (e.g., numpy structured
   array) for performance / decoder integration. Provisional: keep the
   sidecar a typed dict in Python for the MVP; convert to a structured
   array if/when a decoder consumer demands it.
-- **Initial-state correlation across sites.** §3 makes
-  `initial_state` an independent per-site distribution. sqale-sim
-  matches this. If a hardware model needs correlated initial states,
-  that is a separate feature; reject correlated initial-state config
-  in this MVP.
+
+### Resolved during note revision
+
+- **`RL` (loss reload).** Closed: no new circuit op in MVP. Lost-site
+  reset rejects unless `policy.reset_restores_lost` is set, in which
+  case existing `R`/`RX`/`RY` ops restore the site to a known
+  computational state. The table in §5.2 reflects this.
+- **Initial-state correlation across sites.** Closed: out of scope.
+  `initial_state` is an independent per-site distribution; a future
+  feature can add correlated initial states without breaking this
+  schema.
+- **Source-independence enforcement point.** Closed: not a
+  construction-time invariant. Source-dependent matrices construct
+  fine; the runtime sampler rejects only when a transition fires on a
+  site whose source category is unknown-coherent `Computational` and
+  the instrument is not source-independent on `Computational` levels.
+  See §4.
 
 ## 9. Out of scope but planned-for
 

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -23,13 +23,13 @@ Authoritative inputs:
 
 **In:** state-independent structural loss; known-source classical
 transitions; classical status-to-status transitions; reset/reload
-restoring a site when the policy allows it; per-trajectory concrete
+restoring a qubit when the policy allows it; per-trajectory concrete
 statuses; per-trajectory initial-state sampling; semantic validation
 that the configured instrument set is pre-sampleable.
 
 **Out:** unknown coherent state-dependent transitions; exact diagonal
 no-jump filters; segmented JIT replan/resume; dynamic control-flow IR
-above HIR; per-site classical distributions; full qudit simulation;
+above HIR; per-qubit classical distributions; full qudit simulation;
 new circuit-level instructions (no `LOSS(p)`, no
 `TRANSITION_INSTRUMENT`, no parser changes); compile cache.
 
@@ -41,90 +41,131 @@ do not feed a new instruction surface in this MVP.
 
 ## 2. Status representation
 
-### 2.1 Categories (fixed C++ enum)
+### 2.0 Terminology
+
+This MVP tracks noncomputational level by clifft circuit qubit index.
+The doc uses "qubit" consistently with the rest of clifft's API and
+internals (`Target::qubit`, `num_qubits`). It does not yet model atom
+identity or trap site separately; a later movement-aware extension can
+distinguish atom, trap site, and circuit qubit.
+
+### 2.1 Level categories vs. qubit status kinds
+
+The model has two related-but-distinct enums.
+
+`LevelCategory` is a property of a *level* in the model:
 
 ```cpp
 enum class LevelCategory : uint8_t {
-    Computational      = 0,  // coherent, in superposition
-    KnownComputational = 1,  // coherent level whose physical bit
-                             // has been sampled (post-Z-collapse)
-    Leaked             = 2,  // present, outside computational subspace
-    Lost               = 3,  // absent / vacuum
+    Computational = 0,  // coherent, in superposition by default
+    Leaked        = 1,  // present, outside computational subspace
+    Lost          = 2,  // absent / vacuum
 };
 ```
 
-Rewrite policies key off `LevelCategory`. The set is fixed; users may
-not extend it.
+`QubitStatusKind` is a per-qubit *runtime* tag carried in the
+trajectory. It splits the computational case by whether the
+energy-basis value has been resolved:
+
+```cpp
+enum class QubitStatusKind : uint8_t {
+    ComputationalUnknown = 0,  // in H_C, energy-basis value unresolved
+    ComputationalKnown   = 1,  // in H_C with a known g/e value
+    Leaked               = 2,
+    Lost                 = 3,
+};
+```
+
+Splitting the runtime tag from the level-property enum lets us
+encode "computational but unknown" as a kind that *cannot* carry a
+specific level id, enforcing the source-resolved invariant
+structurally rather than by convention. See §2.3.
 
 ### 2.2 Levels (model-defined)
 
 A `Level` is a model-defined tag with a stable integer id, a label, and
-an *intrinsic* category. Intrinsic category is the default category for
-a freshly-sampled site holding that level. A site whose level is
-intrinsically `Computational` may toggle between the runtime categories
-`Computational` and `KnownComputational` freely during simulation — a
-Z-basis measurement or Z-basis reset promotes it to `KnownComputational`
-(`known = 1`), and any subsequent quantum gate clears `known` back to 0
-(Hadamard on `|0>` is the canonical example).
+a `LevelCategory`. Qubits transition between status kinds during
+simulation:
 
-What is *not* in MVP scope is re-entering the computational subspace
-from a noncomputational level. Once a site is `Leaked` or `Lost`, it
-returns to a computational category only via reset/reload — and only
-when the policy explicitly allows it (`Leaked` → Computational via
-`R`/`RX`/`RY`; `Lost` → Computational only when
-`policy.reset_restores_lost` is set). There is no spontaneous coherent
-return from a leaked level back into a superposition with `g`/`e`.
+- `ComputationalUnknown ↔ ComputationalKnown`: a Z-basis measurement
+  or Z-basis reset promotes `Unknown → Known` with the sampled level
+  id (`g` or `e`). Any subsequent quantum gate that does not preserve
+  the energy basis demotes `Known → Unknown`, discarding the level id
+  (Hadamard on `|0>` is the canonical example).
+- `(anything) → Leaked` or `Lost`: via a transition jump.
+- `Leaked / Lost → ComputationalKnown`: only via reset/reload, gated
+  by policy. `Leaked → Known` via `R`/`RX`/`RY` is allowed; `Lost →
+  Known` only when `policy.reset_restores_lost` is set. There is no
+  spontaneous coherent return from a leaked level back into a
+  superposition with `g`/`e`.
 
-A `Computational`-intrinsic level must also declare a `basis_bit`
+A `Computational`-category level must also declare a `basis_bit`
 (0 or 1) identifying which computational basis state it represents.
 The rewriter uses this to prepend a preparation gate when an initial
-sample places the site in a `Computational` level whose `basis_bit`
-is not 0 (the SVM default initialization). `Leaked` and `Lost` levels
-have no `basis_bit`.
+sample places the qubit in `ComputationalKnown` with a level whose
+`basis_bit` is not 0 (the SVM default initialization). `Leaked` and
+`Lost` levels have no `basis_bit`.
 
 Default level set for the MVP (sqale-aligned):
 
-| id | label    | intrinsic category | basis_bit | notes                          |
-|----|----------|--------------------|-----------|--------------------------------|
-| 0  | `g`      | Computational      | 0         | logical 0                      |
-| 1  | `e`      | Computational      | 1         | logical 1                      |
-| 2  | `leak_g` | Leaked             | —         | metastable / Rydberg "leak g"  |
-| 3  | `leak_e` | Leaked             | —         | metastable / Rydberg "leak e"  |
-| 4  | `lost`   | Lost               | —         | empty trap / vacuum            |
+| id | label    | category      | basis_bit | notes                          |
+|----|----------|---------------|-----------|--------------------------------|
+| 0  | `g`      | Computational | 0         | logical 0                      |
+| 1  | `e`      | Computational | 1         | logical 1                      |
+| 2  | `leak_g` | Leaked        | —         | metastable / Rydberg "leak g"  |
+| 3  | `leak_e` | Leaked        | —         | metastable / Rydberg "leak e"  |
+| 4  | `lost`   | Lost          | —         | empty trap / vacuum            |
 
 Users may construct a `NonComputationalModel` with a different level
 set, but the default ships unchanged.
 
-### 2.3 Per-trajectory site state
+### 2.3 Per-trajectory qubit state
 
 ```cpp
-// One byte per site: bit 7 carries `known`, bits 0-6 carry `level_id`.
-// (A `: 1` / `: 7` bitfield struct is not guaranteed by the standard
-// to pack into one byte; explicit masking guarantees the layout.)
-using SiteStatus = uint8_t;
+constexpr uint8_t kInvalidLevel = 0xFF;
 
-constexpr uint8_t kSiteStatusKnownBit  = 0x80;
-constexpr uint8_t kSiteStatusLevelMask = 0x7F;  // supports up to 128 levels
-
-inline uint8_t site_level(SiteStatus s)        { return s & kSiteStatusLevelMask; }
-inline bool    site_known(SiteStatus s)        { return (s & kSiteStatusKnownBit) != 0; }
-inline SiteStatus make_site_status(uint8_t level_id, bool known) {
-    return static_cast<SiteStatus>(level_id | (known ? kSiteStatusKnownBit : 0));
-}
+struct QubitStatus {
+    QubitStatusKind kind;
+    uint8_t level_id;  // meaning depends on `kind` (see invariants)
+};
 ```
 
-Trajectory state during history sampling is `std::vector<SiteStatus>
-statuses;` — one byte per site, allocated once per history. The
-runtime-effective category at site `i` is:
+The two fields together carry the runtime status of one qubit during
+history sampling. Trajectory state is `std::vector<QubitStatus>
+statuses;`, two bytes per qubit.
 
-- `model.levels[site_level(statuses[i])].intrinsic_category`, *unless*
-- the intrinsic category is `Computational` and `site_known(statuses[i])`
-  is true, in which case the effective category is
-  `KnownComputational`.
+**Invariants (enforced by constructors and helpers, not by ad-hoc
+reads):**
+
+| `kind`                  | `level_id` constraint                          |
+|-------------------------|------------------------------------------------|
+| `ComputationalUnknown`  | `kInvalidLevel` (no source level is resolved)  |
+| `ComputationalKnown`    | must be a `Computational`-category level id    |
+| `Leaked`                | must be a `Leaked`-category level id           |
+| `Lost`                  | must be a `Lost`-category level id             |
+
+Callers go through named accessors that enforce these:
+
+```cpp
+bool is_unknown_computational(const QubitStatus& s);
+
+// Returns level_id when kind is ComputationalKnown / Leaked / Lost;
+// nullopt when kind is ComputationalUnknown.
+std::optional<uint8_t> known_source_level(const QubitStatus& s);
+
+// Asserts/throws if called on ComputationalUnknown.
+uint8_t require_classical_source_level(const QubitStatus& s);
+```
+
+Most rewrite-policy entries only need `s.kind`; only source-dependent
+transitions need to read the level id, and they go through
+`known_source_level` or `require_classical_source_level` so the
+"unknown coherent" rejection path is structurally enforced.
 
 "Known" here means known *in the energy basis* (`g`/`e`) — the basis
 in which transition matrices are indexed. X- and Y-basis measurements
-or resets do not produce `known=1`; see §5.2.1.
+or resets do not produce `ComputationalKnown`; they leave the qubit in
+`ComputationalUnknown` (see §5.2.1).
 
 ## 3. `NonComputationalModel` API
 
@@ -143,37 +184,61 @@ model = clifft.NonComputationalModel(
         clifft.Level("lost",   category="lost"),
     ],
 
-    # Independent per-site initial level distribution.
-    # Indices into levels[]; sums to 1 per site (validated in C++).
+    # Independent per-qubit initial level distribution.
+    # Indices into levels[]; sums to 1 per qubit (validated in C++).
     initial_state=[0.0065, 0.96, 0.0065, 0.027, 0.0],
 
     # Per-gate transition instruments. Matrix shorthand uses T[to, from]
     # convention. Keys are gate names from the existing clifft circuit
     # vocabulary; unknown keys reject at validation time.
+    #
+    # MVP semantics for every entry:
+    #   - The instrument fires AFTER the gate.
+    #   - "target" means a qubit operand of the gate, not a record
+    #     target.
+    #   - For multi-qubit gates, the instrument applies INDEPENDENTLY
+    #     to each qubit operand (per-qubit marginal). Joint/correlated
+    #     two-qubit instruments are out of scope; see section 9.
     transitions={
         "CZ": clifft.TransitionInstrument(matrix=[...]),   # 5x5
         "RZ": clifft.TransitionInstrument(matrix=[...]),
     },
 
     # Level -> visible-symbol classifier applied at measurement.
-    # Row-stochastic `symbols x levels` matrix using
-    # matrix[symbol_idx, level_id] = P(symbol | level).
-    # Optional; default is identity-on-computational + reject on
-    # leaked/lost (i.e. policy must say what M of a noncomputational
-    # site returns).
+    # Shape: (len(symbols), len(levels)). Entry matrix[s, l] is
+    # P(symbol=s | level=l).
+    #
+    # The matrix is COLUMN-SUBSTOCHASTIC: each column sum lies in
+    # [0, 1] and the deficit `1 - sum(column)` is implicit
+    # P(reject | level). A classifier call that samples "reject"
+    # raises with the offending qubit and level. Default identity +
+    # reject is just:
+    #     [[1, 0, 0, 0, 0],   # P("0" | level) over [g, e, leak_g, leak_e, lost]
+    #      [0, 1, 0, 0, 0]]   # P("1" | level)
+    # which has column sums [1, 1, 0, 0, 0] — leaked/lost reject
+    # with probability 1.
     classifier=clifft.MeasurementClassifier(
-        symbols=["0", "1"],     # 2-symbol binary record by default
-        matrix=[[...], [...]],  # shape (len(symbols), len(levels))
+        symbols=["0", "1"],
+        matrix=[[1, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0]],
     ),
 
     # Policy hooks for downstream operations on noncomputational
-    # sites. See §5 for the default table.
+    # qubits. See section 5 for the default table.
     policy=clifft.NonComputationalPolicy(
-        lost_measurement="random",  # | "zero" | "one" | "reject"
+        reset_restores_lost=False,
         # ... other knobs, default-reject for ambiguous cases.
     ),
 )
 ```
+
+There is intentionally *no* separate `lost_measurement` policy knob.
+Lost-qubit measurement behavior is fully specified by the classifier
+matrix's `lost`-level column (with deficit = reject). Users who want
+random-bit-on-lost configure
+`classifier.matrix[:, lost_id] = [0.5, 0.5]`; users who want
+deterministic-0-on-lost set `[1.0, 0.0]`; users who want reject leave
+the column at zero. One way to specify, not two.
 
 `clifft.Level`, `clifft.TransitionInstrument`,
 `clifft.MeasurementClassifier`, `clifft.NonComputationalPolicy`, and
@@ -193,8 +258,8 @@ namespace clifft {
 
 struct Level {
     std::string label;
-    LevelCategory intrinsic_category;
-    std::optional<uint8_t> basis_bit;  // required if intrinsic_category == Computational
+    LevelCategory category;
+    std::optional<uint8_t> basis_bit;  // required iff category == Computational
 };
 
 class TransitionInstrument {
@@ -212,15 +277,20 @@ public:
     // ... accessors for per-source branches, no-jump weight per source, etc.
 };
 
-// Distinct from TransitionInstrument: rectangular row-stochastic map
-// from levels to reported user-facing symbols. No no-jump branch, no
-// concept of source-independence on Computational levels.
+// Distinct from TransitionInstrument: rectangular column-substochastic
+// map from levels to reported user-facing symbols. Column sums lie in
+// [0, 1]; the deficit per level is implicit P(reject | level). No
+// no-jump branch, no concept of source-independence on Computational
+// levels.
 class MeasurementClassifier {
 public:
     static MeasurementClassifier from_matrix(
         std::vector<std::string> symbols,
         std::vector<std::vector<double>> matrix);  // shape (symbols, levels)
 
+    // P(reject | level) = 1 - sum_s matrix[s, level], computed at
+    // construction and used by the sampler.
+    double reject_probability(uint8_t level_id) const;
     // ... accessors
 };
 
@@ -251,19 +321,23 @@ representable in the MVP.
 ### 4.1 Construction-time checks (always run, throw on failure)
 
 1. **Level set well-formed.** Every level id in `[0, len(levels))`,
-   intrinsic categories all in the enum. Every `Computational`-intrinsic
+   categories all in `LevelCategory`. Every `Computational`-category
    level declares a `basis_bit` in `{0, 1}`; non-`Computational` levels
    omit it.
 2. **Initial state is a probability vector** over `levels`. Sums to 1
    within tolerance.
 3. **Transition matrices are square**, of size `len(levels)`, entries
-   in `[0, 1]`.
-4. **Column sums in [0, 1].** Implied no-jump weight per source is
-   `1 - sum(col)`.
-5. **Classifier matrix shape and rows.** If a `MeasurementClassifier`
-   is provided, its matrix has shape `(len(symbols), len(levels))`,
-   every entry is in `[0, 1]`, and every column (per-level row over
-   symbols) sums to 1 within tolerance.
+   in `[0, 1]`. (Square because each instrument fires per qubit
+   operand; per-qubit shape is `len(levels) x len(levels)`. Joint
+   correlated two-qubit instruments would be a different type, out
+   of scope.)
+4. **Transition matrix column sums in [0, 1].** Implied no-jump weight
+   per source is `1 - sum(col)`.
+5. **Classifier matrix is column-substochastic.** If a
+   `MeasurementClassifier` is provided, its matrix has shape
+   `(len(symbols), len(levels))`, every entry is in `[0, 1]`, and
+   every column sum lies in `[0, 1]`. The deficit per column is
+   `P(reject | level)`.
 6. **Policy values are well-formed** (enum values, not free strings on
    the C++ side; Python sugar translates).
 7. **Transition keys reference known gate names** in clifft's circuit
@@ -273,7 +347,7 @@ Each `TransitionInstrument` also computes and caches a derived flag
 at construction:
 
 - `is_source_independent_on_computational`: true iff every column whose
-  source level is intrinsic `Computational` is bit-identical (within
+  source level has category `Computational` is bit-identical (within
   tolerance) to the others.
 
 This flag is *not* a validation gate — source-dependent matrices are
@@ -283,17 +357,17 @@ context at sample time. The sqale-aligned `cz_transition_matrix` and
 columns; they are valid `TransitionInstrument`s and will be accepted
 here.
 
-### 4.2 Sample-time check (per (transition, target-site) firing)
+### 4.2 Sample-time check (per (transition, target-qubit) firing)
 
-When a transition fires on a target site at category `c`:
+When a transition fires on a target qubit with `QubitStatus s`:
 
-- `c == KnownComputational`: use the column matching the known level
+- `s.kind == ComputationalKnown`: use the column for `s.level_id`
   directly. Always allowed.
-- `c == Leaked` or `c == Lost`: use the column matching the level
-  directly. Classical Markov update. Always allowed.
-- `c == Computational` (coherent, unknown): require
+- `s.kind == Leaked` or `s.kind == Lost`: use the column for
+  `s.level_id` directly. Classical Markov update. Always allowed.
+- `s.kind == ComputationalUnknown`: require
   `is_source_independent_on_computational` on this instrument. If
-  false, reject with an error naming the op index, the site, and the
+  false, reject with an error naming the op index, the qubit, and the
   instrument — pointing the user at the cut between MVP and the later
   diagonal-filter extension. If true, the no-jump branch is scalar on
   `H_C` and the jump branches are source-independent; sample without
@@ -311,54 +385,59 @@ that only ever fires on known-or-classical sources runs fine in MVP.
 For each shot:
 
 1. **Sample initial statuses.** One draw from `initial_state` per
-   site. The sampled level is a classical fact, so the initial
-   `known` bit is 1 for every site (it is moot on `Leaked`/`Lost`).
+   qubit. The sampled level is a classical fact: the resulting
+   `QubitStatus` is `ComputationalKnown` (with the sampled level id)
+   if the level's category is `Computational`, else `Leaked` or
+   `Lost` (with the sampled level id) per the level's category.
 2. **Translate known computational initial levels into prep gates.**
-   For every site sampled to a `Computational` level whose
-   `basis_bit == 1`, the rewriter prepends an `X` on that site so the
-   SVM's `|0...0>` initial state matches the sampled known level.
-   `basis_bit == 0` requires no prep. `Leaked`/`Lost` initial sites
-   need no quantum prep (their computational amplitude is irrelevant);
-   the lost/leaked policy gates downstream ops on them from op 0.
+   For every qubit whose initial sample is `ComputationalKnown` with
+   a level whose `basis_bit == 1`, the rewriter prepends an `X` on
+   that qubit so the SVM's `|0...0>` initial state matches the
+   sampled known level. `basis_bit == 0` requires no prep.
+   `Leaked`/`Lost` initial qubits need no quantum prep (their
+   computational amplitude is irrelevant); the lost/leaked policy
+   gates downstream ops on them from op 0.
 3. **Walk the circuit ops in order, sampling transitions and updating
    statuses.** For each op, consult the model's transitions and the
-   site statuses. Apply the §4.2 sample-time check on the source
-   context. Sample any per-target branches. Record the resulting
-   `NonComputationalHistory` (sequence of (op-index, site, sampled
-   branch, status-update, optional herald)). Update the `known` bit
+   per-qubit statuses. Apply the §4.2 sample-time check on the source
+   context (per qubit operand, since transitions are per-qubit
+   marginals). Sample any per-qubit branches. Record the resulting
+   `NonComputationalHistory` (sequence of (op-index, qubit, sampled
+   branch, status-update, optional herald)). Update the status `kind`
    per §5.2.1 below.
 4. **Rewrite the original circuit using the history.** Produce a new
    ordinary clifft circuit (no new instructions). Drop, keep, or
    replace ops per the policy table. Insert an `R` op at structural
-   loss points where the lost site was previously coherent (see §5.3).
+   loss points where the lost qubit was previously coherent (see §5.3).
 5. **Compile the rewritten circuit** through the ordinary
    trace/lower/bytecode pipeline.
 6. **Sample one shot** on the SVM.
 7. **Return** the user-facing `(measurements, detectors, observables)`
    unchanged from the existing API, plus the noncomputational metadata
-   sidecar: `(history, per-site final status, classifier output, herald
-   bits)`.
+   sidecar: `(history, per-qubit final status, classifier output,
+   herald bits)`.
 
 The C++ orchestrator owns steps 1-7. Caching of step 5 across shots
 is deferred (see §1, "Out").
 
 ### 5.2 Default rewrite-policy table
 
-Rows are (operation kind, site category at op time). "Reject" means
-the C++ rewrite raises with a clear message naming the op index and
-site; no silent approximation. "Apply, clear known" means the op runs
-unchanged but the site's `known` bit is set to 0 afterward (per §5.2.1).
+Rows are (operation kind, `QubitStatusKind` at op time). "Reject"
+means the C++ rewrite raises with a clear message naming the op index
+and qubit; no silent approximation. "Apply, demote to Unknown" means
+the op runs unchanged but the qubit's status transitions
+`ComputationalKnown → ComputationalUnknown` afterward (per §5.2.1).
 
-| Operation                | Computational         | KnownComputational                  | Leaked                                  | Lost                                              |
+| Operation                | ComputationalUnknown | ComputationalKnown                  | Leaked                                  | Lost                                              |
 |--------------------------|-----------------------|--------------------------------------|------------------------------------------|---------------------------------------------------|
-| Single-qubit gate        | apply                 | apply, clear known                  | reject (policy override allowed)        | drop                                              |
-| Single-qubit Pauli noise | apply                 | apply, clear known                  | drop                                    | drop                                              |
-| Two-qubit gate           | apply                 | apply, clear known on both           | reject                                  | reject (policy override: drop)                    |
-| MPP / multi-target meas  | apply                 | apply, clear known on all            | reject                                  | reject                                            |
-| Visible Z-basis meas (`M`/`MR`) | apply, set known after | apply, outcome = sampled known value | classifier → visible bit; default reject | policy: random / zero / one / reject |
-| Visible X/Y-basis meas (`MX`/`MY`/`MRX`/`MRY`) | apply, **clear known** | apply, **clear known** | classifier → visible bit; default reject | policy: random / zero / one / reject |
-| Z-basis reset `R`        | apply, set known after | apply, set known after | restore to known computational          | reject unless `policy.reset_restores_lost` is set |
-| X/Y-basis reset `RX`/`RY` | apply, **clear known** | apply, **clear known** | restore to coherent computational (known = 0) | reject unless `policy.reset_restores_lost` is set |
+| Single-qubit gate        | apply                 | apply, demote to Unknown            | reject (policy override allowed)        | drop                                              |
+| Single-qubit Pauli noise | apply                 | apply, demote to Unknown            | drop                                    | drop                                              |
+| Two-qubit gate           | apply                 | apply, demote to Unknown on both    | reject                                  | reject (policy override: drop)                    |
+| MPP / multi-target meas  | apply                 | apply, demote to Unknown on all     | reject                                  | reject                                            |
+| Visible Z-basis meas (`M`/`MR`) | apply, promote to Known | apply, outcome = current `level_id` | classifier; reject probability per `lost`/`leak` column | classifier; reject probability per `lost` column  |
+| Visible X/Y-basis meas (`MX`/`MY`/`MRX`/`MRY`) | apply, stays Unknown | apply, demote to Unknown | classifier; as above | classifier; as above |
+| Z-basis reset `R`        | apply, promote to Known (`g`) | apply, set `level_id = g` | restore to ComputationalKnown (`g`) | reject unless `policy.reset_restores_lost` is set; then restore to ComputationalKnown (`g`) |
+| X/Y-basis reset `RX`/`RY` | apply, stays Unknown | apply, demote to Unknown | restore to ComputationalUnknown      | reject unless `policy.reset_restores_lost` is set; then restore to ComputationalUnknown |
 | Detector / Observable    | unchanged             | unchanged                            | unchanged                               | unchanged                                         |
 
 Notes:
@@ -366,48 +445,53 @@ Notes:
 - "Policy override allowed" means the cell rejects by default but the
   user may set a `NonComputationalPolicy` field to flip it to a
   specific behavior. The MVP exposes overrides only where listed.
-- There is no separate `RL` op in MVP. Lost-site reset rejects by
+- There is no separate `RL` op in MVP. Lost-qubit reset rejects by
   default; the `policy.reset_restores_lost` flag turns it into a
-  reload that restores the site to a known computational state. See
-  §8 for the rationale.
-- "Apply, clear known" is the conservative default: we drop knownness
-  on any quantum gate touching a `KnownComputational` site. This loses
-  some optimization opportunity (X on a known site could keep
-  knownness with a flipped value; Z/S/T preserve it as a phase), but
-  the conservative rule sidesteps gate-by-gate classification in MVP.
-  Refinement is a later pass once the trajectory infrastructure is in
-  place. The reviewer's framing applies: knownness is produced by
-  initial sampling, measurement/collapse, and reset/reload; ordinary
-  quantum gates clear it unless explicitly handled.
+  reload that restores the qubit to a `ComputationalKnown` status.
+  See §8 for the rationale.
+- **Lost-qubit measurement is fully specified by the classifier
+  matrix's `lost` column.** There is no separate `lost_measurement`
+  policy knob: random-bit is `[0.5, 0.5]`, deterministic-0 is
+  `[1, 0]`, reject is `[0, 0]`.
+- "Apply, demote to Unknown" is the conservative default: we drop
+  knownness on any quantum gate touching a `ComputationalKnown`
+  qubit. This loses some optimization opportunity (X on a known qubit
+  could keep knownness with a flipped value; Z/S/T preserve it as a
+  phase), but the conservative rule sidesteps gate-by-gate
+  classification in MVP. Refinement is a later pass.
 
-### 5.2.1 Knownness transitions
+### 5.2.1 QubitStatusKind transitions
 
-A site's `known` bit transitions as follows during history sampling:
+A qubit's `QubitStatusKind` transitions as follows during history
+sampling:
 
-| Cause                                            | Effect                                                  |
-|--------------------------------------------------|---------------------------------------------------------|
-| Initial-state sample (any level)                 | `known = 1`                                             |
-| Any quantum gate touching site (single or multi) | `known = 0` on every touched site                       |
-| Z-basis measurement (`M`/`MR`)                   | `known = 1`, level updated to `g` or `e` per outcome    |
-| X- or Y-basis measurement (`MX`/`MY`/`MRX`/`MRY`)| `known = 0` (post-state is in X- or Y-basis, not energy basis) |
-| Z-basis reset `R`                                | `known = 1` (reset is to a known energy-basis state)    |
-| X- or Y-basis reset `RX`/`RY`                    | `known = 0` (reset is to a known X/Y-basis state, but `known` is energy-basis) |
-| Reload via `policy.reset_restores_lost` (Z-basis) | `known = 1`                                            |
-| Transition jump to a new computational-intrinsic level | `known = 1` (destination level is the known value)      |
-| Transition jump to a noncomputational level      | `known` bit moot; site category becomes Leaked or Lost   |
+| Cause                                            | Effect                                                                  |
+|--------------------------------------------------|-------------------------------------------------------------------------|
+| Initial-state sample (Computational level)       | `ComputationalKnown(level_id)`                                          |
+| Initial-state sample (Leaked level)              | `Leaked(level_id)`                                                      |
+| Initial-state sample (Lost level)                | `Lost(level_id)`                                                        |
+| Any quantum gate touching qubit, kind == Known   | demote to `ComputationalUnknown`                                        |
+| Z-basis measurement (`M`/`MR`)                   | `ComputationalKnown(g)` or `ComputationalKnown(e)` per outcome          |
+| X- or Y-basis measurement (`MX`/`MY`/`MRX`/`MRY`)| post-state is in X/Y basis, not energy basis: `ComputationalUnknown`    |
+| Z-basis reset `R`                                | `ComputationalKnown(g)`                                                 |
+| X- or Y-basis reset `RX`/`RY`                    | `ComputationalUnknown`                                                  |
+| Reload via `policy.reset_restores_lost` (Z-basis) | `ComputationalKnown(g)`                                                |
+| Transition jump to a Computational-category level | `ComputationalKnown(destination_level_id)`                             |
+| Transition jump to a Leaked-category level        | `Leaked(destination_level_id)`                                         |
+| Transition jump to a Lost-category level          | `Lost(destination_level_id)`                                           |
 
-The "known" bit means *known in the energy basis* (`g`/`e`) — the
-basis transition matrices are indexed in. A site that is in a known
-X-basis or Y-basis state after `RX`/`MY`/etc. is still coherent in
-the energy basis (a superposition of `g` and `e`), so its category
-remains `Computational`. Source-dependent transitions on it will hit
+"Known" here means known *in the energy basis* (`g`/`e`) — the basis
+transition matrices are indexed in. A qubit that is in a known X- or
+Y-basis state after `RX`/`MY`/etc. is still coherent in the energy
+basis (a superposition of `g` and `e`), so its kind is
+`ComputationalUnknown`. Source-dependent transitions on it will hit
 the §4.2 sample-time rejection unless the instrument is
 source-independent on Computational sources.
 
 ### 5.3 Hidden trace-out at structural loss
 
-When a site that is currently `Computational` (coherent) transitions
-to `Lost`, theory requires a hidden Z-basis measurement to unravel the
+When a qubit whose status is `ComputationalUnknown` transitions to
+`Lost`, theory requires a hidden Z-basis measurement to unravel the
 partial trace. clifft already has the infrastructure for this: the
 `R`/`RX`/`RY` reset ops are lowered by the frontend
 (`src/clifft/frontend/frontend.cc:618-694`) to a *hidden* measurement
@@ -418,8 +502,8 @@ survivors is the correct conditional state. This is exactly the
 trace-out unraveling the loss event needs.
 
 The MVP rewriter takes advantage of this directly. At a structural
-loss event on a previously-coherent site, the rewriter inserts a
-single `R` op on that site in the rewritten circuit. Concretely:
+loss event on a `ComputationalUnknown` qubit, the rewriter inserts a
+single `R` op on that qubit in the rewritten circuit. Concretely:
 
 1. **No new HIR op or circuit instruction is introduced.** The
    rewriter emits an existing `R` op; the existing frontend lowering
@@ -442,15 +526,15 @@ single `R` op on that site in the rewritten circuit. Concretely:
    out of scope for MVP. The noncomputational sidecar therefore does
    not include trace-out outcomes in v1.
 
-After the inserted `R`, the rewriter marks the site `Lost` in the
-trajectory and drops every subsequent op on that site per the policy
-table. Note that `R` semantically leaves the site in `|0>` known
-computational — that residual state is immediately reinterpreted as
-`Lost` by the trajectory; the SVM's own post-`R` state on that qubit
-is irrelevant because no later op reads from it.
+After the inserted `R`, the rewriter marks the qubit `Lost` in the
+trajectory and drops every subsequent op on that qubit per the policy
+table. Note that `R` semantically leaves the qubit in `|0>`
+ComputationalKnown — that residual state is immediately reinterpreted
+as `Lost` by the trajectory; the SVM's own post-`R` state on that
+qubit is irrelevant because no later op reads from it.
 
-If a site transitions to `Lost` while it is already `KnownComputational`
-or already noncomputational (`Leaked` or starting `Lost`), no quantum
+If a qubit transitions to `Lost` while it is already
+`ComputationalKnown`, `Leaked`, or starting `Lost`, no quantum
 trace-out is needed — the destination is purely a status update with
 no `R` insertion required.
 
@@ -462,21 +546,24 @@ Proposed layout under `src/clifft/noncomp/` (new directory):
 2. `transition_instrument.h/.cc` — `TransitionInstrument`,
    matrix-to-branch expansion, derived
    `is_source_independent_on_computational` flag. Depends on `level.h`.
-3. `classifier.h/.cc` — `MeasurementClassifier`, row-stochastic
-   `(symbols, levels)` map. Depends on `level.h`.
+3. `classifier.h/.cc` — `MeasurementClassifier`, column-substochastic
+   `(symbols, levels)` map with derived `reject_probability(level_id)`.
+   Depends on `level.h`.
 4. `policy.h` — `NonComputationalPolicy` struct with enums for the
-   ambiguous-case overrides. Zero deps.
+   ambiguous-case overrides (`reset_restores_lost`, etc.). Zero deps.
 5. `model.h/.cc` — `NonComputationalModel`, all construction-time
    validation per §4.1. Depends on (1)-(4).
-6. `history.h` — `SiteStatus` (the packed byte from §2.3),
-   `NonComputationalHistory` (sequence of (op-index, site, branch,
+6. `qubit_status.h` — `QubitStatusKind` enum, `QubitStatus` struct,
+   invariant-enforcing accessors (`known_source_level`,
+   `require_classical_source_level`, `is_unknown_computational`).
+   `NonComputationalHistory` (sequence of (op-index, qubit, branch,
    status-update, herald)). Depends on (1).
 7. `sampler.h/.cc` — history sampler that walks the parsed circuit,
-   updates `SiteStatus` per shot, and enforces the §4.2 sample-time
-   source-context check. Depends on (1)-(6), `clifft::Circuit`,
-   `clifft::AstNode`.
+   updates `QubitStatus` per shot, and enforces the §4.2 sample-time
+   source-context check via the qubit_status accessors. Depends on
+   (1)-(6), `clifft::Circuit`, `clifft::AstNode`.
 8. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
-   `(original, history, model)`, inserting `R` at coherent-site loss
+   `(original, history, model)`, inserting `R` at coherent-qubit loss
    points and `X` prep for `basis_bit==1` initial samples. Depends on
    (1)-(7) and `clifft::Circuit`.
 9. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
@@ -494,16 +581,24 @@ Each test category lands once the headers it needs are in place. C++
 tests under `tests/test_noncomp_*.cc`; Python tests under
 `tests/python/test_noncomputational.py`.
 
-1. **`level`, `transition_instrument`, `classifier` unit tests.**
+1. **`level`, `transition_instrument`, `classifier`,
+   `qubit_status` unit tests.**
    - Default level set roundtrips; `basis_bit` required iff
-     intrinsic category is Computational.
+     `LevelCategory::Computational`.
    - Matrix orientation: `T[to, from]` matches a known per-column
      no-jump weight.
    - `is_source_independent_on_computational` is true for identical
      `g`/`e` columns, false when they differ. Construction does *not*
      throw on differing-column instruments — both must build cleanly.
-   - `MeasurementClassifier` matrix shape and per-level column sums
-     enforced; mismatched (symbols, levels) dimensions rejected.
+   - `MeasurementClassifier` matrix shape and per-column substochasticity
+     enforced; column-sum > 1 rejected; mismatched (symbols, levels)
+     dimensions rejected. `reject_probability(level_id)` matches
+     `1 - sum(column)` for several hand-built matrices.
+   - `QubitStatus` invariants: `make_computational_known(g_id)` builds
+     fine; `make_computational_known(leak_g_id)` rejects;
+     `require_classical_source_level` on a `ComputationalUnknown`
+     status asserts/throws; `known_source_level` returns `nullopt` on
+     `ComputationalUnknown` and the carried level id otherwise.
 2. **`model` validation tests.**
    - Initial-state sum, unknown-gate keys, classifier shape, policy
      enum values all reject at construction with a named field.
@@ -514,28 +609,30 @@ tests under `tests/test_noncomp_*.cc`; Python tests under
    - Initial-state-only sampling produces marginal frequencies within
      a binomial bound at large N.
    - Sample-time §4.2 rejection: applying a source-dependent
-     transition to an unknown-coherent Computational site raises an
-     error naming the op, site, and instrument. Applying the same
-     transition to a `KnownComputational` site (post Z-basis `M`)
+     transition to a `ComputationalUnknown` qubit raises an error
+     naming the op, qubit, and instrument. Applying the same
+     transition to a `ComputationalKnown` qubit (post Z-basis `M`)
      succeeds.
 4. **`rewriter` unit tests.**
-   - Initial `e` sample on a site emits a leading `X` prep; initial
+   - Initial `e` sample on a qubit emits a leading `X` prep; initial
      `g` does not.
-   - Lost-site single-q gate dropped; two-q gate rejected by default.
+   - Lost-qubit single-q gate dropped; two-q gate rejected by default.
    - Reset on lost rejected by default; `policy.reset_restores_lost`
-     enables restoration.
+     enables restoration to `ComputationalKnown(g)`.
    - **Trace-out via inserted `R`**: at a structural-loss event on a
-     previously-coherent site, an `R` is emitted on that site. The
-     compiled rewritten circuit's
+     previously-`ComputationalUnknown` qubit, an `R` is emitted on
+     that qubit. The compiled rewritten circuit's
      `hir.num_hidden_measurements` increments by one, and the
      visible-record layout (and `rec[-k]` references in detectors and
      observables) is unchanged. Verified on a circuit that has
      detectors before *and* after the loss point.
-   - Z-basis vs X/Y-basis measurement/reset: a `KnownComputational`
-     site produced by `M` retains `known=1`; the same site after `MX`
-     has `known=0`. (Single-site assertions on the sampler output.)
-   - Lost visible-measurement policy `"random"` and `"zero"` each
-     produce the configured output.
+   - Z-basis vs X/Y-basis measurement/reset: a qubit kind is
+     `ComputationalKnown` after `M`; the same qubit's kind after `MX`
+     is `ComputationalUnknown`. (Single-qubit assertions on sampler
+     output.)
+   - Lost-qubit visible measurement: classifier columns `[0.5, 0.5]`,
+     `[1, 0]`, `[0, 0]` produce random / deterministic-0 / reject
+     respectively.
 5. **End-to-end `sample_noncomputational` Python tests.**
    - Visible measurement record layout unchanged vs. a lossless run
      where the model is configured with zero loss probability.
@@ -565,27 +662,27 @@ rewriter PR:
   not load-bearing for correctness. Provisional: do not expose them in
   MVP. Re-enable later if a decoder or debugging workflow needs them.
 - **Herald metadata transport.** The orchestrator sidecar shape is
-  written above as "per-site final status + classifier output + herald
-  bits". We may want a more structured sidecar (e.g., numpy structured
-  array) for performance / decoder integration. Provisional: keep the
-  sidecar a typed dict in Python for the MVP; convert to a structured
-  array if/when a decoder consumer demands it.
+  written above as "per-qubit final status + classifier output +
+  herald bits". We may want a more structured sidecar (e.g., numpy
+  structured array) for performance / decoder integration.
+  Provisional: keep the sidecar a typed dict in Python for the MVP;
+  convert to a structured array if/when a decoder consumer demands it.
 
 ### Resolved during note revision
 
-- **`RL` (loss reload).** Closed: no new circuit op in MVP. Lost-site
+- **`RL` (loss reload).** Closed: no new circuit op in MVP. Lost-qubit
   reset rejects unless `policy.reset_restores_lost` is set, in which
-  case existing `R`/`RX`/`RY` ops restore the site to a known
+  case existing `R`/`RX`/`RY` ops restore the qubit to a known
   computational state. The table in §5.2 reflects this.
-- **Initial-state correlation across sites.** Closed: out of scope.
-  `initial_state` is an independent per-site distribution; a future
+- **Initial-state correlation across qubits.** Closed: out of scope.
+  `initial_state` is an independent per-qubit distribution; a future
   feature can add correlated initial states without breaking this
   schema.
 - **Source-independence enforcement point.** Closed: not a
   construction-time invariant. Source-dependent matrices construct
   fine; the runtime sampler rejects only when a transition fires on a
-  site whose source category is unknown-coherent `Computational` and
-  the instrument is not source-independent on `Computational` levels.
+  qubit whose `QubitStatusKind` is `ComputationalUnknown` and the
+  instrument is not source-independent on `Computational` levels.
   See §4.
 
 ## 9. Out of scope but planned-for
@@ -593,6 +690,17 @@ rewriter PR:
 - `LOSS(p) targets...` Stim instruction as syntactic sugar.
 - Diagonal `aI + bZ` filter for state-dependent no-jump (the natural
   next exact-mode extension).
+- Sqale-compat **equalized-rates** approximation mode for
+  unknown-coherent sources hitting source-dependent transitions —
+  surfaced as an opt-in policy knob (e.g.,
+  `policy.unknown_source_policy = "equalize_rates" | "reject"`),
+  defaulting to `"reject"` even after this lands. The exact diagonal
+  filter is the load-bearing path; the equalized-rates mode exists for
+  comparison against sqale-sim outputs.
+- Joint / correlated multi-qubit `TransitionInstrument` (instead of
+  per-qubit marginal): a different type with shape
+  `len(levels)^k x len(levels)^k` for `k` operands. Out of scope for
+  MVP; CZ and similar gates use independent marginals.
 - Compile cache by rewritten-circuit hash, with observable compile
   count.
 - Segmented JIT / replan for true topology changes mid-shot.

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -1,0 +1,412 @@
+<!--pytest-codeblocks:skipfile-->
+# Noncomputational Structural-History MVP — Design Note
+
+Working contract for the long-running feature branch
+`codex/noncomputational-structural-mvp`. This document is local to the
+branch; it is not intended to ship to `main` as a long-lived
+architecture doc. It exists so that API and policy decisions are
+visible and pushback can happen before code accumulates.
+
+Authoritative inputs:
+
+- GitHub issue
+  [#104](https://github.com/unitaryfoundation/clifft/issues/104) (scope
+  and constraints).
+- Theory note `~/NONCOMPUTATIONAL_TRAJECTORY_MODEL.tex` (semantics).
+- Prior sqale-sim draft
+  [Infleqtion/client-superstaq#1353](https://github.com/Infleqtion/client-superstaq/pull/1353)
+  (compatibility target for the exact subset).
+- Reviewer answers in the implementation-kickoff thread (this file
+  captures the resolved decisions).
+
+## 1. Scope summary
+
+**In:** state-independent structural loss; known-source classical
+transitions; classical status-to-status transitions; reset/reload
+restoring a site when the policy allows it; per-trajectory concrete
+statuses; per-trajectory initial-state sampling; semantic validation
+that the configured instrument set is pre-sampleable.
+
+**Out:** unknown coherent state-dependent transitions; exact diagonal
+no-jump filters; segmented JIT replan/resume; dynamic control-flow IR
+above HIR; per-site classical distributions; full qudit simulation;
+new circuit-level instructions (no `LOSS(p)`, no
+`TRANSITION_INSTRUMENT`, no parser changes); compile cache.
+
+**Status of `LOSS(p)` syntax:** deferred. A later PR may add it as
+syntactic sugar over this model. The prior LOSS design notes (`R` vs
+`RL` split, random lost-measurement default, deltakit-style
+`HERALD_LEAKAGE_EVENT` shape) feed the rewrite-policy table in §5; they
+do not feed a new instruction surface in this MVP.
+
+## 2. Status representation
+
+### 2.1 Categories (fixed C++ enum)
+
+```cpp
+enum class LevelCategory : uint8_t {
+    Computational      = 0,  // coherent, in superposition
+    KnownComputational = 1,  // coherent level whose physical bit
+                             // has been sampled (post-Z-collapse)
+    Leaked             = 2,  // present, outside computational subspace
+    Lost               = 3,  // absent / vacuum
+};
+```
+
+Rewrite policies key off `LevelCategory`. The set is fixed; users may
+not extend it.
+
+### 2.2 Levels (model-defined)
+
+A `Level` is a model-defined tag with a stable integer id, a label, and
+an *intrinsic* category. Intrinsic category is the default category for
+a freshly-sampled site holding that level. A `Computational` level can
+be promoted to `KnownComputational` at runtime (via a sampled
+Z-collapse); the reverse promotion (re-coherence) is not in MVP scope.
+
+Default level set for the MVP (sqale-aligned):
+
+| id | label    | intrinsic category | notes                          |
+|----|----------|--------------------|--------------------------------|
+| 0  | `g`      | Computational      | logical 0                      |
+| 1  | `e`      | Computational      | logical 1                      |
+| 2  | `leak_g` | Leaked             | metastable / Rydberg "leak g"  |
+| 3  | `leak_e` | Leaked             | metastable / Rydberg "leak e"  |
+| 4  | `lost`   | Lost               | empty trap / vacuum            |
+
+Users may construct a `NonComputationalModel` with a different level
+set, but the default ships unchanged.
+
+### 2.3 Per-trajectory site state
+
+```cpp
+struct SiteStatus {
+    uint8_t level_id;   // index into model.levels
+    uint8_t known : 1;  // only meaningful when category == Computational
+    uint8_t reserved : 7;
+};
+```
+
+Trajectory state during history sampling is `std::vector<SiteStatus>
+statuses;` — one byte per site, allocated once per history. The
+runtime-effective category at site `i` is:
+
+- `model.levels[statuses[i].level_id].intrinsic_category`, *unless*
+- the intrinsic category is `Computational` and `statuses[i].known == 1`,
+  in which case the effective category is `KnownComputational`.
+
+## 3. `NonComputationalModel` API
+
+### 3.1 Python ergonomic shape
+
+```python
+import clifft
+
+model = clifft.NonComputationalModel(
+    # Optional; defaults to the sqale-aligned 5-level set above.
+    levels=[
+        clifft.Level("g",      category="computational"),
+        clifft.Level("e",      category="computational"),
+        clifft.Level("leak_g", category="leaked"),
+        clifft.Level("leak_e", category="leaked"),
+        clifft.Level("lost",   category="lost"),
+    ],
+
+    # Independent per-site initial level distribution.
+    # Indices into levels[]; sums to 1 per site (validated in C++).
+    initial_state=[0.0065, 0.96, 0.0065, 0.027, 0.0],
+
+    # Per-gate transition instruments. Matrix shorthand uses T[to, from]
+    # convention. Keys are gate names from the existing clifft circuit
+    # vocabulary; unknown keys reject at validation time.
+    transitions={
+        "CZ": clifft.TransitionInstrument(matrix=[...]),   # 5x5
+        "RZ": clifft.TransitionInstrument(matrix=[...]),
+    },
+
+    # Level -> visible-symbol classifier applied at measurement.
+    # Optional; default is identity-on-computational + reject on
+    # leaked/lost (i.e. policy must say what M of a noncomputational
+    # site returns).
+    classifier=clifft.TransitionInstrument(matrix=[...]),
+
+    # Policy hooks for downstream operations on noncomputational
+    # sites. See §5 for the default table.
+    policy=clifft.NonComputationalPolicy(
+        lost_measurement="random",  # | "zero" | "one" | "reject"
+        # ... other knobs, default-reject for ambiguous cases.
+    ),
+)
+```
+
+`clifft.Level`, `clifft.TransitionInstrument`,
+`clifft.NonComputationalPolicy`, and `clifft.NonComputationalModel` are
+all nanobind-bound C++ classes. Python provides keyword constructors
+and `__repr__`. No pydantic; light shape checks (e.g.,
+`isinstance(matrix, list)`) on the Python side, semantic validation
+(column sums, source-independence, unknown-gate rejection,
+intrinsic-category consistency) on the C++ side at model construction.
+
+### 3.2 C++ side
+
+```cpp
+namespace clifft {
+
+struct Level {
+    std::string label;
+    LevelCategory intrinsic_category;
+};
+
+class TransitionInstrument {
+public:
+    // Construct from a square matrix using T[to, from] convention.
+    // Validates column sums in [0, 1] and source-independence
+    // (every column on Computational sources must have the same
+    // probability vector); throws on failure.
+    static TransitionInstrument from_matrix(
+        std::vector<std::vector<double>> matrix);
+
+    // ... accessors for branches, no-jump weight per source, etc.
+};
+
+class NonComputationalModel {
+public:
+    NonComputationalModel(
+        std::vector<Level> levels,
+        std::vector<double> initial_state,
+        std::map<std::string, TransitionInstrument> transitions,
+        std::optional<TransitionInstrument> classifier,
+        NonComputationalPolicy policy);
+
+    // Throws at construction if any invariant violates pre-sampleability.
+    // ... accessors
+};
+
+}  // namespace clifft
+```
+
+## 4. Pre-sampleability validation
+
+Validation runs once at `NonComputationalModel` construction. Failures
+throw with a message naming the offending field. Checks:
+
+1. **Level set well-formed.** Every level id in `[0, len(levels))`,
+   intrinsic categories all in the enum.
+2. **Initial state is a probability vector** over `levels`. Sums to 1
+   within tolerance.
+3. **Transition matrices are square**, of size `len(levels)`, entries
+   in `[0, 1]`.
+4. **Column sums in [0, 1].** Implied no-jump weight per source is
+   `1 - sum(col)`.
+5. **Source-independence for Computational sources.** For every
+   transition, every column whose source is a `Computational` level
+   must be identical. This is the "pre-sampleable" condition: no two
+   Computational source levels have distinguishable jump rates. If
+   violated, raise with a message naming the operation and the
+   differing columns. (This is exactly the cut between the MVP and the
+   later diagonal-filter work.)
+6. **Classifier sources cover the full level set** if provided.
+7. **Policy values are well-formed** (enum values, not free strings on
+   the C++ side; Python sugar translates).
+8. **Transition keys reference known gate names** in clifft's circuit
+   vocabulary; unknown keys reject.
+
+Sources that are intrinsic `Leaked` or `Lost` are not subject to (5) —
+their transitions are classical Markov updates by definition.
+
+## 5. Sampling, rewrite, and policy table
+
+### 5.1 Pipeline
+
+For each shot:
+
+1. **Sample initial statuses.** One draw from `initial_state` per
+   site. Initial `known` bit is 1 (the sampled level is, by
+   construction, a classical fact).
+2. **Walk the circuit ops in order, sampling transitions and updating
+   statuses.** For each op, consult the model's transitions and the
+   site statuses. Sample any per-target branches. Record the resulting
+   `NonComputationalHistory` (sequence of (op-index, site, sampled
+   branch, status-update, optional herald)).
+3. **Rewrite the original circuit using the history.** Produce a new
+   ordinary clifft circuit (no new instructions). Drop, keep, or
+   replace ops per the policy table. Insert hidden trace-out
+   measurements at structural loss points where the lost site was
+   coherent (see §5.3).
+4. **Compile the rewritten circuit** through the ordinary
+   trace/lower/bytecode pipeline.
+5. **Sample one shot** on the SVM.
+6. **Strip hidden record positions** from the measurement array (see
+   §5.3) and return the user-facing `(measurements, detectors,
+   observables)` plus the noncomputational metadata sidecar:
+   `(history, per-site final status, classifier output, herald bits)`.
+
+The C++ orchestrator owns steps 1-6. Caching of step 4 across shots is
+deferred (see §1, "Out").
+
+### 5.2 Default rewrite-policy table
+
+Rows are (operation kind, site category at op time). "Reject" means
+the C++ rewrite raises with a clear message naming the op index and
+site; no silent approximation.
+
+| Operation                | Computational     | KnownComputational            | Leaked                          | Lost                            |
+|--------------------------|-------------------|-------------------------------|---------------------------------|---------------------------------|
+| Single-qubit gate        | apply             | apply (rehydrates known state) | reject (policy override allowed) | drop                            |
+| Single-qubit Pauli noise | apply             | apply                          | drop                            | drop                            |
+| Two-qubit gate           | apply             | apply                          | reject                          | reject (policy override: drop)  |
+| MPP / multi-target meas  | apply             | apply                          | reject                          | reject                          |
+| Visible single-q meas    | apply             | apply (sampled-known outcome)  | classifier → visible bit; default reject | policy: random / zero / one / reject |
+| Reset `R`                | apply             | apply                          | restore to known computational  | reject (use `RL` for reload)    |
+| Reload `RL`              | apply             | apply                          | restore                         | restore                         |
+| Detector / Observable    | unchanged         | unchanged                      | unchanged                       | unchanged                       |
+
+Notes:
+
+- "Policy override allowed" means the cell rejects by default but the
+  user may set a `NonComputationalPolicy` field to flip it to a
+  specific behavior. The MVP exposes overrides only where listed.
+- `RL` (reload) is the loss-restoration operation analog from the
+  prior LOSS design notes; it differs from `R` (computational reset)
+  in that it can promote a `Lost` site back to a known computational
+  state. If we do not want to add `RL` as a new HIR-level op in this
+  MVP, `RL` collapses to a model-config flag on existing `R` ops; that
+  decision is open (see §8).
+
+### 5.3 Hidden trace-out at structural loss
+
+When a site that is currently `Computational` (coherent) transitions
+to `Lost`, theory requires a hidden Z-basis measurement to unravel the
+partial trace. The rewriter inserts an ordinary `M` op at that point.
+Two consequences:
+
+1. **The hidden M consumes a measurement slot** in the rewritten
+   circuit. The rewriter tracks the slot offset and **renumbers every
+   subsequent `rec[-k]` reference** in detectors, observables, and
+   classical feedback so visible record layout is unchanged. This is a
+   straightforward pre-compile pass over the rewritten ops.
+2. **The hidden slot is stripped from user output.** The orchestrator
+   carries a `std::vector<uint64_t> hidden_slot_indices` per
+   rewritten-circuit instance; after the SVM returns the full
+   measurement array it removes those indices before exposing the
+   `measurements` array. The hidden outcome is *not* discarded
+   internally — it becomes part of the noncomputational metadata
+   sidecar (under "trace-out outcomes") for debugging and validation.
+
+This keeps the rewriter's output in ordinary clifft syntax (no new HIR
+op required) and isolates the hidden-record handling to two small
+helpers on the orchestrator path. It does mean every history pays one
+extra M per coherent-site loss in compile work; for the MVP that is
+acceptable.
+
+## 6. New C++ headers and dependency order
+
+Proposed layout under `src/clifft/noncomp/` (new directory):
+
+1. `level.h` — `LevelCategory` enum, `Level` struct. Zero deps.
+2. `transition_instrument.h/.cc` — `TransitionInstrument`,
+   matrix-to-branch expansion, source-independence check. Depends on
+   `level.h`.
+3. `policy.h` — `NonComputationalPolicy` struct with enums for the
+   ambiguous-case overrides. Zero deps.
+4. `model.h/.cc` — `NonComputationalModel`, all semantic validation.
+   Depends on (1)-(3).
+5. `history.h` — `SiteStatus`, `NonComputationalHistory` (sequence of
+   (op-index, site, branch, status-update, herald)). Depends on (1).
+6. `sampler.h/.cc` — history sampler that walks the parsed circuit and
+   updates `SiteStatus` per shot. Depends on (1)-(5), `clifft::Circuit`,
+   `clifft::AstNode`.
+7. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
+   `(original, history, model)` and computes the
+   `hidden_slot_indices` sidecar. Depends on (1)-(6) and
+   `clifft::Circuit`.
+8. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
+   point that runs the full pipeline. Depends on (1)-(7), the existing
+   compile pipeline, and the SVM.
+
+Python bindings in `src/python/bindings.cc` expose:
+`Level`, `TransitionInstrument`, `NonComputationalPolicy`,
+`NonComputationalModel`, `sample_noncomputational(circuit_text, model,
+shots, seed=None)`.
+
+## 7. Test plan (dependency order)
+
+Each test category lands once the headers it needs are in place. C++
+tests under `tests/test_noncomp_*.cc`; Python tests under
+`tests/python/test_noncomputational.py`.
+
+1. **`level` and `transition_instrument` unit tests.**
+   - Default level set roundtrips.
+   - Matrix orientation: `T[to, from]` matches a known per-column
+     no-jump weight.
+   - Source-independence check rejects a hand-crafted Computational
+     pair of differing columns; accepts identical columns.
+2. **`model` validation tests.**
+   - Initial-state sum, unknown-gate keys, classifier shape, policy
+     enum values.
+3. **`history` sampler tests.**
+   - Deterministic seed → fixed history.
+   - Initial-state-only sampling produces marginal frequencies within
+     a binomial bound at large N.
+4. **`rewriter` unit tests.**
+   - Lost-site single-q gate dropped; two-q gate rejected by default.
+   - Reset on lost rejected; `RL` (or its config-flag analog) restores.
+   - Hidden M insertion at coherent-site loss, with `rec[-k]`
+     renumbering verified on a circuit that has detectors before *and*
+     after the loss point.
+   - Lost visible-measurement policy `"random"` and `"zero"` each
+     produce the configured output.
+5. **End-to-end `sample_noncomputational` Python tests.**
+   - Visible measurement record layout unchanged vs. lossless run with
+     `LOSS=0`.
+   - Survivor statistics on a small (3-qubit) entangled circuit with
+     forced loss match a Python brute-force enumerator within shot
+     noise.
+   - `LOSS=1` (every site lost initially) returns a trivial output and
+     a full noncomp sidecar.
+6. **Regression / smoke.**
+   - Existing `compile()` / `sample()` paths unchanged. Run the
+     current C++ and Python suites; both stay green.
+
+Validation oracle for (5): a small Python brute-force enumerator that
+walks the circuit with explicit density matrices over computational
+qubits + classical statuses. Bounded to ~4 qubits and ~10 events;
+fast enough for parameter sweeps. No sqale-sim dependency in the
+MVP.
+
+## 8. Open questions to settle before §6 step 7 (`rewriter`)
+
+These do not block the design note but should be settled before the
+rewriter PR:
+
+- **`RL` as a new HIR op vs. a config flag on existing `R`.** A new op
+  adds a parser/lower change (which we said we would not do in MVP),
+  but folding it into `R` via a policy flag makes the semantics
+  context-sensitive (same circuit text means different things
+  depending on the model). Provisional: config flag on the model
+  (`policy.reset_restores_lost = bool`), no new circuit op. If we
+  later add `LOSS(p)` syntax, `RL` rides with it.
+- **Herald metadata transport.** The orchestrator sidecar shape is
+  written above as "per-site final status + classifier output + herald
+  bits". We may want a more structured sidecar (e.g., numpy structured
+  array) for performance / decoder integration. Provisional: keep the
+  sidecar a typed dict in Python for the MVP; convert to a structured
+  array if/when a decoder consumer demands it.
+- **Initial-state correlation across sites.** §3 makes
+  `initial_state` an independent per-site distribution. sqale-sim
+  matches this. If a hardware model needs correlated initial states,
+  that is a separate feature; reject correlated initial-state config
+  in this MVP.
+
+## 9. Out of scope but planned-for
+
+- `LOSS(p) targets...` Stim instruction as syntactic sugar.
+- Diagonal `aI + bZ` filter for state-dependent no-jump (the natural
+  next exact-mode extension).
+- Compile cache by rewritten-circuit hash, with observable compile
+  count.
+- Segmented JIT / replan for true topology changes mid-shot.
+- Decoder-side integration of herald bits.
+
+These are explicitly outside the MVP and should not constrain the
+schemas above beyond what is already noted.

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -60,9 +60,20 @@ not extend it.
 
 A `Level` is a model-defined tag with a stable integer id, a label, and
 an *intrinsic* category. Intrinsic category is the default category for
-a freshly-sampled site holding that level. A `Computational` level can
-be promoted to `KnownComputational` at runtime (via a sampled
-Z-collapse); the reverse promotion (re-coherence) is not in MVP scope.
+a freshly-sampled site holding that level. A site whose level is
+intrinsically `Computational` may toggle between the runtime categories
+`Computational` and `KnownComputational` freely during simulation — a
+Z-basis measurement or Z-basis reset promotes it to `KnownComputational`
+(`known = 1`), and any subsequent quantum gate clears `known` back to 0
+(Hadamard on `|0>` is the canonical example).
+
+What is *not* in MVP scope is re-entering the computational subspace
+from a noncomputational level. Once a site is `Leaked` or `Lost`, it
+returns to a computational category only via reset/reload — and only
+when the policy explicitly allows it (`Leaked` → Computational via
+`R`/`RX`/`RY`; `Lost` → Computational only when
+`policy.reset_restores_lost` is set). There is no spontaneous coherent
+return from a leaked level back into a superposition with `g`/`e`.
 
 A `Computational`-intrinsic level must also declare a `basis_bit`
 (0 or 1) identifying which computational basis state it represents.

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -87,20 +87,33 @@ set, but the default ships unchanged.
 ### 2.3 Per-trajectory site state
 
 ```cpp
-struct SiteStatus {
-    uint8_t level_id;   // index into model.levels
-    uint8_t known : 1;  // only meaningful when category == Computational
-    uint8_t reserved : 7;
-};
+// One byte per site: bit 7 carries `known`, bits 0-6 carry `level_id`.
+// (A `: 1` / `: 7` bitfield struct is not guaranteed by the standard
+// to pack into one byte; explicit masking guarantees the layout.)
+using SiteStatus = uint8_t;
+
+constexpr uint8_t kSiteStatusKnownBit  = 0x80;
+constexpr uint8_t kSiteStatusLevelMask = 0x7F;  // supports up to 128 levels
+
+inline uint8_t site_level(SiteStatus s)        { return s & kSiteStatusLevelMask; }
+inline bool    site_known(SiteStatus s)        { return (s & kSiteStatusKnownBit) != 0; }
+inline SiteStatus make_site_status(uint8_t level_id, bool known) {
+    return static_cast<SiteStatus>(level_id | (known ? kSiteStatusKnownBit : 0));
+}
 ```
 
 Trajectory state during history sampling is `std::vector<SiteStatus>
 statuses;` — one byte per site, allocated once per history. The
 runtime-effective category at site `i` is:
 
-- `model.levels[statuses[i].level_id].intrinsic_category`, *unless*
-- the intrinsic category is `Computational` and `statuses[i].known == 1`,
-  in which case the effective category is `KnownComputational`.
+- `model.levels[site_level(statuses[i])].intrinsic_category`, *unless*
+- the intrinsic category is `Computational` and `site_known(statuses[i])`
+  is true, in which case the effective category is
+  `KnownComputational`.
+
+"Known" here means known *in the energy basis* (`g`/`e`) — the basis
+in which transition matrices are indexed. X- and Y-basis measurements
+or resets do not produce `known=1`; see §5.2.1.
 
 ## 3. `NonComputationalModel` API
 
@@ -132,10 +145,15 @@ model = clifft.NonComputationalModel(
     },
 
     # Level -> visible-symbol classifier applied at measurement.
+    # Row-stochastic `symbols x levels` matrix using
+    # matrix[symbol_idx, level_id] = P(symbol | level).
     # Optional; default is identity-on-computational + reject on
     # leaked/lost (i.e. policy must say what M of a noncomputational
     # site returns).
-    classifier=clifft.TransitionInstrument(matrix=[...]),
+    classifier=clifft.MeasurementClassifier(
+        symbols=["0", "1"],     # 2-symbol binary record by default
+        matrix=[[...], [...]],  # shape (len(symbols), len(levels))
+    ),
 
     # Policy hooks for downstream operations on noncomputational
     # sites. See §5 for the default table.
@@ -147,12 +165,15 @@ model = clifft.NonComputationalModel(
 ```
 
 `clifft.Level`, `clifft.TransitionInstrument`,
-`clifft.NonComputationalPolicy`, and `clifft.NonComputationalModel` are
-all nanobind-bound C++ classes. Python provides keyword constructors
-and `__repr__`. No pydantic; light shape checks (e.g.,
-`isinstance(matrix, list)`) on the Python side, semantic validation
-(column sums, source-independence, unknown-gate rejection,
-intrinsic-category consistency) on the C++ side at model construction.
+`clifft.MeasurementClassifier`, `clifft.NonComputationalPolicy`, and
+`clifft.NonComputationalModel` are all nanobind-bound C++ classes.
+Python provides keyword constructors and `__repr__`. No pydantic;
+light shape checks (e.g., `isinstance(matrix, list)`) on the Python
+side, semantic validation (column sums, unknown-gate rejection,
+intrinsic-category consistency, classifier shape) on the C++ side at
+model construction. Source-independence is *cached* on each
+`TransitionInstrument` at construction but is not a construction-time
+invariant; the runtime sampler uses it as the §4.2 gate.
 
 ### 3.2 C++ side
 
@@ -162,18 +183,34 @@ namespace clifft {
 struct Level {
     std::string label;
     LevelCategory intrinsic_category;
+    std::optional<uint8_t> basis_bit;  // required if intrinsic_category == Computational
 };
 
 class TransitionInstrument {
 public:
     // Construct from a square matrix using T[to, from] convention.
-    // Validates column sums in [0, 1] and source-independence
-    // (every column on Computational sources must have the same
-    // probability vector); throws on failure.
+    // Validates matrix shape and that every column sum lies in [0, 1].
+    // Computes the cached flag `is_source_independent_on_computational`
+    // but does NOT reject source-dependent matrices here; whether a
+    // source-dependent matrix is applicable is checked at sample time
+    // (see section 4.2).
     static TransitionInstrument from_matrix(
         std::vector<std::vector<double>> matrix);
 
-    // ... accessors for branches, no-jump weight per source, etc.
+    bool is_source_independent_on_computational() const;
+    // ... accessors for per-source branches, no-jump weight per source, etc.
+};
+
+// Distinct from TransitionInstrument: rectangular row-stochastic map
+// from levels to reported user-facing symbols. No no-jump branch, no
+// concept of source-independence on Computational levels.
+class MeasurementClassifier {
+public:
+    static MeasurementClassifier from_matrix(
+        std::vector<std::string> symbols,
+        std::vector<std::vector<double>> matrix);  // shape (symbols, levels)
+
+    // ... accessors
 };
 
 class NonComputationalModel {
@@ -182,10 +219,12 @@ public:
         std::vector<Level> levels,
         std::vector<double> initial_state,
         std::map<std::string, TransitionInstrument> transitions,
-        std::optional<TransitionInstrument> classifier,
+        std::optional<MeasurementClassifier> classifier,
         NonComputationalPolicy policy);
 
-    // Throws at construction if any invariant violates pre-sampleability.
+    // Throws at construction on shape/probability/key validation
+    // failures (section 4.1). Source-context validity is enforced at
+    // sample time (section 4.2).
     // ... accessors
 };
 
@@ -210,7 +249,10 @@ representable in the MVP.
    in `[0, 1]`.
 4. **Column sums in [0, 1].** Implied no-jump weight per source is
    `1 - sum(col)`.
-5. **Classifier sources cover the full level set** if provided.
+5. **Classifier matrix shape and rows.** If a `MeasurementClassifier`
+   is provided, its matrix has shape `(len(symbols), len(levels))`,
+   every entry is in `[0, 1]`, and every column (per-level row over
+   symbols) sums to 1 within tolerance.
 6. **Policy values are well-formed** (enum values, not free strings on
    the C++ side; Python sugar translates).
 7. **Transition keys reference known gate names** in clifft's circuit
@@ -302,8 +344,10 @@ unchanged but the site's `known` bit is set to 0 afterward (per §5.2.1).
 | Single-qubit Pauli noise | apply                 | apply, clear known                  | drop                                    | drop                                              |
 | Two-qubit gate           | apply                 | apply, clear known on both           | reject                                  | reject (policy override: drop)                    |
 | MPP / multi-target meas  | apply                 | apply, clear known on all            | reject                                  | reject                                            |
-| Visible single-q meas    | apply                 | apply, outcome = sampled known value | classifier → visible bit; default reject | policy: random / zero / one / reject              |
-| Reset `R` (or `RX`/`RY`) | apply                 | apply                                | restore to known computational          | reject unless `policy.reset_restores_lost` is set |
+| Visible Z-basis meas (`M`/`MR`) | apply, set known after | apply, outcome = sampled known value | classifier → visible bit; default reject | policy: random / zero / one / reject |
+| Visible X/Y-basis meas (`MX`/`MY`/`MRX`/`MRY`) | apply, **clear known** | apply, **clear known** | classifier → visible bit; default reject | policy: random / zero / one / reject |
+| Z-basis reset `R`        | apply, set known after | apply, set known after | restore to known computational          | reject unless `policy.reset_restores_lost` is set |
+| X/Y-basis reset `RX`/`RY` | apply, **clear known** | apply, **clear known** | restore to coherent computational (known = 0) | reject unless `policy.reset_restores_lost` is set |
 | Detector / Observable    | unchanged             | unchanged                            | unchanged                               | unchanged                                         |
 
 Notes:
@@ -333,10 +377,21 @@ A site's `known` bit transitions as follows during history sampling:
 |--------------------------------------------------|---------------------------------------------------------|
 | Initial-state sample (any level)                 | `known = 1`                                             |
 | Any quantum gate touching site (single or multi) | `known = 0` on every touched site                       |
-| Visible measurement                              | `known = 1` after sampling the outcome                  |
-| Reset `R`/`RX`/`RY`                              | `known = 1` (reset is to a known computational state)   |
-| Reload via `policy.reset_restores_lost`          | `known = 1`                                             |
-| Transition jump to a new level                   | `known = 1` if destination level is `KnownComputational` after the transition; otherwise the bit is moot |
+| Z-basis measurement (`M`/`MR`)                   | `known = 1`, level updated to `g` or `e` per outcome    |
+| X- or Y-basis measurement (`MX`/`MY`/`MRX`/`MRY`)| `known = 0` (post-state is in X- or Y-basis, not energy basis) |
+| Z-basis reset `R`                                | `known = 1` (reset is to a known energy-basis state)    |
+| X- or Y-basis reset `RX`/`RY`                    | `known = 0` (reset is to a known X/Y-basis state, but `known` is energy-basis) |
+| Reload via `policy.reset_restores_lost` (Z-basis) | `known = 1`                                            |
+| Transition jump to a new computational-intrinsic level | `known = 1` (destination level is the known value)      |
+| Transition jump to a noncomputational level      | `known` bit moot; site category becomes Leaked or Lost   |
+
+The "known" bit means *known in the energy basis* (`g`/`e`) — the
+basis transition matrices are indexed in. A site that is in a known
+X-basis or Y-basis state after `RX`/`MY`/etc. is still coherent in
+the energy basis (a superposition of `g` and `e`), so its category
+remains `Computational`. Source-dependent transitions on it will hit
+the §4.2 sample-time rejection unless the instrument is
+source-independent on Computational sources.
 
 ### 5.3 Hidden trace-out at structural loss
 
@@ -367,10 +422,14 @@ single `R` op on that site in the rewritten circuit. Concretely:
 3. **No output stripping pass is needed.** The SVM does not emit
    hidden-measurement slots into the user-facing measurement array;
    `compile()` / `sample()` already enforce that.
-4. **The trace-out outcome can still be surfaced for debugging** by
-   reading the SVM's hidden-record buffer after sampling. Whether to
-   expose it in the noncomputational sidecar is an open knob (see §8);
-   for MVP correctness it is not required.
+4. **The trace-out outcome is consumed internally and not exposed.**
+   The frontend's hidden-measurement slot drives the corrective Pauli
+   on the residual state, but `sample()` sizes `result.measurements`
+   to `program.num_measurements` (visible only) and never propagates
+   hidden slots out (see `src/clifft/svm/svm.cc:199-205`). Surfacing
+   the outcome would require extending the SVM result struct; that is
+   out of scope for MVP. The noncomputational sidecar therefore does
+   not include trace-out outcomes in v1.
 
 After the inserted `R`, the rewriter marks the site `Lost` in the
 trajectory and drops every subsequent op on that site per the policy
@@ -390,29 +449,33 @@ Proposed layout under `src/clifft/noncomp/` (new directory):
 
 1. `level.h` — `LevelCategory` enum, `Level` struct. Zero deps.
 2. `transition_instrument.h/.cc` — `TransitionInstrument`,
-   matrix-to-branch expansion, source-independence check. Depends on
-   `level.h`.
-3. `policy.h` — `NonComputationalPolicy` struct with enums for the
+   matrix-to-branch expansion, derived
+   `is_source_independent_on_computational` flag. Depends on `level.h`.
+3. `classifier.h/.cc` — `MeasurementClassifier`, row-stochastic
+   `(symbols, levels)` map. Depends on `level.h`.
+4. `policy.h` — `NonComputationalPolicy` struct with enums for the
    ambiguous-case overrides. Zero deps.
-4. `model.h/.cc` — `NonComputationalModel`, all semantic validation.
-   Depends on (1)-(3).
-5. `history.h` — `SiteStatus`, `NonComputationalHistory` (sequence of
-   (op-index, site, branch, status-update, herald)). Depends on (1).
-6. `sampler.h/.cc` — history sampler that walks the parsed circuit and
-   updates `SiteStatus` per shot. Depends on (1)-(5), `clifft::Circuit`,
+5. `model.h/.cc` — `NonComputationalModel`, all construction-time
+   validation per §4.1. Depends on (1)-(4).
+6. `history.h` — `SiteStatus` (the packed byte from §2.3),
+   `NonComputationalHistory` (sequence of (op-index, site, branch,
+   status-update, herald)). Depends on (1).
+7. `sampler.h/.cc` — history sampler that walks the parsed circuit,
+   updates `SiteStatus` per shot, and enforces the §4.2 sample-time
+   source-context check. Depends on (1)-(6), `clifft::Circuit`,
    `clifft::AstNode`.
-7. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
-   `(original, history, model)` and computes the
-   `hidden_slot_indices` sidecar. Depends on (1)-(6) and
-   `clifft::Circuit`.
-8. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
-   point that runs the full pipeline. Depends on (1)-(7), the existing
+8. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
+   `(original, history, model)`, inserting `R` at coherent-site loss
+   points and `X` prep for `basis_bit==1` initial samples. Depends on
+   (1)-(7) and `clifft::Circuit`.
+9. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
+   point that runs the full pipeline. Depends on (1)-(8), the existing
    compile pipeline, and the SVM.
 
 Python bindings in `src/python/bindings.cc` expose:
-`Level`, `TransitionInstrument`, `NonComputationalPolicy`,
-`NonComputationalModel`, `sample_noncomputational(circuit_text, model,
-shots, seed=None)`.
+`Level`, `TransitionInstrument`, `MeasurementClassifier`,
+`NonComputationalPolicy`, `NonComputationalModel`,
+`sample_noncomputational(circuit_text, model, shots, seed=None)`.
 
 ## 7. Test plan (dependency order)
 
@@ -420,35 +483,56 @@ Each test category lands once the headers it needs are in place. C++
 tests under `tests/test_noncomp_*.cc`; Python tests under
 `tests/python/test_noncomputational.py`.
 
-1. **`level` and `transition_instrument` unit tests.**
-   - Default level set roundtrips.
+1. **`level`, `transition_instrument`, `classifier` unit tests.**
+   - Default level set roundtrips; `basis_bit` required iff
+     intrinsic category is Computational.
    - Matrix orientation: `T[to, from]` matches a known per-column
      no-jump weight.
-   - Source-independence check rejects a hand-crafted Computational
-     pair of differing columns; accepts identical columns.
+   - `is_source_independent_on_computational` is true for identical
+     `g`/`e` columns, false when they differ. Construction does *not*
+     throw on differing-column instruments — both must build cleanly.
+   - `MeasurementClassifier` matrix shape and per-level column sums
+     enforced; mismatched (symbols, levels) dimensions rejected.
 2. **`model` validation tests.**
    - Initial-state sum, unknown-gate keys, classifier shape, policy
-     enum values.
+     enum values all reject at construction with a named field.
+   - Source-dependent transitions in `model.transitions` build fine;
+     no rejection at construction.
 3. **`history` sampler tests.**
    - Deterministic seed → fixed history.
    - Initial-state-only sampling produces marginal frequencies within
      a binomial bound at large N.
+   - Sample-time §4.2 rejection: applying a source-dependent
+     transition to an unknown-coherent Computational site raises an
+     error naming the op, site, and instrument. Applying the same
+     transition to a `KnownComputational` site (post Z-basis `M`)
+     succeeds.
 4. **`rewriter` unit tests.**
+   - Initial `e` sample on a site emits a leading `X` prep; initial
+     `g` does not.
    - Lost-site single-q gate dropped; two-q gate rejected by default.
-   - Reset on lost rejected; `RL` (or its config-flag analog) restores.
-   - Hidden M insertion at coherent-site loss, with `rec[-k]`
-     renumbering verified on a circuit that has detectors before *and*
-     after the loss point.
+   - Reset on lost rejected by default; `policy.reset_restores_lost`
+     enables restoration.
+   - **Trace-out via inserted `R`**: at a structural-loss event on a
+     previously-coherent site, an `R` is emitted on that site. The
+     compiled rewritten circuit's
+     `hir.num_hidden_measurements` increments by one, and the
+     visible-record layout (and `rec[-k]` references in detectors and
+     observables) is unchanged. Verified on a circuit that has
+     detectors before *and* after the loss point.
+   - Z-basis vs X/Y-basis measurement/reset: a `KnownComputational`
+     site produced by `M` retains `known=1`; the same site after `MX`
+     has `known=0`. (Single-site assertions on the sampler output.)
    - Lost visible-measurement policy `"random"` and `"zero"` each
      produce the configured output.
 5. **End-to-end `sample_noncomputational` Python tests.**
-   - Visible measurement record layout unchanged vs. lossless run with
-     `LOSS=0`.
+   - Visible measurement record layout unchanged vs. a lossless run
+     where the model is configured with zero loss probability.
    - Survivor statistics on a small (3-qubit) entangled circuit with
      forced loss match a Python brute-force enumerator within shot
      noise.
-   - `LOSS=1` (every site lost initially) returns a trivial output and
-     a full noncomp sidecar.
+   - "Everything lost initially" (initial_state concentrates on
+     `lost`) returns a trivial output and a full noncomp sidecar.
 6. **Regression / smoke.**
    - Existing `compile()` / `sample()` paths unchanged. Run the
      current C++ and Python suites; both stay green.


### PR DESCRIPTION
First commit on the noncomputational MVP feature branch (#104). Captures the resolved API and policy shape from the kickoff thread + two rounds of review so subsequent implementation PRs land against an agreed contract.

**Targets the feature branch, not main.** This branch is the long-running integration point; per the issue, partial work does not merge to main.

## What's in the note

- **Two distinct enums (§2.1).** `LevelCategory` (3 values: `Computational`, `Leaked`, `Lost`) is a *level* property in the model. `QubitStatusKind` (4 values: `ComputationalUnknown`, `ComputationalKnown`, `Leaked`, `Lost`) is the *per-qubit runtime* tag carried in the trajectory.
- **Tagged `QubitStatus` (§2.3).** `{kind, level_id}` struct with structural invariants — `ComputationalUnknown` carries `kInvalidLevel`, so source-dependent reads on unresolved qubits cannot accidentally consult a stale level id. Invariants enforced by named accessors (`known_source_level`, `require_classical_source_level`), not by convention.
- **Default sqale-aligned level set**: `g`, `e`, `leak_g`, `leak_e`, `lost` with `basis_bit` for the computational levels.
- **Model-attached configuration** via `NonComputationalModel(levels, initial_state, transitions, classifier, policy)`. nanobind-bound C++ classes (no pydantic). No new parser instructions in this MVP.
- **Transitions fire after the gate, per qubit operand (per-qubit marginal).** Joint correlated multi-qubit instruments are out of scope.
- **`MeasurementClassifier` is column-substochastic**: per-level column sums in [0, 1], deficit = implicit reject probability. Default identity + reject is just `[[1,0,0,0,0], [0,1,0,0,0]]`. No separate `lost_measurement` policy knob — lost-qubit measurement is fully specified by the classifier's `lost` column.
- **Validation split (§4)**:
  - Construction time: shape + probability checks (column sums, classifier substochasticity, unknown-gate rejection, etc.). Source-dependent matrices construct fine.
  - Sample time: §4.2 source-context check. Applying a source-dependent transition to a `ComputationalUnknown` qubit rejects cleanly with op/qubit/instrument named; applying it to a `ComputationalKnown` qubit succeeds.
- **Sample-history → rewrite-to-ordinary-clifft-circuit → compile → sample** pipeline (§5.1). Compile cache deferred.
- **Default rewrite-policy table (§5.2)** keyed on `(operation, QubitStatusKind)` with explicit reject-by-default rows for ambiguous cases.
- **Hidden trace-out at coherent-qubit loss (§5.3)** uses clifft's existing hidden-measurement infrastructure (`src/clifft/frontend/frontend.cc:618-694`): the rewriter inserts an ordinary `R` op; the frontend lowers it to a hidden measurement with its own slot counter and conditional correction. No `rec[-k]` renumbering, no output stripping, no new HIR op.
- **C++ header dependency order** under a new `src/clifft/noncomp/` tree (§6), with a matching **test plan** (§7) including QubitStatus invariant tests and column-substochastic classifier checks.

## Resolved by the two review rounds

- `RL` (loss reload) is a `policy.reset_restores_lost` flag, not a new circuit op.
- Source-independence is *cached* on each `TransitionInstrument` at construction; it is not a construction-time validation gate.
- `KnownComputational` is not a `LevelCategory` enum value; it lives in `QubitStatusKind` as the runtime tag.
- Knownness is energy-basis-specific: `M`/`R` set it; `MX`/`MY`/`RX`/`RY` do not.
- Sqale-compat equalized-rates approximation deferred to §9 as a future opt-in policy knob; MVP rejects strictly.

## Test plan

- [x] Pre-commit clean
- [ ] Reviewer agrees that the tagged `QubitStatus` representation is the implementation contract
- [ ] Reviewer agrees with the §5.2 rewrite-policy table and the §5.3 R-insertion trace-out strategy
