### PR TITLE
feat: add Qiskit BackendV2 provider

### DIFF
--- a/src/python/clifft/qiskit_provider/__init__.py
+++ b/src/python/clifft/qiskit_provider/__init__.py
@@ -16,7 +16,12 @@ Quick start::
 """
 
 from .backend import ClifftBackend
-from .converter import UnsupportedGateError, circuit_to_stim, counts_from_measurements
+from .converter import (
+    UnsupportedGateError,
+    build_meas_map,
+    circuit_to_stim,
+    counts_from_measurements,
+)
 from .job import ClifftJob
 from .provider import ClifftProvider
 
@@ -25,6 +30,7 @@ __all__ = [
     "ClifftJob",
     "ClifftProvider",
     "UnsupportedGateError",
+    "build_meas_map",
     "circuit_to_stim",
     "counts_from_measurements",
 ]

--- a/src/python/clifft/qiskit_provider/__init__.py
+++ b/src/python/clifft/qiskit_provider/__init__.py
@@ -1,0 +1,30 @@
+"""Clifft Qiskit provider — run Qiskit circuits through the Clifft simulator.
+
+Quick start::
+
+    from clifft.qiskit_provider import ClifftProvider
+    from qiskit import QuantumCircuit
+
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+
+    backend = ClifftProvider().get_backend("clifft")
+    job = backend.run(qc, shots=1000)
+    print(job.result().get_counts())  # {'00': ~500, '11': ~500}
+"""
+
+from .backend import ClifftBackend
+from .converter import UnsupportedGateError, circuit_to_stim, counts_from_measurements
+from .job import ClifftJob
+from .provider import ClifftProvider
+
+__all__ = [
+    "ClifftBackend",
+    "ClifftJob",
+    "ClifftProvider",
+    "UnsupportedGateError",
+    "circuit_to_stim",
+    "counts_from_measurements",
+]

--- a/src/python/clifft/qiskit_provider/backend.py
+++ b/src/python/clifft/qiskit_provider/backend.py
@@ -1,0 +1,165 @@
+"""ClifftBackend: Qiskit BackendV2 that runs circuits through Clifft."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.providers import BackendV2, Options
+from qiskit.result import Result
+from qiskit.result.models import ExperimentResult, ExperimentResultData
+from qiskit.transpiler import Target
+
+import clifft
+
+from .converter import UnsupportedGateError, circuit_to_stim, counts_from_measurements
+from .job import ClifftJob
+
+# Basis gates the backend natively accepts without transpilation
+_BASIS_GATES = [
+    "h", "s", "sdg", "t", "tdg",
+    "x", "y", "z",
+    "cx", "cy", "cz",
+    "rx", "ry", "rz",
+    "measure", "reset",
+]
+
+
+class ClifftBackend(BackendV2):
+    """Qiskit backend that simulates circuits using the Clifft simulator.
+
+    Clifft is a fast exact simulator for near-Clifford circuits.  It accepts
+    Stim-format circuits; this backend converts Qiskit QuantumCircuits
+    automatically.
+
+    Usage::
+
+        from clifft.qiskit_provider import ClifftProvider
+
+        backend = ClifftProvider().get_backend("clifft")
+        job = backend.run(circuit, shots=1000)
+        counts = job.result().get_counts()
+
+    Gates that are not in the Clifft basis raise ``UnsupportedGateError``.
+    Transpile first with ``qiskit.transpile(circuit, backend=backend)``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="clifft")
+        self._target = self._build_target()
+
+    # ------------------------------------------------------------------
+    # BackendV2 interface
+    # ------------------------------------------------------------------
+
+    @property
+    def target(self) -> Target:
+        return self._target
+
+    @property
+    def max_circuits(self) -> int:
+        return 300
+
+    @classmethod
+    def _default_options(cls) -> Options:
+        return Options(shots=1024)
+
+    def run(
+        self,
+        circuits: Union[QuantumCircuit, list[QuantumCircuit]],
+        *,
+        shots: int | None = None,
+        **kwargs: object,
+    ) -> ClifftJob:
+        """Run one or more circuits through Clifft and return a job.
+
+        Args:
+            circuits: A single QuantumCircuit or a list of them.
+            shots: Number of shots (default: 1024).
+            **kwargs: Ignored (for forward compatibility).
+
+        Returns:
+            A completed :class:`ClifftJob` whose ``.result()`` is
+            immediately available.
+
+        Raises:
+            UnsupportedGateError: If a circuit contains gates not in
+                the Clifft basis.  Transpile first.
+        """
+        if shots is None:
+            shots = self.options.shots
+
+        if isinstance(circuits, QuantumCircuit):
+            circuits = [circuits]
+
+        experiment_results = [
+            self._run_one(qc, shots=shots) for qc in circuits
+        ]
+
+        result = Result(
+            backend_name=self.name,
+            backend_version="0.1.0",
+            qobj_id="",
+            job_id="",
+            success=all(r.success for r in experiment_results),
+            results=experiment_results,
+        )
+        return ClifftJob(self, result)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_one(self, qc: QuantumCircuit, *, shots: int) -> ExperimentResult:
+        """Compile and sample a single circuit; return an ExperimentResult."""
+        stim_text = circuit_to_stim(qc)
+        prog = clifft.compile(stim_text)
+        result = clifft.sample(prog, shots)
+
+        num_clbits = qc.num_clbits
+        counts = counts_from_measurements(result.measurements, num_clbits)
+
+        data = ExperimentResultData(counts={hex(int(k, 2)): v for k, v in counts.items()})
+        return ExperimentResult(
+            shots=shots,
+            success=True,
+            data=data,
+            header=_CircuitHeader(qc.name, num_clbits),
+            status="DONE",
+        )
+
+    @staticmethod
+    def _build_target() -> Target:
+        """Build a minimal all-to-all Target for transpilation hints."""
+        from qiskit.circuit.library import (
+            CXGate, CYGate, CZGate,
+            HGate, IGate, RXGate, RYGate, RZGate,
+            Reset, SGate, SdgGate, TGate, TdgGate,
+            XGate, YGate, ZGate,
+        )
+        from qiskit.circuit.measure import Measure
+        from qiskit.circuit import Parameter
+
+        theta = Parameter("θ")
+        target = Target(num_qubits=30)
+        for gate in [
+            HGate(), SGate(), SdgGate(), TGate(), TdgGate(),
+            XGate(), YGate(), ZGate(), IGate(),
+            RXGate(theta), RYGate(theta), RZGate(theta),
+            CXGate(), CYGate(), CZGate(),
+            Measure(), Reset(),
+        ]:
+            target.add_instruction(gate)
+        return target
+
+
+class _CircuitHeader:
+    """Minimal header-like object carrying clbit count for Result."""
+
+    def __init__(self, name: str, n_clbits: int) -> None:
+        self.name = name
+        self.creg_sizes = [["c", n_clbits]]
+        self.memory_slots = n_clbits
+
+    def items(self):
+        return self.__dict__.items()

--- a/src/python/clifft/qiskit_provider/backend.py
+++ b/src/python/clifft/qiskit_provider/backend.py
@@ -12,7 +12,7 @@ from qiskit.transpiler import Target
 
 import clifft
 
-from .converter import circuit_to_stim, counts_from_measurements
+from .converter import build_meas_map, circuit_to_stim, counts_from_measurements
 from .job import ClifftJob
 
 # Basis gates the backend natively accepts without transpilation
@@ -126,7 +126,8 @@ class ClifftBackend(BackendV2):
         result = clifft.sample(prog, shots)
 
         num_clbits = qc.num_clbits
-        counts = counts_from_measurements(result.measurements, num_clbits)
+        meas_map = build_meas_map(qc)
+        counts = counts_from_measurements(result.measurements, num_clbits, meas_map=meas_map)
 
         data = ExperimentResultData(counts={hex(int(k, 2)): v for k, v in counts.items()})
         return ExperimentResult(

--- a/src/python/clifft/qiskit_provider/backend.py
+++ b/src/python/clifft/qiskit_provider/backend.py
@@ -12,16 +12,27 @@ from qiskit.transpiler import Target
 
 import clifft
 
-from .converter import UnsupportedGateError, circuit_to_stim, counts_from_measurements
+from .converter import circuit_to_stim, counts_from_measurements
 from .job import ClifftJob
 
 # Basis gates the backend natively accepts without transpilation
 _BASIS_GATES = [
-    "h", "s", "sdg", "t", "tdg",
-    "x", "y", "z",
-    "cx", "cy", "cz",
-    "rx", "ry", "rz",
-    "measure", "reset",
+    "h",
+    "s",
+    "sdg",
+    "t",
+    "tdg",
+    "x",
+    "y",
+    "z",
+    "cx",
+    "cy",
+    "cz",
+    "rx",
+    "ry",
+    "rz",
+    "measure",
+    "reset",
 ]
 
 
@@ -92,9 +103,7 @@ class ClifftBackend(BackendV2):
         if isinstance(circuits, QuantumCircuit):
             circuits = [circuits]
 
-        experiment_results = [
-            self._run_one(qc, shots=shots) for qc in circuits
-        ]
+        experiment_results = [self._run_one(qc, shots=shots) for qc in circuits]
 
         result = Result(
             backend_name=self.name,
@@ -131,23 +140,47 @@ class ClifftBackend(BackendV2):
     @staticmethod
     def _build_target() -> Target:
         """Build a minimal all-to-all Target for transpilation hints."""
+        from qiskit.circuit import Parameter
         from qiskit.circuit.library import (
-            CXGate, CYGate, CZGate,
-            HGate, IGate, RXGate, RYGate, RZGate,
-            Reset, SGate, SdgGate, TGate, TdgGate,
-            XGate, YGate, ZGate,
+            CXGate,
+            CYGate,
+            CZGate,
+            HGate,
+            IGate,
+            Reset,
+            RXGate,
+            RYGate,
+            RZGate,
+            SdgGate,
+            SGate,
+            TdgGate,
+            TGate,
+            XGate,
+            YGate,
+            ZGate,
         )
         from qiskit.circuit.measure import Measure
-        from qiskit.circuit import Parameter
 
         theta = Parameter("θ")
         target = Target(num_qubits=30)
         for gate in [
-            HGate(), SGate(), SdgGate(), TGate(), TdgGate(),
-            XGate(), YGate(), ZGate(), IGate(),
-            RXGate(theta), RYGate(theta), RZGate(theta),
-            CXGate(), CYGate(), CZGate(),
-            Measure(), Reset(),
+            HGate(),
+            SGate(),
+            SdgGate(),
+            TGate(),
+            TdgGate(),
+            XGate(),
+            YGate(),
+            ZGate(),
+            IGate(),
+            RXGate(theta),
+            RYGate(theta),
+            RZGate(theta),
+            CXGate(),
+            CYGate(),
+            CZGate(),
+            Measure(),
+            Reset(),
         ]:
             target.add_instruction(gate)
         return target
@@ -161,5 +194,5 @@ class _CircuitHeader:
         self.creg_sizes = [["c", n_clbits]]
         self.memory_slots = n_clbits
 
-    def items(self):
+    def items(self) -> object:
         return self.__dict__.items()

--- a/src/python/clifft/qiskit_provider/converter.py
+++ b/src/python/clifft/qiskit_provider/converter.py
@@ -10,7 +10,7 @@ suggesting the caller transpile first.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from qiskit.circuit import QuantumCircuit
@@ -66,12 +66,10 @@ def circuit_to_stim(qc: QuantumCircuit, *, clbit_order: str = "little") -> str:
 
     lines: list[str] = []
     qubit_indices = {bit: i for i, bit in enumerate(qc.qubits)}
-    clbit_indices = {bit: i for i, bit in enumerate(qc.clbits)}
 
     for instruction in qc.data:
         op = instruction.operation
         qargs = instruction.qubits
-        cargs = instruction.clbits
         name = op.name
         q = [qubit_indices[b] for b in qargs]
 
@@ -141,23 +139,22 @@ def circuit_to_stim(qc: QuantumCircuit, *, clbit_order: str = "little") -> str:
         # --- Unitary (arbitrary matrix): not expressible in Stim directly ---
         if name == "unitary":
             raise UnsupportedGateError(
-                f"Gate 'unitary' cannot be converted to Stim automatically. "
-                f"Transpile to the Clifford+T basis first using "
-                f"qiskit.compiler.transpile(circuit, basis_gates=['h','s','t','cx','measure','reset'])."
+                "Gate 'unitary' cannot be converted to Stim automatically. "
+                "Transpile to the Clifford+T basis first: "
+                "qiskit.transpile(circuit, backend=backend)."
             )
 
         raise UnsupportedGateError(
             f"Gate '{name}' is not supported by the Clifft Qiskit provider. "
-            f"Transpile to the Clifford+T basis first:\n"
-            f"  from qiskit import transpile\n"
-            f"  transpile(circuit, basis_gates=['h','s','sdg','t','tdg','cx','x','y','z','measure','reset'])"
+            f"Transpile to the Clifford+T basis first: "
+            f"qiskit.transpile(circuit, backend=backend)."
         )
 
     return "\n".join(lines) if lines else "# empty circuit"
 
 
 def counts_from_measurements(
-    measurements: "import numpy; numpy.ndarray",  # type: ignore[type-arg]
+    measurements: Any,
     num_clbits: int,
     *,
     clbit_order: str = "little",

--- a/src/python/clifft/qiskit_provider/converter.py
+++ b/src/python/clifft/qiskit_provider/converter.py
@@ -153,11 +153,25 @@ def circuit_to_stim(qc: QuantumCircuit, *, clbit_order: str = "little") -> str:
     return "\n".join(lines) if lines else "# empty circuit"
 
 
+def build_meas_map(qc: "QuantumCircuit") -> list[int]:
+    """Return a list mapping Stim measurement index → classical bit index.
+
+    The i-th entry is the cbit index that the i-th ``measure`` instruction
+    in the circuit writes to, preserving the circuit's ``measure(q, c)``
+    intent even when classical bit indices are not sequential.
+    """
+    clbit_indices = {bit: i for i, bit in enumerate(qc.clbits)}
+    return [
+        clbit_indices[instr.clbits[0]] for instr in qc.data if instr.operation.name == "measure"
+    ]
+
+
 def counts_from_measurements(
     measurements: Any,
     num_clbits: int,
     *,
     clbit_order: str = "little",
+    meas_map: list[int] | None = None,
 ) -> dict[str, int]:
     """Convert a Clifft measurement array to a Qiskit-style counts dict.
 
@@ -166,13 +180,24 @@ def counts_from_measurements(
         num_clbits: Number of classical bits in the original circuit.
         clbit_order: ``"little"`` produces Qiskit's default little-endian
             bitstrings (rightmost bit = clbit 0).
+        meas_map: Mapping from Stim measurement index to classical bit index,
+            as returned by ``build_meas_map``.  When supplied, each
+            measurement result is placed at the correct cbit position rather
+            than filling slots sequentially.
 
     Returns:
         Dict mapping bitstring → count, e.g. ``{"00": 512, "11": 512}``.
     """
     counts: dict[str, int] = {}
     for row in measurements:
-        bits = row[:num_clbits]
+        bits = [0] * num_clbits
+        for meas_idx, bit_val in enumerate(row):
+            if meas_map is not None:
+                if meas_idx < len(meas_map):
+                    bits[meas_map[meas_idx]] = int(bit_val)
+            else:
+                if meas_idx < num_clbits:
+                    bits[meas_idx] = int(bit_val)
         if clbit_order == "little":
             bitstr = "".join(str(b) for b in reversed(bits))
         else:

--- a/src/python/clifft/qiskit_provider/converter.py
+++ b/src/python/clifft/qiskit_provider/converter.py
@@ -1,0 +1,189 @@
+"""Qiskit QuantumCircuit → Stim text converter.
+
+Translates a Qiskit QuantumCircuit into the Stim circuit text format that
+Clifft accepts.  Supports the Clifford+T basis plus continuous rotations.
+
+Unsupported gates raise ``UnsupportedGateError`` with a clear message
+suggesting the caller transpile first.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
+
+
+class UnsupportedGateError(Exception):
+    """Raised when a gate cannot be expressed in Clifft's Stim format."""
+
+
+# Map Qiskit gate names → Stim gate names (1-qubit, no args)
+_CLIFFORD_1Q: dict[str, str] = {
+    "h": "H",
+    "s": "S",
+    "sdg": "S_DAG",
+    "t": "T",
+    "tdg": "T_DAG",
+    "x": "X",
+    "y": "Y",
+    "z": "Z",
+    "id": "I",
+}
+
+# 2-qubit Clifford gates: Qiskit name → Stim name
+_CLIFFORD_2Q: dict[str, str] = {
+    "cx": "CX",
+    "cnot": "CX",
+    "cy": "CY",
+    "cz": "CZ",
+    "swap": "SWAP",
+}
+
+
+def circuit_to_stim(qc: QuantumCircuit, *, clbit_order: str = "little") -> str:
+    """Convert a Qiskit QuantumCircuit to a Stim circuit string.
+
+    Args:
+        qc: Qiskit QuantumCircuit.  Barriers are silently skipped.
+            Unsupported gates raise ``UnsupportedGateError`` — transpile
+            the circuit to the Clifford+T basis before calling this.
+        clbit_order: ``"little"`` (default) maps classical bit *i* to
+            Stim measurement record position *i*, matching Qiskit's
+            little-endian ordering.  ``"big"`` reverses the bit order in
+            the returned count strings.
+
+    Returns:
+        Stim-format circuit string, ready for ``clifft.compile()``.
+
+    Raises:
+        UnsupportedGateError: If an unrecognised gate is encountered.
+    """
+    if clbit_order not in ("little", "big"):
+        raise ValueError("clbit_order must be 'little' or 'big'")
+
+    lines: list[str] = []
+    qubit_indices = {bit: i for i, bit in enumerate(qc.qubits)}
+    clbit_indices = {bit: i for i, bit in enumerate(qc.clbits)}
+
+    for instruction in qc.data:
+        op = instruction.operation
+        qargs = instruction.qubits
+        cargs = instruction.clbits
+        name = op.name
+        q = [qubit_indices[b] for b in qargs]
+
+        # --- Barrier / global phase: skip silently ---
+        if name in ("barrier", "delay", "global_phase"):
+            continue
+
+        # --- 1-qubit Clifford gates ---
+        if name in _CLIFFORD_1Q:
+            stim_name = _CLIFFORD_1Q[name]
+            lines.append(f"{stim_name} {' '.join(map(str, q))}")
+            continue
+
+        # --- 2-qubit Clifford gates ---
+        if name in _CLIFFORD_2Q:
+            stim_name = _CLIFFORD_2Q[name]
+            lines.append(f"{stim_name} {q[0]} {q[1]}")
+            continue
+
+        # --- Rotation gates (angles in radians → half-turns for Stim) ---
+        if name == "rx":
+            alpha = _rad_to_half_turns(float(op.params[0]))
+            lines.append(f"R_X({alpha:.10g}) {q[0]}")
+            continue
+        if name == "ry":
+            alpha = _rad_to_half_turns(float(op.params[0]))
+            lines.append(f"R_Y({alpha:.10g}) {q[0]}")
+            continue
+        if name in ("rz", "p", "u1"):
+            alpha = _rad_to_half_turns(float(op.params[0]))
+            lines.append(f"R_Z({alpha:.10g}) {q[0]}")
+            continue
+        if name in ("u", "u3"):
+            theta = _rad_to_half_turns(float(op.params[0]))
+            phi = _rad_to_half_turns(float(op.params[1]))
+            lam = _rad_to_half_turns(float(op.params[2]))
+            lines.append(f"U3({theta:.10g}, {phi:.10g}, {lam:.10g}) {q[0]}")
+            continue
+        if name == "u2":
+            # u2(phi, lam) = u3(π/2, phi, lam)
+            theta = 0.5
+            phi = _rad_to_half_turns(float(op.params[0]))
+            lam = _rad_to_half_turns(float(op.params[1]))
+            lines.append(f"U3({theta:.10g}, {phi:.10g}, {lam:.10g}) {q[0]}")
+            continue
+        if name == "rxx":
+            alpha = _rad_to_half_turns(float(op.params[0]))
+            lines.append(f"R_XX({alpha:.10g}) {q[0]} {q[1]}")
+            continue
+        if name == "ryy":
+            alpha = _rad_to_half_turns(float(op.params[0]))
+            lines.append(f"R_YY({alpha:.10g}) {q[0]} {q[1]}")
+            continue
+        if name == "rzz":
+            alpha = _rad_to_half_turns(float(op.params[0]))
+            lines.append(f"R_ZZ({alpha:.10g}) {q[0]} {q[1]}")
+            continue
+
+        # --- Measure & reset ---
+        if name == "measure":
+            lines.append(f"M {q[0]}")
+            continue
+        if name == "reset":
+            lines.append(f"R {q[0]}")
+            continue
+
+        # --- Unitary (arbitrary matrix): not expressible in Stim directly ---
+        if name == "unitary":
+            raise UnsupportedGateError(
+                f"Gate 'unitary' cannot be converted to Stim automatically. "
+                f"Transpile to the Clifford+T basis first using "
+                f"qiskit.compiler.transpile(circuit, basis_gates=['h','s','t','cx','measure','reset'])."
+            )
+
+        raise UnsupportedGateError(
+            f"Gate '{name}' is not supported by the Clifft Qiskit provider. "
+            f"Transpile to the Clifford+T basis first:\n"
+            f"  from qiskit import transpile\n"
+            f"  transpile(circuit, basis_gates=['h','s','sdg','t','tdg','cx','x','y','z','measure','reset'])"
+        )
+
+    return "\n".join(lines) if lines else "# empty circuit"
+
+
+def counts_from_measurements(
+    measurements: "import numpy; numpy.ndarray",  # type: ignore[type-arg]
+    num_clbits: int,
+    *,
+    clbit_order: str = "little",
+) -> dict[str, int]:
+    """Convert a Clifft measurement array to a Qiskit-style counts dict.
+
+    Args:
+        measurements: uint8 array of shape ``(shots, num_measurements)``.
+        num_clbits: Number of classical bits in the original circuit.
+        clbit_order: ``"little"`` produces Qiskit's default little-endian
+            bitstrings (rightmost bit = clbit 0).
+
+    Returns:
+        Dict mapping bitstring → count, e.g. ``{"00": 512, "11": 512}``.
+    """
+    counts: dict[str, int] = {}
+    for row in measurements:
+        bits = row[:num_clbits]
+        if clbit_order == "little":
+            bitstr = "".join(str(b) for b in reversed(bits))
+        else:
+            bitstr = "".join(str(b) for b in bits)
+        counts[bitstr] = counts.get(bitstr, 0) + 1
+    return counts
+
+
+def _rad_to_half_turns(radians: float) -> float:
+    """Convert radians to Stim's half-turn unit (alpha * π = radians)."""
+    return radians / math.pi

--- a/src/python/clifft/qiskit_provider/job.py
+++ b/src/python/clifft/qiskit_provider/job.py
@@ -1,0 +1,38 @@
+"""ClifftJob: Qiskit JobV1 wrapper around a synchronous Clifft result."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from qiskit.providers import JobV1
+from qiskit.providers.jobstatus import JobStatus
+
+if TYPE_CHECKING:
+    from qiskit.providers import Backend
+    from qiskit.result import Result
+
+
+class ClifftJob(JobV1):
+    """Synchronous Qiskit job wrapping a pre-computed Clifft result.
+
+    Because Clifft executes synchronously, the result is available
+    immediately after construction.  ``status()`` always returns DONE
+    and ``result()`` never blocks.
+    """
+
+    def __init__(self, backend: Backend, result: Result) -> None:
+        super().__init__(backend, str(uuid.uuid4()))
+        self._result = result
+
+    def result(self) -> Result:
+        return self._result
+
+    def cancel(self) -> None:
+        pass
+
+    def status(self) -> JobStatus:
+        return JobStatus.DONE
+
+    def submit(self) -> None:
+        pass

--- a/src/python/clifft/qiskit_provider/provider.py
+++ b/src/python/clifft/qiskit_provider/provider.py
@@ -1,0 +1,32 @@
+"""ClifftProvider: minimal provider exposing ClifftBackend."""
+
+from __future__ import annotations
+
+from .backend import ClifftBackend
+
+
+class ClifftProvider:
+    """Provider for the Clifft near-Clifford simulator.
+
+    Usage::
+
+        from clifft.qiskit_provider import ClifftProvider
+
+        provider = ClifftProvider()
+        backend = provider.get_backend("clifft")
+        job = backend.run(circuit, shots=1000)
+        counts = job.result().get_counts()
+    """
+
+    def __init__(self) -> None:
+        self._backend = ClifftBackend()
+
+    def backends(self, name: str | None = None, **kwargs: object) -> list[ClifftBackend]:
+        if name is None or name == "clifft":
+            return [self._backend]
+        return []
+
+    def get_backend(self, name: str = "clifft", **kwargs: object) -> ClifftBackend:
+        if name != "clifft":
+            raise ValueError(f"Unknown backend '{name}'. Only 'clifft' is available.")
+        return self._backend

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import math
 
-import numpy as np
 import pytest
 from qiskit import QuantumCircuit, transpile
 from qiskit.providers.jobstatus import JobStatus
@@ -26,10 +25,10 @@ from clifft.qiskit_provider import (
     circuit_to_stim,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _bell() -> QuantumCircuit:
     qc = QuantumCircuit(2, 2)
@@ -56,6 +55,7 @@ def _counts_close(a: dict[str, int], b: dict[str, int], shots: int, sigma: int =
 # Provider / backend API
 # ---------------------------------------------------------------------------
 
+
 class TestProviderAPI:
     def test_get_backend_returns_clifft_backend(self) -> None:
         backend = ClifftProvider().get_backend("clifft")
@@ -81,6 +81,7 @@ class TestProviderAPI:
 # Converter unit tests
 # ---------------------------------------------------------------------------
 
+
 class TestConverter:
     def test_bell_stim_text(self) -> None:
         qc = QuantumCircuit(2, 2)
@@ -95,6 +96,7 @@ class TestConverter:
 
     def test_unsupported_gate_raises(self) -> None:
         from qiskit.circuit.library import CCXGate
+
         qc = QuantumCircuit(3, 1)
         qc.append(CCXGate(), [0, 1, 2])
         with pytest.raises(UnsupportedGateError):
@@ -137,6 +139,7 @@ class TestConverter:
 # Functional tests
 # ---------------------------------------------------------------------------
 
+
 class TestBellCircuit:
     SHOTS = 4096
 
@@ -174,11 +177,11 @@ class TestStatisticalEquivalence:
     def _aer_counts(self, qc: QuantumCircuit) -> dict[str, int]:
         sim = AerSimulator()
         result = sim.run(qc, shots=self.SHOTS).result()
-        return result.get_counts()
+        return dict(result.get_counts())
 
     def _clifft_counts(self, qc: QuantumCircuit) -> dict[str, int]:
         backend = ClifftProvider().get_backend("clifft")
-        return backend.run(qc, shots=self.SHOTS).result().get_counts()
+        return dict(backend.run(qc, shots=self.SHOTS).result().get_counts())
 
     def test_bell_matches_aer(self) -> None:
         qc = _bell()

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -245,6 +245,42 @@ class TestToffoliTranspiled:
         assert sum(counts.values()) == self.SHOTS
 
 
+class TestClbitOrdering:
+    """Classical bit ordering must respect measure(qubit, cbit) targets."""
+
+    SHOTS = 200
+
+    def _aer_counts(self, qc: QuantumCircuit) -> dict[str, int]:
+        sim = AerSimulator()
+        return dict(sim.run(qc, shots=self.SHOTS).result().get_counts())
+
+    def _clifft_counts(self, qc: QuantumCircuit) -> dict[str, int]:
+        backend = ClifftProvider().get_backend("clifft")
+        return dict(backend.run(qc, shots=self.SHOTS).result().get_counts())
+
+    def test_permuted_clbit_mapping_matches_aer(self) -> None:
+        # qubit 0 → cbit 2, qubit 1 → cbit 0; qubit 2 unmeasured
+        # Expected: cbit2=1, cbit1=0, cbit0=0 → "100"
+        qc = QuantumCircuit(3, 3)
+        qc.x(0)
+        qc.measure(0, 2)
+        qc.measure(1, 0)
+        clifft_counts = self._clifft_counts(qc)
+        aer_counts = self._aer_counts(qc)
+        assert clifft_counts == aer_counts, f"Clifft {clifft_counts} != Aer {aer_counts}"
+
+    def test_reversed_two_qubit_mapping(self) -> None:
+        # measure qubit 0 → cbit 1, qubit 1 → cbit 0 (reversed vs natural)
+        # qubit 0 = |1>, qubit 1 = |0> → expected "01" (cbit1=1, cbit0=0)
+        qc = QuantumCircuit(2, 2)
+        qc.x(0)
+        qc.measure(0, 1)
+        qc.measure(1, 0)
+        clifft_counts = self._clifft_counts(qc)
+        aer_counts = self._aer_counts(qc)
+        assert clifft_counts == aer_counts, f"Clifft {clifft_counts} != Aer {aer_counts}"
+
+
 class TestMultiCircuit:
     def test_batch_two_circuits(self) -> None:
         backend = ClifftProvider().get_backend("clifft")

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -1,0 +1,273 @@
+"""Tests for the Clifft Qiskit backend provider.
+
+Validates:
+- Bell circuit counts against reference
+- Statistical equivalence with Qiskit Aer
+- Multi-circuit batch runs
+- Transpilation of CCX (Toffoli) circuits
+- Unsupported gate error handling
+- Provider / backend API surface
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from qiskit import QuantumCircuit, transpile
+from qiskit.providers.jobstatus import JobStatus
+from qiskit_aer import AerSimulator
+
+from clifft.qiskit_provider import (
+    ClifftBackend,
+    ClifftProvider,
+    UnsupportedGateError,
+    circuit_to_stim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bell() -> QuantumCircuit:
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+
+def _counts_close(a: dict[str, int], b: dict[str, int], shots: int, sigma: int = 5) -> bool:
+    """Return True if two count dicts agree within 5-sigma for each key."""
+    all_keys = set(a) | set(b)
+    for key in all_keys:
+        ca, cb = a.get(key, 0), b.get(key, 0)
+        # Binomial std dev for the larger of the two
+        p = max(ca, cb) / shots
+        std = math.sqrt(shots * p * (1 - p)) if 0 < p < 1 else 1.0
+        if abs(ca - cb) > sigma * std:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Provider / backend API
+# ---------------------------------------------------------------------------
+
+class TestProviderAPI:
+    def test_get_backend_returns_clifft_backend(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        assert isinstance(backend, ClifftBackend)
+
+    def test_provider_backends_list(self) -> None:
+        p = ClifftProvider()
+        assert len(p.backends()) == 1
+        assert p.backends()[0].name == "clifft"
+
+    def test_unknown_backend_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown backend"):
+            ClifftProvider().get_backend("fake")
+
+    def test_backend_name(self) -> None:
+        assert ClifftBackend().name == "clifft"
+
+    def test_backend_max_circuits(self) -> None:
+        assert ClifftBackend().max_circuits >= 1
+
+
+# ---------------------------------------------------------------------------
+# Converter unit tests
+# ---------------------------------------------------------------------------
+
+class TestConverter:
+    def test_bell_stim_text(self) -> None:
+        qc = QuantumCircuit(2, 2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+        stim = circuit_to_stim(qc)
+        assert "H 0" in stim
+        assert "CX 0 1" in stim
+        assert "M 0" in stim
+        assert "M 1" in stim
+
+    def test_unsupported_gate_raises(self) -> None:
+        from qiskit.circuit.library import CCXGate
+        qc = QuantumCircuit(3, 1)
+        qc.append(CCXGate(), [0, 1, 2])
+        with pytest.raises(UnsupportedGateError):
+            circuit_to_stim(qc)
+
+    def test_rotation_gates_convert(self) -> None:
+        qc = QuantumCircuit(1)
+        qc.rx(math.pi / 4, 0)
+        qc.ry(math.pi / 2, 0)
+        qc.rz(math.pi, 0)
+        stim = circuit_to_stim(qc)
+        assert "R_X" in stim
+        assert "R_Y" in stim
+        assert "R_Z" in stim
+
+    def test_clifford_gates_convert(self) -> None:
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.s(0)
+        qc.sdg(0)
+        qc.t(0)
+        qc.tdg(0)
+        qc.cx(0, 1)
+        qc.cy(0, 1)
+        qc.cz(0, 1)
+        stim = circuit_to_stim(qc)
+        for gate in ("H", "S", "S_DAG", "T", "T_DAG", "CX", "CY", "CZ"):
+            assert gate in stim
+
+    def test_barrier_silently_skipped(self) -> None:
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.barrier()
+        qc.cx(0, 1)
+        stim = circuit_to_stim(qc)
+        assert "barrier" not in stim.lower()
+
+
+# ---------------------------------------------------------------------------
+# Functional tests
+# ---------------------------------------------------------------------------
+
+class TestBellCircuit:
+    SHOTS = 4096
+
+    def test_bell_only_00_and_11(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        job = backend.run(_bell(), shots=self.SHOTS)
+        counts = job.result().get_counts()
+        assert set(counts.keys()) <= {"00", "11"}, f"Unexpected keys: {counts.keys()}"
+
+    def test_bell_roughly_half_half(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        job = backend.run(_bell(), shots=self.SHOTS)
+        counts = job.result().get_counts()
+        total = sum(counts.values())
+        assert total == self.SHOTS
+        assert abs(counts.get("00", 0) - counts.get("11", 0)) < 0.15 * self.SHOTS
+
+    def test_job_status_done(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        job = backend.run(_bell(), shots=100)
+        assert job.status() == JobStatus.DONE
+
+    def test_result_success(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        job = backend.run(_bell(), shots=100)
+        assert job.result().success
+
+
+class TestStatisticalEquivalence:
+    """Compare Clifft counts against Qiskit Aer on several circuits."""
+
+    SHOTS = 8192
+    SIGMA = 5
+
+    def _aer_counts(self, qc: QuantumCircuit) -> dict[str, int]:
+        sim = AerSimulator()
+        result = sim.run(qc, shots=self.SHOTS).result()
+        return result.get_counts()
+
+    def _clifft_counts(self, qc: QuantumCircuit) -> dict[str, int]:
+        backend = ClifftProvider().get_backend("clifft")
+        return backend.run(qc, shots=self.SHOTS).result().get_counts()
+
+    def test_bell_matches_aer(self) -> None:
+        qc = _bell()
+        assert _counts_close(self._clifft_counts(qc), self._aer_counts(qc), self.SHOTS, self.SIGMA)
+
+    def test_ghz_3q_matches_aer(self) -> None:
+        qc = QuantumCircuit(3, 3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.measure([0, 1, 2], [0, 1, 2])
+        assert _counts_close(self._clifft_counts(qc), self._aer_counts(qc), self.SHOTS, self.SIGMA)
+
+    def test_t_gate_circuit_matches_aer(self) -> None:
+        qc = QuantumCircuit(1, 1)
+        qc.h(0)
+        qc.t(0)
+        qc.h(0)
+        qc.measure(0, 0)
+        assert _counts_close(self._clifft_counts(qc), self._aer_counts(qc), self.SHOTS, self.SIGMA)
+
+    def test_4qubit_clifford_matches_aer(self) -> None:
+        qc = QuantumCircuit(4, 4)
+        qc.h([0, 1, 2, 3])
+        qc.cx(0, 1)
+        qc.cz(2, 3)
+        qc.s(0)
+        qc.t(2)
+        qc.measure([0, 1, 2, 3], [0, 1, 2, 3])
+        assert _counts_close(self._clifft_counts(qc), self._aer_counts(qc), self.SHOTS, self.SIGMA)
+
+
+class TestToffoliTranspiled:
+    """CCX (Toffoli) should work after transpilation to Clifford+T basis."""
+
+    SHOTS = 4096
+
+    def test_ccx_transpiled_runs(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        qc = QuantumCircuit(3, 3)
+        qc.x([0, 1])
+        qc.ccx(0, 1, 2)
+        qc.measure([0, 1, 2], [0, 1, 2])
+        transpiled = transpile(qc, backend=backend)
+        job = backend.run(transpiled, shots=self.SHOTS)
+        counts = job.result().get_counts()
+        assert counts.get("111", 0) == self.SHOTS, f"Expected all '111', got {counts}"
+
+    def test_ccz_transpiled_runs(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        qc = QuantumCircuit(3, 3)
+        qc.x([0, 1])
+        qc.h(2)
+        qc.ccx(0, 1, 2)
+        qc.h(2)
+        qc.measure([0, 1, 2], [0, 1, 2])
+        transpiled = transpile(qc, backend=backend)
+        job = backend.run(transpiled, shots=self.SHOTS)
+        counts = job.result().get_counts()
+        # After CCZ with x|0>, x|1>, h|2>: qubit 2 should flip → "110" + measure
+        assert sum(counts.values()) == self.SHOTS
+
+
+class TestMultiCircuit:
+    def test_batch_two_circuits(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        qc1 = _bell()
+        qc2 = QuantumCircuit(1, 1)
+        qc2.x(0)
+        qc2.measure(0, 0)
+        job = backend.run([qc1, qc2], shots=100)
+        result = job.result()
+        assert result.success
+        counts0 = result.get_counts(0)
+        counts1 = result.get_counts(1)
+        assert set(counts0.keys()) <= {"00", "11"}
+        assert counts1 == {"1": 100}
+
+    def test_deterministic_x_gate(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        counts = backend.run(qc, shots=200).result().get_counts()
+        assert counts == {"1": 200}
+
+    def test_deterministic_zero(self) -> None:
+        backend = ClifftProvider().get_backend("clifft")
+        qc = QuantumCircuit(1, 1)
+        qc.measure(0, 0)
+        counts = backend.run(qc, shots=200).result().get_counts()
+        assert counts == {"0": 200}


### PR DESCRIPTION
Closes #39

## Design

- **Location:** optional subpackage at `clifft/qiskit_provider/` — Qiskit is not a hard dep on the core
- **Interface:** `BackendV2` only (Qiskit 2.x — `BackendV1`/`ProviderV1` removed in 2.0)
- **Gate set:** `H S S† T T† X Y Z I CX CY CZ RX RY RZ measure reset` — anything else raises `UnsupportedGateError`
- **Gate mapping:** Clifford gates map by name; rotation angles converted radians → half-turns (÷ π) for Stim; `barrier`/`delay` silently skipped
- **Bit ordering:** little-endian (Qiskit convention) — Clifft's measurement array is read left-to-right per shot and passed through Qiskit's `Result` machinery
- **Transpilation:** expected before `run()`, not inside it — `ClifftBackend.target` exposes a full 30-qubit all-to-all `Target` so `qiskit.transpile(qc, backend=backend)` works correctly

## Summary

Implements a Qiskit `BackendV2` provider that bridges Qiskit `QuantumCircuit` → Stim text → Clifft compiler/sampler → Qiskit `Result`, letting Clifft work as a drop-in simulator in any Qiskit workflow.

```python
from clifft.qiskit_provider import ClifftProvider

backend = ClifftProvider().get_backend("clifft")
job = backend.run(circuit, shots=1000)
counts = job.result().get_counts()
```

## New modules under `clifft/qiskit_provider/`

- **`converter.py`** — `QuantumCircuit` → Stim text
- **`job.py`** — `ClifftJob(JobV1)`: synchronous wrapper, always `DONE`
- **`backend.py`** — `ClifftBackend(BackendV2)`: all-to-all `Target`, single and batched circuit runs
- **`provider.py`** — `ClifftProvider.get_backend("clifft")`

## Tests (23 passing)

- Provider API surface
- Gate conversion unit tests
- Bell circuit correctness (only `00`/`11`, ~50/50 split)
- Statistical equivalence vs Qiskit Aer on Bell, GHZ-3q, T-gate, 4-qubit Clifford (5-sigma)
- Toffoli (CCX/CCZ) after transpilation to Clifford+T basis
- Multi-circuit batch runs