### PR TITLE
feat(noncomp): Python bindings + spec-based model builder (G2a)

### DIFF
--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -151,6 +151,28 @@ NonComputationalModel::NonComputationalModel(
     }
 }
 
+NonComputationalModel NonComputationalModel::from_spec(
+    LevelSet levels, std::vector<double> initial_state,
+    const std::map<std::string, std::vector<std::vector<double>>>& transition_matrices,
+    std::optional<ClassifierSpec> classifier_spec, NonComputationalPolicy policy) {
+    // Build each component against the single `levels` table, so every
+    // fingerprint matches by construction and the constructor's cross-object
+    // checks pass without the caller ever touching a fingerprint or level id.
+    std::map<std::string, TransitionInstrument> transitions;
+    for (const auto& [gate, matrix] : transition_matrices) {
+        transitions.emplace(gate, TransitionInstrument::from_matrix(matrix, levels));
+    }
+
+    std::optional<MeasurementClassifier> classifier;
+    if (classifier_spec.has_value()) {
+        classifier = MeasurementClassifier::from_matrix(std::move(classifier_spec->symbols),
+                                                        std::move(classifier_spec->matrix), levels);
+    }
+
+    return NonComputationalModel(std::move(levels), std::move(initial_state),
+                                 std::move(transitions), std::move(classifier), policy);
+}
+
 double NonComputationalModel::initial_probability(uint8_t level_id) const {
     if (level_id >= initial_state_.size()) {
         throw std::invalid_argument("NonComputationalModel::initial_probability: index " +

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -35,6 +35,14 @@
 
 namespace clifft {
 
+// Raw classifier spec for the spec-based builder: the symbol labels and the
+// column-substochastic matrix P[symbol][level]. Bundled so the builder takes an
+// optional classifier without a separate presence flag.
+struct ClassifierSpec {
+    std::vector<std::string> symbols;
+    std::vector<std::vector<double>> matrix;
+};
+
 class NonComputationalModel {
   public:
     // Validates that:
@@ -56,6 +64,18 @@ class NonComputationalModel {
                           std::map<std::string, TransitionInstrument> transitions,
                           std::optional<MeasurementClassifier> classifier,
                           NonComputationalPolicy policy);
+
+    // Spec-based construction (the binding-facing path, design 3.3): build
+    // every TransitionInstrument and the classifier against `levels` from raw
+    // matrices, then assemble. Because all components are built against the one
+    // LevelSet, callers never construct those objects or deal with level
+    // fingerprints. `transition_matrices` maps a gate-name string to its
+    // T[to][from] matrix; `classifier_spec` is optional. Validation and
+    // throwing match the component from_matrix factories and the constructor.
+    static NonComputationalModel from_spec(
+        LevelSet levels, std::vector<double> initial_state,
+        const std::map<std::string, std::vector<std::vector<double>>>& transition_matrices,
+        std::optional<ClassifierSpec> classifier_spec, NonComputationalPolicy policy);
 
     const LevelSet& levels() const { return levels_; }
     size_t num_levels() const { return levels_.size(); }

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -65,13 +65,13 @@ class NonComputationalModel {
                           std::optional<MeasurementClassifier> classifier,
                           NonComputationalPolicy policy);
 
-    // Spec-based construction (the binding-facing path, design 3.3): build
-    // every TransitionInstrument and the classifier against `levels` from raw
-    // matrices, then assemble. Because all components are built against the one
-    // LevelSet, callers never construct those objects or deal with level
-    // fingerprints. `transition_matrices` maps a gate-name string to its
-    // T[to][from] matrix; `classifier_spec` is optional. Validation and
-    // throwing match the component from_matrix factories and the constructor.
+    // Spec-based construction: build every TransitionInstrument and the
+    // classifier against `levels` from raw matrices, then assemble. Because all
+    // components are built against the one LevelSet, callers never construct
+    // those objects or deal with level fingerprints. `transition_matrices` maps
+    // a gate-name string to its T[to][from] matrix; `classifier_spec` is
+    // optional. Validation and throwing match the component from_matrix
+    // factories and the constructor.
     static NonComputationalModel from_spec(
         LevelSet levels, std::vector<double> initial_state,
         const std::map<std::string, std::vector<std::vector<double>>>& transition_matrices,

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -3,6 +3,11 @@
 #include "clifft/circuit/circuit.h"
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/orchestrator.h"
+#include "clifft/noncomp/policy.h"
+#include "clifft/noncomp/qubit_status.h"
 #include "clifft/optimizer/bytecode_pass.h"
 #include "clifft/optimizer/drop_non_unitary_pass.h"
 #include "clifft/optimizer/expand_t_pass.h"
@@ -28,6 +33,7 @@
 #include <nanobind/make_iterator.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/map.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
@@ -51,12 +57,88 @@ nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> vec,
     return nb::ndarray<nb::numpy, T, nb::c_contig>(data, shape, owner);
 }
 
+// Noncomputational (leakage/loss) bindings. Raw spec-builder + sampler entry
+// points; the ergonomic surface (Model, Classifier, sample) lives in the
+// clifft.noncomp Python wrapper. The model is an opaque handle.
+void register_noncomp(nb::module_& m) {
+    nb::class_<clifft::NonComputationalModel>(m, "_NonComputationalModel");
+
+    m.def(
+        "_build_noncomp_model",
+        [](std::vector<double> initial_state,
+           std::map<std::string, std::vector<std::vector<double>>> transitions,
+           std::optional<std::vector<std::string>> classifier_symbols,
+           std::optional<std::vector<std::vector<double>>> classifier_matrix,
+           bool reset_restores_lost) {
+            clifft::NonComputationalPolicy policy;
+            policy.reset_restores_lost = reset_restores_lost;
+
+            std::optional<clifft::ClassifierSpec> spec;
+            if (classifier_symbols.has_value() || classifier_matrix.has_value()) {
+                if (!classifier_symbols.has_value() || !classifier_matrix.has_value()) {
+                    throw std::invalid_argument(
+                        "noncomp model: a classifier needs both symbols and a matrix");
+                }
+                spec = clifft::ClassifierSpec{std::move(*classifier_symbols),
+                                              std::move(*classifier_matrix)};
+            }
+
+            return clifft::NonComputationalModel::from_spec(clifft::LevelSet::default_set(),
+                                                            std::move(initial_state), transitions,
+                                                            std::move(spec), policy);
+        },
+        nb::arg("initial_state"), nb::arg("transitions"),
+        nb::arg("classifier_symbols") = nb::none(), nb::arg("classifier_matrix") = nb::none(),
+        nb::arg("reset_restores_lost") = false,
+        "Build a default 5-level NonComputationalModel from raw matrices. See "
+        "clifft.noncomp.Model.");
+
+    m.def(
+        "_sample_noncomputational",
+        [](const clifft::Circuit& circuit, const clifft::NonComputationalModel& model,
+           uint32_t shots, std::optional<uint64_t> seed) {
+            clifft::NonComputationalSample r;
+            {
+                nb::gil_scoped_release release;
+                r = clifft::sample_noncomputational(circuit, model, shots, seed);
+            }
+            // Collapse per-qubit final status to {0 computational, 1 leaked,
+            // 2 lost}; the internal known/unknown computational split is not
+            // surfaced in the Python sidecar.
+            std::vector<uint8_t> status(r.final_status.size());
+            for (size_t i = 0; i < r.final_status.size(); ++i) {
+                switch (r.final_status[i].kind()) {
+                    case clifft::QubitStatusKind::Leaked:
+                        status[i] = 1;
+                        break;
+                    case clifft::QubitStatusKind::Lost:
+                        status[i] = 2;
+                        break;
+                    default:
+                        status[i] = 0;
+                        break;
+                }
+            }
+            auto meas = vec_to_numpy(std::move(r.measurements), {shots, r.num_measurements});
+            auto det = vec_to_numpy(std::move(r.detectors), {shots, r.num_detectors});
+            auto obs = vec_to_numpy(std::move(r.observables), {shots, r.num_observables});
+            auto fs = vec_to_numpy(std::move(status), {shots, r.num_qubits});
+            return nb::make_tuple(meas, det, obs, fs, r.num_qubits, r.num_measurements,
+                                  r.num_detectors, r.num_observables);
+        },
+        nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
+        "Sample a noncomputational model. Returns (measurements, detectors, observables, "
+        "final_status, num_qubits, num_measurements, num_detectors, num_observables).");
+}
+
 NB_MODULE(_clifft_core, m) {
     m.doc() = "Clifft core C++ extension module";
 
     nb::exception<clifft::ParseError>(m, "ParseError");
 
     m.def("version", []() { return clifft::kVersion; }, "Return the Clifft version string");
+
+    register_noncomp(m);
 
     m.def(
         "svm_backend", []() { return clifft::svm_backend(); },

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -54,6 +54,7 @@ def _check_multiprocessing_omp() -> None:
 _check_multiprocessing_omp()
 del _check_multiprocessing_omp
 
+from clifft import noncomp
 from clifft._clifft_core import (
     AstNode,
     BytecodePass,
@@ -413,6 +414,7 @@ __all__ = [
     "get_num_threads",
     "get_statevector",
     "lower",
+    "noncomp",
     "parse",
     "parse_file",
     "record_probabilities",

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -1,0 +1,177 @@
+"""Noncomputational (leakage/loss) sampling.
+
+Prototype API on the noncomputational feature branch. It drives a structural
+leakage/loss trajectory model on top of the ordinary Clifft sampler:
+
+    import clifft
+    from clifft import noncomp
+
+    model = noncomp.Model(
+        initial_state=[1, 0, 0, 0, 0],                  # P(level) over the 5-level set
+        transitions={"S": T},                           # gate -> T[to][from]
+        classifier=noncomp.Classifier(["0", "1"], P),   # optional; P[symbol][level]
+        reset_restores_lost=False,
+    )
+    r = noncomp.sample("H 0\\nCX 0 1\\nS 0\\nM 0\\nM 1\\n", model, shots=1000, seed=7)
+    r.measurements   # np.uint8 [shots, num_measurements]
+    r.final_status   # np.uint8 [shots, num_qubits], values in QubitStatusKind
+
+The model uses the default five-level set (g, e, leak_g, leak_e, lost). Only a
+two-symbol classifier with stochastic columns is supported; substochastic
+(reject) columns and non-binary classifiers raise.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from enum import IntEnum
+from typing import Iterator
+
+import numpy as np
+import numpy.typing as npt
+
+from clifft import _clifft_core
+
+__all__ = ["Classifier", "Model", "NonComputationalSample", "QubitStatusKind", "sample"]
+
+Matrix = Sequence[Sequence[float]]
+
+
+class QubitStatusKind(IntEnum):
+    """A qubit's final status in the per-shot sidecar."""
+
+    COMPUTATIONAL = 0
+    LEAKED = 1
+    LOST = 2
+
+
+def _as_matrix(matrix: Matrix) -> list[list[float]]:
+    """Normalize a nested sequence or 2-D array to list-of-lists of float."""
+    return [[float(x) for x in row] for row in matrix]
+
+
+class Classifier:
+    """A measurement classifier: symbol labels and ``P[symbol][level]``.
+
+    For the MVP this must be binary (two symbols), and each level's column must
+    sum to one; substochastic (reject) columns are not supported yet.
+    """
+
+    __slots__ = ("symbols", "matrix")
+
+    def __init__(self, symbols: Sequence[str], matrix: Matrix) -> None:
+        self.symbols = [str(s) for s in symbols]
+        self.matrix = _as_matrix(matrix)
+
+
+class Model:
+    """A noncomputational trajectory model over the default five-level set.
+
+    Args:
+        initial_state: probability per level, ``P(level)``, summing to one.
+        transitions: maps a gate-name string to its ``T[to][from]`` matrix.
+        classifier: optional :class:`Classifier` for leaked/lost measurements.
+        reset_restores_lost: if true, a reset on a lost qubit restores it.
+
+    Construction validates shapes, probabilities, gate keys, and level table
+    consistency in C++, raising ``ValueError`` on any problem.
+    """
+
+    __slots__ = ("_handle",)
+
+    def __init__(
+        self,
+        initial_state: Sequence[float],
+        transitions: Mapping[str, Matrix] | None = None,
+        classifier: Classifier | None = None,
+        reset_restores_lost: bool = False,
+    ) -> None:
+        transition_matrices = {
+            str(gate): _as_matrix(matrix) for gate, matrix in (transitions or {}).items()
+        }
+        symbols = None if classifier is None else classifier.symbols
+        matrix = None if classifier is None else classifier.matrix
+        self._handle = _clifft_core._build_noncomp_model(
+            [float(p) for p in initial_state],
+            transition_matrices,
+            symbols,
+            matrix,
+            bool(reset_restores_lost),
+        )
+
+
+class NonComputationalSample:
+    """Result of :func:`sample`: the visible records plus a status sidecar.
+
+    Attributes:
+        measurements, detectors, observables: uint8 arrays, shape (shots, width).
+        final_status: uint8 array (shots, num_qubits) of :class:`QubitStatusKind`.
+        shots, num_qubits, num_measurements, num_detectors, num_observables: ints.
+    """
+
+    __slots__ = (
+        "measurements",
+        "detectors",
+        "observables",
+        "final_status",
+        "shots",
+        "num_qubits",
+        "num_measurements",
+        "num_detectors",
+        "num_observables",
+    )
+
+    def __init__(
+        self,
+        measurements: npt.NDArray[np.uint8],
+        detectors: npt.NDArray[np.uint8],
+        observables: npt.NDArray[np.uint8],
+        final_status: npt.NDArray[np.uint8],
+        num_qubits: int,
+        num_measurements: int,
+        num_detectors: int,
+        num_observables: int,
+    ) -> None:
+        self.measurements = measurements
+        self.detectors = detectors
+        self.observables = observables
+        self.final_status = final_status
+        self.shots = int(measurements.shape[0])
+        self.num_qubits = int(num_qubits)
+        self.num_measurements = int(num_measurements)
+        self.num_detectors = int(num_detectors)
+        self.num_observables = int(num_observables)
+
+    def __iter__(self) -> Iterator[npt.NDArray[np.uint8]]:
+        """Yield (measurements, detectors, observables) for tuple unpacking."""
+        yield self.measurements
+        yield self.detectors
+        yield self.observables
+
+    def __repr__(self) -> str:
+        return (
+            f"NonComputationalSample(shots={self.shots}, num_qubits={self.num_qubits}, "
+            f"num_measurements={self.num_measurements}, num_detectors={self.num_detectors}, "
+            f"num_observables={self.num_observables})"
+        )
+
+
+def sample(
+    circuit: object,
+    model: Model,
+    shots: int,
+    seed: int | None = None,
+) -> NonComputationalSample:
+    """Sample ``circuit`` under ``model`` for ``shots`` shots.
+
+    ``circuit`` is a parsed ``clifft.Circuit`` or a Stim-format string. Returns a
+    :class:`NonComputationalSample`. Raises ``ValueError`` when the trajectory
+    policy rejects an operation, when a leaked/lost measurement needs a
+    classifier the model lacks, or when a classifier column is unsupported.
+    """
+    if isinstance(circuit, str):
+        circuit = _clifft_core.parse(circuit)
+    meas, det, obs, status, num_qubits, num_meas, num_det, num_obs = (
+        _clifft_core._sample_noncomputational(circuit, model._handle, shots, seed)
+    )
+    return NonComputationalSample(meas, det, obs, status, num_qubits, num_meas, num_det, num_obs)

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -1,7 +1,7 @@
 """Noncomputational (leakage/loss) sampling.
 
-Prototype API on the noncomputational feature branch. It drives a structural
-leakage/loss trajectory model on top of the ordinary Clifft sampler:
+Drives a structural leakage/loss trajectory model on top of the ordinary Clifft
+sampler:
 
     import clifft
     from clifft import noncomp
@@ -16,9 +16,10 @@ leakage/loss trajectory model on top of the ordinary Clifft sampler:
     r.measurements   # np.uint8 [shots, num_measurements]
     r.final_status   # np.uint8 [shots, num_qubits], values in QubitStatusKind
 
-The model uses the default five-level set (g, e, leak_g, leak_e, lost). Only a
-two-symbol classifier with stochastic columns is supported; substochastic
-(reject) columns and non-binary classifiers raise.
+This API supports exactly the built-in five-level set, named by ``Level`` and
+``LEVELS`` (g, e, leak_g, leak_e, lost); matrix rows and columns are indexed by
+``Level``. Only a two-symbol classifier with stochastic columns is supported;
+substochastic (reject) columns and non-binary classifiers raise.
 """
 
 from __future__ import annotations
@@ -32,7 +33,15 @@ import numpy.typing as npt
 
 from clifft import _clifft_core
 
-__all__ = ["Classifier", "Model", "NonComputationalSample", "QubitStatusKind", "sample"]
+__all__ = [
+    "LEVELS",
+    "Classifier",
+    "Level",
+    "Model",
+    "NonComputationalSample",
+    "QubitStatusKind",
+    "sample",
+]
 
 Matrix = Sequence[Sequence[float]]
 
@@ -45,6 +54,19 @@ class QubitStatusKind(IntEnum):
     LOST = 2
 
 
+class Level(IntEnum):
+    """Indices of the built-in five-level model, for naming matrix rows/columns."""
+
+    G = 0
+    E = 1
+    LEAK_G = 2
+    LEAK_E = 3
+    LOST = 4
+
+
+LEVELS = ("g", "e", "leak_g", "leak_e", "lost")
+
+
 def _as_matrix(matrix: Matrix) -> list[list[float]]:
     """Normalize a nested sequence or 2-D array to list-of-lists of float."""
     return [[float(x) for x in row] for row in matrix]
@@ -53,8 +75,8 @@ def _as_matrix(matrix: Matrix) -> list[list[float]]:
 class Classifier:
     """A measurement classifier: symbol labels and ``P[symbol][level]``.
 
-    For the MVP this must be binary (two symbols), and each level's column must
-    sum to one; substochastic (reject) columns are not supported yet.
+    This must be binary (two symbols), and each level's column must sum to one;
+    substochastic (reject) columns are not supported.
     """
 
     __slots__ = ("symbols", "matrix")
@@ -65,7 +87,7 @@ class Classifier:
 
 
 class Model:
-    """A noncomputational trajectory model over the default five-level set.
+    """A noncomputational trajectory model over the built-in five-level set.
 
     Args:
         initial_state: probability per level, ``P(level)``, summing to one.
@@ -106,6 +128,8 @@ class NonComputationalSample:
     Attributes:
         measurements, detectors, observables: uint8 arrays, shape (shots, width).
         final_status: uint8 array (shots, num_qubits) of :class:`QubitStatusKind`.
+            Coarse: it reports computational/leaked/lost, not the specific leaked
+            or lost level.
         shots, num_qubits, num_measurements, num_detectors, num_observables: ints.
     """
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(clifft_tests
     test_noncomp_transition_instrument.cc
     test_noncomp_classifier.cc
     test_noncomp_model.cc
+    test_noncomp_model_builder.cc
     test_noncomp_status_step.cc
     test_noncomp_op_role.cc
     test_noncomp_sampler.cc

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -13,7 +13,7 @@ import pytest
 
 from clifft import noncomp
 
-LEAK_G, LEAK_E, LOST = 2, 3, 4
+LEAK_G, LEAK_E, LOST = noncomp.Level.LEAK_G, noncomp.Level.LEAK_E, noncomp.Level.LOST
 ALL_G = [1.0, 0.0, 0.0, 0.0, 0.0]
 ALL_E = [0.0, 1.0, 0.0, 0.0, 0.0]
 COMPUTATIONAL = noncomp.QubitStatusKind.COMPUTATIONAL
@@ -28,8 +28,8 @@ def _zeros(rows: int, cols: int) -> list[list[float]]:
 def transition_to(level: int) -> list[list[float]]:
     """T[to][from]: g and e both jump to `level` (source-independent)."""
     m = _zeros(5, 5)
-    m[level][0] = 1.0
-    m[level][1] = 1.0
+    m[level][noncomp.Level.G] = 1.0
+    m[level][noncomp.Level.E] = 1.0
     return m
 
 
@@ -52,7 +52,12 @@ def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
 # --- 1. Model construction -------------------------------------------------
 
 
-def test_build_default_model_needs_no_level_ids():
+def test_level_names_and_indices():
+    assert noncomp.LEVELS == ("g", "e", "leak_g", "leak_e", "lost")
+    assert (int(noncomp.Level.G), int(noncomp.Level.LEAK_G), int(noncomp.Level.LOST)) == (0, 2, 4)
+
+
+def test_build_model_needs_no_level_ids():
     # A full model is described by matrices + initial probabilities alone.
     model = noncomp.Model(
         initial_state=ALL_G,

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -1,0 +1,253 @@
+"""Python-facing tests for the noncomputational (leakage/loss) API.
+
+Covers model construction, end-to-end sampling, classifier/record semantics,
+and record-layout invariants through the clifft.noncomp surface. The model uses
+the default five-level set (g=0, e=1, leak_g=2, leak_e=3, lost=4); matrices are
+positional over those levels, so no level ids appear in the API.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from clifft import noncomp
+
+LEAK_G, LEAK_E, LOST = 2, 3, 4
+ALL_G = [1.0, 0.0, 0.0, 0.0, 0.0]
+ALL_E = [0.0, 1.0, 0.0, 0.0, 0.0]
+COMPUTATIONAL = noncomp.QubitStatusKind.COMPUTATIONAL
+LEAKED = noncomp.QubitStatusKind.LEAKED
+LOST_KIND = noncomp.QubitStatusKind.LOST
+
+
+def _zeros(rows: int, cols: int) -> list[list[float]]:
+    return [[0.0] * cols for _ in range(rows)]
+
+
+def transition_to(level: int) -> list[list[float]]:
+    """T[to][from]: g and e both jump to `level` (source-independent)."""
+    m = _zeros(5, 5)
+    m[level][0] = 1.0
+    m[level][1] = 1.0
+    return m
+
+
+def classifier_for(level: int, col: list[float]) -> noncomp.Classifier:
+    """Binary classifier; `level`'s column is `col`, every other column is symbol 0."""
+    m = _zeros(2, 5)
+    for lvl in range(5):
+        m[0][lvl] = 1.0
+    m[0][level] = col[0]
+    m[1][level] = col[1]
+    return noncomp.Classifier(["0", "1"], m)
+
+
+def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
+    return noncomp.Model(
+        initial_state=ALL_G, transitions={"S": transition_to(LEAK_G)}, classifier=classifier
+    )
+
+
+# --- 1. Model construction -------------------------------------------------
+
+
+def test_build_default_model_needs_no_level_ids():
+    # A full model is described by matrices + initial probabilities alone.
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transition_to(LEAK_G)},
+        classifier=classifier_for(LEAK_G, [0.0, 1.0]),
+        reset_restores_lost=True,
+    )
+    assert isinstance(model, noncomp.Model)
+
+
+def test_initial_state_wrong_sum_raises():
+    with pytest.raises(ValueError):
+        noncomp.Model(initial_state=[0.5, 0.0, 0.0, 0.0, 0.0])
+
+
+def test_initial_state_wrong_length_raises():
+    with pytest.raises(ValueError):
+        noncomp.Model(initial_state=[1.0, 0.0])
+
+
+def test_initial_state_out_of_range_probability_raises():
+    with pytest.raises(ValueError):
+        noncomp.Model(initial_state=[2.0, -1.0, 0.0, 0.0, 0.0])
+
+
+def test_unknown_gate_key_raises():
+    with pytest.raises(ValueError, match="transition key"):
+        noncomp.Model(initial_state=ALL_G, transitions={"NOTAGATE": transition_to(LEAK_G)})
+
+
+def test_transition_wrong_shape_raises():
+    with pytest.raises(ValueError):
+        noncomp.Model(initial_state=ALL_G, transitions={"S": _zeros(4, 4)})
+
+
+# --- 2. End-to-end sampling ------------------------------------------------
+
+
+def test_lossless_matches_plain_record_shape():
+    model = noncomp.Model(initial_state=ALL_G)
+    r = noncomp.sample("H 0\nM 0\n", model, shots=512, seed=2)
+    assert r.measurements.shape == (512, 1)
+    assert r.num_measurements == 1
+    ones = int(r.measurements.sum())
+    assert 200 < ones < 312  # H then M is ~50/50
+
+
+def test_initial_one_population_prep_is_deterministic():
+    # initial all-e is computational |1>: X-prep makes M read 1 every shot.
+    model = noncomp.Model(initial_state=ALL_E)
+    r = noncomp.sample("M 0\n", model, shots=64, seed=3)
+    assert (r.measurements == 1).all()
+
+
+def test_state_independent_loss_changes_final_status():
+    model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
+    r = noncomp.sample("H 0\nS 0\n", model, shots=16, seed=4)
+    assert (r.final_status == LOST_KIND).all()
+
+
+def test_known_source_dependent_transition_accepted():
+    # Source-dependent (g->leak_g, e->leak_e). At S entry the qubit is
+    # ComputationalKnown(g) -- no scrambling yet -- so the source is pinned.
+    t = _zeros(5, 5)
+    t[LEAK_G][0] = 1.0
+    t[LEAK_E][1] = 1.0
+    model = noncomp.Model(initial_state=ALL_G, transitions={"S": t})
+    r = noncomp.sample("S 0\n", model, shots=8, seed=5)
+    assert (r.final_status == LEAKED).all()
+
+
+def test_unknown_source_dependent_transition_rejected():
+    t = _zeros(5, 5)
+    t[LEAK_G][0] = 1.0
+    t[LEAK_E][1] = 1.0
+    model = noncomp.Model(initial_state=ALL_G, transitions={"S": t})
+    with pytest.raises(ValueError, match="source-dependent"):
+        noncomp.sample("H 0\nS 0\n", model, shots=8, seed=6)
+
+
+def test_reset_reload_policy_changes_lost_site():
+    circuit = "H 0\nS 0\nR 0\n"
+    reject = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
+    with pytest.raises(ValueError, match="not representable"):
+        noncomp.sample(circuit, reject, shots=8, seed=7)
+
+    restore = noncomp.Model(
+        initial_state=ALL_G, transitions={"S": transition_to(LOST)}, reset_restores_lost=True
+    )
+    r = noncomp.sample(circuit, restore, shots=8, seed=7)
+    assert (r.final_status == COMPUTATIONAL).all()
+
+
+# --- 3. Classifier / record semantics --------------------------------------
+
+
+def test_leaked_classifier_bit_in_measurements():
+    model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
+    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=64, seed=8)
+    assert (r.measurements == 1).all()
+
+
+def test_classifier_bit_feeds_detector():
+    model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
+    r = noncomp.sample("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n", model, shots=64, seed=9)
+    assert r.num_detectors == 1
+    assert (r.detectors == 1).all()
+
+
+def test_classifier_bit_feeds_observable():
+    model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
+    r = noncomp.sample("H 0\nS 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n", model, shots=64, seed=10)
+    assert r.num_observables == 1
+    assert (r.observables == 1).all()
+
+
+def test_lost_measurement_classifier_bit():
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transition_to(LOST)},
+        classifier=classifier_for(LOST, [0.0, 1.0]),
+    )
+    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=64, seed=11)
+    assert (r.measurements == 1).all()
+
+
+def test_measure_reset_on_leaked_preserves_slot_and_resets():
+    model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
+    r = noncomp.sample("H 0\nS 0\nMR 0\nM 0\n", model, shots=64, seed=12)
+    assert r.num_measurements == 2
+    assert (r.measurements[:, 0] == 1).all()  # MR slot: classifier bit
+    assert (r.measurements[:, 1] == 0).all()  # reset, then M reads 0
+
+
+def test_missing_classifier_on_leaked_measurement_raises():
+    model = leak_model(classifier=None)
+    with pytest.raises(ValueError, match="classifier"):
+        noncomp.sample("H 0\nS 0\nM 0\n", model, shots=8, seed=13)
+
+
+def test_substochastic_classifier_column_unsupported():
+    model = leak_model(classifier_for(LEAK_G, [0.3, 0.3]))  # column sums to 0.6
+    with pytest.raises(ValueError, match="reject columns are not supported"):
+        noncomp.sample("H 0\nS 0\nM 0\n", model, shots=8, seed=14)
+
+
+def test_non_binary_classifier_unsupported():
+    mat = _zeros(3, 5)
+    for lvl in range(5):
+        mat[0][lvl] = 1.0
+    mat[0][LEAK_G], mat[1][LEAK_G], mat[2][LEAK_G] = 0.5, 0.3, 0.2
+    model = leak_model(noncomp.Classifier(["0", "1", "2"], mat))
+    with pytest.raises(ValueError, match="two-symbol"):
+        noncomp.sample("H 0\nS 0\nM 0\n", model, shots=8, seed=15)
+
+
+# --- 4. Record layout invariants -------------------------------------------
+
+
+def test_hidden_trace_out_does_not_shift_visible_count():
+    plain = noncomp.Model(initial_state=ALL_G)
+    rp = noncomp.sample("H 0\nCX 0 1\nM 0\nM 1\n", plain, shots=8, seed=16)
+    assert rp.num_measurements == 2
+
+    # Losing q0 inserts a hidden trace-out R, but the visible record is unchanged.
+    lossy = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transition_to(LOST)},
+        classifier=classifier_for(LOST, [1.0, 0.0]),
+    )
+    r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", lossy, shots=8, seed=17)
+    assert r.num_measurements == 2
+
+
+def test_zero_shots_reports_widths_and_empty_arrays():
+    model = noncomp.Model(initial_state=ALL_G)
+    r = noncomp.sample("H 0\nM 0\nDETECTOR rec[-1]\n", model, shots=0, seed=1)
+    assert r.shots == 0
+    assert r.num_measurements == 1
+    assert r.num_detectors == 1
+    assert r.measurements.shape == (0, 1)
+    assert r.detectors.shape == (0, 1)
+
+
+def test_final_status_shape_is_shots_by_qubits():
+    model = noncomp.Model(initial_state=ALL_G)
+    r = noncomp.sample("H 0\nCX 0 1\nM 0\nM 1\n", model, shots=32, seed=18)
+    assert r.final_status.shape == (32, 2)
+
+
+def test_deterministic_in_seed():
+    model = leak_model(classifier_for(LEAK_G, [0.5, 0.5]))
+    circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\n"
+    a = noncomp.sample(circuit, model, shots=128, seed=42)
+    b = noncomp.sample(circuit, model, shots=128, seed=42)
+    assert np.array_equal(a.measurements, b.measurements)
+    assert np.array_equal(a.detectors, b.detectors)
+    assert np.array_equal(a.final_status, b.final_status)

--- a/tests/test_noncomp_model_builder.cc
+++ b/tests/test_noncomp_model_builder.cc
@@ -1,0 +1,113 @@
+#include "clifft/circuit/gate_data.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/policy.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using clifft::ClassifierSpec;
+using clifft::GateType;
+using clifft::LevelSet;
+using clifft::NonComputationalModel;
+using clifft::NonComputationalPolicy;
+
+namespace {
+
+// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
+constexpr uint8_t kLost = 4;
+
+std::vector<std::vector<double>> zeros(size_t rows, size_t cols) {
+    return std::vector<std::vector<double>>(rows, std::vector<double>(cols, 0.0));
+}
+
+// T[to][from]: g and e both jump to lost with certainty.
+std::vector<std::vector<double>> lost_transition() {
+    auto m = zeros(5, 5);
+    m[kLost][0] = 1.0;
+    m[kLost][1] = 1.0;
+    return m;
+}
+
+std::map<std::string, std::vector<std::vector<double>>> lost_on(const std::string& gate) {
+    std::map<std::string, std::vector<std::vector<double>>> t;
+    t.emplace(gate, lost_transition());
+    return t;
+}
+
+ClassifierSpec binary_lost_classifier() {
+    ClassifierSpec spec;
+    spec.symbols = {"0", "1"};
+    spec.matrix = zeros(2, 5);
+    spec.matrix[0][kLost] = 1.0;  // lost -> symbol 0
+    return spec;
+}
+
+std::vector<double> all_g() {
+    return {1.0, 0.0, 0.0, 0.0, 0.0};
+}
+
+}  // namespace
+
+TEST_CASE("from_spec: builds a working model from raw matrices") {
+    NonComputationalModel model =
+        NonComputationalModel::from_spec(LevelSet::default_set(), all_g(), lost_on("S"),
+                                         binary_lost_classifier(), NonComputationalPolicy{});
+
+    REQUIRE(model.num_levels() == 5);
+    REQUIRE(model.transition_for(GateType::S) != nullptr);
+    REQUIRE(model.classifier() != nullptr);
+    REQUIRE(model.initial_probability(0) == 1.0);
+}
+
+TEST_CASE("from_spec: a model without a classifier reports none") {
+    NonComputationalModel model = NonComputationalModel::from_spec(
+        LevelSet::default_set(), all_g(), lost_on("S"), std::nullopt, NonComputationalPolicy{});
+    REQUIRE(model.classifier() == nullptr);
+}
+
+TEST_CASE("from_spec: a Stim gate alias resolves to the canonical transition key") {
+    // "CNOT" canonicalizes to CX; transition_for(CX) must find it.
+    NonComputationalModel model = NonComputationalModel::from_spec(
+        LevelSet::default_set(), all_g(), lost_on("CNOT"), std::nullopt, NonComputationalPolicy{});
+    REQUIRE(model.transition_for(GateType::CX) != nullptr);
+}
+
+TEST_CASE("from_spec: an unknown gate key raises") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(LevelSet::default_set(), all_g(), lost_on("NOTAGATE"),
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("transition key"));
+}
+
+TEST_CASE("from_spec: a classifier matrix with the wrong level count raises") {
+    ClassifierSpec spec;
+    spec.symbols = {"0", "1"};
+    spec.matrix = zeros(2, 4);  // 4 level columns, table has 5
+    REQUIRE_THROWS_AS(
+        NonComputationalModel::from_spec(LevelSet::default_set(), all_g(), lost_on("S"), spec,
+                                         NonComputationalPolicy{}),
+        std::invalid_argument);
+}
+
+TEST_CASE("from_spec: a transition matrix with the wrong shape raises") {
+    std::map<std::string, std::vector<std::vector<double>>> t;
+    t.emplace("S", zeros(4, 4));  // 4x4, table has 5 levels
+    REQUIRE_THROWS_AS(NonComputationalModel::from_spec(LevelSet::default_set(), all_g(), t,
+                                                       std::nullopt, NonComputationalPolicy{}),
+                      std::invalid_argument);
+}
+
+TEST_CASE("from_spec: an initial-state vector that does not sum to one raises") {
+    REQUIRE_THROWS_AS(
+        NonComputationalModel::from_spec(LevelSet::default_set(), {0.5, 0.0, 0.0, 0.0, 0.0},
+                                         lost_on("S"), std::nullopt, NonComputationalPolicy{}),
+        std::invalid_argument);
+}


### PR DESCRIPTION
> ⚠️ **Prototype — feature-branch work.** Targets the long-running `codex/noncomputational-structural-mvp` branch, not `main`, and is reviewed less strictly than main-targeting PRs.

G2a — makes the noncomputational MVP usable from Python. The oracle validation and sqale-style examples are the G2b follow-up.

## C++
`NonComputationalModel::from_spec(...)` builds every `TransitionInstrument` and the classifier against one `LevelSet` from raw matrices, so callers never construct those objects or touch level fingerprints/ids (design §3.3).

## Python (`clifft.noncomp`)
```python
from clifft import noncomp
model = noncomp.Model(initial_state=[1,0,0,0,0], transitions={"S": T},
                      classifier=noncomp.Classifier(["0","1"], P), reset_restores_lost=False)
r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=1000, seed=7)
# r.measurements / .detectors / .observables / .final_status  -> np.uint8
```
- Fixed built-in five-level set, named by `noncomp.Level` / `noncomp.LEVELS`; matrix rows/columns are indexed by `Level` (no level-id objects, no bare indices). There is no generic/custom-level path in Python.
- `final_status` is coarse: `{Computational, Leaked, Lost}` (`QubitStatusKind`); the specific leaked/lost level is not exposed.
- `reset_restores_lost` is the only exposed policy flag; `unknown_source_policy` stays internal (single value today).
- Errors surface only where reachable: bad shapes/probabilities, unknown gate keys, unknown-source transitions, and substochastic / non-binary classifiers.

## Deferred (per discussion)
Custom level sets, an exact `final_level` sidecar (specific leaked/lost level), the independent density-matrix oracle, and sqale-style examples → follow-up. The oracle will validate **supported output distributions**, not trace-out isolation.

## Tests
- C++: `from_spec` construction + validation/error propagation (7 cases).
- Python: model construction, end-to-end sampling, classifier/record semantics, record-layout invariants (24 cases).
- Full C++ suite green (914 cases); Python suite green (stim-dependent modules need the optional `stim` test dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

