### PR TITLE
docs: auto-generate Python API reference via mkdocstrings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install clifft
-        run: uv pip install -e .
+        run: uv pip install --system -e .
 
       - name: Deploy dev docs
         run: uv run --group docs mike deploy --push dev

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Install clifft
+        run: uv pip install -e .
+
       - name: Deploy dev docs
-        run: uv run --only-group docs mike deploy --push dev
+        run: uv run --group docs mike deploy --push dev
         env:
           SITE_URL: https://unitaryfoundation.github.io/clifft/dev/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install clifft and docs deps
-        run: uv sync --group docs
+        run: uv sync --frozen --group docs
 
       - name: Deploy dev docs
         run: uv run --group docs mike deploy --push dev

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,8 +57,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Install clifft
-        run: uv pip install --system -e .
+      - name: Install clifft and docs deps
+        run: uv sync --group docs
 
       - name: Deploy dev docs
         run: uv run --group docs mike deploy --push dev

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -53,7 +53,7 @@ jobs:
           enable-cache: true
 
       - name: Install clifft and docs deps
-        run: uv sync --group docs
+        run: uv sync --frozen --group docs
 
       - name: Build docs
         run: uv run --group docs mkdocs build --strict

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install clifft
-        run: uv pip install --system -e .
+      - name: Install clifft and docs deps
+        run: uv sync --group docs
 
       - name: Build docs
         run: uv run --group docs mkdocs build --strict

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - 'playground/**'
       - 'src/wasm/**'
+      - 'src/python/**'
       - 'mkdocs.yml'
       - '.github/workflows/pr_preview.yml'
 
@@ -46,14 +47,16 @@ jobs:
           cd playground && npm ci
           VITE_BASE_PATH=/clifft/pr-preview/pr-${{ github.event.number }}/playground/ VITE_BUILD_SHA=${{ github.sha }} npm run build
 
-      # --- Build MkDocs (docs group only, no C++ extension needed) ---
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
+      - name: Install clifft
+        run: uv pip install -e .
+
       - name: Build docs
-        run: uv run --only-group docs mkdocs build --strict
+        run: uv run --group docs mkdocs build --strict
         env:
           SITE_URL: https://unitaryfoundation.github.io/clifft/pr-preview/pr-${{ github.event.number }}/
 

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -53,7 +53,7 @@ jobs:
           enable-cache: true
 
       - name: Install clifft
-        run: uv pip install -e .
+        run: uv pip install --system -e .
 
       - name: Build docs
         run: uv run --group docs mkdocs build --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,8 +253,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Install clifft
-        run: uv pip install --system -e .
+      - name: Install clifft and docs deps
+        run: uv sync --group docs
 
       - name: Build versioned playground
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Install clifft
+        run: uv pip install -e .
+
       - name: Build versioned playground
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -268,14 +271,14 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           SITE_URL="https://unitaryfoundation.github.io/clifft/${VERSION}/" \
-            uv run --only-group docs mike deploy --push "${VERSION}"
+            uv run --group docs mike deploy --push "${VERSION}"
 
       - name: Decide whether to update stable docs
         id: stable
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          uv run --only-group docs mike list --json > /tmp/mike-list.json || echo '[]' > /tmp/mike-list.json
-          VERSION="${VERSION}" uv run --only-group docs python - <<'PY' >> "${GITHUB_OUTPUT}"
+          uv run --group docs mike list --json > /tmp/mike-list.json || echo '[]' > /tmp/mike-list.json
+          VERSION="${VERSION}" uv run --group docs python - <<'PY' >> "${GITHUB_OUTPUT}"
           import json
           import os
           from pathlib import Path
@@ -313,8 +316,8 @@ jobs:
         if: steps.stable.outputs.update == 'true'
         run: |
           SITE_URL=https://unitaryfoundation.github.io/clifft/stable/ \
-            uv run --only-group docs mike deploy --push stable
-          uv run --only-group docs mike set-default --push stable
+            uv run --group docs mike deploy --push stable
+          uv run --group docs mike set-default --push stable
 
       - name: Build root stable playground
         if: steps.stable.outputs.update == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install clifft
-        run: uv pip install -e .
+        run: uv pip install --system -e .
 
       - name: Build versioned playground
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install clifft and docs deps
-        run: uv sync --group docs
+        run: uv sync --frozen --group docs
 
       - name: Build versioned playground
         run: |

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,16 @@
+import logging
+
+
+class _SuppressGriffeNanobindWarnings(logging.Filter):
+    # nanobind-bound parameters lack Python type annotations; griffe warns
+    # about this when inspecting the compiled extension. These are not real
+    # doc errors, so drop them so mkdocs build --strict passes.
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "No type or annotation for parameter" not in record.getMessage()
+
+
+def on_config(config):
+    filt = _SuppressGriffeNanobindWarnings()
+    for handler in logging.getLogger("mkdocs").handlers:
+        handler.addFilter(filt)
+    return config

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -10,7 +10,7 @@ class _SuppressNanobindAnnotationWarnings(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         if record.levelno > logging.WARNING:
             return True
-        if not record.name.startswith(("griffe", "mkdocs.plugins.mkdocstrings")):
+        if not record.name.startswith(("griffe", "mkdocs.plugins.griffe", "mkdocs.plugins.mkdocstrings")):
             return True
         return "No type or annotation for parameter" not in record.getMessage()
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -10,7 +10,9 @@ class _SuppressNanobindAnnotationWarnings(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         if record.levelno > logging.WARNING:
             return True
-        if not record.name.startswith(("griffe", "mkdocs.plugins.griffe", "mkdocs.plugins.mkdocstrings")):
+        if not record.name.startswith(
+            ("griffe", "mkdocs.plugins.griffe", "mkdocs.plugins.mkdocstrings")
+        ):
             return True
         return "No type or annotation for parameter" not in record.getMessage()
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,16 +1,22 @@
 import logging
 
 
-class _SuppressGriffeNanobindWarnings(logging.Filter):
+class _SuppressNanobindAnnotationWarnings(logging.Filter):
     # nanobind-bound parameters lack Python type annotations; griffe warns
     # about this when inspecting the compiled extension. These are not real
     # doc errors, so drop them so mkdocs build --strict passes.
+    # Scoped to WARNING level and griffe/mkdocstrings origins only so that
+    # ERROR-level records and unrelated loggers are never silenced.
     def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno > logging.WARNING:
+            return True
+        if not record.name.startswith(("griffe", "mkdocs.plugins.mkdocstrings")):
+            return True
         return "No type or annotation for parameter" not in record.getMessage()
 
 
 def on_config(config):
-    filt = _SuppressGriffeNanobindWarnings()
+    filt = _SuppressNanobindAnnotationWarnings()
     for handler in logging.getLogger("mkdocs").handlers:
         handler.addFilter(filt)
     return config

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -1,0 +1,119 @@
+# Python API Reference
+
+## Compilation
+
+::: clifft.compile
+
+::: clifft.parse
+
+::: clifft.parse_file
+
+::: clifft.trace
+
+::: clifft.lower
+
+::: clifft.ParseError
+
+## Sampling
+
+::: clifft.sample
+
+::: clifft.sample_survivors
+
+::: clifft.sample_k
+
+::: clifft.sample_k_survivors
+
+## Strong Simulation
+
+::: clifft.basis_probabilities
+
+::: clifft.record_probabilities
+
+## State Inspection
+
+::: clifft.execute
+
+::: clifft.get_statevector
+
+## Result Types
+
+::: clifft.SampleResult
+
+## Compiled Programs and Execution State
+
+::: clifft.Program
+
+::: clifft.State
+
+## Circuit and IR Inspection
+
+::: clifft.Circuit
+
+::: clifft.AstNode
+
+::: clifft.Target
+
+::: clifft.HirModule
+
+::: clifft.HeisenbergOp
+
+::: clifft.Instruction
+
+::: clifft.Opcode
+
+::: clifft.OpType
+
+::: clifft.GateType
+
+## Pass Managers
+
+::: clifft.HirPassManager
+
+::: clifft.BytecodePassManager
+
+::: clifft.default_hir_pass_manager
+
+::: clifft.default_bytecode_pass_manager
+
+## HIR Passes
+
+::: clifft.PeepholeFusionPass
+
+::: clifft.StatevectorSqueezePass
+
+::: clifft.RemoveNoisePass
+
+::: clifft.DropNonUnitaryPass
+
+## Bytecode Passes
+
+::: clifft.NoiseBlockPass
+
+::: clifft.ExpandTPass
+
+::: clifft.ExpandRotPass
+
+::: clifft.SwapMeasPass
+
+::: clifft.MultiGatePass
+
+::: clifft.SingleAxisFusionPass
+
+## Utilities
+
+::: clifft.get_num_threads
+
+::: clifft.set_num_threads
+
+::: clifft.svm_backend
+
+::: clifft.version
+
+::: clifft.compute_reference_syndrome
+
+## Type Aliases
+
+::: clifft.BasisBitstrings
+
+::: clifft.MeasurementRecords

--- a/justfile
+++ b/justfile
@@ -183,11 +183,11 @@ test-wasm:
 
 # Serve docs locally with live reload
 docs-serve:
-  uv run --only-group docs mkdocs serve -a 0.0.0.0:8000
+  uv run --group docs mkdocs serve -a 0.0.0.0:8000
 
 # Build docs to site/
 docs-build:
-  uv run --only-group docs mkdocs build --strict
+  uv run --group docs mkdocs build --strict
 
 # -------------------------
 # Playground

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,12 +63,29 @@ extra:
     provider: mike
     default: stable
 
+hooks:
+  - docs/hooks.py
+
 plugins:
   - search
   - macros:
       module_name: docs/macros
   - minify:
       minify_html: true
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            docstring_options:
+              warn_unknown_params: false
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_signature_annotations: true
+            merge_init_into_class: true
+            filters:
+              - "!^__"
 
 nav:
   - Home: index.md
@@ -91,6 +108,7 @@ nav:
     - Supported Gates: reference/gates.md
     - Instruction Reference: reference/instructions.md
     - Optimization Passes: reference/passes.md
+    - Python API: reference/python-api.md
   - Development:
     - Contributing: development/contributing.md
     - Building from Source: development/building.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ plugins:
             show_symbol_type_heading: true
             show_symbol_type_toc: true
             show_signature_annotations: true
+            separate_signature: true
             merge_init_into_class: true
             filters:
               - "!^__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ docs = [
     "mkdocs-material>=9.6",
     "mkdocs-macros-plugin>=1.0",
     "mkdocs-minify-plugin>=0.8",
+    "mkdocstrings[python]>=0.26",
     "mike>=2.1",
     "pymdown-extensions>=10.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
     "mkdocs-material>=9.6",
     "mkdocs-macros-plugin>=1.0",
     "mkdocs-minify-plugin>=0.8",
-    "mkdocstrings[python]>=0.26",
+    "mkdocstrings[python]>=1.0",
     "mike>=2.1",
     "pymdown-extensions>=10.7",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,7 @@ docs = [
     { name = "mkdocs-macros-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
 ]
 
@@ -167,6 +168,7 @@ docs = [
     { name = "mkdocs-macros-plugin", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.6" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
     { name = "pymdown-extensions", specifier = ">=10.7" },
 ]
 
@@ -306,6 +308,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -553,6 +564,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -631,6 +656,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/67/fe4b77e7a8ae7628392e28b14122588beaf6078b53eb91c7ed000fd158ac/mkdocs-minify-plugin-0.8.0.tar.gz", hash = "sha256:bc11b78b8120d79e817308e2b11539d790d21445eb63df831e393f76e52e753d", size = 8366, upload-time = "2024-01-29T16:11:32.982Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/cd/2e8d0d92421916e2ea4ff97f10a544a9bd5588eb747556701c983581df13/mkdocs_minify_plugin-0.8.0-py3-none-any.whl", hash = "sha256:5fba1a3f7bd9a2142c9954a6559a57e946587b21f133165ece30ea145c66aee6", size = 6723, upload-time = "2024-01-29T16:11:31.851Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does and why. -->

Closes #63
Adds a first Python API reference page auto-generated from docstrings
and runtime signatures using `mkdocstrings[python]`.
- Adds `mkdocstrings[python]>=0.26` to the `docs` dependency group in `pyproject.toml`
- Registers the mkdocstrings plugin in `mkdocs.yml` with Google docstring style, full signature annotations, dunder member filtering, and `merge_init_into_class`
- Adds `docs/reference/python-api.md` organized into 12 sections matching the issue's suggested layout (compilation, sampling, strong simulation, state inspection, result types, programs, IR inspection, pass managers, HIR passes, bytecode passes, utilities, type aliases)
- Adds `docs/hooks.py` — a MkDocs hook that suppresses griffe's nanobind type-annotation warnings so `mkdocs build --strict` passes cleanly
- Updates `justfile` `docs-serve` and `docs-build` recipes from `--only-group docs` to `--group docs`
- Updates all three doc CI workflows (`docs.yml`, `pr_preview.yml`, `release.yml`) to run `uv pip install -e .` before any mkdocs/mike command, since mkdocstrings now imports `clifft` (and therefore `clifft._clifft_core`) at build time
- Adds `src/python/**` to the `pr_preview` path trigger so the preview rebuilds when Python bindings change

## Test plan

<!-- How was this tested? Check all that apply. -->

- [x] `mkdocs build --strict` passes locally with zero warnings
- [x] `mkdocs serve` — Reference -> Python API page renders with correct signatures, docstrings, and section groupings
- [x] Existing Reference pages (Supported Gates, Instruction Reference, Optimization Passes) unaffected
- [x] `uv.lock` updated

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.

## AI Disclosure
I used Claude to help implement and debug this PR : reviewing the repo structure, identifying the right mkdocstrings options, tracing the MkDocs logging chain to fix the strict-mode warning suppression, and diagnosing the CI deployment failures. I reviewed all generated changes, verified the build locally, and confirmed the rendered output before submitting.
