### PR TITLE
feat(noncomp): history sampler + shared status stepper (PR E)

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -582,6 +582,44 @@ basis (a superposition of `g` and `e`), so its kind is
 the §4.2 sample-time rejection unless the instrument is
 source-independent on Computational sources.
 
+### 5.2.2 History status is *pre-SVM-known*, not trajectory-physical
+
+The status the history sampler tracks is what is **classically known
+before SVM execution**, which is narrower than the physically-collapsed
+trajectory state. The sampler runs entirely before the SVM (§5.1 steps
+3 vs 6), so it cannot consult a measurement outcome that only exists
+inside the SVM.
+
+The consequences, which override the naive reading of the §5.2.1 table:
+
+- **`M` on `ComputationalKnown(g/e)`**: status stays known. The value
+  was already classically known, so a later source-dependent
+  transition may use it.
+- **`M` on `ComputationalUnknown`**: the history status stays
+  `ComputationalUnknown`. It does **not** promote to
+  `ComputationalKnown`, because the outcome is produced by the SVM, not
+  the history sampler. (The SVM still performs the real quantum
+  measurement and collapse; that is independent of the history layer.)
+  A source-dependent transition fired on this qubit afterward rejects
+  per §4.2 unless the instrument is source-independent on Computational
+  sources.
+- **`R` / `MR` (Z-basis)**: produce `ComputationalKnown(g)` — the value
+  comes from the instruction, not an SVM outcome, so it is pre-SVM
+  known.
+- **`RX` / `RY` / `MRX` / `MRY`**: produce `ComputationalUnknown` (not a
+  `g`/`e` energy eigenstate), as in §5.2.1.
+
+The §5.2.1 row "`M` → `ComputationalKnown(g)` or `(e)` per outcome"
+describes the *physical* trajectory inside a single shot; it is **not**
+the precompile history status unless the value was already known before
+SVM execution. "Measure, then use the measured value to drive a later
+noncomputational transition" requires a segmented runtime / replan and
+is out of scope for the pre-sampled MVP (§9). The history layer must
+not pre-sample measurement outcomes: doing so would either skip the
+measurement back-action on the computational state or force a
+branch-and-continue boundary, which is exactly the dynamic/JIT path
+deferred in §1.
+
 ### 5.3 Hidden trace-out at noncomputational transitions
 
 Whenever a qubit whose status is `ComputationalUnknown` transitions

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(clifft_core STATIC
     noncomp/transition_instrument.cc
     noncomp/classifier.cc
     noncomp/model.cc
+    noncomp/status_step.cc
+    noncomp/sampler.cc
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(clifft_core STATIC
     svm/svm_scalar.cc
     svm/svm_state.cc
     util/introspection.cc
+    util/xoshiro.cc
     noncomp/transition_instrument.cc
     noncomp/classifier.cc
     noncomp/model.cc

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(clifft_core STATIC
     noncomp/classifier.cc
     noncomp/model.cc
     noncomp/status_step.cc
+    noncomp/op_role.cc
     noncomp/sampler.cc
 )
 

--- a/src/clifft/noncomp/history.h
+++ b/src/clifft/noncomp/history.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// NonComputationalHistory: the canonical, minimal record of one sampled
+// trajectory through a circuit.
+//
+// It stores only the *random* facts a replay needs to be deterministic:
+//   - the initial sampled status of each qubit, and
+//   - the outcome of every transition instrument that was consulted, in
+//     circuit-walk order.
+//
+// Everything else (each qubit's status at each operation) is a derived
+// view: replay the circuit through the same status stepper, consuming
+// these outcomes in order. Per-operation statuses are intentionally not
+// materialized here, and transition outcomes are not part of the
+// user-facing sample result -- they belong to optional sidecar/debug
+// output.
+
+#include "clifft/noncomp/qubit_status.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace clifft {
+
+// One consulted transition instrument: the sampled outcome for a single
+// (operation, qubit operand). Recorded whether or not a jump occurred,
+// so a replay consumes exactly one record per consulted operand.
+struct TransitionRecord {
+    uint32_t op_index;          // index into Circuit::nodes
+    uint32_t qubit;             // qubit operand id
+    bool jumped;                // true if the instrument fired a jump
+    uint8_t destination_level;  // jump target; kInvalidLevel when !jumped
+};
+
+struct NonComputationalHistory {
+    // Sampled initial status, one entry per qubit (index == qubit id).
+    std::vector<QubitStatus> initial_status;
+
+    // Consulted transition outcomes, in circuit-walk order.
+    std::vector<TransitionRecord> transitions;
+};
+
+}  // namespace clifft

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -66,6 +66,8 @@ class LevelSet {
     explicit LevelSet(std::vector<Level> levels) : levels_(std::move(levels)) {
         validate();
         fingerprint_ = compute_fingerprint();
+        computational_zero_id_ = find_computational_id(BasisBit::Zero);
+        computational_one_id_ = find_computational_id(BasisBit::One);
     }
 
     // Default level set: g, e, leak_g, leak_e, lost.
@@ -113,9 +115,44 @@ class LevelSet {
         return QubitStatus::lost_unchecked(level_id);
     }
 
+    // Ids of the unique Computational levels with basis_bit == Zero (g)
+    // and == One (e). Validation guarantees exactly one of each, so
+    // these always refer to real levels in this table.
+    uint8_t computational_zero_id() const { return computational_zero_id_; }
+    uint8_t computational_one_id() const { return computational_one_id_; }
+
+    // QubitStatus for a level id, dispatched on the level's category:
+    // Computational -> ComputationalKnown, Leaked -> Leaked, Lost -> Lost.
+    // Used by the history stepper to turn a sampled transition
+    // destination into the resulting qubit status.
+    QubitStatus status_for(uint8_t level_id) const {
+        require_in_range(level_id, "status_for");
+        switch (levels_[level_id].category) {
+            case LevelCategory::Computational:
+                return QubitStatus::computational_known_unchecked(level_id);
+            case LevelCategory::Leaked:
+                return QubitStatus::leaked_unchecked(level_id);
+            case LevelCategory::Lost:
+                return QubitStatus::lost_unchecked(level_id);
+        }
+        throw std::invalid_argument("LevelSet::status_for: unrecognized category");
+    }
+
   private:
     std::vector<Level> levels_;
     uint64_t fingerprint_ = 0;
+    uint8_t computational_zero_id_ = kInvalidLevel;
+    uint8_t computational_one_id_ = kInvalidLevel;
+
+    uint8_t find_computational_id(BasisBit bit) const {
+        for (size_t i = 0; i < levels_.size(); ++i) {
+            if (levels_[i].category == LevelCategory::Computational &&
+                levels_[i].basis_bit == bit) {
+                return static_cast<uint8_t>(i);
+            }
+        }
+        return kInvalidLevel;  // unreachable: validate() guarantees one of each
+    }
 
     // FNV-1a over a canonical byte serialization of each level. The
     // label is length-prefixed so that, e.g., {"ab", "c"} and {"a",

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -20,7 +20,7 @@ namespace {
 // silently accepted. Excludes annotations, identity no-ops, the
 // classical measurement pad (MPAD), the expectation-value probe, and
 // noise channels (whose composition with a level transition is
-// deliberately left undefined in the MVP).
+// deliberately left unmodeled).
 bool supports_transition(GateType g) {
     if (is_clifford(g)) {
         return true;  // single- and two-qubit Clifford gates

--- a/src/clifft/noncomp/op_role.cc
+++ b/src/clifft/noncomp/op_role.cc
@@ -1,0 +1,37 @@
+#include "clifft/noncomp/op_role.h"
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+
+namespace clifft {
+
+std::vector<QubitOperand> qubit_operands(const AstNode& node) {
+    std::vector<QubitOperand> operands;
+
+    // MPAD pads the measurement record; its targets are classical 0/1
+    // literals, not qubit indices.
+    if (node.gate == GateType::MPAD) {
+        return operands;
+    }
+
+    // A record control marks a classically-controlled feedback node; the
+    // parser only allows that on CX/CZ, with the record target first.
+    bool feedback = false;
+    for (const Target& target : node.targets) {
+        if (target.is_rec()) {
+            feedback = true;
+            break;
+        }
+    }
+
+    const OperandRole role = feedback ? OperandRole::Feedback : OperandRole::Physical;
+    for (const Target& target : node.targets) {
+        if (target.is_rec()) {
+            continue;  // record reference, not a qubit operand
+        }
+        operands.push_back(QubitOperand{target.value(), role});
+    }
+    return operands;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/op_role.cc
+++ b/src/clifft/noncomp/op_role.cc
@@ -3,6 +3,9 @@
 #include "clifft/circuit/gate_data.h"
 #include "clifft/circuit/target.h"
 
+#include <stdexcept>
+#include <string>
+
 namespace clifft {
 
 std::vector<QubitOperand> qubit_operands(const AstNode& node) {
@@ -14,17 +17,38 @@ std::vector<QubitOperand> qubit_operands(const AstNode& node) {
         return operands;
     }
 
-    // A record control marks a classically-controlled feedback node; the
-    // parser only allows that on CX/CZ, with the record target first.
-    bool feedback = false;
+    bool has_rec = false;
     for (const Target& target : node.targets) {
         if (target.is_rec()) {
-            feedback = true;
+            has_rec = true;
             break;
         }
     }
 
-    const OperandRole role = feedback ? OperandRole::Feedback : OperandRole::Physical;
+    OperandRole role = OperandRole::Physical;
+    if (has_rec) {
+        // A record target accompanies a qubit only as CX/CZ classical
+        // feedback (conditional X can flip g<->e; conditional Z is
+        // phase-only). Otherwise it is a rec-only annotation -- DETECTOR,
+        // OBSERVABLE_INCLUDE, READOUT_NOISE -- which has no qubit operands.
+        // A record alongside a qubit on any other gate is a shape this
+        // layer does not model.
+        if (node.gate == GateType::CX) {
+            role = OperandRole::FeedbackX;
+        } else if (node.gate == GateType::CZ) {
+            role = OperandRole::FeedbackZ;
+        } else {
+            for (const Target& target : node.targets) {
+                if (!target.is_rec()) {
+                    throw std::invalid_argument(
+                        "qubit_operands: record-controlled qubit target on gate '" +
+                        std::string(gate_name(node.gate)) + "'; expected CX/CZ feedback");
+                }
+            }
+            return operands;  // rec-only annotation: no qubit operands
+        }
+    }
+
     for (const Target& target : node.targets) {
         if (target.is_rec()) {
             continue;  // record reference, not a qubit operand

--- a/src/clifft/noncomp/op_role.h
+++ b/src/clifft/noncomp/op_role.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// Classify an operation's targets into the qubit operands that carry
+// noncomputational semantics, with the role each plays.
+//
+// The same GateType can be physically different things, so the history
+// sampler and the rewriter must not key behavior on GateType alone: a
+// CX/CZ with a record control is a virtual frame correction (Feedback),
+// not a physical entangler; MPAD targets are classical literals, not
+// qubits; detector/observable targets are record references. This shared
+// helper resolves those, so both consumers agree on what is a qubit and
+// what it means.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/status_step.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace clifft {
+
+struct QubitOperand {
+    uint32_t qubit;
+    OperandRole role;
+};
+
+// The qubit operands of a node, in target order, skipping non-qubit
+// targets (record references, MPAD pad literals). A node with a record
+// control is classical feedback, so its qubit operands get the Feedback
+// role; otherwise operands are Physical.
+std::vector<QubitOperand> qubit_operands(const AstNode& node);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -76,7 +76,7 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
             // Feedback corrections are virtual: they never fire a
             // transition. Physical operands consult the instrument (if
             // any) for this gate.
-            if (operand.role == OperandRole::Feedback || instrument == nullptr) {
+            if (operand.role != OperandRole::Physical || instrument == nullptr) {
                 status[qubit] = normal_post_op_status(s_in, gate, operand.role, policy, levels);
                 continue;
             }

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -12,19 +12,6 @@
 
 namespace clifft {
 
-namespace {
-
-// Portable [0, 1) draw: the top 53 bits of a 64-bit word scaled to the
-// unit interval. Xoshiro256PlusPlus (the same generator the SVM uses)
-// produces an identical sequence across compilers, and this extraction
-// avoids std::uniform_real_distribution, whose algorithm varies across
-// standard libraries -- together they keep a fixed seed reproducible.
-double next_unit(Xoshiro256PlusPlus& rng) {
-    return static_cast<double>(rng() >> 11) * 0x1.0p-53;
-}
-
-}  // namespace
-
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed) {
     const LevelSet& levels = model.levels();
@@ -40,7 +27,7 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
     // initial-state distribution. The last level catches any
     // floating-point tail so a draw always resolves to a level.
     for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
-        const double u = next_unit(rng);
+        const double u = rng.next_double();
         double acc = 0.0;
         uint8_t chosen = static_cast<uint8_t>(num_levels - 1);
         for (uint8_t l = 0; l < num_levels; ++l) {
@@ -104,7 +91,7 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
             // Sample the outcome: the no-jump weight occupies [0, w), the
             // jump targets partition [w, 1). last_positive catches a
             // floating-point tail so u >= w always resolves to a jump.
-            const double u = next_unit(rng);
+            const double u = rng.next_double();
             const double no_jump = instrument->no_jump_weight(source_col);
             TransitionOutcome outcome;
             if (u >= no_jump) {

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -1,0 +1,137 @@
+#include "clifft/noncomp/sampler.h"
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+#include "clifft/noncomp/status_step.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <cstdint>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+namespace clifft {
+
+namespace {
+
+// Portable [0, 1) draw: the top 53 bits of a 64-bit word scaled to the
+// unit interval. std::mt19937_64's sequence is standardized and this
+// extraction avoids std::uniform_real_distribution, whose algorithm
+// varies across standard libraries -- both together keep "fixed seed ->
+// fixed history" stable across platforms.
+double next_unit(std::mt19937_64& rng) {
+    return static_cast<double>(rng() >> 11) * 0x1.0p-53;
+}
+
+}  // namespace
+
+HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
+                             uint64_t seed) {
+    const LevelSet& levels = model.levels();
+    const NonComputationalPolicy& policy = model.policy();
+    const size_t num_levels = levels.size();
+
+    std::mt19937_64 rng(seed);
+
+    HistorySample result;
+    result.history.initial_status.reserve(circuit.num_qubits);
+
+    // Step 1: sample each qubit's initial level independently from the
+    // shared initial-state distribution. The last level catches any
+    // floating-point tail so a draw always resolves to a level.
+    for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
+        const double u = next_unit(rng);
+        double acc = 0.0;
+        uint8_t chosen = static_cast<uint8_t>(num_levels - 1);
+        for (uint8_t l = 0; l < num_levels; ++l) {
+            acc += model.initial_probability(l);
+            if (u < acc) {
+                chosen = l;
+                break;
+            }
+        }
+        result.history.initial_status.push_back(levels.status_for(chosen));
+    }
+
+    std::vector<QubitStatus> status = result.history.initial_status;
+
+    // Step 3: walk the operations, sampling attached transitions per
+    // qubit operand and advancing each qubit's status.
+    for (uint32_t op_index = 0; op_index < circuit.nodes.size(); ++op_index) {
+        const AstNode& node = circuit.nodes[op_index];
+        const GateType gate = node.gate;
+        const TransitionInstrument* instrument = model.transition_for(gate);
+
+        for (const Target& target : node.targets) {
+            if (target.is_rec()) {
+                continue;  // classical record reference, not a qubit operand
+            }
+            const uint32_t qubit = target.value();
+            if (qubit >= status.size()) {
+                continue;  // operand outside the sampled qubit range
+            }
+
+            const QubitStatus s_in = status[qubit];
+
+            if (instrument == nullptr) {
+                status[qubit] = normal_post_op_status(s_in, gate, policy, levels);
+                continue;
+            }
+
+            // Section 4.2 source-context check and column selection.
+            uint8_t source_col;
+            if (s_in.kind() == QubitStatusKind::ComputationalUnknown) {
+                if (!instrument->is_source_independent_on_computational()) {
+                    throw std::invalid_argument(
+                        "sample_history: source-dependent transition on gate '" +
+                        std::string(gate_name(gate)) + "' fired on ComputationalUnknown qubit " +
+                        std::to_string(qubit) + " at op " + std::to_string(op_index) +
+                        "; not representable in the MVP");
+                }
+                // Computational columns are identical here, so any one
+                // serves; use g.
+                source_col = levels.computational_zero_id();
+            } else {
+                source_col = s_in.level_id();
+            }
+
+            // Sample the outcome: the no-jump weight occupies [0, w), the
+            // jump targets partition [w, 1). last_positive catches a
+            // floating-point tail so u >= w always resolves to a jump.
+            const double u = next_unit(rng);
+            const double no_jump = instrument->no_jump_weight(source_col);
+            TransitionOutcome outcome;
+            if (u >= no_jump) {
+                double acc = no_jump;
+                int last_positive = -1;
+                for (uint8_t to = 0; to < num_levels; ++to) {
+                    const double p = instrument->prob(to, source_col);
+                    if (p > 0.0) {
+                        last_positive = to;
+                    }
+                    acc += p;
+                    if (u < acc) {
+                        outcome.jumped = true;
+                        outcome.destination_level = to;
+                        break;
+                    }
+                }
+                if (!outcome.jumped && last_positive >= 0) {
+                    outcome.jumped = true;
+                    outcome.destination_level = static_cast<uint8_t>(last_positive);
+                }
+            }
+
+            result.history.transitions.push_back(
+                TransitionRecord{op_index, qubit, outcome.jumped,
+                                 outcome.jumped ? outcome.destination_level : kInvalidLevel});
+
+            status[qubit] = step_status(s_in, gate, outcome, policy, levels);
+        }
+    }
+
+    result.final_status = status;
+    return result;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -1,7 +1,7 @@
 #include "clifft/noncomp/sampler.h"
 
 #include "clifft/circuit/gate_data.h"
-#include "clifft/circuit/target.h"
+#include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
 
@@ -62,19 +62,22 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
         const GateType gate = node.gate;
         const TransitionInstrument* instrument = model.transition_for(gate);
 
-        for (const Target& target : node.targets) {
-            if (target.is_rec()) {
-                continue;  // classical record reference, not a qubit operand
-            }
-            const uint32_t qubit = target.value();
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            const uint32_t qubit = operand.qubit;
             if (qubit >= status.size()) {
-                continue;  // operand outside the sampled qubit range
+                throw std::invalid_argument(
+                    "sample_history: operand qubit " + std::to_string(qubit) +
+                    " is out of range (circuit declares " + std::to_string(status.size()) +
+                    " qubits) at op " + std::to_string(op_index));
             }
 
             const QubitStatus s_in = status[qubit];
 
-            if (instrument == nullptr) {
-                status[qubit] = normal_post_op_status(s_in, gate, policy, levels);
+            // Feedback corrections are virtual: they never fire a
+            // transition. Physical operands consult the instrument (if
+            // any) for this gate.
+            if (operand.role == OperandRole::Feedback || instrument == nullptr) {
+                status[qubit] = normal_post_op_status(s_in, gate, operand.role, policy, levels);
                 continue;
             }
 
@@ -126,7 +129,7 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                 TransitionRecord{op_index, qubit, outcome.jumped,
                                  outcome.jumped ? outcome.destination_level : kInvalidLevel});
 
-            status[qubit] = step_status(s_in, gate, outcome, policy, levels);
+            status[qubit] = step_status(s_in, gate, OperandRole::Physical, outcome, policy, levels);
         }
     }
 

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -4,9 +4,9 @@
 #include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
+#include "clifft/util/xoshiro.h"
 
 #include <cstdint>
-#include <random>
 #include <stdexcept>
 #include <string>
 
@@ -15,11 +15,11 @@ namespace clifft {
 namespace {
 
 // Portable [0, 1) draw: the top 53 bits of a 64-bit word scaled to the
-// unit interval. std::mt19937_64's sequence is standardized and this
-// extraction avoids std::uniform_real_distribution, whose algorithm
-// varies across standard libraries -- both together keep "fixed seed ->
-// fixed history" stable across platforms.
-double next_unit(std::mt19937_64& rng) {
+// unit interval. Xoshiro256PlusPlus (the same generator the SVM uses)
+// produces an identical sequence across compilers, and this extraction
+// avoids std::uniform_real_distribution, whose algorithm varies across
+// standard libraries -- together they keep a fixed seed reproducible.
+double next_unit(Xoshiro256PlusPlus& rng) {
     return static_cast<double>(rng() >> 11) * 0x1.0p-53;
 }
 
@@ -31,13 +31,13 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
     const NonComputationalPolicy& policy = model.policy();
     const size_t num_levels = levels.size();
 
-    std::mt19937_64 rng(seed);
+    Xoshiro256PlusPlus rng(seed);
 
     HistorySample result;
     result.history.initial_status.reserve(circuit.num_qubits);
 
-    // Step 1: sample each qubit's initial level independently from the
-    // shared initial-state distribution. The last level catches any
+    // Sample each qubit's initial level independently from the shared
+    // initial-state distribution. The last level catches any
     // floating-point tail so a draw always resolves to a level.
     for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
         const double u = next_unit(rng);
@@ -55,8 +55,8 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
 
     std::vector<QubitStatus> status = result.history.initial_status;
 
-    // Step 3: walk the operations, sampling attached transitions per
-    // qubit operand and advancing each qubit's status.
+    // Walk the operations, sampling attached transitions per qubit
+    // operand and advancing each qubit's status.
     for (uint32_t op_index = 0; op_index < circuit.nodes.size(); ++op_index) {
         const AstNode& node = circuit.nodes[op_index];
         const GateType gate = node.gate;
@@ -81,7 +81,9 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                 continue;
             }
 
-            // Section 4.2 source-context check and column selection.
+            // Source-context check and column selection: an unknown
+            // computational source has no definite level, so a
+            // source-dependent instrument cannot pick a column for it.
             uint8_t source_col;
             if (s_in.kind() == QubitStatusKind::ComputationalUnknown) {
                 if (!instrument->is_source_independent_on_computational()) {
@@ -89,7 +91,8 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                         "sample_history: source-dependent transition on gate '" +
                         std::string(gate_name(gate)) + "' fired on ComputationalUnknown qubit " +
                         std::to_string(qubit) + " at op " + std::to_string(op_index) +
-                        "; not representable in the MVP");
+                        "; a source-dependent instrument cannot be applied to a qubit whose "
+                        "computational state is unknown");
                 }
                 // Computational columns are identical here, so any one
                 // serves; use g.

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// History sampler: walks a parsed circuit once and samples a single
+// noncomputational trajectory under a model.
+//
+// It owns step 3 of the section 5.1 pipeline (sample initial statuses,
+// then per operation sample any attached transition and advance each
+// qubit's status). It does not rewrite, compile, or run the SVM, and it
+// never consults a measurement outcome -- the status it tracks is the
+// pre-SVM-known status of section 5.2.2. Sampling is deterministic in
+// the seed.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/history.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/qubit_status.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace clifft {
+
+struct HistorySample {
+    // Canonical record: initial statuses plus sampled transition outcomes.
+    NonComputationalHistory history;
+    // Derived convenience: each qubit's status after the full walk.
+    std::vector<QubitStatus> final_status;
+};
+
+// Sample one trajectory over `circuit` under `model`, deterministic in
+// `seed`. Throws std::invalid_argument on a section 4.2 source-context
+// violation: a source-dependent transition firing on a
+// ComputationalUnknown qubit, naming the operation, qubit, and gate.
+HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
+                             uint64_t seed);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -3,12 +3,13 @@
 // History sampler: walks a parsed circuit once and samples a single
 // noncomputational trajectory under a model.
 //
-// It owns step 3 of the section 5.1 pipeline (sample initial statuses,
-// then per operation sample any attached transition and advance each
-// qubit's status). It does not rewrite, compile, or run the SVM, and it
-// never consults a measurement outcome -- the status it tracks is the
-// pre-SVM-known status of section 5.2.2. Sampling is deterministic in
-// the seed.
+// It performs the sampling pass only: sample initial statuses, then per
+// operation sample any attached transition and advance each qubit's
+// status. It does not rewrite, compile, or run the SVM, and it never
+// consults a measurement outcome -- the status it tracks is what is
+// classically known before the simulation runs (a Z-basis measurement on
+// an unknown qubit does not pin a value here). Sampling is deterministic
+// in the seed.
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/history.h"
@@ -28,9 +29,9 @@ struct HistorySample {
 };
 
 // Sample one trajectory over `circuit` under `model`, deterministic in
-// `seed`. Throws std::invalid_argument on a section 4.2 source-context
-// violation: a source-dependent transition firing on a
-// ComputationalUnknown qubit, naming the operation, qubit, and gate.
+// `seed`. Throws std::invalid_argument on a source-context violation: a
+// source-dependent transition firing on a ComputationalUnknown qubit,
+// naming the operation, qubit, and gate.
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed);
 

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -6,16 +6,19 @@ QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, Opera
                                   const NonComputationalPolicy& policy, const LevelSet& levels) {
     const QubitStatusKind kind = entry.kind();
 
-    if (role == OperandRole::Feedback) {
-        // A classically-controlled Pauli frame correction (CX/CZ with a
-        // record control) is virtual, so it cannot leak or lose a qubit.
-        // A conditional X may flip g<->e on a control bit that is unknown
-        // before SVM execution, so a known computational qubit demotes to
-        // unknown; noncomputational and already-unknown qubits are left as
-        // they are.
+    if (role == OperandRole::FeedbackX) {
+        // A classically-controlled X is virtual (no leakage), but may flip
+        // g<->e on a control bit unknown before SVM execution, so a known
+        // computational qubit demotes; noncomputational and already-unknown
+        // qubits are left as they are.
         if (kind == QubitStatusKind::ComputationalKnown) {
             return QubitStatus::computational_unknown();
         }
+        return entry;
+    }
+    if (role == OperandRole::FeedbackZ) {
+        // A classically-controlled Z is phase-only: it cannot change the
+        // energy level, so the status is unchanged.
         return entry;
     }
 

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -1,0 +1,59 @@
+#include "clifft/noncomp/status_step.h"
+
+namespace clifft {
+
+QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate,
+                                  const NonComputationalPolicy& policy, const LevelSet& levels) {
+    const QubitStatusKind kind = entry.kind();
+
+    const bool z_reset = gate == GateType::R || gate == GateType::MR;
+    const bool xy_reset = gate == GateType::RX || gate == GateType::RY || gate == GateType::MRX ||
+                          gate == GateType::MRY;
+
+    if (kind == QubitStatusKind::Leaked || kind == QubitStatusKind::Lost) {
+        // A noncomputational qubit's status changes only when a reset
+        // restores it; every other operation leaves it untouched (the
+        // rewriter's policy table decides drop vs. reject). Lost is only
+        // restorable when the policy opts in; Leaked always restores.
+        const bool restorable = kind == QubitStatusKind::Leaked || policy.reset_restores_lost;
+        if (z_reset && restorable) {
+            return levels.computational_known(levels.computational_zero_id());
+        }
+        if (xy_reset && restorable) {
+            return QubitStatus::computational_unknown();
+        }
+        return entry;
+    }
+
+    // Computational source (Known or Unknown).
+    if (z_reset) {
+        return levels.computational_known(levels.computational_zero_id());
+    }
+    if (xy_reset) {
+        return QubitStatus::computational_unknown();
+    }
+    if (gate == GateType::M) {
+        // Pre-SVM-known semantics: a Z-basis measurement does not pin a
+        // value the history layer can use. Known stays Known (its value
+        // was already known); Unknown stays Unknown (the outcome lives in
+        // the SVM, not here).
+        return entry;
+    }
+    if (gate == GateType::EXP_VAL || gate == GateType::MPAD) {
+        return entry;  // non-destructive probe / classical measurement pad
+    }
+    // Any other quantum operation -- a gate, Pauli noise, or an X/Y or
+    // multi-qubit measurement -- collapses a definite energy level, so a
+    // known computational qubit demotes to unknown.
+    return QubitStatus::computational_unknown();
+}
+
+QubitStatus step_status(const QubitStatus& entry, GateType gate, const TransitionOutcome& outcome,
+                        const NonComputationalPolicy& policy, const LevelSet& levels) {
+    if (outcome.jumped) {
+        return levels.status_for(outcome.destination_level);
+    }
+    return normal_post_op_status(entry, gate, policy, levels);
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -2,9 +2,22 @@
 
 namespace clifft {
 
-QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate,
+QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, OperandRole role,
                                   const NonComputationalPolicy& policy, const LevelSet& levels) {
     const QubitStatusKind kind = entry.kind();
+
+    if (role == OperandRole::Feedback) {
+        // A classically-controlled Pauli frame correction (CX/CZ with a
+        // record control) is virtual, so it cannot leak or lose a qubit.
+        // A conditional X may flip g<->e on a control bit that is unknown
+        // before SVM execution, so a known computational qubit demotes to
+        // unknown; noncomputational and already-unknown qubits are left as
+        // they are.
+        if (kind == QubitStatusKind::ComputationalKnown) {
+            return QubitStatus::computational_unknown();
+        }
+        return entry;
+    }
 
     const bool z_reset = gate == GateType::R || gate == GateType::MR;
     const bool xy_reset = gate == GateType::RX || gate == GateType::RY || gate == GateType::MRX ||
@@ -48,12 +61,13 @@ QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate,
     return QubitStatus::computational_unknown();
 }
 
-QubitStatus step_status(const QubitStatus& entry, GateType gate, const TransitionOutcome& outcome,
-                        const NonComputationalPolicy& policy, const LevelSet& levels) {
+QubitStatus step_status(const QubitStatus& entry, GateType gate, OperandRole role,
+                        const TransitionOutcome& outcome, const NonComputationalPolicy& policy,
+                        const LevelSet& levels) {
     if (outcome.jumped) {
         return levels.status_for(outcome.destination_level);
     }
-    return normal_post_op_status(entry, gate, policy, levels);
+    return normal_post_op_status(entry, gate, role, policy, levels);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -28,9 +28,10 @@ QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, Opera
 
     if (kind == QubitStatusKind::Leaked || kind == QubitStatusKind::Lost) {
         // A noncomputational qubit's status changes only when a reset
-        // restores it; every other operation leaves it untouched (the
-        // rewriter's policy table decides drop vs. reject). Lost is only
-        // restorable when the policy opts in; Leaked always restores.
+        // restores it; every other operation leaves it untouched (whether
+        // that operation is dropped or rejected is decided later by the
+        // rewriter). Lost is only restorable when the policy opts in;
+        // Leaked always restores.
         const bool restorable = kind == QubitStatusKind::Leaked || policy.reset_restores_lost;
         if (z_reset && restorable) {
             return levels.computational_known(levels.computational_zero_id());

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// Shared qubit-status stepper for the noncomputational history layer.
+//
+// Both the history sampler (which samples a transition outcome) and the
+// rewriter (which replays a recorded one) advance a qubit's status the
+// same way; that logic lives here, in one place, so the two stay in
+// sync. It implements the section 5.2.1 / 5.2.2 status-transition rules
+// plus the section 5.2 reset-restore behavior.
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/qubit_status.h"
+
+#include <cstdint>
+
+namespace clifft {
+
+// Outcome of consulting one transition instrument for a single
+// (operation, qubit operand).
+struct TransitionOutcome {
+    bool jumped = false;
+    uint8_t destination_level = kInvalidLevel;  // valid iff jumped
+};
+
+// The qubit's status after an operation given only the operation's
+// normal status effect (no transition fired). Implements: Z-basis reset
+// -> Known(g); X/Y reset -> Unknown; Z-basis measurement preserves the
+// pre-SVM-known status; non-destructive probes preserve status; every
+// other quantum operation demotes a computational qubit to Unknown; a
+// Leaked/Lost qubit is only changed by a reset that restores it.
+QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate,
+                                  const NonComputationalPolicy& policy, const LevelSet& levels);
+
+// Full per-target step: a sampled jump destination wins; otherwise the
+// operation's normal status effect applies (section 5.2 per-target order
+// steps 4-5).
+QubitStatus step_status(const QubitStatus& entry, GateType gate, const TransitionOutcome& outcome,
+                        const NonComputationalPolicy& policy, const LevelSet& levels);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -21,10 +21,13 @@ namespace clifft {
 // mean physically different things: a CX with two qubit operands is a
 // physical entangler, but a CX with a record control is a virtual,
 // frame-level Pauli correction. The role, not the gate alone, drives the
-// noncomputational status effect.
+// noncomputational status effect. The two feedback roles split on the
+// correction's basis: a conditional X can flip the energy level, a
+// conditional Z is phase-only and leaves it intact.
 enum class OperandRole {
-    Physical,  // a real qubit operand of a physical operation
-    Feedback,  // qubit target of a classically-controlled Pauli (CX/CZ rec q)
+    Physical,   // a real qubit operand of a physical operation
+    FeedbackX,  // target of a classically-controlled X (CX rec q)
+    FeedbackZ,  // target of a classically-controlled Z (CZ rec q)
 };
 
 // Outcome of consulting one transition instrument for a single
@@ -40,10 +43,10 @@ struct TransitionOutcome {
 // preserves the pre-SVM-known status; non-destructive probes preserve
 // status; every other quantum operation demotes a computational qubit to
 // Unknown; a Leaked/Lost qubit is only changed by a reset that restores
-// it. For a Feedback operand: the correction is virtual (no leakage), but
-// a conditional X may flip g<->e on a control bit unknown before SVM
-// execution, so a known computational qubit demotes to Unknown while
-// noncomputational and already-unknown qubits are left as they are.
+// it. A feedback operand never leaks (the correction is virtual): a
+// FeedbackX may flip g<->e on a control bit unknown before SVM execution,
+// so it demotes a known computational qubit; a FeedbackZ is phase-only and
+// leaves the status untouched.
 QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, OperandRole role,
                                   const NonComputationalPolicy& policy, const LevelSet& levels);
 

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -5,8 +5,9 @@
 // Both the history sampler (which samples a transition outcome) and the
 // rewriter (which replays a recorded one) advance a qubit's status the
 // same way; that logic lives here, in one place, so the two stay in
-// sync. It implements the section 5.2.1 / 5.2.2 status-transition rules
-// plus the section 5.2 reset-restore behavior.
+// sync. It covers gate demotion, the measurement and reset effects
+// (including the pre-SVM-known measurement rule), reset-restore of
+// leaked/lost qubits, and the feedback rules.
 
 #include "clifft/circuit/gate_data.h"
 #include "clifft/noncomp/level.h"
@@ -51,8 +52,7 @@ QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, Opera
                                   const NonComputationalPolicy& policy, const LevelSet& levels);
 
 // Full per-target step: a sampled jump destination wins; otherwise the
-// operation's normal status effect applies (section 5.2 per-target order
-// steps 4-5).
+// operation's normal status effect applies.
 QubitStatus step_status(const QubitStatus& entry, GateType gate, OperandRole role,
                         const TransitionOutcome& outcome, const NonComputationalPolicy& policy,
                         const LevelSet& levels);

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -17,6 +17,16 @@
 
 namespace clifft {
 
+// The role a qubit operand plays in an operation. The same GateType can
+// mean physically different things: a CX with two qubit operands is a
+// physical entangler, but a CX with a record control is a virtual,
+// frame-level Pauli correction. The role, not the gate alone, drives the
+// noncomputational status effect.
+enum class OperandRole {
+    Physical,  // a real qubit operand of a physical operation
+    Feedback,  // qubit target of a classically-controlled Pauli (CX/CZ rec q)
+};
+
 // Outcome of consulting one transition instrument for a single
 // (operation, qubit operand).
 struct TransitionOutcome {
@@ -25,18 +35,23 @@ struct TransitionOutcome {
 };
 
 // The qubit's status after an operation given only the operation's
-// normal status effect (no transition fired). Implements: Z-basis reset
-// -> Known(g); X/Y reset -> Unknown; Z-basis measurement preserves the
-// pre-SVM-known status; non-destructive probes preserve status; every
-// other quantum operation demotes a computational qubit to Unknown; a
-// Leaked/Lost qubit is only changed by a reset that restores it.
-QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate,
+// normal status effect (no transition fired). For a Physical operand:
+// Z-basis reset -> Known(g); X/Y reset -> Unknown; Z-basis measurement
+// preserves the pre-SVM-known status; non-destructive probes preserve
+// status; every other quantum operation demotes a computational qubit to
+// Unknown; a Leaked/Lost qubit is only changed by a reset that restores
+// it. For a Feedback operand: the correction is virtual (no leakage), but
+// a conditional X may flip g<->e on a control bit unknown before SVM
+// execution, so a known computational qubit demotes to Unknown while
+// noncomputational and already-unknown qubits are left as they are.
+QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, OperandRole role,
                                   const NonComputationalPolicy& policy, const LevelSet& levels);
 
 // Full per-target step: a sampled jump destination wins; otherwise the
 // operation's normal status effect applies (section 5.2 per-target order
 // steps 4-5).
-QubitStatus step_status(const QubitStatus& entry, GateType gate, const TransitionOutcome& outcome,
-                        const NonComputationalPolicy& policy, const LevelSet& levels);
+QubitStatus step_status(const QubitStatus& entry, GateType gate, OperandRole role,
+                        const TransitionOutcome& outcome, const NonComputationalPolicy& policy,
+                        const LevelSet& levels);
 
 }  // namespace clifft

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clifft/backend/backend.h"
+#include "clifft/util/xoshiro.h"
 
 #include "stim.h"
 
@@ -17,77 +18,6 @@
 #include <vector>
 
 namespace clifft {
-
-// =============================================================================
-// Scientific PRNG: xoshiro256++ (Seeded by SplitMix64)
-// =============================================================================
-//
-// Reference implementation of xoshiro256++ 1.0 by David Blackman and
-// Sebastiano Vigna (vigna@acm.org), described in:
-//
-//   Blackman, D. & Vigna, S. (2021). "Scrambled Linear Pseudorandom
-//   Number Generators." ACM Trans. Math. Softw. 47(4), Article 36.
-//   https://doi.org/10.1145/3460772
-//
-// Source: https://prng.di.unimi.it/xoshiro256plusplus.c
-// Seeding: https://prng.di.unimi.it/splitmix64.c
-// License: Public domain (CC0)
-//
-// Period: 2^256-1. State: 32 bytes (vs MT19937's 2504 bytes), making per-shot
-// reseeding ~100x cheaper. Uses pure bitwise math to guarantee identical
-// sequences across GCC/Clang/MSVC.
-
-class Xoshiro256PlusPlus {
-  public:
-    explicit Xoshiro256PlusPlus(uint64_t seed_val = 0) { seed(seed_val); }
-
-    // Seed from a single 64-bit value via SplitMix64 expansion.
-    inline void seed(uint64_t seed_val) {
-        uint64_t z = seed_val;
-        s_[0] = splitmix64(z);
-        s_[1] = splitmix64(z);
-        s_[2] = splitmix64(z);
-        s_[3] = splitmix64(z);
-    }
-
-    // Seed all 256 bits directly (e.g. from hardware entropy).
-    inline void seed_full(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) {
-        s_[0] = s0;
-        s_[1] = s1;
-        s_[2] = s2;
-        s_[3] = s3;
-    }
-
-    // Seed from OS hardware entropy (std::random_device).
-    // Uses the glibc /dev/urandom workaround from Stim for
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
-    void seed_from_entropy();
-
-    inline uint64_t operator()() {
-        const uint64_t result = std::rotl(s_[0] + s_[3], 23) + s_[0];
-        const uint64_t t = s_[1] << 17;
-
-        s_[2] ^= s_[0];
-        s_[3] ^= s_[1];
-        s_[1] ^= s_[2];
-        s_[0] ^= s_[3];
-
-        s_[2] ^= t;
-        s_[3] = std::rotl(s_[3], 45);
-
-        return result;
-    }
-
-  private:
-    uint64_t s_[4];
-
-    static inline uint64_t splitmix64(uint64_t& state) {
-        uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
-        z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
-        z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
-        return z ^ (z >> 31);
-    }
-};
 
 // =============================================================================
 // Schrodinger Virtual Machine State

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -74,10 +74,11 @@ class SchrodingerState {
     [[nodiscard]] uint64_t v_size() const { return 1ULL << active_k; }
     [[nodiscard]] uint64_t array_size() const { return array_size_; }
 
-    // Generate random double in [0, 1) using deterministic bit manipulation.
-    // CRITICAL: Do NOT use std::uniform_real_distribution -- its output is
-    // implementation-defined and varies across compilers (GCC vs Clang vs MSVC).
-    [[nodiscard]] double random_double() { return static_cast<double>(rng_() >> 11) * 0x1.0p-53; }
+    // Generate random double in [0, 1). The extraction lives on the
+    // generator so the SVM and the noncomp sampler draw it identically;
+    // it deliberately avoids std::uniform_real_distribution, whose output
+    // varies across compilers.
+    [[nodiscard]] double random_double() { return rng_.next_double(); }
 
     // --- Factored State Components ---
 

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <cstring>
 #include <new>
-#include <random>
 #include <stdexcept>
 
 #if defined(__linux__)
@@ -12,22 +11,6 @@
 #endif
 
 namespace clifft {
-
-// =============================================================================
-// PRNG Entropy Seeding
-// =============================================================================
-
-void Xoshiro256PlusPlus::seed_from_entropy() {
-    // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
-    // See https://github.com/quantumlib/Stim/issues/26
-#if defined(__linux__) && defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
-    std::random_device rd("/dev/urandom");
-#else
-    std::random_device rd;
-#endif
-    auto rd64 = [&rd]() -> uint64_t { return (static_cast<uint64_t>(rd()) << 32) | rd(); };
-    seed_full(rd64(), rd64(), rd64(), rd64());
-}
 
 // =============================================================================
 // SchrodingerState Implementation

--- a/src/clifft/util/xoshiro.cc
+++ b/src/clifft/util/xoshiro.cc
@@ -1,0 +1,19 @@
+#include "clifft/util/xoshiro.h"
+
+#include <random>
+
+namespace clifft {
+
+void Xoshiro256PlusPlus::seed_from_entropy() {
+    // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
+    // See https://github.com/quantumlib/Stim/issues/26
+#if defined(__linux__) && defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
+    std::random_device rd("/dev/urandom");
+#else
+    std::random_device rd;
+#endif
+    auto rd64 = [&rd]() -> uint64_t { return (static_cast<uint64_t>(rd()) << 32) | rd(); };
+    seed_full(rd64(), rd64(), rd64(), rd64());
+}
+
+}  // namespace clifft

--- a/src/clifft/util/xoshiro.h
+++ b/src/clifft/util/xoshiro.h
@@ -65,6 +65,15 @@ class Xoshiro256PlusPlus {
         return result;
     }
 
+    // Uniform draw in [0, 1): the top 53 bits of a 64-bit word scaled to
+    // the unit interval. The fixed bitwise generator and this extraction
+    // (rather than std::uniform_real_distribution, whose algorithm varies
+    // across standard libraries) keep a seeded sequence reproducible across
+    // compilers.
+    [[nodiscard]] inline double next_double() {
+        return static_cast<double>((*this)() >> 11) * 0x1.0p-53;
+    }
+
   private:
     uint64_t s_[4];
 

--- a/src/clifft/util/xoshiro.h
+++ b/src/clifft/util/xoshiro.h
@@ -1,0 +1,79 @@
+#pragma once
+
+// =============================================================================
+// Scientific PRNG: xoshiro256++ (Seeded by SplitMix64)
+// =============================================================================
+//
+// Reference implementation of xoshiro256++ 1.0 by David Blackman and
+// Sebastiano Vigna (vigna@acm.org), described in:
+//
+//   Blackman, D. & Vigna, S. (2021). "Scrambled Linear Pseudorandom
+//   Number Generators." ACM Trans. Math. Softw. 47(4), Article 36.
+//   https://doi.org/10.1145/3460772
+//
+// Source: https://prng.di.unimi.it/xoshiro256plusplus.c
+// Seeding: https://prng.di.unimi.it/splitmix64.c
+// License: Public domain (CC0)
+//
+// Period: 2^256-1. State: 32 bytes (vs MT19937's 2504 bytes), making per-shot
+// reseeding ~100x cheaper. Uses pure bitwise math to guarantee identical
+// sequences across GCC/Clang/MSVC.
+
+#include <bit>
+#include <cstdint>
+
+namespace clifft {
+
+class Xoshiro256PlusPlus {
+  public:
+    explicit Xoshiro256PlusPlus(uint64_t seed_val = 0) { seed(seed_val); }
+
+    // Seed from a single 64-bit value via SplitMix64 expansion.
+    inline void seed(uint64_t seed_val) {
+        uint64_t z = seed_val;
+        s_[0] = splitmix64(z);
+        s_[1] = splitmix64(z);
+        s_[2] = splitmix64(z);
+        s_[3] = splitmix64(z);
+    }
+
+    // Seed all 256 bits directly (e.g. from hardware entropy).
+    inline void seed_full(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) {
+        s_[0] = s0;
+        s_[1] = s1;
+        s_[2] = s2;
+        s_[3] = s3;
+    }
+
+    // Seed from OS hardware entropy (std::random_device).
+    // Uses the glibc /dev/urandom workaround from Stim for
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
+    void seed_from_entropy();
+
+    inline uint64_t operator()() {
+        const uint64_t result = std::rotl(s_[0] + s_[3], 23) + s_[0];
+        const uint64_t t = s_[1] << 17;
+
+        s_[2] ^= s_[0];
+        s_[3] ^= s_[1];
+        s_[1] ^= s_[2];
+        s_[0] ^= s_[3];
+
+        s_[2] ^= t;
+        s_[3] = std::rotl(s_[3], 45);
+
+        return result;
+    }
+
+  private:
+    uint64_t s_[4];
+
+    static inline uint64_t splitmix64(uint64_t& state) {
+        uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
+        z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+        z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+        return z ^ (z >> 31);
+    }
+};
+
+}  // namespace clifft

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_scalar.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_state.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/util/introspection.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/util/xoshiro.cc
 )
 
 target_include_directories(clifft_core PUBLIC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(clifft_tests
     test_noncomp_classifier.cc
     test_noncomp_model.cc
     test_noncomp_status_step.cc
+    test_noncomp_op_role.cc
     test_noncomp_sampler.cc
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ add_executable(clifft_tests
     test_noncomp_transition_instrument.cc
     test_noncomp_classifier.cc
     test_noncomp_model.cc
+    test_noncomp_status_step.cc
+    test_noncomp_sampler.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_op_role.cc
+++ b/tests/test_noncomp_op_role.cc
@@ -1,0 +1,73 @@
+#include "clifft/circuit/circuit.h"
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/circuit/target.h"
+#include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/status_step.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <stdexcept>
+#include <vector>
+
+using clifft::AstNode;
+using clifft::Circuit;
+using clifft::GateType;
+using clifft::OperandRole;
+using clifft::parse;
+using clifft::qubit_operands;
+using clifft::QubitOperand;
+using clifft::Target;
+
+namespace {
+
+AstNode node(GateType gate, std::vector<Target> targets, std::vector<double> args = {}) {
+    return AstNode{gate, std::move(targets), std::move(args), 0};
+}
+
+}  // namespace
+
+TEST_CASE("qubit_operands: physical gate yields Physical operands in target order") {
+    std::vector<QubitOperand> ops =
+        qubit_operands(node(GateType::CX, {Target::qubit(0), Target::qubit(1)}));
+    REQUIRE(ops.size() == 2);
+    REQUIRE(ops[0].qubit == 0);
+    REQUIRE(ops[0].role == OperandRole::Physical);
+    REQUIRE(ops[1].qubit == 1);
+    REQUIRE(ops[1].role == OperandRole::Physical);
+}
+
+TEST_CASE("qubit_operands: CX feedback yields a single FeedbackX operand") {
+    std::vector<QubitOperand> ops =
+        qubit_operands(node(GateType::CX, {Target::rec(0), Target::qubit(1)}));
+    REQUIRE(ops.size() == 1);
+    REQUIRE(ops[0].qubit == 1);
+    REQUIRE(ops[0].role == OperandRole::FeedbackX);
+}
+
+TEST_CASE("qubit_operands: CZ feedback yields a single FeedbackZ operand") {
+    std::vector<QubitOperand> ops =
+        qubit_operands(node(GateType::CZ, {Target::rec(0), Target::qubit(1)}));
+    REQUIRE(ops.size() == 1);
+    REQUIRE(ops[0].qubit == 1);
+    REQUIRE(ops[0].role == OperandRole::FeedbackZ);
+}
+
+TEST_CASE("qubit_operands: parsed feedback matches the hand-built classification") {
+    Circuit c = parse("M 0\nCX rec[-1] 1\n");
+    std::vector<QubitOperand> ops = qubit_operands(c.nodes.back());
+    REQUIRE(ops.size() == 1);
+    REQUIRE(ops[0].qubit == 1);
+    REQUIRE(ops[0].role == OperandRole::FeedbackX);
+}
+
+TEST_CASE("qubit_operands: non-qubit operations produce no operands") {
+    REQUIRE(qubit_operands(node(GateType::MPAD, {Target::qubit(1)})).empty());
+    REQUIRE(qubit_operands(node(GateType::DETECTOR, {Target::rec(0)})).empty());
+    REQUIRE(qubit_operands(node(GateType::OBSERVABLE_INCLUDE, {Target::rec(0)})).empty());
+    REQUIRE(qubit_operands(node(GateType::READOUT_NOISE, {Target::rec(0)}, {0.1})).empty());
+}
+
+TEST_CASE("qubit_operands: a record control with a qubit on a non-CX/CZ gate is rejected") {
+    REQUIRE_THROWS_AS(qubit_operands(node(GateType::H, {Target::rec(0), Target::qubit(1)})),
+                      std::invalid_argument);
+}

--- a/tests/test_noncomp_op_role.cc
+++ b/tests/test_noncomp_op_role.cc
@@ -36,6 +36,18 @@ TEST_CASE("qubit_operands: physical gate yields Physical operands in target orde
     REQUIRE(ops[1].role == OperandRole::Physical);
 }
 
+TEST_CASE("qubit_operands: MPP yields its Pauli-tagged qubits in target order as Physical") {
+    Circuit c = parse("MPP X0*Z1*Y2");
+    std::vector<QubitOperand> ops = qubit_operands(c.nodes.back());
+    REQUIRE(ops.size() == 3);
+    REQUIRE(ops[0].qubit == 0);
+    REQUIRE(ops[1].qubit == 1);
+    REQUIRE(ops[2].qubit == 2);
+    REQUIRE(ops[0].role == OperandRole::Physical);
+    REQUIRE(ops[1].role == OperandRole::Physical);
+    REQUIRE(ops[2].role == OperandRole::Physical);
+}
+
 TEST_CASE("qubit_operands: CX feedback yields a single FeedbackX operand") {
     std::vector<QubitOperand> ops =
         qubit_operands(node(GateType::CX, {Target::rec(0), Target::qubit(1)}));

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -1,5 +1,6 @@
 #include "clifft/circuit/circuit.h"
 #include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/parser.h"
 #include "clifft/circuit/target.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
@@ -24,6 +25,7 @@ using clifft::HistorySample;
 using clifft::LevelSet;
 using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
+using clifft::parse;
 using clifft::QubitStatusKind;
 using clifft::sample_history;
 using clifft::Target;
@@ -50,6 +52,14 @@ TransitionInstrument lose_from_g(const LevelSet& levels) {
 // Source-independent: never jumps (all-zero columns are equal).
 TransitionInstrument never_jumps(const LevelSet& levels) {
     return TransitionInstrument::from_matrix(zeros5(), levels);
+}
+
+// Source-dependent: g jumps to lost with probability 0.3. T[lost][g] is
+// the g-source -> lost-destination entry, so this also pins orientation.
+TransitionInstrument lose_from_g_30pct(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLost][0] = 0.3;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
 NonComputationalModel make_model(std::vector<double> initial_state,
@@ -135,9 +145,91 @@ TEST_CASE("sample_history: source-dependent transition on a known qubit is allow
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
     HistorySample s = sample_history(c, model, 1);
+    // One record per operand, in target order.
     REQUIRE(s.history.transitions.size() == 2);
+    REQUIRE(s.history.transitions[0].op_index == 0);
+    REQUIRE(s.history.transitions[0].qubit == 0);
+    REQUIRE(s.history.transitions[1].op_index == 0);
+    REQUIRE(s.history.transitions[1].qubit == 1);
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
     REQUIRE(s.final_status[1].kind() == QubitStatusKind::Lost);
+}
+
+TEST_CASE("sample_history: classical feedback fires no transition and demotes the target") {
+    // Parsed so the rec-target encoding is exercised: M then a conditional
+    // X on qubit 1 controlled by the measurement record.
+    Circuit c = parse("M 0\nCX rec[-1] 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CX", lose_from_g(LevelSet::default_set()));  // would jump g->lost
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    // The CX is virtual feedback, so no transition is consulted; qubit 1 is
+    // demoted, not lost. (M has no transition; qubit 0 stays Known(g).)
+    REQUIRE(s.history.transitions.empty());
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(s.final_status[1].kind() == QubitStatusKind::ComputationalUnknown);
+}
+
+TEST_CASE("sample_history: M on Unknown then a source-dependent transition rejects") {
+    Circuit c = parse("H 0\nM 0\nCZ 0 1\n");  // H -> Unknown; M keeps Unknown
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    REQUIRE_THROWS_WITH(sample_history(c, model, 1),
+                        ContainsSubstring("CZ") && ContainsSubstring("ComputationalUnknown"));
+}
+
+TEST_CASE("sample_history: reset before a source-dependent transition is allowed") {
+    Circuit c = parse("H 0\nR 0\nCZ 0 1\n");  // R restores qubit 0 to Known(g)
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);               // no throw: source is Known(g)
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);  // g -> lost
+}
+
+TEST_CASE("sample_history: a partial jump probability matches its frequency") {
+    // 2000 independent qubits, each a single H carrying a g->lost(0.3)
+    // transition; all start Known(g). Tests probabilistic sampling and the
+    // T[to, from] orientation (a transposed matrix would never fire).
+    Circuit c;
+    c.num_qubits = 2000;
+    for (uint32_t q = 0; q < c.num_qubits; ++q) {
+        c.nodes.push_back(op(GateType::H, {q}));
+    }
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("H", lose_from_g_30pct(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 99);
+    size_t lost = 0;
+    for (const auto& status : s.final_status) {
+        if (status.kind() == QubitStatusKind::Lost) {
+            ++lost;
+        }
+    }
+    // Expected 600; +/-120 is ~7 sigma, so this never flakes for the seed.
+    REQUIRE(lost > 480);
+    REQUIRE(lost < 720);
+}
+
+TEST_CASE("sample_history: lost-qubit reset restoration is policy-gated") {
+    Circuit c = parse("R 0\n");
+    const std::vector<double> all_lost = {0.0, 0.0, 0.0, 0.0, 1.0};
+
+    // Default: a lost qubit's reset does not restore it.
+    NonComputationalModel keep = make_model(all_lost, {});
+    REQUIRE(sample_history(c, keep, 1).final_status[0].kind() == QubitStatusKind::Lost);
+
+    // With the policy set, the reset restores it to Known(g).
+    NonComputationalPolicy restore;
+    restore.reset_restores_lost = true;
+    NonComputationalModel reload = make_model(all_lost, {}, restore);
+    HistorySample s = sample_history(c, reload, 1);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::ComputationalKnown);
 }
 
 TEST_CASE("sample_history: source-dependent transition on an unknown qubit rejects") {

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -185,6 +185,18 @@ TEST_CASE("sample_history: conditional-Z feedback preserves a known target and f
     REQUIRE(s.final_status[1].level_id() == 0);  // g
 }
 
+TEST_CASE("sample_history: MPP demotes each measured known qubit to Unknown") {
+    Circuit c = parse("MPP X0*Z1");  // multi-qubit measurement on two Known(g) qubits
+    NonComputationalModel model = make_model(all_g(), {});  // no MPP transition attached
+
+    HistorySample s = sample_history(c, model, 1);
+    // A multi-qubit measurement collapses each operand's definite level, so
+    // both qubits demote; with no instrument attached, nothing fires.
+    REQUIRE(s.history.transitions.empty());
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::ComputationalUnknown);
+    REQUIRE(s.final_status[1].kind() == QubitStatusKind::ComputationalUnknown);
+}
+
 TEST_CASE("sample_history: M on Unknown then a source-dependent transition rejects") {
     Circuit c = parse("H 0\nM 0\nCZ 0 1\n");  // H -> Unknown; M keeps Unknown
     std::map<std::string, TransitionInstrument> transitions;

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -171,6 +171,20 @@ TEST_CASE("sample_history: classical feedback fires no transition and demotes th
     REQUIRE(s.final_status[1].kind() == QubitStatusKind::ComputationalUnknown);
 }
 
+TEST_CASE("sample_history: conditional-Z feedback preserves a known target and fires nothing") {
+    Circuit c = parse("M 0\nCZ rec[-1] 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));  // would jump g->lost
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    // Conditional Z is phase-only: qubit 1 stays Known(g), and no
+    // transition is consulted on the virtual correction.
+    REQUIRE(s.history.transitions.empty());
+    REQUIRE(s.final_status[1].kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(s.final_status[1].level_id() == 0);  // g
+}
+
 TEST_CASE("sample_history: M on Unknown then a source-dependent transition rejects") {
     Circuit c = parse("H 0\nM 0\nCZ 0 1\n");  // H -> Unknown; M keeps Unknown
     std::map<std::string, TransitionInstrument> transitions;

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -1,0 +1,171 @@
+#include "clifft/circuit/circuit.h"
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/qubit_status.h"
+#include "clifft/noncomp/sampler.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using clifft::AstNode;
+using clifft::Circuit;
+using clifft::GateType;
+using clifft::HistorySample;
+using clifft::LevelSet;
+using clifft::NonComputationalModel;
+using clifft::NonComputationalPolicy;
+using clifft::QubitStatusKind;
+using clifft::sample_history;
+using clifft::Target;
+using clifft::TransitionInstrument;
+
+namespace {
+
+// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
+constexpr uint8_t kE = 1;
+constexpr uint8_t kLost = 4;
+
+std::vector<std::vector<double>> zeros5() {
+    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
+}
+
+// Source-dependent: g certainly jumps to lost, e does nothing. The g and
+// e columns differ, so is_source_independent_on_computational() is false.
+TransitionInstrument lose_from_g(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLost][0] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent: never jumps (all-zero columns are equal).
+TransitionInstrument never_jumps(const LevelSet& levels) {
+    return TransitionInstrument::from_matrix(zeros5(), levels);
+}
+
+NonComputationalModel make_model(std::vector<double> initial_state,
+                                 std::map<std::string, TransitionInstrument> transitions,
+                                 NonComputationalPolicy policy = {}) {
+    return NonComputationalModel(LevelSet::default_set(), std::move(initial_state),
+                                 std::move(transitions), std::nullopt, policy);
+}
+
+std::vector<double> all_g() {
+    return {1.0, 0.0, 0.0, 0.0, 0.0};
+}
+
+AstNode op(GateType gate, std::vector<uint32_t> qubits) {
+    std::vector<Target> targets;
+    targets.reserve(qubits.size());
+    for (uint32_t q : qubits) {
+        targets.push_back(Target::qubit(q));
+    }
+    return AstNode{gate, std::move(targets), {}, 0};
+}
+
+}  // namespace
+
+TEST_CASE("sample_history: a fixed seed produces an identical history") {
+    Circuit c;
+    c.num_qubits = 64;  // no ops; exercises initial-state sampling
+    NonComputationalModel model = make_model({0.5, 0.5, 0.0, 0.0, 0.0}, {});
+
+    HistorySample a = sample_history(c, model, 777);
+    HistorySample b = sample_history(c, model, 777);
+
+    REQUIRE(a.history.initial_status.size() == b.history.initial_status.size());
+    for (size_t i = 0; i < a.history.initial_status.size(); ++i) {
+        REQUIRE(a.history.initial_status[i].kind() == b.history.initial_status[i].kind());
+        REQUIRE(a.history.initial_status[i].level_id() == b.history.initial_status[i].level_id());
+    }
+}
+
+TEST_CASE("sample_history: initial-state marginals match the distribution") {
+    Circuit c;
+    c.num_qubits = 2000;  // no ops
+    NonComputationalModel model = make_model({0.7, 0.3, 0.0, 0.0, 0.0}, {});
+
+    HistorySample s = sample_history(c, model, 12345);
+    size_t e_count = 0;
+    for (const auto& status : s.history.initial_status) {
+        if (status.kind() == QubitStatusKind::ComputationalKnown && status.level_id() == kE) {
+            ++e_count;
+        }
+    }
+    // Expected 600; a generous +/-120 band is ~6 sigma, so this never
+    // flakes for the fixed seed.
+    REQUIRE(e_count > 480);
+    REQUIRE(e_count < 720);
+}
+
+TEST_CASE("sample_history: a transition on a known source fires and updates the status") {
+    Circuit c;
+    c.num_qubits = 1;
+    c.nodes.push_back(op(GateType::H, {0}));
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("H", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    // g jumps to lost with certainty, so the jump destination wins over
+    // H's normal demotion.
+    REQUIRE(s.history.transitions.size() == 1);
+    REQUIRE(s.history.transitions[0].op_index == 0);
+    REQUIRE(s.history.transitions[0].qubit == 0);
+    REQUIRE(s.history.transitions[0].jumped);
+    REQUIRE(s.history.transitions[0].destination_level == kLost);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+}
+
+TEST_CASE("sample_history: source-dependent transition on a known qubit is allowed") {
+    Circuit c;
+    c.num_qubits = 2;
+    c.nodes.push_back(op(GateType::CZ, {0, 1}));  // both operands start Known(g)
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.history.transitions.size() == 2);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+    REQUIRE(s.final_status[1].kind() == QubitStatusKind::Lost);
+}
+
+TEST_CASE("sample_history: source-dependent transition on an unknown qubit rejects") {
+    Circuit c;
+    c.num_qubits = 2;
+    c.nodes.push_back(op(GateType::H, {0}));      // demotes qubit 0 to Unknown
+    c.nodes.push_back(op(GateType::CZ, {0, 1}));  // source-dependent transition here
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    REQUIRE_THROWS_WITH(sample_history(c, model, 1),
+                        ContainsSubstring("CZ") && ContainsSubstring("qubit 0") &&
+                            ContainsSubstring("op 1") && ContainsSubstring("ComputationalUnknown"));
+}
+
+TEST_CASE("sample_history: source-independent transition on an unknown qubit is allowed") {
+    Circuit c;
+    c.num_qubits = 1;
+    c.nodes.push_back(op(GateType::H, {0}));  // Known(g) -> Unknown (no jump)
+    c.nodes.push_back(op(GateType::H, {0}));  // fires on the Unknown qubit
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("H", never_jumps(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.history.transitions.size() == 2);
+    REQUIRE_FALSE(s.history.transitions[0].jumped);
+    REQUIRE_FALSE(s.history.transitions[1].jumped);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::ComputationalUnknown);
+}

--- a/tests/test_noncomp_status_step.cc
+++ b/tests/test_noncomp_status_step.cc
@@ -25,7 +25,8 @@ constexpr uint8_t kLeakG = 2;
 constexpr uint8_t kLost = 4;
 
 constexpr OperandRole kPhysical = OperandRole::Physical;
-constexpr OperandRole kFeedback = OperandRole::Feedback;
+constexpr OperandRole kFeedbackX = OperandRole::FeedbackX;
+constexpr OperandRole kFeedbackZ = OperandRole::FeedbackZ;
 
 }  // namespace
 
@@ -100,20 +101,30 @@ TEST_CASE("normal_post_op_status: leaked reset restores; lost reset is policy-ga
     REQUIRE(lost_restored.level_id() == kG);
 }
 
-TEST_CASE("normal_post_op_status: feedback demotes a known qubit and never restores") {
+TEST_CASE("normal_post_op_status: FeedbackX demotes a known qubit and never restores") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
-    // A conditional Pauli on a known qubit may flip g<->e unknowably, so
-    // it demotes -- even for a gate (CX) that would otherwise act.
+    // A conditional X on a known qubit may flip g<->e unknowably, so it
+    // demotes -- even though CX as a gate would otherwise act physically.
     QubitStatus known = normal_post_op_status(levels.computational_known(kG), GateType::CX,
-                                              kFeedback, policy, levels);
+                                              kFeedbackX, policy, levels);
     REQUIRE(known.kind() == QubitStatusKind::ComputationalUnknown);
     // Noncomputational qubits are untouched by a virtual correction (no
     // reset-restore on feedback).
     QubitStatus leaked =
-        normal_post_op_status(levels.leaked(kLeakG), GateType::CX, kFeedback, policy, levels);
+        normal_post_op_status(levels.leaked(kLeakG), GateType::CX, kFeedbackX, policy, levels);
     REQUIRE(leaked.kind() == QubitStatusKind::Leaked);
     REQUIRE(leaked.level_id() == kLeakG);
+}
+
+TEST_CASE("normal_post_op_status: FeedbackZ preserves a known qubit") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    // A conditional Z is phase-only, so it cannot change the energy level.
+    QubitStatus known = normal_post_op_status(levels.computational_known(kE), GateType::CZ,
+                                              kFeedbackZ, policy, levels);
+    REQUIRE(known.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(known.level_id() == kE);
 }
 
 TEST_CASE("step_status: a jump destination wins over the normal post-op status") {

--- a/tests/test_noncomp_status_step.cc
+++ b/tests/test_noncomp_status_step.cc
@@ -1,0 +1,119 @@
+#include "clifft/circuit/gate_data.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/qubit_status.h"
+#include "clifft/noncomp/status_step.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using clifft::GateType;
+using clifft::LevelSet;
+using clifft::NonComputationalPolicy;
+using clifft::normal_post_op_status;
+using clifft::QubitStatus;
+using clifft::QubitStatusKind;
+using clifft::step_status;
+using clifft::TransitionOutcome;
+
+namespace {
+
+// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
+constexpr uint8_t kG = 0;
+constexpr uint8_t kE = 1;
+constexpr uint8_t kLeakG = 2;
+constexpr uint8_t kLost = 4;
+
+}  // namespace
+
+TEST_CASE("normal_post_op_status: a quantum gate demotes a known computational qubit") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    QubitStatus out =
+        normal_post_op_status(levels.computational_known(kG), GateType::H, policy, levels);
+    REQUIRE(out.kind() == QubitStatusKind::ComputationalUnknown);
+}
+
+TEST_CASE("normal_post_op_status: a Z-basis M preserves the pre-SVM-known status") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    // Known stays Known (value was already known).
+    QubitStatus known =
+        normal_post_op_status(levels.computational_known(kE), GateType::M, policy, levels);
+    REQUIRE(known.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(known.level_id() == kE);
+    // Unknown stays Unknown (outcome lives in the SVM, not the history).
+    QubitStatus unknown =
+        normal_post_op_status(QubitStatus::computational_unknown(), GateType::M, policy, levels);
+    REQUIRE(unknown.kind() == QubitStatusKind::ComputationalUnknown);
+}
+
+TEST_CASE("normal_post_op_status: Z-basis reset yields Known(g), X/Y reset yields Unknown") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    QubitStatus r =
+        normal_post_op_status(QubitStatus::computational_unknown(), GateType::R, policy, levels);
+    REQUIRE(r.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(r.level_id() == kG);
+    QubitStatus rx =
+        normal_post_op_status(levels.computational_known(kG), GateType::RX, policy, levels);
+    REQUIRE(rx.kind() == QubitStatusKind::ComputationalUnknown);
+}
+
+TEST_CASE("normal_post_op_status: a non-destructive probe preserves status") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    QubitStatus out =
+        normal_post_op_status(levels.computational_known(kG), GateType::EXP_VAL, policy, levels);
+    REQUIRE(out.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(out.level_id() == kG);
+}
+
+TEST_CASE("normal_post_op_status: a gate leaves a noncomputational qubit untouched") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    QubitStatus out = normal_post_op_status(levels.leaked(kLeakG), GateType::H, policy, levels);
+    REQUIRE(out.kind() == QubitStatusKind::Leaked);
+    REQUIRE(out.level_id() == kLeakG);
+}
+
+TEST_CASE("normal_post_op_status: leaked reset restores; lost reset is policy-gated") {
+    LevelSet levels = LevelSet::default_set();
+
+    // Leaked always restores on reset.
+    NonComputationalPolicy policy;
+    QubitStatus leaked_r =
+        normal_post_op_status(levels.leaked(kLeakG), GateType::R, policy, levels);
+    REQUIRE(leaked_r.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(leaked_r.level_id() == kG);
+
+    // Lost stays lost unless the policy opts in.
+    QubitStatus lost_default =
+        normal_post_op_status(levels.lost(kLost), GateType::R, policy, levels);
+    REQUIRE(lost_default.kind() == QubitStatusKind::Lost);
+
+    NonComputationalPolicy restore;
+    restore.reset_restores_lost = true;
+    QubitStatus lost_restored =
+        normal_post_op_status(levels.lost(kLost), GateType::R, restore, levels);
+    REQUIRE(lost_restored.kind() == QubitStatusKind::ComputationalKnown);
+    REQUIRE(lost_restored.level_id() == kG);
+}
+
+TEST_CASE("step_status: a jump destination wins over the normal post-op status") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    TransitionOutcome jump{true, kLeakG};
+    QubitStatus out =
+        step_status(levels.computational_known(kG), GateType::H, jump, policy, levels);
+    REQUIRE(out.kind() == QubitStatusKind::Leaked);
+    REQUIRE(out.level_id() == kLeakG);
+}
+
+TEST_CASE("step_status: no jump falls back to the normal post-op status") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    TransitionOutcome no_jump{false, clifft::kInvalidLevel};
+    QubitStatus out =
+        step_status(levels.computational_known(kG), GateType::H, no_jump, policy, levels);
+    REQUIRE(out.kind() == QubitStatusKind::ComputationalUnknown);
+}

--- a/tests/test_noncomp_status_step.cc
+++ b/tests/test_noncomp_status_step.cc
@@ -10,6 +10,7 @@ using clifft::GateType;
 using clifft::LevelSet;
 using clifft::NonComputationalPolicy;
 using clifft::normal_post_op_status;
+using clifft::OperandRole;
 using clifft::QubitStatus;
 using clifft::QubitStatusKind;
 using clifft::step_status;
@@ -23,47 +24,48 @@ constexpr uint8_t kE = 1;
 constexpr uint8_t kLeakG = 2;
 constexpr uint8_t kLost = 4;
 
+constexpr OperandRole kPhysical = OperandRole::Physical;
+constexpr OperandRole kFeedback = OperandRole::Feedback;
+
 }  // namespace
 
 TEST_CASE("normal_post_op_status: a quantum gate demotes a known computational qubit") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
-    QubitStatus out =
-        normal_post_op_status(levels.computational_known(kG), GateType::H, policy, levels);
+    QubitStatus out = normal_post_op_status(levels.computational_known(kG), GateType::H, kPhysical,
+                                            policy, levels);
     REQUIRE(out.kind() == QubitStatusKind::ComputationalUnknown);
 }
 
 TEST_CASE("normal_post_op_status: a Z-basis M preserves the pre-SVM-known status") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
-    // Known stays Known (value was already known).
-    QubitStatus known =
-        normal_post_op_status(levels.computational_known(kE), GateType::M, policy, levels);
+    QubitStatus known = normal_post_op_status(levels.computational_known(kE), GateType::M,
+                                              kPhysical, policy, levels);
     REQUIRE(known.kind() == QubitStatusKind::ComputationalKnown);
     REQUIRE(known.level_id() == kE);
-    // Unknown stays Unknown (outcome lives in the SVM, not the history).
-    QubitStatus unknown =
-        normal_post_op_status(QubitStatus::computational_unknown(), GateType::M, policy, levels);
+    QubitStatus unknown = normal_post_op_status(QubitStatus::computational_unknown(), GateType::M,
+                                                kPhysical, policy, levels);
     REQUIRE(unknown.kind() == QubitStatusKind::ComputationalUnknown);
 }
 
 TEST_CASE("normal_post_op_status: Z-basis reset yields Known(g), X/Y reset yields Unknown") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
-    QubitStatus r =
-        normal_post_op_status(QubitStatus::computational_unknown(), GateType::R, policy, levels);
+    QubitStatus r = normal_post_op_status(QubitStatus::computational_unknown(), GateType::R,
+                                          kPhysical, policy, levels);
     REQUIRE(r.kind() == QubitStatusKind::ComputationalKnown);
     REQUIRE(r.level_id() == kG);
-    QubitStatus rx =
-        normal_post_op_status(levels.computational_known(kG), GateType::RX, policy, levels);
+    QubitStatus rx = normal_post_op_status(levels.computational_known(kG), GateType::RX, kPhysical,
+                                           policy, levels);
     REQUIRE(rx.kind() == QubitStatusKind::ComputationalUnknown);
 }
 
 TEST_CASE("normal_post_op_status: a non-destructive probe preserves status") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
-    QubitStatus out =
-        normal_post_op_status(levels.computational_known(kG), GateType::EXP_VAL, policy, levels);
+    QubitStatus out = normal_post_op_status(levels.computational_known(kG), GateType::EXP_VAL,
+                                            kPhysical, policy, levels);
     REQUIRE(out.kind() == QubitStatusKind::ComputationalKnown);
     REQUIRE(out.level_id() == kG);
 }
@@ -71,7 +73,8 @@ TEST_CASE("normal_post_op_status: a non-destructive probe preserves status") {
 TEST_CASE("normal_post_op_status: a gate leaves a noncomputational qubit untouched") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
-    QubitStatus out = normal_post_op_status(levels.leaked(kLeakG), GateType::H, policy, levels);
+    QubitStatus out =
+        normal_post_op_status(levels.leaked(kLeakG), GateType::H, kPhysical, policy, levels);
     REQUIRE(out.kind() == QubitStatusKind::Leaked);
     REQUIRE(out.level_id() == kLeakG);
 }
@@ -79,24 +82,38 @@ TEST_CASE("normal_post_op_status: a gate leaves a noncomputational qubit untouch
 TEST_CASE("normal_post_op_status: leaked reset restores; lost reset is policy-gated") {
     LevelSet levels = LevelSet::default_set();
 
-    // Leaked always restores on reset.
     NonComputationalPolicy policy;
     QubitStatus leaked_r =
-        normal_post_op_status(levels.leaked(kLeakG), GateType::R, policy, levels);
+        normal_post_op_status(levels.leaked(kLeakG), GateType::R, kPhysical, policy, levels);
     REQUIRE(leaked_r.kind() == QubitStatusKind::ComputationalKnown);
     REQUIRE(leaked_r.level_id() == kG);
 
-    // Lost stays lost unless the policy opts in.
     QubitStatus lost_default =
-        normal_post_op_status(levels.lost(kLost), GateType::R, policy, levels);
+        normal_post_op_status(levels.lost(kLost), GateType::R, kPhysical, policy, levels);
     REQUIRE(lost_default.kind() == QubitStatusKind::Lost);
 
     NonComputationalPolicy restore;
     restore.reset_restores_lost = true;
     QubitStatus lost_restored =
-        normal_post_op_status(levels.lost(kLost), GateType::R, restore, levels);
+        normal_post_op_status(levels.lost(kLost), GateType::R, kPhysical, restore, levels);
     REQUIRE(lost_restored.kind() == QubitStatusKind::ComputationalKnown);
     REQUIRE(lost_restored.level_id() == kG);
+}
+
+TEST_CASE("normal_post_op_status: feedback demotes a known qubit and never restores") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    // A conditional Pauli on a known qubit may flip g<->e unknowably, so
+    // it demotes -- even for a gate (CX) that would otherwise act.
+    QubitStatus known = normal_post_op_status(levels.computational_known(kG), GateType::CX,
+                                              kFeedback, policy, levels);
+    REQUIRE(known.kind() == QubitStatusKind::ComputationalUnknown);
+    // Noncomputational qubits are untouched by a virtual correction (no
+    // reset-restore on feedback).
+    QubitStatus leaked =
+        normal_post_op_status(levels.leaked(kLeakG), GateType::CX, kFeedback, policy, levels);
+    REQUIRE(leaked.kind() == QubitStatusKind::Leaked);
+    REQUIRE(leaked.level_id() == kLeakG);
 }
 
 TEST_CASE("step_status: a jump destination wins over the normal post-op status") {
@@ -104,7 +121,7 @@ TEST_CASE("step_status: a jump destination wins over the normal post-op status")
     NonComputationalPolicy policy;
     TransitionOutcome jump{true, kLeakG};
     QubitStatus out =
-        step_status(levels.computational_known(kG), GateType::H, jump, policy, levels);
+        step_status(levels.computational_known(kG), GateType::H, kPhysical, jump, policy, levels);
     REQUIRE(out.kind() == QubitStatusKind::Leaked);
     REQUIRE(out.level_id() == kLeakG);
 }
@@ -113,7 +130,7 @@ TEST_CASE("step_status: no jump falls back to the normal post-op status") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;
     TransitionOutcome no_jump{false, clifft::kInvalidLevel};
-    QubitStatus out =
-        step_status(levels.computational_known(kG), GateType::H, no_jump, policy, levels);
+    QubitStatus out = step_status(levels.computational_known(kG), GateType::H, kPhysical, no_jump,
+                                  policy, levels);
     REQUIRE(out.kind() == QubitStatusKind::ComputationalUnknown);
 }


### PR DESCRIPTION
PR E in the noncomputational MVP sequence (after #112). Adds the step-3 **history sampler** and the **shared status stepper** it relies on, bundling design steps 7 (`history.h`) and 8 (`sampler.h/.cc`) per the agreed scope.

## What it does
`sample_history(circuit, model, seed)` walks a parsed `Circuit` once and samples one noncomputational trajectory:
1. Sample each qubit's initial level from `model.initial_state()` (independent per qubit).
2. Walk ops in order; for each qubit operand, consult the gate's transition instrument (if any), run the §4.2 source-context check, sample no-jump/jump, and advance the qubit's status.

It records the **canonical, minimal** `NonComputationalHistory` — initial statuses + sampled transition outcomes (one record per consulted operand, jump or no-jump). Per-op statuses are intentionally *not* materialized; they're a derived view via replay through the shared stepper. The sampler does **not** rewrite, compile, or run the SVM, and never consults a measurement outcome. Deterministic in `seed` (`std::mt19937_64` + a portable `[0,1)` extraction, so fixed seed → fixed history across platforms).

## Shared status stepper (`status_step.{h,cc}`)
The §5.2.1 / §5.2.2 status-transition rules (plus §5.2 reset-restore) live in one place so the sampler and the future rewriter advance status identically:
- A transition's **source level is the status at op entry**; the gate's normal effect (e.g. demotion) is applied after.
- A sampled **jump destination wins** over the normal post-op status.
- A Z-basis `M` keeps the **pre-SVM-known** status (§5.2.2): `Known` stays `Known`, `Unknown` stays `Unknown` — it does not promote, since the outcome lives in the SVM.
- `R`/`MR` → `Known(g)`; `RX`/`RY`/`MRX`/`MRY` → `Unknown`; non-destructive probes preserve status; a Leaked/Lost qubit changes only on a restoring reset (Lost gated by `policy.reset_restores_lost`).

## §4.2 enforcement
A source-dependent transition firing on a `ComputationalUnknown` qubit raises, naming the op index, qubit, and gate. `Known`/`Leaked`/`Lost` sources use their level's column directly; source-independent instruments are allowed on `Unknown` (columns are identical, so `g`'s column is used).

## Supporting change
`LevelSet` gains `computational_zero_id()` / `computational_one_id()` and `status_for(level_id)` (category-dispatched `QubitStatus`), which the stepper needs.

## Design note
Includes the §5.2.2 clarification (history status is pre-SVM-known, not trajectory-physical) settled in review.

## Tests
`test_noncomp_status_step.cc` (stepper rules) and `test_noncomp_sampler.cc` (deterministic seed, initial-state marginals, transition firing, §4.2 allow/reject). Full Debug suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review changes

Address a multi-LLM review of the sampler:

- **Operand roles (the key fix).** Classical Pauli feedback (`CX`/`CZ` with a record control) was being treated as a physical gate — it would consult the gate's transition instrument and demote the target like an entangler. A new shared `op_role.{h,cc}` classifier resolves each node's qubit operands and their role (`Physical` vs `Feedback`), skipping record references and `MPAD` pad literals. The sampler fires **no transition** on a `Feedback` operand, and the stepper demotes a known qubit there (a conditional X can flip `g<->e` on a pre-SVM-unknown control bit) while leaving noncomputational qubits untouched. The stepper now takes the role, not bare `GateType`.
- A qubit operand outside the circuit's range now **throws** instead of being silently skipped.
- Expanded tests: parsed-circuit feedback, `M`-on-Unknown then rejecting source-dependent transition, reset-before-transition acceptance, a **probabilistic** jump frequency that pins `T[to, from]` orientation, multi-target record ordering, and policy-gated lost-qubit reset restoration through the sampler.

## Review changes (round 2)

- **Conditional-Z feedback fix.** Feedback was uniformly demoting the target, but a conditional Z (`CZ rec q`) is phase-only and cannot change the energy level, so it must preserve `ComputationalKnown(g/e)`. Split the feedback role into `FeedbackX` (demotes, may flip `g<->e`) and `FeedbackZ` (preserves); the classifier assigns it from the gate and the stepper branches on the role.
- **`qubit_operands()` invariant enforced.** A record target accompanies a qubit operand only as CX/CZ feedback; rec-only annotations (`DETECTOR`/`OBSERVABLE_INCLUDE`/`READOUT_NOISE`) yield no qubit operands, and a record control with a qubit operand on any other gate now throws rather than being silently treated as feedback.
- Added `tests/test_noncomp_op_role.cc` (feedback roles, rec-only annotations, `MPAD`, the rejection invariant) plus sampler/stepper coverage for conditional-Z preservation.


## Review changes (round 3)

Addresses the two review comments on the sampler (commit `ad78e2a`):

- **Shared xoshiro RNG.** The sampler drew from `std::mt19937_64`; it now uses `Xoshiro256PlusPlus`, the same scientific PRNG the SVM sampler uses. The generator is hoisted out of `svm.h` into a shared `util/xoshiro.h` that both the SVM and the sampler include, so there is one cross-platform-reproducible generator instead of two. The portable `[0, 1)` extraction is unchanged, so a fixed seed still maps to a fixed history.
- **Self-contained comments.** Dropped the design-doc section/step references (`section 4.2`, `step 3`, "the MVP") from the sampler, stepper, and model comments so they stand on their own once the design note is removed. No behavior change; full Debug suite green.


### Added coverage (commit `a316227`)

Pinned the MPP corner that review flagged as easy to get wrong: `qubit_operands` returns an `MPP`'s Pauli-tagged qubits in target order as `Physical`, and an `MPP` with no attached transition demotes each `Known(g)` operand to `Unknown` (the stepper's measurement-collapse fallthrough). Behavior was already correct; these lock it in.


### RNG follow-up (commit `7a8ce1e`)

Made `Xoshiro256PlusPlus` a fully self-contained utility:

- Moved `seed_from_entropy()` from `svm/svm_state.cc` into a new `util/xoshiro.cc`, so the generator no longer has an out-of-line member defined in an SVM translation unit (`<random>` is no longer needed in `svm_state.cc`). This also lets the noncomp side default to entropy seeding later without depending on the SVM.
- Added a canonical `next_double()` to the generator; the SVM's `random_double()` and the sampler both draw through it, so the `[0, 1)` extraction has one definition instead of two copies of the same bit math. Header-inline, so the SVM hot path is unchanged.

No behavior change; Debug and Release suites green.


_Build note (commit `f1aba72`): the wasm target keeps its own `clifft_core` source list in `src/wasm/CMakeLists.txt`; since it compiles `svm_state.cc` (which calls `seed_from_entropy()`), it also needs `util/xoshiro.cc`. Added there too; verified against the `emscripten/emsdk:3.1.74` image._
