### PR TITLE
build: hide vendored Stim symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Install Python package
         run: uv pip install -e ".[dev]"
 
+      - name: Audit Python extension exports
+        run: uv run python tools/ci/audit_python_exports.py
+
       - name: Run Python tests (default ISA)
         run: uv run pytest tests/python/ -v
 
@@ -252,6 +255,9 @@ jobs:
         run: |
           uv venv .smoke-venv
           uv pip install --python .smoke-venv -e ".[dev]"
+
+      - name: Audit Python extension exports
+        run: .smoke-venv/bin/python tools/ci/audit_python_exports.py
 
       - name: Install qemu-user
         run: sudo apt-get install -y qemu-user
@@ -335,6 +341,9 @@ jobs:
 
       - name: Install Python package
         run: uv pip install -e ".[dev]"
+
+      - name: Audit Python extension exports
+        run: uv run python tools/ci/audit_python_exports.py
 
       - name: Run Python tests
         run: uv run pytest tests/python/ -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,11 @@ jobs:
           CIBW_BEFORE_BUILD: pip install setuptools-scm
           # Install libomp on macOS for OpenMP support in wheels
           CIBW_BEFORE_ALL_MACOS: brew install libomp
-          # Smoke-test: import the built package
-          CIBW_TEST_COMMAND: python -c "import clifft; print(clifft.__version__); print(clifft.CPU_BASELINE); print(clifft.svm_backend())"
+          # Smoke-test: import the built package and audit exported symbols
+          CIBW_TEST_COMMAND: >-
+            python -c "import clifft; print(clifft.__version__); print(clifft.CPU_BASELINE); print(clifft.svm_backend())"
+            &&
+            python {project}/tools/ci/audit_python_exports.py
 
       # QEMU smoke against the just-built Linux x86_64 wheel. Catches
       # AVX-512 leakage into the AVX-2 dispatch path (would SIGILL the

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -33,6 +33,16 @@ nanobind_add_module(
 # Link against our core library
 target_link_libraries(_clifft_core PRIVATE clifft_core)
 
+# The Python module should not expose symbols from static vendored
+# dependencies such as Stim as part of Clifft's dynamic ABI.
+if(UNIX AND NOT APPLE)
+    target_link_options(_clifft_core PRIVATE
+        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/clifft_core.lds")
+elseif(APPLE)
+    target_link_options(_clifft_core PRIVATE
+        "LINKER:-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/clifft_core.exp")
+endif()
+
 # OpenMP for set_num_threads / get_num_threads bindings.
 # The Homebrew libomp hint may already be set by src/clifft/CMakeLists.txt,
 # but scikit-build-core may invoke this file in a separate configure.

--- a/src/python/clifft_core.exp
+++ b/src/python/clifft_core.exp
@@ -1,0 +1,1 @@
+_PyInit__clifft_core

--- a/src/python/clifft_core.lds
+++ b/src/python/clifft_core.lds
@@ -1,0 +1,6 @@
+{
+    global:
+        PyInit__clifft_core;
+    local:
+        *;
+};

--- a/tools/ci/audit_python_exports.py
+++ b/tools/ci/audit_python_exports.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Audit dynamic exports from the installed Python extension."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def extension_path() -> Path:
+    module = importlib.import_module("clifft._clifft_core")
+    module_file = module.__file__
+    if module_file is None:
+        raise RuntimeError("clifft._clifft_core does not have a __file__ attribute")
+    return Path(module_file).resolve()
+
+
+def nm_command(path: Path) -> list[str] | None:
+    nm = shutil.which("nm")
+    if nm is None:
+        raise RuntimeError("nm was not found on PATH")
+
+    system = platform.system()
+    if system == "Linux":
+        return [nm, "-D", "--defined-only", str(path)]
+    if system == "Darwin":
+        return [nm, "-gU", str(path)]
+    return None
+
+
+def expected_init_symbol() -> str:
+    if platform.system() == "Darwin":
+        return "_PyInit__clifft_core"
+    return "PyInit__clifft_core"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--extension",
+        type=Path,
+        default=None,
+        help="Path to _clifft_core extension. Defaults to importing clifft._clifft_core.",
+    )
+    args = parser.parse_args()
+
+    path = args.extension.resolve() if args.extension is not None else extension_path()
+    command = nm_command(path)
+    if command is None:
+        print(f"Skipping export audit on unsupported platform: {platform.system()}")
+        return 0
+
+    result = subprocess.run(command, check=True, text=True, capture_output=True)
+    exported = result.stdout.splitlines()
+
+    init_symbol = expected_init_symbol()
+    if not any(init_symbol in line for line in exported):
+        print(f"Expected exported Python init symbol not found: {init_symbol}", file=sys.stderr)
+        print(f"Audited extension: {path}", file=sys.stderr)
+        return 1
+
+    stim_exports = [line for line in exported if "stim" in line]
+    if stim_exports:
+        print("Vendored Stim symbols are exported from the Python extension:", file=sys.stderr)
+        for line in stim_exports[:20]:
+            print(line, file=sys.stderr)
+        if len(stim_exports) > 20:
+            print(f"... {len(stim_exports) - 20} more", file=sys.stderr)
+        print(f"Audited extension: {path}", file=sys.stderr)
+        return 1
+
+    print(f"Export audit passed for {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- restrict the Python extension export table to the module init symbol on Linux and macOS
- add a reusable CI audit that imports clifft._clifft_core and checks dynamic exports for leaked Stim symbols
- run the audit in CI Python installs and cibuildwheel release smoke tests

Closes #109

## Verification
- uv run python tools/ci/audit_python_exports.py
- nm -gU .venv/lib/python3.14/site-packages/clifft/_clifft_core.abi3.so
- uv run pytest tests/python/ -v
- uv run pre-commit run --all-files