### PR TITLE
feat(noncomp): Level, NonComputationalPolicy, QubitStatus value types

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -103,11 +103,17 @@ simulation:
   `g`/`e`.
 
 A `Computational`-category level must also declare a `basis_bit`
-(0 or 1) identifying which computational basis state it represents.
-The rewriter uses this to prepend a preparation gate when an initial
-sample places the qubit in `ComputationalKnown` with a level whose
-`basis_bit` is not 0 (the SVM default initialization). `Leaked` and
-`Lost` levels have no `basis_bit`.
+(`Zero` or `One`, exposed as a `BasisBit` enum) identifying which
+computational basis state it represents. The rewriter uses this to
+prepend a preparation gate when an initial sample places the qubit
+in `ComputationalKnown` with a level whose `basis_bit` is `One`
+(the SVM default initialization is `|0...0>`).
+
+`Leaked`-category levels may optionally carry a `basis_bit` as
+origin metadata (e.g., to record that the atom leaked from `|1>`).
+No current code path consumes it; consumers that want to integrate
+classifier or decoder metadata can read it directly. `Lost`-category
+levels by convention should leave `basis_bit` empty.
 
 Default level set for the MVP (sqale-aligned):
 
@@ -130,6 +136,11 @@ constexpr uint8_t kInvalidLevel = 0xFF;
 struct QubitStatus {
     QubitStatusKind kind;
     uint8_t level_id;  // meaning depends on `kind` (see invariants)
+
+    static QubitStatus computational_unknown();
+    bool is_unknown_computational() const;
+    std::optional<uint8_t> known_source_level() const;
+    uint8_t require_classical_source_level() const;  // throws on Unknown
 };
 ```
 
@@ -137,8 +148,7 @@ The two fields together carry the runtime status of one qubit during
 history sampling. Trajectory state is `std::vector<QubitStatus>
 statuses;`, two bytes per qubit.
 
-**Invariants (enforced by constructors and helpers, not by ad-hoc
-reads):**
+**Invariants:**
 
 | `kind`                  | `level_id` constraint                          |
 |-------------------------|------------------------------------------------|
@@ -147,28 +157,30 @@ reads):**
 | `Leaked`                | must be a `Leaked`-category level id           |
 | `Lost`                  | must be a `Lost`-category level id             |
 
-Callers go through named accessors that enforce these:
+The canonical construction path is through `LevelSet` (see §3.2),
+which validates the (kind, level_id) pair against its table:
 
 ```cpp
-bool is_unknown_computational(const QubitStatus& s);
-
-// Returns level_id when kind is ComputationalKnown / Leaked / Lost;
-// nullopt when kind is ComputationalUnknown.
-std::optional<uint8_t> known_source_level(const QubitStatus& s);
-
-// Asserts/throws if called on ComputationalUnknown.
-uint8_t require_classical_source_level(const QubitStatus& s);
+QubitStatus s = level_set.computational_known(g_id);
+QubitStatus t = level_set.leaked(leak_g_id);
+QubitStatus u = level_set.lost(lost_id);
+QubitStatus v = QubitStatus::computational_unknown();  // no level id needed
 ```
 
-Most rewrite-policy entries only need `s.kind`; only source-dependent
-transitions need to read the level id, and they go through
-`known_source_level` or `require_classical_source_level` so the
-"unknown coherent" rejection path is structurally enforced.
+Direct aggregate construction `QubitStatus{kind, level_id}` compiles
+but bypasses validation; reserved for tests or interior code where
+the invariant is already established.
 
-"Known" here means known *in the energy basis* (`g`/`e`) — the basis
-in which transition matrices are indexed. X- and Y-basis measurements
-or resets do not produce `ComputationalKnown`; they leave the qubit in
-`ComputationalUnknown` (see §5.2.1).
+Source-dependent transitions must call `known_source_level()` or
+`require_classical_source_level()` so the "unknown coherent"
+rejection path stays consistent: most rewrite-policy entries only
+need `s.kind`; only the source-dependent column lookup needs the
+level id, and the accessors are the only safe way to read it.
+
+"Known" here means known in the computational basis (`|0>` or `|1>`)
+— the basis in which transition matrices are indexed. X- and Y-basis
+measurements or resets do not produce `ComputationalKnown`; they
+leave the qubit in `ComputationalUnknown` (see §5.2.1).
 
 ## 3. `NonComputationalModel` API
 
@@ -259,10 +271,29 @@ invariant; the runtime sampler uses it as the §4.2 gate.
 ```cpp
 namespace clifft {
 
+enum class BasisBit : uint8_t { Zero = 0, One = 1 };
+
 struct Level {
     std::string label;
     LevelCategory category;
-    std::optional<uint8_t> basis_bit;  // required iff category == Computational
+    std::optional<BasisBit> basis_bit;
+};
+
+// Validated level table. Construction runs the section 4.1 level-set
+// checks and throws std::invalid_argument on failure. Owns the
+// QubitStatus factories so that level ids and tables stay paired.
+class LevelSet {
+public:
+    explicit LevelSet(std::vector<Level> levels);
+    static LevelSet default_set();
+
+    std::span<const Level> levels() const;
+    const Level& at(uint8_t level_id) const;
+    size_t size() const;
+
+    QubitStatus computational_known(uint8_t level_id) const;
+    QubitStatus leaked(uint8_t level_id) const;
+    QubitStatus lost(uint8_t level_id) const;
 };
 
 class TransitionInstrument {
@@ -300,7 +331,7 @@ public:
 class NonComputationalModel {
 public:
     NonComputationalModel(
-        std::vector<Level> levels,
+        LevelSet levels,
         std::vector<double> initial_state,
         std::map<std::string, TransitionInstrument> transitions,
         std::optional<MeasurementClassifier> classifier,
@@ -324,9 +355,12 @@ representable in the MVP.
 ### 4.1 Construction-time checks (always run, throw on failure)
 
 1. **Level set well-formed.** Every level id in `[0, len(levels))`,
-   categories all in `LevelCategory`. Every `Computational`-category
-   level declares a `basis_bit` in `{0, 1}`; non-`Computational` levels
-   omit it.
+   categories all in `LevelCategory` (unrecognized enum values reject).
+   Every `Computational`-category level declares a `basis_bit` (the
+   `BasisBit` enum restricts the value to `Zero` or `One`
+   structurally). Non-`Computational` levels may carry a `basis_bit`
+   as metadata; for `Lost`-category levels the convention is to
+   leave it empty.
 2. **Initial state is a probability vector** over `levels`. Sums to 1
    within tolerance.
 3. **Transition matrices are square**, of size `len(levels)`, entries
@@ -560,37 +594,40 @@ and destination kind is `Leaked` or `Lost`.
 
 Proposed layout under `src/clifft/noncomp/` (new directory):
 
-1. `level.h` — `LevelCategory` enum, `Level` struct. Zero deps.
-2. `transition_instrument.h/.cc` — `TransitionInstrument`,
+1. `qubit_status.h` — `QubitStatusKind` enum, `QubitStatus` aggregate
+   with `computational_unknown()` factory and accessors
+   (`is_unknown_computational`, `known_source_level`,
+   `require_classical_source_level`). Zero clifft-internal deps.
+2. `level.h` — `LevelCategory` enum, `BasisBit` enum, `Level` struct,
+   `LevelSet` (validated table that owns the `QubitStatus` factories
+   `computational_known` / `leaked` / `lost`). Depends on (1).
+3. `transition_instrument.h/.cc` — `TransitionInstrument`,
    matrix-to-branch expansion, derived
-   `is_source_independent_on_computational` flag. Depends on `level.h`.
-3. `classifier.h/.cc` — `MeasurementClassifier`, column-substochastic
+   `is_source_independent_on_computational` flag. Depends on (2).
+4. `classifier.h/.cc` — `MeasurementClassifier`, column-substochastic
    `(symbols, levels)` map with derived `reject_probability(level_id)`.
-   Depends on `level.h`.
-4. `policy.h` — `NonComputationalPolicy` struct with enums for the
-   ambiguous-case overrides (`reset_restores_lost`, etc.). Zero deps.
-5. `model.h/.cc` — `NonComputationalModel`, all construction-time
-   validation per §4.1. Depends on (1)-(4).
-6. `qubit_status.h` — `QubitStatusKind` enum, `QubitStatus` struct,
-   invariant-enforcing accessors (`known_source_level`,
-   `require_classical_source_level`, `is_unknown_computational`).
-   `NonComputationalHistory` (sequence of (op-index, qubit, branch,
-   status-update, herald)). Depends on (1).
-7. `sampler.h/.cc` — history sampler that walks the parsed circuit,
+   Depends on (2).
+5. `policy.h` — `NonComputationalPolicy` struct. Zero deps.
+6. `model.h/.cc` — `NonComputationalModel`, all construction-time
+   validation per §4.1. Depends on (1)-(5).
+7. `history.h` — `NonComputationalHistory` (sequence of (op-index,
+   qubit, branch, status-update, herald)). Depends on (1).
+8. `sampler.h/.cc` — history sampler that walks the parsed circuit,
    updates `QubitStatus` per shot, and enforces the §4.2 sample-time
    source-context check via the qubit_status accessors. Depends on
-   (1)-(6), `clifft::Circuit`, `clifft::AstNode`.
-8. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
+   (1)-(7), `clifft::Circuit`, `clifft::AstNode`.
+9. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
    `(original, history, model)`, inserting `R` at coherent-qubit loss
-   points and `X` prep for `basis_bit==1` initial samples. Depends on
-   (1)-(7) and `clifft::Circuit`.
-9. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
-   point that runs the full pipeline. Depends on (1)-(8), the existing
-   compile pipeline, and the SVM.
+   points and `X` prep for `basis_bit == One` initial samples.
+   Depends on (1)-(8) and `clifft::Circuit`.
+10. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
+    point that runs the full pipeline. Depends on (1)-(9), the
+    existing compile pipeline, and the SVM.
 
-Python bindings in `src/python/bindings.cc` expose:
-`Level`, `TransitionInstrument`, `MeasurementClassifier`,
-`NonComputationalPolicy`, `NonComputationalModel`,
+Python bindings in `src/python/bindings.cc` expose: `Level`,
+`BasisBit`, `LevelSet`, `TransitionInstrument`,
+`MeasurementClassifier`, `NonComputationalPolicy`,
+`NonComputationalModel`,
 `sample_noncomputational(circuit_text, model, shots, seed=None)`.
 
 ## 7. Test plan (dependency order)
@@ -599,10 +636,12 @@ Each test category lands once the headers it needs are in place. C++
 tests under `tests/test_noncomp_*.cc`; Python tests under
 `tests/python/test_noncomputational.py`.
 
-1. **`level`, `transition_instrument`, `classifier`,
-   `qubit_status` unit tests.**
-   - Default level set roundtrips; `basis_bit` required iff
-     `LevelCategory::Computational`.
+1. **`qubit_status`, `level`, `transition_instrument`, `classifier`
+   unit tests.**
+   - `LevelSet::default_set()` validates; missing `basis_bit` on a
+     Computational level rejects; unrecognized `LevelCategory` enum
+     value rejects; oversized level set rejects. Leaked-with-`basis_bit`
+     is accepted as optional metadata.
    - Matrix orientation: `T[to, from]` matches a known per-column
      no-jump weight.
    - `is_source_independent_on_computational` is true for identical
@@ -612,10 +651,10 @@ tests under `tests/test_noncomp_*.cc`; Python tests under
      enforced; column-sum > 1 rejected; mismatched (symbols, levels)
      dimensions rejected. `reject_probability(level_id)` matches
      `1 - sum(column)` for several hand-built matrices.
-   - `QubitStatus` invariants: `make_computational_known(g_id)` builds
-     fine; `make_computational_known(leak_g_id)` rejects;
-     `require_classical_source_level` on a `ComputationalUnknown`
-     status asserts/throws; `known_source_level` returns `nullopt` on
+   - `LevelSet` status factories: `computational_known(g_id)` builds
+     fine; `computational_known(leak_g_id)` rejects;
+     `require_classical_source_level()` on a `ComputationalUnknown`
+     status throws; `known_source_level()` returns `nullopt` on
      `ComputationalUnknown` and the carried level id otherwise.
 2. **`model` validation tests.**
    - Initial-state sum, unknown-gate keys, classifier shape, policy

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -113,7 +113,16 @@ in `ComputationalKnown` with a level whose `basis_bit` is `One`
 origin metadata (e.g., to record that the atom leaked from `|1>`).
 No current code path consumes it; consumers that want to integrate
 classifier or decoder metadata can read it directly. `Lost`-category
-levels by convention should leave `basis_bit` empty.
+levels must leave `basis_bit` empty — "lost from `|1>`" provenance,
+if ever needed, belongs in an event record or in distinct lost
+levels, not in the default lost level.
+
+`LevelSet` validation also requires the level table to contain
+exactly one `Computational` level with `basis_bit == Zero` and
+exactly one with `basis_bit == One`. Downstream paths (visible
+Z-basis measurement, Z-basis reset, initial prep, classifier
+defaults) need unambiguous `g`/`e` ids; duplicates or missing
+canonical levels reject at `LevelSet` construction.
 
 Default level set for the MVP (sqale-aligned):
 
@@ -133,14 +142,27 @@ set, but the default ships unchanged.
 ```cpp
 constexpr uint8_t kInvalidLevel = 0xFF;
 
-struct QubitStatus {
-    QubitStatusKind kind;
-    uint8_t level_id;  // meaning depends on `kind` (see invariants)
-
+class QubitStatus {
+public:
     static QubitStatus computational_unknown();
+
+    // Build a known-source status without validating level_id against
+    // a table. Reserved for tests and interior code; user code should
+    // go through LevelSet's validated factories.
+    static QubitStatus computational_known_unchecked(uint8_t level_id);
+    static QubitStatus leaked_unchecked(uint8_t level_id);
+    static QubitStatus lost_unchecked(uint8_t level_id);
+
+    QubitStatusKind kind() const;
+    uint8_t level_id() const;
     bool is_unknown_computational() const;
     std::optional<uint8_t> known_source_level() const;
     uint8_t require_classical_source_level() const;  // throws on Unknown
+
+private:
+    QubitStatus(QubitStatusKind kind, uint8_t level_id);
+    QubitStatusKind kind_;
+    uint8_t level_id_;
 };
 ```
 
@@ -167,9 +189,10 @@ QubitStatus u = level_set.lost(lost_id);
 QubitStatus v = QubitStatus::computational_unknown();  // no level id needed
 ```
 
-Direct aggregate construction `QubitStatus{kind, level_id}` compiles
-but bypasses validation; reserved for tests or interior code where
-the invariant is already established.
+`QubitStatus` is non-aggregate; its constructor is private. The
+`_unchecked` static factories exist for tests and for interior code
+where the invariant is already established (the name is the
+warning); user code goes through `LevelSet`.
 
 Source-dependent transitions must call `known_source_level()` or
 `require_classical_source_level()` so the "unknown coherent"
@@ -358,9 +381,11 @@ representable in the MVP.
    categories all in `LevelCategory` (unrecognized enum values reject).
    Every `Computational`-category level declares a `basis_bit` (the
    `BasisBit` enum restricts the value to `Zero` or `One`
-   structurally). Non-`Computational` levels may carry a `basis_bit`
-   as metadata; for `Lost`-category levels the convention is to
-   leave it empty.
+   structurally). `Leaked` levels may carry a `basis_bit` as
+   optional metadata; `Lost` levels must not. The table must contain
+   exactly one Computational level with `basis_bit == Zero` and
+   exactly one with `basis_bit == One` (downstream code needs
+   unambiguous `g`/`e` ids).
 2. **Initial state is a probability vector** over `levels`. Sums to 1
    within tolerance.
 3. **Transition matrices are square**, of size `len(levels)`, entries

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -12,8 +12,16 @@
 //     for basis_bit == One initial samples.
 //   - For LevelCategory::Leaked, basis_bit is optional metadata
 //     (origin / classifier hint). No current code path consumes it.
-//   - For LevelCategory::Lost, basis_bit should be left empty by
-//     convention. A vacated trap carries no useful state.
+//   - For LevelCategory::Lost, basis_bit MUST be empty. "Lost from
+//     |1>" provenance, if ever needed, belongs in an event record or
+//     in distinct lost levels — not the default lost level.
+//
+// LevelSet validation also enforces that the level table contains
+// exactly one Computational level with basis_bit == Zero and exactly
+// one with basis_bit == One. Downstream paths (visible Z-basis
+// measurement, Z-basis reset, initial prep, classifier defaults)
+// need unambiguous g/e ids; duplicates or missing canonical levels
+// reject at LevelSet construction.
 //
 // LevelSet wraps a std::vector<Level>, runs validation in its ctor,
 // and owns the QubitStatus factories that bind a level id to this
@@ -81,17 +89,17 @@ class LevelSet {
     // of the matching category in this table.
     QubitStatus computational_known(uint8_t level_id) const {
         check_kind(level_id, LevelCategory::Computational, "computational_known");
-        return QubitStatus{QubitStatusKind::ComputationalKnown, level_id};
+        return QubitStatus::computational_known_unchecked(level_id);
     }
 
     QubitStatus leaked(uint8_t level_id) const {
         check_kind(level_id, LevelCategory::Leaked, "leaked");
-        return QubitStatus{QubitStatusKind::Leaked, level_id};
+        return QubitStatus::leaked_unchecked(level_id);
     }
 
     QubitStatus lost(uint8_t level_id) const {
         check_kind(level_id, LevelCategory::Lost, "lost");
-        return QubitStatus{QubitStatusKind::Lost, level_id};
+        return QubitStatus::lost_unchecked(level_id);
     }
 
   private:
@@ -106,6 +114,8 @@ class LevelSet {
                                         std::to_string(levels_.size()) +
                                         " entries; max supported is 128");
         }
+        size_t computational_zero_count = 0;
+        size_t computational_one_count = 0;
         for (size_t i = 0; i < levels_.size(); ++i) {
             const Level& lv = levels_[i];
             switch (lv.category) {
@@ -115,18 +125,39 @@ class LevelSet {
                                                     std::to_string(i) +
                                                     ") is Computational but has no basis_bit");
                     }
+                    if (*lv.basis_bit == BasisBit::Zero) {
+                        ++computational_zero_count;
+                    } else {
+                        ++computational_one_count;
+                    }
                     break;
                 case LevelCategory::Leaked:
+                    // basis_bit allowed as optional origin metadata.
+                    break;
                 case LevelCategory::Lost:
-                    // Leaked: basis_bit allowed as optional metadata.
-                    // Lost: basis_bit should be empty by convention but
-                    // is not structurally enforced.
+                    if (lv.basis_bit.has_value()) {
+                        throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
+                                                    std::to_string(i) +
+                                                    ") is Lost and must not carry basis_bit");
+                    }
                     break;
                 default:
                     throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
                                                 std::to_string(i) +
                                                 ") has an unrecognized LevelCategory value");
             }
+        }
+        if (computational_zero_count != 1) {
+            throw std::invalid_argument(
+                "LevelSet: expected exactly one Computational level with basis_bit == Zero, "
+                "got " +
+                std::to_string(computational_zero_count));
+        }
+        if (computational_one_count != 1) {
+            throw std::invalid_argument(
+                "LevelSet: expected exactly one Computational level with basis_bit == One, "
+                "got " +
+                std::to_string(computational_one_count));
         }
     }
 

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -1,0 +1,88 @@
+#pragma once
+
+// Level categories and the per-level model record for the
+// noncomputational trajectory MVP. See design/noncomputational-mvp.md.
+//
+// A Level is a model-defined tag with a stable integer id (its index
+// into the level table), a human-readable label, a LevelCategory, and
+// an optional basis_bit identifying which computational basis state a
+// Computational-category level represents.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace clifft {
+
+enum class LevelCategory : uint8_t {
+    Computational = 0,
+    Leaked = 1,
+    Lost = 2,
+};
+
+struct Level {
+    std::string label;
+    LevelCategory category;
+    // Required when category == Computational; must be omitted otherwise.
+    // Identifies the computational basis state (0 or 1) this level
+    // represents. Used by the rewriter to prepend an X prep for
+    // basis_bit == 1 initial samples.
+    std::optional<uint8_t> basis_bit;
+};
+
+// Sqale-aligned default level set: g, e, leak_g, leak_e, lost.
+// Stable order; the integer ids are positional.
+inline std::vector<Level> default_levels() {
+    return {
+        Level{"g", LevelCategory::Computational, uint8_t{0}},
+        Level{"e", LevelCategory::Computational, uint8_t{1}},
+        Level{"leak_g", LevelCategory::Leaked, std::nullopt},
+        Level{"leak_e", LevelCategory::Leaked, std::nullopt},
+        Level{"lost", LevelCategory::Lost, std::nullopt},
+    };
+}
+
+// Validates the structural invariants of a level set. Throws
+// std::invalid_argument naming the offending entry on failure.
+//
+// Checks:
+//   - level set is non-empty and at most 128 entries (so a level_id
+//     fits in 7 bits if a future implementation packs the byte);
+//   - every Computational-category level has a basis_bit in {0, 1};
+//   - every Leaked/Lost-category level has basis_bit unset.
+inline void validate_levels(std::span<const Level> levels) {
+    if (levels.empty()) {
+        throw std::invalid_argument("validate_levels: level set is empty");
+    }
+    if (levels.size() > 128) {
+        throw std::invalid_argument("validate_levels: level set has " +
+                                    std::to_string(levels.size()) +
+                                    " entries; max supported is 128");
+    }
+    for (size_t i = 0; i < levels.size(); ++i) {
+        const Level& lv = levels[i];
+        if (lv.category == LevelCategory::Computational) {
+            if (!lv.basis_bit.has_value()) {
+                throw std::invalid_argument("validate_levels: level '" + lv.label + "' (id " +
+                                            std::to_string(i) +
+                                            ") is Computational but has no basis_bit");
+            }
+            if (*lv.basis_bit > 1) {
+                throw std::invalid_argument("validate_levels: level '" + lv.label +
+                                            "' has basis_bit = " + std::to_string(*lv.basis_bit) +
+                                            "; must be 0 or 1");
+            }
+        } else {
+            if (lv.basis_bit.has_value()) {
+                throw std::invalid_argument("validate_levels: level '" + lv.label + "' (id " +
+                                            std::to_string(i) +
+                                            ") is non-Computational but has basis_bit set");
+            }
+        }
+    }
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -1,18 +1,35 @@
 #pragma once
 
-// Level categories and the per-level model record for the
-// noncomputational trajectory MVP. See design/noncomputational-mvp.md.
+// Level definitions and the validated level table.
 //
 // A Level is a model-defined tag with a stable integer id (its index
 // into the level table), a human-readable label, a LevelCategory, and
-// an optional basis_bit identifying which computational basis state a
-// Computational-category level represents.
+// an optional basis_bit:
+//
+//   - For LevelCategory::Computational, basis_bit is REQUIRED and
+//     identifies which computational basis state (|0> or |1>) the
+//     level represents. The rewriter uses it to prepend an X prep
+//     for basis_bit == One initial samples.
+//   - For LevelCategory::Leaked, basis_bit is optional metadata
+//     (origin / classifier hint). No current code path consumes it.
+//   - For LevelCategory::Lost, basis_bit should be left empty by
+//     convention. A vacated trap carries no useful state.
+//
+// LevelSet wraps a std::vector<Level>, runs validation in its ctor,
+// and owns the QubitStatus factories that bind a level id to this
+// specific table. Construction of QubitStatus values for non-Unknown
+// kinds should go through LevelSet so the (kind, level_id) pair is
+// guaranteed to refer to a real level of the matching category in a
+// known table.
+
+#include "clifft/noncomp/qubit_status.h"
 
 #include <cstdint>
 #include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace clifft {
@@ -23,66 +40,112 @@ enum class LevelCategory : uint8_t {
     Lost = 2,
 };
 
+enum class BasisBit : uint8_t {
+    Zero = 0,
+    One = 1,
+};
+
 struct Level {
     std::string label;
     LevelCategory category;
-    // Required when category == Computational; must be omitted otherwise.
-    // Identifies the computational basis state (0 or 1) this level
-    // represents. Used by the rewriter to prepend an X prep for
-    // basis_bit == 1 initial samples.
-    std::optional<uint8_t> basis_bit;
+    std::optional<BasisBit> basis_bit;
 };
 
-// Sqale-aligned default level set: g, e, leak_g, leak_e, lost.
-// Stable order; the integer ids are positional.
-inline std::vector<Level> default_levels() {
-    return {
-        Level{"g", LevelCategory::Computational, uint8_t{0}},
-        Level{"e", LevelCategory::Computational, uint8_t{1}},
-        Level{"leak_g", LevelCategory::Leaked, std::nullopt},
-        Level{"leak_e", LevelCategory::Leaked, std::nullopt},
-        Level{"lost", LevelCategory::Lost, std::nullopt},
-    };
-}
+class LevelSet {
+  public:
+    // Validates the level table; throws std::invalid_argument with a
+    // named field on failure.
+    explicit LevelSet(std::vector<Level> levels) : levels_(std::move(levels)) { validate(); }
 
-// Validates the structural invariants of a level set. Throws
-// std::invalid_argument naming the offending entry on failure.
-//
-// Checks:
-//   - level set is non-empty and at most 128 entries (so a level_id
-//     fits in 7 bits if a future implementation packs the byte);
-//   - every Computational-category level has a basis_bit in {0, 1};
-//   - every Leaked/Lost-category level has basis_bit unset.
-inline void validate_levels(std::span<const Level> levels) {
-    if (levels.empty()) {
-        throw std::invalid_argument("validate_levels: level set is empty");
+    // Default level set: g, e, leak_g, leak_e, lost.
+    // Stable order; the integer ids are positional.
+    static LevelSet default_set() {
+        return LevelSet({
+            Level{"g", LevelCategory::Computational, BasisBit::Zero},
+            Level{"e", LevelCategory::Computational, BasisBit::One},
+            Level{"leak_g", LevelCategory::Leaked, std::nullopt},
+            Level{"leak_e", LevelCategory::Leaked, std::nullopt},
+            Level{"lost", LevelCategory::Lost, std::nullopt},
+        });
     }
-    if (levels.size() > 128) {
-        throw std::invalid_argument("validate_levels: level set has " +
-                                    std::to_string(levels.size()) +
-                                    " entries; max supported is 128");
+
+    std::span<const Level> levels() const { return levels_; }
+    size_t size() const { return levels_.size(); }
+
+    const Level& at(uint8_t level_id) const {
+        require_in_range(level_id, "at");
+        return levels_[level_id];
     }
-    for (size_t i = 0; i < levels.size(); ++i) {
-        const Level& lv = levels[i];
-        if (lv.category == LevelCategory::Computational) {
-            if (!lv.basis_bit.has_value()) {
-                throw std::invalid_argument("validate_levels: level '" + lv.label + "' (id " +
-                                            std::to_string(i) +
-                                            ") is Computational but has no basis_bit");
-            }
-            if (*lv.basis_bit > 1) {
-                throw std::invalid_argument("validate_levels: level '" + lv.label +
-                                            "' has basis_bit = " + std::to_string(*lv.basis_bit) +
-                                            "; must be 0 or 1");
-            }
-        } else {
-            if (lv.basis_bit.has_value()) {
-                throw std::invalid_argument("validate_levels: level '" + lv.label + "' (id " +
-                                            std::to_string(i) +
-                                            ") is non-Computational but has basis_bit set");
+
+    // QubitStatus factories: validate that level_id refers to a level
+    // of the matching category in this table.
+    QubitStatus computational_known(uint8_t level_id) const {
+        check_kind(level_id, LevelCategory::Computational, "computational_known");
+        return QubitStatus{QubitStatusKind::ComputationalKnown, level_id};
+    }
+
+    QubitStatus leaked(uint8_t level_id) const {
+        check_kind(level_id, LevelCategory::Leaked, "leaked");
+        return QubitStatus{QubitStatusKind::Leaked, level_id};
+    }
+
+    QubitStatus lost(uint8_t level_id) const {
+        check_kind(level_id, LevelCategory::Lost, "lost");
+        return QubitStatus{QubitStatusKind::Lost, level_id};
+    }
+
+  private:
+    std::vector<Level> levels_;
+
+    void validate() const {
+        if (levels_.empty()) {
+            throw std::invalid_argument("LevelSet: level set is empty");
+        }
+        if (levels_.size() > 128) {
+            throw std::invalid_argument("LevelSet: level set has " +
+                                        std::to_string(levels_.size()) +
+                                        " entries; max supported is 128");
+        }
+        for (size_t i = 0; i < levels_.size(); ++i) {
+            const Level& lv = levels_[i];
+            switch (lv.category) {
+                case LevelCategory::Computational:
+                    if (!lv.basis_bit.has_value()) {
+                        throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
+                                                    std::to_string(i) +
+                                                    ") is Computational but has no basis_bit");
+                    }
+                    break;
+                case LevelCategory::Leaked:
+                case LevelCategory::Lost:
+                    // Leaked: basis_bit allowed as optional metadata.
+                    // Lost: basis_bit should be empty by convention but
+                    // is not structurally enforced.
+                    break;
+                default:
+                    throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
+                                                std::to_string(i) +
+                                                ") has an unrecognized LevelCategory value");
             }
         }
     }
-}
+
+    void require_in_range(uint8_t level_id, const char* fn) const {
+        if (level_id >= levels_.size()) {
+            throw std::invalid_argument(std::string("LevelSet::") + fn + ": level_id " +
+                                        std::to_string(level_id) + " out of range (size " +
+                                        std::to_string(levels_.size()) + ")");
+        }
+    }
+
+    void check_kind(uint8_t level_id, LevelCategory expected, const char* fn) const {
+        require_in_range(level_id, fn);
+        if (levels_[level_id].category != expected) {
+            throw std::invalid_argument(std::string("LevelSet::") + fn + ": level '" +
+                                        levels_[level_id].label +
+                                        "' has category that does not match the requested kind");
+        }
+    }
+};
 
 }  // namespace clifft

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// Policy knobs for the noncomputational trajectory MVP. See
+// design/noncomputational-mvp.md sections 4.2 and 5.2.
+
+#include <cstdint>
+
+namespace clifft {
+
+// How the runtime sampler handles a source-dependent transition that
+// fires on a ComputationalUnknown qubit. The MVP exposes only Reject;
+// the EqualizeRates compat mode (section 9 of the design note) is
+// future work but the enum slot is reserved now so adding it later
+// does not break the ABI.
+enum class UnknownSourcePolicy : uint8_t {
+    Reject = 0,
+    // EqualizeRates = 1,  // reserved for future sqale-compat approximation
+};
+
+struct NonComputationalPolicy {
+    // When true, lost-qubit reset (R/RX/RY) restores the qubit to a
+    // computational state per the section 5.2 table. When false
+    // (default), lost-qubit reset rejects.
+    bool reset_restores_lost = false;
+
+    UnknownSourcePolicy unknown_source_policy = UnknownSourcePolicy::Reject;
+};
+
+}  // namespace clifft

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -1,26 +1,20 @@
 #pragma once
 
-// Policy knobs for the noncomputational trajectory MVP. See
-// design/noncomputational-mvp.md sections 4.2 and 5.2.
+// Policy knobs for the noncomputational trajectory model.
 
 #include <cstdint>
 
 namespace clifft {
 
-// How the runtime sampler handles a source-dependent transition that
-// fires on a ComputationalUnknown qubit. The MVP exposes only Reject;
-// the EqualizeRates compat mode (section 9 of the design note) is
-// future work but the enum slot is reserved now so adding it later
-// does not break the ABI.
+// Policy for transitions that fire on a ComputationalUnknown qubit.
 enum class UnknownSourcePolicy : uint8_t {
     Reject = 0,
-    // EqualizeRates = 1,  // reserved for future sqale-compat approximation
 };
 
 struct NonComputationalPolicy {
     // When true, lost-qubit reset (R/RX/RY) restores the qubit to a
-    // computational state per the section 5.2 table. When false
-    // (default), lost-qubit reset rejects.
+    // computational state. When false (default), lost-qubit reset
+    // rejects.
     bool reset_restores_lost = false;
 
     UnknownSourcePolicy unknown_source_policy = UnknownSourcePolicy::Reject;

--- a/src/clifft/noncomp/qubit_status.h
+++ b/src/clifft/noncomp/qubit_status.h
@@ -17,18 +17,13 @@
 //                          the Lost level (typically a single
 //                          "lost" level).
 //
-// QubitStatus is a plain aggregate so callers may construct it via
-// designated initializers when convenient, but the canonical builders
-// live on LevelSet (see level.h):
-//
-//   LevelSet::computational_known(level_id)
-//   LevelSet::leaked(level_id)
-//   LevelSet::lost(level_id)
-//
-// Those factories validate that the level id refers to a level of
-// the matching category in the LevelSet's table. Direct aggregate
-// construction bypasses that check and should be reserved for tests
-// or interior code where the invariant is already established.
+// QubitStatus is non-aggregate; the only construction paths are the
+// public static factories. The canonical validated builders live on
+// LevelSet (see level.h), which calls the _unchecked factories here
+// after checking the level id matches the requested kind in its
+// table. The _unchecked factories are public for use by tests and
+// by interior code where the invariant is already established; their
+// name is the warning.
 
 #include <cstdint>
 #include <optional>
@@ -47,25 +42,38 @@ enum class QubitStatusKind : uint8_t {
 // Valid only with kind == ComputationalUnknown.
 constexpr uint8_t kInvalidLevel = 0xFF;
 
-struct QubitStatus {
-    QubitStatusKind kind;
-    uint8_t level_id;
-
-    // The no-resolved-source case has no level id to record.
+class QubitStatus {
+  public:
     static QubitStatus computational_unknown() {
-        return QubitStatus{QubitStatusKind::ComputationalUnknown, kInvalidLevel};
+        return QubitStatus(QubitStatusKind::ComputationalUnknown, kInvalidLevel);
     }
 
-    bool is_unknown_computational() const { return kind == QubitStatusKind::ComputationalUnknown; }
+    // Construct a known-source status without checking level_id against
+    // a level table. Tests and interior code may call these; user code
+    // should prefer LevelSet::computational_known / leaked / lost.
+    static QubitStatus computational_known_unchecked(uint8_t level_id) {
+        return QubitStatus(QubitStatusKind::ComputationalKnown, level_id);
+    }
+    static QubitStatus leaked_unchecked(uint8_t level_id) {
+        return QubitStatus(QubitStatusKind::Leaked, level_id);
+    }
+    static QubitStatus lost_unchecked(uint8_t level_id) {
+        return QubitStatus(QubitStatusKind::Lost, level_id);
+    }
 
-    // Returns the resolved level id when the qubit has a known
-    // source (ComputationalKnown, Leaked, or Lost); nullopt when the
-    // source is unresolved (ComputationalUnknown).
+    QubitStatusKind kind() const { return kind_; }
+    uint8_t level_id() const { return level_id_; }
+
+    bool is_unknown_computational() const { return kind_ == QubitStatusKind::ComputationalUnknown; }
+
+    // Returns the resolved level id when the qubit has a known source
+    // (ComputationalKnown, Leaked, or Lost); nullopt when the source
+    // is unresolved (ComputationalUnknown).
     std::optional<uint8_t> known_source_level() const {
-        if (kind == QubitStatusKind::ComputationalUnknown) {
+        if (kind_ == QubitStatusKind::ComputationalUnknown) {
             return std::nullopt;
         }
-        return level_id;
+        return level_id_;
     }
 
     // Like known_source_level but throws on ComputationalUnknown. Use
@@ -73,13 +81,19 @@ struct QubitStatus {
     // (classical Markov transitions; selecting a transition-matrix
     // column for a known-coherent source).
     uint8_t require_classical_source_level() const {
-        if (kind == QubitStatusKind::ComputationalUnknown) {
+        if (kind_ == QubitStatusKind::ComputationalUnknown) {
             throw std::invalid_argument(
                 "require_classical_source_level: qubit kind is "
                 "ComputationalUnknown; no resolved level id");
         }
-        return level_id;
+        return level_id_;
     }
+
+  private:
+    QubitStatus(QubitStatusKind kind, uint8_t level_id) : kind_(kind), level_id_(level_id) {}
+
+    QubitStatusKind kind_;
+    uint8_t level_id_;
 };
 
 }  // namespace clifft

--- a/src/clifft/noncomp/qubit_status.h
+++ b/src/clifft/noncomp/qubit_status.h
@@ -1,30 +1,38 @@
 #pragma once
 
-// Per-qubit runtime status for the noncomputational trajectory MVP.
-// See design/noncomputational-mvp.md section 2.1 (enums) and 2.3
-// (tagged QubitStatus + invariants).
+// Per-qubit runtime status carried by a sampled trajectory.
 //
-// The tag QubitStatusKind splits the computational case by whether
-// the energy-basis value has been resolved. The level_id field has a
-// meaning that depends on the tag:
+// QubitStatusKind tags how much we know about the qubit's state:
 //
-//   ComputationalUnknown : level_id == kInvalidLevel (no resolved source)
-//   ComputationalKnown   : level_id is a Computational-category level
-//   Leaked               : level_id is a Leaked-category level
-//   Lost                 : level_id is a Lost-category level
+//   ComputationalUnknown : in an arbitrary quantum state on H_C
+//                          (a superposition of |0> and |1>). The
+//                          level_id field is not meaningful.
+//   ComputationalKnown   : in a known computational basis state
+//                          (|0> or |1>). level_id identifies which
+//                          Computational level the qubit holds.
+//   Leaked               : outside the computational subspace.
+//                          level_id identifies which Leaked level
+//                          the qubit holds.
+//   Lost                 : absent / vacuum. level_id identifies
+//                          the Lost level (typically a single
+//                          "lost" level).
 //
-// Factories enforce these invariants at construction time so that an
-// "unknown coherent" qubit cannot accidentally expose a stale level
-// id to a source-dependent transition. Accessors enforce the
-// invariants on read.
-
-#include "clifft/noncomp/level.h"
+// QubitStatus is a plain aggregate so callers may construct it via
+// designated initializers when convenient, but the canonical builders
+// live on LevelSet (see level.h):
+//
+//   LevelSet::computational_known(level_id)
+//   LevelSet::leaked(level_id)
+//   LevelSet::lost(level_id)
+//
+// Those factories validate that the level id refers to a level of
+// the matching category in the LevelSet's table. Direct aggregate
+// construction bypasses that check and should be reserved for tests
+// or interior code where the invariant is already established.
 
 #include <cstdint>
 #include <optional>
-#include <span>
 #include <stdexcept>
-#include <string>
 
 namespace clifft {
 
@@ -42,73 +50,36 @@ constexpr uint8_t kInvalidLevel = 0xFF;
 struct QubitStatus {
     QubitStatusKind kind;
     uint8_t level_id;
+
+    // The no-resolved-source case has no level id to record.
+    static QubitStatus computational_unknown() {
+        return QubitStatus{QubitStatusKind::ComputationalUnknown, kInvalidLevel};
+    }
+
+    bool is_unknown_computational() const { return kind == QubitStatusKind::ComputationalUnknown; }
+
+    // Returns the resolved level id when the qubit has a known
+    // source (ComputationalKnown, Leaked, or Lost); nullopt when the
+    // source is unresolved (ComputationalUnknown).
+    std::optional<uint8_t> known_source_level() const {
+        if (kind == QubitStatusKind::ComputationalUnknown) {
+            return std::nullopt;
+        }
+        return level_id;
+    }
+
+    // Like known_source_level but throws on ComputationalUnknown. Use
+    // in code paths where the caller must consult a definite level id
+    // (classical Markov transitions; selecting a transition-matrix
+    // column for a known-coherent source).
+    uint8_t require_classical_source_level() const {
+        if (kind == QubitStatusKind::ComputationalUnknown) {
+            throw std::invalid_argument(
+                "require_classical_source_level: qubit kind is "
+                "ComputationalUnknown; no resolved level id");
+        }
+        return level_id;
+    }
 };
-
-// Factories ---------------------------------------------------------------
-
-inline QubitStatus make_computational_unknown() {
-    return QubitStatus{QubitStatusKind::ComputationalUnknown, kInvalidLevel};
-}
-
-namespace detail {
-inline void check_level_for_kind(uint8_t level_id, LevelCategory expected,
-                                 std::span<const Level> levels, const char* factory_name) {
-    if (level_id >= levels.size()) {
-        throw std::invalid_argument(std::string(factory_name) + ": level_id " +
-                                    std::to_string(level_id) + " out of range (level set has " +
-                                    std::to_string(levels.size()) + " entries)");
-    }
-    if (levels[level_id].category != expected) {
-        throw std::invalid_argument(std::string(factory_name) + ": level '" +
-                                    levels[level_id].label +
-                                    "' has category that does not match the requested kind");
-    }
-}
-}  // namespace detail
-
-inline QubitStatus make_computational_known(uint8_t level_id, std::span<const Level> levels) {
-    detail::check_level_for_kind(level_id, LevelCategory::Computational, levels,
-                                 "make_computational_known");
-    return QubitStatus{QubitStatusKind::ComputationalKnown, level_id};
-}
-
-inline QubitStatus make_leaked(uint8_t level_id, std::span<const Level> levels) {
-    detail::check_level_for_kind(level_id, LevelCategory::Leaked, levels, "make_leaked");
-    return QubitStatus{QubitStatusKind::Leaked, level_id};
-}
-
-inline QubitStatus make_lost(uint8_t level_id, std::span<const Level> levels) {
-    detail::check_level_for_kind(level_id, LevelCategory::Lost, levels, "make_lost");
-    return QubitStatus{QubitStatusKind::Lost, level_id};
-}
-
-// Accessors ---------------------------------------------------------------
-
-inline bool is_unknown_computational(const QubitStatus& s) {
-    return s.kind == QubitStatusKind::ComputationalUnknown;
-}
-
-// Returns the resolved level id when the qubit has a known source
-// (ComputationalKnown, Leaked, or Lost); nullopt when the source is
-// unresolved (ComputationalUnknown).
-inline std::optional<uint8_t> known_source_level(const QubitStatus& s) {
-    if (s.kind == QubitStatusKind::ComputationalUnknown) {
-        return std::nullopt;
-    }
-    return s.level_id;
-}
-
-// Like known_source_level but throws std::invalid_argument on
-// ComputationalUnknown. Use in code paths where the caller must consult
-// a definite level id (classical Markov transitions; selecting a
-// transition-matrix column for a known-coherent source).
-inline uint8_t require_classical_source_level(const QubitStatus& s) {
-    if (s.kind == QubitStatusKind::ComputationalUnknown) {
-        throw std::invalid_argument(
-            "require_classical_source_level: qubit kind is "
-            "ComputationalUnknown; no resolved level id");
-    }
-    return s.level_id;
-}
 
 }  // namespace clifft

--- a/src/clifft/noncomp/qubit_status.h
+++ b/src/clifft/noncomp/qubit_status.h
@@ -1,0 +1,114 @@
+#pragma once
+
+// Per-qubit runtime status for the noncomputational trajectory MVP.
+// See design/noncomputational-mvp.md section 2.1 (enums) and 2.3
+// (tagged QubitStatus + invariants).
+//
+// The tag QubitStatusKind splits the computational case by whether
+// the energy-basis value has been resolved. The level_id field has a
+// meaning that depends on the tag:
+//
+//   ComputationalUnknown : level_id == kInvalidLevel (no resolved source)
+//   ComputationalKnown   : level_id is a Computational-category level
+//   Leaked               : level_id is a Leaked-category level
+//   Lost                 : level_id is a Lost-category level
+//
+// Factories enforce these invariants at construction time so that an
+// "unknown coherent" qubit cannot accidentally expose a stale level
+// id to a source-dependent transition. Accessors enforce the
+// invariants on read.
+
+#include "clifft/noncomp/level.h"
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+
+namespace clifft {
+
+enum class QubitStatusKind : uint8_t {
+    ComputationalUnknown = 0,
+    ComputationalKnown = 1,
+    Leaked = 2,
+    Lost = 3,
+};
+
+// Sentinel for the level_id field when no specific level is resolved.
+// Valid only with kind == ComputationalUnknown.
+constexpr uint8_t kInvalidLevel = 0xFF;
+
+struct QubitStatus {
+    QubitStatusKind kind;
+    uint8_t level_id;
+};
+
+// Factories ---------------------------------------------------------------
+
+inline QubitStatus make_computational_unknown() {
+    return QubitStatus{QubitStatusKind::ComputationalUnknown, kInvalidLevel};
+}
+
+namespace detail {
+inline void check_level_for_kind(uint8_t level_id, LevelCategory expected,
+                                 std::span<const Level> levels, const char* factory_name) {
+    if (level_id >= levels.size()) {
+        throw std::invalid_argument(std::string(factory_name) + ": level_id " +
+                                    std::to_string(level_id) + " out of range (level set has " +
+                                    std::to_string(levels.size()) + " entries)");
+    }
+    if (levels[level_id].category != expected) {
+        throw std::invalid_argument(std::string(factory_name) + ": level '" +
+                                    levels[level_id].label +
+                                    "' has category that does not match the requested kind");
+    }
+}
+}  // namespace detail
+
+inline QubitStatus make_computational_known(uint8_t level_id, std::span<const Level> levels) {
+    detail::check_level_for_kind(level_id, LevelCategory::Computational, levels,
+                                 "make_computational_known");
+    return QubitStatus{QubitStatusKind::ComputationalKnown, level_id};
+}
+
+inline QubitStatus make_leaked(uint8_t level_id, std::span<const Level> levels) {
+    detail::check_level_for_kind(level_id, LevelCategory::Leaked, levels, "make_leaked");
+    return QubitStatus{QubitStatusKind::Leaked, level_id};
+}
+
+inline QubitStatus make_lost(uint8_t level_id, std::span<const Level> levels) {
+    detail::check_level_for_kind(level_id, LevelCategory::Lost, levels, "make_lost");
+    return QubitStatus{QubitStatusKind::Lost, level_id};
+}
+
+// Accessors ---------------------------------------------------------------
+
+inline bool is_unknown_computational(const QubitStatus& s) {
+    return s.kind == QubitStatusKind::ComputationalUnknown;
+}
+
+// Returns the resolved level id when the qubit has a known source
+// (ComputationalKnown, Leaked, or Lost); nullopt when the source is
+// unresolved (ComputationalUnknown).
+inline std::optional<uint8_t> known_source_level(const QubitStatus& s) {
+    if (s.kind == QubitStatusKind::ComputationalUnknown) {
+        return std::nullopt;
+    }
+    return s.level_id;
+}
+
+// Like known_source_level but throws std::invalid_argument on
+// ComputationalUnknown. Use in code paths where the caller must consult
+// a definite level id (classical Markov transitions; selecting a
+// transition-matrix column for a known-coherent source).
+inline uint8_t require_classical_source_level(const QubitStatus& s) {
+    if (s.kind == QubitStatusKind::ComputationalUnknown) {
+        throw std::invalid_argument(
+            "require_classical_source_level: qubit kind is "
+            "ComputationalUnknown; no resolved level id");
+    }
+    return s.level_id;
+}
+
+}  // namespace clifft

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(clifft_tests
     test_exp_value.cc
     test_openmp.cc
     test_fuzz.cc
+    test_noncomp_value_types.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_value_types.cc
+++ b/tests/test_noncomp_value_types.cc
@@ -9,98 +9,164 @@
 #include <vector>
 
 using Catch::Matchers::ContainsSubstring;
-using clifft::is_unknown_computational;
+using clifft::BasisBit;
 using clifft::kInvalidLevel;
-using clifft::known_source_level;
 using clifft::Level;
 using clifft::LevelCategory;
-using clifft::make_computational_known;
-using clifft::make_computational_unknown;
-using clifft::make_leaked;
-using clifft::make_lost;
+using clifft::LevelSet;
 using clifft::NonComputationalPolicy;
+using clifft::QubitStatus;
 using clifft::QubitStatusKind;
-using clifft::require_classical_source_level;
 using clifft::UnknownSourcePolicy;
 
 // =========================================================================
-// Level
+// LevelSet construction / validation
 // =========================================================================
 
-TEST_CASE("Level: default set matches the sqale-aligned schema") {
-    auto levels = clifft::default_levels();
-
-    REQUIRE(levels.size() == 5);
-
-    REQUIRE(levels[0].label == "g");
-    REQUIRE(levels[0].category == LevelCategory::Computational);
-    REQUIRE(levels[0].basis_bit.has_value());
-    REQUIRE(*levels[0].basis_bit == 0);
-
-    REQUIRE(levels[1].label == "e");
-    REQUIRE(levels[1].category == LevelCategory::Computational);
-    REQUIRE(*levels[1].basis_bit == 1);
-
-    REQUIRE(levels[2].label == "leak_g");
-    REQUIRE(levels[2].category == LevelCategory::Leaked);
-    REQUIRE_FALSE(levels[2].basis_bit.has_value());
-
-    REQUIRE(levels[3].label == "leak_e");
-    REQUIRE(levels[3].category == LevelCategory::Leaked);
-    REQUIRE_FALSE(levels[3].basis_bit.has_value());
-
-    REQUIRE(levels[4].label == "lost");
-    REQUIRE(levels[4].category == LevelCategory::Lost);
-    REQUIRE_FALSE(levels[4].basis_bit.has_value());
+TEST_CASE("LevelSet: default_set validates and exposes the expected levels") {
+    LevelSet set = LevelSet::default_set();
+    REQUIRE(set.size() == 5);
+    REQUIRE(set.at(0).category == LevelCategory::Computational);
+    REQUIRE(set.at(0).basis_bit == BasisBit::Zero);
+    REQUIRE(set.at(1).category == LevelCategory::Computational);
+    REQUIRE(set.at(1).basis_bit == BasisBit::One);
+    REQUIRE(set.at(2).category == LevelCategory::Leaked);
+    REQUIRE(set.at(4).category == LevelCategory::Lost);
 }
 
-TEST_CASE("validate_levels: accepts the default set") {
-    auto levels = clifft::default_levels();
-    REQUIRE_NOTHROW(clifft::validate_levels(levels));
+TEST_CASE("LevelSet: rejects empty level set") {
+    REQUIRE_THROWS_AS(LevelSet(std::vector<Level>{}), std::invalid_argument);
 }
 
-TEST_CASE("validate_levels: rejects empty level set") {
-    std::vector<Level> empty;
-    REQUIRE_THROWS_AS(clifft::validate_levels(empty), std::invalid_argument);
-}
-
-TEST_CASE("validate_levels: rejects Computational level missing basis_bit") {
+TEST_CASE("LevelSet: rejects Computational level missing basis_bit") {
     std::vector<Level> levels = {
         Level{"g", LevelCategory::Computational, std::nullopt},
     };
-    REQUIRE_THROWS_WITH(clifft::validate_levels(levels),
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
                         ContainsSubstring("Computational") && ContainsSubstring("basis_bit"));
 }
 
-TEST_CASE("validate_levels: rejects Computational level with basis_bit > 1") {
+TEST_CASE("LevelSet: accepts Leaked level carrying optional basis_bit metadata") {
     std::vector<Level> levels = {
-        Level{"weird", LevelCategory::Computational, uint8_t{2}},
+        Level{"g", LevelCategory::Computational, BasisBit::Zero},
+        Level{"e", LevelCategory::Computational, BasisBit::One},
+        // Single Leaked level with origin metadata.
+        Level{"leak", LevelCategory::Leaked, BasisBit::One},
+        Level{"lost", LevelCategory::Lost, std::nullopt},
     };
-    REQUIRE_THROWS_WITH(clifft::validate_levels(levels), ContainsSubstring("basis_bit"));
+    REQUIRE_NOTHROW(LevelSet(std::move(levels)));
 }
 
-TEST_CASE("validate_levels: rejects Leaked level carrying a basis_bit") {
-    std::vector<Level> levels = {
-        Level{"leak_g", LevelCategory::Leaked, uint8_t{0}},
-    };
-    REQUIRE_THROWS_WITH(clifft::validate_levels(levels),
-                        ContainsSubstring("non-Computational") && ContainsSubstring("basis_bit"));
-}
-
-TEST_CASE("validate_levels: rejects Lost level carrying a basis_bit") {
-    std::vector<Level> levels = {
-        Level{"lost", LevelCategory::Lost, uint8_t{0}},
-    };
-    REQUIRE_THROWS_AS(clifft::validate_levels(levels), std::invalid_argument);
-}
-
-TEST_CASE("validate_levels: rejects level sets above the 128-entry cap") {
+TEST_CASE("LevelSet: rejects level set above the 128-entry cap") {
     std::vector<Level> levels;
     levels.reserve(129);
     for (size_t i = 0; i < 129; ++i) {
-        levels.push_back(Level{"L" + std::to_string(i), LevelCategory::Computational, uint8_t{0}});
+        levels.push_back(
+            Level{"L" + std::to_string(i), LevelCategory::Computational, BasisBit::Zero});
     }
-    REQUIRE_THROWS_WITH(clifft::validate_levels(levels), ContainsSubstring("128"));
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)), ContainsSubstring("128"));
+}
+
+TEST_CASE("LevelSet: rejects unrecognized LevelCategory enum value") {
+    std::vector<Level> levels = {
+        Level{"weird", static_cast<LevelCategory>(99), std::nullopt},
+    };
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
+                        ContainsSubstring("unrecognized LevelCategory"));
+}
+
+// =========================================================================
+// LevelSet status factories
+// =========================================================================
+
+TEST_CASE("LevelSet::computational_known accepts a Computational level id") {
+    LevelSet set = LevelSet::default_set();
+    QubitStatus s = set.computational_known(0);
+    REQUIRE(s.kind == QubitStatusKind::ComputationalKnown);
+    REQUIRE(s.level_id == 0);
+
+    QubitStatus t = set.computational_known(1);
+    REQUIRE(t.kind == QubitStatusKind::ComputationalKnown);
+    REQUIRE(t.level_id == 1);
+}
+
+TEST_CASE("LevelSet::computational_known rejects non-Computational ids") {
+    LevelSet set = LevelSet::default_set();
+    REQUIRE_THROWS_AS(set.computational_known(2),  // leak_g
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(set.computational_known(4),  // lost
+                      std::invalid_argument);
+}
+
+TEST_CASE("LevelSet::computational_known rejects out-of-range id") {
+    LevelSet set = LevelSet::default_set();
+    REQUIRE_THROWS_WITH(set.computational_known(99), ContainsSubstring("out of range"));
+}
+
+TEST_CASE("LevelSet::leaked accepts a Leaked level id, rejects others") {
+    LevelSet set = LevelSet::default_set();
+    REQUIRE_NOTHROW(set.leaked(2));   // leak_g
+    REQUIRE_NOTHROW(set.leaked(3));   // leak_e
+    REQUIRE_THROWS_AS(set.leaked(0),  // g
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(set.leaked(4),  // lost
+                      std::invalid_argument);
+}
+
+TEST_CASE("LevelSet::lost accepts a Lost level id, rejects others") {
+    LevelSet set = LevelSet::default_set();
+    REQUIRE_NOTHROW(set.lost(4));   // lost
+    REQUIRE_THROWS_AS(set.lost(0),  // g
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(set.lost(2),  // leak_g
+                      std::invalid_argument);
+}
+
+// =========================================================================
+// QubitStatus
+// =========================================================================
+
+TEST_CASE("QubitStatus::computational_unknown carries kInvalidLevel") {
+    QubitStatus s = QubitStatus::computational_unknown();
+    REQUIRE(s.kind == QubitStatusKind::ComputationalUnknown);
+    REQUIRE(s.level_id == kInvalidLevel);
+}
+
+TEST_CASE("QubitStatus::is_unknown_computational is true only for Unknown") {
+    LevelSet set = LevelSet::default_set();
+    REQUIRE(QubitStatus::computational_unknown().is_unknown_computational());
+    REQUIRE_FALSE(set.computational_known(0).is_unknown_computational());
+    REQUIRE_FALSE(set.leaked(2).is_unknown_computational());
+    REQUIRE_FALSE(set.lost(4).is_unknown_computational());
+}
+
+TEST_CASE("QubitStatus::known_source_level returns nullopt on Unknown, id otherwise") {
+    LevelSet set = LevelSet::default_set();
+
+    REQUIRE_FALSE(QubitStatus::computational_unknown().known_source_level().has_value());
+
+    auto k = set.computational_known(1).known_source_level();
+    REQUIRE(k.has_value());
+    REQUIRE(*k == 1);
+
+    auto leaked = set.leaked(2).known_source_level();
+    REQUIRE(leaked.has_value());
+    REQUIRE(*leaked == 2);
+
+    auto lost = set.lost(4).known_source_level();
+    REQUIRE(lost.has_value());
+    REQUIRE(*lost == 4);
+}
+
+TEST_CASE("QubitStatus::require_classical_source_level throws on Unknown") {
+    LevelSet set = LevelSet::default_set();
+
+    REQUIRE_THROWS_AS(QubitStatus::computational_unknown().require_classical_source_level(),
+                      std::invalid_argument);
+
+    REQUIRE(set.computational_known(0).require_classical_source_level() == 0);
+    REQUIRE(set.leaked(3).require_classical_source_level() == 3);
+    REQUIRE(set.lost(4).require_classical_source_level() == 4);
 }
 
 // =========================================================================
@@ -117,102 +183,4 @@ TEST_CASE("NonComputationalPolicy: explicit overrides round-trip") {
     NonComputationalPolicy policy;
     policy.reset_restores_lost = true;
     REQUIRE(policy.reset_restores_lost == true);
-}
-
-// =========================================================================
-// QubitStatus factories: invariants are structural
-// =========================================================================
-
-TEST_CASE("make_computational_unknown: carries kInvalidLevel") {
-    auto s = make_computational_unknown();
-    REQUIRE(s.kind == QubitStatusKind::ComputationalUnknown);
-    REQUIRE(s.level_id == kInvalidLevel);
-}
-
-TEST_CASE("make_computational_known: accepts a Computational level") {
-    auto levels = clifft::default_levels();
-    auto s = make_computational_known(0, levels);  // g
-    REQUIRE(s.kind == QubitStatusKind::ComputationalKnown);
-    REQUIRE(s.level_id == 0);
-
-    auto t = make_computational_known(1, levels);  // e
-    REQUIRE(t.kind == QubitStatusKind::ComputationalKnown);
-    REQUIRE(t.level_id == 1);
-}
-
-TEST_CASE("make_computational_known: rejects a Leaked level") {
-    auto levels = clifft::default_levels();
-    REQUIRE_THROWS_AS(make_computational_known(2, levels),  // leak_g
-                      std::invalid_argument);
-}
-
-TEST_CASE("make_computational_known: rejects a Lost level") {
-    auto levels = clifft::default_levels();
-    REQUIRE_THROWS_AS(make_computational_known(4, levels),  // lost
-                      std::invalid_argument);
-}
-
-TEST_CASE("make_computational_known: rejects out-of-range level_id") {
-    auto levels = clifft::default_levels();
-    REQUIRE_THROWS_WITH(make_computational_known(99, levels), ContainsSubstring("out of range"));
-}
-
-TEST_CASE("make_leaked: accepts a Leaked level, rejects others") {
-    auto levels = clifft::default_levels();
-    REQUIRE_NOTHROW(make_leaked(2, levels));   // leak_g
-    REQUIRE_NOTHROW(make_leaked(3, levels));   // leak_e
-    REQUIRE_THROWS_AS(make_leaked(0, levels),  // g
-                      std::invalid_argument);
-    REQUIRE_THROWS_AS(make_leaked(4, levels),  // lost
-                      std::invalid_argument);
-}
-
-TEST_CASE("make_lost: accepts a Lost level, rejects others") {
-    auto levels = clifft::default_levels();
-    REQUIRE_NOTHROW(make_lost(4, levels));   // lost
-    REQUIRE_THROWS_AS(make_lost(0, levels),  // g
-                      std::invalid_argument);
-    REQUIRE_THROWS_AS(make_lost(2, levels),  // leak_g
-                      std::invalid_argument);
-}
-
-// =========================================================================
-// QubitStatus accessors
-// =========================================================================
-
-TEST_CASE("is_unknown_computational: true only for ComputationalUnknown") {
-    auto levels = clifft::default_levels();
-    REQUIRE(is_unknown_computational(make_computational_unknown()));
-    REQUIRE_FALSE(is_unknown_computational(make_computational_known(0, levels)));
-    REQUIRE_FALSE(is_unknown_computational(make_leaked(2, levels)));
-    REQUIRE_FALSE(is_unknown_computational(make_lost(4, levels)));
-}
-
-TEST_CASE("known_source_level: nullopt on Unknown, the level id otherwise") {
-    auto levels = clifft::default_levels();
-
-    REQUIRE_FALSE(known_source_level(make_computational_unknown()).has_value());
-
-    auto k = known_source_level(make_computational_known(1, levels));
-    REQUIRE(k.has_value());
-    REQUIRE(*k == 1);
-
-    auto leaked = known_source_level(make_leaked(2, levels));
-    REQUIRE(leaked.has_value());
-    REQUIRE(*leaked == 2);
-
-    auto lost = known_source_level(make_lost(4, levels));
-    REQUIRE(lost.has_value());
-    REQUIRE(*lost == 4);
-}
-
-TEST_CASE("require_classical_source_level: throws on Unknown, returns id otherwise") {
-    auto levels = clifft::default_levels();
-
-    REQUIRE_THROWS_AS(require_classical_source_level(make_computational_unknown()),
-                      std::invalid_argument);
-
-    REQUIRE(require_classical_source_level(make_computational_known(0, levels)) == 0);
-    REQUIRE(require_classical_source_level(make_leaked(3, levels)) == 3);
-    REQUIRE(require_classical_source_level(make_lost(4, levels)) == 4);
 }

--- a/tests/test_noncomp_value_types.cc
+++ b/tests/test_noncomp_value_types.cc
@@ -1,0 +1,218 @@
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/qubit_status.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <stdexcept>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using clifft::is_unknown_computational;
+using clifft::kInvalidLevel;
+using clifft::known_source_level;
+using clifft::Level;
+using clifft::LevelCategory;
+using clifft::make_computational_known;
+using clifft::make_computational_unknown;
+using clifft::make_leaked;
+using clifft::make_lost;
+using clifft::NonComputationalPolicy;
+using clifft::QubitStatusKind;
+using clifft::require_classical_source_level;
+using clifft::UnknownSourcePolicy;
+
+// =========================================================================
+// Level
+// =========================================================================
+
+TEST_CASE("Level: default set matches the sqale-aligned schema") {
+    auto levels = clifft::default_levels();
+
+    REQUIRE(levels.size() == 5);
+
+    REQUIRE(levels[0].label == "g");
+    REQUIRE(levels[0].category == LevelCategory::Computational);
+    REQUIRE(levels[0].basis_bit.has_value());
+    REQUIRE(*levels[0].basis_bit == 0);
+
+    REQUIRE(levels[1].label == "e");
+    REQUIRE(levels[1].category == LevelCategory::Computational);
+    REQUIRE(*levels[1].basis_bit == 1);
+
+    REQUIRE(levels[2].label == "leak_g");
+    REQUIRE(levels[2].category == LevelCategory::Leaked);
+    REQUIRE_FALSE(levels[2].basis_bit.has_value());
+
+    REQUIRE(levels[3].label == "leak_e");
+    REQUIRE(levels[3].category == LevelCategory::Leaked);
+    REQUIRE_FALSE(levels[3].basis_bit.has_value());
+
+    REQUIRE(levels[4].label == "lost");
+    REQUIRE(levels[4].category == LevelCategory::Lost);
+    REQUIRE_FALSE(levels[4].basis_bit.has_value());
+}
+
+TEST_CASE("validate_levels: accepts the default set") {
+    auto levels = clifft::default_levels();
+    REQUIRE_NOTHROW(clifft::validate_levels(levels));
+}
+
+TEST_CASE("validate_levels: rejects empty level set") {
+    std::vector<Level> empty;
+    REQUIRE_THROWS_AS(clifft::validate_levels(empty), std::invalid_argument);
+}
+
+TEST_CASE("validate_levels: rejects Computational level missing basis_bit") {
+    std::vector<Level> levels = {
+        Level{"g", LevelCategory::Computational, std::nullopt},
+    };
+    REQUIRE_THROWS_WITH(clifft::validate_levels(levels),
+                        ContainsSubstring("Computational") && ContainsSubstring("basis_bit"));
+}
+
+TEST_CASE("validate_levels: rejects Computational level with basis_bit > 1") {
+    std::vector<Level> levels = {
+        Level{"weird", LevelCategory::Computational, uint8_t{2}},
+    };
+    REQUIRE_THROWS_WITH(clifft::validate_levels(levels), ContainsSubstring("basis_bit"));
+}
+
+TEST_CASE("validate_levels: rejects Leaked level carrying a basis_bit") {
+    std::vector<Level> levels = {
+        Level{"leak_g", LevelCategory::Leaked, uint8_t{0}},
+    };
+    REQUIRE_THROWS_WITH(clifft::validate_levels(levels),
+                        ContainsSubstring("non-Computational") && ContainsSubstring("basis_bit"));
+}
+
+TEST_CASE("validate_levels: rejects Lost level carrying a basis_bit") {
+    std::vector<Level> levels = {
+        Level{"lost", LevelCategory::Lost, uint8_t{0}},
+    };
+    REQUIRE_THROWS_AS(clifft::validate_levels(levels), std::invalid_argument);
+}
+
+TEST_CASE("validate_levels: rejects level sets above the 128-entry cap") {
+    std::vector<Level> levels;
+    levels.reserve(129);
+    for (size_t i = 0; i < 129; ++i) {
+        levels.push_back(Level{"L" + std::to_string(i), LevelCategory::Computational, uint8_t{0}});
+    }
+    REQUIRE_THROWS_WITH(clifft::validate_levels(levels), ContainsSubstring("128"));
+}
+
+// =========================================================================
+// NonComputationalPolicy
+// =========================================================================
+
+TEST_CASE("NonComputationalPolicy: defaults are conservative") {
+    NonComputationalPolicy policy;
+    REQUIRE(policy.reset_restores_lost == false);
+    REQUIRE(policy.unknown_source_policy == UnknownSourcePolicy::Reject);
+}
+
+TEST_CASE("NonComputationalPolicy: explicit overrides round-trip") {
+    NonComputationalPolicy policy;
+    policy.reset_restores_lost = true;
+    REQUIRE(policy.reset_restores_lost == true);
+}
+
+// =========================================================================
+// QubitStatus factories: invariants are structural
+// =========================================================================
+
+TEST_CASE("make_computational_unknown: carries kInvalidLevel") {
+    auto s = make_computational_unknown();
+    REQUIRE(s.kind == QubitStatusKind::ComputationalUnknown);
+    REQUIRE(s.level_id == kInvalidLevel);
+}
+
+TEST_CASE("make_computational_known: accepts a Computational level") {
+    auto levels = clifft::default_levels();
+    auto s = make_computational_known(0, levels);  // g
+    REQUIRE(s.kind == QubitStatusKind::ComputationalKnown);
+    REQUIRE(s.level_id == 0);
+
+    auto t = make_computational_known(1, levels);  // e
+    REQUIRE(t.kind == QubitStatusKind::ComputationalKnown);
+    REQUIRE(t.level_id == 1);
+}
+
+TEST_CASE("make_computational_known: rejects a Leaked level") {
+    auto levels = clifft::default_levels();
+    REQUIRE_THROWS_AS(make_computational_known(2, levels),  // leak_g
+                      std::invalid_argument);
+}
+
+TEST_CASE("make_computational_known: rejects a Lost level") {
+    auto levels = clifft::default_levels();
+    REQUIRE_THROWS_AS(make_computational_known(4, levels),  // lost
+                      std::invalid_argument);
+}
+
+TEST_CASE("make_computational_known: rejects out-of-range level_id") {
+    auto levels = clifft::default_levels();
+    REQUIRE_THROWS_WITH(make_computational_known(99, levels), ContainsSubstring("out of range"));
+}
+
+TEST_CASE("make_leaked: accepts a Leaked level, rejects others") {
+    auto levels = clifft::default_levels();
+    REQUIRE_NOTHROW(make_leaked(2, levels));   // leak_g
+    REQUIRE_NOTHROW(make_leaked(3, levels));   // leak_e
+    REQUIRE_THROWS_AS(make_leaked(0, levels),  // g
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(make_leaked(4, levels),  // lost
+                      std::invalid_argument);
+}
+
+TEST_CASE("make_lost: accepts a Lost level, rejects others") {
+    auto levels = clifft::default_levels();
+    REQUIRE_NOTHROW(make_lost(4, levels));   // lost
+    REQUIRE_THROWS_AS(make_lost(0, levels),  // g
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(make_lost(2, levels),  // leak_g
+                      std::invalid_argument);
+}
+
+// =========================================================================
+// QubitStatus accessors
+// =========================================================================
+
+TEST_CASE("is_unknown_computational: true only for ComputationalUnknown") {
+    auto levels = clifft::default_levels();
+    REQUIRE(is_unknown_computational(make_computational_unknown()));
+    REQUIRE_FALSE(is_unknown_computational(make_computational_known(0, levels)));
+    REQUIRE_FALSE(is_unknown_computational(make_leaked(2, levels)));
+    REQUIRE_FALSE(is_unknown_computational(make_lost(4, levels)));
+}
+
+TEST_CASE("known_source_level: nullopt on Unknown, the level id otherwise") {
+    auto levels = clifft::default_levels();
+
+    REQUIRE_FALSE(known_source_level(make_computational_unknown()).has_value());
+
+    auto k = known_source_level(make_computational_known(1, levels));
+    REQUIRE(k.has_value());
+    REQUIRE(*k == 1);
+
+    auto leaked = known_source_level(make_leaked(2, levels));
+    REQUIRE(leaked.has_value());
+    REQUIRE(*leaked == 2);
+
+    auto lost = known_source_level(make_lost(4, levels));
+    REQUIRE(lost.has_value());
+    REQUIRE(*lost == 4);
+}
+
+TEST_CASE("require_classical_source_level: throws on Unknown, returns id otherwise") {
+    auto levels = clifft::default_levels();
+
+    REQUIRE_THROWS_AS(require_classical_source_level(make_computational_unknown()),
+                      std::invalid_argument);
+
+    REQUIRE(require_classical_source_level(make_computational_known(0, levels)) == 0);
+    REQUIRE(require_classical_source_level(make_leaked(3, levels)) == 3);
+    REQUIRE(require_classical_source_level(make_lost(4, levels)) == 4);
+}

--- a/tests/test_noncomp_value_types.cc
+++ b/tests/test_noncomp_value_types.cc
@@ -41,6 +41,7 @@ TEST_CASE("LevelSet: rejects empty level set") {
 TEST_CASE("LevelSet: rejects Computational level missing basis_bit") {
     std::vector<Level> levels = {
         Level{"g", LevelCategory::Computational, std::nullopt},
+        Level{"e", LevelCategory::Computational, BasisBit::One},
     };
     REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
                         ContainsSubstring("Computational") && ContainsSubstring("basis_bit"));
@@ -55,6 +56,16 @@ TEST_CASE("LevelSet: accepts Leaked level carrying optional basis_bit metadata")
         Level{"lost", LevelCategory::Lost, std::nullopt},
     };
     REQUIRE_NOTHROW(LevelSet(std::move(levels)));
+}
+
+TEST_CASE("LevelSet: rejects Lost level carrying basis_bit") {
+    std::vector<Level> levels = {
+        Level{"g", LevelCategory::Computational, BasisBit::Zero},
+        Level{"e", LevelCategory::Computational, BasisBit::One},
+        Level{"lost", LevelCategory::Lost, BasisBit::One},
+    };
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
+                        ContainsSubstring("Lost") && ContainsSubstring("basis_bit"));
 }
 
 TEST_CASE("LevelSet: rejects level set above the 128-entry cap") {
@@ -75,6 +86,42 @@ TEST_CASE("LevelSet: rejects unrecognized LevelCategory enum value") {
                         ContainsSubstring("unrecognized LevelCategory"));
 }
 
+TEST_CASE("LevelSet: rejects two Computational/Zero levels") {
+    std::vector<Level> levels = {
+        Level{"g1", LevelCategory::Computational, BasisBit::Zero},
+        Level{"g2", LevelCategory::Computational, BasisBit::Zero},
+        Level{"e", LevelCategory::Computational, BasisBit::One},
+    };
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
+                        ContainsSubstring("Zero") && ContainsSubstring("got 2"));
+}
+
+TEST_CASE("LevelSet: rejects missing Computational/Zero level") {
+    std::vector<Level> levels = {
+        Level{"e", LevelCategory::Computational, BasisBit::One},
+    };
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
+                        ContainsSubstring("Zero") && ContainsSubstring("got 0"));
+}
+
+TEST_CASE("LevelSet: rejects two Computational/One levels") {
+    std::vector<Level> levels = {
+        Level{"g", LevelCategory::Computational, BasisBit::Zero},
+        Level{"e1", LevelCategory::Computational, BasisBit::One},
+        Level{"e2", LevelCategory::Computational, BasisBit::One},
+    };
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
+                        ContainsSubstring("One") && ContainsSubstring("got 2"));
+}
+
+TEST_CASE("LevelSet: rejects missing Computational/One level") {
+    std::vector<Level> levels = {
+        Level{"g", LevelCategory::Computational, BasisBit::Zero},
+    };
+    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
+                        ContainsSubstring("One") && ContainsSubstring("got 0"));
+}
+
 // =========================================================================
 // LevelSet status factories
 // =========================================================================
@@ -82,12 +129,12 @@ TEST_CASE("LevelSet: rejects unrecognized LevelCategory enum value") {
 TEST_CASE("LevelSet::computational_known accepts a Computational level id") {
     LevelSet set = LevelSet::default_set();
     QubitStatus s = set.computational_known(0);
-    REQUIRE(s.kind == QubitStatusKind::ComputationalKnown);
-    REQUIRE(s.level_id == 0);
+    REQUIRE(s.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(s.level_id() == 0);
 
     QubitStatus t = set.computational_known(1);
-    REQUIRE(t.kind == QubitStatusKind::ComputationalKnown);
-    REQUIRE(t.level_id == 1);
+    REQUIRE(t.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(t.level_id() == 1);
 }
 
 TEST_CASE("LevelSet::computational_known rejects non-Computational ids") {
@@ -128,8 +175,8 @@ TEST_CASE("LevelSet::lost accepts a Lost level id, rejects others") {
 
 TEST_CASE("QubitStatus::computational_unknown carries kInvalidLevel") {
     QubitStatus s = QubitStatus::computational_unknown();
-    REQUIRE(s.kind == QubitStatusKind::ComputationalUnknown);
-    REQUIRE(s.level_id == kInvalidLevel);
+    REQUIRE(s.kind() == QubitStatusKind::ComputationalUnknown);
+    REQUIRE(s.level_id() == kInvalidLevel);
 }
 
 TEST_CASE("QubitStatus::is_unknown_computational is true only for Unknown") {
@@ -167,6 +214,22 @@ TEST_CASE("QubitStatus::require_classical_source_level throws on Unknown") {
     REQUIRE(set.computational_known(0).require_classical_source_level() == 0);
     REQUIRE(set.leaked(3).require_classical_source_level() == 3);
     REQUIRE(set.lost(4).require_classical_source_level() == 4);
+}
+
+TEST_CASE("QubitStatus _unchecked factories build without table validation") {
+    // These are the only paths that don't require a LevelSet. Useful
+    // for interior code and tests; the name flags the responsibility.
+    QubitStatus s = QubitStatus::computational_known_unchecked(7);
+    REQUIRE(s.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(s.level_id() == 7);
+
+    QubitStatus t = QubitStatus::leaked_unchecked(9);
+    REQUIRE(t.kind() == QubitStatusKind::Leaked);
+    REQUIRE(t.level_id() == 9);
+
+    QubitStatus u = QubitStatus::lost_unchecked(11);
+    REQUIRE(u.kind() == QubitStatusKind::Lost);
+    REQUIRE(u.level_id() == 11);
 }
 
 // =========================================================================


### PR DESCRIPTION
First implementation PR on the noncomputational MVP feature branch. Lands the foundational value types from §6 of the design note (#105).

**Targets the feature branch, not main.** Per #104, partial work does not merge to main.

## What's in

Three header-only modules under `src/clifft/noncomp/`:

| File | Contents |
|---|---|
| `qubit_status.h` | `QubitStatusKind` enum (4 values — the runtime tag), `QubitStatus` class with private constructor and `_unchecked` static factories, `kInvalidLevel` sentinel, member accessors (`kind()`, `level_id()`, `is_unknown_computational()`, `known_source_level()`, `require_classical_source_level()`). Aggregate-init `QubitStatus{kind, level_id}` does not compile; user code goes through `LevelSet`. |
| `level.h` | `LevelCategory` enum (3 values), `BasisBit` enum (`Zero`/`One`), `Level` struct, **`LevelSet`** — validated wrapper around `std::vector<Level>` that owns the `QubitStatus` factories so level ids stay bound to a specific table. `default_set()` for the `g`/`e`/`leak_g`/`leak_e`/`lost` set. |
| `policy.h` | `NonComputationalPolicy { reset_restores_lost, unknown_source_policy }`. `UnknownSourcePolicy` is a one-value enum (`Reject`) holding the slot for future opt-in modes. |

Plus `tests/test_noncomp_value_types.cc` — 23 Catch2 cases covering construction/validation, the `LevelSet` status factories, the `QubitStatus` accessors and `_unchecked` factories, and the policy defaults.

## Validation rules (enforced in `LevelSet` ctor)

- Level set non-empty, `<=` 128 entries.
- Every `LevelCategory` value is one of the named enum members (unrecognized values reject).
- Every `Computational` level declares a `basis_bit`. `BasisBit` is an enum so the value is structurally `Zero` or `One`.
- `Leaked` levels may carry a `basis_bit` as optional origin metadata.
- `Lost` levels must not carry a `basis_bit`.
- The table contains **exactly one** Computational level with `basis_bit == Zero` and **exactly one** with `basis_bit == One`. Downstream code (visible Z-basis `M`/`R`, initial prep, classifier defaults) needs unambiguous `g`/`e` ids; duplicates or missing canonical levels reject.

`LevelSet`'s `computational_known(id)` / `leaked(id)` / `lost(id)` factories then validate that `id` refers to a level of the matching category in this table before returning a `QubitStatus`. No more `(level_id, levels)` free-function pairs.

## What's not in

Per the design-note staging plan: no `TransitionInstrument`, no `MeasurementClassifier`, no `NonComputationalModel`, no sampler/rewriter, no nanobind bindings. Each lands in a later PR; bindings come once the full surface exists so Python users see one coherent API drop.

## Test plan

- [x] `uv tool run pre-commit run --all-files` clean
- [x] Debug build: full suite passes (786/786 tests, including the 23 new ones)
- [x] Release build: 23 new tests pass

## Notes

- `clifft::` namespace, no nested `noncomp` sub-namespace — matches existing project convention.
- Design note (`design/noncomputational-mvp.md`) updated in the same branch to match: §2.2 (Lost rejects basis_bit, canonical Zero/One rule), §2.3 (`QubitStatus` non-aggregate with `_unchecked` factories), §3.2 (`LevelSet` C++ surface), §4.1 (validation rules), §6 (header dependency order — `qubit_status.h` now precedes `level.h`).
- `validate_levels` is no longer exposed as a free function; its job moved into `LevelSet`'s constructor.
