### PR TITLE
feat: add SPP/SPP_DAG/TPP/TPP_DAG Pauli-product phase gates

### DIFF
--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -38,6 +38,16 @@ Clifft extends Stim with discrete and arbitrary-angle non-Clifford gates. These 
 |------|-------|
 | `T` | $\pi/8$ gate |
 | `T_DAG` | Inverse $\pi/8$ gate |
+| `TPP` | Non-Clifford; $\exp(-i\pi/8 \cdot P)$, rewound via inverse tableau, emitted as `T_GATE` |
+| `TPP_DAG` | Non-Clifford; $\exp(+i\pi/8 \cdot P$), inverse TPP |
+
+`TPP` and `TPP_DAG` use the same Pauli product syntax as `SPP`. Odd `!` count
+flips the gate direction:
+```
+TPP X0*Z1         # exp(-i*pi/8 * X0*Z1), emitted as a single T_GATE
+TPP !Y1           # = TPP_DAG Y1
+TPP !X0*!Z1       # = TPP X0*Z1 (double ! cancels)
+```
 
 ### Rewrite Gates
 
@@ -108,6 +118,25 @@ target count is 64 qubits per instruction.
 
 Two-qubit Cliffords are also absorbed at compile time.
 
+### Multi-Qubit Pauli-Product Phase Gates
+
+| Gate | Cost | Notes |
+|------|------|-------|
+| `SPP` | Clifford (absorbed) | $\exp(-i\pi/4 \cdot P)$ where $P$ is a Pauli product |
+| `SPP_DAG` | Clifford (absorbed) | $\exp(+i\pi/4 \cdot P)$ (inverse SPP) |
+
+The target list uses Stim's Pauli product syntax, same as `MPP`:
+```
+SPP X0*Z1 Y2*Z3
+```
+
+The `!` prefix on a Pauli term inverts its sign in the product; odd `!` count flips
+the gate direction:
+```
+SPP !X0*Z1       # = SPP_DAG X0*Z1  (one !, gate flips)
+SPP !X0*!Z1      # = SPP X0*Z1      (two !, gate stays)
+```
+
 ## Measurements and Resets
 
 | Instruction | Notes |
@@ -127,9 +156,9 @@ Two-qubit Cliffords are also absorbed at compile time.
 | Instruction | Notes |
 |-------------|-------|
 | `MPP` | Multi-Pauli product measurement |
-| `MXX` | Pair XX measurement (desugared to MPP) |
-| `MYY` | Pair YY measurement (desugared to MPP) |
-| `MZZ` | Pair ZZ measurement (desugared to MPP) |
+| `MXX` | Pair XX measurement (rewritten to MPP) |
+| `MYY` | Pair YY measurement (rewritten to MPP) |
+| `MZZ` | Pair ZZ measurement (rewritten to MPP) |
 
 ## Noise Channels
 

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -225,4 +225,3 @@ Results are available via `SampleResult.exp_vals` (shape `(shots, num_exp_vals)`
 |------|----------|--------|
 | `HERALDED_ERASE` | Noise | Heralded erasure not modeled |
 | `HERALDED_PAULI_CHANNEL_1` | Noise | Heralded channel not modeled |
-| `SPP`, `SPP_DAG` | Pauli product phase | Generalized S/S_DAG gate over Pauli products |

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -87,9 +87,9 @@ enum class GateType : uint16_t {
     MR,   // Measure + reset (Z-basis) - result visible
     MRX,  // Measure + reset (X-basis) - result visible
     MPP,  // Multi-Pauli measurement
-    MXX,  // Pair measurement in XX basis (desugars to MPP)
-    MYY,  // Pair measurement in YY basis (desugars to MPP)
-    MZZ,  // Pair measurement in ZZ basis (desugars to MPP)
+    MXX,  // Pair measurement in XX basis (rewritten to MPP)
+    MYY,  // Pair measurement in YY basis (rewritten to MPP)
+    MZZ,  // Pair measurement in ZZ basis (rewritten to MPP)
 
     // Resets (no visible measurement)
     R,    // Reset to |0> (Z-basis)

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -131,6 +131,12 @@ enum class GateType : uint16_t {
     // Annotations
     TICK,  // Timing layer marker (no-op)
 
+    // Pauli-product phase gates
+    SPP,      // Pauli product phase (Clifford, like S on a Pauli product)
+    SPP_DAG,  // Inverse Pauli product phase (Clifford)
+    TPP,      // Pauli product pi/8 gate (non-Clifford, like T on a Pauli product)
+    TPP_DAG,  // Inverse Pauli product pi/8 gate (non-Clifford)
+
     // Simulation-only probes
     EXP_VAL,  // Non-destructive expectation value
 
@@ -267,6 +273,11 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = A, .name = "DETECTOR"},
     {.arity = A, .name = "OBSERVABLE_INCLUDE"},
     {.arity = A, .name = "TICK"},
+    // Pauli-product phase gates
+    {.arity = ML, .clifford = true, .name = "SPP"},
+    {.arity = ML, .clifford = true, .name = "SPP_DAG"},
+    {.arity = ML, .name = "TPP"},
+    {.arity = ML, .name = "TPP_DAG"},
     // Simulation-only probes
     {.arity = ML, .name = "EXP_VAL"},
     // Sentinel

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -699,7 +699,7 @@ class Parser {
                         line_num);
                 }
 
-                // MXX/MYY/MZZ: desugar into MPP with Pauli-tagged targets.
+                // MXX/MYY/MZZ: rewrite to MPP with Pauli-tagged targets.
                 if (gate == GateType::MXX || gate == GateType::MYY || gate == GateType::MZZ) {
                     uint32_t pauli_flag = (gate == GateType::MXX)   ? Target::kPauliX
                                           : (gate == GateType::MYY) ? Target::kPauliY
@@ -1150,8 +1150,9 @@ class Parser {
     }
 
     // Parse SPP/SPP_DAG/TPP/TPP_DAG with Pauli products.
-    // Each whitespace-separated product is like "X0*Z1" or "!X0*Y1".
-    // The '!' prefix on a product inverts the gate type (SPP -> SPP_DAG, TPP -> TPP_DAG).
+    // Each whitespace-separated product is like "X0*Z1" or "!X0*Z1".
+    // The '!' prefix before a Pauli term inverts that term's sign in the product.
+    // Odd count of '!' across all terms flips the gate type (SPP <-> SPP_DAG, TPP <-> TPP_DAG).
     void parse_pauli_product_gate(GateType base_gate, std::string_view targets_str,
                                   uint32_t line_num, Circuit& circuit) {
         std::string_view remaining = targets_str;
@@ -1169,31 +1170,9 @@ class Parser {
             }
             product_count++;
 
-            // Check for '!' prefix to invert gate type.
-            GateType gate = base_gate;
-            if (!product_str.empty() && product_str[0] == '!') {
-                product_str.remove_prefix(1);
-                switch (base_gate) {
-                    case GateType::SPP:
-                        gate = GateType::SPP_DAG;
-                        break;
-                    case GateType::SPP_DAG:
-                        gate = GateType::SPP;
-                        break;
-                    case GateType::TPP:
-                        gate = GateType::TPP_DAG;
-                        break;
-                    case GateType::TPP_DAG:
-                        gate = GateType::TPP;
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            // Parse Pauli product like "X0*Z1".
             std::vector<Target> pauli_targets;
             std::unordered_set<uint32_t> seen_qubits;
+            int inversion_count = 0;
 
             size_t pos = 0;
             while (pos < product_str.size()) {
@@ -1203,6 +1182,16 @@ class Parser {
                     }
                     pos++;
                     continue;
+                }
+
+                if (product_str[pos] == '!') {
+                    inversion_count++;
+                    pos++;
+                    if (pos >= product_str.size() ||
+                        (product_str[pos] != 'X' && product_str[pos] != 'Y' &&
+                         product_str[pos] != 'Z')) {
+                        throw ParseError("Expected Pauli letter after '!'", line_num);
+                    }
                 }
 
                 char pauli_char = product_str[pos];
@@ -1218,8 +1207,8 @@ class Parser {
                         pauli_flag = Target::kPauliZ;
                         break;
                     default:
-                        throw ParseError("Invalid Pauli in " + std::string(gate_name(gate)) + ": " +
-                                             std::string(1, pauli_char),
+                        throw ParseError("Invalid Pauli in " + std::string(gate_name(base_gate)) +
+                                             ": " + std::string(1, pauli_char),
                                          line_num);
                 }
                 pos++;
@@ -1261,7 +1250,29 @@ class Parser {
                 throw ParseError("Empty Pauli product", line_num);
             }
 
-            // Emit one AstNode per product.
+            GateType gate;
+            if (inversion_count % 2 == 0) {
+                gate = base_gate;
+            } else {
+                switch (base_gate) {
+                    case GateType::SPP:
+                        gate = GateType::SPP_DAG;
+                        break;
+                    case GateType::SPP_DAG:
+                        gate = GateType::SPP;
+                        break;
+                    case GateType::TPP:
+                        gate = GateType::TPP_DAG;
+                        break;
+                    case GateType::TPP_DAG:
+                        gate = GateType::TPP;
+                        break;
+                    default:
+                        gate = base_gate;
+                        break;
+                }
+            }
+
             circuit.nodes.push_back({gate, std::move(pauli_targets), {}, line_num});
         }
 

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -317,6 +317,12 @@ class Parser {
             case GateType::ELSE_CORRELATED_ERROR:
                 parse_correlated_error(gate, rest, line_num, circuit, args);
                 break;
+            case GateType::SPP:
+            case GateType::SPP_DAG:
+            case GateType::TPP:
+            case GateType::TPP_DAG:
+                parse_pauli_product_gate(gate, rest, line_num, circuit);
+                break;
             case GateType::DETECTOR:
                 parse_detector(rest, line_num, circuit);
                 break;
@@ -1141,6 +1147,128 @@ class Parser {
         auto pauli_targets = parse_pauli_product(product_str, "R_PAULI", line_num, circuit);
 
         circuit.nodes.push_back({GateType::R_PAULI, std::move(pauli_targets), args, line_num});
+    }
+
+    // Parse SPP/SPP_DAG/TPP/TPP_DAG with Pauli products.
+    // Each whitespace-separated product is like "X0*Z1" or "!X0*Y1".
+    // The '!' prefix on a product inverts the gate type (SPP -> SPP_DAG, TPP -> TPP_DAG).
+    void parse_pauli_product_gate(GateType base_gate, std::string_view targets_str,
+                                  uint32_t line_num, Circuit& circuit) {
+        std::string_view remaining = targets_str;
+        uint32_t product_count = 0;
+
+        while (true) {
+            std::string_view product_str = next_token(remaining);
+            if (product_str.empty())
+                break;
+
+            if (product_count >= kMaxTargetsPerInstruction) {
+                throw ParseError("Too many products (limit: " +
+                                     std::to_string(kMaxTargetsPerInstruction) + ")",
+                                 line_num);
+            }
+            product_count++;
+
+            // Check for '!' prefix to invert gate type.
+            GateType gate = base_gate;
+            if (!product_str.empty() && product_str[0] == '!') {
+                product_str.remove_prefix(1);
+                switch (base_gate) {
+                    case GateType::SPP:
+                        gate = GateType::SPP_DAG;
+                        break;
+                    case GateType::SPP_DAG:
+                        gate = GateType::SPP;
+                        break;
+                    case GateType::TPP:
+                        gate = GateType::TPP_DAG;
+                        break;
+                    case GateType::TPP_DAG:
+                        gate = GateType::TPP;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // Parse Pauli product like "X0*Z1".
+            std::vector<Target> pauli_targets;
+            std::unordered_set<uint32_t> seen_qubits;
+
+            size_t pos = 0;
+            while (pos < product_str.size()) {
+                if (product_str[pos] == '*') {
+                    if (pos == 0 || pos + 1 >= product_str.size() || product_str[pos + 1] == '*') {
+                        throw ParseError("Malformed Pauli product: misplaced '*'", line_num);
+                    }
+                    pos++;
+                    continue;
+                }
+
+                char pauli_char = product_str[pos];
+                uint32_t pauli_flag;
+                switch (pauli_char) {
+                    case 'X':
+                        pauli_flag = Target::kPauliX;
+                        break;
+                    case 'Y':
+                        pauli_flag = Target::kPauliY;
+                        break;
+                    case 'Z':
+                        pauli_flag = Target::kPauliZ;
+                        break;
+                    default:
+                        throw ParseError("Invalid Pauli in " + std::string(gate_name(gate)) +
+                                             ": " + std::string(1, pauli_char),
+                                         line_num);
+                }
+                pos++;
+
+                size_t num_start = pos;
+                while (pos < product_str.size() && std::isdigit(product_str[pos])) {
+                    pos++;
+                }
+
+                if (num_start == pos) {
+                    throw ParseError("Expected qubit index after Pauli letter", line_num);
+                }
+
+                uint32_t qubit;
+                if (!parse_uint(
+                        std::string_view(product_str).substr(num_start, pos - num_start), qubit)) {
+                    throw ParseError("Invalid qubit index in Pauli product", line_num);
+                }
+
+                if (qubit >= (1u << 28)) {
+                    throw ParseError("Qubit index too large (must be < 2^28)", line_num);
+                }
+
+                if (!seen_qubits.insert(qubit).second) {
+                    throw ParseError("Duplicate qubit in Pauli product", line_num);
+                }
+
+                if (pauli_targets.size() >= kMaxTargetsPerInstruction) {
+                    throw ParseError("Too many Pauli terms in product (limit: " +
+                                         std::to_string(kMaxTargetsPerInstruction) + ")",
+                                     line_num);
+                }
+
+                pauli_targets.push_back(Target::pauli(qubit, pauli_flag));
+                circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
+            }
+
+            if (pauli_targets.empty()) {
+                throw ParseError("Empty Pauli product", line_num);
+            }
+
+            // Emit one AstNode per product.
+            circuit.nodes.push_back({gate, std::move(pauli_targets), {}, line_num});
+        }
+
+        if (product_count == 0) {
+            throw ParseError(std::string(gate_name(base_gate)) + " requires at least one Pauli product",
+                             line_num);
+        }
     }
 
     // Parse DETECTOR with rec[-k] targets.

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -1163,9 +1163,9 @@ class Parser {
                 break;
 
             if (product_count >= kMaxTargetsPerInstruction) {
-                throw ParseError("Too many products (limit: " +
-                                     std::to_string(kMaxTargetsPerInstruction) + ")",
-                                 line_num);
+                throw ParseError(
+                    "Too many products (limit: " + std::to_string(kMaxTargetsPerInstruction) + ")",
+                    line_num);
             }
             product_count++;
 
@@ -1218,8 +1218,8 @@ class Parser {
                         pauli_flag = Target::kPauliZ;
                         break;
                     default:
-                        throw ParseError("Invalid Pauli in " + std::string(gate_name(gate)) +
-                                             ": " + std::string(1, pauli_char),
+                        throw ParseError("Invalid Pauli in " + std::string(gate_name(gate)) + ": " +
+                                             std::string(1, pauli_char),
                                          line_num);
                 }
                 pos++;
@@ -1234,8 +1234,8 @@ class Parser {
                 }
 
                 uint32_t qubit;
-                if (!parse_uint(
-                        std::string_view(product_str).substr(num_start, pos - num_start), qubit)) {
+                if (!parse_uint(std::string_view(product_str).substr(num_start, pos - num_start),
+                                qubit)) {
                     throw ParseError("Invalid qubit index in Pauli product", line_num);
                 }
 
@@ -1266,8 +1266,9 @@ class Parser {
         }
 
         if (product_count == 0) {
-            throw ParseError(std::string(gate_name(base_gate)) + " requires at least one Pauli product",
-                             line_num);
+            throw ParseError(
+                std::string(gate_name(base_gate)) + " requires at least one Pauli product",
+                line_num);
         }
     }
 

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -611,7 +611,7 @@ HirModule trace(const Circuit& circuit) {
                 // onto an accumulator, apply S/S_DAG, unfold, un-diagonalize.
                 // Since S is Clifford, the entire decomposition is absorbed into
                 // the tableau by prepending the inverse (right-multiplying inv_state).
-                
+
                 // Collect non-identity targets with their Pauli types.
                 struct PauliQubit {
                     uint32_t qubit;

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -363,6 +363,8 @@ size_t count_pauli_masks(const Circuit& circuit) {
             case GateType::R_ZZ:
                 count += n_targets / 2;
                 break;
+            case GateType::TPP:
+            case GateType::TPP_DAG:
             case GateType::R_PAULI:
             case GateType::EXP_VAL:
             case GateType::MPP:
@@ -599,6 +601,105 @@ HirModule trace(const Circuit& circuit) {
                 bool _;
                 auto obs = build_pauli_string(node.targets, circuit.num_qubits, _);
                 trace_pauli_rotation(sim, hir, obs, alpha);
+                break;
+            }
+
+            case GateType::SPP:
+            case GateType::SPP_DAG: {
+                // SPP = exp(-i*pi/4 * P) where P is a Pauli product.
+                // Decomposition: diagonalize each Pauli to Z, fold with CX
+                // onto an accumulator, apply S/S_DAG, unfold, un-diagonalize.
+                // Since S is Clifford, the entire decomposition is absorbed into
+                // the tableau by prepending the inverse (right-multiplying inv_state).
+                
+                // Collect non-identity targets with their Pauli types.
+                struct PauliQubit {
+                    uint32_t qubit;
+                    uint32_t pauli_type;
+                };
+                std::vector<PauliQubit> pauli_qubits;
+                for (const auto& target : node.targets) {
+                    uint32_t q = target.value();
+                    uint32_t p = target.pauli();
+                    if (p != Target::kPauliNone) {
+                        pauli_qubits.push_back({q, p});
+                    }
+                }
+                if (pauli_qubits.empty()) {
+                    throw std::runtime_error(
+                        "SPP/SPP_DAG requires at least one non-identity Pauli");
+                }
+
+                // Step 1: Diagonalize non-Z Paulis to Z
+                for (const auto& pq : pauli_qubits) {
+                    size_t q = static_cast<size_t>(pq.qubit);
+                    switch (pq.pauli_type) {
+                        case Target::kPauliX:
+                            sim.inv_state.prepend_H_XZ(q);
+                            break;
+                        case Target::kPauliY:
+                            sim.inv_state.prepend_H_YZ(q);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                // Step 2: Fold onto accumulator using CX gates
+                uint32_t accumulator = pauli_qubits.back().qubit;
+                for (size_t i = 0; i + 1 < pauli_qubits.size(); i++) {
+                    uint32_t q = pauli_qubits[i].qubit;
+                    if (q != accumulator) {
+                        sim.inv_state.prepend_ZCX(static_cast<size_t>(q),
+                                                  static_cast<size_t>(accumulator));
+                    }
+                }
+
+                // Step 3: Apply S (SPP_DAG) or S^† (SPP) on accumulator
+                if (node.gate == GateType::SPP_DAG) {
+                    sim.inv_state.prepend_SQRT_Z(static_cast<size_t>(accumulator));
+                } else {
+                    sim.inv_state.prepend_SQRT_Z_DAG(static_cast<size_t>(accumulator));
+                }
+
+                // Step 4: Unfold (same CX gates)
+                for (size_t i = 0; i + 1 < pauli_qubits.size(); i++) {
+                    uint32_t q = pauli_qubits[i].qubit;
+                    if (q != accumulator) {
+                        sim.inv_state.prepend_ZCX(static_cast<size_t>(q),
+                                                  static_cast<size_t>(accumulator));
+                    }
+                }
+
+                // Step 5: Undo diagonalization
+                for (const auto& pq : pauli_qubits) {
+                    size_t q = static_cast<size_t>(pq.qubit);
+                    switch (pq.pauli_type) {
+                        case Target::kPauliX:
+                            sim.inv_state.prepend_H_XZ(q);
+                            break;
+                        case Target::kPauliY:
+                            sim.inv_state.prepend_H_YZ(q);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                break;
+            }
+
+            case GateType::TPP:
+            case GateType::TPP_DAG: {
+                // TPP = exp(-i*pi/8 * P). Rewind through inv_state, emit T_GATE.
+                bool dagger = (node.gate == GateType::TPP_DAG);
+                bool inversion_parity;
+                auto obs = build_pauli_string(node.targets, circuit.num_qubits, inversion_parity);
+                stim::PauliString<kStimWidth> rewound = sim.inv_state(obs);
+                uint32_t n = sim.inv_state.num_qubits;
+                hir.append_tgate(dagger, [&](MutablePauliMaskView slot) {
+                    copy_rewound_into(rewound, n, slot.x(), slot.z());
+                    slot.set_sign(rewound.sign ^ inversion_parity);
+                });
                 break;
             }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1815,3 +1815,206 @@ TEST_CASE("Frontend: R_Z global phase accumulation", "[frontend][rotation]") {
     CHECK(hir.global_weight.real() == Catch::Approx(expected_re).epsilon(1e-12));
     CHECK(hir.global_weight.imag() == Catch::Approx(expected_im).epsilon(1e-12));
 }
+
+// -----------------------------------------------------------------------------
+// SPP / SPP_DAG front-end tests (Clifford, absorbed into tableau)
+// -----------------------------------------------------------------------------
+
+TEST_CASE("Frontend: SPP on Z is absorbed - no HIR ops", "[frontend][spp]") {
+    auto circuit = parse("SPP Z0");
+    auto hir = trace(circuit);
+    // SPP on Z is just S, all Clifford, absorbed
+    REQUIRE(hir.num_ops() == 0);
+}
+
+TEST_CASE("Frontend: SPP on multi-qubit product absorbed", "[frontend][spp]") {
+    auto circuit = parse("SPP X0*Z1 Y2");
+    auto hir = trace(circuit);
+    // All Cliffords absorbed, no HIR ops
+    REQUIRE(hir.num_ops() == 0);
+}
+
+TEST_CASE("Frontend: SPP_DAG absorbed", "[frontend][spp]") {
+    auto circuit = parse("SPP_DAG X0*Y1");
+    auto hir = trace(circuit);
+    REQUIRE(hir.num_ops() == 0);
+}
+
+TEST_CASE("Frontend: SPP followed by T - T sees rotated basis", "[frontend][spp]") {
+    // SPP X0 rotates the Z axis to Y on qubit 0
+    // So T 0 after SPP X0 should have mask Y0
+    auto circuit = parse(R"(
+        SPP X0
+        T 0
+    )");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+
+    // After SPP X0, Z0 is conjugated to Y0: destab=X0, stab=Z0
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
+    REQUIRE(hir.sign(hir.ops[0]) == false);
+}
+
+TEST_CASE("Frontend: SPP_DAG followed by T - T sees opposite rotated basis", "[frontend][spp]") {
+    // SPP_DAG X0 rotates the Z axis to -Y on qubit 0
+    auto circuit = parse(R"(
+        SPP_DAG X0
+        T 0
+    )");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+
+    // After SPP_DAG X0, Z0 is conjugated to -Y0: destab=X0, stab=Z0, sign=true
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
+    REQUIRE(hir.sign(hir.ops[0]) == true);
+}
+
+TEST_CASE("Frontend: SPP with H entangling then T - multi-qubit mask", "[frontend][spp]") {
+    // SPP X0*Z1 then H 1 then T 1
+    // SPP absorbed, then H, then T sees Z1 rewound through SPP and H
+    auto circuit = parse(R"(
+        SPP X0*Z1
+        H 1
+        T 1
+    )");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+
+    // After SPP X0*Z1 and H 1:
+    // SPP^† = exp(+i*pi/4 * X0*Z1) acts on qubits 0 and 1
+    // Z1 rewound through H then SPP^†:
+    //   H on q1: Z1 -> X1
+    //   SPP^†: exp(+i*pi/4*X0*Z1) X1 exp(-i*pi/4*X0*Z1) = -X0*Z1 * X1 * X0*Z1 = -X0*Z1*X1*X0*Z1
+    // Actually this is complex. Let's just verify the HIR has 1 op and check structure.
+    // The key test is that SPP is fully absorbed (no T_GATE from SPP itself).
+    REQUIRE(hir.destab_mask(hir.ops[0]) != 0 || hir.stab_mask(hir.ops[0]) != 0);
+}
+
+// -----------------------------------------------------------------------------
+// TPP / TPP_DAG front-end tests (non-Clifford, emit T_GATE)
+// -----------------------------------------------------------------------------
+
+TEST_CASE("Frontend: TPP Z0 emits T_GATE with Z mask", "[frontend][tpp]") {
+    // TPP Z0 = exp(-i*pi/8 * Z0) = T 0
+    auto circuit = parse("TPP Z0");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.ops[0].is_dagger() == false);
+
+    // Rewound Z0 is just Z0
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
+    REQUIRE(hir.sign(hir.ops[0]) == false);
+}
+
+TEST_CASE("Frontend: TPP X0 emits T_GATE with X mask", "[frontend][tpp]") {
+    // TPP X0 = exp(-i*pi/8 * X0)
+    auto circuit = parse("TPP X0");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.ops[0].is_dagger() == false);
+
+    // Rewound X0 is X0 (no Cliffords to rewind through)
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);
+}
+
+TEST_CASE("Frontend: H then TPP X0 - mask reflects rewound X through H", "[frontend][tpp]") {
+    // H 0 maps Z0 <-> X0, so TPP X0 after H sees Z0
+    auto circuit = parse(R"(
+        H 0
+        TPP X0
+    )");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.ops[0].is_dagger() == false);
+
+    // H maps X0 -> Z0
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
+}
+
+TEST_CASE("Frontend: TPP_DAG Z0 emits dagger T_GATE", "[frontend][tpp]") {
+    auto circuit = parse("TPP_DAG Z0");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.ops[0].is_dagger() == true);
+    REQUIRE(hir.destab_mask(hir.ops[0]) == 0);
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
+}
+
+TEST_CASE("Frontend: TPP multi-qubit product emits multi-qubit mask", "[frontend][tpp]") {
+    auto circuit = parse("TPP X0*Z1");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.ops[0].is_dagger() == false);
+
+    // Rewound X0*Z1 is X0*Z1 (no Cliffords)
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(1));
+}
+
+TEST_CASE("Frontend: TPP on Y product emits multi-qubit mask", "[frontend][tpp]") {
+    auto circuit = parse("TPP Y0*Y1");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+
+    // Y has both X and Z bits: Y0*Y1 = X0*Z0*X1*Z1
+    REQUIRE(hir.destab_mask(hir.ops[0]) == (X(0) | X(1)));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == (Z(0) | Z(1)));
+}
+
+TEST_CASE("Frontend: SPP X0 then TPP Z0 - TPP sees rotated basis", "[frontend][mixed]") {
+    // SPP X0 absorbs (rotates Z to Y), then TPP Z0 emits T_GATE with Y mask
+    auto circuit = parse(R"(
+        SPP X0
+        TPP Z0
+    )");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(hir.ops[0].is_dagger() == false);
+
+    // After SPP X0, Z0 is conjugated to Y0: destab=X0, stab=Z0
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(0));
+    REQUIRE(hir.sign(hir.ops[0]) == false);
+}
+
+TEST_CASE("Frontend: CX entangles then TPP - multi-qubit mask", "[frontend][tpp]") {
+    auto circuit = parse(R"(
+        H 0
+        CX 0 1
+        TPP Z1
+    )");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
+
+    // After H 0; CX 0 1:
+    // Z1 rewound = H_dag CX_dag Z1 CX H = H_dag (Z0 Z1) H = X0 Z1
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(0));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == Z(1));
+}

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1888,8 +1888,10 @@ TEST_CASE("Frontend: SPP with H entangling then T - multi-qubit mask", "[fronten
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
 
-    // SPP is fully absorbed; T 1 sees the rewound Pauli through H and SPP.
-    REQUIRE((hir.destab_mask(hir.ops[0]) != 0 || hir.stab_mask(hir.ops[0]) != 0));
+    // SPP absorbed X0*Z1 then H 1. Rewound Z1 through H1 -> X1; SPP X0*Z1
+    // does not affect qubit 1, so T 1 sees X1: destab[1]=1, stab[1]=0.
+    REQUIRE(hir.destab_mask(hir.ops[0]) == X(1));
+    REQUIRE(hir.stab_mask(hir.ops[0]) == 0);
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1888,13 +1888,7 @@ TEST_CASE("Frontend: SPP with H entangling then T - multi-qubit mask", "[fronten
     REQUIRE(hir.num_ops() == 1);
     REQUIRE(hir.ops[0].op_type() == OpType::T_GATE);
 
-    // After SPP X0*Z1 and H 1:
-    // SPP^† = exp(+i*pi/4 * X0*Z1) acts on qubits 0 and 1
-    // Z1 rewound through H then SPP^†:
-    //   H on q1: Z1 -> X1
-    //   SPP^†: exp(+i*pi/4*X0*Z1) X1 exp(-i*pi/4*X0*Z1) = -X0*Z1 * X1 * X0*Z1 = -X0*Z1*X1*X0*Z1
-    // Actually this is complex. Let's just verify the HIR has 1 op and check structure.
-    // The key test is that SPP is fully absorbed (no T_GATE from SPP itself).
+    // SPP is fully absorbed; T 1 sees the rewound Pauli through H and SPP.
     REQUIRE((hir.destab_mask(hir.ops[0]) != 0 || hir.stab_mask(hir.ops[0]) != 0));
 }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1895,7 +1895,7 @@ TEST_CASE("Frontend: SPP with H entangling then T - multi-qubit mask", "[fronten
     //   SPP^†: exp(+i*pi/4*X0*Z1) X1 exp(-i*pi/4*X0*Z1) = -X0*Z1 * X1 * X0*Z1 = -X0*Z1*X1*X0*Z1
     // Actually this is complex. Let's just verify the HIR has 1 op and check structure.
     // The key test is that SPP is fully absorbed (no T_GATE from SPP itself).
-    REQUIRE(hir.destab_mask(hir.ops[0]) != 0 || hir.stab_mask(hir.ops[0]) != 0);
+    REQUIRE((hir.destab_mask(hir.ops[0]) != 0 || hir.stab_mask(hir.ops[0]) != 0));
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -2003,6 +2003,28 @@ TEST_CASE("Parse SPP rejects duplicate qubit in product", "[parser][spp]") {
     CHECK_NOTHROW(parse("TPP X0 Z0"));
 }
 
+TEST_CASE("Parse SPP with per-term bang parity", "[parser][spp]") {
+    auto circuit = parse("SPP !X0*!Z1");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    // Two ! invert twice -> no net inversion
+    REQUIRE(circuit.nodes[0].gate == GateType::SPP);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    REQUIRE(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
+}
+
+TEST_CASE("Parse TPP with per-term bang on second target", "[parser][tpp]") {
+    auto circuit = parse("TPP X0*!Y1");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    // One ! on second term -> odd count -> invert
+    REQUIRE(circuit.nodes[0].gate == GateType::TPP_DAG);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    REQUIRE(circuit.nodes[0].targets[1].pauli() == Target::kPauliY);
+}
+
 TEST_CASE("GateTraits: SPP/TPP arities and clifford flags", "[gate_data]") {
     CHECK(gate_arity(GateType::SPP) == GateArity::MULTI);
     CHECK(gate_arity(GateType::SPP_DAG) == GateArity::MULTI);

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1898,3 +1898,120 @@ TEST_CASE("GateTraits: rotation gate arities", "[gate_data][rotation]") {
     CHECK(!is_clifford(GateType::R_Z));
     CHECK(!is_measurement(GateType::R_Z));
 }
+
+TEST_CASE("Parse SPP single product", "[parser][spp]") {
+    auto circuit = parse("SPP X0*Z1*Y2");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    REQUIRE(circuit.nodes[0].gate == GateType::SPP);
+    REQUIRE(circuit.nodes[0].targets.size() == 3);
+
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    REQUIRE(circuit.nodes[0].targets[0].value() == 0);
+
+    REQUIRE(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
+    REQUIRE(circuit.nodes[0].targets[1].value() == 1);
+
+    REQUIRE(circuit.nodes[0].targets[2].pauli() == Target::kPauliY);
+    REQUIRE(circuit.nodes[0].targets[2].value() == 2);
+}
+
+TEST_CASE("Parse SPP multiple products", "[parser][spp]") {
+    auto circuit = parse("SPP X0*Z1 Y2");
+
+    REQUIRE(circuit.nodes.size() == 2);
+
+    REQUIRE(circuit.nodes[0].gate == GateType::SPP);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    REQUIRE(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
+
+    REQUIRE(circuit.nodes[1].gate == GateType::SPP);
+    REQUIRE(circuit.nodes[1].targets.size() == 1);
+    REQUIRE(circuit.nodes[1].targets[0].pauli() == Target::kPauliY);
+    REQUIRE(circuit.nodes[1].targets[0].value() == 2);
+}
+
+TEST_CASE("Parse SPP with bang inversion", "[parser][spp]") {
+    auto circuit = parse("SPP !X0*Z1");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    // ! inverts SPP -> SPP_DAG
+    REQUIRE(circuit.nodes[0].gate == GateType::SPP_DAG);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    REQUIRE(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
+}
+
+TEST_CASE("Parse SPP_DAG with bang inversion", "[parser][spp]") {
+    auto circuit = parse("SPP_DAG !X0*Z1");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    // ! inverts SPP_DAG -> SPP
+    REQUIRE(circuit.nodes[0].gate == GateType::SPP);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+}
+
+TEST_CASE("Parse TPP single product", "[parser][tpp]") {
+    auto circuit = parse("TPP X0*Y1");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    REQUIRE(circuit.nodes[0].gate == GateType::TPP);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    REQUIRE(circuit.nodes[0].targets[0].value() == 0);
+    REQUIRE(circuit.nodes[0].targets[1].pauli() == Target::kPauliY);
+    REQUIRE(circuit.nodes[0].targets[1].value() == 1);
+}
+
+TEST_CASE("Parse TPP with bang inversion", "[parser][tpp]") {
+    auto circuit = parse("TPP !Z0");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    // ! inverts TPP -> TPP_DAG
+    REQUIRE(circuit.nodes[0].gate == GateType::TPP_DAG);
+    REQUIRE(circuit.nodes[0].targets.size() == 1);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliZ);
+    REQUIRE(circuit.nodes[0].targets[0].value() == 0);
+}
+
+TEST_CASE("Parse TPP_DAG with bang inversion", "[parser][tpp]") {
+    auto circuit = parse("TPP_DAG !Y1");
+
+    REQUIRE(circuit.nodes.size() == 1);
+    // ! inverts TPP_DAG -> TPP
+    REQUIRE(circuit.nodes[0].gate == GateType::TPP);
+    REQUIRE(circuit.nodes[0].targets.size() == 1);
+    REQUIRE(circuit.nodes[0].targets[0].pauli() == Target::kPauliY);
+    REQUIRE(circuit.nodes[0].targets[0].value() == 1);
+}
+
+TEST_CASE("Parse SPP rejects no products", "[parser][spp]") {
+    CHECK_THROWS_AS(parse("SPP"), ParseError);
+    CHECK_THROWS_AS(parse("SPP_DAG"), ParseError);
+    CHECK_THROWS_AS(parse("TPP"), ParseError);
+    CHECK_THROWS_AS(parse("TPP_DAG"), ParseError);
+}
+
+TEST_CASE("Parse SPP rejects duplicate qubit in product", "[parser][spp]") {
+    CHECK_THROWS_AS(parse("SPP X0*Z0"), ParseError);
+    CHECK_THROWS_AS(parse("TPP Y1*X1"), ParseError);
+    // Different qubits in same product is fine
+    CHECK_NOTHROW(parse("SPP X0*Z1"));
+    // Same qubit in different products is fine
+    CHECK_NOTHROW(parse("SPP X0 Z0"));
+    CHECK_NOTHROW(parse("TPP X0 Z0"));
+}
+
+TEST_CASE("GateTraits: SPP/TPP arities and clifford flags", "[gate_data]") {
+    CHECK(gate_arity(GateType::SPP) == GateArity::MULTI);
+    CHECK(gate_arity(GateType::SPP_DAG) == GateArity::MULTI);
+    CHECK(gate_arity(GateType::TPP) == GateArity::MULTI);
+    CHECK(gate_arity(GateType::TPP_DAG) == GateArity::MULTI);
+    CHECK(is_clifford(GateType::SPP));
+    CHECK(is_clifford(GateType::SPP_DAG));
+    CHECK(!is_clifford(GateType::TPP));
+    CHECK(!is_clifford(GateType::TPP_DAG));
+    CHECK(!is_measurement(GateType::SPP));
+    CHECK(!is_measurement(GateType::TPP));
+}

--- a/tests/test_statevector.cc
+++ b/tests/test_statevector.cc
@@ -1071,3 +1071,116 @@ TEST_CASE("Peephole statevector: optimized equals unoptimized componentwise") {
         }
     }
 }
+
+// =============================================================================
+// SPP/TPP pipeline statevector equivalence tests
+// =============================================================================
+
+TEST_CASE("SPP Z0 on |0> produces normalized |0> state") {
+    auto sv = pipeline_statevector("SPP Z0");
+    REQUIRE(sv.size() == 2);
+    check_normalized(sv, kFloatTol);
+}
+
+TEST_CASE("SPP_DAG Z0 on |0> produces normalized |0> state") {
+    auto sv = pipeline_statevector("SPP_DAG Z0");
+    REQUIRE(sv.size() == 2);
+    check_normalized(sv, kFloatTol);
+}
+
+TEST_CASE("TPP Z0 on |0> produces normalized |0> state") {
+    auto sv = pipeline_statevector("TPP Z0");
+    REQUIRE(sv.size() == 2);
+    check_normalized(sv, kFloatTol);
+}
+
+TEST_CASE("TPP_DAG Z0 on |0> produces normalized |0> state") {
+    auto sv = pipeline_statevector("TPP_DAG Z0");
+    REQUIRE(sv.size() == 2);
+    check_normalized(sv, kFloatTol);
+}
+
+TEST_CASE("SPP X0 on |0> produces equal superposition of |0> and |1>") {
+    auto sv = pipeline_statevector("SPP X0");
+    REQUIRE(sv.size() == 2);
+    check_normalized(sv, kFloatTol);
+    CHECK_THAT(std::abs(sv[0]), Catch::Matchers::WithinAbs(kInvSqrt2, kFloatTol));
+    CHECK_THAT(std::abs(sv[1]), Catch::Matchers::WithinAbs(kInvSqrt2, kFloatTol));
+}
+
+TEST_CASE("TPP X0 on |0> produces equal superposition of |0> and |1>") {
+    auto sv = pipeline_statevector("TPP X0");
+    REQUIRE(sv.size() == 2);
+    check_normalized(sv, kFloatTol);
+    CHECK_THAT(std::abs(sv[0]), Catch::Matchers::WithinAbs(kInvSqrt2, kFloatTol));
+    CHECK_THAT(std::abs(sv[1]), Catch::Matchers::WithinAbs(kInvSqrt2, kFloatTol));
+}
+
+TEST_CASE("SPP multi-qubit product matches sequential single-qubit SPP") {
+    auto sv_multi = pipeline_statevector("SPP X0*Z1");
+    auto sv_seq = pipeline_statevector("SPP Z1\nSPP X0");
+    REQUIRE(sv_multi.size() == 4);
+    REQUIRE(sv_seq.size() == 4);
+    for (size_t i = 0; i < 4; ++i) {
+        check_complex(sv_multi[i], sv_seq[i], kFloatTol);
+    }
+}
+
+TEST_CASE("SPP bang parity: ! applied twice cancels") {
+    auto sv_ref = pipeline_statevector("SPP X0");
+    auto sv_invert = pipeline_statevector("SPP !X0*!Z1\nSPP Z1");
+    REQUIRE(sv_ref.size() == 2);
+    REQUIRE(sv_invert.size() == 4);
+    check_complex(sv_invert[0], sv_ref[0], kFloatTol);
+    check_complex(sv_invert[1], sv_ref[1], kFloatTol);
+}
+
+TEST_CASE("TPP Y0*Y1 matches product of single-qubit TPP Y") {
+    auto sv_multi = pipeline_statevector("TPP Y0*Y1");
+    auto sv_seq = pipeline_statevector("TPP Y1\nTPP Y0");
+    REQUIRE(sv_multi.size() == 4);
+    REQUIRE(sv_seq.size() == 4);
+    for (size_t i = 0; i < 4; ++i) {
+        check_complex(sv_multi[i], sv_seq[i], kFloatTol);
+    }
+}
+
+TEST_CASE("SPP then Clifford then TPP produces normalized state") {
+    auto sv = pipeline_statevector(R"(
+        SPP X0*Z1
+        H 1
+        TPP Z1
+    )");
+    REQUIRE(sv.size() == 4);
+    check_normalized(sv, kFloatTol);
+}
+
+TEST_CASE("SPP Z0 and S 0 produce same statevector") {
+    auto sv_spp = pipeline_statevector("SPP Z0");
+    auto sv_s = pipeline_statevector("S 0");
+    REQUIRE(sv_spp.size() == sv_s.size());
+    for (size_t i = 0; i < sv_spp.size(); ++i) {
+        check_complex(sv_spp[i], sv_s[i], kFloatTol);
+    }
+}
+
+TEST_CASE("TPP Z0 and T 0 produce same statevector") {
+    auto sv_tpp = pipeline_statevector("TPP Z0");
+    auto sv_t = pipeline_statevector("T 0");
+    REQUIRE(sv_tpp.size() == sv_t.size());
+    for (size_t i = 0; i < sv_tpp.size(); ++i) {
+        check_complex(sv_tpp[i], sv_t[i], kFloatTol);
+    }
+}
+
+TEST_CASE("SPP bang parity inverts gate") {
+    auto sv_no_bang = pipeline_statevector("SPP Z0");
+    auto sv_bang = pipeline_statevector("SPP !Z0");
+    auto sv_dag = pipeline_statevector("SPP_DAG Z0");
+    REQUIRE(sv_no_bang.size() == sv_bang.size());
+    REQUIRE(sv_dag.size() == sv_bang.size());
+    // SPP !Z0 should equal SPP_DAG Z0
+    for (size_t i = 0; i < sv_bang.size(); ++i) {
+        check_complex(sv_bang[i], sv_dag[i], kFloatTol);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #130 — adds SPP/SPP_DAG and TPP/TPP_DAG Pauli-product phase gates to the parser, frontend, and gate definitions. SPP is Clifford (absorbed into tableau), TPP is non-Clifford (emits HIR T_GATE via rewinding).

## Test plan

- [x] C++ tests pass (ctest --test-dir build -E Bench --output-on-failure)
- [x] Python tests pass (uv run pytest tests/python/ -v)
- [ ] Doc examples pass (uv run pytest --codeblocks docs/ README.md -v)
- [x] Pre-commit checks pass (uv run pre-commit run --all-files)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's Apache-2.0 license.
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an \`Assisted-by:\` git trailer in the commit message.
