### PR TITLE
feat(noncomp): TransitionInstrument with cached source-independence flag

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(clifft_core STATIC
     svm/svm_scalar.cc
     svm/svm_state.cc
     util/introspection.cc
+    noncomp/transition_instrument.cc
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -1,0 +1,119 @@
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace clifft {
+
+namespace {
+
+// Tolerance for entry / column-sum bounds and for the
+// source-independence equality check. Generous compared to typical
+// floating-point error in user-supplied matrices; we want to admit
+// hand-written tables that sum to 1.0 - epsilon.
+constexpr double kProbTolerance = 1e-12;
+
+bool columns_equal(const std::vector<std::vector<double>>& matrix, uint8_t j1, uint8_t j2) {
+    for (size_t to = 0; to < matrix.size(); ++to) {
+        if (std::abs(matrix[to][j1] - matrix[to][j2]) > kProbTolerance) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<double>> matrix,
+                                                       const LevelSet& levels) {
+    const size_t n = levels.size();
+
+    if (matrix.size() != n) {
+        throw std::invalid_argument("TransitionInstrument::from_matrix: matrix has " +
+                                    std::to_string(matrix.size()) + " rows; expected " +
+                                    std::to_string(n) + " (one per level)");
+    }
+    for (size_t to = 0; to < n; ++to) {
+        if (matrix[to].size() != n) {
+            throw std::invalid_argument(
+                "TransitionInstrument::from_matrix: row " + std::to_string(to) + " has " +
+                std::to_string(matrix[to].size()) + " columns; expected " + std::to_string(n));
+        }
+        for (size_t from = 0; from < n; ++from) {
+            const double v = matrix[to][from];
+            if (v < 0.0 - kProbTolerance || v > 1.0 + kProbTolerance) {
+                throw std::invalid_argument("TransitionInstrument::from_matrix: entry (" +
+                                            std::to_string(to) + ", " + std::to_string(from) +
+                                            ") = " + std::to_string(v) + " out of [0, 1]");
+            }
+        }
+    }
+
+    std::vector<double> column_sums(n, 0.0);
+    for (size_t from = 0; from < n; ++from) {
+        double sum = 0.0;
+        for (size_t to = 0; to < n; ++to) {
+            sum += matrix[to][from];
+        }
+        if (sum < 0.0 - kProbTolerance || sum > 1.0 + kProbTolerance) {
+            throw std::invalid_argument("TransitionInstrument::from_matrix: column " +
+                                        std::to_string(from) + " sum = " + std::to_string(sum) +
+                                        " out of [0, 1]");
+        }
+        column_sums[from] = sum;
+    }
+
+    // is_source_independent_on_computational: every column whose source
+    // level has category Computational must equal the first such column
+    // within tolerance. Vacuously true if there are fewer than two
+    // Computational levels (LevelSet validation guarantees exactly two:
+    // basis_bit == Zero and basis_bit == One).
+    bool flag = true;
+    const auto levels_span = levels.levels();
+    uint8_t first_comp = 0xFF;
+    for (size_t from = 0; from < n; ++from) {
+        if (levels_span[from].category == LevelCategory::Computational) {
+            if (first_comp == 0xFF) {
+                first_comp = static_cast<uint8_t>(from);
+            } else if (!columns_equal(matrix, first_comp, static_cast<uint8_t>(from))) {
+                flag = false;
+                break;
+            }
+        }
+    }
+
+    return TransitionInstrument(std::move(matrix), std::move(column_sums), flag);
+}
+
+TransitionInstrument::TransitionInstrument(std::vector<std::vector<double>> matrix,
+                                           std::vector<double> column_sums,
+                                           bool is_source_independent_on_computational)
+    : matrix_(std::move(matrix)),
+      column_sums_(std::move(column_sums)),
+      is_source_independent_on_computational_(is_source_independent_on_computational) {}
+
+double TransitionInstrument::prob(uint8_t to, uint8_t from) const {
+    if (to >= matrix_.size() || from >= matrix_.size()) {
+        throw std::invalid_argument("TransitionInstrument::prob: index (" + std::to_string(to) +
+                                    ", " + std::to_string(from) + ") out of range (num_levels " +
+                                    std::to_string(matrix_.size()) + ")");
+    }
+    return matrix_[to][from];
+}
+
+double TransitionInstrument::column_sum(uint8_t from) const {
+    if (from >= column_sums_.size()) {
+        throw std::invalid_argument("TransitionInstrument::column_sum: index " +
+                                    std::to_string(from) + " out of range (num_levels " +
+                                    std::to_string(column_sums_.size()) + ")");
+    }
+    return column_sums_[from];
+}
+
+double TransitionInstrument::no_jump_weight(uint8_t from) const {
+    return 1.0 - column_sum(from);
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -29,15 +29,6 @@ bool is_finite_robust(double v) {
     return (bits & kExpMask) != kExpMask;
 }
 
-bool columns_equal(const std::vector<std::vector<double>>& matrix, uint8_t j1, uint8_t j2) {
-    for (size_t to = 0; to < matrix.size(); ++to) {
-        if (std::abs(matrix[to][j1] - matrix[to][j2]) > kProbTolerance) {
-            return false;
-        }
-    }
-    return true;
-}
-
 }  // namespace
 
 TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<double>> matrix,
@@ -49,6 +40,10 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
                                     std::to_string(matrix.size()) + " rows; expected " +
                                     std::to_string(n) + " (one per level)");
     }
+
+    // Single pass: validate row width and entry bounds while copying
+    // into the flat row-major buffer.
+    std::vector<double> flat(n * n);
     for (size_t to = 0; to < n; ++to) {
         if (matrix[to].size() != n) {
             throw std::invalid_argument(
@@ -67,6 +62,7 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
                                             ") = " + std::to_string(v) +
                                             " is not finite or is out of [0, 1]");
             }
+            flat[to * n + from] = v;
         }
     }
 
@@ -74,7 +70,7 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
     for (size_t from = 0; from < n; ++from) {
         double sum = 0.0;
         for (size_t to = 0; to < n; ++to) {
-            sum += matrix[to][from];
+            sum += flat[to * n + from];
         }
         // Reject sums that exceed 1 by more than floating drift.
         // Within tolerance, clamp so prob() and no_jump_weight()
@@ -96,33 +92,42 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
     const auto levels_span = levels.levels();
     uint8_t first_comp = 0xFF;
     for (size_t from = 0; from < n; ++from) {
-        if (levels_span[from].category == LevelCategory::Computational) {
-            if (first_comp == 0xFF) {
-                first_comp = static_cast<uint8_t>(from);
-            } else if (!columns_equal(matrix, first_comp, static_cast<uint8_t>(from))) {
+        if (levels_span[from].category != LevelCategory::Computational) {
+            continue;
+        }
+        if (first_comp == 0xFF) {
+            first_comp = static_cast<uint8_t>(from);
+            continue;
+        }
+        for (size_t to = 0; to < n; ++to) {
+            if (std::abs(flat[to * n + first_comp] - flat[to * n + from]) > kProbTolerance) {
                 flag = false;
                 break;
             }
         }
+        if (!flag) {
+            break;
+        }
     }
 
-    return TransitionInstrument(std::move(matrix), std::move(column_sums), flag);
+    return TransitionInstrument(std::move(flat), std::move(column_sums), flag);
 }
 
-TransitionInstrument::TransitionInstrument(std::vector<std::vector<double>> matrix,
+TransitionInstrument::TransitionInstrument(std::vector<double> matrix_flat,
                                            std::vector<double> column_sums,
                                            bool is_source_independent_on_computational)
-    : matrix_(std::move(matrix)),
+    : matrix_flat_(std::move(matrix_flat)),
       column_sums_(std::move(column_sums)),
       is_source_independent_on_computational_(is_source_independent_on_computational) {}
 
 double TransitionInstrument::prob(uint8_t to, uint8_t from) const {
-    if (to >= matrix_.size() || from >= matrix_.size()) {
+    const size_t n = column_sums_.size();
+    if (to >= n || from >= n) {
         throw std::invalid_argument("TransitionInstrument::prob: index (" + std::to_string(to) +
                                     ", " + std::to_string(from) + ") out of range (num_levels " +
-                                    std::to_string(matrix_.size()) + ")");
+                                    std::to_string(n) + ")");
     }
-    return matrix_[to][from];
+    return matrix_flat_[static_cast<size_t>(to) * n + static_cast<size_t>(from)];
 }
 
 double TransitionInstrument::column_sum(uint8_t from) const {

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -43,10 +43,15 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
         }
         for (size_t from = 0; from < n; ++from) {
             const double v = matrix[to][from];
-            if (v < 0.0 - kProbTolerance || v > 1.0 + kProbTolerance) {
+            // Raw user entries must be finite and lie strictly in [0, 1]:
+            // tolerance applies only to derived column sums below.
+            // !(v >= 0.0 && v <= 1.0) also catches NaN, since any
+            // NaN comparison is false.
+            if (!(v >= 0.0 && v <= 1.0)) {
                 throw std::invalid_argument("TransitionInstrument::from_matrix: entry (" +
                                             std::to_string(to) + ", " + std::to_string(from) +
-                                            ") = " + std::to_string(v) + " out of [0, 1]");
+                                            ") = " + std::to_string(v) +
+                                            " is not finite or is out of [0, 1]");
             }
         }
     }
@@ -57,12 +62,15 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
         for (size_t to = 0; to < n; ++to) {
             sum += matrix[to][from];
         }
-        if (sum < 0.0 - kProbTolerance || sum > 1.0 + kProbTolerance) {
+        // Reject sums that exceed 1 by more than floating drift.
+        // Within tolerance, clamp so prob() and no_jump_weight()
+        // never report values outside [0, 1].
+        if (sum > 1.0 + kProbTolerance) {
             throw std::invalid_argument("TransitionInstrument::from_matrix: column " +
                                         std::to_string(from) + " sum = " + std::to_string(sum) +
-                                        " out of [0, 1]");
+                                        " exceeds 1");
         }
-        column_sums[from] = sum;
+        column_sums[from] = sum > 1.0 ? 1.0 : sum;
     }
 
     // is_source_independent_on_computational: every column whose source

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -3,11 +3,17 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
 namespace clifft {
+
+// is_finite_robust below assumes IEEE 754 doubles (every Clifft
+// target satisfies this). Make the assumption explicit.
+static_assert(std::numeric_limits<double>::is_iec559,
+              "TransitionInstrument requires IEEE 754 doubles");
 
 namespace {
 

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -1,6 +1,8 @@
 #include "clifft/noncomp/transition_instrument.h"
 
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -14,6 +16,18 @@ namespace {
 // floating-point error in user-supplied matrices; we want to admit
 // hand-written tables that sum to 1.0 - epsilon.
 constexpr double kProbTolerance = 1e-12;
+
+// Release builds use -ffast-math, which implies -ffinite-math-only.
+// That lets the compiler assume operands are finite, folding away
+// std::isfinite() and turning `v >= 0.0 && v <= 1.0` into something
+// that passes NaN through. Inspect the IEEE 754 bit pattern
+// instead: a non-finite double has all exponent bits set.
+bool is_finite_robust(double v) {
+    uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
+}
 
 bool columns_equal(const std::vector<std::vector<double>>& matrix, uint8_t j1, uint8_t j2) {
     for (size_t to = 0; to < matrix.size(); ++to) {
@@ -45,9 +59,9 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
             const double v = matrix[to][from];
             // Raw user entries must be finite and lie strictly in [0, 1]:
             // tolerance applies only to derived column sums below.
-            // !(v >= 0.0 && v <= 1.0) also catches NaN, since any
-            // NaN comparison is false.
-            if (!(v >= 0.0 && v <= 1.0)) {
+            // is_finite_robust runs first because -ffast-math folds
+            // std::isfinite() / NaN-aware comparisons away.
+            if (!is_finite_robust(v) || v < 0.0 || v > 1.0) {
                 throw std::invalid_argument("TransitionInstrument::from_matrix: entry (" +
                                             std::to_string(to) + ", " + std::to_string(from) +
                                             ") = " + std::to_string(v) +

--- a/src/clifft/noncomp/transition_instrument.h
+++ b/src/clifft/noncomp/transition_instrument.h
@@ -9,6 +9,18 @@
 // gives the total jump probability out of that source, and the
 // deficit `1 - column_sum` is the implicit no-jump weight.
 //
+// Convention: every matrix entry, diagonal included, represents a
+// discrete *transition event*. A non-zero matrix[a][a] is NOT the
+// probability that source `a` stays at level `a`; it is the
+// probability of a transition event that happens to land back at
+// the source level (e.g., a depolarizing error that ends in the
+// same level). The "nothing happened" branch ("no-jump") lives in
+// the column deficit, not the diagonal. This mirrors the Kraus
+// structure in which each jump is its own Kraus operator and
+// no-jump is the complement; it also makes the no-jump back-action
+// under unknown-coherent sources (the aI + bZ filter) a single
+// special case rather than something carved out of the diagonal.
+//
 // Construction binds the instrument to a LevelSet so the matrix
 // shape can be checked against the level table and the
 // is_source_independent_on_computational flag can be computed.

--- a/src/clifft/noncomp/transition_instrument.h
+++ b/src/clifft/noncomp/transition_instrument.h
@@ -49,7 +49,7 @@ class TransitionInstrument {
     static TransitionInstrument from_matrix(std::vector<std::vector<double>> matrix,
                                             const LevelSet& levels);
 
-    size_t num_levels() const { return matrix_.size(); }
+    size_t num_levels() const { return column_sums_.size(); }
 
     // T[to, from]. Throws on out-of-range indices.
     double prob(uint8_t to, uint8_t from) const;
@@ -67,10 +67,13 @@ class TransitionInstrument {
     }
 
   private:
-    TransitionInstrument(std::vector<std::vector<double>> matrix, std::vector<double> column_sums,
+    TransitionInstrument(std::vector<double> matrix_flat, std::vector<double> column_sums,
                          bool is_source_independent_on_computational);
 
-    std::vector<std::vector<double>> matrix_;
+    // Row-major flat storage: matrix_flat_[to * num_levels() + from].
+    // One allocation, contiguous memory; column-traversal accessors
+    // walk a single buffer instead of dereferencing per-row vectors.
+    std::vector<double> matrix_flat_;
     std::vector<double> column_sums_;
     bool is_source_independent_on_computational_;
 };

--- a/src/clifft/noncomp/transition_instrument.h
+++ b/src/clifft/noncomp/transition_instrument.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// TransitionInstrument: a per-qubit transition matrix with cached
+// derived properties.
+//
+// The matrix uses T[to, from] convention: matrix[to][from] is the
+// probability of the qubit transitioning from level `from` to level
+// `to`. Each column corresponds to one source level; the column sum
+// gives the total jump probability out of that source, and the
+// deficit `1 - column_sum` is the implicit no-jump weight.
+//
+// Construction binds the instrument to a LevelSet so the matrix
+// shape can be checked against the level table and the
+// is_source_independent_on_computational flag can be computed.
+// Source-dependent matrices (where Computational-category columns
+// differ) are valid here; whether they are applicable to a given
+// qubit is enforced at sample time against the QubitStatusKind of
+// the target qubit.
+
+#include "clifft/noncomp/level.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace clifft {
+
+class TransitionInstrument {
+  public:
+    // Validates that:
+    //   - matrix is square with dimension equal to levels.size();
+    //   - every entry lies in [0, 1];
+    //   - every column sum lies in [0, 1].
+    // Computes and caches is_source_independent_on_computational (true
+    // iff every column whose source level has category Computational
+    // is bit-identical within tolerance to the others).
+    static TransitionInstrument from_matrix(std::vector<std::vector<double>> matrix,
+                                            const LevelSet& levels);
+
+    size_t num_levels() const { return matrix_.size(); }
+
+    // T[to, from]. Throws on out-of-range indices.
+    double prob(uint8_t to, uint8_t from) const;
+
+    // Sum of column `from`, the total jump probability out of that
+    // source level. Cached at construction.
+    double column_sum(uint8_t from) const;
+
+    // 1 - column_sum(from): the implicit no-jump weight for that
+    // source level.
+    double no_jump_weight(uint8_t from) const;
+
+    bool is_source_independent_on_computational() const {
+        return is_source_independent_on_computational_;
+    }
+
+  private:
+    TransitionInstrument(std::vector<std::vector<double>> matrix, std::vector<double> column_sums,
+                         bool is_source_independent_on_computational);
+
+    std::vector<std::vector<double>> matrix_;
+    std::vector<double> column_sums_;
+    bool is_source_independent_on_computational_;
+};
+
+}  // namespace clifft

--- a/src/clifft/noncomp/transition_instrument.h
+++ b/src/clifft/noncomp/transition_instrument.h
@@ -45,7 +45,7 @@ class TransitionInstrument {
     //   - every column sum lies in [0, 1].
     // Computes and caches is_source_independent_on_computational (true
     // iff every column whose source level has category Computational
-    // is bit-identical within tolerance to the others).
+    // is equal within tolerance to the others).
     static TransitionInstrument from_matrix(std::vector<std::vector<double>> matrix,
                                             const LevelSet& levels);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(clifft_tests
     test_openmp.cc
     test_fuzz.cc
     test_noncomp_value_types.cc
+    test_noncomp_transition_instrument.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_transition_instrument.cc
+++ b/tests/test_noncomp_transition_instrument.cc
@@ -1,0 +1,183 @@
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <stdexcept>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::WithinAbs;
+using clifft::LevelSet;
+using clifft::TransitionInstrument;
+
+namespace {
+
+// 5x5 zero matrix sized for the default level set.
+std::vector<std::vector<double>> zero5() {
+    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
+}
+
+}  // namespace
+
+// =========================================================================
+// Shape validation
+// =========================================================================
+
+TEST_CASE("TransitionInstrument: accepts a zero matrix") {
+    LevelSet levels = LevelSet::default_set();
+    REQUIRE_NOTHROW(TransitionInstrument::from_matrix(zero5(), levels));
+}
+
+TEST_CASE("TransitionInstrument: rejects wrong row count") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> bad(4, std::vector<double>(5, 0.0));
+    REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(bad), levels),
+                        ContainsSubstring("4 rows") && ContainsSubstring("expected 5"));
+}
+
+TEST_CASE("TransitionInstrument: rejects jagged row width") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> bad = zero5();
+    bad[2].pop_back();  // row 2 now has 4 columns
+    REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(bad), levels),
+                        ContainsSubstring("row 2") && ContainsSubstring("4 columns"));
+}
+
+// =========================================================================
+// Entry / column-sum validation
+// =========================================================================
+
+TEST_CASE("TransitionInstrument: rejects negative entry") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[1][0] = -0.1;
+    REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(m), levels),
+                        ContainsSubstring("entry") && ContainsSubstring("out of [0, 1]"));
+}
+
+TEST_CASE("TransitionInstrument: rejects entry above 1") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[1][0] = 1.5;
+    REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(m), levels),
+                        ContainsSubstring("out of [0, 1]"));
+}
+
+TEST_CASE("TransitionInstrument: rejects column sum above 1") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[2][0] = 0.6;
+    m[3][0] = 0.6;  // column 0 sums to 1.2
+    REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(m), levels),
+                        ContainsSubstring("column 0") && ContainsSubstring("sum"));
+}
+
+// =========================================================================
+// Accessors
+// =========================================================================
+
+TEST_CASE("TransitionInstrument: column_sum and no_jump_weight match the matrix") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    // Source 0: 30% jump to level 2, 10% jump to level 4 -> column sum 0.4.
+    m[2][0] = 0.3;
+    m[4][0] = 0.1;
+    // Source 1: 70% jump to level 3 -> column sum 0.7.
+    m[3][1] = 0.7;
+
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+
+    REQUIRE(instr.num_levels() == 5);
+    REQUIRE_THAT(instr.column_sum(0), WithinAbs(0.4, 1e-12));
+    REQUIRE_THAT(instr.column_sum(1), WithinAbs(0.7, 1e-12));
+    REQUIRE_THAT(instr.column_sum(2), WithinAbs(0.0, 1e-12));
+    REQUIRE_THAT(instr.no_jump_weight(0), WithinAbs(0.6, 1e-12));
+    REQUIRE_THAT(instr.no_jump_weight(1), WithinAbs(0.3, 1e-12));
+    REQUIRE_THAT(instr.no_jump_weight(2), WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("TransitionInstrument: prob returns the entry under T[to, from] convention") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[3][1] = 0.25;  // P(level 3 | from level 1) = 0.25
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+
+    REQUIRE_THAT(instr.prob(3, 1), WithinAbs(0.25, 1e-12));
+    REQUIRE_THAT(instr.prob(1, 3), WithinAbs(0.0, 1e-12));
+}
+
+TEST_CASE("TransitionInstrument: prob rejects out-of-range index") {
+    LevelSet levels = LevelSet::default_set();
+    auto instr = TransitionInstrument::from_matrix(zero5(), levels);
+    REQUIRE_THROWS_AS(instr.prob(7, 0), std::invalid_argument);
+    REQUIRE_THROWS_AS(instr.prob(0, 7), std::invalid_argument);
+}
+
+TEST_CASE("TransitionInstrument: column_sum rejects out-of-range index") {
+    LevelSet levels = LevelSet::default_set();
+    auto instr = TransitionInstrument::from_matrix(zero5(), levels);
+    REQUIRE_THROWS_AS(instr.column_sum(99), std::invalid_argument);
+}
+
+// =========================================================================
+// is_source_independent_on_computational
+// =========================================================================
+
+TEST_CASE("TransitionInstrument: source-independent flag true for all-zero matrix") {
+    LevelSet levels = LevelSet::default_set();
+    auto instr = TransitionInstrument::from_matrix(zero5(), levels);
+    REQUIRE(instr.is_source_independent_on_computational());
+}
+
+TEST_CASE("TransitionInstrument: source-independent flag true when g/e columns match") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    // g and e columns identical: both jump 0.2 to leak_g, 0.1 to lost.
+    m[2][0] = 0.2;
+    m[4][0] = 0.1;
+    m[2][1] = 0.2;
+    m[4][1] = 0.1;
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+    REQUIRE(instr.is_source_independent_on_computational());
+}
+
+TEST_CASE("TransitionInstrument: source-independent flag false when g/e columns differ") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    // g column jumps to leak_g; e column jumps to leak_e. Different.
+    m[2][0] = 0.1;
+    m[3][1] = 0.1;
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+    REQUIRE_FALSE(instr.is_source_independent_on_computational());
+}
+
+TEST_CASE("TransitionInstrument: only Computational-source columns affect the flag") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    // g and e columns identical (both empty); leak_g column has non-trivial
+    // content. The flag should still be true since leak_g is not Computational.
+    m[4][2] = 0.5;  // leak_g -> lost with prob 0.5
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+    REQUIRE(instr.is_source_independent_on_computational());
+}
+
+TEST_CASE("TransitionInstrument: tolerance — sub-1e-12 column difference still independent") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[2][0] = 0.3;
+    m[2][1] = 0.3 + 1e-13;  // within tolerance
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+    REQUIRE(instr.is_source_independent_on_computational());
+}
+
+TEST_CASE("TransitionInstrument: tolerance — 1e-9 column difference is not independent") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[2][0] = 0.3;
+    m[2][1] = 0.3 + 1e-9;  // exceeds tolerance
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+    REQUIRE_FALSE(instr.is_source_independent_on_computational());
+}

--- a/tests/test_noncomp_transition_instrument.cc
+++ b/tests/test_noncomp_transition_instrument.cc
@@ -5,6 +5,8 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -72,7 +74,46 @@ TEST_CASE("TransitionInstrument: rejects column sum above 1") {
     m[2][0] = 0.6;
     m[3][0] = 0.6;  // column 0 sums to 1.2
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(m), levels),
-                        ContainsSubstring("column 0") && ContainsSubstring("sum"));
+                        ContainsSubstring("column 0") && ContainsSubstring("exceeds 1"));
+}
+
+TEST_CASE("TransitionInstrument: rejects NaN entry") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[1][0] = std::numeric_limits<double>::quiet_NaN();
+    REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(m), levels),
+                        ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
+}
+
+TEST_CASE("TransitionInstrument: rejects positive infinity entry") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    m[1][0] = std::numeric_limits<double>::infinity();
+    REQUIRE_THROWS_AS(TransitionInstrument::from_matrix(std::move(m), levels),
+                      std::invalid_argument);
+}
+
+TEST_CASE("TransitionInstrument: entry validation has no tolerance slack") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    // Just barely above 1: with no tolerance on entries, this must reject.
+    m[1][0] = std::nextafter(1.0, 2.0);
+    REQUIRE_THROWS_AS(TransitionInstrument::from_matrix(std::move(m), levels),
+                      std::invalid_argument);
+}
+
+TEST_CASE("TransitionInstrument: column sum within tolerance above 1 is clamped") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = zero5();
+    // Three entries near 1/3 that sum to 1.0 + a few ULPs of floating drift.
+    // Each entry must individually pass the strict [0, 1] check.
+    m[0][0] = 1.0 / 3.0;
+    m[1][0] = 1.0 / 3.0;
+    m[2][0] = 1.0 / 3.0;
+    auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
+    // column_sum is clamped to [0, 1] so no_jump_weight is non-negative.
+    REQUIRE(instr.column_sum(0) <= 1.0);
+    REQUIRE(instr.no_jump_weight(0) >= 0.0);
 }
 
 // =========================================================================
@@ -164,7 +205,7 @@ TEST_CASE("TransitionInstrument: only Computational-source columns affect the fl
     REQUIRE(instr.is_source_independent_on_computational());
 }
 
-TEST_CASE("TransitionInstrument: tolerance — sub-1e-12 column difference still independent") {
+TEST_CASE("TransitionInstrument: tolerance - sub-1e-12 column difference still independent") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = zero5();
     m[2][0] = 0.3;
@@ -173,7 +214,7 @@ TEST_CASE("TransitionInstrument: tolerance — sub-1e-12 column difference still
     REQUIRE(instr.is_source_independent_on_computational());
 }
 
-TEST_CASE("TransitionInstrument: tolerance — 1e-9 column difference is not independent") {
+TEST_CASE("TransitionInstrument: tolerance - 1e-9 column difference is not independent") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = zero5();
     m[2][0] = 0.3;

--- a/tests/test_noncomp_transition_instrument.cc
+++ b/tests/test_noncomp_transition_instrument.cc
@@ -105,15 +105,22 @@ TEST_CASE("TransitionInstrument: entry validation has no tolerance slack") {
 TEST_CASE("TransitionInstrument: column sum within tolerance above 1 is clamped") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = zero5();
-    // Three entries near 1/3 that sum to 1.0 + a few ULPs of floating drift.
-    // Each entry must individually pass the strict [0, 1] check.
-    m[0][0] = 1.0 / 3.0;
-    m[1][0] = 1.0 / 3.0;
-    m[2][0] = 1.0 / 3.0;
+    // Two entries whose sum is the next representable double above 1.0
+    // (1.0 + 2^-52, ~2.22e-16). Each entry passes the strict [0, 1]
+    // entry check, the sum is strictly > 1.0 yet well within
+    // kProbTolerance, and the addition is exact (no rounding) so the
+    // test behaves identically in Debug and Release.
+    const double a = std::nextafter(std::nextafter(0.5, 1.0), 1.0);  // 0.5 + 2^-52
+    const double b = 0.5;
+    REQUIRE(a + b > 1.0);  // guards against the test going stale if the inputs change
+    REQUIRE(a + b < 1.0 + 1e-12);
+    m[0][0] = a;
+    m[1][0] = b;
+
     auto instr = TransitionInstrument::from_matrix(std::move(m), levels);
     // column_sum is clamped to [0, 1] so no_jump_weight is non-negative.
-    REQUIRE(instr.column_sum(0) <= 1.0);
-    REQUIRE(instr.no_jump_weight(0) >= 0.0);
+    REQUIRE(instr.column_sum(0) == 1.0);
+    REQUIRE(instr.no_jump_weight(0) == 0.0);
 }
 
 // =========================================================================


### PR DESCRIPTION
Second implementation PR on the noncomputational MVP feature branch. Lands `TransitionInstrument` per §3.2 + §4.1 of the design note.

**Targets the feature branch, not main.** Per #104, partial work does not merge to main.

## What's in

`src/clifft/noncomp/transition_instrument.{h,cc}` — square `T[to, from]` matrix bound to a `LevelSet` at construction.

- **`TransitionInstrument::from_matrix(matrix, levels)`** validates:
  - matrix is square with dimension == `levels.size()`
  - every entry is in `[0, 1]`
  - every column sum is in `[0, 1]` (deficit = implicit no-jump weight)
- **Cached flag** `is_source_independent_on_computational`: true iff every `Computational`-category source column is bit-identical within `1e-12` to the others. Source-dependent matrices construct cleanly; applicability is enforced at sample time per §4.2.
- **Accessors**: `num_levels()`, `prob(to, from)`, `column_sum(from)`, `no_jump_weight(from)`, `is_source_independent_on_computational()`. Out-of-range accessors throw with named fields.

The `LevelSet` is consumed at construction time to size-check the matrix and identify Computational columns. The instrument doesn't carry a `LevelSet` reference afterward; downstream consistency is the model's responsibility (next PR).

## What's not in

- Per-source branch enumeration / sampling API — deferred to the sampler PR, where the concrete use shape will pin down what's needed.
- No nanobind bindings yet (whole-surface drop after the model lands).

## Test plan

- [x] `uv tool run pre-commit run --all-files` clean
- [x] Debug build: full suite passes (802/802 tests, including the 16 new ones)
- [x] Release build: 16 new tests pass

16 cases:
- Shape: zero matrix accepted; wrong row count, jagged row width rejected.
- Bounds: negative entry, entry > 1, column sum > 1 all rejected with named fields.
- Accessors: `column_sum` / `no_jump_weight` match hand-built matrices; `prob` respects `T[to, from]` orientation; out-of-range `prob` and `column_sum` throw.
- Source-independence flag: true for all-zero matrix and for matched g/e columns; false when g/e columns differ; only Computational-source columns affect the flag (leak_g column differing has no effect); 1e-13 difference still independent, 1e-9 not.

## Next

PR C: `classifier.{h,cc}` — column-substochastic `(symbols, levels)` map with derived `reject_probability(level_id)`.