### PR TITLE
chore(noncomp): use std::format for validation error messages

### DIFF
--- a/src/clifft/noncomp/classifier.cc
+++ b/src/clifft/noncomp/classifier.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <format>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -45,9 +46,10 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
         // The public symbol index APIs use uint8_t. Allowing more than
         // 256 symbols would make indices >= 256 unaddressable through
         // prob() / symbol_label() and silently wrap on conversion.
-        throw std::invalid_argument("MeasurementClassifier::from_matrix: symbols list has " +
-                                    std::to_string(symbols.size()) +
-                                    " entries; max supported is 256");
+        throw std::invalid_argument(
+            std::format("MeasurementClassifier::from_matrix: symbols list has {} entries; "
+                        "max supported is 256",
+                        symbols.size()));
     }
     {
         std::unordered_set<std::string> seen;
@@ -55,7 +57,7 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
         for (const auto& s : symbols) {
             if (!seen.insert(s).second) {
                 throw std::invalid_argument(
-                    "MeasurementClassifier::from_matrix: duplicate symbol '" + s + "'");
+                    std::format("MeasurementClassifier::from_matrix: duplicate symbol '{}'", s));
             }
         }
     }
@@ -64,9 +66,10 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
     const size_t l_n = levels.size();
 
     if (matrix.size() != s_n) {
-        throw std::invalid_argument("MeasurementClassifier::from_matrix: matrix has " +
-                                    std::to_string(matrix.size()) + " rows; expected " +
-                                    std::to_string(s_n) + " (one per symbol)");
+        throw std::invalid_argument(
+            std::format("MeasurementClassifier::from_matrix: matrix has {} rows; expected {} "
+                        "(one per symbol)",
+                        matrix.size(), s_n));
     }
 
     // Single pass: validate row width and entry bounds while copying
@@ -74,20 +77,20 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
     std::vector<double> flat(s_n * l_n);
     for (size_t s = 0; s < s_n; ++s) {
         if (matrix[s].size() != l_n) {
-            throw std::invalid_argument("MeasurementClassifier::from_matrix: row " +
-                                        std::to_string(s) + " has " +
-                                        std::to_string(matrix[s].size()) + " columns; expected " +
-                                        std::to_string(l_n) + " (one per level)");
+            throw std::invalid_argument(
+                std::format("MeasurementClassifier::from_matrix: row {} has {} columns; "
+                            "expected {} (one per level)",
+                            s, matrix[s].size(), l_n));
         }
         for (size_t l = 0; l < l_n; ++l) {
             const double v = matrix[s][l];
             // is_finite_robust runs first because -ffast-math folds
             // std::isfinite() / NaN-aware comparisons away.
             if (!is_finite_robust(v) || v < 0.0 || v > 1.0) {
-                throw std::invalid_argument("MeasurementClassifier::from_matrix: entry (" +
-                                            std::to_string(s) + ", " + std::to_string(l) +
-                                            ") = " + std::to_string(v) +
-                                            " is not finite or is out of [0, 1]");
+                throw std::invalid_argument(
+                    std::format("MeasurementClassifier::from_matrix: entry ({}, {}) = {} "
+                                "is not finite or is out of [0, 1]",
+                                s, l, v));
             }
             flat[s * l_n + l] = v;
         }
@@ -100,9 +103,8 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
             sum += flat[s * l_n + l];
         }
         if (sum > 1.0 + kProbTolerance) {
-            throw std::invalid_argument("MeasurementClassifier::from_matrix: column " +
-                                        std::to_string(l) + " sum = " + std::to_string(sum) +
-                                        " exceeds 1");
+            throw std::invalid_argument(std::format(
+                "MeasurementClassifier::from_matrix: column {} sum = {} exceeds 1", l, sum));
         }
         // Deficit is the implicit reject probability, clamped to [0, 1]
         // so accessors never report a negative number under floating
@@ -123,9 +125,10 @@ MeasurementClassifier::MeasurementClassifier(std::vector<std::string> symbols,
 
 const std::string& MeasurementClassifier::symbol_label(uint8_t symbol_idx) const {
     if (symbol_idx >= symbols_.size()) {
-        throw std::invalid_argument("MeasurementClassifier::symbol_label: index " +
-                                    std::to_string(symbol_idx) + " out of range (num_symbols " +
-                                    std::to_string(symbols_.size()) + ")");
+        throw std::invalid_argument(
+            std::format("MeasurementClassifier::symbol_label: index {} out of range "
+                        "(num_symbols {})",
+                        static_cast<unsigned>(symbol_idx), symbols_.size()));
     }
     return symbols_[symbol_idx];
 }
@@ -134,19 +137,20 @@ double MeasurementClassifier::prob(uint8_t symbol_idx, uint8_t level_id) const {
     const size_t s_n = symbols_.size();
     const size_t l_n = reject_probs_.size();
     if (symbol_idx >= s_n || level_id >= l_n) {
-        throw std::invalid_argument("MeasurementClassifier::prob: index (" +
-                                    std::to_string(symbol_idx) + ", " + std::to_string(level_id) +
-                                    ") out of range (num_symbols " + std::to_string(s_n) +
-                                    ", num_levels " + std::to_string(l_n) + ")");
+        throw std::invalid_argument(std::format(
+            "MeasurementClassifier::prob: index ({}, {}) out of range "
+            "(num_symbols {}, num_levels {})",
+            static_cast<unsigned>(symbol_idx), static_cast<unsigned>(level_id), s_n, l_n));
     }
     return matrix_flat_[static_cast<size_t>(symbol_idx) * l_n + static_cast<size_t>(level_id)];
 }
 
 double MeasurementClassifier::reject_probability(uint8_t level_id) const {
     if (level_id >= reject_probs_.size()) {
-        throw std::invalid_argument("MeasurementClassifier::reject_probability: index " +
-                                    std::to_string(level_id) + " out of range (num_levels " +
-                                    std::to_string(reject_probs_.size()) + ")");
+        throw std::invalid_argument(
+            std::format("MeasurementClassifier::reject_probability: index {} out of range "
+                        "(num_levels {})",
+                        static_cast<unsigned>(level_id), reject_probs_.size()));
     }
     return reject_probs_[level_id];
 }

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -33,6 +33,7 @@
 #include "clifft/noncomp/qubit_status.h"
 
 #include <cstdint>
+#include <format>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -110,9 +111,8 @@ class LevelSet {
             throw std::invalid_argument("LevelSet: level set is empty");
         }
         if (levels_.size() > 128) {
-            throw std::invalid_argument("LevelSet: level set has " +
-                                        std::to_string(levels_.size()) +
-                                        " entries; max supported is 128");
+            throw std::invalid_argument(std::format(
+                "LevelSet: level set has {} entries; max supported is 128", levels_.size()));
         }
         size_t computational_zero_count = 0;
         size_t computational_one_count = 0;
@@ -121,9 +121,9 @@ class LevelSet {
             switch (lv.category) {
                 case LevelCategory::Computational:
                     if (!lv.basis_bit.has_value()) {
-                        throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
-                                                    std::to_string(i) +
-                                                    ") is Computational but has no basis_bit");
+                        throw std::invalid_argument(std::format(
+                            "LevelSet: level '{}' (id {}) is Computational but has no basis_bit",
+                            lv.label, i));
                     }
                     if (*lv.basis_bit == BasisBit::Zero) {
                         ++computational_zero_count;
@@ -136,45 +136,45 @@ class LevelSet {
                     break;
                 case LevelCategory::Lost:
                     if (lv.basis_bit.has_value()) {
-                        throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
-                                                    std::to_string(i) +
-                                                    ") is Lost and must not carry basis_bit");
+                        throw std::invalid_argument(std::format(
+                            "LevelSet: level '{}' (id {}) is Lost and must not carry basis_bit",
+                            lv.label, i));
                     }
                     break;
                 default:
-                    throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
-                                                std::to_string(i) +
-                                                ") has an unrecognized LevelCategory value");
+                    throw std::invalid_argument(std::format(
+                        "LevelSet: level '{}' (id {}) has an unrecognized LevelCategory value",
+                        lv.label, i));
             }
         }
         if (computational_zero_count != 1) {
-            throw std::invalid_argument(
+            throw std::invalid_argument(std::format(
                 "LevelSet: expected exactly one Computational level with basis_bit == Zero, "
-                "got " +
-                std::to_string(computational_zero_count));
+                "got {}",
+                computational_zero_count));
         }
         if (computational_one_count != 1) {
-            throw std::invalid_argument(
+            throw std::invalid_argument(std::format(
                 "LevelSet: expected exactly one Computational level with basis_bit == One, "
-                "got " +
-                std::to_string(computational_one_count));
+                "got {}",
+                computational_one_count));
         }
     }
 
     void require_in_range(uint8_t level_id, const char* fn) const {
         if (level_id >= levels_.size()) {
-            throw std::invalid_argument(std::string("LevelSet::") + fn + ": level_id " +
-                                        std::to_string(level_id) + " out of range (size " +
-                                        std::to_string(levels_.size()) + ")");
+            throw std::invalid_argument(
+                std::format("LevelSet::{}: level_id {} out of range (size {})", fn,
+                            static_cast<unsigned>(level_id), levels_.size()));
         }
     }
 
     void check_kind(uint8_t level_id, LevelCategory expected, const char* fn) const {
         require_in_range(level_id, fn);
         if (levels_[level_id].category != expected) {
-            throw std::invalid_argument(std::string("LevelSet::") + fn + ": level '" +
-                                        levels_[level_id].label +
-                                        "' has category that does not match the requested kind");
+            throw std::invalid_argument(std::format(
+                "LevelSet::{}: level '{}' has category that does not match the requested kind", fn,
+                levels_[level_id].label));
         }
     }
 };

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <format>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -42,9 +43,10 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
     const size_t n = levels.size();
 
     if (matrix.size() != n) {
-        throw std::invalid_argument("TransitionInstrument::from_matrix: matrix has " +
-                                    std::to_string(matrix.size()) + " rows; expected " +
-                                    std::to_string(n) + " (one per level)");
+        throw std::invalid_argument(
+            std::format("TransitionInstrument::from_matrix: matrix has {} rows; expected {} "
+                        "(one per level)",
+                        matrix.size(), n));
     }
 
     // Single pass: validate row width and entry bounds while copying
@@ -53,8 +55,9 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
     for (size_t to = 0; to < n; ++to) {
         if (matrix[to].size() != n) {
             throw std::invalid_argument(
-                "TransitionInstrument::from_matrix: row " + std::to_string(to) + " has " +
-                std::to_string(matrix[to].size()) + " columns; expected " + std::to_string(n));
+                std::format("TransitionInstrument::from_matrix: row {} has {} columns; "
+                            "expected {}",
+                            to, matrix[to].size(), n));
         }
         for (size_t from = 0; from < n; ++from) {
             const double v = matrix[to][from];
@@ -63,10 +66,10 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
             // is_finite_robust runs first because -ffast-math folds
             // std::isfinite() / NaN-aware comparisons away.
             if (!is_finite_robust(v) || v < 0.0 || v > 1.0) {
-                throw std::invalid_argument("TransitionInstrument::from_matrix: entry (" +
-                                            std::to_string(to) + ", " + std::to_string(from) +
-                                            ") = " + std::to_string(v) +
-                                            " is not finite or is out of [0, 1]");
+                throw std::invalid_argument(
+                    std::format("TransitionInstrument::from_matrix: entry ({}, {}) = {} "
+                                "is not finite or is out of [0, 1]",
+                                to, from, v));
             }
             flat[to * n + from] = v;
         }
@@ -82,9 +85,8 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
         // Within tolerance, clamp so prob() and no_jump_weight()
         // never report values outside [0, 1].
         if (sum > 1.0 + kProbTolerance) {
-            throw std::invalid_argument("TransitionInstrument::from_matrix: column " +
-                                        std::to_string(from) + " sum = " + std::to_string(sum) +
-                                        " exceeds 1");
+            throw std::invalid_argument(std::format(
+                "TransitionInstrument::from_matrix: column {} sum = {} exceeds 1", from, sum));
         }
         column_sums[from] = sum > 1.0 ? 1.0 : sum;
     }
@@ -129,18 +131,20 @@ TransitionInstrument::TransitionInstrument(std::vector<double> matrix_flat,
 double TransitionInstrument::prob(uint8_t to, uint8_t from) const {
     const size_t n = column_sums_.size();
     if (to >= n || from >= n) {
-        throw std::invalid_argument("TransitionInstrument::prob: index (" + std::to_string(to) +
-                                    ", " + std::to_string(from) + ") out of range (num_levels " +
-                                    std::to_string(n) + ")");
+        throw std::invalid_argument(
+            std::format("TransitionInstrument::prob: index ({}, {}) out of range "
+                        "(num_levels {})",
+                        static_cast<unsigned>(to), static_cast<unsigned>(from), n));
     }
     return matrix_flat_[static_cast<size_t>(to) * n + static_cast<size_t>(from)];
 }
 
 double TransitionInstrument::column_sum(uint8_t from) const {
     if (from >= column_sums_.size()) {
-        throw std::invalid_argument("TransitionInstrument::column_sum: index " +
-                                    std::to_string(from) + " out of range (num_levels " +
-                                    std::to_string(column_sums_.size()) + ")");
+        throw std::invalid_argument(
+            std::format("TransitionInstrument::column_sum: index {} out of range "
+                        "(num_levels {})",
+                        static_cast<unsigned>(from), column_sums_.size()));
     }
     return column_sums_[from];
 }


### PR DESCRIPTION
Replaces `std::to_string` string concatenation with `std::format` across the noncomp validation code added on this branch:

- `classifier.cc` — `MeasurementClassifier::from_matrix` and the index accessors
- `transition_instrument.cc` — `TransitionInstrument::from_matrix` and accessors
- `level.h` — `LevelSet::validate`, `require_in_range`, `check_kind`

`uint8_t` indices are cast to `unsigned` in the format args so they render as numbers — `std::format` treats `unsigned char` as a character type and would otherwise print the glyph (`std::to_string` promoted to int).

Error-message text is preserved; the `ContainsSubstring` assertions in the noncomp test suites still pass (130 assertions, 63 cases, Debug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)