### PR TITLE
ci: enforce uv lockfile in workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -203,11 +203,11 @@ jobs:
       - name: Install Python package
         env:
           SKBUILD_CMAKE_BUILD_TYPE: Release
-        run: uv pip install -e ".[dev]"
+        run: uv sync --locked
 
       - name: Run pytest-benchmark suite
         run: |
-          uv run pytest tools/bench/ \
+          uv run --locked pytest tools/bench/ \
             --benchmark-only \
             --benchmark-json=python-bench.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
+      - name: Check uv lockfile
+        run: uv lock --check
+
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:
@@ -182,18 +185,18 @@ jobs:
         shell: bash
 
       - name: Install Python package
-        run: uv pip install -e ".[dev]"
+        run: uv sync --locked
 
       - name: Run Python tests (default ISA)
-        run: uv run pytest tests/python/ -v
+        run: uv run --locked pytest tests/python/ -v
 
       - name: Run Python tests (scalar ISA)
         env:
           CLIFFT_FORCE_ISA: scalar
-        run: uv run pytest tests/python/ -v
+        run: uv run --locked pytest tests/python/ -v
 
       - name: Test documentation code examples
-        run: uv run pytest --codeblocks docs/ README.md -v
+        run: uv run --locked pytest --codeblocks docs/ README.md -v
 
   release-cpp-smoke:
     needs: lint
@@ -251,7 +254,8 @@ jobs:
           SKBUILD_CMAKE_BUILD_TYPE: Release
         run: |
           uv venv .smoke-venv
-          uv pip install --python .smoke-venv -e ".[dev]"
+          . .smoke-venv/bin/activate
+          uv sync --locked --active --no-dev
 
       - name: Install qemu-user
         run: sudo apt-get install -y qemu-user
@@ -334,7 +338,7 @@ jobs:
         shell: bash
 
       - name: Install Python package
-        run: uv pip install -e ".[dev]"
+        run: uv sync --locked
 
       - name: Run Python tests
-        run: uv run pytest tests/python/ -v
+        run: uv run --locked pytest tests/python/ -v

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,7 @@ jobs:
       # ---------- Python Test Coverage (C++ and Python) ----------
       # Build extension with coverage instrumentation
       - name: Install Python package with coverage
-        run: uv pip install -e ".[dev]"
+        run: uv sync --locked
         env:
           CMAKE_ARGS: "-DCLIFFT_COVERAGE=ON"
           SKBUILD_BUILD_TYPE: Debug
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run Python tests
         run: |
-          uv run pytest tests/python/ -v \
+          uv run --locked pytest tests/python/ -v \
             --cov=clifft \
             --cov-report=xml:build/python-coverage.xml
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,9 +58,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install clifft and docs deps
-        run: uv sync --frozen --group docs
+        run: uv sync --locked --group docs
 
       - name: Deploy dev docs
-        run: uv run --group docs mike deploy --push dev
+        run: uv run --locked --group docs mike deploy --push dev
         env:
           SITE_URL: https://unitaryfoundation.github.io/clifft/dev/

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -53,10 +53,10 @@ jobs:
           enable-cache: true
 
       - name: Install clifft and docs deps
-        run: uv sync --frozen --group docs
+        run: uv sync --locked --group docs
 
       - name: Build docs
-        run: uv run --group docs mkdocs build --strict
+        run: uv run --locked --group docs mkdocs build --strict
         env:
           SITE_URL: https://unitaryfoundation.github.io/clifft/pr-preview/pr-${{ github.event.number }}/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install clifft and docs deps
-        run: uv sync --frozen --group docs
+        run: uv sync --locked --group docs
 
       - name: Build versioned playground
         run: |
@@ -271,14 +271,14 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           SITE_URL="https://unitaryfoundation.github.io/clifft/${VERSION}/" \
-            uv run --group docs mike deploy --push "${VERSION}"
+            uv run --locked --group docs mike deploy --push "${VERSION}"
 
       - name: Decide whether to update stable docs
         id: stable
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          uv run --group docs mike list --json > /tmp/mike-list.json || echo '[]' > /tmp/mike-list.json
-          VERSION="${VERSION}" uv run --group docs python - <<'PY' >> "${GITHUB_OUTPUT}"
+          uv run --locked --group docs mike list --json > /tmp/mike-list.json || echo '[]' > /tmp/mike-list.json
+          VERSION="${VERSION}" uv run --locked --group docs python - <<'PY' >> "${GITHUB_OUTPUT}"
           import json
           import os
           from pathlib import Path
@@ -316,8 +316,8 @@ jobs:
         if: steps.stable.outputs.update == 'true'
         run: |
           SITE_URL=https://unitaryfoundation.github.io/clifft/stable/ \
-            uv run --group docs mike deploy --push stable
-          uv run --group docs mike set-default --push stable
+            uv run --locked --group docs mike deploy --push stable
+          uv run --locked --group docs mike set-default --push stable
 
       - name: Build root stable playground
         if: steps.stable.outputs.update == 'true'

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ docs = [
     { name = "mkdocs-macros-plugin", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.6" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0" },
     { name = "pymdown-extensions", specifier = ">=10.7" },
 ]
 


### PR DESCRIPTION
## Summary
- update uv.lock to match the docs dependency group constraint
- add an explicit CI lockfile freshness check
- replace extras-style uv installs with lockfile-backed sync/run commands across CI, docs, coverage, benchmarks, and release docs

## Validation
- UV_CACHE_DIR=/tmp/clifft-uv-cache uv lock --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/ci.yml .github/workflows/bench.yml .github/workflows/coverage.yml .github/workflows/docs.yml .github/workflows/pr_preview.yml .github/workflows/release.yml
- UV_CACHE_DIR=/tmp/clifft-uv-cache uv sync --locked --dry-run
- UV_CACHE_DIR=/tmp/clifft-uv-cache uv sync --locked --group docs --dry-run
- UV_CACHE_DIR=/tmp/clifft-uv-cache uv venv /tmp/clifft-smoke-venv && . /tmp/clifft-smoke-venv/bin/activate && UV_CACHE_DIR=/tmp/clifft-uv-cache uv sync --locked --active --no-dev --dry-run
- UV_CACHE_DIR=/tmp/clifft-uv-cache PRE_COMMIT_HOME=/tmp/clifft-pre-commit-cache uv run --locked pre-commit run --all-files