### PR TITLE
feat(noncomp): materialize the carrier at computational transition destinations

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -620,7 +620,7 @@ measurement back-action on the computational state or force a
 branch-and-continue boundary, which is exactly the dynamic/JIT path
 deferred in §1.
 
-### 5.3 Hidden trace-out at noncomputational transitions
+### 5.3 Hidden carrier edits at transition jumps
 
 Whenever a qubit whose status is `ComputationalUnknown` transitions
 to a noncomputational kind (either `Leaked` or `Lost`), theory
@@ -688,13 +688,63 @@ needed. The relevant carrier state is therefore
 would leave if no jump fired — evaluated with the *entry* status still
 used for transition source-column selection.
 
+#### 5.3.1 Carrier materialization at computational destinations
+
+A jump can also land *inside* the computational subspace (§5.2.1 row
+"jump to a Computational-category level →
+`ComputationalKnown(destination_level_id)`"): a relaxation entry such
+as `T[g][e]`, or a recapture entry such as `T[g][lost]`. Updating the
+trajectory status alone is not enough there — the SVM carrier must be
+*materialized* at the destination level, or the bookkeeping silently
+diverges from the quantum state (a `Known(e)` qubit whose matrix says
+it relaxed to `g` would keep measuring 1).
+
+Conditional on the jump branch, the destination state is the definite
+level `|d>` regardless of what the base op left behind, i.e. the
+channel `rho -> |d><d| (x) Tr_q(rho)`. The reset lowering implements
+exactly that: a hidden Z-basis measurement plus a corrective Pauli
+collapses and rezeros the carrier to `|0>`. So the rewriter inserts,
+immediately after the base op:
+
+- an `R` on the qubit, always; and
+- an `X` after it when the destination is the `basis_bit == One`
+  computational level.
+
+The edit is deliberately uniform over the carrier state the base op
+would leave:
+
+- **Coherent / entangled** (`ComputationalUnknown`): the hidden
+  measurement is the correct unraveling of the collapse, exactly as in
+  the trace-out case above.
+- **Definite** (`ComputationalKnown(k)`): the hidden measurement is
+  deterministic (no branch, no rank growth); the `R`(+`X`) prepares
+  `|d>` whether or not `k == d`.
+- **Stale noncomputational residual** (`Leaked`/`Lost` source whose
+  carrier was never traced out because it was a definite atom at
+  departure time): the `R` rezeros the leftover amplitude before the
+  destination is prepared, so a recapture never resurrects a stale
+  bit.
+
+Both inserted ops are invisible to the record: `R` lowers to a hidden
+measurement slot and `X` is a unitary, so points 1-4 above apply
+unchanged and no `rec[-k]` index moves.
+
+Timing convention: the transition's source column is selected from the
+**op-entry** status, but the jump branch is applied **after** the base
+operation. A measurement whose instrument relaxes `e -> g` therefore
+records the pre-relaxation bit, and the qubit is prepared at `g` after
+the readout.
+
 Summary rule, per qubit operand of an op:
 
     pre             = status entering the op
     post_if_no_jump = normal_post_op_status(pre, op)
     outcome         = sampled/replayed transition branch (source column from pre)
-    insert R iff outcome jumps to a Leaked/Lost level
-                 AND post_if_no_jump is ComputationalUnknown
+    if outcome jumps to a Computational level d:
+        insert R, then X if d is the One level   (materialize the carrier)
+    else if outcome jumps to a Leaked/Lost level
+                 AND post_if_no_jump is ComputationalUnknown:
+        insert R                                  (hidden trace-out)
     final status    = outcome destination (jump wins)
 
 ## 6. New C++ headers and dependency order

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -2,6 +2,7 @@
 
 #include "clifft/circuit/gate_data.h"
 #include "clifft/circuit/target.h"
+#include "clifft/noncomp/level.h"
 #include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
@@ -78,6 +79,14 @@ AstNode single_qubit_op(GateType gate, uint32_t qubit) {
     return AstNode{gate, {Target::qubit(qubit)}, {}, 0};
 }
 
+// A hidden carrier edit appended after an op for one operand's jump: an R
+// collapses and rezeros the carrier, and an X then prepares |1> when the
+// jump lands on the basis_bit == One computational level.
+struct CarrierEdit {
+    uint32_t qubit;
+    bool prepare_one;
+};
+
 }  // namespace
 
 Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
@@ -94,8 +103,8 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
 
     // Copy so every circuit-level field carries over (and any field added to
     // Circuit later is not silently dropped); only the node list is rebuilt.
-    // The inserted X-prep and trace-out R ops are not visible measurements, so
-    // the record-layout counts stay valid.
+    // The inserted X-prep, hidden R, and destination-prep X ops are not
+    // visible measurements, so the record-layout counts stay valid.
     Circuit out = original;
     out.nodes.clear();
     out.nodes.reserve(original.nodes.size() + original.num_qubits);
@@ -120,7 +129,7 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
         const TransitionInstrument* instrument = model.transition_for(gate);
 
         bool drop_op = false;
-        std::vector<uint32_t> trace_out;  // qubits needing a trace-out R after this op
+        std::vector<CarrierEdit> carrier_edits;  // hidden edits appended after this op
 
         for (const QubitOperand& operand : qubit_operands(node)) {
             const uint32_t qubit = operand.qubit;
@@ -165,16 +174,25 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
                     break;
             }
 
-            // Trace-out decision: the carrier state the base op would leave
-            // with no jump. A jump to a noncomputational level from a coherent
-            // carrier needs a hidden Z-basis unraveling.
+            // Carrier-edit decision for a jump. A jump into the computational
+            // subspace materializes the carrier at the destination level: the
+            // R collapses whatever the base op left -- a coherent
+            // superposition, a definite level, or a stale residual on a
+            // recaptured leaked/lost qubit -- and the X then prepares |1> for
+            // a One-level destination. A jump out of the computational
+            // subspace needs a hidden Z-basis unraveling (trace-out) only
+            // when the carrier the base op would leave with no jump is
+            // coherent.
             if (outcome.jumped) {
-                const QubitStatus post_if_no_jump =
-                    normal_post_op_status(pre, gate, operand.role, policy, levels);
-                const QubitStatusKind dest = levels.status_for(outcome.destination_level).kind();
-                if ((dest == QubitStatusKind::Leaked || dest == QubitStatusKind::Lost) &&
-                    post_if_no_jump.kind() == QubitStatusKind::ComputationalUnknown) {
-                    trace_out.push_back(qubit);
+                const Level& dest = levels.at(outcome.destination_level);
+                if (dest.category == LevelCategory::Computational) {
+                    carrier_edits.push_back({qubit, dest.basis_bit == BasisBit::One});
+                } else {
+                    const QubitStatus post_if_no_jump =
+                        normal_post_op_status(pre, gate, operand.role, policy, levels);
+                    if (post_if_no_jump.kind() == QubitStatusKind::ComputationalUnknown) {
+                        carrier_edits.push_back({qubit, false});
+                    }
                 }
             }
 
@@ -184,8 +202,11 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
         if (!drop_op) {
             out.nodes.push_back(node);
         }
-        for (uint32_t qubit : trace_out) {
-            out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+        for (const CarrierEdit& edit : carrier_edits) {
+            out.nodes.push_back(single_qubit_op(GateType::R, edit.qubit));
+            if (edit.prepare_one) {
+                out.nodes.push_back(single_qubit_op(GateType::X, edit.qubit));
+            }
         }
     }
 

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -23,6 +23,14 @@
 //      index. "Coherent" means the carrier state the base operation would
 //      leave with no jump is ComputationalUnknown -- a qubit a gate has just
 //      made coherent still needs trace-out even if it entered known.
+//   4. Carrier materialization: when a jump lands on a computational level,
+//      insert an R (plus an X for the basis_bit == One level) immediately
+//      after the operation, so the SVM carrier is prepared at the definite
+//      destination level. This is done for every carrier state: it is the
+//      collapse unraveling for a coherent carrier, a deterministic re-prep
+//      for a known one, and it rezeros a stale residual when a leaked or
+//      lost qubit is recaptured. Like the trace-out, it shifts no record
+//      index.
 //
 // Transition outcomes are consumed from history.transitions in the same
 // order the sampler produced them (one record per Physical operand of a gate

--- a/tests/python/test_noncomp_examples.py
+++ b/tests/python/test_noncomp_examples.py
@@ -16,6 +16,7 @@ import pytest
 from clifft import noncomp
 
 Level = noncomp.Level
+COMPUTATIONAL = noncomp.QubitStatusKind.COMPUTATIONAL
 LEAKED = noncomp.QubitStatusKind.LEAKED
 LOST = noncomp.QubitStatusKind.LOST
 SHOTS = 8000
@@ -74,6 +75,18 @@ def test_example_after_gate_leakage_with_classifier():
     r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=3)
     assert (np.asarray(r.measurements)[:, 0] == 1).all()
     assert (np.asarray(r.final_status) == LEAKED).all()
+
+
+def test_example_relaxation_to_ground_on_known_qubit():
+    # A known |1> qubit relaxes to g at the S gate; the M must read the
+    # relaxed 0, not the stale |1>, and the qubit stays computational.
+    model = noncomp.Model(
+        initial_state=[0.0, 1.0, 0.0, 0.0, 0.0],
+        transitions={"S": _transition({(Level.G, Level.E): 1.0})},
+    )
+    r = noncomp.sample("S 0\nM 0\n", model, shots=64, seed=6)
+    assert (np.asarray(r.measurements)[:, 0] == 0).all()
+    assert (np.asarray(r.final_status) == COMPUTATIONAL).all()
 
 
 # --- Intentionally unsupported -----------------------------------------------

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -120,6 +120,20 @@ def test_classifier_replacement_distribution(col, expected):
     assert abs(_p1(r, 0) - expected) < BAND
 
 
+def test_partial_relaxation_matches_analytic_mixture():
+    # With probability p the S transition collapses the H-prepared |+> to g;
+    # otherwise the carrier stays coherent. P(M=1) = (1 - p) * P(1 | H|0>).
+    p = 0.3
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={"S": _transition({(Level.G, Level.G): p, (Level.G, Level.E): p})},
+    )
+    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=6)
+    h = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
+    expected = (1 - p) * oracle.prob_one(h, 0, 1)
+    assert abs(_p1(r, 0) - expected) < BAND
+
+
 def test_survivor_marginal_equals_partial_trace():
     # Bell pair, lose qubit 0. The survivor's record marginal must equal the
     # reference partial trace (0.5), and the lost record follows the classifier.

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -24,6 +24,7 @@ using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
 using clifft::NonComputationalSample;
 using clifft::parse;
+using clifft::QubitStatusKind;
 using clifft::sample_noncomputational;
 using clifft::TransitionInstrument;
 
@@ -50,6 +51,22 @@ TransitionInstrument always_lost(const LevelSet& levels) {
     auto m = zeros5();
     m[kLost][0] = 1.0;
     m[kLost][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent: g and e both jump to the computational g level.
+TransitionInstrument always_to_g(const LevelSet& levels) {
+    auto m = zeros5();
+    m[0][0] = 1.0;
+    m[0][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent: g and e both jump to the computational e level.
+TransitionInstrument always_to_e(const LevelSet& levels) {
+    auto m = zeros5();
+    m[1][0] = 1.0;
+    m[1][1] = 1.0;
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
@@ -82,6 +99,9 @@ NonComputationalModel make_model(std::vector<double> initial_state,
 
 std::vector<double> all_g() {
     return {1.0, 0.0, 0.0, 0.0, 0.0};
+}
+std::vector<double> all_e() {
+    return {0.0, 1.0, 0.0, 0.0, 0.0};
 }
 
 }  // namespace
@@ -282,5 +302,106 @@ TEST_CASE("sample_noncomputational: a leaked measurement feeds the observable th
     REQUIRE(s.observables.size() == 200);
     for (uint8_t o : s.observables) {
         REQUIRE(o == 1);
+    }
+}
+
+TEST_CASE("sample_noncomputational: a jump to the ground level forces the measurement to 0") {
+    // The S transition collapses the H-prepared |+> to the g level; without
+    // the materializing carrier edit the M would read 1 on ~half the shots.
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_to_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 200, 1);
+    for (uint8_t bit : s.measurements) {
+        REQUIRE(bit == 0);
+    }
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.final_status[shot].kind() == QubitStatusKind::ComputationalKnown);
+        REQUIRE(s.final_status[shot].level_id() == 0);
+    }
+}
+
+TEST_CASE("sample_noncomputational: a jump to the excited level forces the measurement to 1") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_to_e(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 200, 1);
+    for (uint8_t bit : s.measurements) {
+        REQUIRE(bit == 1);
+    }
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.final_status[shot].kind() == QubitStatusKind::ComputationalKnown);
+        REQUIRE(s.final_status[shot].level_id() == 1);
+    }
+}
+
+TEST_CASE("sample_noncomputational: a partial jump to ground matches the analytic mixture") {
+    // With probability p the S transition collapses the H-prepared |+> to g;
+    // otherwise the carrier stays coherent. P(M = 1) = (1 - p) / 2 = 0.35.
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    auto m = zeros5();
+    m[0][0] = 0.3;
+    m[0][1] = 0.3;
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S",
+                        TransitionInstrument::from_matrix(std::move(m), LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 4000, 3);
+    size_t ones = 0;
+    for (uint8_t bit : s.measurements) {
+        ones += bit;
+    }
+    REQUIRE(ones > 1220);  // expected 1400; generous band
+    REQUIRE(ones < 1580);
+}
+
+TEST_CASE("sample_noncomputational: a measurement records the pre-relaxation bit") {
+    // The transition's source column is read at op entry and its jump applies
+    // after the base op: the first M reads the original |1>, the relaxation
+    // then materializes g, and the second M reads the relaxed 0.
+    Circuit c = parse("M 0\nM 0\n");
+    auto m = zeros5();
+    m[0][1] = 1.0;  // e relaxes to g with certainty; g stays
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("M",
+                        TransitionInstrument::from_matrix(std::move(m), LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_e(), std::move(transitions));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
+    REQUIRE(s.num_measurements == 2);
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.measurements[shot * 2 + 0] == 1);  // pre-relaxation bit
+        REQUIRE(s.measurements[shot * 2 + 1] == 0);  // relaxed |0>
+    }
+}
+
+TEST_CASE("sample_noncomputational: recapturing a lost qubit clears the stale residual") {
+    // The first M loses the known |1> qubit with no trace-out R (a definite
+    // atom needs no unraveling), so a stale |1> residual stays in the SVM.
+    // The second M is classified (lost at entry) and its attached recapture
+    // jump materializes g; the third M must read the recaptured 0, not the
+    // residual.
+    Circuit c = parse("M 0\nM 0\nM 0\n");
+    auto m = zeros5();
+    m[kLost][1] = 1.0;  // e is lost with certainty
+    m[0][kLost] = 1.0;  // a lost qubit is recaptured at g with certainty
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("M",
+                        TransitionInstrument::from_matrix(std::move(m), LevelSet::default_set()));
+    NonComputationalModel model =
+        make_model(all_e(), std::move(transitions),
+                   classifier_with(LevelSet::default_set(), kLost, {1.0, 0.0}));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 64, 7);
+    REQUIRE(s.num_measurements == 3);
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.measurements[shot * 3 + 0] == 1);  // real pre-loss bit
+        REQUIRE(s.measurements[shot * 3 + 1] == 0);  // classifier bit for the lost site
+        REQUIRE(s.measurements[shot * 3 + 2] == 0);  // recaptured |0>, residual cleared
     }
 }

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -68,6 +68,37 @@ TransitionInstrument always_leaked(const LevelSet& levels) {
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
+// Source-independent: g and e both jump to the computational g level.
+TransitionInstrument always_to_g(const LevelSet& levels) {
+    auto m = zeros5();
+    m[0][0] = 1.0;
+    m[0][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent: g and e both jump to the computational e level.
+TransitionInstrument always_to_e(const LevelSet& levels) {
+    auto m = zeros5();
+    m[1][0] = 1.0;
+    m[1][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-dependent relaxation: e decays to g with certainty, g stays.
+TransitionInstrument relax_e_to_g(const LevelSet& levels) {
+    auto m = zeros5();
+    m[0][1] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
+// Source-independent on computational (both columns zero): only a lost
+// qubit jumps, back to the computational g level (recapture).
+TransitionInstrument recapture_lost_to_g(const LevelSet& levels) {
+    auto m = zeros5();
+    m[0][kLost] = 1.0;
+    return TransitionInstrument::from_matrix(std::move(m), levels);
+}
+
 NonComputationalModel make_model(std::vector<double> initial_state,
                                  std::map<std::string, TransitionInstrument> transitions,
                                  NonComputationalPolicy policy = {}) {
@@ -298,4 +329,84 @@ TEST_CASE("rewrite: a measure-and-reset on a leaked qubit is kept") {
 
     Circuit rw = rewritten(c, model, 1);
     REQUIRE(count_gate(rw, GateType::MR) == 1);
+}
+
+TEST_CASE("rewrite: a jump to the |0> computational level inserts an R, no X") {
+    Circuit c = parse("H 0\nS 0\n");  // H makes qubit 0 coherent at the jump
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_to_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    // H, S kept; one materializing R appended after S, no destination-prep X.
+    REQUIRE(rw.nodes.size() == 3);
+    REQUIRE(rw.nodes[2].gate == GateType::R);
+    REQUIRE(rw.nodes[2].targets[0].value() == 0);
+    REQUIRE(count_gate(rw, GateType::X) == 0);
+}
+
+TEST_CASE("rewrite: a jump to the |1> computational level inserts an R then an X") {
+    Circuit c = parse("H 0\nS 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_to_e(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(rw.nodes.size() == 4);
+    REQUIRE(rw.nodes[2].gate == GateType::R);
+    REQUIRE(rw.nodes[2].targets[0].value() == 0);
+    REQUIRE(rw.nodes[3].gate == GateType::X);
+    REQUIRE(rw.nodes[3].targets[0].value() == 0);
+}
+
+TEST_CASE("rewrite: a known carrier that relaxes is re-prepared at the destination") {
+    // Qubit 0 enters S as Known(e) (initial X-prep), and the attached
+    // relaxation sends it to g. Even though the carrier is definite, the
+    // materializing R is inserted so the SVM state is re-prepared at |0>.
+    Circuit c = parse("S 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", relax_e_to_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_e(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    // X (initial |1> prep), S, R (materialize at g).
+    REQUIRE(rw.nodes.size() == 3);
+    REQUIRE(rw.nodes[0].gate == GateType::X);
+    REQUIRE(rw.nodes[1].gate == GateType::S);
+    REQUIRE(rw.nodes[2].gate == GateType::R);
+}
+
+TEST_CASE("rewrite: a materializing R/X does not shift visible measurements or detectors") {
+    Circuit c = parse("M 0\nDETECTOR rec[-1]\nH 1\nS 1\nM 0\nDETECTOR rec[-1]\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_to_e(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+
+    HirModule base = trace(c);
+    HirModule hir = trace(rw);
+    default_hir_pass_manager().run(hir);
+
+    REQUIRE(hir.num_measurements == base.num_measurements);  // visible record unchanged
+    REQUIRE(hir.num_detectors == base.num_detectors);
+    REQUIRE(hir.detector_targets == base.detector_targets);
+    REQUIRE(hir.num_hidden_measurements == base.num_hidden_measurements + 1);
+}
+
+TEST_CASE("rewrite: recapturing a lost qubit rezeros its stale residual") {
+    // H entangles nothing here but leaves qubit 0 coherent; S loses it (with a
+    // trace-out R that may collapse to |1>), and the X's attached transition
+    // recaptures it at g. The X itself is dropped (lost operand at entry) but
+    // the recapture still materializes the carrier with a second R, clearing
+    // whatever residual the trace-out left behind.
+    Circuit c = parse("H 0\nS 0\nX 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    transitions.emplace("X", recapture_lost_to_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::X) == 0);  // base X dropped, no |1> prep
+    REQUIRE(count_gate(rw, GateType::R) == 2);  // trace-out, then materialization
 }


### PR DESCRIPTION
> [!NOTE]
> Prototype work on the `codex/noncomputational-structural-mvp` feature branch — less-strict review bar; nothing here lands on `main` directly.

Fixes the silent divergence found in the implementation review (GAP A): a transition jump landing on a **computational** level — a relaxation entry such as `T[g][e]`, or a recapture entry such as `T[g][lost]` — updated only the trajectory status. The rewriter made no circuit edit, so the SVM carrier and the bookkeeping disagreed: a known `|1>` qubit whose matrix relaxed it to `g` kept measuring 1, and the status laundered to `Known(g)` also disabled the source-dependence guard for everything downstream.

## The fix

Conditional on the jump branch, the destination state is the definite level `|d>` regardless of the prior carrier: `rho -> |d><d| (x) Tr_q(rho)`. The rewriter now inserts, immediately after the base op:

- a hidden `R` on the qubit, always; and
- an `X` after it when the destination is the `basis_bit == One` computational level.

The edit is deliberately uniform over the carrier state the base op would leave:

| carrier at jump time | what the R(+X) does |
|---|---|
| coherent / entangled (`ComputationalUnknown`) | correct collapse unraveling, same as the existing trace-out |
| definite (`ComputationalKnown(k)`) | deterministic re-prep at `|d>` (no branch, no rank growth) |
| stale residual (recaptured `Leaked`/`Lost`) | rezeros the leftover amplitude so recapture never resurrects a stale bit |

Both inserted ops are invisible to the record (`R` lowers to a hidden measurement, `X` is a unitary), so no visible measurement slot or `rec[-k]` index moves — covered by a structural HIR test.

Timing convention (now documented in §5.3.1): the transition's source column is selected from the **op-entry** status and the jump branch applies **after** the base op, so an `M` with an attached relaxation records the pre-relaxation bit.

## Changes

- `src/clifft/noncomp/rewriter.cc/.h` — three-way carrier-edit decision (`CarrierEdit {qubit, prepare_one}`): computational destination → materialize; leaked/lost destination → existing coherent-only trace-out, unchanged
- `design/noncomputational-mvp.md` — §5.3 retitled, new §5.3.1 with the channel, the three carrier cases, record-layout safety, and the timing convention; summary rule updated
- Tests:
  - C++ rewriter (structural): R-only for a `|0>`-level destination, R-then-X for `|1>`, re-prep on a known carrier, no detector/record shift, double-R on lost→recapture
  - C++ orchestrator (end-to-end): deterministic 0 / deterministic 1 after a forced jump (fails ~half the shots without the fix), partial relaxation `P(M=1) = 0.35` analytic mixture, M-then-relax ordering `[1, 0]`, stale-residual recapture `[1, 0, 0]`
  - Python: known-qubit relaxation example; oracle cross-check of the partial-relaxation mixture

## Verification

- Debug + Release C++ suites green (`~[bench]`, 924 cases / 122,495 assertions)
- Python suite green (574 passed)
- `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)