### PR TITLE
ci: skip PR preview cleanup for forks

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -100,7 +100,7 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-24.04
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
     concurrency:
       group: docs-deploy
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Skip PR preview cleanup on closed fork PRs, matching the deploy job guard
- Avoid cleanup attempts/comments for previews that were never deployed

## Testing

- uv run pre-commit run --all-files

Fixes the failure seen in Docs PR Preview run 27022984190, where a fork PR close event attempted cleanup/commenting and hit `Resource not accessible by integration`.