### PR TITLE
docs(design): sqale-sim alignment spike findings + checkpoint plan

### DIFF
--- a/design/sqale-alignment.md
+++ b/design/sqale-alignment.md
@@ -1,17 +1,20 @@
-# sqale-sim alignment spike
+# sqale-sim alignment: spike findings and checkpoint plan
 
-Status: prototype spike on the `codex/noncomputational-structural-mvp` feature
-branch. This document is the standalone record of a one-time validation: how the
-clifft noncomputational MVP compares to Infleqtion's sqale-sim leakage simulator,
-where they agree, where they differ, and how fast clifft is by comparison. It is
-a decision artifact, not a spec.
+Status: design doc on the `codex/noncomputational-structural-mvp` feature
+branch. Part one records a one-time validation spike: how the clifft
+noncomputational MVP compares to Infleqtion's sqale-sim leakage simulator,
+where they agree, where they differ, and how fast clifft is by comparison.
+Part two is the plan of record for the next phase: a checkpoint that covers
+sqale-sim's noise model as far as possible within clifft's ahead-of-time
+architecture, with the residual approximations characterized and measured
+rather than discovered.
 
 ## Why
 
 The noncomputational MVP was built to recreate sqale-sim's loss/leakage
 simulation capability in clifft's near-Clifford style, with the hope of being
-substantially faster than their cirq-stabilizer prototype. Before investing in
-more features, this spike answers three questions:
+substantially faster than their cirq-stabilizer prototype. The spike answered
+three questions:
 
 1. Correctness: does clifft produce the right physics where the two simulators
    model the same thing?
@@ -41,15 +44,28 @@ stabilizer/Clifford quantum core plus a classical leakage tracker. Specifics:
 - It also models coherent errors (gate over-rotations, CZ/movement phase errors)
   and Pauli-twirls non-Clifford gates to stay on the stabilizer simulator. The
   clifft MVP models none of these.
-- Two important internal behaviors:
+- Important internal behaviors, read from `leakage_sim.py`:
   - It propagates the classical leakage distribution and samples late; an
     `oversample` option amortizes one stabilizer run over many leakage draws.
     That amortization requires terminal measurements, so it does not apply to
     multi-round QEC circuits.
-  - For a leakage jump on a qubit that is not in a definite computational state,
-    it does not handle the source-dependence exactly: it equalizes the
-    computational columns and collapses the qubit, with a code comment noting
-    this is a conservative approximation. Only its dense reference is exact.
+  - At a jump site (`_apply_jump`) it first queries the stabilizer tableau
+    (`_promote_classical`): if the qubit is deterministic in Z it takes an
+    exact per-column path. Only for a genuinely indeterminate qubit does it
+    approximate (`_approximate_jumps`): it pads the lower-rate computational
+    column's diagonal so both columns sum to the same total (the padding is a
+    pseudo self-jump, i.e. pure dephasing), draws "jump fired" at that
+    equalized rate, and on fire Born-measures the qubit on the stabilizer
+    state and draws the destination from the measured bit's column. A code
+    comment notes this is a conservative approximation; only its dense
+    reference is exact.
+  - Downstream gates touching a leaked or lost qubit are skipped, lazily.
+    Diagonal gates on classically-tracked qubits are no-ops; any other gate
+    triggers a subspace measurement (`_collapse_qubit_subspace`): if the level
+    is computational the qubit re-enters the stabilizer simulator and the gate
+    proceeds, otherwise the entire operation is skipped, identity on the
+    partner included. Jump channels still fire on leaked qubits (that branch
+    precedes the skip), so re-entry through from-leak transition columns works.
 - It ships a dense density-matrix reference, `simulate_true_distribution`, which
   its own unit tests assert against. We use that as the ground truth here.
 
@@ -119,53 +135,205 @@ cost, far above plain sampling), but clifft is far enough ahead that this is not
 a competitive bottleneck. Caching the rewrite/compile would buy roughly another
 order of magnitude; it is an optimization, not a requirement for parity.
 
-## Gaps
+## Gap analysis
 
 Matches today (clifft equals sqale's dense truth): initial population, binary
 readout classifier, pure-leakage transitions that are either known-source or
 source-independent, and the performance shown above.
 
-Two gaps define the boundary of the exact overlap:
+The spike originally identified two gaps. Their status:
 
-- Gap A, computational-to-computational transfer. sqale's matrices may move
-  population between computational levels (for example `g -> e`); sqale moves the
-  amplitude and the readout changes, whereas clifft tracks the level label but
-  does not flip the simulator state, so it silently ignores the readout effect.
-  clifft should at least reject or warn on a computational-destination
-  transition; modeling it faithfully means treating it as a Pauli error.
-- Gap B, source-dependent leakage on a superposed qubit. clifft rejects this
-  (it cannot pick a source column for an unknown computational state). Note that
-  sqale's fast path does not do this exactly either; it equalizes the columns and
-  collapses the qubit. So parity here is implementing the same equalized-rates
-  approximation, not matching an exact behavior.
+- Gap A, computational-destination transitions (for example relaxation mass
+  such as `T[g][e]`): **resolved**. clifft now materializes the carrier at the
+  sampled destination level (a hidden reset, plus an X for a `basis_bit == One`
+  destination, inserted after the base op), implementing the channel
+  `rho -> |d><d| (x) Tr_q(rho)`. Relaxation and recapture entries are modeled
+  exactly; the spike-era behavior of silently tracking the level label without
+  updating the simulator state is gone.
+- Gap B, source-dependent transitions on a qubit whose computational state is
+  not known: **open**, and the gating gap for realistic circuits. clifft
+  rejects these (it cannot pick a source column). sqale's fast path cannot do
+  them exactly either; it takes the equalize-and-collapse approximation
+  described above. Parity here means implementing the same approximation, not
+  matching an exact behavior.
+- A third gap became visible once Gap B's fix was scoped: **structural policy
+  on leaked/lost operands**. sqale skips downstream operations touching a
+  leaked or lost qubit (identity on the survivors); clifft's defaults reject
+  most of these cases (two-qubit gates on a lost operand, gates on leaked
+  operands, multi-qubit noise and classical feedback on lost operands). Without
+  a skip-equivalent policy, any multi-round circuit rejects shortly after its
+  first leak event, regardless of Gap B.
 
 Consequence: sqale's real device matrices mix computational transfer with
-leakage and apply it on superposed qubits, so they hit both gaps. The exact
-overlap is the clean subset (known-source or source-independent, pure leakage).
+leakage and apply it on superposed qubits over many rounds. Covering them needs
+Gap B plus the drop policy; Gap A is already done.
 
-## Ranked next work, if continuing
+## Checkpoint plan
 
-1. Equalized-rates / unknown-source approximation (Gap B). This is what widens
-   the overlap from the clean subset to sqale's real circuits, and sqale itself
-   only approximates here, so it is achievable parity. The MVP design already
-   anticipates an `unknown_source_policy = equalize_rates` knob.
-2. Ternary loss herald (a readout "loss" symbol). Leakage detection is the point
-   of QEC leakage studies, and it is needed to compare measurement records once a
-   lost level is populated.
-3. Gap A guard: reject or warn on a computational-destination transition. A cheap
-   correctness and trust fix; full computational-transfer modeling as a Pauli
-   error is separate and lower priority.
-4. Coherent errors (over-rotations, phase). Large in sqale's real model, but not
-   the validation bottleneck; clifft could model these exactly rather than
-   twirling them, which would be an accuracy advantage.
-5. Rewrite/compile caching. A performance optimization; not needed for parity
-   given the current ~60x margin.
-6. Movement / atom-site semantics, correlated two-qubit leakage, exact diagonal
-   filters. Future or out of scope.
+Goal: run sqale-sim's full default noise model (the 2LQ-paper neutral-atom
+parameter set) end to end on clifft, matching its fast path within shot noise
+on all marginal statistics, with every residual approximation named, bounded,
+and measured.
 
-## Conclusion
+### Constraint envelope
 
-clifft is correct where it overlaps sqale-sim and is decisively faster (~60-90x)
-on QEC-style circuits, so the approach is worth continuing. The single
-highest-value next feature is the equalized-rates approximation (Gap B), which
-extends the exact overlap to the kind of circuits sqale actually runs.
+Two architectural principles bound this checkpoint:
+
+1. **Ahead-of-time only.** Every noncomputational event is resolved before
+   compilation: the trajectory sampler decides what happens, the rewriter
+   materializes it, and the compiled circuit is straight-line. No runtime
+   branching, no segmented execution, no JIT.
+2. **No coherent noise simulation.** Coherent control errors are converted to
+   twirled Pauli channels ahead of time. This matches the reference
+   simulator's own fast path, which Pauli-twirls non-Clifford gates; its dense
+   simulator is the only place coherent noise is simulated coherently.
+
+### Coverage target
+
+| Mechanism (sqale `SqaleNoiseParams`) | clifft status under the envelope |
+| --- | --- |
+| `initial_state_probs` | exact today |
+| `classifier_errors` (g/e confusion) | exact today |
+| Transition matrices: pure leak, known-source or source-independent | exact today |
+| Transition matrices: computational destinations (relaxation/recapture) | exact today (carrier materialization) |
+| Transition matrices: source-dependent on an indeterminate qubit | build: equalized-rates approximation; marginals exact on Clifford circuits, two documented divergences (below) |
+| Downstream ops on leaked/lost qubits | build: drop policy profile (identity on survivors, equals sqale's lazy skip) |
+| Lost level at readout (ternary symbol "2") | build: three-symbol classifier; herald delivered in the sidecar, visible record stays binary |
+| `cz_phase_error`, `movement_phase_error` (stochastic Z) | expressible as `Z_ERROR` instructions; verify passthrough on the noncomputational path |
+| `gr_*` / `rz_relative_overrotation` (coherent) | build: twirl-to-Pauli conversion helper, channels inserted ahead of time |
+| Exact state-dependent jumps; movement/atom-site semantics; correlated two-qubit leakage; `oversample` | out of scope (see successor architecture; `oversample` is inapplicable to multi-round QEC circuits anyway) |
+
+### Work items
+
+1. **Equalized rates plus drop policy (one unit; they are only useful
+   together).** Sampler policy `unknown_source_policy = equalize_rates`: pad
+   the lower-rate computational column's diagonal so both columns sum to
+   `p_max` (the padding is a pseudo self-jump, i.e. dephasing), draw firing at
+   `p_max` ahead of time, on fire draw the source bit uniformly and the
+   destination from that renormalized column. The collapse reuses existing
+   machinery: trace-out reset for leaked/lost destinations, carrier
+   materialization for computational destinations (for the pseudo self-jump
+   the inserted reset is the dephasing itself). Alongside it, a policy profile
+   that drops operations on leaked/lost operands (two-qubit gates, noise,
+   classical feedback) instead of rejecting, matching sqale's skip. The drop
+   is statistically equivalent to their lazy skip because both are samplings
+   of the same Markov branch process, early versus late, with downstream
+   treatment depending only on the branch. Also folds in the sampler
+   initial-draw floating-point-tail fix.
+2. **Ternary loss herald.** Three-symbol classifier columns where the third
+   symbol heralds loss. The visible record stays binary (record-layout
+   invariance is load-bearing); the herald symbol is returned per measurement
+   in the sidecar. An in-record herald bit is deferred until decoder work
+   needs it. Includes the base-3 adapter for comparing against sqale records.
+3. **Coherent-error compatibility.** Verify Pauli/`Z_ERROR` channels pass
+   through the noncomputational path on alive operands (and drop on
+   leaked/lost ones), then add a helper converting over-rotation and phase
+   parameters to Pauli channel probabilities via the standard twirl formula
+   `p_P = |tr(U P)|^2 / 4`. Kept out of the noncomputational model surface:
+   these are explicit noise instructions in the circuit.
+4. **Validation campaign.** See below.
+5. **Demonstration notebook.** A plain `examples/*.ipynb` walking from the
+   physics (extended Hilbert space, loss versus leakage, transition matrices
+   as quantum instruments, state-dependent versus state-independent
+   transitions, why equalized rates is the honest classical-sampling
+   approximation) through the API by physical scenario (Bell-pair loss to a
+   50/50 survivor, relaxation with an analytic check, heralded loss), to a
+   realistic neutral-atom model on a repetition-code memory circuit, accuracy
+   comparisons against the dense oracle (including exact-versus-twirled
+   over-rotation, where clifft's near-Clifford exactness is an accuracy edge),
+   and a closing capability/gap summary. No cirq-superstaq dependency:
+   external comparisons appear as cited result tables from the local
+   differential.
+
+### Known divergences from sqale's fast path
+
+The equalized-rates feature matches sqale's fast path exactly in all marginal
+statistics on Clifford circuits. This is structural, not luck: in a stabilizer
+state a qubit at a jump site is either deterministic in Z (both simulators
+take an exact path) or its measurement is exactly 50/50, so drawing the source
+bit uniformly ahead of time reproduces the Born marginal identically. Two
+joint-statistics divergences remain:
+
+1. **Destination-partner correlations.** sqale Born-measures the qubit at the
+   jump and conditions the destination on that bit, so the destination level
+   (and hence the leaked qubit's readout symbol) is correlated with entangled
+   partners. clifft's ahead-of-time source draw is independent of the
+   simulator's internal collapse, so the joint distribution of the leaked
+   qubit's symbol and its partners' records decorrelates while every marginal
+   matches. Closing this requires the destination to depend on a runtime
+   outcome, which is exactly the runtime-branching boundary of the constraint
+   envelope. Second order in the leak rate; measured, not fixed, in this
+   checkpoint.
+2. **Gate-deterministic but untracked states.** sqale's exact-path test
+   queries the stabilizer tableau; clifft's status tracker only knows
+   instruction-determined states (after reset or by prior status). A qubit
+   made deterministic by gate algebra (for example two consecutive H gates, or
+   an X echo) takes sqale's exact path but clifft's approximate path, where
+   the uniform source draw can leak or flip a qubit that deterministically
+   could not. The error is bounded by the equalized rate per site (the same
+   scale as the noise being modeled: misattributed noise, not a new O(1)
+   error) and only applies to the deterministic-but-untracked subset of sites,
+   which is small in typical QEC circuits (mid-round data qubits are genuinely
+   entangled; ancillas are instruction-known after reset). The mitigation,
+   maintaining a Clifford tableau in the trajectory sampler to promote a
+   status to known whenever the tableau is deterministic, is compatible with
+   the constraint envelope but is built only if the validation probes show it
+   matters. It could not promote through a measurement in any case:
+   measurement outcomes live in the simulator and are not pre-sampled.
+
+### Validation
+
+Confidence comes from a campaign, not just unit tests:
+
+- **Differential on the full default model.** Run the local differential on
+  the complete 2LQ-paper parameter set on repetition-code circuits: clifft
+  versus sqale's fast sampler (expect shot-noise agreement on marginals), and
+  both versus `simulate_true_distribution` on tiny circuits (quantifies the
+  approximation error the two fast paths share). Results land in this
+  document.
+- **Divergence probes.** Two targeted differentials: a Bell pair with a
+  source-dependent leak comparing the joint distribution of the leaked
+  qubit's symbol and the partner's record (measures divergence 1), and a
+  deterministic-but-untracked micro-case with consecutive H gates before the
+  jump site (bounds divergence 2).
+- **Committed oracle extensions.** Extend the in-tree density-matrix oracle
+  with the equalized channel as an explicit CPTP map and with the ternary
+  classifier, so the new features are cross-checked in CI without any
+  external dependency.
+- **Analytic micro-cases.** A plus state under an equalized leak
+  (hand-computable dephasing and jump statistics) and a single twirled
+  over-rotation versus its exact simulation.
+
+### Success criterion
+
+Full default-parameter repetition-code circuits run end to end on clifft with
+no rejects, matching sqale's fast path within shot noise on all marginal
+statistics, with the residual joint-statistics divergence quantified in this
+document.
+
+## Successor architecture (out of scope, named)
+
+The three residual approximations of this checkpoint, the destination-partner
+correlation loss, the deterministic-but-untracked class, and the equalization
+dephasing itself, share one root cause: the destination of a fired jump should
+depend on a measurement outcome that exists only inside the simulator at
+runtime. Everything else stays ahead-of-time. The successor is therefore a
+segmented-continuation ladder:
+
+1. **Per-shot two-branch precompilation.** Trajectory sampling already fixes
+   where jumps fire, ahead of time and state-independently; the only runtime
+   choice is one bit per fired jump. A shot needs `2^f` precompiled
+   continuations where `f` is the number of fired jumps in that shot, which at
+   realistic rates is almost always 0 and occasionally 1. A segmented runtime
+   selects the continuation on the collapse outcome; nothing is compiled at
+   runtime.
+2. **JIT or cached continuations**, only if branch counts or compile costs
+   ever bite.
+
+Any rung of this ladder does more than fix the divergences: once the runtime
+can branch on the collapse outcome, the equalization is unnecessary and the
+exact state-dependent no-jump filter can be applied as a localized spectral
+Kraus branch (`a I + b Z_v`) on the active state, at which point clifft is no
+longer matching the reference fast path but its dense ground truth, while
+staying near-Clifford fast. That is the designated next tier after this
+checkpoint, deliberately not part of it.

--- a/design/sqale-alignment.md
+++ b/design/sqale-alignment.md
@@ -1,0 +1,171 @@
+# sqale-sim alignment spike
+
+Status: prototype spike on the `codex/noncomputational-structural-mvp` feature
+branch. This document is the standalone record of a one-time validation: how the
+clifft noncomputational MVP compares to Infleqtion's sqale-sim leakage simulator,
+where they agree, where they differ, and how fast clifft is by comparison. It is
+a decision artifact, not a spec.
+
+## Why
+
+The noncomputational MVP was built to recreate sqale-sim's loss/leakage
+simulation capability in clifft's near-Clifford style, with the hope of being
+substantially faster than their cirq-stabilizer prototype. Before investing in
+more features, this spike answers three questions:
+
+1. Correctness: does clifft produce the right physics where the two simulators
+   model the same thing?
+2. Performance: is clifft fast enough to justify continuing?
+3. Gaps: what does sqale-sim do that clifft does not, ranked, so feature work
+   can be prioritized by evidence.
+
+Reference: Infleqtion `client-superstaq` PR #1353 (`cirq_superstaq/sim/`), read
+at head `f007480`. The leakage sim is not on PyPI; it lives only in that PR.
+
+## What sqale-sim is
+
+Architecturally it is the same idea as clifft's noncomputational path: a
+stabilizer/Clifford quantum core plus a classical leakage tracker. Specifics:
+
+- `LeakageState` extends cirq's `StabilizerSimulationState` and adds a per-qubit
+  `ClassicalDistribution` over a 5-level qudit. The five levels correspond 1:1 to
+  clifft's default set: `0=g, 1=e, 2=leak_g, 3=leak_e, 4=lost`.
+- Leakage is expressed as `JumpChannel` transition matrices attached to CZ and RZ
+  gates, where `T[i, j]` is the probability of jumping from level `j` to level
+  `i`, and a column summing to less than one leaves the remainder as "no jump."
+  This is the same `T[to][from]` convention and the same no-jump-is-the-deficit
+  semantics clifft uses.
+- The readout classifier is itself a transition channel and is ternary: levels
+  `g, leak_g` read 0; `e, leak_e` read 1; `lost` reads a third symbol "2" (a
+  heralded-loss outcome). clifft's classifier is binary.
+- It also models coherent errors (gate over-rotations, CZ/movement phase errors)
+  and Pauli-twirls non-Clifford gates to stay on the stabilizer simulator. The
+  clifft MVP models none of these.
+- Two important internal behaviors:
+  - It propagates the classical leakage distribution and samples late; an
+    `oversample` option amortizes one stabilizer run over many leakage draws.
+    That amortization requires terminal measurements, so it does not apply to
+    multi-round QEC circuits.
+  - For a leakage jump on a qubit that is not in a definite computational state,
+    it does not handle the source-dependence exactly: it equalizes the
+    computational columns and collapses the qubit, with a code comment noting
+    this is a conservative approximation. Only its dense reference is exact.
+- It ships a dense density-matrix reference, `simulate_true_distribution`, which
+  its own unit tests assert against. We use that as the ground truth here.
+
+## Methodology
+
+Differential comparison: build a clifft `noncomp.Model` equivalent to a given
+sqale scenario, run `sample_noncomputational`, and compare the output
+distribution to sqale's `simulate_true_distribution` within shot noise.
+
+Reconciliation needed to line the two up:
+
+- Levels map 1:1 (above).
+- sqale prepends a pi pulse that flips the computational subspace (`g <-> e`) and
+  no-ops on leak/lost. We absorb it by swapping the `g` and `e` entries of
+  clifft's `initial_state`; clifft's normal `|1>` X-prep plus a binary classifier
+  then reproduces sqale's readout with no extra gate (and avoids clifft rejecting
+  an X applied to an initially-leaked qubit).
+- The leakage transition is hooked on a Z-type gate (`S`), which sqale treats as
+  an RZ (`ZPowGate`) carrying its `rz_transition_matrix`.
+
+Performance: a ladder on repetition-code memory circuits (H'd data qubits, CX
+syndrome rounds with ancilla measure-reset, an `S` layer on the data carrying the
+leakage hook, terminal data measurement), comparing clifft plain, clifft noncomp
+with no events, with certain leakage, and with low-probability leakage, against
+sqale's per-shot sampler. The clifft Python extension was a Release build.
+
+Reproduction: install cirq-superstaq from the PR ref into a local venv and run
+the local (uncommitted) spike scripts:
+
+```
+uv pip install "cirq-superstaq @ \
+  git+https://github.com/Infleqtion/client-superstaq.git@f007480#subdirectory=cirq-superstaq"
+.venv/bin/python sqale_align_local/differential.py
+.venv/bin/python sqale_align_local/perf.py
+```
+
+The sqale dependency and the comparison scripts are deliberately kept local and
+out of the committed dependencies and CI.
+
+## Correctness results
+
+Where clifft and sqale model the same thing, clifft reproduces sqale's dense
+ground truth within shot noise:
+
+| Scenario | Agrees |
+| --- | --- |
+| Initial leakage population + classifier | yes |
+| Pure-leakage transition with a known computational source | yes |
+| Source-independent leakage on a superposed qubit | yes |
+
+## Performance results
+
+Repetition-code memory circuits, milliseconds per shot (clifft = noncomp with
+low-probability leakage; sqale = per-shot sampler):
+
+| Qubits | clifft noncomp | sqale | speedup |
+| --- | --- | --- | --- |
+| 5 | 0.024 | 2.2 | ~90x |
+| 17 | 0.14 | 9.2 | ~67x |
+| 33 | 0.30 | 21 | ~71x |
+| 49 | 0.99 | 57 | ~58x |
+
+clifft is roughly 60-90x faster across the range, and the gap holds as the qubit
+count grows. Per-shot recompilation is clifft's dominant per-shot cost in the
+noncomputational path (the no-event noncomp time is close to the compile-once
+cost, far above plain sampling), but clifft is far enough ahead that this is not
+a competitive bottleneck. Caching the rewrite/compile would buy roughly another
+order of magnitude; it is an optimization, not a requirement for parity.
+
+## Gaps
+
+Matches today (clifft equals sqale's dense truth): initial population, binary
+readout classifier, pure-leakage transitions that are either known-source or
+source-independent, and the performance shown above.
+
+Two gaps define the boundary of the exact overlap:
+
+- Gap A, computational-to-computational transfer. sqale's matrices may move
+  population between computational levels (for example `g -> e`); sqale moves the
+  amplitude and the readout changes, whereas clifft tracks the level label but
+  does not flip the simulator state, so it silently ignores the readout effect.
+  clifft should at least reject or warn on a computational-destination
+  transition; modeling it faithfully means treating it as a Pauli error.
+- Gap B, source-dependent leakage on a superposed qubit. clifft rejects this
+  (it cannot pick a source column for an unknown computational state). Note that
+  sqale's fast path does not do this exactly either; it equalizes the columns and
+  collapses the qubit. So parity here is implementing the same equalized-rates
+  approximation, not matching an exact behavior.
+
+Consequence: sqale's real device matrices mix computational transfer with
+leakage and apply it on superposed qubits, so they hit both gaps. The exact
+overlap is the clean subset (known-source or source-independent, pure leakage).
+
+## Ranked next work, if continuing
+
+1. Equalized-rates / unknown-source approximation (Gap B). This is what widens
+   the overlap from the clean subset to sqale's real circuits, and sqale itself
+   only approximates here, so it is achievable parity. The MVP design already
+   anticipates an `unknown_source_policy = equalize_rates` knob.
+2. Ternary loss herald (a readout "loss" symbol). Leakage detection is the point
+   of QEC leakage studies, and it is needed to compare measurement records once a
+   lost level is populated.
+3. Gap A guard: reject or warn on a computational-destination transition. A cheap
+   correctness and trust fix; full computational-transfer modeling as a Pauli
+   error is separate and lower priority.
+4. Coherent errors (over-rotations, phase). Large in sqale's real model, but not
+   the validation bottleneck; clifft could model these exactly rather than
+   twirling them, which would be an accuracy advantage.
+5. Rewrite/compile caching. A performance optimization; not needed for parity
+   given the current ~60x margin.
+6. Movement / atom-site semantics, correlated two-qubit leakage, exact diagonal
+   filters. Future or out of scope.
+
+## Conclusion
+
+clifft is correct where it overlaps sqale-sim and is decisively faster (~60-90x)
+on QEC-style circuits, so the approach is worth continuing. The single
+highest-value next feature is the equalized-rates approximation (Gap B), which
+extends the exact overlap to the kind of circuits sqale actually runs.

--- a/design/sqale-alignment.md
+++ b/design/sqale-alignment.md
@@ -135,6 +135,13 @@ cost, far above plain sampling), but clifft is far enough ahead that this is not
 a competitive bottleneck. Caching the rewrite/compile would buy roughly another
 order of magnitude; it is an optimization, not a requirement for parity.
 
+These are local spike results: produced by the uncommitted scripts described
+under Methodology, on a Release build, on the repetition-code family described
+there. The checkpoint plan below replaces them with auditable numbers: a
+committed, optional benchmark script whose clifft-side ladder always runs and
+whose sqale comparison column activates only when cirq-superstaq is installed
+locally (mirroring the optional differential test), never in CI.
+
 ## Gap analysis
 
 Matches today (clifft equals sqale's dense truth): initial population, binary
@@ -170,10 +177,13 @@ Gap B plus the drop policy; Gap A is already done.
 
 ## Checkpoint plan
 
-Goal: run sqale-sim's full default noise model (the 2LQ-paper neutral-atom
-parameter set) end to end on clifft, matching its fast path within shot noise
-on all marginal statistics, with every residual approximation named, bounded,
-and measured.
+Goal: run a sqale fast-path-compatible default profile (the 2LQ-paper
+neutral-atom parameter set, as translated into the supported circuit family)
+end to end on clifft, agreeing with sqale's fast path within shot noise on
+marginal statistics, with every residual approximation named, bounded, and
+measured. "Compatible profile" is deliberate: the doc's own divergence and
+out-of-scope sections bound what this checkpoint covers, so it does not claim
+the full model.
 
 ### Constraint envelope
 
@@ -196,14 +206,20 @@ Two architectural principles bound this checkpoint:
 | `classifier_errors` (g/e confusion) | exact today |
 | Transition matrices: pure leak, known-source or source-independent | exact today |
 | Transition matrices: computational destinations (relaxation/recapture) | exact today (carrier materialization) |
-| Transition matrices: source-dependent on an indeterminate qubit | build: equalized-rates approximation; marginals exact on Clifford circuits, two documented divergences (below) |
-| Downstream ops on leaked/lost qubits | build: drop policy profile (identity on survivors, equals sqale's lazy skip) |
+| Transition matrices: source-dependent on an indeterminate qubit | build: equalized-rates approximation (opt-in; default remains reject); designed to match fast-path marginals on Clifford circuits, two documented divergences (below) |
+| Downstream ops on leaked/lost qubits | build: opt-in drop policy (identity on survivors, equals sqale's lazy skip; default remains reject) |
 | Lost level at readout (ternary symbol "2") | build: three-symbol classifier; herald delivered in the sidecar, visible record stays binary |
 | `cz_phase_error`, `movement_phase_error` (stochastic Z) | expressible as `Z_ERROR` instructions; verify passthrough on the noncomputational path |
 | `gr_*` / `rz_relative_overrotation` (coherent) | build: twirl-to-Pauli conversion helper, channels inserted ahead of time |
 | Exact state-dependent jumps; movement/atom-site semantics; correlated two-qubit leakage; `oversample` | out of scope (see successor architecture; `oversample` is inapplicable to multi-round QEC circuits anyway) |
 
 ### Work items
+
+The notebook comes last on purpose: it reports measured evidence, so the
+features and the divergence probes must exist first. The twirl helper lands
+before the final differential because the default parameter set includes
+coherent terms; running the full-profile comparison earlier would either zero
+them or require a second pass.
 
 1. **Equalized rates plus drop policy (one unit; they are only useful
    together).** Sampler policy `unknown_source_policy = equalize_rates`: pad
@@ -213,26 +229,43 @@ Two architectural principles bound this checkpoint:
    destination from that renormalized column. The collapse reuses existing
    machinery: trace-out reset for leaked/lost destinations, carrier
    materialization for computational destinations (for the pseudo self-jump
-   the inserted reset is the dephasing itself). Alongside it, a policy profile
-   that drops operations on leaked/lost operands (two-qubit gates, noise,
-   classical feedback) instead of rejecting, matching sqale's skip. The drop
-   is statistically equivalent to their lazy skip because both are samplings
-   of the same Markov branch process, early versus late, with downstream
-   treatment depending only on the branch. Also folds in the sampler
-   initial-draw floating-point-tail fix.
-2. **Ternary loss herald.** Three-symbol classifier columns where the third
+   the inserted reset is the dephasing itself). Alongside it, a policy that
+   drops operations on leaked/lost operands (two-qubit gates, noise,
+   classical feedback) instead of rejecting. Both policies are **explicitly
+   opt-in**: the defaults remain `reject`, which stays the honest exact mode.
+   The knob names are neutral and descriptive (for example
+   `lost_leaked_ops = "reject" | "drop"`), with this document, not the API,
+   recording that drop matches sqale's skip. The drop is statistically
+   equivalent to their lazy skip because both are samplings of the same
+   Markov branch process, early versus late, with downstream treatment
+   depending only on the branch. Also folds in the sampler initial-draw
+   floating-point-tail fix.
+2. **Divergence probes.** Tests for the two documented divergences below,
+   before any narrative depends on them. The in-tree density-matrix oracle
+   can model both destination semantics as explicit CPTP maps, the
+   collapse-conditioned destination (sqale's) and the independent draw
+   (clifft's), so a committed CI test can quantify divergence 1 with no
+   external dependency; the local differential then confirms that bound
+   against sqale's real sampler. Divergence 2 gets a
+   deterministic-but-untracked micro-case (consecutive H gates before the
+   jump site).
+3. **Ternary loss herald.** Three-symbol classifier columns where the third
    symbol heralds loss. The visible record stays binary (record-layout
    invariance is load-bearing); the herald symbol is returned per measurement
    in the sidecar. An in-record herald bit is deferred until decoder work
    needs it. Includes the base-3 adapter for comparing against sqale records.
-3. **Coherent-error compatibility.** Verify Pauli/`Z_ERROR` channels pass
+4. **Coherent-error compatibility.** Verify Pauli/`Z_ERROR` channels pass
    through the noncomputational path on alive operands (and drop on
    leaked/lost ones), then add a helper converting over-rotation and phase
    parameters to Pauli channel probabilities via the standard twirl formula
    `p_P = |tr(U P)|^2 / 4`. Kept out of the noncomputational model surface:
    these are explicit noise instructions in the circuit.
-4. **Validation campaign.** See below.
-5. **Demonstration notebook.** A plain `examples/*.ipynb` walking from the
+5. **Differential and performance rerun, with auditable artifacts.** Rerun
+   the differential and the performance ladder on the full translated default
+   profile, commit the optional benchmark script described under Performance
+   results, and replace the spike numbers in this document with reproducible
+   ones (circuit family, shot counts, build type recorded alongside).
+6. **Demonstration notebook.** A plain `examples/*.ipynb` walking from the
    physics (extended Hilbert space, loss versus leakage, transition matrices
    as quantum instruments, state-dependent versus state-independent
    transitions, why equalized rates is the honest classical-sampling
@@ -247,12 +280,13 @@ Two architectural principles bound this checkpoint:
 
 ### Known divergences from sqale's fast path
 
-The equalized-rates feature matches sqale's fast path exactly in all marginal
-statistics on Clifford circuits. This is structural, not luck: in a stabilizer
-state a qubit at a jump site is either deterministic in Z (both simulators
-take an exact path) or its measurement is exactly 50/50, so drawing the source
-bit uniformly ahead of time reproduces the Born marginal identically. Two
-joint-statistics divergences remain:
+The equalized-rates feature is intended to match sqale's fast path on marginal
+statistics on Clifford circuits; the divergence probes verify this rather than
+assume it. The design argument is structural: in a stabilizer state a qubit at
+a jump site is either deterministic in Z (both simulators take an exact path)
+or its measurement is exactly 50/50, so drawing the source bit uniformly ahead
+of time reproduces the Born marginal. Two joint-statistics divergences remain
+by design:
 
 1. **Destination-partner correlations.** sqale Born-measures the qubit at the
    jump and conditions the destination on that bit, so the destination level
@@ -285,17 +319,17 @@ joint-statistics divergences remain:
 
 Confidence comes from a campaign, not just unit tests:
 
-- **Differential on the full default model.** Run the local differential on
-  the complete 2LQ-paper parameter set on repetition-code circuits: clifft
-  versus sqale's fast sampler (expect shot-noise agreement on marginals), and
-  both versus `simulate_true_distribution` on tiny circuits (quantifies the
-  approximation error the two fast paths share). Results land in this
-  document.
-- **Divergence probes.** Two targeted differentials: a Bell pair with a
-  source-dependent leak comparing the joint distribution of the leaked
-  qubit's symbol and the partner's record (measures divergence 1), and a
-  deterministic-but-untracked micro-case with consecutive H gates before the
-  jump site (bounds divergence 2).
+- **Differential on the translated default profile.** Run the local
+  differential on the 2LQ-paper parameter set, as translated, on
+  repetition-code circuits: clifft versus sqale's fast sampler (expect
+  shot-noise agreement on marginals), and both versus
+  `simulate_true_distribution` on tiny circuits (quantifies the approximation
+  error the two fast paths share). Results land in this document.
+- **Divergence probes** (work item 2): a Bell pair with a source-dependent
+  leak comparing the joint distribution of the leaked qubit's symbol and the
+  partner's record (measures divergence 1, with the oracle's two-semantics
+  CPTP bound committed in CI), and a deterministic-but-untracked micro-case
+  with consecutive H gates before the jump site (bounds divergence 2).
 - **Committed oracle extensions.** Extend the in-tree density-matrix oracle
   with the equalized channel as an explicit CPTP map and with the ternary
   classifier, so the new features are cross-checked in CI without any
@@ -306,10 +340,10 @@ Confidence comes from a campaign, not just unit tests:
 
 ### Success criterion
 
-Full default-parameter repetition-code circuits run end to end on clifft with
-no rejects, matching sqale's fast path within shot noise on all marginal
-statistics, with the residual joint-statistics divergence quantified in this
-document.
+Repetition-code circuits under the translated default profile run end to end
+on clifft with no rejects (compatibility policies enabled), agreeing with
+sqale's fast path within shot noise on marginal statistics, with the residual
+joint-statistics divergences quantified in this document by the probes.
 
 ## Successor architecture (out of scope, named)
 


### PR DESCRIPTION
> [!NOTE]
> Prototype work on the `codex/noncomputational-structural-mvp` feature branch — less-strict review bar than `main`.

This PR started as the standalone record of the sqale-sim alignment spike (correctness on the overlap, ~60-90x perf, ranked gaps). It now also carries the **plan of record for the next phase**, after stepping back from the spike findings:

- **Spike record updates**: Gap A (computational-destination transitions) is rewritten as resolved — carrier materialization (#136) models relaxation/recapture exactly. A third gap is named: structural policy on leaked/lost operands (sqale skips, clifft's defaults reject), which gates multi-round circuits just as much as Gap B.
- **Checkpoint plan**: cover sqale-sim's full default (2LQ-paper) noise model within a stated constraint envelope — everything resolved ahead of time (no JIT/segmented execution), no coherent noise simulation (coherent control errors twirled to Pauli channels, matching sqale's own fast path). Includes a per-mechanism coverage table, the work items (equalized-rates + drop policy as one unit; ternary loss herald via sidecar; twirl-compatibility helper; validation campaign; demonstration notebook), and a success criterion.
- **Documented divergences**: the equalized-rates design matches sqale's fast path exactly in all marginals on Clifford circuits (structural argument included); the two residual joint-statistics divergences (destination-partner correlations; gate-deterministic-but-untracked states) are characterized, bounded, and assigned validation probes instead of being left to discovery.
- **Successor architecture**: the segmented-continuation ladder is named as the designated next tier (it subsumes all three residual approximations and upgrades clifft from fast-path parity to dense-reference accuracy), deliberately out of scope here.

The branch was rebased onto the feature-branch tip (post-#136).
- **Review tweaks (second commit)**: goal softened to a fast-path-compatible translated default profile; perf numbers labeled as local spike results with a committed optional benchmark script planned; marginal-match stated as an intended property verified by probes; equalize-rates and drop policies made explicitly opt-in behind neutral knob names (default stays reject); work items reordered so divergence probes precede the notebook and the twirl helper precedes the full-profile differential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)