### PR TITLE
feat(noncomp): NonComputationalModel with construction-time validation

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -369,6 +369,35 @@ public:
 }  // namespace clifft
 ```
 
+### 3.3 Construction paths (compositional now, spec-based later)
+
+The C++ constructor above is *compositional*: the caller builds each
+`TransitionInstrument` / `MeasurementClassifier` against a `LevelSet`,
+then hands the pre-built objects to the model. This keeps instruments
+independently constructible and testable, but it admits a misuse a
+level-count check cannot catch — a component built against a
+different but same-sized `LevelSet` would bind its columns to the
+wrong level ids. To close that, each instrument and classifier records
+a deterministic `LevelSet::fingerprint()` (over each level's label,
+category, and basis_bit, in order) at construction, and the model
+rejects any component whose fingerprint does not match its own table.
+
+The fingerprint exists *only* to guard the compositional path. The
+intended **primary, Python-facing** construction is spec-based: the
+model receives raw matrices and symbols and constructs every bound
+component against its single `LevelSet` internally, so there is only
+one level table in scope and no fingerprint is needed or surfaced.
+
+Plan: add a spec-based `NonComputationalModel` builder (raw
+`transition` matrices + classifier spec, built against the model's
+`LevelSet`) when bindings land (§6 step 9/10), and bind *that* shape
+in Python. At that point decide whether the compositional constructor
+stays public or becomes an internal/test-only entry. Fingerprints
+must not leak into the Python API or user docs. Transition keys are
+accepted as gate-name strings but canonicalized to `GateType`
+internally; only hookable physical gates are allowed (no annotations,
+identity no-ops, `MPAD`, `EXP_VAL`, or noise channels in the MVP).
+
 ## 4. Validation: construction-time vs. sample-time
 
 Validation is split: model construction checks shape and self-consistency;
@@ -654,6 +683,12 @@ Python bindings in `src/python/bindings.cc` expose: `Level`,
 `MeasurementClassifier`, `NonComputationalPolicy`,
 `NonComputationalModel`,
 `sample_noncomputational(circuit_text, model, shots, seed=None)`.
+
+When step 10 lands, add the spec-based `NonComputationalModel`
+construction path described in §3.3 (raw transition matrices +
+classifier spec built against the model's own `LevelSet`) and bind
+that shape in Python, rather than exposing the compositional
+constructor and its `LevelSet`-fingerprint mechanics to users.
 
 ## 7. Test plan (dependency order)
 

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(clifft_core STATIC
     util/introspection.cc
     noncomp/transition_instrument.cc
     noncomp/classifier.cc
+    noncomp/model.cc
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.

--- a/src/clifft/noncomp/classifier.cc
+++ b/src/clifft/noncomp/classifier.cc
@@ -1,39 +1,14 @@
 #include "clifft/noncomp/classifier.h"
 
+#include "clifft/noncomp/numeric.h"
+
 #include <cstdint>
-#include <cstring>
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
 namespace clifft {
-
-// is_finite_robust below assumes IEEE 754 doubles (every Clifft
-// target satisfies this). Make the assumption explicit.
-static_assert(std::numeric_limits<double>::is_iec559,
-              "MeasurementClassifier requires IEEE 754 doubles");
-
-namespace {
-
-// Tolerance for column-sum bounds and the reject-probability clamp.
-// Matches TransitionInstrument's behavior: raw user entries are
-// strict, derived sums tolerate floating drift and clamp on overshoot.
-constexpr double kProbTolerance = 1e-12;
-
-// Release builds use -ffast-math, which implies -ffinite-math-only.
-// That folds away std::isfinite() and lets `v >= 0.0 && v <= 1.0`
-// pass NaN through. Inspect the IEEE 754 bit pattern instead: a
-// non-finite double has all exponent bits set.
-bool is_finite_robust(double v) {
-    uint64_t bits;
-    std::memcpy(&bits, &v, sizeof(bits));
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
-    return (bits & kExpMask) != kExpMask;
-}
-
-}  // namespace
 
 MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string> symbols,
                                                          std::vector<std::vector<double>> matrix,

--- a/src/clifft/noncomp/classifier.cc
+++ b/src/clifft/noncomp/classifier.cc
@@ -111,15 +111,18 @@ MeasurementClassifier MeasurementClassifier::from_matrix(std::vector<std::string
         reject_probs[l] = 1.0 - clamped;
     }
 
-    return MeasurementClassifier(std::move(symbols), std::move(flat), std::move(reject_probs));
+    return MeasurementClassifier(std::move(symbols), std::move(flat), std::move(reject_probs),
+                                 levels.fingerprint());
 }
 
 MeasurementClassifier::MeasurementClassifier(std::vector<std::string> symbols,
                                              std::vector<double> matrix_flat,
-                                             std::vector<double> reject_probs)
+                                             std::vector<double> reject_probs,
+                                             uint64_t level_fingerprint)
     : symbols_(std::move(symbols)),
       matrix_flat_(std::move(matrix_flat)),
-      reject_probs_(std::move(reject_probs)) {}
+      reject_probs_(std::move(reject_probs)),
+      level_fingerprint_(level_fingerprint) {}
 
 const std::string& MeasurementClassifier::symbol_label(uint8_t symbol_idx) const {
     if (symbol_idx >= symbols_.size()) {

--- a/src/clifft/noncomp/classifier.h
+++ b/src/clifft/noncomp/classifier.h
@@ -47,14 +47,20 @@ class MeasurementClassifier {
     // floating drift in the column sum.
     double reject_probability(uint8_t level_id) const;
 
+    // Fingerprint of the LevelSet this classifier was built against.
+    // A model rejects a classifier whose fingerprint does not match
+    // its own level table.
+    uint64_t level_fingerprint() const { return level_fingerprint_; }
+
   private:
     MeasurementClassifier(std::vector<std::string> symbols, std::vector<double> matrix_flat,
-                          std::vector<double> reject_probs);
+                          std::vector<double> reject_probs, uint64_t level_fingerprint);
 
     std::vector<std::string> symbols_;
     // Row-major flat storage: matrix_flat_[symbol * num_levels() + level_id].
     std::vector<double> matrix_flat_;
     std::vector<double> reject_probs_;
+    uint64_t level_fingerprint_;
 };
 
 }  // namespace clifft

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -63,7 +63,10 @@ class LevelSet {
   public:
     // Validates the level table; throws std::invalid_argument with a
     // named field on failure.
-    explicit LevelSet(std::vector<Level> levels) : levels_(std::move(levels)) { validate(); }
+    explicit LevelSet(std::vector<Level> levels) : levels_(std::move(levels)) {
+        validate();
+        fingerprint_ = compute_fingerprint();
+    }
 
     // Default level set: g, e, leak_g, leak_e, lost.
     // Stable order; the integer ids are positional.
@@ -79,6 +82,14 @@ class LevelSet {
 
     std::span<const Level> levels() const { return levels_; }
     size_t size() const { return levels_.size(); }
+
+    // Deterministic schema signature over (label, category, basis_bit)
+    // per level, in order. Two tables that agree on every level's
+    // identity share a fingerprint; any difference in labels, order,
+    // categories, or basis bits changes it. Instruments and classifiers
+    // record the fingerprint of the table they were built against so a
+    // model can reject a component bound to a different table.
+    uint64_t fingerprint() const { return fingerprint_; }
 
     const Level& at(uint8_t level_id) const {
         require_in_range(level_id, "at");
@@ -104,6 +115,34 @@ class LevelSet {
 
   private:
     std::vector<Level> levels_;
+    uint64_t fingerprint_ = 0;
+
+    // FNV-1a over a canonical byte serialization of each level. The
+    // label is length-prefixed so that, e.g., {"ab", "c"} and {"a",
+    // "bc"} do not collide; the basis_bit absence is encoded with a
+    // sentinel distinct from its Zero/One values. Hand-rolled (not
+    // std::hash) so the value is stable across platforms and runs.
+    uint64_t compute_fingerprint() const {
+        constexpr uint64_t kOffsetBasis = 1469598103934665603ULL;
+        constexpr uint64_t kPrime = 1099511628211ULL;
+        uint64_t h = kOffsetBasis;
+        const auto mix = [&h](uint8_t byte) {
+            h ^= byte;
+            h *= kPrime;
+        };
+        for (const Level& lv : levels_) {
+            const uint64_t len = lv.label.size();
+            for (int i = 0; i < 8; ++i) {
+                mix(static_cast<uint8_t>((len >> (8 * i)) & 0xFFu));
+            }
+            for (const char c : lv.label) {
+                mix(static_cast<uint8_t>(c));
+            }
+            mix(static_cast<uint8_t>(lv.category));
+            mix(lv.basis_bit.has_value() ? static_cast<uint8_t>(*lv.basis_bit) : 0xFFu);
+        }
+        return h;
+    }
 
     void validate() const {
         if (levels_.empty()) {

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -35,6 +36,28 @@ bool is_finite_robust(double v) {
     return (bits & kExpMask) != kExpMask;
 }
 
+// A transition instrument models the noncomputational side effects of a
+// physical qubit operation, so it may only key a gate that represents
+// one. Annotations, identity no-ops, the classical measurement pad, the
+// expectation-value probe, and noise channels (whose composition with a
+// level transition is deliberately left undefined in the MVP) are not
+// hookable.
+bool is_hookable_transition_gate(GateType g) {
+    if (g == GateType::UNKNOWN) {
+        return false;
+    }
+    if (gate_arity(g) == GateArity::ANNOTATION) {
+        return false;
+    }
+    if (is_identity_noop(g) || is_noise_gate(g) || is_exp_val(g)) {
+        return false;
+    }
+    if (g == GateType::MPAD) {
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 NonComputationalModel::NonComputationalModel(
@@ -43,10 +66,10 @@ NonComputationalModel::NonComputationalModel(
     std::optional<MeasurementClassifier> classifier, NonComputationalPolicy policy)
     : levels_(std::move(levels)),
       initial_state_(std::move(initial_state)),
-      transitions_(std::move(transitions)),
       classifier_(std::move(classifier)),
       policy_(policy) {
     const size_t n = levels_.size();
+    const uint64_t fingerprint = levels_.fingerprint();
 
     // Initial state must be a probability vector over the levels.
     if (initial_state_.size() != n) {
@@ -70,27 +93,60 @@ NonComputationalModel::NonComputationalModel(
         throw std::invalid_argument("NonComputationalModel: initial_state sums to " +
                                     std::to_string(sum) + "; must sum to 1");
     }
+    // Normalize away the within-tolerance drift so the sampler never has
+    // to compensate for an unsampled tail.
+    for (double& p : initial_state_) {
+        p /= sum;
+    }
 
-    // Transition keys must name gates in clifft's vocabulary, and each
-    // instrument must span the same level table as the model.
-    for (const auto& [gate, instrument] : transitions_) {
-        if (parse_gate_name(gate) == GateType::UNKNOWN) {
-            throw std::invalid_argument("NonComputationalModel: transition key '" + gate +
+    // Transition keys must name hookable physical gates, canonicalized to
+    // GateType so the sampler resolves them against the parsed circuit
+    // and no two spellings of one gate shadow each other. Each instrument
+    // must have been built against this model's level table.
+    std::map<GateType, std::string> first_spelling;
+    for (auto& [name, instrument] : transitions) {
+        const GateType gate = parse_gate_name(name);
+        if (gate == GateType::UNKNOWN) {
+            throw std::invalid_argument("NonComputationalModel: transition key '" + name +
                                         "' is not a recognized gate name");
         }
+        if (!is_hookable_transition_gate(gate)) {
+            throw std::invalid_argument("NonComputationalModel: transition key '" + name + "' (" +
+                                        std::string(gate_name(gate)) +
+                                        ") is not a hookable physical gate");
+        }
         if (instrument.num_levels() != n) {
-            throw std::invalid_argument("NonComputationalModel: transition '" + gate + "' spans " +
+            throw std::invalid_argument("NonComputationalModel: transition '" + name + "' spans " +
                                         std::to_string(instrument.num_levels()) +
                                         " levels; expected " + std::to_string(n) +
                                         " to match the level table");
         }
+        if (instrument.level_fingerprint() != fingerprint) {
+            throw std::invalid_argument("NonComputationalModel: transition '" + name +
+                                        "' was built against a different level table");
+        }
+        auto [it, inserted] = transitions_.emplace(gate, std::move(instrument));
+        if (!inserted) {
+            throw std::invalid_argument(
+                "NonComputationalModel: transition keys '" + first_spelling.at(gate) + "' and '" +
+                name + "' both resolve to gate '" + std::string(gate_name(gate)) + "'");
+        }
+        first_spelling.emplace(gate, name);
     }
 
-    // The classifier, if present, must span the same level table.
-    if (classifier_.has_value() && classifier_->num_levels() != n) {
-        throw std::invalid_argument(
-            "NonComputationalModel: classifier spans " + std::to_string(classifier_->num_levels()) +
-            " levels; expected " + std::to_string(n) + " to match the level table");
+    // The classifier, if present, must have been built against the same
+    // level table.
+    if (classifier_.has_value()) {
+        if (classifier_->num_levels() != n) {
+            throw std::invalid_argument("NonComputationalModel: classifier spans " +
+                                        std::to_string(classifier_->num_levels()) +
+                                        " levels; expected " + std::to_string(n) +
+                                        " to match the level table");
+        }
+        if (classifier_->level_fingerprint() != fingerprint) {
+            throw std::invalid_argument(
+                "NonComputationalModel: classifier was built against a different level table");
+        }
     }
 
     // Policy must hold recognized enum values.
@@ -112,9 +168,17 @@ double NonComputationalModel::initial_probability(uint8_t level_id) const {
     return initial_state_[level_id];
 }
 
-const TransitionInstrument* NonComputationalModel::transition_for(std::string_view gate) const {
-    const auto it = transitions_.find(std::string(gate));
+const TransitionInstrument* NonComputationalModel::transition_for(GateType gate) const {
+    const auto it = transitions_.find(gate);
     return it == transitions_.end() ? nullptr : &it->second;
+}
+
+const TransitionInstrument* NonComputationalModel::transition_for(std::string_view gate) const {
+    const GateType type = parse_gate_name(gate);
+    if (type == GateType::UNKNOWN) {
+        return nullptr;
+    }
+    return transition_for(type);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -1,10 +1,9 @@
 #include "clifft/noncomp/model.h"
 
 #include "clifft/circuit/gate_data.h"
+#include "clifft/noncomp/numeric.h"
 
 #include <cstdint>
-#include <cstring>
-#include <limits>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -12,50 +11,43 @@
 
 namespace clifft {
 
-// is_finite_robust below assumes IEEE 754 doubles (every Clifft
-// target satisfies this). Make the assumption explicit.
-static_assert(std::numeric_limits<double>::is_iec559,
-              "NonComputationalModel requires IEEE 754 doubles");
-
 namespace {
 
-// Tolerance for the initial-state sum-to-one check. Matches the
-// derived-quantity tolerance used by TransitionInstrument and
-// MeasurementClassifier: raw entries are strict, the derived sum
-// tolerates floating drift.
-constexpr double kProbTolerance = 1e-12;
-
-// Release builds use -ffast-math, which implies -ffinite-math-only.
-// That folds away std::isfinite() and lets `v >= 0.0 && v <= 1.0`
-// pass NaN through. Inspect the IEEE 754 bit pattern instead: a
-// non-finite double has all exponent bits set.
-bool is_finite_robust(double v) {
-    uint64_t bits;
-    std::memcpy(&bits, &v, sizeof(bits));
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
-    return (bits & kExpMask) != kExpMask;
-}
-
 // A transition instrument models the noncomputational side effects of a
-// physical qubit operation, so it may only key a gate that represents
-// one. Annotations, identity no-ops, the classical measurement pad, the
-// expectation-value probe, and noise channels (whose composition with a
-// level transition is deliberately left undefined in the MVP) are not
-// hookable.
-bool is_hookable_transition_gate(GateType g) {
-    if (g == GateType::UNKNOWN) {
-        return false;
+// physical qubit operation, so it may key only a gate that represents
+// one. This allowlist defaults to false: a newly added GateType is
+// rejected until it is deliberately classified here, rather than being
+// silently accepted. Excludes annotations, identity no-ops, the
+// classical measurement pad (MPAD), the expectation-value probe, and
+// noise channels (whose composition with a level transition is
+// deliberately left undefined in the MVP).
+bool supports_transition(GateType g) {
+    if (is_clifford(g)) {
+        return true;  // single- and two-qubit Clifford gates
     }
-    if (gate_arity(g) == GateArity::ANNOTATION) {
-        return false;
+    if (is_reset(g)) {
+        return true;  // R, RX, RY
     }
-    if (is_identity_noop(g) || is_noise_gate(g) || is_exp_val(g)) {
-        return false;
+    if (is_measurement(g) && g != GateType::MPAD) {
+        return true;  // M, MX, MY, MR, MRX, MRY, MPP, MXX, MYY, MZZ
     }
-    if (g == GateType::MPAD) {
-        return false;
+    switch (g) {
+        // Non-Clifford unitaries: no trait flag distinguishes these, so
+        // they are named explicitly.
+        case GateType::T:
+        case GateType::T_DAG:
+        case GateType::R_X:
+        case GateType::R_Y:
+        case GateType::R_Z:
+        case GateType::U3:
+        case GateType::R_XX:
+        case GateType::R_YY:
+        case GateType::R_ZZ:
+        case GateType::R_PAULI:
+            return true;
+        default:
+            return false;
     }
-    return true;
 }
 
 }  // namespace
@@ -110,10 +102,10 @@ NonComputationalModel::NonComputationalModel(
             throw std::invalid_argument("NonComputationalModel: transition key '" + name +
                                         "' is not a recognized gate name");
         }
-        if (!is_hookable_transition_gate(gate)) {
+        if (!supports_transition(gate)) {
             throw std::invalid_argument("NonComputationalModel: transition key '" + name + "' (" +
                                         std::string(gate_name(gate)) +
-                                        ") is not a hookable physical gate");
+                                        ") does not support a transition instrument");
         }
         if (instrument.num_levels() != n) {
             throw std::invalid_argument("NonComputationalModel: transition '" + name + "' spans " +

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -1,0 +1,120 @@
+#include "clifft/noncomp/model.h"
+
+#include "clifft/circuit/gate_data.h"
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace clifft {
+
+// is_finite_robust below assumes IEEE 754 doubles (every Clifft
+// target satisfies this). Make the assumption explicit.
+static_assert(std::numeric_limits<double>::is_iec559,
+              "NonComputationalModel requires IEEE 754 doubles");
+
+namespace {
+
+// Tolerance for the initial-state sum-to-one check. Matches the
+// derived-quantity tolerance used by TransitionInstrument and
+// MeasurementClassifier: raw entries are strict, the derived sum
+// tolerates floating drift.
+constexpr double kProbTolerance = 1e-12;
+
+// Release builds use -ffast-math, which implies -ffinite-math-only.
+// That folds away std::isfinite() and lets `v >= 0.0 && v <= 1.0`
+// pass NaN through. Inspect the IEEE 754 bit pattern instead: a
+// non-finite double has all exponent bits set.
+bool is_finite_robust(double v) {
+    uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
+}
+
+}  // namespace
+
+NonComputationalModel::NonComputationalModel(
+    LevelSet levels, std::vector<double> initial_state,
+    std::map<std::string, TransitionInstrument> transitions,
+    std::optional<MeasurementClassifier> classifier, NonComputationalPolicy policy)
+    : levels_(std::move(levels)),
+      initial_state_(std::move(initial_state)),
+      transitions_(std::move(transitions)),
+      classifier_(std::move(classifier)),
+      policy_(policy) {
+    const size_t n = levels_.size();
+
+    // Initial state must be a probability vector over the levels.
+    if (initial_state_.size() != n) {
+        throw std::invalid_argument("NonComputationalModel: initial_state has " +
+                                    std::to_string(initial_state_.size()) + " entries; expected " +
+                                    std::to_string(n) + " (one per level)");
+    }
+    double sum = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        const double p = initial_state_[i];
+        // is_finite_robust runs first because -ffast-math folds
+        // std::isfinite() / NaN-aware comparisons away.
+        if (!is_finite_robust(p) || p < 0.0 || p > 1.0) {
+            throw std::invalid_argument("NonComputationalModel: initial_state entry " +
+                                        std::to_string(i) + " = " + std::to_string(p) +
+                                        " is not finite or is out of [0, 1]");
+        }
+        sum += p;
+    }
+    if (sum < 1.0 - kProbTolerance || sum > 1.0 + kProbTolerance) {
+        throw std::invalid_argument("NonComputationalModel: initial_state sums to " +
+                                    std::to_string(sum) + "; must sum to 1");
+    }
+
+    // Transition keys must name gates in clifft's vocabulary, and each
+    // instrument must span the same level table as the model.
+    for (const auto& [gate, instrument] : transitions_) {
+        if (parse_gate_name(gate) == GateType::UNKNOWN) {
+            throw std::invalid_argument("NonComputationalModel: transition key '" + gate +
+                                        "' is not a recognized gate name");
+        }
+        if (instrument.num_levels() != n) {
+            throw std::invalid_argument("NonComputationalModel: transition '" + gate + "' spans " +
+                                        std::to_string(instrument.num_levels()) +
+                                        " levels; expected " + std::to_string(n) +
+                                        " to match the level table");
+        }
+    }
+
+    // The classifier, if present, must span the same level table.
+    if (classifier_.has_value() && classifier_->num_levels() != n) {
+        throw std::invalid_argument(
+            "NonComputationalModel: classifier spans " + std::to_string(classifier_->num_levels()) +
+            " levels; expected " + std::to_string(n) + " to match the level table");
+    }
+
+    // Policy must hold recognized enum values.
+    switch (policy_.unknown_source_policy) {
+        case UnknownSourcePolicy::Reject:
+            break;
+        default:
+            throw std::invalid_argument(
+                "NonComputationalModel: unrecognized unknown_source_policy value");
+    }
+}
+
+double NonComputationalModel::initial_probability(uint8_t level_id) const {
+    if (level_id >= initial_state_.size()) {
+        throw std::invalid_argument("NonComputationalModel::initial_probability: index " +
+                                    std::to_string(level_id) + " out of range (num_levels " +
+                                    std::to_string(initial_state_.size()) + ")");
+    }
+    return initial_state_[level_id];
+}
+
+const TransitionInstrument* NonComputationalModel::transition_for(std::string_view gate) const {
+    const auto it = transitions_.find(std::string(gate));
+    return it == transitions_.end() ? nullptr : &it->second;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -8,12 +8,18 @@
 //
 // Construction runs the model-wide consistency checks (initial state is
 // a probability vector over the levels; every instrument and the
-// classifier span the same level table; transition keys name real
-// gates; policy values are recognized) and throws std::invalid_argument
-// on failure. Whether a transition's source context is representable is
-// a sample-time concern enforced by the sampler against the target
-// qubit's QubitStatusKind, not here.
+// classifier were built against this model's level table; transition
+// keys name hookable physical gates; policy values are recognized) and
+// throws std::invalid_argument on failure. Whether a transition's
+// source context is representable is a sample-time concern enforced by
+// the sampler against the target qubit's QubitStatusKind, not here.
+//
+// Transition keys are supplied as gate-name strings (Stim aliases such
+// as "CNOT" are accepted) but stored canonicalized to GateType, so the
+// sampler resolves them against the parsed circuit's GateType directly
+// and two spellings of the same gate cannot silently shadow each other.
 
+#include "clifft/circuit/gate_data.h"
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/policy.h"
@@ -33,11 +39,14 @@ class NonComputationalModel {
   public:
     // Validates that:
     //   - initial_state has one entry per level, each finite and in
-    //     [0, 1], summing to 1 within tolerance;
-    //   - every transition key names a gate in clifft's vocabulary;
-    //   - every TransitionInstrument spans the same number of levels as
-    //     the level table;
-    //   - the classifier, if present, spans the same number of levels;
+    //     [0, 1]; the distribution is normalized to sum to exactly 1
+    //     after checking it sums to 1 within tolerance;
+    //   - every transition key names a hookable physical gate (no
+    //     annotations, identity no-ops, noise channels, or synthetic
+    //     gates), and no two keys canonicalize to the same gate;
+    //   - every TransitionInstrument and the classifier, if present,
+    //     were built against this model's level table (fingerprint
+    //     match);
     //   - the policy holds recognized enum values.
     // The level table itself is already validated by LevelSet, and each
     // instrument's entry / column-sum bounds are validated at its own
@@ -51,16 +60,19 @@ class NonComputationalModel {
     const LevelSet& levels() const { return levels_; }
     size_t num_levels() const { return levels_.size(); }
 
-    // P(initial level). The distribution sums to 1 within tolerance.
+    // P(initial level). The stored distribution sums to exactly 1.
     // Throws on an out-of-range level id.
     double initial_probability(uint8_t level_id) const;
     const std::vector<double>& initial_state() const { return initial_state_; }
 
-    const std::map<std::string, TransitionInstrument>& transitions() const { return transitions_; }
+    const std::map<GateType, TransitionInstrument>& transitions() const { return transitions_; }
 
     // Transition instrument declared for a gate, or nullptr if the model
-    // declares none. The sampler resolves and caches these per gate; the
-    // lookup constructs a temporary key and is not meant for hot paths.
+    // declares none. The GateType overload is what the sampler uses; the
+    // string overload canonicalizes the name first (returning nullptr
+    // for an unrecognized name) and is a convenience for callers holding
+    // a gate-name string.
+    const TransitionInstrument* transition_for(GateType gate) const;
     const TransitionInstrument* transition_for(std::string_view gate) const;
 
     // The classifier, or nullptr if the model has none.
@@ -73,7 +85,7 @@ class NonComputationalModel {
   private:
     LevelSet levels_;
     std::vector<double> initial_state_;
-    std::map<std::string, TransitionInstrument> transitions_;
+    std::map<GateType, TransitionInstrument> transitions_;
     std::optional<MeasurementClassifier> classifier_;
     NonComputationalPolicy policy_;
 };

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -1,0 +1,81 @@
+#pragma once
+
+// NonComputationalModel: the assembled, validated trajectory model.
+//
+// Ties together a LevelSet, a per-level initial-state distribution, a
+// gate-keyed table of TransitionInstruments, an optional
+// MeasurementClassifier, and the NonComputationalPolicy knobs.
+//
+// Construction runs the model-wide consistency checks (initial state is
+// a probability vector over the levels; every instrument and the
+// classifier span the same level table; transition keys name real
+// gates; policy values are recognized) and throws std::invalid_argument
+// on failure. Whether a transition's source context is representable is
+// a sample-time concern enforced by the sampler against the target
+// qubit's QubitStatusKind, not here.
+
+#include "clifft/noncomp/classifier.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace clifft {
+
+class NonComputationalModel {
+  public:
+    // Validates that:
+    //   - initial_state has one entry per level, each finite and in
+    //     [0, 1], summing to 1 within tolerance;
+    //   - every transition key names a gate in clifft's vocabulary;
+    //   - every TransitionInstrument spans the same number of levels as
+    //     the level table;
+    //   - the classifier, if present, spans the same number of levels;
+    //   - the policy holds recognized enum values.
+    // The level table itself is already validated by LevelSet, and each
+    // instrument's entry / column-sum bounds are validated at its own
+    // construction; this constructor checks only the cross-object
+    // consistency that no single component can see on its own.
+    NonComputationalModel(LevelSet levels, std::vector<double> initial_state,
+                          std::map<std::string, TransitionInstrument> transitions,
+                          std::optional<MeasurementClassifier> classifier,
+                          NonComputationalPolicy policy);
+
+    const LevelSet& levels() const { return levels_; }
+    size_t num_levels() const { return levels_.size(); }
+
+    // P(initial level). The distribution sums to 1 within tolerance.
+    // Throws on an out-of-range level id.
+    double initial_probability(uint8_t level_id) const;
+    const std::vector<double>& initial_state() const { return initial_state_; }
+
+    const std::map<std::string, TransitionInstrument>& transitions() const { return transitions_; }
+
+    // Transition instrument declared for a gate, or nullptr if the model
+    // declares none. The sampler resolves and caches these per gate; the
+    // lookup constructs a temporary key and is not meant for hot paths.
+    const TransitionInstrument* transition_for(std::string_view gate) const;
+
+    // The classifier, or nullptr if the model has none.
+    const MeasurementClassifier* classifier() const {
+        return classifier_.has_value() ? &classifier_.value() : nullptr;
+    }
+
+    const NonComputationalPolicy& policy() const { return policy_; }
+
+  private:
+    LevelSet levels_;
+    std::vector<double> initial_state_;
+    std::map<std::string, TransitionInstrument> transitions_;
+    std::optional<MeasurementClassifier> classifier_;
+    NonComputationalPolicy policy_;
+};
+
+}  // namespace clifft

--- a/src/clifft/noncomp/numeric.h
+++ b/src/clifft/noncomp/numeric.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// Shared numeric helpers for noncomputational model validation.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+namespace clifft {
+
+// The IEEE 754 bit tricks below assume that layout. Make it explicit.
+static_assert(std::numeric_limits<double>::is_iec559, "clifft::noncomp requires IEEE 754 doubles");
+
+// Tolerance for derived-quantity bounds (column sums, the
+// initial-state sum, source-independence equality). Raw user-supplied
+// matrix entries are checked strictly against [0, 1]; only quantities
+// derived from them tolerate this much floating drift.
+inline constexpr double kProbTolerance = 1e-12;
+
+// Release builds use -ffast-math, which implies -ffinite-math-only.
+// That folds away std::isfinite() and lets `v >= 0.0 && v <= 1.0`
+// pass NaN through. Inspect the IEEE 754 bit pattern instead: a
+// non-finite double has all exponent bits set.
+inline bool is_finite_robust(double v) {
+    uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -116,15 +116,18 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
         }
     }
 
-    return TransitionInstrument(std::move(flat), std::move(column_sums), flag);
+    return TransitionInstrument(std::move(flat), std::move(column_sums), flag,
+                                levels.fingerprint());
 }
 
 TransitionInstrument::TransitionInstrument(std::vector<double> matrix_flat,
                                            std::vector<double> column_sums,
-                                           bool is_source_independent_on_computational)
+                                           bool is_source_independent_on_computational,
+                                           uint64_t level_fingerprint)
     : matrix_flat_(std::move(matrix_flat)),
       column_sums_(std::move(column_sums)),
-      is_source_independent_on_computational_(is_source_independent_on_computational) {}
+      is_source_independent_on_computational_(is_source_independent_on_computational),
+      level_fingerprint_(level_fingerprint) {}
 
 double TransitionInstrument::prob(uint8_t to, uint8_t from) const {
     const size_t n = column_sums_.size();

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -1,41 +1,14 @@
 #include "clifft/noncomp/transition_instrument.h"
 
+#include "clifft/noncomp/numeric.h"
+
 #include <cmath>
 #include <cstdint>
-#include <cstring>
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
 namespace clifft {
-
-// is_finite_robust below assumes IEEE 754 doubles (every Clifft
-// target satisfies this). Make the assumption explicit.
-static_assert(std::numeric_limits<double>::is_iec559,
-              "TransitionInstrument requires IEEE 754 doubles");
-
-namespace {
-
-// Tolerance for entry / column-sum bounds and for the
-// source-independence equality check. Generous compared to typical
-// floating-point error in user-supplied matrices; we want to admit
-// hand-written tables that sum to 1.0 - epsilon.
-constexpr double kProbTolerance = 1e-12;
-
-// Release builds use -ffast-math, which implies -ffinite-math-only.
-// That lets the compiler assume operands are finite, folding away
-// std::isfinite() and turning `v >= 0.0 && v <= 1.0` into something
-// that passes NaN through. Inspect the IEEE 754 bit pattern
-// instead: a non-finite double has all exponent bits set.
-bool is_finite_robust(double v) {
-    uint64_t bits;
-    std::memcpy(&bits, &v, sizeof(bits));
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
-    return (bits & kExpMask) != kExpMask;
-}
-
-}  // namespace
 
 TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<double>> matrix,
                                                        const LevelSet& levels) {

--- a/src/clifft/noncomp/transition_instrument.h
+++ b/src/clifft/noncomp/transition_instrument.h
@@ -66,9 +66,14 @@ class TransitionInstrument {
         return is_source_independent_on_computational_;
     }
 
+    // Fingerprint of the LevelSet this instrument was built against.
+    // A model rejects an instrument whose fingerprint does not match
+    // its own level table.
+    uint64_t level_fingerprint() const { return level_fingerprint_; }
+
   private:
     TransitionInstrument(std::vector<double> matrix_flat, std::vector<double> column_sums,
-                         bool is_source_independent_on_computational);
+                         bool is_source_independent_on_computational, uint64_t level_fingerprint);
 
     // Row-major flat storage: matrix_flat_[to * num_levels() + from].
     // One allocation, contiguous memory; column-traversal accessors
@@ -76,6 +81,7 @@ class TransitionInstrument {
     std::vector<double> matrix_flat_;
     std::vector<double> column_sums_;
     bool is_source_independent_on_computational_;
+    uint64_t level_fingerprint_;
 };
 
 }  // namespace clifft

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(clifft_tests
     test_noncomp_value_types.cc
     test_noncomp_transition_instrument.cc
     test_noncomp_classifier.cc
+    test_noncomp_model.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -196,7 +196,8 @@ TEST_CASE("NonComputationalModel: rejects a non-hookable noise-channel transitio
     REQUIRE_THROWS_WITH(
         NonComputationalModel(LevelSet::default_set(), default_initial_state(),
                               std::move(transitions), std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("DEPOLARIZE1") && ContainsSubstring("not a hookable physical gate"));
+        ContainsSubstring("DEPOLARIZE1") &&
+            ContainsSubstring("does not support a transition instrument"));
 }
 
 TEST_CASE("NonComputationalModel: rejects a non-hookable annotation transition key") {
@@ -206,7 +207,7 @@ TEST_CASE("NonComputationalModel: rejects a non-hookable annotation transition k
     REQUIRE_THROWS_WITH(
         NonComputationalModel(LevelSet::default_set(), default_initial_state(),
                               std::move(transitions), std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("not a hookable physical gate"));
+        ContainsSubstring("does not support a transition instrument"));
 }
 
 TEST_CASE("NonComputationalModel: rejects two keys resolving to the same gate") {

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -1,0 +1,214 @@
+#include "clifft/noncomp/classifier.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::WithinAbs;
+using clifft::LevelSet;
+using clifft::MeasurementClassifier;
+using clifft::NonComputationalModel;
+using clifft::NonComputationalPolicy;
+using clifft::TransitionInstrument;
+using clifft::UnknownSourcePolicy;
+
+namespace {
+
+// Identity transition on the default 5-level set: every source stays at
+// its own level (column sums all 1). Valid as an instrument.
+TransitionInstrument identity_transition(const LevelSet& levels) {
+    const size_t n = levels.size();
+    std::vector<std::vector<double>> m(n, std::vector<double>(n, 0.0));
+    for (size_t i = 0; i < n; ++i) {
+        m[i][i] = 1.0;
+    }
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// "Identity + reject" classifier for the default 5-level set.
+MeasurementClassifier identity_classifier(const LevelSet& levels) {
+    return MeasurementClassifier::from_matrix({"0", "1"},
+                                              {
+                                                  {1, 0, 0, 0, 0},
+                                                  {0, 1, 0, 0, 0},
+                                              },
+                                              levels);
+}
+
+// A valid probability vector over the default 5 levels.
+std::vector<double> default_initial_state() {
+    return {0.5, 0.3, 0.1, 0.05, 0.05};
+}
+
+// A two-level set (g, e), distinct in size from the default 5-level set.
+LevelSet two_level_set() {
+    using clifft::BasisBit;
+    using clifft::Level;
+    using clifft::LevelCategory;
+    return LevelSet({
+        Level{"g", LevelCategory::Computational, BasisBit::Zero},
+        Level{"e", LevelCategory::Computational, BasisBit::One},
+    });
+}
+
+}  // namespace
+
+// =========================================================================
+// Construction: happy paths
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: accepts a fully specified default model") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("DEPOLARIZE1", identity_transition(levels));
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
+                                std::move(transitions), identity_classifier(levels),
+                                NonComputationalPolicy{});
+    REQUIRE(model.num_levels() == 5);
+    REQUIRE(model.transitions().size() == 1);
+    REQUIRE(model.classifier() != nullptr);
+    REQUIRE(model.classifier()->num_levels() == 5);
+}
+
+TEST_CASE("NonComputationalModel: accepts a model with no classifier") {
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(), {}, std::nullopt,
+                                NonComputationalPolicy{});
+    REQUIRE(model.classifier() == nullptr);
+    REQUIRE(model.transitions().empty());
+}
+
+TEST_CASE("NonComputationalModel: accepts an initial state at the sum tolerance boundary") {
+    // Sum is 1 + 2^-52, representable and well within kProbTolerance.
+    const double a = std::nextafter(std::nextafter(0.5, 1.0), 1.0);
+    const double b = 0.5;
+    REQUIRE(a + b > 1.0);  // guard: the inputs really do overshoot 1
+    NonComputationalModel model(two_level_set(), {a, b}, {}, std::nullopt,
+                                NonComputationalPolicy{});
+    REQUIRE(model.num_levels() == 2);
+}
+
+// =========================================================================
+// Construction: initial-state validation
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: rejects initial state with wrong length") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), {0.5, 0.5}, {}, std::nullopt,
+                              NonComputationalPolicy{}),
+        ContainsSubstring("initial_state has 2 entries") && ContainsSubstring("expected 5"));
+}
+
+TEST_CASE("NonComputationalModel: rejects initial state entry out of [0, 1]") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), {1.5, -0.5, 0.0, 0.0, 0.0}, {}, std::nullopt,
+                              NonComputationalPolicy{}),
+        ContainsSubstring("initial_state entry 0") && ContainsSubstring("out of [0, 1]"));
+}
+
+TEST_CASE("NonComputationalModel: rejects NaN initial state entry") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    REQUIRE_THROWS_WITH(NonComputationalModel(two_level_set(), {nan, 1.0}, {}, std::nullopt,
+                                              NonComputationalPolicy{}),
+                        ContainsSubstring("not finite"));
+}
+
+TEST_CASE("NonComputationalModel: rejects initial state that does not sum to 1") {
+    REQUIRE_THROWS_WITH(NonComputationalModel(two_level_set(), {0.2, 0.2}, {}, std::nullopt,
+                                              NonComputationalPolicy{}),
+                        ContainsSubstring("sums to") && ContainsSubstring("must sum to 1"));
+}
+
+// =========================================================================
+// Construction: transition validation
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: rejects an unknown transition gate key") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("NOT_A_GATE", identity_transition(levels));
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
+                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("NOT_A_GATE") && ContainsSubstring("not a recognized gate name"));
+}
+
+TEST_CASE("NonComputationalModel: rejects a transition spanning the wrong number of levels") {
+    LevelSet small = two_level_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    // Instrument built against the 2-level set, used in a 5-level model.
+    transitions.emplace("DEPOLARIZE1", identity_transition(small));
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
+                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("DEPOLARIZE1") && ContainsSubstring("spans 2 levels") &&
+            ContainsSubstring("expected 5"));
+}
+
+// =========================================================================
+// Construction: classifier validation
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: rejects a classifier spanning the wrong number of levels") {
+    LevelSet small = two_level_set();
+    // Classifier built against the 2-level set, used in a 5-level model.
+    MeasurementClassifier wrong = MeasurementClassifier::from_matrix({"0", "1"},
+                                                                     {
+                                                                         {1, 0},
+                                                                         {0, 1},
+                                                                     },
+                                                                     small);
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(), {},
+                              std::move(wrong), NonComputationalPolicy{}),
+        ContainsSubstring("classifier spans 2 levels") && ContainsSubstring("expected 5"));
+}
+
+// =========================================================================
+// Accessors
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: initial_probability returns per-level values") {
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(), {}, std::nullopt,
+                                NonComputationalPolicy{});
+    REQUIRE_THAT(model.initial_probability(0), WithinAbs(0.5, 1e-12));
+    REQUIRE_THAT(model.initial_probability(4), WithinAbs(0.05, 1e-12));
+}
+
+TEST_CASE("NonComputationalModel: initial_probability throws on out-of-range level") {
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(), {}, std::nullopt,
+                                NonComputationalPolicy{});
+    REQUIRE_THROWS_WITH(model.initial_probability(5), ContainsSubstring("out of range"));
+}
+
+TEST_CASE("NonComputationalModel: transition_for resolves known gates and misses absent ones") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("DEPOLARIZE1", identity_transition(levels));
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
+                                std::move(transitions), std::nullopt, NonComputationalPolicy{});
+    REQUIRE(model.transition_for("DEPOLARIZE1") != nullptr);
+    REQUIRE(model.transition_for("DEPOLARIZE1")->num_levels() == 5);
+    REQUIRE(model.transition_for("CX") == nullptr);
+}
+
+TEST_CASE("NonComputationalModel: policy accessor reflects the constructed policy") {
+    NonComputationalPolicy policy;
+    policy.reset_restores_lost = true;
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(), {}, std::nullopt,
+                                policy);
+    REQUIRE(model.policy().reset_restores_lost == true);
+    REQUIRE(model.policy().unknown_source_policy == UnknownSourcePolicy::Reject);
+}

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -1,3 +1,4 @@
+#include "clifft/circuit/gate_data.h"
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
@@ -18,6 +19,7 @@
 
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
+using clifft::GateType;
 using clifft::LevelSet;
 using clifft::MeasurementClassifier;
 using clifft::NonComputationalModel;
@@ -27,18 +29,15 @@ using clifft::UnknownSourcePolicy;
 
 namespace {
 
-// Identity transition on the default 5-level set: every source stays at
-// its own level (column sums all 1). Valid as an instrument.
-TransitionInstrument identity_transition(const LevelSet& levels) {
+// All-zero transition: every source has no-jump weight 1, i.e. nothing
+// happens. The honest no-op default; valid against any level table.
+TransitionInstrument zero_transition(const LevelSet& levels) {
     const size_t n = levels.size();
     std::vector<std::vector<double>> m(n, std::vector<double>(n, 0.0));
-    for (size_t i = 0; i < n; ++i) {
-        m[i][i] = 1.0;
-    }
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
-// "Identity + reject" classifier for the default 5-level set.
+// "Identity + reject" classifier for a 5-level set.
 MeasurementClassifier identity_classifier(const LevelSet& levels) {
     return MeasurementClassifier::from_matrix({"0", "1"},
                                               {
@@ -64,6 +63,29 @@ LevelSet two_level_set() {
     });
 }
 
+// A second valid 5-level set with different labels: same size as
+// default_set but a distinct fingerprint.
+LevelSet relabeled_five_level_set() {
+    using clifft::BasisBit;
+    using clifft::Level;
+    using clifft::LevelCategory;
+    return LevelSet({
+        Level{"zero", LevelCategory::Computational, BasisBit::Zero},
+        Level{"one", LevelCategory::Computational, BasisBit::One},
+        Level{"leak0", LevelCategory::Leaked, std::nullopt},
+        Level{"leak1", LevelCategory::Leaked, std::nullopt},
+        Level{"gone", LevelCategory::Lost, std::nullopt},
+    });
+}
+
+double sum(const std::vector<double>& v) {
+    double s = 0.0;
+    for (double x : v) {
+        s += x;
+    }
+    return s;
+}
+
 }  // namespace
 
 // =========================================================================
@@ -73,7 +95,7 @@ LevelSet two_level_set() {
 TEST_CASE("NonComputationalModel: accepts a fully specified default model") {
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
-    transitions.emplace("DEPOLARIZE1", identity_transition(levels));
+    transitions.emplace("H", zero_transition(levels));
     NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
                                 std::move(transitions), identity_classifier(levels),
                                 NonComputationalPolicy{});
@@ -98,6 +120,28 @@ TEST_CASE("NonComputationalModel: accepts an initial state at the sum tolerance 
     NonComputationalModel model(two_level_set(), {a, b}, {}, std::nullopt,
                                 NonComputationalPolicy{});
     REQUIRE(model.num_levels() == 2);
+}
+
+TEST_CASE("NonComputationalModel: normalizes the stored initial state") {
+    // Sum is 1 + 1e-13: inside kProbTolerance but well above 1e-15, so a
+    // normalized vector is distinguishable from the raw input.
+    const std::vector<double> raw = {0.5 + 1e-13, 0.5};
+    REQUIRE(sum(raw) > 1.0 + 1e-15);  // guard: raw input is not already normalized
+    NonComputationalModel model(two_level_set(), raw, {}, std::nullopt, NonComputationalPolicy{});
+    REQUIRE_THAT(sum(model.initial_state()), WithinAbs(1.0, 1e-15));
+}
+
+TEST_CASE("NonComputationalModel: canonicalizes alias transition keys to GateType") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CNOT", zero_transition(levels));  // alias for CX
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
+                                std::move(transitions), std::nullopt, NonComputationalPolicy{});
+    // Stored and resolvable under the canonical gate, not the alias spelling.
+    REQUIRE(model.transitions().count(GateType::CX) == 1);
+    REQUIRE(model.transition_for(GateType::CX) != nullptr);
+    REQUIRE(model.transition_for("CX") != nullptr);
+    REQUIRE(model.transition_for("CNOT") != nullptr);
 }
 
 // =========================================================================
@@ -138,23 +182,64 @@ TEST_CASE("NonComputationalModel: rejects initial state that does not sum to 1")
 TEST_CASE("NonComputationalModel: rejects an unknown transition gate key") {
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
-    transitions.emplace("NOT_A_GATE", identity_transition(levels));
+    transitions.emplace("NOT_A_GATE", zero_transition(levels));
     REQUIRE_THROWS_WITH(
         NonComputationalModel(LevelSet::default_set(), default_initial_state(),
                               std::move(transitions), std::nullopt, NonComputationalPolicy{}),
         ContainsSubstring("NOT_A_GATE") && ContainsSubstring("not a recognized gate name"));
 }
 
+TEST_CASE("NonComputationalModel: rejects a non-hookable noise-channel transition key") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("DEPOLARIZE1", zero_transition(levels));
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
+                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("DEPOLARIZE1") && ContainsSubstring("not a hookable physical gate"));
+}
+
+TEST_CASE("NonComputationalModel: rejects a non-hookable annotation transition key") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("TICK", zero_transition(levels));
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
+                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("not a hookable physical gate"));
+}
+
+TEST_CASE("NonComputationalModel: rejects two keys resolving to the same gate") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CX", zero_transition(levels));
+    transitions.emplace("CNOT", zero_transition(levels));  // also CX
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
+                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("both resolve to gate 'CX'"));
+}
+
 TEST_CASE("NonComputationalModel: rejects a transition spanning the wrong number of levels") {
     LevelSet small = two_level_set();
     std::map<std::string, TransitionInstrument> transitions;
     // Instrument built against the 2-level set, used in a 5-level model.
-    transitions.emplace("DEPOLARIZE1", identity_transition(small));
+    transitions.emplace("H", zero_transition(small));
     REQUIRE_THROWS_WITH(
         NonComputationalModel(LevelSet::default_set(), default_initial_state(),
                               std::move(transitions), std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("DEPOLARIZE1") && ContainsSubstring("spans 2 levels") &&
-            ContainsSubstring("expected 5"));
+        ContainsSubstring("'H' spans 2 levels") && ContainsSubstring("expected 5"));
+}
+
+TEST_CASE("NonComputationalModel: rejects a same-size transition built against a different table") {
+    LevelSet other = relabeled_five_level_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    // Same size (5) as default_set but a different fingerprint.
+    transitions.emplace("H", zero_transition(other));
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
+                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("'H'") && ContainsSubstring("different level table"));
 }
 
 // =========================================================================
@@ -174,6 +259,14 @@ TEST_CASE("NonComputationalModel: rejects a classifier spanning the wrong number
         NonComputationalModel(LevelSet::default_set(), default_initial_state(), {},
                               std::move(wrong), NonComputationalPolicy{}),
         ContainsSubstring("classifier spans 2 levels") && ContainsSubstring("expected 5"));
+}
+
+TEST_CASE("NonComputationalModel: rejects a same-size classifier built against a different table") {
+    LevelSet other = relabeled_five_level_set();
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel(LevelSet::default_set(), default_initial_state(), {},
+                              identity_classifier(other), NonComputationalPolicy{}),
+        ContainsSubstring("classifier") && ContainsSubstring("different level table"));
 }
 
 // =========================================================================
@@ -196,12 +289,15 @@ TEST_CASE("NonComputationalModel: initial_probability throws on out-of-range lev
 TEST_CASE("NonComputationalModel: transition_for resolves known gates and misses absent ones") {
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
-    transitions.emplace("DEPOLARIZE1", identity_transition(levels));
+    transitions.emplace("H", zero_transition(levels));
     NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
                                 std::move(transitions), std::nullopt, NonComputationalPolicy{});
-    REQUIRE(model.transition_for("DEPOLARIZE1") != nullptr);
-    REQUIRE(model.transition_for("DEPOLARIZE1")->num_levels() == 5);
+    REQUIRE(model.transition_for(GateType::H) != nullptr);
+    REQUIRE(model.transition_for("H") != nullptr);
+    REQUIRE(model.transition_for(GateType::CX) == nullptr);
     REQUIRE(model.transition_for("CX") == nullptr);
+    // An unrecognized name canonicalizes to nothing rather than throwing.
+    REQUIRE(model.transition_for("NOT_A_GATE") == nullptr);
 }
 
 TEST_CASE("NonComputationalModel: policy accessor reflects the constructed policy") {


### PR DESCRIPTION
PR D in the noncomputational MVP sequence (after #108). Adds `NonComputationalModel` in `src/clifft/noncomp/model.{h,cc}` — the assembled, validated model that ties together the pieces built in #106–#108 — plus the review-driven hardening below.

## What it does
Constructor takes a `LevelSet`, a per-level `initial_state` distribution, a gate-keyed `std::map<std::string, TransitionInstrument>`, an optional `MeasurementClassifier`, and a `NonComputationalPolicy`, and runs the **construction-time consistency checks** that no single component can see on its own.

- **Initial state is a probability vector** over the levels: one entry per level, each finite and in `[0, 1]` (strict), summing to 1 within `kProbTolerance`. The stored distribution is then **normalized** so no sampler has to compensate for within-tolerance drift.
- **Transition keys are canonicalized to `GateType`.** Stim aliases (`CNOT`→`CX`, `RZ`→`R`, `MZ`→`M`, …) resolve to their canonical gate, and two keys that collapse to the same gate are rejected. The model stores `std::map<GateType, TransitionInstrument>`, so the sampler resolves transitions against the parsed circuit's `GateType` directly — a stored alias spelling can't silently shadow a configured transition.
- **Transition keys must name a gate that supports a transition instrument.** An explicit allowlist that defaults to false (Cliffords, non-Clifford unitaries, measurements except `MPAD`, resets); annotations, identity no-ops, `MPAD`, `EXP_VAL`, and noise channels are rejected, and any newly-added `GateType` is rejected until deliberately classified. Leakage riding on a noise instruction is out of MVP scope until the sampler defines composition semantics.
- **Components are bound by level-table fingerprint.** `LevelSet` exposes a deterministic `fingerprint()` (FNV-1a over each level's `(label, category, basis_bit)` in order); `TransitionInstrument`/`MeasurementClassifier` record it at construction, and the model rejects any component whose fingerprint differs. This catches a same-sized but differently ordered/labeled table that a level-count check accepts.

Per the design contract, **source-context validity stays a sample-time concern** (the sampler checks it against the target qubit's `QubitStatusKind`) and is not enforced at construction.

The `LevelSet` fingerprint guards the **compositional** C++ constructor only. The intended Python-facing path is spec-based (raw matrices built against the model's single `LevelSet`), documented in design note §3.3 and planned for the bindings step — fingerprints will not surface in the Python API.

## Review changes
Multi-LLM review across two rounds:
- **Round 1:** alias canonicalization + duplicate rejection; table-fingerprint binding instead of size-only checks; initial-state normalization; the hookable-gate allowlist excluding noise for the MVP; zero-matrix no-op test helper.
- **Round 2:** hoisted the duplicated `is_finite_robust` / `kProbTolerance` / IEEE-754 `static_assert` into `clifft/noncomp/numeric.h`; inverted the transition-gate check to a fail-closed allowlist; renamed `is_hookable_transition_gate` → `supports_transition` (`"hook"` collides with the QEC hook-error term).

Touches the merged `TransitionInstrument`/`MeasurementClassifier` to add the fingerprint accessor and share the numeric header.

## Tests
`tests/test_noncomp_model.cc` covers happy paths, every rejection branch (length/range/NaN/sum, unknown key, non-supported noise + annotation keys, duplicate canonical keys, wrong-size and wrong-fingerprint instrument/classifier), normalization, alias canonicalization, and accessors. Full Debug suite green (853 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
