### PR TITLE
feat(noncomp): orchestrator with classifier injection (PR G)

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(clifft_core STATIC
     noncomp/op_role.cc
     noncomp/sampler.cc
     noncomp/rewriter.cc
+    noncomp/orchestrator.cc
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -5,6 +5,7 @@
 #include "clifft/circuit/target.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
+#include "clifft/noncomp/numeric.h"
 #include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/sampler.h"
@@ -39,8 +40,9 @@ uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
 }
 
 // Sample a measurement-record bit from the classifier for a qubit at `level`.
-// Symbols partition [0, sum-of-column); the deficit is the reject region, and
-// a draw there raises. Symbol index maps to the record bit as zero/non-zero.
+// The classifier must be two-symbol with a stochastic column for this level
+// (symbol 0 owns [0, prob0), symbol 1 owns the rest); the symbol index is the
+// injected record bit. A substochastic (reject) column is unsupported here.
 uint8_t classifier_bit(const MeasurementClassifier& classifier, uint8_t level,
                        Xoshiro256PlusPlus& rng, GateType gate, uint32_t op_index, uint32_t qubit) {
     // Binary record injection maps the sampled symbol index directly to the
@@ -54,18 +56,27 @@ uint8_t classifier_bit(const MeasurementClassifier& classifier, uint8_t level,
             std::string(gate_name(gate)) + "' on qubit " + std::to_string(qubit) + " at op " +
             std::to_string(op_index) + ")");
     }
-    const double u = rng.next_double();
-    double acc = 0.0;
-    for (uint8_t s = 0; s < classifier.num_symbols(); ++s) {
-        acc += classifier.prob(s, level);
-        if (u < acc) {
-            return s;  // symbol index 0 or 1 is the record bit
-        }
+    // A substochastic column reserves probability for a reject (heralded abort)
+    // outcome that has no binary record bit. That path is not wired through this
+    // entry point yet, so the column must sum to one within tolerance; a reject
+    // column is an explicit error rather than a silently dropped or aborted shot.
+    const double reject = classifier.reject_probability(level);
+    if (reject > kProbTolerance) {
+        throw std::invalid_argument(
+            "sample_noncomputational: classifier reject columns are not supported yet; the column "
+            "for level " +
+            std::to_string(level) + " sums to less than one (reject probability " +
+            std::to_string(reject) + ", measurement '" + std::string(gate_name(gate)) +
+            "' on qubit " + std::to_string(qubit) + " at op " + std::to_string(op_index) + ")");
     }
-    throw std::invalid_argument("sample_noncomputational: classifier rejected the measurement '" +
-                                std::string(gate_name(gate)) + "' on qubit " +
-                                std::to_string(qubit) + " at op " + std::to_string(op_index) +
-                                " (level " + std::to_string(level) + ")");
+    const double u = rng.next_double();
+    // Two symbols and a column summing to one (both checked above): symbol 0
+    // owns [0, prob0) and symbol 1 owns the remainder, so the symbol index is
+    // the record bit. Any tolerance-sized rounding residual falls to symbol 1.
+    if (u < classifier.prob(0, level)) {
+        return 0;
+    }
+    return 1;
 }
 
 GateType reset_for(GateType measure_reset) {

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -43,12 +43,23 @@ uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
 // a draw there raises. Symbol index maps to the record bit as zero/non-zero.
 uint8_t classifier_bit(const MeasurementClassifier& classifier, uint8_t level,
                        Xoshiro256PlusPlus& rng, GateType gate, uint32_t op_index, uint32_t qubit) {
+    // Binary record injection maps the sampled symbol index directly to the
+    // record bit, which is faithful only for a two-symbol classifier. A richer
+    // alphabet has no defined symbol-to-bit mapping and is not representable.
+    if (classifier.num_symbols() != 2) {
+        throw std::invalid_argument(
+            "sample_noncomputational: injecting a measurement on a noncomputational qubit "
+            "requires a two-symbol classifier, but the model's has " +
+            std::to_string(classifier.num_symbols()) + " symbols (measurement '" +
+            std::string(gate_name(gate)) + "' on qubit " + std::to_string(qubit) + " at op " +
+            std::to_string(op_index) + ")");
+    }
     const double u = rng.next_double();
     double acc = 0.0;
     for (uint8_t s = 0; s < classifier.num_symbols(); ++s) {
         acc += classifier.prob(s, level);
         if (u < acc) {
-            return s != 0 ? 1 : 0;
+            return s;  // symbol index 0 or 1 is the record bit
         }
     }
     throw std::invalid_argument("sample_noncomputational: classifier rejected the measurement '" +
@@ -166,6 +177,18 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
+    // The visible record layout is invariant under rewriting and injection, so
+    // the record widths come straight from the circuit and hold even for zero
+    // shots.
+    result.num_measurements = circuit.num_measurements;
+    result.num_detectors = circuit.num_detectors;
+    result.num_observables = circuit.num_observables;
+
+    if (circuit.num_exp_vals != 0) {
+        throw std::invalid_argument(
+            "sample_noncomputational: EXP_VAL probes are not supported in noncomputational "
+            "sampling");
+    }
     if (shots == 0) {
         return result;
     }
@@ -179,7 +202,6 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
         global_seed = entropy();
     }
 
-    bool counts_set = false;
     for (uint32_t shot = 0; shot < shots; ++shot) {
         HistorySample hs =
             sample_history(circuit, model, derive_seed(global_seed, shot, kHistoryDomain));
@@ -190,12 +212,6 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
         CompiledModule program = compile_circuit(injected);
         SampleResult sr = sample(program, 1, derive_seed(global_seed, shot, kSvmDomain));
 
-        if (!counts_set) {
-            result.num_measurements = program.num_measurements;
-            result.num_detectors = program.num_detectors;
-            result.num_observables = program.num_observables;
-            counts_set = true;
-        }
         result.measurements.insert(result.measurements.end(), sr.measurements.begin(),
                                    sr.measurements.end());
         result.detectors.insert(result.detectors.end(), sr.detectors.begin(), sr.detectors.end());

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -1,0 +1,211 @@
+#include "clifft/noncomp/orchestrator.h"
+
+#include "clifft/backend/backend.h"
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/rewriter.h"
+#include "clifft/noncomp/sampler.h"
+#include "clifft/noncomp/status_step.h"
+#include "clifft/noncomp/transition_instrument.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/svm/svm.h"
+#include "clifft/util/xoshiro.h"
+
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace clifft {
+
+namespace {
+
+// Distinct domain tags so per-shot sub-seeds for the three RNG consumers
+// never coincide (seeding all from the same value would correlate them).
+constexpr uint64_t kHistoryDomain = 0x1;
+constexpr uint64_t kClassifierDomain = 0x2;
+constexpr uint64_t kSvmDomain = 0x3;
+
+// SplitMix64 finalizer over a mix of the global seed, shot, and domain.
+uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
+    uint64_t z = global ^ (shot * 0x9E3779B97F4A7C15ULL) ^ (domain * 0xBF58476D1CE4E5B9ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+// Sample a measurement-record bit from the classifier for a qubit at `level`.
+// Symbols partition [0, sum-of-column); the deficit is the reject region, and
+// a draw there raises. Symbol index maps to the record bit as zero/non-zero.
+uint8_t classifier_bit(const MeasurementClassifier& classifier, uint8_t level,
+                       Xoshiro256PlusPlus& rng, GateType gate, uint32_t op_index, uint32_t qubit) {
+    const double u = rng.next_double();
+    double acc = 0.0;
+    for (uint8_t s = 0; s < classifier.num_symbols(); ++s) {
+        acc += classifier.prob(s, level);
+        if (u < acc) {
+            return s != 0 ? 1 : 0;
+        }
+    }
+    throw std::invalid_argument("sample_noncomputational: classifier rejected the measurement '" +
+                                std::string(gate_name(gate)) + "' on qubit " +
+                                std::to_string(qubit) + " at op " + std::to_string(op_index) +
+                                " (level " + std::to_string(level) + ")");
+}
+
+GateType reset_for(GateType measure_reset) {
+    switch (measure_reset) {
+        case GateType::MRX:
+            return GateType::RX;
+        case GateType::MRY:
+            return GateType::RY;
+        default:
+            return GateType::R;  // MR
+    }
+}
+
+AstNode single_target(GateType gate, uint32_t value) {
+    return AstNode{gate, {Target::qubit(value)}, {}, 0};
+}
+
+// Replay `original` + `history` to find each leaked/lost measurement's visible
+// record slot and its sampled classifier bit, then swap those slots in
+// `rewritten`: M -> MPAD(bit); a measure-and-reset -> MPAD(bit) plus the
+// matching reset. The rewriter has already guaranteed only M / measure-reset
+// measurements reach a noncomputational operand.
+Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
+                          const NonComputationalHistory& history,
+                          const NonComputationalModel& model, Xoshiro256PlusPlus& rng) {
+    const LevelSet& levels = model.levels();
+    const NonComputationalPolicy& policy = model.policy();
+    const MeasurementClassifier* classifier = model.classifier();
+
+    std::map<uint32_t, uint8_t> slot_to_bit;
+    std::vector<QubitStatus> status = history.initial_status;
+    size_t trans_cursor = 0;
+    uint32_t slot = 0;
+    for (uint32_t op_index = 0; op_index < original.nodes.size(); ++op_index) {
+        const AstNode& node = original.nodes[op_index];
+        const GateType gate = node.gate;
+        const TransitionInstrument* instrument = model.transition_for(gate);
+        const bool measurement = is_measurement(gate);
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            const uint32_t qubit = operand.qubit;
+            const QubitStatus pre = status[qubit];
+            TransitionOutcome outcome;
+            if (operand.role == OperandRole::Physical && instrument != nullptr) {
+                const TransitionRecord& record = history.transitions[trans_cursor++];
+                outcome.jumped = record.jumped;
+                outcome.destination_level = record.destination_level;
+            }
+            if (measurement &&
+                (pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost)) {
+                if (classifier == nullptr) {
+                    throw std::invalid_argument(
+                        "sample_noncomputational: measurement '" + std::string(gate_name(gate)) +
+                        "' on a noncomputational qubit " + std::to_string(qubit) + " at op " +
+                        std::to_string(op_index) +
+                        " requires a classifier, but the model has none");
+                }
+                slot_to_bit[slot] =
+                    classifier_bit(*classifier, pre.level_id(), rng, gate, op_index, qubit);
+            }
+            status[qubit] = step_status(pre, gate, operand.role, outcome, policy, levels);
+        }
+        if (measurement) {
+            ++slot;
+        }
+    }
+
+    if (slot_to_bit.empty()) {
+        return rewritten;
+    }
+
+    Circuit out = rewritten;
+    out.nodes.clear();
+    out.nodes.reserve(rewritten.nodes.size() + slot_to_bit.size());
+    uint32_t out_slot = 0;
+    for (const AstNode& node : rewritten.nodes) {
+        if (!is_measurement(node.gate)) {
+            out.nodes.push_back(node);
+            continue;
+        }
+        auto it = slot_to_bit.find(out_slot);
+        ++out_slot;
+        if (it == slot_to_bit.end()) {
+            out.nodes.push_back(node);  // computational measurement, kept as-is
+            continue;
+        }
+        const uint8_t bit = it->second;
+        const uint32_t qubit = qubit_operands(node).front().qubit;
+        out.nodes.push_back(single_target(GateType::MPAD, bit));
+        if (is_measure_reset(node.gate)) {
+            out.nodes.push_back(single_target(reset_for(node.gate), qubit));
+        }
+    }
+    return out;
+}
+
+CompiledModule compile_circuit(const Circuit& circuit) {
+    HirModule hir = trace(circuit);
+    default_hir_pass_manager().run(hir);
+    CompiledModule program = lower(hir);
+    default_bytecode_pass_manager().run(program);
+    return program;
+}
+
+}  // namespace
+
+NonComputationalSample sample_noncomputational(const Circuit& circuit,
+                                               const NonComputationalModel& model, uint32_t shots,
+                                               std::optional<uint64_t> seed) {
+    NonComputationalSample result;
+    result.shots = shots;
+    result.num_qubits = circuit.num_qubits;
+    if (shots == 0) {
+        return result;
+    }
+
+    uint64_t global_seed;
+    if (seed.has_value()) {
+        global_seed = *seed;
+    } else {
+        Xoshiro256PlusPlus entropy;
+        entropy.seed_from_entropy();
+        global_seed = entropy();
+    }
+
+    bool counts_set = false;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        HistorySample hs =
+            sample_history(circuit, model, derive_seed(global_seed, shot, kHistoryDomain));
+        Circuit rw = rewrite(circuit, hs.history, model);
+        Xoshiro256PlusPlus classifier_rng(derive_seed(global_seed, shot, kClassifierDomain));
+        Circuit injected = inject_classifier(circuit, rw, hs.history, model, classifier_rng);
+
+        CompiledModule program = compile_circuit(injected);
+        SampleResult sr = sample(program, 1, derive_seed(global_seed, shot, kSvmDomain));
+
+        if (!counts_set) {
+            result.num_measurements = program.num_measurements;
+            result.num_detectors = program.num_detectors;
+            result.num_observables = program.num_observables;
+            counts_set = true;
+        }
+        result.measurements.insert(result.measurements.end(), sr.measurements.begin(),
+                                   sr.measurements.end());
+        result.detectors.insert(result.detectors.end(), sr.detectors.begin(), sr.detectors.end());
+        result.observables.insert(result.observables.end(), sr.observables.begin(),
+                                  sr.observables.end());
+        result.final_status.insert(result.final_status.end(), hs.final_status.begin(),
+                                   hs.final_status.end());
+    }
+
+    return result;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// Orchestrator: the top-level noncomputational sampling entry point.
+//
+// sample_noncomputational(circuit, model, shots, seed) runs the full per-shot
+// pipeline and returns the user-facing records plus a noncomputational
+// sidecar. For each shot it:
+//   1. samples a structural history (initial statuses + transition outcomes);
+//   2. rewrites the circuit for that history (X-prep, trace-out R, policy);
+//   3. injects the model classifier's outcome for each measurement on a
+//      leaked/lost qubit -- swapping M for MPAD(bit), and a measure-and-reset
+//      for MPAD(bit) plus the matching reset -- so the forced bit reaches the
+//      SVM's detector/observable evaluation, not just postprocessing;
+//   4. compiles the result through the ordinary pipeline and samples one shot.
+//
+// Randomness is deterministic in `seed`: each shot draws domain-separated
+// sub-seeds for the history sampler, the classifier, and the SVM, so the
+// three streams never coincide. With no seed, a global seed is drawn from OS
+// entropy and the run is non-reproducible.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/qubit_status.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace clifft {
+
+// Aggregated result of a noncomputational sampling run.
+struct NonComputationalSample {
+    uint32_t shots = 0;
+    uint32_t num_qubits = 0;
+    uint32_t num_measurements = 0;
+    uint32_t num_detectors = 0;
+    uint32_t num_observables = 0;
+
+    // User-facing records, row-major [shot, slot].
+    std::vector<uint8_t> measurements;
+    std::vector<uint8_t> detectors;
+    std::vector<uint8_t> observables;
+
+    // Sidecar: each qubit's final status per shot, row-major [shot, qubit].
+    std::vector<QubitStatus> final_status;
+};
+
+// Throws std::invalid_argument when the trajectory policy rejects an
+// operation, when a measurement on a leaked/lost qubit needs a classifier the
+// model does not provide, or when the classifier rejects an outcome.
+NonComputationalSample sample_noncomputational(const Circuit& circuit,
+                                               const NonComputationalModel& model, uint32_t shots,
+                                               std::optional<uint64_t> seed = std::nullopt);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -47,7 +47,9 @@ struct NonComputationalSample {
 
 // Throws std::invalid_argument when the trajectory policy rejects an
 // operation, when a measurement on a leaked/lost qubit needs a classifier the
-// model does not provide, or when the classifier rejects an outcome.
+// model does not provide, or when such a classifier column is not a two-symbol
+// stochastic column. Reject (substochastic) classifier columns model a
+// heralded abort outcome and are not supported by this entry point yet.
 NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                const NonComputationalModel& model, uint32_t shots,
                                                std::optional<uint64_t> seed = std::nullopt);

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -35,10 +35,21 @@ OpAction operand_action(GateType gate, QubitStatusKind kind, const NonComputatio
     if (is_identity_noop(gate)) {
         return OpAction::Apply;
     }
-    // Measurements are kept so the visible record and its rec[-k] references
-    // do not shift; the leaked/lost outcome is reinterpreted downstream.
+    // A measure-and-reset both records an outcome and restores the site, so it
+    // is gated like a reset: a leaked qubit always restores, a lost qubit only
+    // when the policy opts in. The recorded outcome is supplied by the model's
+    // classifier downstream.
+    if (is_measure_reset(gate)) {
+        return (!lost || policy.reset_restores_lost) ? OpAction::Apply : OpAction::Reject;
+    }
+    // A plain measurement keeps its visible record slot so the record and its
+    // rec[-k] references do not shift; on a leaked/lost qubit the outcome is
+    // supplied by the model's classifier downstream. That substitution is a
+    // single record bit, faithful only for a Z-basis M. An X/Y-basis (MX/MY)
+    // or multi-qubit-parity (MPP) measurement has no faithful single-bit form
+    // on a noncomputational operand, so it is not representable and rejects.
     if (is_measurement(gate)) {
-        return OpAction::Apply;
+        return gate == GateType::M ? OpAction::Apply : OpAction::Reject;
     }
     // A reset restores a leaked qubit always, a lost qubit only by policy;
     // a lost-qubit reset otherwise rejects.
@@ -57,9 +68,9 @@ OpAction operand_action(GateType gate, QubitStatusKind kind, const NonComputatio
         // A single-qubit gate on a leaked qubit rejects by default.
         return OpAction::Reject;
     }
-    // Anything else touching a leaked or lost operand -- a two-qubit gate,
-    // a multi-qubit measurement-class op, classical feedback onto a vacated
-    // site -- is ambiguous and rejects by default.
+    // Anything else touching a leaked or lost operand -- a two-qubit gate, a
+    // two-qubit noise channel, or classical feedback onto a vacated site -- is
+    // ambiguous and rejects by default.
     return OpAction::Reject;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(clifft_tests
     test_noncomp_op_role.cc
     test_noncomp_sampler.cc
     test_noncomp_rewriter.cc
+    test_noncomp_orchestrator.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -31,6 +31,7 @@ namespace {
 
 // Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
 constexpr uint8_t kLeakG = 2;
+constexpr uint8_t kLost = 4;
 
 std::vector<std::vector<double>> zeros5() {
     return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
@@ -44,17 +45,31 @@ TransitionInstrument always_leaked(const LevelSet& levels) {
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
-// Two-symbol classifier. The leak_g column gets `leakg`; every other level is
-// a deterministic symbol 0, which is never consulted (only noncomputational
-// qubits are classified, and these tests only leak to leak_g).
-MeasurementClassifier make_classifier(const LevelSet& levels, std::vector<double> leakg) {
+// Source-independent: g and e both jump to lost with certainty.
+TransitionInstrument always_lost(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLost][0] = 1.0;
+    m[kLost][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Two-symbol classifier whose column for `level` is `col`; every other level
+// is a deterministic symbol 0. Only noncomputational qubits are classified, so
+// the computational columns are never consulted in these tests.
+MeasurementClassifier classifier_with(const LevelSet& levels, uint8_t level,
+                                      std::vector<double> col) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    for (size_t level = 0; level < 5; ++level) {
-        m[0][level] = 1.0;  // symbol "0"
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;  // symbol "0"
     }
-    m[0][kLeakG] = leakg[0];
-    m[1][kLeakG] = leakg[1];
+    m[0][level] = col[0];
+    m[1][level] = col[1];
     return MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
+}
+
+// The common case: classify the leak_g column.
+MeasurementClassifier make_classifier(const LevelSet& levels, std::vector<double> leakg) {
+    return classifier_with(levels, kLeakG, std::move(leakg));
 }
 
 NonComputationalModel make_model(std::vector<double> initial_state,
@@ -130,16 +145,25 @@ TEST_CASE("sample_noncomputational: a partial classifier bit matches its frequen
     REQUIRE(ones < 1150);
 }
 
-TEST_CASE("sample_noncomputational: a rejecting classifier raises") {
+TEST_CASE("sample_noncomputational: a substochastic classifier column is unsupported and raises") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    std::map<std::string, TransitionInstrument> transitions;
-    transitions.emplace("S", always_leaked(LevelSet::default_set()));
-    // leak_g column sums to 0 -> reject probability 1.
-    NonComputationalModel model = make_model(all_g(), std::move(transitions),
-                                             make_classifier(LevelSet::default_set(), {0.0, 0.0}));
 
-    REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 16, 1),
-                        ContainsSubstring("classifier rejected"));
+    // A partially substochastic leak_g column (sums to 0.8) reserves reject
+    // probability, which this entry point does not support.
+    std::map<std::string, TransitionInstrument> partial;
+    partial.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel partial_model = make_model(
+        all_g(), std::move(partial), make_classifier(LevelSet::default_set(), {0.5, 0.3}));
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, partial_model, 16, 1),
+                        ContainsSubstring("classifier reject columns are not supported"));
+
+    // A fully reject column (sums to 0) is refused the same way, not sampled.
+    std::map<std::string, TransitionInstrument> empty;
+    empty.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel empty_model =
+        make_model(all_g(), std::move(empty), make_classifier(LevelSet::default_set(), {0.0, 0.0}));
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, empty_model, 16, 1),
+                        ContainsSubstring("classifier reject columns are not supported"));
 }
 
 TEST_CASE("sample_noncomputational: a measurement on a leaked qubit without a classifier raises") {
@@ -222,4 +246,41 @@ TEST_CASE("sample_noncomputational: deterministic in the seed") {
     NonComputationalSample b = sample_noncomputational(c, model, 128, 42);
     REQUIRE(a.measurements == b.measurements);
     REQUIRE(a.detectors == b.detectors);
+}
+
+TEST_CASE(
+    "sample_noncomputational: a lost-qubit measurement feeds the detector the classifier bit") {
+    // A lost qubit (vacated site) is still measured; the classifier supplies
+    // the record bit just as for a leaked qubit, so the detector reads it.
+    Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+
+    // Force the lost column -> symbol 1 -> record bit 1.
+    NonComputationalModel model =
+        make_model(all_g(), std::move(transitions),
+                   classifier_with(LevelSet::default_set(), kLost, {0.0, 1.0}));
+    NonComputationalSample s = sample_noncomputational(c, model, 200, 9);
+    REQUIRE(s.num_detectors == 1);
+    REQUIRE(s.detectors.size() == 200);
+    for (uint8_t d : s.detectors) {
+        REQUIRE(d == 1);  // detector saw the lost-column classifier bit
+    }
+}
+
+TEST_CASE("sample_noncomputational: a leaked measurement feeds the observable the classifier bit") {
+    Circuit c = parse("H 0\nS 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+
+    // Force leak_g -> symbol 1 -> record bit 1; the observable must see it,
+    // not the residual |0>.
+    NonComputationalModel model = make_model(all_g(), std::move(transitions),
+                                             make_classifier(LevelSet::default_set(), {0.0, 1.0}));
+    NonComputationalSample s = sample_noncomputational(c, model, 200, 11);
+    REQUIRE(s.num_observables == 1);
+    REQUIRE(s.observables.size() == 200);
+    for (uint8_t o : s.observables) {
+        REQUIRE(o == 1);
+    }
 }

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -152,6 +152,47 @@ TEST_CASE("sample_noncomputational: a measurement on a leaked qubit without a cl
                         ContainsSubstring("requires a classifier"));
 }
 
+TEST_CASE("sample_noncomputational: a non-binary classifier rejects on injection") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+
+    // Three symbols: no defined symbol-to-record-bit mapping for the binary record.
+    std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
+    for (size_t level = 0; level < 5; ++level) {
+        m[0][level] = 1.0;
+    }
+    m[0][kLeakG] = 0.5;
+    m[1][kLeakG] = 0.3;
+    m[2][kLeakG] = 0.2;
+    MeasurementClassifier three =
+        MeasurementClassifier::from_matrix({"0", "1", "2"}, std::move(m), LevelSet::default_set());
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(three));
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 16, 1),
+                        ContainsSubstring("two-symbol classifier"));
+}
+
+TEST_CASE("sample_noncomputational: a circuit with EXP_VAL probes rejects") {
+    Circuit c;
+    c.num_qubits = 1;
+    c.num_exp_vals = 1;  // EXP_VAL output is not carried by the noncomp sidecar
+    NonComputationalModel model = make_model(all_g(), {});
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 4, 1), ContainsSubstring("EXP_VAL"));
+}
+
+TEST_CASE("sample_noncomputational: zero shots still reports the record shape") {
+    Circuit c = parse("H 0\nM 0\nDETECTOR rec[-1]\n");
+    NonComputationalModel model = make_model(all_g(), {});
+
+    NonComputationalSample s = sample_noncomputational(c, model, 0, 1);
+    REQUIRE(s.shots == 0);
+    REQUIRE(s.num_measurements == 1);  // record widths hold even with no shots
+    REQUIRE(s.num_detectors == 1);
+    REQUIRE(s.measurements.empty());
+    REQUIRE(s.detectors.empty());
+}
+
 TEST_CASE("sample_noncomputational: a measure-and-reset on a leaked qubit injects and restores") {
     // MR on the leaked qubit records the classifier bit AND resets the site to
     // |0>; the following M then deterministically reads 0 -- proving the reset

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -1,0 +1,184 @@
+#include "clifft/circuit/circuit.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/noncomp/classifier.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/orchestrator.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/qubit_status.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using clifft::Circuit;
+using clifft::LevelSet;
+using clifft::MeasurementClassifier;
+using clifft::NonComputationalModel;
+using clifft::NonComputationalPolicy;
+using clifft::NonComputationalSample;
+using clifft::parse;
+using clifft::sample_noncomputational;
+using clifft::TransitionInstrument;
+
+namespace {
+
+// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
+constexpr uint8_t kLeakG = 2;
+
+std::vector<std::vector<double>> zeros5() {
+    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
+}
+
+// Source-independent: g and e both jump to leak_g with certainty.
+TransitionInstrument always_leaked(const LevelSet& levels) {
+    auto m = zeros5();
+    m[kLeakG][0] = 1.0;
+    m[kLeakG][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Two-symbol classifier. The leak_g column gets `leakg`; every other level is
+// a deterministic symbol 0, which is never consulted (only noncomputational
+// qubits are classified, and these tests only leak to leak_g).
+MeasurementClassifier make_classifier(const LevelSet& levels, std::vector<double> leakg) {
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    for (size_t level = 0; level < 5; ++level) {
+        m[0][level] = 1.0;  // symbol "0"
+    }
+    m[0][kLeakG] = leakg[0];
+    m[1][kLeakG] = leakg[1];
+    return MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
+}
+
+NonComputationalModel make_model(std::vector<double> initial_state,
+                                 std::map<std::string, TransitionInstrument> transitions,
+                                 std::optional<MeasurementClassifier> classifier = std::nullopt,
+                                 NonComputationalPolicy policy = {}) {
+    return NonComputationalModel(LevelSet::default_set(), std::move(initial_state),
+                                 std::move(transitions), std::move(classifier), policy);
+}
+
+std::vector<double> all_g() {
+    return {1.0, 0.0, 0.0, 0.0, 0.0};
+}
+
+}  // namespace
+
+TEST_CASE("sample_noncomputational: a lossless model returns the plain record shape") {
+    Circuit c = parse("H 0\nM 0\n");
+    NonComputationalModel model = make_model(all_g(), {});
+
+    NonComputationalSample s = sample_noncomputational(c, model, 1000, 7);
+    REQUIRE(s.shots == 1000);
+    REQUIRE(s.num_measurements == 1);
+    REQUIRE(s.measurements.size() == 1000);
+    REQUIRE(s.final_status.size() == 1000);  // one qubit per shot
+
+    size_t ones = 0;
+    for (uint8_t bit : s.measurements) {
+        ones += bit;
+    }
+    REQUIRE(ones > 400);  // H 0 then M 0 is ~50/50; generous band
+    REQUIRE(ones < 600);
+}
+
+TEST_CASE(
+    "sample_noncomputational: a leaked measurement feeds the detector with the classifier bit") {
+    Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+
+    // Classifier forces leak_g -> symbol 1 -> record bit 1.
+    NonComputationalModel one =
+        make_model(all_g(), transitions, make_classifier(LevelSet::default_set(), {0.0, 1.0}));
+    NonComputationalSample s1 = sample_noncomputational(c, one, 200, 1);
+    REQUIRE(s1.num_detectors == 1);
+    REQUIRE(s1.detectors.size() == 200);
+    for (uint8_t d : s1.detectors) {
+        REQUIRE(d == 1);  // detector saw the forced classifier bit, not the residual |0>
+    }
+
+    // Classifier forces leak_g -> symbol 0 -> record bit 0.
+    NonComputationalModel zero = make_model(all_g(), std::move(transitions),
+                                            make_classifier(LevelSet::default_set(), {1.0, 0.0}));
+    NonComputationalSample s0 = sample_noncomputational(c, zero, 200, 1);
+    for (uint8_t d : s0.detectors) {
+        REQUIRE(d == 0);
+    }
+}
+
+TEST_CASE("sample_noncomputational: a partial classifier bit matches its frequency") {
+    Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions),
+                                             make_classifier(LevelSet::default_set(), {0.5, 0.5}));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 2000, 3);
+    size_t ones = 0;
+    for (uint8_t d : s.detectors) {
+        ones += d;
+    }
+    REQUIRE(ones > 850);  // expected 1000; generous band
+    REQUIRE(ones < 1150);
+}
+
+TEST_CASE("sample_noncomputational: a rejecting classifier raises") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    // leak_g column sums to 0 -> reject probability 1.
+    NonComputationalModel model = make_model(all_g(), std::move(transitions),
+                                             make_classifier(LevelSet::default_set(), {0.0, 0.0}));
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 16, 1),
+                        ContainsSubstring("classifier rejected"));
+}
+
+TEST_CASE("sample_noncomputational: a measurement on a leaked qubit without a classifier raises") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));  // no classifier
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 16, 1),
+                        ContainsSubstring("requires a classifier"));
+}
+
+TEST_CASE("sample_noncomputational: a measure-and-reset on a leaked qubit injects and restores") {
+    // MR on the leaked qubit records the classifier bit AND resets the site to
+    // |0>; the following M then deterministically reads 0 -- proving the reset
+    // actually ran in the SVM, not just in the trajectory bookkeeping.
+    Circuit c = parse("H 0\nS 0\nMR 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions),
+                                             make_classifier(LevelSet::default_set(), {0.0, 1.0}));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
+    REQUIRE(s.num_measurements == 2);
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.measurements[shot * 2 + 0] == 1);  // MR slot: forced classifier bit
+        REQUIRE(s.measurements[shot * 2 + 1] == 0);  // M slot: restored |0>
+    }
+}
+
+TEST_CASE("sample_noncomputational: deterministic in the seed") {
+    Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions),
+                                             make_classifier(LevelSet::default_set(), {0.5, 0.5}));
+
+    NonComputationalSample a = sample_noncomputational(c, model, 128, 42);
+    NonComputationalSample b = sample_noncomputational(c, model, 128, 42);
+    REQUIRE(a.measurements == b.measurements);
+    REQUIRE(a.detectors == b.detectors);
+}

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -244,7 +244,7 @@ TEST_CASE("rewrite: a lost-qubit reset rejects by default and restores under pol
     REQUIRE(count_gate(rw, GateType::R) == 2);
 }
 
-TEST_CASE("rewrite: a measurement on a lost qubit is kept") {
+TEST_CASE("rewrite: a plain Z measurement on a lost qubit is kept") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("S", always_lost(LevelSet::default_set()));
@@ -253,4 +253,49 @@ TEST_CASE("rewrite: a measurement on a lost qubit is kept") {
     Circuit rw = rewritten(c, model, 1);
     REQUIRE(count_gate(rw, GateType::M) == 1);
     REQUIRE(rw.num_measurements == 1);  // visible record preserved
+}
+
+TEST_CASE("rewrite: an X/Y-basis or multi-qubit measurement on a lost qubit rejects") {
+    std::map<std::string, TransitionInstrument> mx;
+    mx.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel m_mx = make_model(all_g(), std::move(mx));
+    Circuit cx = parse("H 0\nS 0\nMX 0\n");
+    HistorySample sx = sample_history(cx, m_mx, 1);
+    REQUIRE_THROWS_WITH(rewrite(cx, sx.history, m_mx),
+                        ContainsSubstring("MX") && ContainsSubstring("Lost"));
+
+    std::map<std::string, TransitionInstrument> mp;
+    mp.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel m_mp = make_model(all_g(), std::move(mp));
+    Circuit cp = parse("H 0\nS 0\nMPP X0\n");
+    HistorySample sp = sample_history(cp, m_mp, 1);
+    REQUIRE_THROWS_WITH(rewrite(cp, sp.history, m_mp),
+                        ContainsSubstring("MPP") && ContainsSubstring("Lost"));
+}
+
+TEST_CASE("rewrite: a measure-and-reset on a lost qubit rejects by default, kept under policy") {
+    Circuit c = parse("H 0\nS 0\nMR 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+
+    NonComputationalModel reject = make_model(all_g(), transitions);
+    HistorySample s = sample_history(c, reject, 1);
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, reject),
+                        ContainsSubstring("MR") && ContainsSubstring("Lost"));
+
+    NonComputationalPolicy restore;
+    restore.reset_restores_lost = true;
+    NonComputationalModel reload = make_model(all_g(), std::move(transitions), restore);
+    Circuit rw = rewritten(c, reload, 1);
+    REQUIRE(count_gate(rw, GateType::MR) == 1);  // kept; orchestrator injects later
+}
+
+TEST_CASE("rewrite: a measure-and-reset on a leaked qubit is kept") {
+    Circuit c = parse("H 0\nS 0\nMR 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::MR) == 1);
 }


### PR DESCRIPTION
PR G in the noncomputational MVP sequence (after #114). Adds the **C++ orchestrator** that drives the full per-shot pipeline, plus a rewriter-policy tightening it depends on. This is the G1 (C++) half; bindings + the spec-based model builder + Python end-to-end tests are G2.

## What it does
`sample_noncomputational(circuit, model, shots, seed) -> NonComputationalSample` runs, per shot:
1. **sample** a structural history (sampler);
2. **rewrite** the circuit for that history (PR F: X-prep, trace-out R, policy);
3. **inject** the classifier outcome for each measurement on a leaked/lost qubit;
4. **compile** through the ordinary pipeline (`trace → default HIR passes → lower → default bytecode passes`) and **sample** one shot on the SVM.

It returns the user-facing records (`measurements`/`detectors`/`observables`) plus a sidecar of each qubit's final status per shot.

## Classifier injection (the crux)
A leaked/lost qubit's measurement outcome is determined by the model's classifier, and that bit must reach **detector/observable evaluation inside the SVM** — postprocessing after sampling would be too late, since detectors XOR record bits at sample time. So the orchestrator forces the bit into the circuit:
- `M → MPAD(bit)` — `MPAD` is a deterministic, visible, one-slot record write, so the detector sees the classifier bit.
- measure-and-reset `→ MPAD(bit); R/RX/RY` — keeps the visible slot **and** actually resets the SVM qubit (verified by a test where the following `M` reads `0`).

Injection targets the **visible record slot** (found by replaying the original circuit), so it's independent of the rewriter's inserted X/R nodes — the `M → MPAD` swap is 1-slot-for-1-slot, so the record layout and `rec[-k]` references are preserved. A noncomp measurement requires a two-symbol classifier with a **stochastic** column for that level; a missing classifier raises.

## Classifier reject columns (unsupported for now)
A substochastic classifier column reserves probability for a heralded-abort (reject) outcome that has no binary record bit. Rather than sample into that deficit and abort a multi-shot run nondeterministically (discarding already-completed shots), `sample_noncomputational` refuses such a column **up front** with a clear "reject columns are not supported yet" error, fired when a leaked/lost measurement actually consults it. The herald path is deferred to a later PR.

## Rewriter policy tightening (commit `6a94f6c`)
Per the design discussion, the "which measurement types are representable on a noncomputational operand" call is a deterministic `(gate, status)` decision, so it lives in the rewriter (`operand_action`), not the orchestrator. Tightened: a plain `M` is kept; a measure-and-reset (`MR`/`MRX`/`MRY`) is kept but gated like a reset; an `MX`/`MY`/`MPP` on a leaked/lost operand now **rejects** (no faithful single-bit substitute) rather than being silently kept. (Revising merged PR F directly, per the agreement that early PRs can change for a better design.)

## Seeding
Deterministic in `seed`: each shot derives domain-separated sub-seeds for the history sampler, the classifier, and the SVM, so the three streams never coincide (per the seed-separation note). No seed → a global seed from OS entropy.

## Sidecar
Minimal for now: per-shot per-qubit final status. Richer sidecar (classifier symbol streams, herald bits) is deferred until a consumer needs it.

## Tests
`test_noncomp_orchestrator.cc` (12 cases) proves the pipeline end to end: lossless record shape, **a leaked qubit's measurement driving a detector to the classifier-forced bit** (the headline check) and the analogous `OBSERVABLE_INCLUDE` check, **lost-qubit** measurement injection, partial-bit frequency, **substochastic-column-unsupported** and missing-classifier raises, the non-binary-classifier reject, measure-and-reset injects+restores, `EXP_VAL`/zero-shots guards, and deterministic seeding. Plus rewriter cases for the tightened policy. Full Debug suite green (903 cases); CI exercises Release as well.

## Next (G2)
nanobind bindings for the noncomp types + `sample_noncomputational`, the spec-based `NonComputationalModel` builder (§3.3), and the Python end-to-end tests (§7.5) — including the analytic / brute-force-enumerator validation and the Bell-pair trace-out check we set aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

