### PR TITLE
test(noncomp): density-matrix oracle cross-check + worked examples (G2b)

### DIFF
--- a/tests/python/test_noncomp_examples.py
+++ b/tests/python/test_noncomp_examples.py
@@ -1,0 +1,104 @@
+"""Worked examples for the categories our model supports exactly, plus the
+ones it intentionally rejects. Mirrors sqale-sim style scenarios and documents
+the supported boundary.
+
+These complement the unit coverage in test_noncomp.py and the oracle
+cross-checks in test_noncomp_oracle.py; here the emphasis is on small,
+readable end-to-end scenarios -- especially initial noncomputational
+populations, which the other files do not exercise.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from clifft import noncomp
+
+Level = noncomp.Level
+LEAKED = noncomp.QubitStatusKind.LEAKED
+LOST = noncomp.QubitStatusKind.LOST
+SHOTS = 8000
+BAND = 0.04
+
+
+def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
+    m = [[0.0] * 5 for _ in range(2)]  # P[symbol][level]
+    for lvl in range(5):
+        m[0][lvl] = 1.0
+    m[0][level], m[1][level] = col[0], col[1]
+    return noncomp.Classifier(["0", "1"], m)
+
+
+def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
+    m = [[0.0] * 5 for _ in range(5)]  # T[to][from]
+    for (to, frm), p in entries.items():
+        m[to][frm] = p
+    return m
+
+
+# --- Supported categories ----------------------------------------------------
+
+
+def test_example_initial_leaked_population():
+    # 30% of shots start in leak_g; the classifier (leak_g -> 1) sets their
+    # record bit, and g (-> 0) sets the rest. So P(record=1) == P(leak_g) == 0.3.
+    model = noncomp.Model(
+        initial_state=[0.7, 0.0, 0.3, 0.0, 0.0],
+        classifier=_classifier(Level.LEAK_G, [0.0, 1.0]),
+    )
+    r = noncomp.sample("M 0\n", model, shots=SHOTS, seed=1)
+    assert abs(np.asarray(r.measurements)[:, 0].mean() - 0.3) < BAND
+    assert abs((np.asarray(r.final_status) == LEAKED).mean() - 0.3) < BAND
+
+
+def test_example_initial_lost_population():
+    # Half the shots start lost; final status reflects it.
+    model = noncomp.Model(
+        initial_state=[0.5, 0.0, 0.0, 0.0, 0.5],
+        classifier=_classifier(Level.LOST, [1.0, 0.0]),
+    )
+    r = noncomp.sample("M 0\n", model, shots=SHOTS, seed=2)
+    assert abs((np.asarray(r.final_status) == LOST).mean() - 0.5) < BAND
+
+
+def test_example_after_gate_leakage_with_classifier():
+    # A gate leaks the qubit; its measurement is classified.
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={
+            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
+        },
+        classifier=_classifier(Level.LEAK_G, [0.0, 1.0]),
+    )
+    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=3)
+    assert (np.asarray(r.measurements)[:, 0] == 1).all()
+    assert (np.asarray(r.final_status) == LEAKED).all()
+
+
+# --- Intentionally unsupported -----------------------------------------------
+
+
+def test_reject_unknown_coherent_source_dependent_transition():
+    # Source-dependent (g->leak_g, e->leak_e) fired on a coherent (post-H) qubit:
+    # the source level is unknown, so the trajectory cannot pick a column.
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={
+            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_E, Level.E): 1.0})
+        },
+    )
+    with pytest.raises(ValueError, match="source-dependent"):
+        noncomp.sample("H 0\nS 0\n", model, shots=8, seed=4)
+
+
+def test_reject_two_qubit_gate_on_leaked_qubit():
+    # Once qubit 0 is leaked, a following entangling gate on it is ambiguous.
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={
+            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
+        },
+    )
+    with pytest.raises(ValueError, match="not representable"):
+        noncomp.sample("H 0\nS 0\nCX 0 1\n", model, shots=8, seed=5)

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -133,3 +133,4 @@ def test_survivor_marginal_equals_partial_trace():
     bell = oracle.apply_cx(oracle.apply_1q(oracle.zero_state(2), "H", 0, 2), 0, 1, 2)
     expected_survivor = oracle.marginal_one_after_trace_out(bell, lost=0, survivor=1, n=2)
     assert abs(_p1(r, 1) - expected_survivor) < BAND  # survivor (M 1) == partial trace
+    assert abs(_p1(r, 0) - 0.5) < BAND  # lost record (M 0) follows the [0.5, 0.5] classifier

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -1,0 +1,135 @@
+"""Cross-check clifft.noncomp sampling against an independent reference.
+
+The reference (``utils_noncomp_oracle``) is a tiny numpy density-matrix
+simulator built from first principles, plus explicit closed-form probabilities
+for the classical events (initial level, transitions, classifier). It is
+independent of clifft's sampler/rewriter/SVM. We first self-check the reference
+against clifft's own simulator on lossless circuits, then use it to validate the
+supported noncomputational subset within shot noise.
+
+Scope note: comparing output distributions cannot isolate the hidden trace-out
+(a lost qubit that never re-enters is observationally identical with or without
+it); that mechanism is covered by the C++ structural test. Here the oracle
+validates the supported output distributions: initial population, transition
+probability, classifier replacement, and the survivor marginal as a partial
+trace.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+import utils_noncomp_oracle as oracle
+
+import clifft
+from clifft import noncomp
+
+Level = noncomp.Level
+BAND = 0.04  # ~7 sigma at 8000 shots for p near 0.5
+SHOTS = 8000
+
+
+def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
+    """5x5 T[to][from]; a column's deficit below 1 is the no-jump (stay) weight."""
+    m = [[0.0] * 5 for _ in range(5)]
+    for (to, frm), p in entries.items():
+        m[to][frm] = p
+    return m
+
+
+def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
+    m = [[0.0] * 5 for _ in range(2)]  # P[symbol][level], two symbols
+    for lvl in range(5):
+        m[0][lvl] = 1.0
+    m[0][level], m[1][level] = col[0], col[1]
+    return noncomp.Classifier(["0", "1"], m)
+
+
+def _p1(result: noncomp.NonComputationalSample, slot: int) -> float:
+    return float(np.asarray(result.measurements)[:, slot].mean())
+
+
+# --- Self-check: the reference agrees with clifft on lossless circuits --------
+
+
+def _matches_clifft(text: str, state: npt.NDArray[np.complex128], n: int) -> None:
+    empirical = np.asarray(clifft.sample(clifft.compile(text), SHOTS, 7).measurements)
+    for q in range(n):
+        assert abs(oracle.prob_one(state, q, n) - empirical[:, q].mean()) < BAND
+
+
+def test_oracle_quantum_core_matches_clifft():
+    h = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
+    _matches_clifft("H 0\nM 0\n", h, 1)
+    _matches_clifft("X 0\nM 0\n", oracle.apply_1q(oracle.zero_state(1), "X", 0, 1), 1)
+    _matches_clifft("H 0\nS 0\nM 0\n", oracle.apply_1q(h, "S", 0, 1), 1)
+    bell = oracle.apply_cx(oracle.apply_1q(oracle.zero_state(2), "H", 0, 2), 0, 1, 2)
+    _matches_clifft("H 0\nCX 0 1\nM 0\nM 1\n", bell, 2)
+
+
+def test_oracle_partial_trace_of_bell_is_maximally_mixed():
+    state = oracle.apply_cx(oracle.apply_1q(oracle.zero_state(2), "H", 0, 2), 0, 1, 2)
+    assert abs(oracle.marginal_one_after_trace_out(state, lost=0, survivor=1, n=2) - 0.5) < 1e-12
+
+
+# --- Supported noncomputational subset vs the reference -----------------------
+
+
+def test_lossless_matches_clifft_distribution():
+    text = "H 0\nCX 0 1\nM 0\nM 1\n"
+    model = noncomp.Model(initial_state=[1.0, 0.0, 0.0, 0.0, 0.0])
+    nc = noncomp.sample(text, model, shots=SHOTS, seed=1)
+    plain = np.asarray(clifft.sample(clifft.compile(text), SHOTS, 1).measurements)
+    nc_m = np.asarray(nc.measurements)
+    for q in range(2):
+        assert abs(nc_m[:, q].mean() - plain[:, q].mean()) < BAND
+    # Bell correlation preserved in both.
+    assert (nc_m[:, 0] == nc_m[:, 1]).mean() > 0.99
+
+
+def test_initial_population_sampling():
+    # 70% g (-> 0), 30% e (-> 1 via X-prep); expected P(record=1) = 0.3.
+    model = noncomp.Model(initial_state=[0.7, 0.3, 0.0, 0.0, 0.0])
+    r = noncomp.sample("M 0\n", model, shots=SHOTS, seed=2)
+    assert abs(_p1(r, 0) - 0.3) < BAND
+
+
+def test_transition_probability_on_known_source():
+    # On known g, S jumps to leak_g with prob 0.4 (deficit 0.6 stays g).
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={"S": _transition({(Level.LEAK_G, Level.G): 0.4})},
+    )
+    r = noncomp.sample("S 0\n", model, shots=SHOTS, seed=3)
+    leaked = (np.asarray(r.final_status) == noncomp.QubitStatusKind.LEAKED).mean()
+    assert abs(leaked - 0.4) < BAND
+
+
+@pytest.mark.parametrize("col,expected", [([0.0, 1.0], 1.0), ([1.0, 0.0], 0.0), ([0.5, 0.5], 0.5)])
+def test_classifier_replacement_distribution(col, expected):
+    # Always leak to leak_g, then the classifier's column sets the record bit.
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={
+            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
+        },
+        classifier=_classifier(Level.LEAK_G, col),
+    )
+    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=4)
+    assert abs(_p1(r, 0) - expected) < BAND
+
+
+def test_survivor_marginal_equals_partial_trace():
+    # Bell pair, lose qubit 0. The survivor's record marginal must equal the
+    # reference partial trace (0.5), and the lost record follows the classifier.
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={"S": _transition({(Level.LOST, Level.G): 1.0, (Level.LOST, Level.E): 1.0})},
+        classifier=_classifier(Level.LOST, [0.5, 0.5]),
+    )
+    r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=SHOTS, seed=5)
+
+    bell = oracle.apply_cx(oracle.apply_1q(oracle.zero_state(2), "H", 0, 2), 0, 1, 2)
+    expected_survivor = oracle.marginal_one_after_trace_out(bell, lost=0, survivor=1, n=2)
+    assert abs(_p1(r, 1) - expected_survivor) < BAND  # survivor (M 1) == partial trace

--- a/tests/python/utils_noncomp_oracle.py
+++ b/tests/python/utils_noncomp_oracle.py
@@ -86,9 +86,14 @@ def reduced_density(
 def marginal_one_after_trace_out(
     state: npt.NDArray[np.complex128], lost: int, survivor: int, n: int
 ) -> float:
-    """P(survivor Z = 1) after tracing out the `lost` qubit (a partial trace)."""
-    # Tracing out one qubit then reading another reduces to the survivor's own
-    # reduced density matrix (the trace is linear and the lost qubit factors out
-    # of the survivor marginal), so reuse reduced_density on the survivor.
+    """P(survivor Z = 1) after the `lost` qubit is traced out.
+
+    The survivor's single-qubit marginal is its reduced density matrix, which
+    traces out every other qubit regardless, so the result does not depend on
+    which other qubit is named `lost`. The parameter documents the scenario
+    (lose `lost`, read `survivor`) and must differ from `survivor`.
+    """
+    if lost == survivor:
+        raise ValueError("lost and survivor must be different qubits")
     rho = reduced_density(state, survivor, n)
     return float(np.real(rho[1, 1]))

--- a/tests/python/utils_noncomp_oracle.py
+++ b/tests/python/utils_noncomp_oracle.py
@@ -1,0 +1,94 @@
+"""Tiny dense reference for cross-checking noncomputational sampling.
+
+Test-only. A minimal density-matrix simulator over the computational subspace
+(<= 3 qubits), built from first principles -- statevector unitaries, Born-rule
+Z measurement, and partial trace -- and deliberately independent of clifft's
+sampler, rewriter, and SVM. Combined with explicit classical probabilities for
+initial levels, transitions, and the classifier, it yields expected output
+distributions to compare against ``clifft.noncomp.sample`` within shot noise.
+
+Scope: the exact supported subset only -- small Clifford circuits, a Z-basis
+binary classifier, and state-independent loss handled as a true partial trace.
+This is not a general simulator and must not grow into one; the lossless
+self-check tests guard that its quantum core is correct before it is trusted to
+judge the noncomputational pipeline.
+
+Qubit/bit convention: qubit 0 is the most significant factor in the Kronecker
+product, matching how the self-check compares against clifft's records.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+_I = np.eye(2, dtype=complex)
+_P0 = np.array([[1, 0], [0, 0]], dtype=complex)
+_P1 = np.array([[0, 0], [0, 1]], dtype=complex)
+
+GATES_1Q: dict[str, npt.NDArray[np.complex128]] = {
+    "I": _I,
+    "X": np.array([[0, 1], [1, 0]], dtype=complex),
+    "Y": np.array([[0, -1j], [1j, 0]], dtype=complex),
+    "Z": np.array([[1, 0], [0, -1]], dtype=complex),
+    "H": np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2),
+    "S": np.array([[1, 0], [0, 1j]], dtype=complex),
+}
+
+
+def zero_state(n: int) -> npt.NDArray[np.complex128]:
+    """The |0...0> statevector for n qubits."""
+    v = np.zeros(2**n, dtype=complex)
+    v[0] = 1.0
+    return v
+
+
+def _embed(u: npt.NDArray[np.complex128], q: int, n: int) -> npt.NDArray[np.complex128]:
+    """Embed a single-qubit operator on qubit q into the n-qubit space."""
+    ops = [_I] * n
+    ops[q] = u
+    full = ops[0]
+    for op in ops[1:]:
+        full = np.kron(full, op)
+    return full
+
+
+def apply_1q(
+    state: npt.NDArray[np.complex128], gate: str, q: int, n: int
+) -> npt.NDArray[np.complex128]:
+    """Apply a named single-qubit gate to qubit q."""
+    return _embed(GATES_1Q[gate], q, n) @ state
+
+
+def apply_cx(
+    state: npt.NDArray[np.complex128], control: int, target: int, n: int
+) -> npt.NDArray[np.complex128]:
+    """Apply CX(control, target)."""
+    u = _embed(_P0, control, n) + _embed(_P1, control, n) @ _embed(GATES_1Q["X"], target, n)
+    return u @ state
+
+
+def prob_one(state: npt.NDArray[np.complex128], q: int, n: int) -> float:
+    """Born-rule probability that a Z measurement of qubit q yields 1."""
+    return float(np.real(state.conj() @ (_embed(_P1, q, n) @ state)))
+
+
+def reduced_density(
+    state: npt.NDArray[np.complex128], keep: int, n: int
+) -> npt.NDArray[np.complex128]:
+    """Reduced 2x2 density matrix of qubit `keep`, tracing out the rest."""
+    psi = state.reshape([2] * n)
+    # Move the kept axis to the front, flatten the rest, then rho = sum_r |a_r><a_r|.
+    psi = np.moveaxis(psi, keep, 0).reshape(2, -1)
+    return psi @ psi.conj().T
+
+
+def marginal_one_after_trace_out(
+    state: npt.NDArray[np.complex128], lost: int, survivor: int, n: int
+) -> float:
+    """P(survivor Z = 1) after tracing out the `lost` qubit (a partial trace)."""
+    # Tracing out one qubit then reading another reduces to the survivor's own
+    # reduced density matrix (the trace is linear and the lost qubit factors out
+    # of the survivor marginal), so reuse reduced_density on the survivor.
+    rho = reduced_density(state, survivor, n)
+    return float(np.real(rho[1, 1]))


### PR DESCRIPTION
> ⚠️ **Prototype — feature-branch work.** Targets the long-running `codex/noncomputational-structural-mvp` branch, not `main`, and is reviewed less strictly than main-targeting PRs.

G2b — the validation campaign for the noncomputational MVP. Test-only; no library changes.

## Independent oracle (`tests/python/utils_noncomp_oracle.py`)
A tiny first-principles numpy density-matrix reference (≤3 qubits: statevector unitaries, Born-rule Z measurement, partial trace), deliberately independent of clifft's sampler/rewriter/SVM. `test_noncomp_oracle.py`:
- **Self-check** vs clifft's own simulator on lossless circuits (validates the reference's quantum core and bit ordering before trusting it).
- Cross-checks `sample_noncomputational` on the supported subset: **initial population**, **transition probability**, **classifier replacement**, **survivor marginal as a partial trace**, and **lossless equivalence**.

## Worked examples (`tests/python/test_noncomp_examples.py`)
sqale-style scenarios for the categories we support exactly — **initial leaked/lost population** (not exercised elsewhere), after-gate leakage with a classifier — plus the categories we **reject**: unknown coherent source-dependent transition, and a two-qubit gate on a leaked qubit.

## Scope
Comparing output distributions **cannot** isolate the hidden trace-out (a lost qubit that never re-enters is observationally identical with or without it), so the oracle validates **supported output distributions**; the trace-out's emission stays covered by the C++ structural test. No `final_level` or custom levels are needed here (both remain deferred).

39 noncomp Python tests pass (`test_noncomp` + oracle + examples); lint clean. The oracle is intentionally minimal and test-only, not a second simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
