### PR TITLE
feat(noncomp): circuit rewriter (PR F)

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -674,13 +674,28 @@ reinterpreted as the noncomputational kind by the trajectory; the
 SVM's own post-`R` state on that qubit is irrelevant because no
 later op reads computational amplitude from it.
 
-If the source kind at the transition is already
-`ComputationalKnown`, `Leaked`, or `Lost`, no quantum trace-out is
-needed: there is no entangled computational amplitude to unravel.
-The transition is a pure status update with no `R` insertion.
+The decision to insert `R` is made on the **computational carrier
+state immediately before the jump destination is installed**, not on
+the qubit's status at op entry. The base operation can make a qubit
+coherent before the after-gate transition fires: a qubit can enter an
+op as `ComputationalKnown(g/e)` and be demoted to `ComputationalUnknown`
+by the gate, after which a jump to `Leaked`/`Lost` still has entangled
+computational amplitude to trace out. Conversely, a qubit that is still
+a definite `ComputationalKnown` atom at jump time (the base op did not
+make it coherent) carries no entanglement to unravel, so no `R` is
+needed. The relevant carrier state is therefore
+`normal_post_op_status(entry, op)` — the status the base operation
+would leave if no jump fired — evaluated with the *entry* status still
+used for transition source-column selection.
 
-Summary rule: insert `R` iff source kind is `ComputationalUnknown`
-and destination kind is `Leaked` or `Lost`.
+Summary rule, per qubit operand of an op:
+
+    pre             = status entering the op
+    post_if_no_jump = normal_post_op_status(pre, op)
+    outcome         = sampled/replayed transition branch (source column from pre)
+    insert R iff outcome jumps to a Leaked/Lost level
+                 AND post_if_no_jump is ComputationalUnknown
+    final status    = outcome destination (jump wins)
 
 ## 6. New C++ headers and dependency order
 

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(clifft_core STATIC
     noncomp/status_step.cc
     noncomp/op_role.cc
     noncomp/sampler.cc
+    noncomp/rewriter.cc
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.

--- a/src/clifft/noncomp/qubit_status.h
+++ b/src/clifft/noncomp/qubit_status.h
@@ -38,6 +38,21 @@ enum class QubitStatusKind : uint8_t {
     Lost = 3,
 };
 
+// Human-readable name of a status kind, for diagnostics.
+inline const char* kind_name(QubitStatusKind kind) {
+    switch (kind) {
+        case QubitStatusKind::ComputationalUnknown:
+            return "ComputationalUnknown";
+        case QubitStatusKind::ComputationalKnown:
+            return "ComputationalKnown";
+        case QubitStatusKind::Leaked:
+            return "Leaked";
+        case QubitStatusKind::Lost:
+            return "Lost";
+    }
+    return "unknown";
+}
+
 // Sentinel for the level_id field when no specific level is resolved.
 // Valid only with kind == ComputationalUnknown.
 constexpr uint8_t kInvalidLevel = 0xFF;

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -18,20 +18,6 @@ namespace {
 // How the base operation is handled for one qubit operand.
 enum class OpAction { Apply, Drop, Reject };
 
-const char* kind_name(QubitStatusKind k) {
-    switch (k) {
-        case QubitStatusKind::ComputationalUnknown:
-            return "ComputationalUnknown";
-        case QubitStatusKind::ComputationalKnown:
-            return "ComputationalKnown";
-        case QubitStatusKind::Leaked:
-            return "Leaked";
-        case QubitStatusKind::Lost:
-            return "Lost";
-    }
-    return "unknown";
-}
-
 // Trajectory policy for one operand, keyed on the operand's status at op
 // entry. A computational qubit (known or unknown) runs every operation; the
 // table below only governs leaked and lost operands. Aggregated across an
@@ -95,14 +81,12 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
                                     std::to_string(original.num_qubits) + " qubits");
     }
 
-    Circuit out;
-    out.num_qubits = original.num_qubits;
-    // Only X-prep and trace-out R ops are inserted, neither of which is a
-    // visible measurement, so the record-layout counts carry over unchanged.
-    out.num_measurements = original.num_measurements;
-    out.num_detectors = original.num_detectors;
-    out.num_observables = original.num_observables;
-    out.num_exp_vals = original.num_exp_vals;
+    // Copy so every circuit-level field carries over (and any field added to
+    // Circuit later is not silently dropped); only the node list is rebuilt.
+    // The inserted X-prep and trace-out R ops are not visible measurements, so
+    // the record-layout counts stay valid.
+    Circuit out = original;
+    out.nodes.clear();
     out.nodes.reserve(original.nodes.size() + original.num_qubits);
 
     std::vector<QubitStatus> status = history.initial_status;

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -1,0 +1,206 @@
+#include "clifft/noncomp/rewriter.h"
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+#include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/status_step.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace clifft {
+
+namespace {
+
+// How the base operation is handled for one qubit operand.
+enum class OpAction { Apply, Drop, Reject };
+
+const char* kind_name(QubitStatusKind k) {
+    switch (k) {
+        case QubitStatusKind::ComputationalUnknown:
+            return "ComputationalUnknown";
+        case QubitStatusKind::ComputationalKnown:
+            return "ComputationalKnown";
+        case QubitStatusKind::Leaked:
+            return "Leaked";
+        case QubitStatusKind::Lost:
+            return "Lost";
+    }
+    return "unknown";
+}
+
+// Trajectory policy for one operand, keyed on the operand's status at op
+// entry. A computational qubit (known or unknown) runs every operation; the
+// table below only governs leaked and lost operands. Aggregated across an
+// operation's operands by the caller: any Reject rejects the whole op, and
+// Drop only ever arises for a single-operand op.
+OpAction operand_action(GateType gate, QubitStatusKind kind, const NonComputationalPolicy& policy) {
+    if (kind == QubitStatusKind::ComputationalKnown ||
+        kind == QubitStatusKind::ComputationalUnknown) {
+        return OpAction::Apply;
+    }
+
+    const bool lost = kind == QubitStatusKind::Lost;
+
+    // An identity no-op is harmless to keep on any qubit.
+    if (is_identity_noop(gate)) {
+        return OpAction::Apply;
+    }
+    // Measurements are kept so the visible record and its rec[-k] references
+    // do not shift; the leaked/lost outcome is reinterpreted downstream.
+    if (is_measurement(gate)) {
+        return OpAction::Apply;
+    }
+    // A reset restores a leaked qubit always, a lost qubit only by policy;
+    // a lost-qubit reset otherwise rejects.
+    if (is_reset(gate)) {
+        return (!lost || policy.reset_restores_lost) ? OpAction::Apply : OpAction::Reject;
+    }
+    // A single-qubit Pauli noise channel drops on a leaked or lost qubit; a
+    // single-qubit unitary gate drops on a lost qubit (no carrier remains).
+    if (gate_arity(gate) == GateArity::SINGLE) {
+        if (is_noise_gate(gate)) {
+            return OpAction::Drop;
+        }
+        if (lost) {
+            return OpAction::Drop;
+        }
+        // A single-qubit gate on a leaked qubit rejects by default.
+        return OpAction::Reject;
+    }
+    // Anything else touching a leaked or lost operand -- a two-qubit gate,
+    // a multi-qubit measurement-class op, classical feedback onto a vacated
+    // site -- is ambiguous and rejects by default.
+    return OpAction::Reject;
+}
+
+AstNode single_qubit_op(GateType gate, uint32_t qubit) {
+    return AstNode{gate, {Target::qubit(qubit)}, {}, 0};
+}
+
+}  // namespace
+
+Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
+                const NonComputationalModel& model) {
+    const LevelSet& levels = model.levels();
+    const NonComputationalPolicy& policy = model.policy();
+
+    if (history.initial_status.size() != original.num_qubits) {
+        throw std::invalid_argument("rewrite: history has " +
+                                    std::to_string(history.initial_status.size()) +
+                                    " initial statuses but circuit declares " +
+                                    std::to_string(original.num_qubits) + " qubits");
+    }
+
+    Circuit out;
+    out.num_qubits = original.num_qubits;
+    // Only X-prep and trace-out R ops are inserted, neither of which is a
+    // visible measurement, so the record-layout counts carry over unchanged.
+    out.num_measurements = original.num_measurements;
+    out.num_detectors = original.num_detectors;
+    out.num_observables = original.num_observables;
+    out.num_exp_vals = original.num_exp_vals;
+    out.nodes.reserve(original.nodes.size() + original.num_qubits);
+
+    std::vector<QubitStatus> status = history.initial_status;
+
+    // Initial-state prep: a sampled known |1> initial level needs a leading X
+    // so the SVM's |0> matches it.
+    for (uint32_t q = 0; q < original.num_qubits; ++q) {
+        const QubitStatus& s = status[q];
+        if (s.kind() == QubitStatusKind::ComputationalKnown &&
+            levels.at(s.level_id()).basis_bit == BasisBit::One) {
+            out.nodes.push_back(single_qubit_op(GateType::X, q));
+        }
+    }
+
+    size_t trans_cursor = 0;
+
+    for (uint32_t op_index = 0; op_index < original.nodes.size(); ++op_index) {
+        const AstNode& node = original.nodes[op_index];
+        const GateType gate = node.gate;
+        const TransitionInstrument* instrument = model.transition_for(gate);
+
+        bool drop_op = false;
+        std::vector<uint32_t> trace_out;  // qubits needing a trace-out R after this op
+
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            const uint32_t qubit = operand.qubit;
+            if (qubit >= status.size()) {
+                throw std::invalid_argument("rewrite: operand qubit " + std::to_string(qubit) +
+                                            " is out of range at op " + std::to_string(op_index));
+            }
+            const QubitStatus pre = status[qubit];
+
+            // Replay the recorded transition for this operand, if the sampler
+            // consulted one (a Physical operand of a gate declaring a
+            // transition). Records are consumed in sampler order.
+            TransitionOutcome outcome;
+            if (operand.role == OperandRole::Physical && instrument != nullptr) {
+                if (trans_cursor >= history.transitions.size()) {
+                    throw std::invalid_argument(
+                        "rewrite: circuit consults more transitions than the history records; "
+                        "history does not describe this circuit");
+                }
+                const TransitionRecord& record = history.transitions[trans_cursor++];
+                if (record.op_index != op_index || record.qubit != qubit) {
+                    throw std::invalid_argument(
+                        "rewrite: transition record (op " + std::to_string(record.op_index) +
+                        ", qubit " + std::to_string(record.qubit) +
+                        ") does not match consult (op " + std::to_string(op_index) + ", qubit " +
+                        std::to_string(qubit) + "); history does not describe this circuit");
+                }
+                outcome.jumped = record.jumped;
+                outcome.destination_level = record.destination_level;
+            }
+
+            switch (operand_action(gate, pre.kind(), policy)) {
+                case OpAction::Reject:
+                    throw std::invalid_argument(
+                        "rewrite: operation '" + std::string(gate_name(gate)) + "' on a " +
+                        kind_name(pre.kind()) + " qubit " + std::to_string(qubit) + " at op " +
+                        std::to_string(op_index) + " is not representable; rejecting");
+                case OpAction::Drop:
+                    drop_op = true;  // single-operand op
+                    break;
+                case OpAction::Apply:
+                    break;
+            }
+
+            // Trace-out decision: the carrier state the base op would leave
+            // with no jump. A jump to a noncomputational level from a coherent
+            // carrier needs a hidden Z-basis unraveling.
+            if (outcome.jumped) {
+                const QubitStatus post_if_no_jump =
+                    normal_post_op_status(pre, gate, operand.role, policy, levels);
+                const QubitStatusKind dest = levels.status_for(outcome.destination_level).kind();
+                if ((dest == QubitStatusKind::Leaked || dest == QubitStatusKind::Lost) &&
+                    post_if_no_jump.kind() == QubitStatusKind::ComputationalUnknown) {
+                    trace_out.push_back(qubit);
+                }
+            }
+
+            status[qubit] = step_status(pre, gate, operand.role, outcome, policy, levels);
+        }
+
+        if (!drop_op) {
+            out.nodes.push_back(node);
+        }
+        for (uint32_t qubit : trace_out) {
+            out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+        }
+    }
+
+    if (trans_cursor != history.transitions.size()) {
+        throw std::invalid_argument(
+            "rewrite: history records more transitions than the circuit consults; "
+            "history does not describe this circuit");
+    }
+
+    return out;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -40,6 +40,12 @@ namespace clifft {
 // operation (naming the operation index, qubit, gate, and status) or when
 // `history` does not describe `original` (qubit count or transition count
 // mismatch).
+//
+// Precondition: `original` is a parser-normalized circuit -- each
+// single-qubit operation is a single-target node and each two-qubit
+// operation is a single pair. The keep / drop / reject decision is made per
+// node, so a hand-built node that packs several single-qubit operands would
+// be dropped or rejected as a whole rather than per operand.
 Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
                 const NonComputationalModel& model);
 

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// Circuit rewriter for the noncomputational history layer.
+//
+// rewrite(original, history, model) replays one sampled trajectory and
+// produces a new ordinary clifft::Circuit ready for the existing compile
+// pipeline -- it introduces no new instruction kinds. It does three things:
+//
+//   1. Initial-state prep: prepend an X on each qubit whose sampled initial
+//      status is ComputationalKnown with a basis_bit == One level, so the
+//      SVM's |0...0> initial state matches the sampled known level.
+//   2. Per-op policy: replay each operation's per-qubit status through the
+//      shared status stepper and keep, drop, or reject the operation. A
+//      measurement is always kept so the visible measurement record (and
+//      every rec[-k] reference into it) is preserved; reinterpreting a
+//      measurement's outcome for a leaked or lost qubit is a sampling /
+//      sidecar concern for the orchestrator, not a circuit edit. An
+//      ambiguous operation on a leaked or lost operand rejects by default.
+//   3. Hidden trace-out: when a coherent qubit jumps to a Leaked or Lost
+//      level, insert an R on that qubit immediately after the operation.
+//      The existing reset lowering turns it into a hidden measurement plus a
+//      corrective Pauli; it adds no visible measurement and shifts no record
+//      index. "Coherent" means the carrier state the base operation would
+//      leave with no jump is ComputationalUnknown -- a qubit a gate has just
+//      made coherent still needs trace-out even if it entered known.
+//
+// Transition outcomes are consumed from history.transitions in the same
+// order the sampler produced them (one record per Physical operand of a gate
+// that declares a transition). The rewriter does not sample, compile, or run
+// the SVM.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/history.h"
+#include "clifft/noncomp/model.h"
+
+namespace clifft {
+
+// Produce the rewritten circuit for `original` under `history` and `model`.
+// Throws std::invalid_argument when the trajectory policy rejects an
+// operation (naming the operation index, qubit, gate, and status) or when
+// `history` does not describe `original` (qubit count or transition count
+// mismatch).
+Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
+                const NonComputationalModel& model);
+
+}  // namespace clifft

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(clifft_tests
     test_noncomp_status_step.cc
     test_noncomp_op_role.cc
     test_noncomp_sampler.cc
+    test_noncomp_rewriter.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -185,6 +185,9 @@ TEST_CASE("rewrite: an inserted R does not shift visible measurements or detecto
 
     REQUIRE(hir.num_measurements == base.num_measurements);  // visible record unchanged
     REQUIRE(hir.num_detectors == base.num_detectors);
+    // The detectors resolve to the same measurement-record indices: the
+    // inserted hidden R renumbered nothing they point at.
+    REQUIRE(hir.detector_targets == base.detector_targets);
     REQUIRE(hir.num_hidden_measurements == base.num_hidden_measurements + 1);
 }
 

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -1,0 +1,253 @@
+#include "clifft/circuit/circuit.h"
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/rewriter.h"
+#include "clifft/noncomp/sampler.h"
+#include "clifft/noncomp/transition_instrument.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using clifft::Circuit;
+using clifft::default_hir_pass_manager;
+using clifft::GateType;
+using clifft::HirModule;
+using clifft::HistorySample;
+using clifft::LevelSet;
+using clifft::NonComputationalModel;
+using clifft::NonComputationalPolicy;
+using clifft::parse;
+using clifft::rewrite;
+using clifft::sample_history;
+using clifft::trace;
+using clifft::TransitionInstrument;
+
+namespace {
+
+// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
+constexpr uint8_t kLeakG = 2;
+constexpr uint8_t kLost = 4;
+
+std::vector<std::vector<double>> zeros5() {
+    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
+}
+
+// Source-dependent (g and e columns differ): g certainly jumps to lost, e
+// does nothing. Allowed only on a known/leaked/lost source.
+TransitionInstrument lose_from_g(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLost][0] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent (identical g and e columns): always jumps to lost.
+TransitionInstrument always_lost(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLost][0] = 1.0;
+    m[kLost][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent: always jumps to leak_g.
+TransitionInstrument always_leaked(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLeakG][0] = 1.0;
+    m[kLeakG][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+NonComputationalModel make_model(std::vector<double> initial_state,
+                                 std::map<std::string, TransitionInstrument> transitions,
+                                 NonComputationalPolicy policy = {}) {
+    return NonComputationalModel(LevelSet::default_set(), std::move(initial_state),
+                                 std::move(transitions), std::nullopt, policy);
+}
+
+std::vector<double> all_g() {
+    return {1.0, 0.0, 0.0, 0.0, 0.0};
+}
+std::vector<double> all_e() {
+    return {0.0, 1.0, 0.0, 0.0, 0.0};
+}
+
+size_t count_gate(const Circuit& c, GateType gate) {
+    size_t n = 0;
+    for (const auto& node : c.nodes) {
+        if (node.gate == gate) {
+            ++n;
+        }
+    }
+    return n;
+}
+
+Circuit rewritten(const Circuit& c, const NonComputationalModel& model, uint64_t seed) {
+    HistorySample s = sample_history(c, model, seed);
+    return rewrite(c, s.history, model);
+}
+
+}  // namespace
+
+TEST_CASE("rewrite: a known |1> initial sample prepends an X, |0> does not") {
+    Circuit c;
+    c.num_qubits = 1;
+
+    Circuit prep_e = rewritten(c, make_model(all_e(), {}), 1);
+    REQUIRE(prep_e.nodes.size() == 1);
+    REQUIRE(prep_e.nodes[0].gate == GateType::X);
+    REQUIRE(prep_e.nodes[0].targets[0].value() == 0);
+
+    Circuit prep_g = rewritten(c, make_model(all_g(), {}), 1);
+    REQUIRE(prep_g.nodes.empty());
+}
+
+TEST_CASE("rewrite: a coherent qubit that jumps to lost gets a trace-out R") {
+    Circuit c = parse("H 0\nS 0\n");  // H makes qubit 0 coherent, then S leaks it
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    // H, S kept; one trace-out R appended after S.
+    REQUIRE(rw.nodes.size() == 3);
+    REQUIRE(rw.nodes[2].gate == GateType::R);
+    REQUIRE(rw.nodes[2].targets[0].value() == 0);
+}
+
+TEST_CASE("rewrite: an op that demotes a known qubit before a jump still inserts the R") {
+    // Qubit 0 enters H as Known(g); H demotes it to coherent Unknown and the
+    // attached transition then leaks it. The carrier is coherent at jump time,
+    // so a trace-out R is required even though the entry status was Known.
+    Circuit c = parse("H 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("H", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(rw.nodes.size() == 2);
+    REQUIRE(rw.nodes[1].gate == GateType::R);
+    REQUIRE(rw.nodes[1].targets[0].value() == 0);
+}
+
+TEST_CASE("rewrite: a still-known atom that is lost gets no trace-out R") {
+    // M preserves Known(g): the qubit is a definite |0> atom at jump time, so
+    // losing it needs no unraveling.
+    Circuit c = parse("M 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("M", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::R) == 0);
+    REQUIRE(count_gate(rw, GateType::M) == 1);  // measurement kept
+}
+
+TEST_CASE("rewrite: an inserted R survives compilation as one hidden measurement") {
+    Circuit c = parse("H 0\nS 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+
+    HirModule base = trace(c);
+    HirModule hir = trace(rw);
+    default_hir_pass_manager().run(hir);
+
+    REQUIRE(hir.num_hidden_measurements == base.num_hidden_measurements + 1);
+    REQUIRE(hir.num_measurements == base.num_measurements);  // no visible measurement added
+}
+
+TEST_CASE("rewrite: an inserted R does not shift visible measurements or detectors") {
+    // Detectors reference the measurement record on both sides of the loss
+    // point; the hidden trace-out R must not renumber them.
+    Circuit c = parse("M 0\nDETECTOR rec[-1]\nH 1\nS 1\nM 0\nDETECTOR rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+
+    HirModule base = trace(c);
+    HirModule hir = trace(rw);
+    default_hir_pass_manager().run(hir);
+
+    REQUIRE(hir.num_measurements == base.num_measurements);  // visible record unchanged
+    REQUIRE(hir.num_detectors == base.num_detectors);
+    REQUIRE(hir.num_hidden_measurements == base.num_hidden_measurements + 1);
+}
+
+TEST_CASE("rewrite: a two-qubit gate on a lost qubit rejects by default") {
+    Circuit c = parse("H 0\nS 0\nCZ 0 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);  // sampler does not enforce policy
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("CZ") &&
+                                                          ContainsSubstring("Lost") &&
+                                                          ContainsSubstring("qubit 0"));
+}
+
+TEST_CASE("rewrite: a single-qubit gate on a leaked qubit rejects by default") {
+    Circuit c = parse("H 0\nS 0\nX 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, model),
+                        ContainsSubstring("Leaked") && ContainsSubstring("qubit 0"));
+}
+
+TEST_CASE("rewrite: a single-qubit gate on a lost qubit is dropped") {
+    Circuit c = parse("H 0\nS 0\nX 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    // The X on the lost qubit is dropped; only the trace-out R remains.
+    REQUIRE(count_gate(rw, GateType::X) == 0);
+    REQUIRE(count_gate(rw, GateType::R) == 1);
+}
+
+TEST_CASE("rewrite: a lost-qubit reset rejects by default and restores under policy") {
+    Circuit c = parse("H 0\nS 0\nR 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+
+    NonComputationalModel reject = make_model(all_g(), transitions);
+    HistorySample s = sample_history(c, reject, 1);
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, reject),
+                        ContainsSubstring("Lost") && ContainsSubstring("qubit 0"));
+
+    NonComputationalPolicy restore;
+    restore.reset_restores_lost = true;
+    NonComputationalModel reload = make_model(all_g(), std::move(transitions), restore);
+    Circuit rw = rewritten(c, reload, 1);
+    // The trace-out R plus the kept original reset.
+    REQUIRE(count_gate(rw, GateType::R) == 2);
+}
+
+TEST_CASE("rewrite: a measurement on a lost qubit is kept") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::M) == 1);
+    REQUIRE(rw.num_measurements == 1);  // visible record preserved
+}


### PR DESCRIPTION
PR F in the noncomputational MVP sequence (after #113). Adds the **circuit rewriter** that replays a sampled trajectory into an ordinary `clifft::Circuit` for the existing compile pipeline.

`rewrite(original, history, model)` does three things, introducing no new instruction kinds:

1. **Initial-state prep** — a leading `X` for each qubit whose sampled initial status is `ComputationalKnown` with a `basis_bit == One` level, so the SVM's `|0...0>` matches the sampled known level.
2. **Per-op policy** — replays each op's per-qubit status through the shared `status_step` stepper, then keeps / drops / rejects the op. Rejections name the op index, qubit, gate, and status.
3. **Hidden trace-out** — inserts an `R` when a coherent carrier jumps to a noncomputational level (see the rule below). The existing reset lowering turns it into a hidden measurement + corrective Pauli — no new visible measurement, no record renumbering.

## Trace-out rule (settled in review, design §5.3 updated)
The `R` decision is made on the **carrier state after the base op's normal effect**, not the entry status, because a gate can make a `Known` qubit coherent before its after-gate transition fires:

```
pre             = status entering the op
post_if_no_jump = normal_post_op_status(pre, op)   # entry status still selects the transition source column
insert R iff outcome jumps to Leaked/Lost AND post_if_no_jump is ComputationalUnknown
```

So `Known(g) → demoted by the gate → jump to lost` **does** get a trace-out, while a still-`Known` atom that is lost does not. The `docs(design)` commit updates the §5.3 summary rule to match.

## Two scoping calls to flag for review
- **Measurements are always kept**, even on leaked/lost operands — dropping one would shift the visible record and break every `rec[-k]` reference. The classifier's *reinterpretation* of a leaked/lost measurement outcome (symbol / reject) is sampling + sidecar, so it lands in the orchestrator (PR G), not here.
- **Ambiguous leaked/lost ops reject by default.** The policy function covers the explicit table cells (single-qubit gate/noise on Lost → drop; reset restores per `reset_restores_lost`; measurements kept) and rejects everything else (two-qubit gates, multi-qubit ops, feedback onto a vacated site). No new override knobs — deferred.

## Why R-insertion + policy ship together
The inserted `R` resets the residual SVM qubit to `|0>`; that is only sound because downstream policy never lets a later op treat that residual as a real computational atom (lost single-qubit gates drop, two-qubit ops reject).

## Tests (`test_noncomp_rewriter.cc`, 11 cases)
Driven from real sampler histories. Cover: `|1>` prep emitted / `|0>` not; the post-op carrier trace-out rule (incl. the `Known`-demoted-then-lost case and the still-`Known`-lost no-`R` case); **`R` survives the default compile pipeline as exactly one hidden measurement**; **visible measurement + detector indices unchanged with detectors before and after the loss point**; two-qubit-on-lost and single-qubit-on-leaked **reject**; single-qubit-on-lost **drops**; lost-qubit reset rejects by default and restores under policy; measurement-on-lost kept. Full Debug and Release suites green (888 cases).

## Next (PR G)
`orchestrator.{h,cc}` + bindings: drive sampler → rewriter → compile → SVM, apply the classifier to leaked/lost measurement outcomes, and assemble the sidecar. Seed handling per the separation note (entropy by default; domain-separate or thread one RNG when an explicit seed is supplied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Review follow-up (`d6ff1ae`): strengthened the record-invariance test to assert `hir.detector_targets` (not just the count) is unchanged, and documented `rewrite()`'s parser-normalized-circuit precondition. The classifier-vs-detectors point from review is a PR G design item (the classifier-sampled bit must be injected in-circuit before the SVM, not postprocessed) and is captured for that PR; it does not change PR F._
