### PR TITLE
feat: add minimal Qiskit backend provider

### DIFF
--- a/docs/guide/qiskit.md
+++ b/docs/guide/qiskit.md
@@ -30,14 +30,16 @@ with Clifft, and returns Qiskit-style counts.
 
 ## Supported basis
 
-The native basis is **Clifford+T**:
+The native basis is **Clifford+T plus single-qubit rotations**:
 
-`h, s, sdg, x, y, z, cx, cy, cz, t, tdg` plus `measure`.
+`h, s, sdg, x, y, z, cx, cy, cz, t, tdg, rx, ry, rz` plus `measure`.
 
-Higher-level gates are decomposed into this basis by the Qiskit transpiler
-before execution. For example `ccx`/`ccz` decompose exactly, and arbitrary
-rotations (`rx`, `ry`, `rz`, `u`, ...) are *approximated* into Clifford+T via
-the transpiler's Solovay-Kitaev synthesis.
+`rx`/`ry`/`rz` map directly to Clifft's `R_X`/`R_Y`/`R_Z` (angles converted from
+radians to Clifft's half-turn units). Higher-level gates are decomposed into
+this basis by the Qiskit transpiler before execution — `ccx`/`ccz` into
+Clifford+T, and any single-qubit unitary (`u`, `p`, ...) or controlled rotation
+exactly into `rx`/`ry`/`rz`. Because rotations are part of the basis, no
+approximate (Solovay-Kitaev) synthesis is involved.
 
 ## Limitations
 

--- a/docs/guide/qiskit.md
+++ b/docs/guide/qiskit.md
@@ -3,6 +3,7 @@
 Run Qiskit circuits on Clifft through a minimal `BackendV2` provider. Install
 the optional dependency:
 
+<!--pytest.mark.skip-->
 ```bash
 pip install clifft[qiskit]
 ```

--- a/docs/guide/qiskit.md
+++ b/docs/guide/qiskit.md
@@ -1,0 +1,52 @@
+# Qiskit provider
+
+Run Qiskit circuits on Clifft through a minimal `BackendV2` provider. Install
+the optional dependency:
+
+```bash
+pip install clifft[qiskit]
+```
+
+## Quickstart
+
+```python
+from qiskit import QuantumCircuit
+from clifft.qiskit import ClifftProvider
+
+qc = QuantumCircuit(2, 2)
+qc.h(0)
+qc.cx(0, 1)
+qc.measure([0, 1], [0, 1])
+
+backend = ClifftProvider().get_backend("clifft")
+counts = backend.run(qc, shots=1000).result().get_counts()
+print(counts)  # ~ {'00': 500, '11': 500}
+```
+
+`backend.run` also accepts a list of circuits. For each circuit the backend
+transpiles into Clifft's supported basis, converts it to Stim text, samples
+with Clifft, and returns Qiskit-style counts.
+
+## Supported basis
+
+The native basis is **Clifford+T**:
+
+`h, s, sdg, x, y, z, cx, cy, cz, t, tdg` plus `measure`.
+
+Higher-level gates are decomposed into this basis by the Qiskit transpiler
+before execution. For example `ccx`/`ccz` decompose exactly, and arbitrary
+rotations (`rx`, `ry`, `rz`, `u`, ...) are *approximated* into Clifford+T via
+the transpiler's Solovay-Kitaev synthesis.
+
+## Limitations
+
+This is an initial prototype. Not supported in this version:
+
+- Non-unitary / structural operations such as `reset`, mid-circuit measurement
+  beyond terminal measurement, and classical control. These raise a
+  `QiskitError`.
+- Noise models, asynchronous jobs, Estimator/Sampler primitives, Qobj/legacy
+  run configuration, and coupling maps / layout constraints.
+
+Importing `clifft` does not import Qiskit; Qiskit is only loaded when you import
+`clifft.qiskit`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
   - User Guide:
     - Compiling Circuits: guide/compilation.md
     - Simulation: guide/simulation.md
+    - Qiskit provider: guide/qiskit.md
     - Performance: guide/performance.md
     - "Tutorial: Strong Simulation": guide/strong-simulation.md
     - "Tutorial: Surface Code": guide/surface-code.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "numpy>=1.26",
 ]
 
+[project.optional-dependencies]
+qiskit = ["qiskit>=1.0"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/src/python/clifft/qiskit/__init__.py
+++ b/src/python/clifft/qiskit/__init__.py
@@ -1,0 +1,5 @@
+"""Qiskit provider/backend for the Clifft simulator (optional ``clifft[qiskit]``)."""
+
+from clifft.qiskit.backend import ClifftBackend, ClifftJob, ClifftProvider
+
+__all__ = ["ClifftBackend", "ClifftJob", "ClifftProvider"]

--- a/src/python/clifft/qiskit/_translate.py
+++ b/src/python/clifft/qiskit/_translate.py
@@ -1,0 +1,80 @@
+"""Translate between Qiskit circuits/results and Clifft's Stim-text API."""
+
+from __future__ import annotations
+
+from qiskit import QuantumCircuit
+from qiskit.exceptions import QiskitError
+
+# Qiskit gate name -> Stim gate name (Clifford+T basis).
+_GATE_MAP = {
+    "h": "H",
+    "x": "X",
+    "y": "Y",
+    "z": "Z",
+    "s": "S",
+    "sdg": "S_DAG",
+    "t": "T",
+    "tdg": "T_DAG",
+    "cx": "CX",
+    "cy": "CY",
+    "cz": "CZ",
+}
+
+# Gates we transpile into (measure is handled separately, not a basis gate).
+CLIFFT_BASIS = ["h", "s", "sdg", "x", "y", "z", "cx", "cy", "cz", "t", "tdg"]
+
+
+def qiskit_to_stim(circuit: QuantumCircuit) -> tuple[str, list[int]]:
+    """Convert a (basis-decomposed) QuantumCircuit to Stim text.
+
+    Returns the Stim program and ``measured_clbits``: the classical-bit index
+    targeted by each ``M`` line, in program order. clifft's
+    ``measurements[:, j]`` is the j-th ``M``, so this list maps sample columns
+    back to Qiskit clbits.
+
+    Raises QiskitError on any operation outside the supported basis.
+    """
+    lines: list[str] = []
+    measured_clbits: list[int] = []
+
+    for instruction in circuit.data:
+        name = instruction.operation.name
+        qubits = [circuit.find_bit(q).index for q in instruction.qubits]
+
+        if name == "measure":
+            clbit = circuit.find_bit(instruction.clbits[0]).index
+            lines.append(f"M {qubits[0]}")
+            measured_clbits.append(clbit)
+        elif name in ("barrier", "id"):
+            # no-ops for sampling
+            continue
+        elif name in _GATE_MAP:
+            lines.append(f"{_GATE_MAP[name]} " + " ".join(str(q) for q in qubits))
+        else:
+            raise QiskitError(
+                f"clifft backend does not support operation '{name}'. "
+                "Supported basis: " + ", ".join(_GATE_MAP) + ", measure."
+            )
+
+    return "\n".join(lines), measured_clbits
+
+
+def counts_from_measurements(
+    measurements, measured_clbits: list[int], num_clbits: int
+) -> dict[str, int]:
+    """Convert clifft's (shots, num_meas) array to a Qiskit counts dict.
+
+    Each shot's measured bits are packed into an integer where clbit ``i``
+    contributes bit ``i`` (Qiskit's little-endian-by-clbit convention). The
+    hex-string keys are rendered to binary by Qiskit's ``get_counts`` using
+    ``memory_slots = num_clbits``, so ordering matches AerSimulator.
+    """
+    counts: dict[str, int] = {}
+    for row in measurements:
+        value = 0
+        for col, clbit in enumerate(measured_clbits):
+            if int(row[col]):
+                value |= 1 << clbit
+        key = hex(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts

--- a/src/python/clifft/qiskit/_translate.py
+++ b/src/python/clifft/qiskit/_translate.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import math
+
 from qiskit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 
-# Qiskit gate name -> Stim gate name (Clifford+T basis).
+# Qiskit gate name -> Stim gate name (non-parameterized Clifford+T gates).
 _GATE_MAP = {
     "h": "H",
     "x": "X",
@@ -20,8 +22,19 @@ _GATE_MAP = {
     "cz": "CZ",
 }
 
+# Single-qubit parameterized rotations: Qiskit name -> Stim name. Clifft uses
+# half-turn angle units, so a Qiskit angle in radians is divided by pi.
+_PARAM_GATE_MAP = {
+    "rx": "R_X",
+    "ry": "R_Y",
+    "rz": "R_Z",
+}
+
 # Gates we transpile into (measure is handled separately, not a basis gate).
-CLIFFT_BASIS = ["h", "s", "sdg", "x", "y", "z", "cx", "cy", "cz", "t", "tdg"]
+# With rx/ry/rz in the basis, the transpiler lowers any single-qubit unitary
+# (u, p, ...) and controlled rotations exactly into this set -- no approximate
+# (Solovay-Kitaev) synthesis is needed.
+CLIFFT_BASIS = ["h", "s", "sdg", "x", "y", "z", "cx", "cy", "cz", "t", "tdg", "rx", "ry", "rz"]
 
 
 def qiskit_to_stim(circuit: QuantumCircuit) -> tuple[str, list[int]]:
@@ -50,10 +63,15 @@ def qiskit_to_stim(circuit: QuantumCircuit) -> tuple[str, list[int]]:
             continue
         elif name in _GATE_MAP:
             lines.append(f"{_GATE_MAP[name]} " + " ".join(str(q) for q in qubits))
+        elif name in _PARAM_GATE_MAP:
+            # radians -> Clifft half-turn units
+            angle = float(instruction.operation.params[0]) / math.pi
+            lines.append(f"{_PARAM_GATE_MAP[name]}({angle}) {qubits[0]}")
         else:
+            supported = ", ".join([*_GATE_MAP, *_PARAM_GATE_MAP])
             raise QiskitError(
                 f"clifft backend does not support operation '{name}'. "
-                "Supported basis: " + ", ".join(_GATE_MAP) + ", measure."
+                f"Supported basis: {supported}, measure."
             )
 
     return "\n".join(lines), measured_clbits

--- a/src/python/clifft/qiskit/_translate.py
+++ b/src/python/clifft/qiskit/_translate.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+import numpy.typing as npt
 from qiskit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 
@@ -78,7 +80,7 @@ def qiskit_to_stim(circuit: QuantumCircuit) -> tuple[str, list[int]]:
 
 
 def counts_from_measurements(
-    measurements, measured_clbits: list[int], num_clbits: int
+    measurements: npt.NDArray[np.uint8], measured_clbits: list[int], num_clbits: int
 ) -> dict[str, int]:
     """Convert clifft's (shots, num_meas) array to a Qiskit counts dict.
 

--- a/src/python/clifft/qiskit/backend.py
+++ b/src/python/clifft/qiskit/backend.py
@@ -36,11 +36,6 @@ from clifft.qiskit._translate import (
     qiskit_to_stim,
 )
 
-# clifft is a simulator with all-to-all connectivity and no fixed qubit count;
-# the Target needs a concrete width for qiskit.transpile(qc, backend=backend) to
-# work, so we advertise a generous default that callers can raise if needed.
-DEFAULT_NUM_QUBITS = 64
-
 
 class ClifftJob(JobV1):
     """Synchronous job holding an already-computed Result."""
@@ -66,15 +61,17 @@ class ClifftBackend(BackendV2):
         self,
         provider: ClifftProvider | None = None,
         name: str = "clifft",
-        num_qubits: int = DEFAULT_NUM_QUBITS,
+        num_qubits: int | None = None,
     ):
         super().__init__(provider=provider, name=name, backend_version="0.1.0")
         self._target = self._build_target(num_qubits)
 
     @staticmethod
-    def _build_target(num_qubits: int) -> Target:
+    def _build_target(num_qubits: int | None) -> Target:
         # all-to-all ideal target advertising the full supported basis, so
         # qiskit.transpile(qc, backend=backend) decomposes into clifft's basis.
+        # num_qubits=None leaves the width unbounded (clifft has no fixed size);
+        # callers may pass an int to advertise a specific qubit count.
         target = Target(num_qubits=num_qubits)
         theta = Parameter("theta")
         for gate in (

--- a/src/python/clifft/qiskit/backend.py
+++ b/src/python/clifft/qiskit/backend.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from typing import Any
 
 from qiskit import QuantumCircuit, transpile
-from qiskit.circuit import Measure
+from qiskit.circuit import Measure, Parameter
 from qiskit.circuit.library import (
     CXGate,
     CYGate,
     CZGate,
     HGate,
+    RXGate,
+    RYGate,
+    RZGate,
     SdgGate,
     SGate,
     TdgGate,
@@ -21,6 +24,7 @@ from qiskit.circuit.library import (
 )
 from qiskit.exceptions import QiskitError
 from qiskit.providers import BackendV2, JobStatus, JobV1, Options
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.result import Result
 from qiskit.result.models import ExperimentResult, ExperimentResultData
 from qiskit.transpiler import Target
@@ -31,6 +35,11 @@ from clifft.qiskit._translate import (
     counts_from_measurements,
     qiskit_to_stim,
 )
+
+# clifft is a simulator with all-to-all connectivity and no fixed qubit count;
+# the Target needs a concrete width for qiskit.transpile(qc, backend=backend) to
+# work, so we advertise a generous default that callers can raise if needed.
+DEFAULT_NUM_QUBITS = 64
 
 
 class ClifftJob(JobV1):
@@ -53,13 +62,21 @@ class ClifftJob(JobV1):
 class ClifftBackend(BackendV2):
     """Run Qiskit circuits on the Clifft near-Clifford simulator."""
 
-    def __init__(self, provider: ClifftProvider | None = None, name: str = "clifft"):
+    def __init__(
+        self,
+        provider: ClifftProvider | None = None,
+        name: str = "clifft",
+        num_qubits: int = DEFAULT_NUM_QUBITS,
+    ):
         super().__init__(provider=provider, name=name, backend_version="0.1.0")
-        self._target = self._build_target()
+        self._target = self._build_target(num_qubits)
 
     @staticmethod
-    def _build_target() -> Target:
-        target = Target()
+    def _build_target(num_qubits: int) -> Target:
+        # all-to-all ideal target advertising the full supported basis, so
+        # qiskit.transpile(qc, backend=backend) decomposes into clifft's basis.
+        target = Target(num_qubits=num_qubits)
+        theta = Parameter("theta")
         for gate in (
             HGate(),
             XGate(),
@@ -72,6 +89,9 @@ class ClifftBackend(BackendV2):
             CXGate(),
             CYGate(),
             CZGate(),
+            RXGate(theta),
+            RYGate(theta),
+            RZGate(theta),
             Measure(),
         ):
             target.add_instruction(gate, name=gate.name)
@@ -135,6 +155,8 @@ class ClifftProvider:
     """Entry point: ``ClifftProvider().get_backend("clifft")``."""
 
     def get_backend(self, name: str = "clifft") -> ClifftBackend:
+        if name != "clifft":
+            raise QiskitBackendNotFoundError(f"No backend matches the name '{name}'.")
         return ClifftBackend(provider=self, name=name)
 
     def backends(self, name: str | None = None) -> list[ClifftBackend]:

--- a/src/python/clifft/qiskit/backend.py
+++ b/src/python/clifft/qiskit/backend.py
@@ -1,0 +1,142 @@
+"""A minimal Qiskit BackendV2 provider that runs circuits on Clifft."""
+
+from __future__ import annotations
+
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit import Measure
+from qiskit.circuit.library import (
+    CXGate,
+    CYGate,
+    CZGate,
+    HGate,
+    SdgGate,
+    SGate,
+    TdgGate,
+    TGate,
+    XGate,
+    YGate,
+    ZGate,
+)
+from qiskit.exceptions import QiskitError
+from qiskit.providers import BackendV2, JobStatus, JobV1, Options
+from qiskit.result import Result
+from qiskit.result.models import ExperimentResult, ExperimentResultData
+from qiskit.transpiler import Target
+
+import clifft
+from clifft.qiskit._translate import (
+    CLIFFT_BASIS,
+    counts_from_measurements,
+    qiskit_to_stim,
+)
+
+
+class ClifftJob(JobV1):
+    """Synchronous job holding an already-computed Result."""
+
+    def __init__(self, backend, job_id: str, result: Result):
+        super().__init__(backend, job_id)
+        self._result = result
+
+    def submit(self):  # work already done synchronously in backend.run
+        pass
+
+    def result(self) -> Result:
+        return self._result
+
+    def status(self) -> JobStatus:
+        return JobStatus.DONE
+
+
+class ClifftBackend(BackendV2):
+    """Run Qiskit circuits on the Clifft near-Clifford simulator."""
+
+    def __init__(self, provider=None, name: str = "clifft"):
+        super().__init__(provider=provider, name=name, backend_version="0.1.0")
+        self._target = self._build_target()
+
+    @staticmethod
+    def _build_target() -> Target:
+        target = Target()
+        for gate in (
+            HGate(),
+            XGate(),
+            YGate(),
+            ZGate(),
+            SGate(),
+            SdgGate(),
+            TGate(),
+            TdgGate(),
+            CXGate(),
+            CYGate(),
+            CZGate(),
+            Measure(),
+        ):
+            target.add_instruction(gate, name=gate.name)
+        return target
+
+    @property
+    def target(self) -> Target:
+        return self._target
+
+    @property
+    def max_circuits(self):
+        return None
+
+    @classmethod
+    def _default_options(cls) -> Options:
+        return Options(shots=1024, seed=None)
+
+    def run(self, run_input, **options) -> ClifftJob:
+        shots = options.get("shots", self.options.shots)
+        seed = options.get("seed", self.options.seed)
+
+        circuits = [run_input] if isinstance(run_input, QuantumCircuit) else list(run_input)
+
+        experiment_results = []
+        for circ in circuits:
+            decomposed = transpile(circ, basis_gates=CLIFFT_BASIS, optimization_level=1)
+            stim_text, measured_clbits = qiskit_to_stim(decomposed)
+            if not measured_clbits:
+                raise QiskitError("clifft backend requires at least one measurement.")
+
+            program = clifft.compile(stim_text)
+            if seed is None:
+                sample = clifft.sample(program, shots=shots)
+            else:
+                sample = clifft.sample(program, shots=shots, seed=seed)
+
+            counts = counts_from_measurements(
+                sample.measurements, measured_clbits, decomposed.num_clbits
+            )
+            experiment_results.append(
+                ExperimentResult(
+                    shots=shots,
+                    success=True,
+                    data=ExperimentResultData(counts=counts),
+                    header={"memory_slots": decomposed.num_clbits, "name": circ.name},
+                )
+            )
+
+        result = Result(
+            backend_name=self.name,
+            backend_version=self.backend_version,
+            qobj_id="clifft",
+            job_id="clifft-job",
+            success=True,
+            results=experiment_results,
+        )
+        return ClifftJob(self, "clifft-job", result)
+
+
+class ClifftProvider:
+    """Entry point: ``ClifftProvider().get_backend("clifft")``."""
+
+    def get_backend(self, name: str = "clifft") -> ClifftBackend:
+        return ClifftBackend(provider=self, name=name)
+
+    def backends(self, name: str | None = None):
+        backend = ClifftBackend(provider=self)
+        if name in (None, "clifft"):
+            return [backend]
+        return []

--- a/src/python/clifft/qiskit/backend.py
+++ b/src/python/clifft/qiskit/backend.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit import Measure
 from qiskit.circuit.library import (
@@ -34,7 +36,7 @@ from clifft.qiskit._translate import (
 class ClifftJob(JobV1):
     """Synchronous job holding an already-computed Result."""
 
-    def __init__(self, backend, job_id: str, result: Result):
+    def __init__(self, backend: BackendV2, job_id: str, result: Result):
         super().__init__(backend, job_id)
         self._result = result
 
@@ -51,7 +53,7 @@ class ClifftJob(JobV1):
 class ClifftBackend(BackendV2):
     """Run Qiskit circuits on the Clifft near-Clifford simulator."""
 
-    def __init__(self, provider=None, name: str = "clifft"):
+    def __init__(self, provider: ClifftProvider | None = None, name: str = "clifft"):
         super().__init__(provider=provider, name=name, backend_version="0.1.0")
         self._target = self._build_target()
 
@@ -87,7 +89,7 @@ class ClifftBackend(BackendV2):
     def _default_options(cls) -> Options:
         return Options(shots=1024, seed=None)
 
-    def run(self, run_input, **options) -> ClifftJob:
+    def run(self, run_input: QuantumCircuit | list[QuantumCircuit], **options: Any) -> ClifftJob:
         shots = options.get("shots", self.options.shots)
         seed = options.get("seed", self.options.seed)
 
@@ -135,7 +137,7 @@ class ClifftProvider:
     def get_backend(self, name: str = "clifft") -> ClifftBackend:
         return ClifftBackend(provider=self, name=name)
 
-    def backends(self, name: str | None = None):
+    def backends(self, name: str | None = None) -> list[ClifftBackend]:
         backend = ClifftBackend(provider=self)
         if name in (None, "clifft"):
             return [backend]

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -150,15 +150,19 @@ def test_permuted_clbit_mapping_matches_aer(backend):
 
 
 def test_transpile_with_backend(backend):
-    # qiskit.transpile(qc, backend=backend) must work: the Target exposes a
-    # concrete num_qubits and the full basis (incl. rotations).
-    assert backend.target.num_qubits >= 1
+    # qiskit.transpile(qc, backend=backend) must work for an arbitrary width:
+    # the Target advertises the full basis (incl. rotations) and an unbounded
+    # num_qubits (None), so circuit width is preserved rather than capped.
+    assert backend.target.num_qubits is None
     assert {"rx", "ry", "rz"}.issubset(backend.target.operation_names)
 
-    qc = QuantumCircuit(1, 1)
+    qc = QuantumCircuit(5, 5)
     qc.h(0)
-    qc.measure(0, 0)
+    for i in range(4):
+        qc.cx(i, i + 1)
+    qc.measure(range(5), range(5))
     transpiled = transpile(qc, backend=backend)
+    assert transpiled.num_qubits == 5
     _assert_close(backend.run(transpiled, shots=SHOTS).result().get_counts(), _aer_counts(qc))
 
 

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -3,8 +3,9 @@
 import pytest
 
 try:
-    from qiskit import QuantumCircuit
+    from qiskit import QuantumCircuit, transpile
     from qiskit.exceptions import QiskitError
+    from qiskit.providers.exceptions import QiskitBackendNotFoundError
     from qiskit_aer import AerSimulator
 
     from clifft.qiskit import ClifftProvider
@@ -112,3 +113,56 @@ def test_unsupported_operation_raises(backend):
     qc.measure(0, 0)
     with pytest.raises(QiskitError):
         backend.run(qc, shots=SHOTS).result()
+
+
+def test_ghz_3q_matches_aer(backend):
+    qc = QuantumCircuit(3, 3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure([0, 1, 2], [0, 1, 2])
+    _assert_close(backend.run(qc, shots=SHOTS).result().get_counts(), _aer_counts(qc))
+
+
+def test_4qubit_clifford_t_matches_aer(backend):
+    qc = QuantumCircuit(4, 4)
+    qc.h([0, 1, 2, 3])
+    qc.cx(0, 1)
+    qc.cz(1, 2)
+    qc.t(2)
+    qc.cx(2, 3)
+    qc.s(3)
+    qc.measure(range(4), range(4))
+    _assert_close(backend.run(qc, shots=SHOTS).result().get_counts(), _aer_counts(qc))
+
+
+def test_permuted_clbit_mapping_matches_aer(backend):
+    # measure qubits into a permuted set of clbits; counts must match Aer's
+    # clbit-indexed ordering rather than qubit order.
+    qc = QuantumCircuit(3, 3)
+    qc.x(0)
+    qc.h(1)
+    qc.cx(1, 2)
+    qc.measure(0, 2)
+    qc.measure(1, 0)
+    qc.measure(2, 1)
+    _assert_close(backend.run(qc, shots=SHOTS).result().get_counts(), _aer_counts(qc))
+
+
+def test_transpile_with_backend(backend):
+    # qiskit.transpile(qc, backend=backend) must work: the Target exposes a
+    # concrete num_qubits and the full basis (incl. rotations).
+    assert backend.target.num_qubits >= 1
+    assert {"rx", "ry", "rz"}.issubset(backend.target.operation_names)
+
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    transpiled = transpile(qc, backend=backend)
+    _assert_close(backend.run(transpiled, shots=SHOTS).result().get_counts(), _aer_counts(qc))
+
+
+def test_get_backend_unknown_name_raises():
+    with pytest.raises(QiskitBackendNotFoundError):
+        ClifftProvider().get_backend("not-clifft")
+    assert ClifftProvider().backends("not-clifft") == []

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -84,6 +84,27 @@ def test_list_of_circuits(backend):
     assert res.get_counts(1) == {"1": SHOTS}
 
 
+def test_native_rotations(backend):
+    # rx/ry/rz are in the basis and map directly to Clifft's R_X/R_Y/R_Z.
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.rz(0.7, 0)
+    qc.rx(0.4, 0)
+    qc.ry(1.1, 0)
+    qc.measure(0, 0)
+    _assert_close(backend.run(qc, shots=SHOTS).result().get_counts(), _aer_counts(qc))
+
+
+def test_u_and_controlled_rotation(backend):
+    # u and controlled rotations are decomposed exactly into rx/ry/rz/cx.
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.u(0.3, 0.5, 0.7, 0)
+    qc.crz(0.9, 0, 1)
+    qc.measure([0, 1], [0, 1])
+    _assert_close(backend.run(qc, shots=SHOTS).result().get_counts(), _aer_counts(qc))
+
+
 def test_unsupported_operation_raises(backend):
     qc = QuantumCircuit(1, 1)
     qc.reset(0)

--- a/tests/python/test_qiskit_provider.py
+++ b/tests/python/test_qiskit_provider.py
@@ -1,0 +1,93 @@
+"""Tests for the Clifft Qiskit backend provider."""
+
+import pytest
+
+try:
+    from qiskit import QuantumCircuit
+    from qiskit.exceptions import QiskitError
+    from qiskit_aer import AerSimulator
+
+    from clifft.qiskit import ClifftProvider
+
+    qiskit_missing = False
+except ImportError:
+    qiskit_missing = True
+
+pytestmark = pytest.mark.skipif(qiskit_missing, reason="qiskit/qiskit-aer not installed")
+
+SHOTS = 4000
+TOL = 0.05
+
+
+def _aer_counts(circuit):
+    result = AerSimulator().run(circuit, shots=SHOTS, seed_simulator=1).result()
+    return result.get_counts()
+
+
+def _assert_close(a, b, shots=SHOTS, tol=TOL):
+    keys = set(a) | set(b)
+    for k in keys:
+        pa = a.get(k, 0) / shots
+        pb = b.get(k, 0) / shots
+        assert abs(pa - pb) < tol, f"{k}: {pa} vs {pb}\n{a}\n{b}"
+
+
+@pytest.fixture
+def backend():
+    return ClifftProvider().get_backend("clifft")
+
+
+def test_bell(backend):
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    counts = backend.run(qc, shots=SHOTS).result().get_counts()
+    _assert_close(counts, _aer_counts(qc))
+
+
+def test_non_clifford_t(backend):
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.t(0)
+    qc.h(0)
+    qc.measure(0, 0)
+    counts = backend.run(qc, shots=SHOTS).result().get_counts()
+    _assert_close(counts, _aer_counts(qc))
+
+
+def test_higher_level_ccx(backend):
+    # ccx is not in the basis; must be transpiled/decomposed into Clifford+T.
+    qc = QuantumCircuit(3, 3)
+    qc.h([0, 1])
+    qc.ccx(0, 1, 2)
+    qc.measure([0, 1, 2], [0, 1, 2])
+    counts = backend.run(qc, shots=SHOTS).result().get_counts()
+    _assert_close(counts, _aer_counts(qc))
+
+
+def test_clbit_ordering(backend):
+    # X on qubit 0 only -> clbit 0 = 1, others 0 -> Qiskit prints '...01'.
+    qc = QuantumCircuit(3, 3)
+    qc.x(0)
+    qc.measure([0, 1, 2], [0, 1, 2])
+    counts = backend.run(qc, shots=SHOTS).result().get_counts()
+    assert set(counts) == {"001"}
+
+
+def test_list_of_circuits(backend):
+    qc = QuantumCircuit(1, 1)
+    qc.x(0)
+    qc.measure(0, 0)
+    res = backend.run([qc, qc], shots=SHOTS).result()
+    assert res.get_counts(0) == {"1": SHOTS}
+    assert res.get_counts(1) == {"1": SHOTS}
+
+
+def test_unsupported_operation_raises(backend):
+    qc = QuantumCircuit(1, 1)
+    qc.reset(0)
+    qc.h(0)
+    qc.measure(0, 0)
+    with pytest.raises(QiskitError):
+        backend.run(qc, shots=SHOTS).result()

--- a/uv.lock
+++ b/uv.lock
@@ -119,6 +119,11 @@ dependencies = [
     { name = "numpy" },
 ]
 
+[package.optional-dependencies]
+qiskit = [
+    { name = "qiskit" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -144,7 +149,11 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "numpy", specifier = ">=1.26" }]
+requires-dist = [
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "qiskit", marker = "extra == 'qiskit'", specifier = ">=1.0" },
+]
+provides-extras = ["qiskit"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Assisted-by: Claude (Opus 4.8) <noreply@anthropic.com>

## Summary

Closes #39. Adds a minimal Qiskit `BackendV2` provider so Qiskit users can run circuits on Clifft without hand-writing Stim. Submitted for unitaryHACK 2026, implementing the design approved in the issue.

```python
from qiskit import QuantumCircuit
from clifft.qiskit import ClifftProvider

qc = QuantumCircuit(2, 2)
qc.h(0); qc.cx(0, 1); qc.measure([0, 1], [0, 1])

backend = ClifftProvider().get_backend("clifft")
counts = backend.run(qc, shots=1000).result().get_counts()
```

### Design (as approved by @bachase)

- **Location:** in-repo optional subpackage `clifft.qiskit`, behind a `clifft[qiskit]` extra, lazily imported - `import clifft` stays Qiskit-free.
- **Interface:** `BackendV2` / `JobV1` / `qiskit.result.Result`, targeting `qiskit>=1.0`.
- **Pipeline:** `QuantumCircuit -> transpile(basis) -> Stim text -> clifft.compile -> clifft.sample -> Qiskit counts`.
- **Basis (v1):** Clifford+T plus single-qubit rotations (`h s sdg x y z cx cy cz t tdg rx ry rz` + `measure`). The gate->Stim map mirrors the existing `tests/python/utils_qiskit.py` translator (inverted); `rx`/`ry`/`rz` map to Clifft's `R_X`/`R_Y`/`R_Z` with radians->half-turns.
- **Transpilation:** done inside `run()` (`transpile(basis_gates=..., optimization_level=1)`, all-to-all). `ccx`/`ccz` decompose into Clifford+T, and any single-qubit unitary (`u`, `p`, ...) or controlled rotation decomposes **exactly** into `rx`/`ry`/`rz` - since rotations are in the basis, no approximate (Solovay-Kitaev) synthesis is used.
- **Measurement/ordering:** each `measure(qubit, clbit)` is tracked so counts use Qiskit's clbit-indexed convention (matches AerSimulator).
- **Errors:** non-unitary/structural ops that can't be lowered (e.g. `reset`) raise a clear `QiskitError`.
- **Docs:** guide page added at `docs/guide/qiskit.md` (quickstart, supported basis, limitations) and wired into the nav.

**Note on rotations:** the issue asked whether `rx`/`ry`/`rz`/`u` should map to Clifft's rotation extensions. They do - `rx`/`ry`/`rz` are in the basis and map directly to `R_X`/`R_Y`/`R_Z`, so rotations (and anything that decomposes into them, e.g. `u`, controlled rotations) are handled **exactly**, with no Solovay-Kitaev approximation. The "unsupported operation" path is exercised with a genuinely non-lowerable op (`reset`).

### Scope / out of scope (v1)

Single synchronous backend, all-to-all, terminal measurement + counts. Out of scope (per the issue): noise models, async jobs, Estimator/Sampler primitives, Qobj/legacy config, symbolic/unbound parameters, coupling maps/layout, pulse.

## Test plan

<!-- How was this tested? Check all that apply. -->

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`) - n/a, Python-only change
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/guide/qiskit.md -v`) - quickstart block passes; install block marked skip
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`) - ruff/ruff-format/clang-format/hygiene clean; the only mypy errors are pre-existing in `docs/guide/scripts/run_benchmark.py` (Unix-only `resource` module, unrelated to this PR)

New tests in `tests/python/test_qiskit_provider.py` (skipped without qiskit/qiskit-aer), compared against Aer with a statistical tolerance:

- Bell, a non-Clifford (T) circuit, a higher-level `ccx` (decomposed), a multi-qubit **clbit-ordering** check, a list of circuits, and an unsupported-operation error.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
