### PR TITLE
feat(noncomp): MeasurementClassifier with cached reject probability

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(clifft_core STATIC
     svm/svm_state.cc
     util/introspection.cc
     noncomp/transition_instrument.cc
+    noncomp/classifier.cc
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.

--- a/src/clifft/noncomp/classifier.cc
+++ b/src/clifft/noncomp/classifier.cc
@@ -41,6 +41,14 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
     if (symbols.empty()) {
         throw std::invalid_argument("MeasurementClassifier::from_matrix: symbols list is empty");
     }
+    if (symbols.size() > 256) {
+        // The public symbol index APIs use uint8_t. Allowing more than
+        // 256 symbols would make indices >= 256 unaddressable through
+        // prob() / symbol_label() and silently wrap on conversion.
+        throw std::invalid_argument("MeasurementClassifier::from_matrix: symbols list has " +
+                                    std::to_string(symbols.size()) +
+                                    " entries; max supported is 256");
+    }
     {
         std::unordered_set<std::string> seen;
         seen.reserve(symbols.size());

--- a/src/clifft/noncomp/classifier.cc
+++ b/src/clifft/noncomp/classifier.cc
@@ -1,0 +1,146 @@
+#include "clifft/noncomp/classifier.h"
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace clifft {
+
+// is_finite_robust below assumes IEEE 754 doubles (every Clifft
+// target satisfies this). Make the assumption explicit.
+static_assert(std::numeric_limits<double>::is_iec559,
+              "MeasurementClassifier requires IEEE 754 doubles");
+
+namespace {
+
+// Tolerance for column-sum bounds and the reject-probability clamp.
+// Matches TransitionInstrument's behavior: raw user entries are
+// strict, derived sums tolerate floating drift and clamp on overshoot.
+constexpr double kProbTolerance = 1e-12;
+
+// Release builds use -ffast-math, which implies -ffinite-math-only.
+// That folds away std::isfinite() and lets `v >= 0.0 && v <= 1.0`
+// pass NaN through. Inspect the IEEE 754 bit pattern instead: a
+// non-finite double has all exponent bits set.
+bool is_finite_robust(double v) {
+    uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
+}
+
+}  // namespace
+
+MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string> symbols,
+                                                         std::vector<std::vector<double>> matrix,
+                                                         const LevelSet& levels) {
+    if (symbols.empty()) {
+        throw std::invalid_argument("MeasurementClassifier::from_matrix: symbols list is empty");
+    }
+    {
+        std::unordered_set<std::string> seen;
+        seen.reserve(symbols.size());
+        for (const auto& s : symbols) {
+            if (!seen.insert(s).second) {
+                throw std::invalid_argument(
+                    "MeasurementClassifier::from_matrix: duplicate symbol '" + s + "'");
+            }
+        }
+    }
+
+    const size_t s_n = symbols.size();
+    const size_t l_n = levels.size();
+
+    if (matrix.size() != s_n) {
+        throw std::invalid_argument("MeasurementClassifier::from_matrix: matrix has " +
+                                    std::to_string(matrix.size()) + " rows; expected " +
+                                    std::to_string(s_n) + " (one per symbol)");
+    }
+
+    // Single pass: validate row width and entry bounds while copying
+    // into the flat row-major buffer.
+    std::vector<double> flat(s_n * l_n);
+    for (size_t s = 0; s < s_n; ++s) {
+        if (matrix[s].size() != l_n) {
+            throw std::invalid_argument("MeasurementClassifier::from_matrix: row " +
+                                        std::to_string(s) + " has " +
+                                        std::to_string(matrix[s].size()) + " columns; expected " +
+                                        std::to_string(l_n) + " (one per level)");
+        }
+        for (size_t l = 0; l < l_n; ++l) {
+            const double v = matrix[s][l];
+            // is_finite_robust runs first because -ffast-math folds
+            // std::isfinite() / NaN-aware comparisons away.
+            if (!is_finite_robust(v) || v < 0.0 || v > 1.0) {
+                throw std::invalid_argument("MeasurementClassifier::from_matrix: entry (" +
+                                            std::to_string(s) + ", " + std::to_string(l) +
+                                            ") = " + std::to_string(v) +
+                                            " is not finite or is out of [0, 1]");
+            }
+            flat[s * l_n + l] = v;
+        }
+    }
+
+    std::vector<double> reject_probs(l_n, 0.0);
+    for (size_t l = 0; l < l_n; ++l) {
+        double sum = 0.0;
+        for (size_t s = 0; s < s_n; ++s) {
+            sum += flat[s * l_n + l];
+        }
+        if (sum > 1.0 + kProbTolerance) {
+            throw std::invalid_argument("MeasurementClassifier::from_matrix: column " +
+                                        std::to_string(l) + " sum = " + std::to_string(sum) +
+                                        " exceeds 1");
+        }
+        // Deficit is the implicit reject probability, clamped to [0, 1]
+        // so accessors never report a negative number under floating
+        // drift in the column sum.
+        const double clamped = sum > 1.0 ? 1.0 : sum;
+        reject_probs[l] = 1.0 - clamped;
+    }
+
+    return MeasurementClassifier(std::move(symbols), std::move(flat), std::move(reject_probs));
+}
+
+MeasurementClassifier::MeasurementClassifier(std::vector<std::string> symbols,
+                                             std::vector<double> matrix_flat,
+                                             std::vector<double> reject_probs)
+    : symbols_(std::move(symbols)),
+      matrix_flat_(std::move(matrix_flat)),
+      reject_probs_(std::move(reject_probs)) {}
+
+const std::string& MeasurementClassifier::symbol_label(uint8_t symbol_idx) const {
+    if (symbol_idx >= symbols_.size()) {
+        throw std::invalid_argument("MeasurementClassifier::symbol_label: index " +
+                                    std::to_string(symbol_idx) + " out of range (num_symbols " +
+                                    std::to_string(symbols_.size()) + ")");
+    }
+    return symbols_[symbol_idx];
+}
+
+double MeasurementClassifier::prob(uint8_t symbol_idx, uint8_t level_id) const {
+    const size_t s_n = symbols_.size();
+    const size_t l_n = reject_probs_.size();
+    if (symbol_idx >= s_n || level_id >= l_n) {
+        throw std::invalid_argument("MeasurementClassifier::prob: index (" +
+                                    std::to_string(symbol_idx) + ", " + std::to_string(level_id) +
+                                    ") out of range (num_symbols " + std::to_string(s_n) +
+                                    ", num_levels " + std::to_string(l_n) + ")");
+    }
+    return matrix_flat_[static_cast<size_t>(symbol_idx) * l_n + static_cast<size_t>(level_id)];
+}
+
+double MeasurementClassifier::reject_probability(uint8_t level_id) const {
+    if (level_id >= reject_probs_.size()) {
+        throw std::invalid_argument("MeasurementClassifier::reject_probability: index " +
+                                    std::to_string(level_id) + " out of range (num_levels " +
+                                    std::to_string(reject_probs_.size()) + ")");
+    }
+    return reject_probs_[level_id];
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/classifier.h
+++ b/src/clifft/noncomp/classifier.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// MeasurementClassifier: column-substochastic map from levels to
+// user-facing measurement symbols.
+//
+// matrix[symbol_index][level_id] = P(symbol | level). For each level,
+// the column (taken across symbols) sums to at most 1; the deficit
+// per column is the implicit P(reject | level). A reject outcome
+// means the model has no opinion about what symbol a measurement on
+// a qubit at this level should produce, and the sampler raises
+// instead of silently picking a bit.
+//
+// Construction binds the classifier to a LevelSet so the per-level
+// column count matches the level table.
+
+#include "clifft/noncomp/level.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace clifft {
+
+class MeasurementClassifier {
+  public:
+    // Validates that:
+    //   - symbols is non-empty and has no duplicate labels;
+    //   - matrix has shape (symbols.size(), levels.size());
+    //   - every entry is finite and lies in [0, 1] (strict);
+    //   - every column sum lies in [0, 1] (the per-level deficit is
+    //     the cached P(reject | level), clamped to 0 on overshoot
+    //     within floating tolerance).
+    static MeasurementClassifier from_matrix(std::vector<std::string> symbols,
+                                             std::vector<std::vector<double>> matrix,
+                                             const LevelSet& levels);
+
+    size_t num_symbols() const { return symbols_.size(); }
+    size_t num_levels() const { return reject_probs_.size(); }
+    const std::string& symbol_label(uint8_t symbol_idx) const;
+
+    // P(symbol | level). Throws on out-of-range indices.
+    double prob(uint8_t symbol_idx, uint8_t level_id) const;
+
+    // 1 - sum_s prob(s, level_id). Cached at construction and
+    // clamped to [0, 1] so it never reports a negative value under
+    // floating drift in the column sum.
+    double reject_probability(uint8_t level_id) const;
+
+  private:
+    MeasurementClassifier(std::vector<std::string> symbols, std::vector<double> matrix_flat,
+                          std::vector<double> reject_probs);
+
+    std::vector<std::string> symbols_;
+    // Row-major flat storage: matrix_flat_[symbol * num_levels() + level_id].
+    // Single allocation, contiguous; mirrors TransitionInstrument's
+    // arena-friendly layout.
+    std::vector<double> matrix_flat_;
+    std::vector<double> reject_probs_;
+};
+
+}  // namespace clifft

--- a/src/clifft/noncomp/classifier.h
+++ b/src/clifft/noncomp/classifier.h
@@ -53,8 +53,6 @@ class MeasurementClassifier {
 
     std::vector<std::string> symbols_;
     // Row-major flat storage: matrix_flat_[symbol * num_levels() + level_id].
-    // Single allocation, contiguous; mirrors TransitionInstrument's
-    // arena-friendly layout.
     std::vector<double> matrix_flat_;
     std::vector<double> reject_probs_;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(clifft_tests
     test_fuzz.cc
     test_noncomp_value_types.cc
     test_noncomp_transition_instrument.cc
+    test_noncomp_classifier.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_classifier.cc
+++ b/tests/test_noncomp_classifier.cc
@@ -48,6 +48,34 @@ TEST_CASE("MeasurementClassifier: rejects empty symbols list") {
         ContainsSubstring("symbols list is empty"));
 }
 
+TEST_CASE("MeasurementClassifier: accepts the 256-symbol boundary (uint8_t addressable)") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::string> symbols;
+    symbols.reserve(256);
+    for (size_t i = 0; i < 256; ++i) {
+        symbols.push_back("s" + std::to_string(i));
+    }
+    // All-zero matrix passes shape and column-sum checks trivially.
+    std::vector<std::vector<double>> m(256, std::vector<double>(5, 0.0));
+    auto classifier = MeasurementClassifier::from_matrix(std::move(symbols), std::move(m), levels);
+    REQUIRE(classifier.num_symbols() == 256);
+    // Highest index is addressable through the uint8_t API.
+    REQUIRE(classifier.symbol_label(255) == "s255");
+}
+
+TEST_CASE("MeasurementClassifier: rejects 257 symbols (above uint8_t addressability)") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::string> symbols;
+    symbols.reserve(257);
+    for (size_t i = 0; i < 257; ++i) {
+        symbols.push_back("s" + std::to_string(i));
+    }
+    std::vector<std::vector<double>> m(257, std::vector<double>(5, 0.0));
+    REQUIRE_THROWS_WITH(
+        MeasurementClassifier::from_matrix(std::move(symbols), std::move(m), levels),
+        ContainsSubstring("257") && ContainsSubstring("256"));
+}
+
 TEST_CASE("MeasurementClassifier: rejects duplicate symbol labels") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = {

--- a/tests/test_noncomp_classifier.cc
+++ b/tests/test_noncomp_classifier.cc
@@ -1,0 +1,214 @@
+#include "clifft/noncomp/classifier.h"
+#include "clifft/noncomp/level.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::WithinAbs;
+using clifft::LevelSet;
+using clifft::MeasurementClassifier;
+
+namespace {
+
+// "Identity + reject" classifier for the default 5-level set:
+// g -> "0", e -> "1", leak_g/leak_e/lost -> reject.
+std::vector<std::vector<double>> default_identity_matrix() {
+    return {
+        {1, 0, 0, 0, 0},  // P("0" | level) over [g, e, leak_g, leak_e, lost]
+        {0, 1, 0, 0, 0},  // P("1" | level)
+    };
+}
+
+}  // namespace
+
+// =========================================================================
+// Construction validation
+// =========================================================================
+
+TEST_CASE("MeasurementClassifier: accepts identity + reject for the default level set") {
+    LevelSet levels = LevelSet::default_set();
+    auto classifier =
+        MeasurementClassifier::from_matrix({"0", "1"}, default_identity_matrix(), levels);
+    REQUIRE(classifier.num_symbols() == 2);
+    REQUIRE(classifier.num_levels() == 5);
+}
+
+TEST_CASE("MeasurementClassifier: rejects empty symbols list") {
+    LevelSet levels = LevelSet::default_set();
+    REQUIRE_THROWS_WITH(
+        MeasurementClassifier::from_matrix({}, std::vector<std::vector<double>>{}, levels),
+        ContainsSubstring("symbols list is empty"));
+}
+
+TEST_CASE("MeasurementClassifier: rejects duplicate symbol labels") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = {
+        {1, 0, 0, 0, 0},
+        {0, 1, 0, 0, 0},
+    };
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "0"}, std::move(m), levels),
+                        ContainsSubstring("duplicate symbol") && ContainsSubstring("'0'"));
+}
+
+TEST_CASE("MeasurementClassifier: rejects wrong row count") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = {
+        {1, 0, 0, 0, 0},
+    };
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                        ContainsSubstring("1 rows") && ContainsSubstring("expected 2"));
+}
+
+TEST_CASE("MeasurementClassifier: rejects wrong column count") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = {
+        {1, 0, 0, 0},  // only 4 columns
+        {0, 1, 0, 0},
+    };
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                        ContainsSubstring("4 columns") && ContainsSubstring("expected 5"));
+}
+
+TEST_CASE("MeasurementClassifier: rejects negative entry") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][0] = -0.1;
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                        ContainsSubstring("entry") && ContainsSubstring("out of [0, 1]"));
+}
+
+TEST_CASE("MeasurementClassifier: rejects entry above 1") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][0] = 1.5;
+    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                      std::invalid_argument);
+}
+
+TEST_CASE("MeasurementClassifier: rejects NaN entry") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][0] = std::numeric_limits<double>::quiet_NaN();
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                        ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
+}
+
+TEST_CASE("MeasurementClassifier: rejects infinity entry") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][0] = std::numeric_limits<double>::infinity();
+    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                      std::invalid_argument);
+}
+
+TEST_CASE("MeasurementClassifier: entry validation has no tolerance slack") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][0] = std::nextafter(1.0, 2.0);
+    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                      std::invalid_argument);
+}
+
+TEST_CASE("MeasurementClassifier: rejects column sum above 1") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][0] = 0.6;
+    m[1][0] = 0.6;  // column 0 sums to 1.2
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
+                        ContainsSubstring("column 0") && ContainsSubstring("exceeds 1"));
+}
+
+TEST_CASE("MeasurementClassifier: column sum within tolerance above 1 clamps reject to 0") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    // Two entries whose sum is the next representable double above 1.0
+    // (1.0 + 2^-52), well within kProbTolerance. Each entry passes the
+    // strict [0, 1] check.
+    const double a = std::nextafter(std::nextafter(0.5, 1.0), 1.0);  // 0.5 + 2^-52
+    const double b = 0.5;
+    REQUIRE(a + b > 1.0);
+    REQUIRE(a + b < 1.0 + 1e-12);
+    m[0][0] = a;
+    m[1][0] = b;
+    auto classifier = MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
+    REQUIRE(classifier.reject_probability(0) == 0.0);
+}
+
+// =========================================================================
+// Accessors
+// =========================================================================
+
+TEST_CASE("MeasurementClassifier: prob returns the entry under (symbol, level) convention") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][2] = 0.25;  // P("0" | leak_g) = 0.25
+    m[1][2] = 0.25;  // P("1" | leak_g) = 0.25; deficit 0.5 = reject prob
+    auto classifier = MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
+
+    REQUIRE_THAT(classifier.prob(0, 0), WithinAbs(1.0, 1e-12));   // P("0" | g)
+    REQUIRE_THAT(classifier.prob(1, 1), WithinAbs(1.0, 1e-12));   // P("1" | e)
+    REQUIRE_THAT(classifier.prob(0, 2), WithinAbs(0.25, 1e-12));  // P("0" | leak_g)
+    REQUIRE_THAT(classifier.prob(1, 2), WithinAbs(0.25, 1e-12));  // P("1" | leak_g)
+    REQUIRE_THAT(classifier.prob(0, 4), WithinAbs(0.0, 1e-12));   // P("0" | lost) = 0
+}
+
+TEST_CASE("MeasurementClassifier: symbol_label returns the constructed strings") {
+    LevelSet levels = LevelSet::default_set();
+    auto classifier =
+        MeasurementClassifier::from_matrix({"zero", "one"}, default_identity_matrix(), levels);
+    REQUIRE(classifier.symbol_label(0) == "zero");
+    REQUIRE(classifier.symbol_label(1) == "one");
+}
+
+TEST_CASE("MeasurementClassifier: out-of-range accessors throw") {
+    LevelSet levels = LevelSet::default_set();
+    auto classifier =
+        MeasurementClassifier::from_matrix({"0", "1"}, default_identity_matrix(), levels);
+    REQUIRE_THROWS_AS(classifier.symbol_label(99), std::invalid_argument);
+    REQUIRE_THROWS_AS(classifier.prob(99, 0), std::invalid_argument);
+    REQUIRE_THROWS_AS(classifier.prob(0, 99), std::invalid_argument);
+    REQUIRE_THROWS_AS(classifier.reject_probability(99), std::invalid_argument);
+}
+
+// =========================================================================
+// reject_probability
+// =========================================================================
+
+TEST_CASE("MeasurementClassifier: identity matrix gives 0 reject on g/e and 1 on leak/lost") {
+    LevelSet levels = LevelSet::default_set();
+    auto classifier =
+        MeasurementClassifier::from_matrix({"0", "1"}, default_identity_matrix(), levels);
+    REQUIRE_THAT(classifier.reject_probability(0), WithinAbs(0.0, 1e-12));  // g
+    REQUIRE_THAT(classifier.reject_probability(1), WithinAbs(0.0, 1e-12));  // e
+    REQUIRE_THAT(classifier.reject_probability(2), WithinAbs(1.0, 1e-12));  // leak_g
+    REQUIRE_THAT(classifier.reject_probability(3), WithinAbs(1.0, 1e-12));  // leak_e
+    REQUIRE_THAT(classifier.reject_probability(4), WithinAbs(1.0, 1e-12));  // lost
+}
+
+TEST_CASE("MeasurementClassifier: all-zero matrix gives reject = 1 for every level") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    auto classifier = MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
+    for (uint8_t l = 0; l < 5; ++l) {
+        REQUIRE_THAT(classifier.reject_probability(l), WithinAbs(1.0, 1e-12));
+    }
+}
+
+TEST_CASE("MeasurementClassifier: random-bit-on-lost policy via 0.5/0.5 column") {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> m = default_identity_matrix();
+    m[0][4] = 0.5;  // P("0" | lost) = 0.5
+    m[1][4] = 0.5;  // P("1" | lost) = 0.5
+    auto classifier = MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
+    REQUIRE_THAT(classifier.reject_probability(4), WithinAbs(0.0, 1e-12));
+    REQUIRE_THAT(classifier.prob(0, 4), WithinAbs(0.5, 1e-12));
+    REQUIRE_THAT(classifier.prob(1, 4), WithinAbs(0.5, 1e-12));
+}


### PR DESCRIPTION
Third implementation PR on the noncomputational MVP feature branch. Lands `MeasurementClassifier` per §3.2 + §4.1 check 5 of the design note.

**Targets the feature branch, not main.** Per #104, partial work does not merge to main.

## What's in

`src/clifft/noncomp/classifier.{h,cc}` — column-substochastic `(symbols, levels)` map bound to a `LevelSet` at construction.

- **`MeasurementClassifier::from_matrix(symbols, matrix, levels)`** validates:
  - `symbols` non-empty, no duplicate labels
  - matrix has shape `(symbols.size(), levels.size())`
  - every entry is finite and strictly in `[0, 1]` (NaN-robust under `-ffast-math` via the IEEE bit-pattern finite check; `static_assert(is_iec559)` documents the assumption)
  - every per-level column sum is in `[0, 1]` (tolerated to `1 + 1e-12` then clamped)
- **`reject_probability(level_id)`** is cached at construction as `1 - column_sum`, clamped so it never reports a negative number under floating drift.
- **Accessors**: `num_symbols`, `num_levels`, `symbol_label`, `prob(symbol, level)`, `reject_probability(level)`. All out-of-range accessors throw with a named field.

Internal storage is a single row-major `std::vector<double>` of size `num_symbols * num_levels`, mirroring `TransitionInstrument`'s arena-friendly layout from PR #107.

## What this enables

`reject_probability(lost)` for the default identity-style classifier is `1.0` — that's the "reject" outcome that lets the model say "the policy does not specify what `M` on a lost qubit should return." Users who want random-bit-on-lost configure the classifier's `lost` column to `[0.5, 0.5]`; deterministic-0 is `[1, 0]`; reject is `[0, 0]`. One specification surface, no separate `lost_measurement` policy knob (per the design-note resolution in PR #105).

## What's not in

- No `NonComputationalModel` yet (PR D); the classifier is a building block.
- No nanobind bindings yet (whole-surface Python drop once the model lands).

## Test plan

- [x] `uv tool run pre-commit run --all-files` clean
- [x] Debug build: full suite passes (824/824 tests, including 18 new)
- [x] Release build: NaN-rejection test passes under `-ffast-math`

18 cases cover:
- Construction validation: identity-style accepted; empty symbols, duplicate labels, wrong row/column count, negative/NaN/infinity entry, `nextafter(1.0)` entry, column sum > 1 all rejected with named fields; column-sum-within-tolerance clamps `reject_probability` to 0 (with the same `a + b > 1.0` guard pattern from PR #107).
- Accessors: `prob(s, l)` orientation; `symbol_label` round-trips constructed strings; out-of-range accessors throw.
- `reject_probability`: identity matrix gives 0 on g/e and 1 on leak_g/leak_e/lost; all-zero matrix gives 1 everywhere; random-bit-on-lost (0.5/0.5 column) gives 0 on lost.

## Next

PR D: `model.{h,cc}` — `NonComputationalModel` ties together `LevelSet`, `TransitionInstrument` map, `MeasurementClassifier`, `NonComputationalPolicy`. Construction-time validation per §4.1.