### PR TITLE
feat(noncomp): equalized-rates approximation and opt-in drop policy

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -456,13 +456,35 @@ When a transition fires on a target qubit with `QubitStatus s`:
   directly. Always allowed.
 - `s.kind == Leaked` or `s.kind == Lost`: use the column for
   `s.level_id` directly. Classical Markov update. Always allowed.
-- `s.kind == ComputationalUnknown`: require
-  `is_source_independent_on_computational` on this instrument. If
-  false, reject with an error naming the op index, the qubit, and the
-  instrument — pointing the user at the cut between MVP and the later
-  diagonal-filter extension. If true, the no-jump branch is scalar on
-  `H_C` and the jump branches are source-independent; sample without
-  consulting amplitudes.
+- `s.kind == ComputationalUnknown`: if
+  `is_source_independent_on_computational` is true, the no-jump branch
+  is scalar on `H_C` and the jump branches are source-independent;
+  sample without consulting amplitudes. Otherwise the behavior is
+  selected by `policy.unknown_source_policy`:
+  - `Reject` (default): reject with an error naming the op index, the
+    qubit, and the instrument — pointing the user at the cut between
+    the exact path and the approximation below (and the later
+    diagonal-filter extension, §9).
+  - `EqualizeRates` (opt-in): the equalized-rates approximation. Every
+    computational column is padded with a diagonal pseudo-jump so each
+    sums to the maximum computational jump rate `p_max`; firing is then
+    source-independent and pre-sampleable at rate `p_max`. On fire the
+    source is drawn uniformly over the computational levels and the
+    destination from that padded, renormalized column. A pseudo-jump
+    lands on the source level itself: a transition event whose only
+    effect is the carrier collapse the rewriter materializes (§5.3.1),
+    i.e. pure dephasing. This is the equalize-and-collapse
+    approximation used by fast-path stabilizer leakage simulators
+    (sqale-sim's sampler among them). Its accuracy envelope: a
+    stabilizer-state source is either tableau-deterministic or exactly
+    unbiased, so every per-qubit marginal is reproduced exactly; but
+    (a) the destination is drawn independently of the simulator's
+    internal collapse, discarding destination-collapse correlations
+    with entangled partners, and (b) a qubit whose state is determined
+    by gate algebra but not by instruction (status is pre-SVM-known,
+    §5.2.2) takes this approximate path where a tableau-tracking
+    simulator would take the exact one. Closing either gap requires
+    runtime branching, which stays out of scope (§9).
 
 This is the "pre-sampleable" boundary, enforced where it actually
 matters (at the unknown-coherent-source point) rather than at model
@@ -619,6 +641,32 @@ not pre-sample measurement outcomes: doing so would either skip the
 measurement back-action on the computational state or force a
 branch-and-continue boundary, which is exactly the dynamic/JIT path
 deferred in §1.
+
+### 5.2.3 Opt-in drop policy for leaked/lost operands
+
+`policy.lost_leaked_ops` selects how the reject cells above behave.
+`Reject` (default) keeps the table exactly as written. `Drop` opts into
+excising each such operation whole — identity on the surviving operands
+— modeling the physical reading that an interaction with a vacated or
+leaked site does not happen:
+
+- single-qubit gate on Leaked: drop (was reject);
+- two-qubit gate, multi-qubit noise channel, or classical feedback with
+  a Leaked or Lost operand: drop whole (was reject);
+- non-restoring lost-qubit reset: drop (was reject);
+- non-restoring lost-qubit measure-and-reset: kept — the visible record
+  slot must survive, the classifier supplies the bit, and the site
+  simply stays lost (was reject);
+- X/Y-basis and multi-target measurements still reject: dropping a
+  measurement would shift the record, and no single-bit substitution is
+  faithful.
+
+A dropped operation has no physical effect, so a surviving operand's
+status keeps its entry value (it is not demoted), and attached
+transitions still fire on every operand from its entry-status column —
+the noise process is not gated by whether the intended gate could act.
+The sampler, the rewriter, and classifier injection all advance
+statuses through this same rule.
 
 ### 5.3 Hidden carrier edits at transition jumps
 
@@ -888,13 +936,6 @@ contract:
 - `LOSS(p) targets...` Stim instruction as syntactic sugar.
 - Diagonal `aI + bZ` filter for state-dependent no-jump (the natural
   next exact-mode extension).
-- Sqale-compat **equalized-rates** approximation mode for
-  unknown-coherent sources hitting source-dependent transitions —
-  surfaced as an opt-in policy knob (e.g.,
-  `policy.unknown_source_policy = "equalize_rates" | "reject"`),
-  defaulting to `"reject"` even after this lands. The exact diagonal
-  filter is the load-bearing path; the equalized-rates mode exists for
-  comparison against sqale-sim outputs.
 - Joint / correlated multi-qubit `TransitionInstrument` (instead of
   per-qubit marginal): a different type with shape
   `len(levels)^k x len(levels)^k` for `k` operands. Out of scope for

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -475,16 +475,20 @@ When a transition fires on a target qubit with `QubitStatus s`:
     effect is the carrier collapse the rewriter materializes (§5.3.1),
     i.e. pure dephasing. This is the equalize-and-collapse
     approximation used by fast-path stabilizer leakage simulators
-    (sqale-sim's sampler among them). Its accuracy envelope: a
-    stabilizer-state source is either tableau-deterministic or exactly
-    unbiased, so every per-qubit marginal is reproduced exactly; but
-    (a) the destination is drawn independently of the simulator's
-    internal collapse, discarding destination-collapse correlations
-    with entangled partners, and (b) a qubit whose state is determined
-    by gate algebra but not by instruction (status is pre-SVM-known,
-    §5.2.2) takes this approximate path where a tableau-tracking
-    simulator would take the exact one. Closing either gap requires
-    runtime branching, which stays out of scope (§9).
+    (sqale-sim's sampler among them). Its accuracy envelope: an
+    unbiased unknown source is matched exactly in every per-qubit
+    marginal (a genuinely indeterminate stabilizer-state qubit is
+    exactly unbiased, so this covers it); but (a) the destination is
+    drawn independently of the simulator's internal collapse,
+    discarding destination-collapse correlations with entangled
+    partners, and (b) the sampler never queries tableau determinism --
+    status is pre-SVM-known (§5.2.2) -- so a qubit whose state is
+    determined by gate algebra but not by instruction takes this
+    approximate path, and its marginals remain approximate where a
+    tableau-tracking simulator is exact. Closing (a) requires runtime
+    branching (out of scope, §9); (b) could be closed ahead of time by
+    tracking a tableau in the sampler, deferred until measured to
+    matter.
 
 This is the "pre-sampleable" boundary, enforced where it actually
 matters (at the unknown-coherent-source point) rather than at model

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -144,10 +144,19 @@ NonComputationalModel::NonComputationalModel(
     // Policy must hold recognized enum values.
     switch (policy_.unknown_source_policy) {
         case UnknownSourcePolicy::Reject:
+        case UnknownSourcePolicy::EqualizeRates:
             break;
         default:
             throw std::invalid_argument(
                 "NonComputationalModel: unrecognized unknown_source_policy value");
+    }
+    switch (policy_.lost_leaked_ops) {
+        case LostLeakedOpsPolicy::Reject:
+        case LostLeakedOpsPolicy::Drop:
+            break;
+        default:
+            throw std::invalid_argument(
+                "NonComputationalModel: unrecognized lost_leaked_ops value");
     }
 }
 

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -115,6 +115,14 @@ Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
         const GateType gate = node.gate;
         const TransitionInstrument* instrument = model.transition_for(gate);
         const bool measurement = is_measurement(gate);
+        // Mirror the sampler/rewriter policy pre-scan so all three trajectory
+        // replays advance statuses identically when an operation is dropped.
+        bool drop_op = false;
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            if (operand_action(gate, status[operand.qubit].kind(), policy) == OperandAction::Drop) {
+                drop_op = true;
+            }
+        }
         for (const QubitOperand& operand : qubit_operands(node)) {
             const uint32_t qubit = operand.qubit;
             const QubitStatus pre = status[qubit];
@@ -136,7 +144,8 @@ Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
                 slot_to_bit[slot] =
                     classifier_bit(*classifier, pre.level_id(), rng, gate, op_index, qubit);
             }
-            status[qubit] = step_status(pre, gate, operand.role, outcome, policy, levels);
+            status[qubit] = drop_op ? step_status_dropped(pre, outcome, levels)
+                                    : step_status(pre, gate, operand.role, outcome, policy, levels);
         }
         if (measurement) {
             ++slot;

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -13,11 +13,11 @@ namespace clifft {
 // so all columns share the maximum computational jump rate, the source is
 // drawn uniformly over the computational levels, and the destination from
 // that padded column. The pseudo-jump collapses the carrier without
-// changing its level (pure dephasing). The approximation reproduces the
-// per-qubit marginals of a stabilizer-state source exactly; it discards
+// changing its level (pure dephasing). The approximation matches
+// unbiased unknown-source computational marginals exactly; it discards
 // the correlation between the destination and the collapse outcome, and
-// it treats a qubit whose state is determined by gate algebra (but not by
-// instruction) as unknown.
+// a state that is gate-determined but tracked as unknown remains
+// approximate (the source is still drawn uniformly).
 enum class UnknownSourcePolicy : uint8_t {
     Reject = 0,
     EqualizeRates = 1,

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -6,18 +6,43 @@
 
 namespace clifft {
 
-// Policy for transitions that fire on a ComputationalUnknown qubit.
+// Policy for source-dependent transitions that fire on a
+// ComputationalUnknown qubit. Reject refuses them (the exact behavior is
+// not representable without runtime branching). EqualizeRates approximates
+// them: every computational column is padded with a diagonal pseudo-jump
+// so all columns share the maximum computational jump rate, the source is
+// drawn uniformly over the computational levels, and the destination from
+// that padded column. The pseudo-jump collapses the carrier without
+// changing its level (pure dephasing). The approximation reproduces the
+// per-qubit marginals of a stabilizer-state source exactly; it discards
+// the correlation between the destination and the collapse outcome, and
+// it treats a qubit whose state is determined by gate algebra (but not by
+// instruction) as unknown.
 enum class UnknownSourcePolicy : uint8_t {
     Reject = 0,
+    EqualizeRates = 1,
+};
+
+// Policy for operations touching a leaked or lost operand that have no
+// representable effect there. Reject refuses them. Drop excises the whole
+// operation (identity on the surviving operands): the physical
+// interaction cannot happen at a vacated or leaked site. Measurements are
+// never dropped -- their visible record slot is preserved and the
+// classifier supplies the outcome.
+enum class LostLeakedOpsPolicy : uint8_t {
+    Reject = 0,
+    Drop = 1,
 };
 
 struct NonComputationalPolicy {
     // When true, lost-qubit reset (R/RX/RY) restores the qubit to a
     // computational state. When false (default), lost-qubit reset
-    // rejects.
+    // rejects (or drops, under LostLeakedOpsPolicy::Drop).
     bool reset_restores_lost = false;
 
     UnknownSourcePolicy unknown_source_policy = UnknownSourcePolicy::Reject;
+
+    LostLeakedOpsPolicy lost_leaked_ops = LostLeakedOpsPolicy::Reject;
 };
 
 }  // namespace clifft

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -16,65 +16,6 @@ namespace clifft {
 
 namespace {
 
-// How the base operation is handled for one qubit operand.
-enum class OpAction { Apply, Drop, Reject };
-
-// Trajectory policy for one operand, keyed on the operand's status at op
-// entry. A computational qubit (known or unknown) runs every operation; the
-// table below only governs leaked and lost operands. Aggregated across an
-// operation's operands by the caller: any Reject rejects the whole op, and
-// Drop only ever arises for a single-operand op.
-OpAction operand_action(GateType gate, QubitStatusKind kind, const NonComputationalPolicy& policy) {
-    if (kind == QubitStatusKind::ComputationalKnown ||
-        kind == QubitStatusKind::ComputationalUnknown) {
-        return OpAction::Apply;
-    }
-
-    const bool lost = kind == QubitStatusKind::Lost;
-
-    // An identity no-op is harmless to keep on any qubit.
-    if (is_identity_noop(gate)) {
-        return OpAction::Apply;
-    }
-    // A measure-and-reset both records an outcome and restores the site, so it
-    // is gated like a reset: a leaked qubit always restores, a lost qubit only
-    // when the policy opts in. The recorded outcome is supplied by the model's
-    // classifier downstream.
-    if (is_measure_reset(gate)) {
-        return (!lost || policy.reset_restores_lost) ? OpAction::Apply : OpAction::Reject;
-    }
-    // A plain measurement keeps its visible record slot so the record and its
-    // rec[-k] references do not shift; on a leaked/lost qubit the outcome is
-    // supplied by the model's classifier downstream. That substitution is a
-    // single record bit, faithful only for a Z-basis M. An X/Y-basis (MX/MY)
-    // or multi-qubit-parity (MPP) measurement has no faithful single-bit form
-    // on a noncomputational operand, so it is not representable and rejects.
-    if (is_measurement(gate)) {
-        return gate == GateType::M ? OpAction::Apply : OpAction::Reject;
-    }
-    // A reset restores a leaked qubit always, a lost qubit only by policy;
-    // a lost-qubit reset otherwise rejects.
-    if (is_reset(gate)) {
-        return (!lost || policy.reset_restores_lost) ? OpAction::Apply : OpAction::Reject;
-    }
-    // A single-qubit Pauli noise channel drops on a leaked or lost qubit; a
-    // single-qubit unitary gate drops on a lost qubit (no carrier remains).
-    if (gate_arity(gate) == GateArity::SINGLE) {
-        if (is_noise_gate(gate)) {
-            return OpAction::Drop;
-        }
-        if (lost) {
-            return OpAction::Drop;
-        }
-        // A single-qubit gate on a leaked qubit rejects by default.
-        return OpAction::Reject;
-    }
-    // Anything else touching a leaked or lost operand -- a two-qubit gate, a
-    // two-qubit noise channel, or classical feedback onto a vacated site -- is
-    // ambiguous and rejects by default.
-    return OpAction::Reject;
-}
-
 AstNode single_qubit_op(GateType gate, uint32_t qubit) {
     return AstNode{gate, {Target::qubit(qubit)}, {}, 0};
 }
@@ -128,15 +69,36 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
         const GateType gate = node.gate;
         const TransitionInstrument* instrument = model.transition_for(gate);
 
+        // Policy pre-scan over entry statuses: any rejecting operand rejects
+        // the whole operation; otherwise any dropping operand drops it whole
+        // (identity on the surviving operands). The scan precedes the
+        // transition replay so a surviving operand's stepping can know the
+        // base operation is gone.
         bool drop_op = false;
-        std::vector<CarrierEdit> carrier_edits;  // hidden edits appended after this op
-
         for (const QubitOperand& operand : qubit_operands(node)) {
             const uint32_t qubit = operand.qubit;
             if (qubit >= status.size()) {
                 throw std::invalid_argument("rewrite: operand qubit " + std::to_string(qubit) +
                                             " is out of range at op " + std::to_string(op_index));
             }
+            switch (operand_action(gate, status[qubit].kind(), policy)) {
+                case OperandAction::Reject:
+                    throw std::invalid_argument(
+                        "rewrite: operation '" + std::string(gate_name(gate)) + "' on a " +
+                        kind_name(status[qubit].kind()) + " qubit " + std::to_string(qubit) +
+                        " at op " + std::to_string(op_index) + " is not representable; rejecting");
+                case OperandAction::Drop:
+                    drop_op = true;
+                    break;
+                case OperandAction::Apply:
+                    break;
+            }
+        }
+
+        std::vector<CarrierEdit> carrier_edits;  // hidden edits appended after this op
+
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            const uint32_t qubit = operand.qubit;
             const QubitStatus pre = status[qubit];
 
             // Replay the recorded transition for this operand, if the sampler
@@ -161,19 +123,6 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
                 outcome.destination_level = record.destination_level;
             }
 
-            switch (operand_action(gate, pre.kind(), policy)) {
-                case OpAction::Reject:
-                    throw std::invalid_argument(
-                        "rewrite: operation '" + std::string(gate_name(gate)) + "' on a " +
-                        kind_name(pre.kind()) + " qubit " + std::to_string(qubit) + " at op " +
-                        std::to_string(op_index) + " is not representable; rejecting");
-                case OpAction::Drop:
-                    drop_op = true;  // single-operand op
-                    break;
-                case OpAction::Apply:
-                    break;
-            }
-
             // Carrier-edit decision for a jump. A jump into the computational
             // subspace materializes the carrier at the destination level: the
             // R collapses whatever the base op left -- a coherent
@@ -182,21 +131,23 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
             // a One-level destination. A jump out of the computational
             // subspace needs a hidden Z-basis unraveling (trace-out) only
             // when the carrier the base op would leave with no jump is
-            // coherent.
+            // coherent; a dropped operation leaves the entry carrier.
             if (outcome.jumped) {
                 const Level& dest = levels.at(outcome.destination_level);
                 if (dest.category == LevelCategory::Computational) {
                     carrier_edits.push_back({qubit, dest.basis_bit == BasisBit::One});
                 } else {
                     const QubitStatus post_if_no_jump =
-                        normal_post_op_status(pre, gate, operand.role, policy, levels);
+                        drop_op ? pre
+                                : normal_post_op_status(pre, gate, operand.role, policy, levels);
                     if (post_if_no_jump.kind() == QubitStatusKind::ComputationalUnknown) {
                         carrier_edits.push_back({qubit, false});
                     }
                 }
             }
 
-            status[qubit] = step_status(pre, gate, operand.role, outcome, policy, levels);
+            status[qubit] = drop_op ? step_status_dropped(pre, outcome, levels)
+                                    : step_status(pre, gate, operand.role, outcome, policy, levels);
         }
 
         if (!drop_op) {

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -15,7 +15,9 @@
 //      every rec[-k] reference into it) is preserved; reinterpreting a
 //      measurement's outcome for a leaked or lost qubit is a sampling /
 //      sidecar concern for the orchestrator, not a circuit edit. An
-//      ambiguous operation on a leaked or lost operand rejects by default.
+//      ambiguous operation on a leaked or lost operand rejects by default;
+//      under LostLeakedOpsPolicy::Drop it is excised whole (identity on the
+//      surviving operands), whose statuses then keep their entry values.
 //   3. Hidden trace-out: when a coherent qubit jumps to a Leaked or Lost
 //      level, insert an R on that qubit immediately after the operation.
 //      The existing reset lowering turns it into a hidden measurement plus a

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -24,20 +24,29 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
     result.history.initial_status.reserve(circuit.num_qubits);
 
     // Sample each qubit's initial level independently from the shared
-    // initial-state distribution. The last level catches any
-    // floating-point tail so a draw always resolves to a level.
+    // initial-state distribution. The last level with positive probability
+    // catches any floating-point tail so a draw always resolves to a level
+    // the distribution can actually produce.
     for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
         const double u = rng.next_double();
         double acc = 0.0;
-        uint8_t chosen = static_cast<uint8_t>(num_levels - 1);
+        int last_positive = 0;
+        int chosen = -1;
         for (uint8_t l = 0; l < num_levels; ++l) {
-            acc += model.initial_probability(l);
+            const double p = model.initial_probability(l);
+            if (p > 0.0) {
+                last_positive = l;
+            }
+            acc += p;
             if (u < acc) {
                 chosen = l;
                 break;
             }
         }
-        result.history.initial_status.push_back(levels.status_for(chosen));
+        if (chosen < 0) {
+            chosen = last_positive;
+        }
+        result.history.initial_status.push_back(levels.status_for(static_cast<uint8_t>(chosen)));
     }
 
     std::vector<QubitStatus> status = result.history.initial_status;
@@ -49,6 +58,12 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
         const GateType gate = node.gate;
         const TransitionInstrument* instrument = model.transition_for(gate);
 
+        // Policy pre-scan over entry statuses, mirroring the rewriter: when
+        // the policy drops the operation whole, a surviving operand's
+        // stepping must know the base operation has no effect. A rejecting
+        // operand is the rewriter's error to report; stepping here treats it
+        // as applied, which is moot once the rewrite throws.
+        bool drop_op = false;
         for (const QubitOperand& operand : qubit_operands(node)) {
             const uint32_t qubit = operand.qubit;
             if (qubit >= status.size()) {
@@ -57,23 +72,40 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                     " is out of range (circuit declares " + std::to_string(status.size()) +
                     " qubits) at op " + std::to_string(op_index));
             }
+            if (operand_action(gate, status[qubit].kind(), policy) == OperandAction::Drop) {
+                drop_op = true;
+            }
+        }
 
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            const uint32_t qubit = operand.qubit;
             const QubitStatus s_in = status[qubit];
 
             // Feedback corrections are virtual: they never fire a
             // transition. Physical operands consult the instrument (if
             // any) for this gate.
             if (operand.role != OperandRole::Physical || instrument == nullptr) {
-                status[qubit] = normal_post_op_status(s_in, gate, operand.role, policy, levels);
+                status[qubit] =
+                    drop_op ? s_in
+                            : normal_post_op_status(s_in, gate, operand.role, policy, levels);
                 continue;
             }
 
             // Source-context check and column selection: an unknown
             // computational source has no definite level, so a
-            // source-dependent instrument cannot pick a column for it.
-            uint8_t source_col;
+            // source-dependent instrument cannot pick a column for it
+            // exactly. The policy chooses between rejecting and the
+            // equalized-rates approximation.
+            bool equalize = false;
+            uint8_t source_col = 0;
             if (s_in.kind() == QubitStatusKind::ComputationalUnknown) {
-                if (!instrument->is_source_independent_on_computational()) {
+                if (instrument->is_source_independent_on_computational()) {
+                    // Computational columns are identical here, so any one
+                    // serves; use g.
+                    source_col = levels.computational_zero_id();
+                } else if (policy.unknown_source_policy == UnknownSourcePolicy::EqualizeRates) {
+                    equalize = true;
+                } else {
                     throw std::invalid_argument(
                         "sample_history: source-dependent transition on gate '" +
                         std::string(gate_name(gate)) + "' fired on ComputationalUnknown qubit " +
@@ -81,37 +113,92 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                         "; a source-dependent instrument cannot be applied to a qubit whose "
                         "computational state is unknown");
                 }
-                // Computational columns are identical here, so any one
-                // serves; use g.
-                source_col = levels.computational_zero_id();
             } else {
                 source_col = s_in.level_id();
             }
 
-            // Sample the outcome: the no-jump weight occupies [0, w), the
-            // jump targets partition [w, 1). last_positive catches a
-            // floating-point tail so u >= w always resolves to a jump.
-            const double u = rng.next_double();
-            const double no_jump = instrument->no_jump_weight(source_col);
             TransitionOutcome outcome;
-            if (u >= no_jump) {
-                double acc = no_jump;
-                int last_positive = -1;
-                for (uint8_t to = 0; to < num_levels; ++to) {
-                    const double p = instrument->prob(to, source_col);
-                    if (p > 0.0) {
-                        last_positive = to;
-                    }
-                    acc += p;
-                    if (u < acc) {
-                        outcome.jumped = true;
-                        outcome.destination_level = to;
-                        break;
+            if (equalize) {
+                // Equalized-rates draw: every computational column is padded
+                // with a diagonal pseudo-jump up to the maximum computational
+                // jump rate p_max, so firing is source-independent and can be
+                // drawn here. On fire the source is drawn uniformly over the
+                // computational levels and the destination from that padded,
+                // renormalized column. A pseudo-jump lands on the source
+                // level itself: a transition event whose only effect is the
+                // carrier collapse the rewriter materializes.
+                double p_max = 0.0;
+                uint8_t num_comp = 0;
+                for (uint8_t l = 0; l < num_levels; ++l) {
+                    if (levels.at(l).category == LevelCategory::Computational) {
+                        ++num_comp;
+                        const double s = instrument->column_sum(l);
+                        if (s > p_max) {
+                            p_max = s;
+                        }
                     }
                 }
-                if (!outcome.jumped && last_positive >= 0) {
-                    outcome.jumped = true;
-                    outcome.destination_level = static_cast<uint8_t>(last_positive);
+                const double u = rng.next_double();
+                if (u >= 1.0 - p_max) {
+                    uint8_t source = levels.computational_zero_id();
+                    uint8_t seen = 0;
+                    const double pick = rng.next_double() * num_comp;
+                    for (uint8_t l = 0; l < num_levels; ++l) {
+                        if (levels.at(l).category != LevelCategory::Computational) {
+                            continue;
+                        }
+                        source = l;
+                        if (pick < ++seen) {
+                            break;
+                        }
+                    }
+                    const double deficit = p_max - instrument->column_sum(source);
+                    const double v = rng.next_double() * p_max;
+                    double acc = 0.0;
+                    int last_positive = -1;
+                    for (uint8_t to = 0; to < num_levels; ++to) {
+                        const double p =
+                            instrument->prob(to, source) + (to == source ? deficit : 0.0);
+                        if (p > 0.0) {
+                            last_positive = to;
+                        }
+                        acc += p;
+                        if (v < acc) {
+                            outcome.jumped = true;
+                            outcome.destination_level = to;
+                            break;
+                        }
+                    }
+                    if (!outcome.jumped && last_positive >= 0) {
+                        outcome.jumped = true;
+                        outcome.destination_level = static_cast<uint8_t>(last_positive);
+                    }
+                }
+            } else {
+                // Sample the outcome: the no-jump weight occupies [0, w), the
+                // jump targets partition [w, 1). last_positive catches a
+                // floating-point tail so u >= w always resolves to a jump.
+                const double u = rng.next_double();
+                const double no_jump = instrument->no_jump_weight(source_col);
+                if (u >= no_jump) {
+                    double acc = no_jump;
+                    int last_positive = -1;
+                    for (uint8_t to = 0; to < num_levels; ++to) {
+                        const double p = instrument->prob(to, source_col);
+                        if (p > 0.0) {
+                            last_positive = to;
+                        }
+                        acc += p;
+                        if (u < acc) {
+                            outcome.jumped = true;
+                            outcome.destination_level = to;
+                            break;
+                        }
+                    }
+                    if (!outcome.jumped && last_positive >= 0) {
+                        outcome.jumped = true;
+                        outcome.destination_level = static_cast<uint8_t>(last_positive);
+                    }
                 }
             }
 
@@ -119,7 +206,9 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                 TransitionRecord{op_index, qubit, outcome.jumped,
                                  outcome.jumped ? outcome.destination_level : kInvalidLevel});
 
-            status[qubit] = step_status(s_in, gate, OperandRole::Physical, outcome, policy, levels);
+            status[qubit] =
+                drop_op ? step_status_dropped(s_in, outcome, levels)
+                        : step_status(s_in, gate, OperandRole::Physical, outcome, policy, levels);
         }
     }
 

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -29,9 +29,11 @@ struct HistorySample {
 };
 
 // Sample one trajectory over `circuit` under `model`, deterministic in
-// `seed`. Throws std::invalid_argument on a source-context violation: a
-// source-dependent transition firing on a ComputationalUnknown qubit,
-// naming the operation, qubit, and gate.
+// `seed`. Under UnknownSourcePolicy::Reject (the default), throws
+// std::invalid_argument on a source-context violation: a source-dependent
+// transition firing on a ComputationalUnknown qubit, naming the operation,
+// qubit, and gate. Under EqualizeRates that case is sampled with the
+// equalized-rates approximation instead (see policy.h).
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed);
 

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -2,6 +2,73 @@
 
 namespace clifft {
 
+OperandAction operand_action(GateType gate, QubitStatusKind kind,
+                             const NonComputationalPolicy& policy) {
+    if (kind == QubitStatusKind::ComputationalKnown ||
+        kind == QubitStatusKind::ComputationalUnknown) {
+        return OperandAction::Apply;
+    }
+
+    const bool lost = kind == QubitStatusKind::Lost;
+    const bool drop = policy.lost_leaked_ops == LostLeakedOpsPolicy::Drop;
+
+    // An identity no-op is harmless to keep on any qubit.
+    if (is_identity_noop(gate)) {
+        return OperandAction::Apply;
+    }
+    // A measure-and-reset both records an outcome and restores the site. The
+    // recorded outcome is supplied by the model's classifier downstream, so
+    // the operation is kept whenever the record slot must exist. A leaked
+    // qubit always restores; a lost qubit restores only when the policy opts
+    // in. A non-restoring lost site still keeps the operation under Drop --
+    // the record slot survives and the site simply stays lost -- and rejects
+    // otherwise.
+    if (is_measure_reset(gate)) {
+        if (!lost || policy.reset_restores_lost) {
+            return OperandAction::Apply;
+        }
+        return drop ? OperandAction::Apply : OperandAction::Reject;
+    }
+    // A plain measurement keeps its visible record slot so the record and its
+    // rec[-k] references do not shift; on a leaked/lost qubit the outcome is
+    // supplied by the model's classifier downstream. That substitution is a
+    // single record bit, faithful only for a Z-basis M. An X/Y-basis (MX/MY)
+    // or multi-qubit-parity (MPP) measurement has no faithful single-bit form
+    // on a noncomputational operand, so it is not representable and rejects
+    // under either policy.
+    if (is_measurement(gate)) {
+        return gate == GateType::M ? OperandAction::Apply : OperandAction::Reject;
+    }
+    // A reset restores a leaked qubit always, a lost qubit only by policy. A
+    // non-restoring lost-qubit reset acts on a vacated site, so it drops
+    // under Drop and rejects otherwise.
+    if (is_reset(gate)) {
+        if (!lost || policy.reset_restores_lost) {
+            return OperandAction::Apply;
+        }
+        return drop ? OperandAction::Drop : OperandAction::Reject;
+    }
+    // A single-qubit Pauli noise channel drops on a leaked or lost qubit; a
+    // single-qubit unitary gate drops on a lost qubit (no carrier remains).
+    if (gate_arity(gate) == GateArity::SINGLE) {
+        if (is_noise_gate(gate)) {
+            return OperandAction::Drop;
+        }
+        if (lost) {
+            return OperandAction::Drop;
+        }
+        // A single-qubit gate on a leaked qubit: the pulse addresses a
+        // carrier outside the computational subspace, so it has no effect
+        // there and drops under Drop; it rejects by default.
+        return drop ? OperandAction::Drop : OperandAction::Reject;
+    }
+    // Anything else touching a leaked or lost operand -- a two-qubit gate, a
+    // two-qubit noise channel, or classical feedback onto a vacated site --
+    // is the interaction that physically cannot happen, so it drops whole
+    // (identity on the surviving operands) under Drop and rejects by default.
+    return drop ? OperandAction::Drop : OperandAction::Reject;
+}
+
 QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, OperandRole role,
                                   const NonComputationalPolicy& policy, const LevelSet& levels) {
     const QubitStatusKind kind = entry.kind();
@@ -72,6 +139,14 @@ QubitStatus step_status(const QubitStatus& entry, GateType gate, OperandRole rol
         return levels.status_for(outcome.destination_level);
     }
     return normal_post_op_status(entry, gate, role, policy, levels);
+}
+
+QubitStatus step_status_dropped(const QubitStatus& entry, const TransitionOutcome& outcome,
+                                const LevelSet& levels) {
+    if (outcome.jumped) {
+        return levels.status_for(outcome.destination_level);
+    }
+    return entry;
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -38,6 +38,21 @@ struct TransitionOutcome {
     uint8_t destination_level = kInvalidLevel;  // valid iff jumped
 };
 
+// How the trajectory policy handles the base operation for one operand,
+// keyed on the operand's status at op entry. Computational operands always
+// apply; the table only governs leaked and lost operands. Aggregated
+// across an operation's operands by the caller: any Reject rejects the
+// whole operation, otherwise any Drop drops it whole (identity on the
+// surviving operands). A dropped operation has no physical effect, so a
+// surviving operand's status keeps its entry value unless a sampled jump
+// overrides it; attached transitions still fire on every operand (the
+// noise process is not gated by whether the intended gate could act).
+// Measurements are never dropped: their visible record slot must survive
+// so rec[-k] references do not shift.
+enum class OperandAction { Apply, Drop, Reject };
+OperandAction operand_action(GateType gate, QubitStatusKind kind,
+                             const NonComputationalPolicy& policy);
+
 // The qubit's status after an operation given only the operation's
 // normal status effect (no transition fired). For a Physical operand:
 // Z-basis reset -> Known(g); X/Y reset -> Unknown; Z-basis measurement
@@ -56,5 +71,10 @@ QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, Opera
 QubitStatus step_status(const QubitStatus& entry, GateType gate, OperandRole role,
                         const TransitionOutcome& outcome, const NonComputationalPolicy& policy,
                         const LevelSet& levels);
+
+// Per-target step when the base operation is dropped: the operation has
+// no physical effect, so only a sampled jump changes the status.
+QubitStatus step_status_dropped(const QubitStatus& entry, const TransitionOutcome& outcome,
+                                const LevelSet& levels);
 
 }  // namespace clifft

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -69,9 +69,29 @@ void register_noncomp(nb::module_& m) {
            std::map<std::string, std::vector<std::vector<double>>> transitions,
            std::optional<std::vector<std::string>> classifier_symbols,
            std::optional<std::vector<std::vector<double>>> classifier_matrix,
-           bool reset_restores_lost) {
+           bool reset_restores_lost, const std::string& unknown_source_policy,
+           const std::string& lost_leaked_ops) {
             clifft::NonComputationalPolicy policy;
             policy.reset_restores_lost = reset_restores_lost;
+            if (unknown_source_policy == "reject") {
+                policy.unknown_source_policy = clifft::UnknownSourcePolicy::Reject;
+            } else if (unknown_source_policy == "equalize_rates") {
+                policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
+            } else {
+                throw std::invalid_argument(
+                    "noncomp model: unknown_source_policy must be 'reject' or 'equalize_rates', "
+                    "got '" +
+                    unknown_source_policy + "'");
+            }
+            if (lost_leaked_ops == "reject") {
+                policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Reject;
+            } else if (lost_leaked_ops == "drop") {
+                policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+            } else {
+                throw std::invalid_argument(
+                    "noncomp model: lost_leaked_ops must be 'reject' or 'drop', got '" +
+                    lost_leaked_ops + "'");
+            }
 
             std::optional<clifft::ClassifierSpec> spec;
             if (classifier_symbols.has_value() || classifier_matrix.has_value()) {
@@ -89,7 +109,8 @@ void register_noncomp(nb::module_& m) {
         },
         nb::arg("initial_state"), nb::arg("transitions"),
         nb::arg("classifier_symbols") = nb::none(), nb::arg("classifier_matrix") = nb::none(),
-        nb::arg("reset_restores_lost") = false,
+        nb::arg("reset_restores_lost") = false, nb::arg("unknown_source_policy") = "reject",
+        nb::arg("lost_leaked_ops") = "reject",
         "Build a default 5-level NonComputationalModel from raw matrices. See "
         "clifft.noncomp.Model.");
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -100,10 +100,10 @@ class Model:
             approximation that pads every computational column with a
             diagonal pseudo-jump up to the maximum computational jump rate,
             draws the source uniformly, and collapses the carrier on every
-            jump. The approximation reproduces per-qubit marginals for
-            stabilizer-state sources; it discards destination-collapse
-            correlations and treats gate-determined (but not
-            instruction-determined) states as unknown.
+            jump. The approximation matches unbiased unknown-source
+            marginals; deterministic-but-untracked states remain
+            approximate, and destination-collapse correlations are
+            discarded.
         lost_leaked_ops: how an operation with no representable effect on a
             leaked or lost operand is handled. ``"reject"`` (the default)
             raises; ``"drop"`` opts into excising the whole operation,

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -94,9 +94,26 @@ class Model:
         transitions: maps a gate-name string to its ``T[to][from]`` matrix.
         classifier: optional :class:`Classifier` for leaked/lost measurements.
         reset_restores_lost: if true, a reset on a lost qubit restores it.
+        unknown_source_policy: how a source-dependent transition on a qubit
+            whose computational state is unknown is handled. ``"reject"``
+            (the default) raises; ``"equalize_rates"`` opts into an
+            approximation that pads every computational column with a
+            diagonal pseudo-jump up to the maximum computational jump rate,
+            draws the source uniformly, and collapses the carrier on every
+            jump. The approximation reproduces per-qubit marginals for
+            stabilizer-state sources; it discards destination-collapse
+            correlations and treats gate-determined (but not
+            instruction-determined) states as unknown.
+        lost_leaked_ops: how an operation with no representable effect on a
+            leaked or lost operand is handled. ``"reject"`` (the default)
+            raises; ``"drop"`` opts into excising the whole operation,
+            acting as the identity on the surviving operands. Measurements
+            are never dropped; their record slot is kept and the classifier
+            supplies the outcome.
 
-    Construction validates shapes, probabilities, gate keys, and level table
-    consistency in C++, raising ``ValueError`` on any problem.
+    Construction validates shapes, probabilities, gate keys, policy values,
+    and level table consistency in C++, raising ``ValueError`` on any
+    problem.
     """
 
     __slots__ = ("_handle",)
@@ -107,6 +124,8 @@ class Model:
         transitions: Mapping[str, Matrix] | None = None,
         classifier: Classifier | None = None,
         reset_restores_lost: bool = False,
+        unknown_source_policy: str = "reject",
+        lost_leaked_ops: str = "reject",
     ) -> None:
         transition_matrices = {
             str(gate): _as_matrix(matrix) for gate, matrix in (transitions or {}).items()
@@ -119,6 +138,8 @@ class Model:
             symbols,
             matrix,
             bool(reset_restores_lost),
+            str(unknown_source_policy),
+            str(lost_leaked_ops),
         )
 
 

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -256,3 +256,72 @@ def test_deterministic_in_seed():
     assert np.array_equal(a.measurements, b.measurements)
     assert np.array_equal(a.detectors, b.detectors)
     assert np.array_equal(a.final_status, b.final_status)
+
+
+# --- 8. Policy knobs --------------------------------------------------------
+
+
+def test_policy_knob_strings_validate():
+    noncomp.Model(
+        initial_state=ALL_G,
+        unknown_source_policy="equalize_rates",
+        lost_leaked_ops="drop",
+    )
+    with pytest.raises(ValueError, match="unknown_source_policy"):
+        noncomp.Model(initial_state=ALL_G, unknown_source_policy="bogus")
+    with pytest.raises(ValueError, match="lost_leaked_ops"):
+        noncomp.Model(initial_state=ALL_G, lost_leaked_ops="bogus")
+
+
+def test_equalize_rates_matches_the_analytic_plus_state_mixture():
+    """|+> under a source-dependent leak (only g leaks, p = 0.4), equalized.
+
+    Fires with probability p; on fire the uniform source draw either leaks
+    (g column, classifier reads 1) or pseudo-jumps onto e (carrier collapses
+    to |1>, reads 1); otherwise the |+> reads 1 half the time. So
+    P(M=1) = p/2 + p/2 + (1-p)/2 = 0.5 + p/2 and P(leaked) = p/2.
+    """
+    leak_from_g_only = _zeros(5, 5)
+    leak_from_g_only[LEAK_G][noncomp.Level.G] = 0.4
+    circuit = "H 0\nS 0\nM 0\n"
+    classifier = classifier_for(LEAK_G, [0.0, 1.0])
+
+    reject_model = noncomp.Model(
+        initial_state=ALL_G, transitions={"S": leak_from_g_only}, classifier=classifier
+    )
+    with pytest.raises(ValueError, match="source-dependent"):
+        noncomp.sample(circuit, reject_model, shots=4, seed=1)
+
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": leak_from_g_only},
+        classifier=classifier,
+        unknown_source_policy="equalize_rates",
+    )
+    r = noncomp.sample(circuit, model, shots=4000, seed=5)
+    assert abs(r.measurements[:, 0].mean() - 0.7) < 0.04
+    assert abs((r.final_status[:, 0] == LEAKED).mean() - 0.2) < 0.035
+
+
+def test_drop_policy_runs_a_multi_round_circuit_through_loss():
+    """A lost data qubit drops its syndrome CXs (identity on the ancilla)."""
+    circuit = "H 0\nS 0\nCX 0 1\nMR 1\nCX 0 1\nMR 1\nM 0\n"
+    transitions = {"S": transition_to(LOST)}
+    classifier = classifier_for(LOST, [0.0, 1.0])
+
+    reject_model = noncomp.Model(
+        initial_state=ALL_G, transitions=transitions, classifier=classifier
+    )
+    with pytest.raises(ValueError, match="CX"):
+        noncomp.sample(circuit, reject_model, shots=4, seed=2)
+
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions=transitions,
+        classifier=classifier,
+        lost_leaked_ops="drop",
+    )
+    r = noncomp.sample(circuit, model, shots=16, seed=2)
+    assert r.num_measurements == 3
+    assert np.array_equal(r.measurements, np.tile([0, 0, 1], (16, 1)))
+    assert np.all(r.final_status[:, 0] == LOST_KIND)

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -405,3 +405,34 @@ TEST_CASE("sample_noncomputational: recapturing a lost qubit clears the stale re
         REQUIRE(s.measurements[shot * 3 + 2] == 0);  // recaptured |0>, residual cleared
     }
 }
+
+TEST_CASE("sample_noncomputational: drop policy runs a multi-round circuit through loss") {
+    // The data qubit is lost up front; both syndrome CXs drop (identity on
+    // the ancilla, which keeps reading 0) and the final data measurement
+    // reads the classifier's lost bit. The default policy rejects the same
+    // circuit at the first CX.
+    Circuit c = parse("H 0\nS 0\nCX 0 1\nMR 1\nCX 0 1\nMR 1\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    MeasurementClassifier cl = classifier_with(LevelSet::default_set(), kLost, {0.0, 1.0});
+
+    NonComputationalPolicy drop_policy;
+    drop_policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    {
+        std::map<std::string, TransitionInstrument> t2;
+        t2.emplace("S", always_lost(LevelSet::default_set()));
+        NonComputationalModel model = make_model(all_g(), std::move(t2), cl, drop_policy);
+        NonComputationalSample r = sample_noncomputational(c, model, 16, 3);
+        REQUIRE(r.num_measurements == 3);
+        for (uint32_t shot = 0; shot < 16; ++shot) {
+            REQUIRE(r.measurements[shot * 3 + 0] == 0);  // ancilla round 1
+            REQUIRE(r.measurements[shot * 3 + 1] == 0);  // ancilla round 2
+            REQUIRE(r.measurements[shot * 3 + 2] == 1);  // lost data, classifier bit
+            REQUIRE(r.final_status[shot * 2 + 0].kind() == QubitStatusKind::Lost);
+        }
+    }
+
+    NonComputationalModel reject_model = make_model(all_g(), std::move(transitions), cl);
+    REQUIRE_THROWS_WITH(sample_noncomputational(c, reject_model, 1, 3),
+                        ContainsSubstring("CX") && ContainsSubstring("Lost"));
+}

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -410,3 +410,101 @@ TEST_CASE("rewrite: recapturing a lost qubit rezeros its stale residual") {
     REQUIRE(count_gate(rw, GateType::X) == 0);  // base X dropped, no |1> prep
     REQUIRE(count_gate(rw, GateType::R) == 2);  // trace-out, then materialization
 }
+
+TEST_CASE("rewrite: drop policy excises a two-qubit gate on a lost operand whole") {
+    Circuit c = parse("H 0\nS 0\nCZ 0 1\nM 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::CZ) == 0);  // identity on the survivor
+    REQUIRE(count_gate(rw, GateType::M) == 1);   // record slot preserved
+    REQUIRE(count_gate(rw, GateType::R) == 1);   // trace-out of the lost qubit
+}
+
+TEST_CASE("rewrite: a dropped gate leaves the surviving operand's status untouched") {
+    // Qubit 0 is lost, so the CZ drops whole and qubit 1 keeps its
+    // instruction-known g status. The later source-dependent consult on
+    // qubit 1 then picks its exact column; had the dropped CZ demoted the
+    // survivor to unknown, the default unknown-source policy would throw.
+    Circuit c = parse("H 0\nS 0\nCZ 0 1\nS_DAG 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    transitions.emplace("S_DAG", lose_from_g(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.final_status[1].kind() == clifft::QubitStatusKind::Lost);
+    Circuit rw = rewrite(c, s.history, model);
+    REQUIRE(count_gate(rw, GateType::CZ) == 0);
+}
+
+TEST_CASE("rewrite: drop policy drops a single-qubit gate on a leaked qubit") {
+    Circuit c = parse("H 0\nS 0\nX 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::X) == 0);
+    REQUIRE(count_gate(rw, GateType::R) == 1);  // trace-out of the leaked qubit
+}
+
+TEST_CASE("rewrite: drop policy drops classical feedback onto a lost qubit") {
+    Circuit c = parse("H 1\nM 1\nH 0\nS 0\nCX rec[-1] 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::CX) == 0);
+}
+
+TEST_CASE("rewrite: drop policy drops a two-qubit noise channel on a lost operand") {
+    Circuit c = parse("H 0\nS 0\nDEPOLARIZE2(0.1) 0 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    Circuit rw = rewritten(c, model, 1);
+    REQUIRE(count_gate(rw, GateType::DEPOLARIZE2) == 0);
+}
+
+TEST_CASE("rewrite: drop policy drops a non-restoring lost reset") {
+    Circuit c = parse("H 0\nS 0\nR 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
+    Circuit rw = rewrite(c, s.history, model);
+    REQUIRE(count_gate(rw, GateType::R) == 1);  // the trace-out only
+}
+
+TEST_CASE("rewrite: drop policy keeps a measure-and-reset on a non-restoring lost qubit") {
+    Circuit c = parse("H 0\nS 0\nMR 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
+    Circuit rw = rewrite(c, s.history, model);
+    REQUIRE(count_gate(rw, GateType::MR) == 1);  // record slot preserved
+}

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -287,3 +287,101 @@ TEST_CASE("sample_history: source-independent transition on an unknown qubit is 
     REQUIRE_FALSE(s.history.transitions[1].jumped);
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::ComputationalUnknown);
 }
+
+TEST_CASE("sample_history: equalize_rates samples an unknown source instead of throwing") {
+    // 200 independent H'd qubits each consult a source-dependent instrument
+    // (g jumps to lost with certainty, e never). Equalized, every consult
+    // fires at p_max = 1; the uniform source draw sends about half to lost
+    // (the g column) and half to a pseudo-jump landing as a known
+    // computational e (the padded e diagonal).
+    constexpr uint32_t kN = 200;
+    Circuit c;
+    c.num_qubits = kN;
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::H, {q}));
+    }
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::S, {q}));
+    }
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", lose_from_g(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    HistorySample s = sample_history(c, model, 7);
+
+    size_t lost = 0;
+    size_t known_e = 0;
+    for (const auto& st : s.final_status) {
+        if (st.kind() == QubitStatusKind::Lost) {
+            ++lost;
+        } else if (st.kind() == QubitStatusKind::ComputationalKnown && st.level_id() == kE) {
+            ++known_e;
+        }
+    }
+    REQUIRE(lost + known_e == kN);  // p_max = 1: every consult fired
+    REQUIRE(lost > kN * 35 / 100);
+    REQUIRE(lost < kN * 65 / 100);
+    REQUIRE(s.history.transitions.size() == kN);
+    for (const auto& rec : s.history.transitions) {
+        REQUIRE(rec.jumped);
+        REQUIRE((rec.destination_level == kE || rec.destination_level == kLost));
+    }
+}
+
+TEST_CASE("sample_history: equalize_rates fires at the maximum computational rate") {
+    // g jumps to lost with probability 0.3 and e never, so p_max = 0.3.
+    // About 30% of unknown-source consults fire; fired consults split evenly
+    // between the lost destination (g column) and the pseudo-jump onto e.
+    constexpr uint32_t kN = 1000;
+    Circuit c;
+    c.num_qubits = kN;
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::H, {q}));
+    }
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::S, {q}));
+    }
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", lose_from_g_30pct(LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    HistorySample s = sample_history(c, model, 11);
+
+    size_t fired = 0;
+    for (const auto& rec : s.history.transitions) {
+        if (rec.jumped) {
+            ++fired;
+        }
+    }
+    size_t lost = 0;
+    for (const auto& st : s.final_status) {
+        if (st.kind() == QubitStatusKind::Lost) {
+            ++lost;
+        }
+    }
+    REQUIRE(fired > 230);
+    REQUIRE(fired < 370);
+    REQUIRE(lost > 90);
+    REQUIRE(lost < 210);
+}
+
+TEST_CASE("sample_history: equalize_rates keeps a known source exact") {
+    // The policy only governs unknown sources: a known g qubit keeps its
+    // exact column, which here jumps to lost with certainty.
+    Circuit c;
+    c.num_qubits = 1;
+    c.nodes.push_back(op(GateType::S, {0}));
+    for (uint64_t seed = 0; seed < 10; ++seed) {
+        std::map<std::string, TransitionInstrument> transitions;
+        transitions.emplace("S", lose_from_g(LevelSet::default_set()));
+        NonComputationalPolicy policy;
+        policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
+        NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+        HistorySample s = sample_history(c, model, seed);
+        REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+    }
+}

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -385,3 +385,44 @@ TEST_CASE("sample_history: equalize_rates keeps a known source exact") {
         REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
     }
 }
+
+TEST_CASE("sample_history: equalize_rates known divergence on a gate-determined state") {
+    // H then H returns each qubit to |g> deterministically, but status
+    // tracking is instruction-known, so the qubit is ComputationalUnknown at
+    // the consult. The exact channel (leaking only from e) could never fire
+    // on |g>; the equalized draw still fires at p_max = 1 and the uniform
+    // source draw loses about half the qubits. This pins the documented
+    // approximation boundary: if status tracking ever starts promoting
+    // gate-determined states, these expectations must change with it.
+    constexpr uint32_t kN = 200;
+    Circuit c;
+    c.num_qubits = kN;
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::H, {q}));
+    }
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::H, {q}));
+    }
+    for (uint32_t q = 0; q < kN; ++q) {
+        c.nodes.push_back(op(GateType::S, {q}));
+    }
+    auto m = zeros5();
+    m[kLost][kE] = 1.0;  // leaks only from e: exact on |g> would never fire
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S",
+                        TransitionInstrument::from_matrix(std::move(m), LevelSet::default_set()));
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+
+    HistorySample s = sample_history(c, model, 13);
+
+    size_t lost = 0;
+    for (const auto& st : s.final_status) {
+        if (st.kind() == QubitStatusKind::Lost) {
+            ++lost;
+        }
+    }
+    REQUIRE(lost > kN * 35 / 100);
+    REQUIRE(lost < kN * 65 / 100);
+}


### PR DESCRIPTION
> [!NOTE]
> Prototype work on the `codex/noncomputational-structural-mvp` feature branch — less-strict review bar than `main`.

Adds the two opt-in policy knobs that widen the noncomputational path from the clean exact subset to realistic multi-round leakage circuits. **Both default to the existing reject behavior**; nothing changes unless opted into.

### `unknown_source_policy = "equalize_rates"`

Samples a source-dependent transition on a `ComputationalUnknown` qubit instead of rejecting. Recipe: pad each computational column with a diagonal pseudo-jump up to the maximum computational rate `p_max`; draw firing at `p_max` ahead of time; on fire draw the source uniformly over computational levels and the destination from that padded, renormalized column. The collapse reuses the existing machinery — trace-out reset for leaked/lost destinations, carrier materialization for computational ones (a pseudo-jump's hidden reset *is* the dephasing). Design doc §4.2 documents the accuracy envelope: unbiased unknown-source marginals are matched exactly; destination-collapse correlations and deterministic-but-untracked states are the two named approximations (closing either requires runtime branching, which stays out of scope).

### `lost_leaked_ops = "drop"`

Excises an operation touching a leaked or lost operand whole — identity on the surviving operands — instead of rejecting: two-qubit gates, multi-qubit noise, classical feedback, single-qubit gates on leaked sites, and non-restoring lost resets. A measure-and-reset on a non-restoring lost site is kept (the record slot must survive; the classifier supplies the bit; the site stays lost). X/Y-basis and multi-target measurements still reject under either policy. The operand-action table moved from the rewriter into `status_step` so the sampler, rewriter, and classifier injection all advance statuses through one shared drop-aware rule: a dropped op does not demote survivors, and attached transitions still fire from entry statuses. Design doc §5.2.3.

### Also

- Fixes the sampler initial-draw floating-point-tail fallback (previously biased toward the last level, i.e. lost; now falls back to the last positive-probability level).
- Python surface: `noncomp.Model(..., unknown_source_policy=..., lost_leaked_ops=...)` string knobs with validation.

### Tests

- C++: 3 sampler equalize cases (fire rate, destination split, known-source exactness), 7 rewriter drop cases (2q/1q/feedback/2q-noise/reset/MR on leaked-lost, plus a structural check that a dropped gate leaves the survivor's status untouched — without drop-aware stepping that case throws), 1 orchestrator end-to-end multi-round-through-loss case with the default-policy contrast.
- Python: knob validation, an analytic |+⟩ equalized-leak mixture (P(M=1) = 0.5 + p/2), and the multi-round drop e2e.
- Debug and Release suites: 935 cases / 122,992 assertions green. Python: 577 green (qiskit-optional modules excluded as usual). Pre-commit clean.

### Review round

Tightened the `equalize_rates` accuracy wording in `policy.h`, the design doc, and the Python docstring (the sampler never queries tableau determinism, so "exact for stabilizer-state sources" overclaimed), and added a sampler test that pins the deterministic-but-untracked divergence (H·H back to |g⟩, leak-from-e channel: exact would never fire, equalized loses ~half) so the approximation boundary cannot be softened silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
