### PR TITLE
feat(noncomp): ternary classifier with a loss-herald sidecar

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -571,7 +571,14 @@ Notes:
 - **Lost-qubit measurement is fully specified by the classifier
   matrix's `lost` column.** There is no separate `lost_measurement`
   policy knob: random-bit is `[0.5, 0.5]`, deterministic-0 is
-  `[1, 0]`, reject is `[0, 0]`.
+  `[1, 0]`, reject is `[0, 0]`. A classifier may carry a third
+  symbol that *heralds* the slot — `[0, 0, 1]` is a deterministic
+  loss herald. The herald is reported per measurement in the result
+  sidecar; the visible record keeps a uniformly drawn bit (a heralded
+  outcome carries no preferred computational value, and a pinned bit
+  would silently bias detectors), so the record layout and every
+  `rec[-k]` reference are unchanged. Alphabets beyond three symbols
+  have no defined mapping onto (bit, herald) and reject at injection.
 - "Apply, demote to Unknown" is the conservative default: we drop
   knownness on any quantum gate touching a `ComputationalKnown`
   qubit. This loses some optimization opportunity (X on a known qubit

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -39,19 +39,31 @@ uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
     return z ^ (z >> 31);
 }
 
-// Sample a measurement-record bit from the classifier for a qubit at `level`.
-// The classifier must be two-symbol with a stochastic column for this level
-// (symbol 0 owns [0, prob0), symbol 1 owns the rest); the symbol index is the
-// injected record bit. A substochastic (reject) column is unsupported here.
-uint8_t classifier_bit(const MeasurementClassifier& classifier, uint8_t level,
-                       Xoshiro256PlusPlus& rng, GateType gate, uint32_t op_index, uint32_t qubit) {
-    // Binary record injection maps the sampled symbol index directly to the
-    // record bit, which is faithful only for a two-symbol classifier. A richer
-    // alphabet has no defined symbol-to-bit mapping and is not representable.
-    if (classifier.num_symbols() != 2) {
+// One sampled classifier outcome for a measurement on a noncomputational
+// qubit: the injected record bit, and whether the herald symbol fired.
+struct ClassifierDraw {
+    uint8_t bit;
+    bool herald;
+};
+
+// Sample a classifier outcome for a qubit at `level`. The classifier must
+// have two or three symbols and a stochastic column for this level. Symbols
+// 0 and 1 map directly to the record bit. A third symbol heralds the
+// measurement: the herald flag is reported in the sidecar and the record bit
+// is drawn uniformly -- the slot still feeds detectors, and a heralded
+// outcome carries no preferred computational value, so a uniform bit keeps
+// downstream detector statistics unbiased rather than silently pinning them.
+// A substochastic (reject) column is unsupported here.
+ClassifierDraw classifier_draw(const MeasurementClassifier& classifier, uint8_t level,
+                               Xoshiro256PlusPlus& rng, GateType gate, uint32_t op_index,
+                               uint32_t qubit) {
+    // Record injection writes one visible bit. Symbols 0/1 are that bit; a
+    // third symbol is the herald. A still-richer alphabet has no defined
+    // mapping onto (bit, herald) and is not representable.
+    if (classifier.num_symbols() != 2 && classifier.num_symbols() != 3) {
         throw std::invalid_argument(
             "sample_noncomputational: injecting a measurement on a noncomputational qubit "
-            "requires a two-symbol classifier, but the model's has " +
+            "requires a two- or three-symbol classifier, but the model's has " +
             std::to_string(classifier.num_symbols()) + " symbols (measurement '" +
             std::string(gate_name(gate)) + "' on qubit " + std::to_string(qubit) + " at op " +
             std::to_string(op_index) + ")");
@@ -70,13 +82,19 @@ uint8_t classifier_bit(const MeasurementClassifier& classifier, uint8_t level,
             "' on qubit " + std::to_string(qubit) + " at op " + std::to_string(op_index) + ")");
     }
     const double u = rng.next_double();
-    // Two symbols and a column summing to one (both checked above): symbol 0
-    // owns [0, prob0) and symbol 1 owns the remainder, so the symbol index is
-    // the record bit. Any tolerance-sized rounding residual falls to symbol 1.
+    // The column sums to one (checked above): symbol 0 owns [0, prob0),
+    // symbol 1 the next interval, and the herald symbol (if any) the
+    // remainder. Any tolerance-sized rounding residual falls to the last
+    // symbol. A two-symbol draw consumes exactly one random number, so
+    // existing two-symbol seeds reproduce.
     if (u < classifier.prob(0, level)) {
-        return 0;
+        return {0, false};
     }
-    return 1;
+    if (classifier.num_symbols() == 2 ||
+        u < classifier.prob(0, level) + classifier.prob(1, level)) {
+        return {1, false};
+    }
+    return {static_cast<uint8_t>(rng.next_double() < 0.5 ? 0 : 1), true};
 }
 
 GateType reset_for(GateType measure_reset) {
@@ -95,18 +113,21 @@ AstNode single_target(GateType gate, uint32_t value) {
 }
 
 // Replay `original` + `history` to find each leaked/lost measurement's visible
-// record slot and its sampled classifier bit, then swap those slots in
+// record slot and its sampled classifier outcome, then swap those slots in
 // `rewritten`: M -> MPAD(bit); a measure-and-reset -> MPAD(bit) plus the
-// matching reset. The rewriter has already guaranteed only M / measure-reset
-// measurements reach a noncomputational operand.
+// matching reset. Herald flags are written into `heralds` (pre-sized to the
+// visible measurement count, zero-filled) at the same slot indices. The
+// rewriter has already guaranteed only M / measure-reset measurements reach a
+// noncomputational operand.
 Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
                           const NonComputationalHistory& history,
-                          const NonComputationalModel& model, Xoshiro256PlusPlus& rng) {
+                          const NonComputationalModel& model, Xoshiro256PlusPlus& rng,
+                          std::vector<uint8_t>& heralds) {
     const LevelSet& levels = model.levels();
     const NonComputationalPolicy& policy = model.policy();
     const MeasurementClassifier* classifier = model.classifier();
 
-    std::map<uint32_t, uint8_t> slot_to_bit;
+    std::map<uint32_t, ClassifierDraw> slot_to_bit;
     std::vector<QubitStatus> status = history.initial_status;
     size_t trans_cursor = 0;
     uint32_t slot = 0;
@@ -141,8 +162,10 @@ Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
                         std::to_string(op_index) +
                         " requires a classifier, but the model has none");
                 }
-                slot_to_bit[slot] =
-                    classifier_bit(*classifier, pre.level_id(), rng, gate, op_index, qubit);
+                const ClassifierDraw draw =
+                    classifier_draw(*classifier, pre.level_id(), rng, gate, op_index, qubit);
+                slot_to_bit[slot] = draw;
+                heralds[slot] = draw.herald ? 1 : 0;
             }
             status[qubit] = drop_op ? step_status_dropped(pre, outcome, levels)
                                     : step_status(pre, gate, operand.role, outcome, policy, levels);
@@ -171,7 +194,7 @@ Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
             out.nodes.push_back(node);  // computational measurement, kept as-is
             continue;
         }
-        const uint8_t bit = it->second;
+        const uint8_t bit = it->second.bit;
         const uint32_t qubit = qubit_operands(node).front().qubit;
         out.nodes.push_back(single_target(GateType::MPAD, bit));
         if (is_measure_reset(node.gate)) {
@@ -227,7 +250,9 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
             sample_history(circuit, model, derive_seed(global_seed, shot, kHistoryDomain));
         Circuit rw = rewrite(circuit, hs.history, model);
         Xoshiro256PlusPlus classifier_rng(derive_seed(global_seed, shot, kClassifierDomain));
-        Circuit injected = inject_classifier(circuit, rw, hs.history, model, classifier_rng);
+        std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
+        Circuit injected =
+            inject_classifier(circuit, rw, hs.history, model, classifier_rng, shot_heralds);
 
         CompiledModule program = compile_circuit(injected);
         SampleResult sr = sample(program, 1, derive_seed(global_seed, shot, kSvmDomain));
@@ -239,6 +264,7 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                   sr.observables.end());
         result.final_status.insert(result.final_status.end(), hs.final_status.begin(),
                                    hs.final_status.end());
+        result.heralds.insert(result.heralds.end(), shot_heralds.begin(), shot_heralds.end());
     }
 
     return result;

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -43,13 +43,21 @@ struct NonComputationalSample {
 
     // Sidecar: each qubit's final status per shot, row-major [shot, qubit].
     std::vector<QubitStatus> final_status;
+
+    // Sidecar: 1 where the classifier sampled the herald (third) symbol for
+    // that visible measurement, row-major [shot, slot]. The visible record
+    // stays binary -- a heralded slot carries a uniformly drawn bit -- so the
+    // record layout and every rec[-k] reference are unchanged; the herald
+    // rides here. All zeros for a two-symbol classifier or none at all.
+    std::vector<uint8_t> heralds;
 };
 
 // Throws std::invalid_argument when the trajectory policy rejects an
 // operation, when a measurement on a leaked/lost qubit needs a classifier the
-// model does not provide, or when such a classifier column is not a two-symbol
-// stochastic column. Reject (substochastic) classifier columns model a
-// heralded abort outcome and are not supported by this entry point yet.
+// model does not provide, or when such a classifier column is not a two- or
+// three-symbol stochastic column (a third symbol heralds the measurement).
+// Reject (substochastic) classifier columns model a heralded abort outcome
+// and are not supported by this entry point yet.
 NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                const NonComputationalModel& model, uint32_t shots,
                                                std::optional<uint64_t> seed = std::nullopt);

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -144,12 +144,13 @@ void register_noncomp(nb::module_& m) {
             auto det = vec_to_numpy(std::move(r.detectors), {shots, r.num_detectors});
             auto obs = vec_to_numpy(std::move(r.observables), {shots, r.num_observables});
             auto fs = vec_to_numpy(std::move(status), {shots, r.num_qubits});
-            return nb::make_tuple(meas, det, obs, fs, r.num_qubits, r.num_measurements,
+            auto her = vec_to_numpy(std::move(r.heralds), {shots, r.num_measurements});
+            return nb::make_tuple(meas, det, obs, fs, her, r.num_qubits, r.num_measurements,
                                   r.num_detectors, r.num_observables);
         },
         nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         "Sample a noncomputational model. Returns (measurements, detectors, observables, "
-        "final_status, num_qubits, num_measurements, num_detectors, num_observables).");
+        "final_status, heralds, num_qubits, num_measurements, num_detectors, num_observables).");
 }
 
 NB_MODULE(_clifft_core, m) {

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -18,8 +18,11 @@ sampler:
 
 This API supports exactly the built-in five-level set, named by ``Level`` and
 ``LEVELS`` (g, e, leak_g, leak_e, lost); matrix rows and columns are indexed by
-``Level``. Only a two-symbol classifier with stochastic columns is supported;
-substochastic (reject) columns and non-binary classifiers raise.
+``Level``. A classifier has two or three symbols with stochastic columns: the
+first two symbols are the record bit, an optional third symbol heralds the
+measurement (reported per slot in ``heralds``; the visible record stays binary
+with a uniformly drawn bit). Substochastic (reject) columns and richer
+alphabets raise.
 """
 
 from __future__ import annotations
@@ -75,8 +78,12 @@ def _as_matrix(matrix: Matrix) -> list[list[float]]:
 class Classifier:
     """A measurement classifier: symbol labels and ``P[symbol][level]``.
 
-    This must be binary (two symbols), and each level's column must sum to one;
-    substochastic (reject) columns are not supported.
+    Two or three symbols; each level's column must sum to one (substochastic
+    reject columns are not supported). The first two symbols map directly to
+    the measurement record bit. An optional third symbol heralds the
+    measurement -- typically the loss outcome -- reported per record slot in
+    :attr:`NonComputationalSample.heralds` while the visible record keeps a
+    uniformly drawn bit, so the record layout is unchanged.
     """
 
     __slots__ = ("symbols", "matrix")
@@ -151,6 +158,8 @@ class NonComputationalSample:
         final_status: uint8 array (shots, num_qubits) of :class:`QubitStatusKind`.
             Coarse: it reports computational/leaked/lost, not the specific leaked
             or lost level.
+        heralds: uint8 array (shots, num_measurements); 1 where the classifier
+            sampled the herald (third) symbol for that slot, else 0.
         shots, num_qubits, num_measurements, num_detectors, num_observables: ints.
     """
 
@@ -159,6 +168,7 @@ class NonComputationalSample:
         "detectors",
         "observables",
         "final_status",
+        "heralds",
         "shots",
         "num_qubits",
         "num_measurements",
@@ -172,6 +182,7 @@ class NonComputationalSample:
         detectors: npt.NDArray[np.uint8],
         observables: npt.NDArray[np.uint8],
         final_status: npt.NDArray[np.uint8],
+        heralds: npt.NDArray[np.uint8],
         num_qubits: int,
         num_measurements: int,
         num_detectors: int,
@@ -181,11 +192,22 @@ class NonComputationalSample:
         self.detectors = detectors
         self.observables = observables
         self.final_status = final_status
+        self.heralds = heralds
         self.shots = int(measurements.shape[0])
         self.num_qubits = int(num_qubits)
         self.num_measurements = int(num_measurements)
         self.num_detectors = int(num_detectors)
         self.num_observables = int(num_observables)
+
+    def symbols(self) -> npt.NDArray[np.uint8]:
+        """Per-slot classifier symbols: the record bit, or 2 where heralded.
+
+        A ternary view of the record for comparing against simulators whose
+        measurement outcomes carry the herald in-band as a third value.
+        """
+        out = self.measurements.copy()
+        out[self.heralds != 0] = 2
+        return out
 
     def __iter__(self) -> Iterator[npt.NDArray[np.uint8]]:
         """Yield (measurements, detectors, observables) for tuple unpacking."""
@@ -216,7 +238,9 @@ def sample(
     """
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)
-    meas, det, obs, status, num_qubits, num_meas, num_det, num_obs = (
+    meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs = (
         _clifft_core._sample_noncomputational(circuit, model._handle, shots, seed)
     )
-    return NonComputationalSample(meas, det, obs, status, num_qubits, num_meas, num_det, num_obs)
+    return NonComputationalSample(
+        meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs
+    )

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -204,14 +204,63 @@ def test_substochastic_classifier_column_unsupported():
         noncomp.sample("H 0\nS 0\nM 0\n", model, shots=8, seed=14)
 
 
-def test_non_binary_classifier_unsupported():
-    mat = _zeros(3, 5)
+def test_four_symbol_classifier_unsupported():
+    mat = _zeros(4, 5)
     for lvl in range(5):
         mat[0][lvl] = 1.0
-    mat[0][LEAK_G], mat[1][LEAK_G], mat[2][LEAK_G] = 0.5, 0.3, 0.2
-    model = leak_model(noncomp.Classifier(["0", "1", "2"], mat))
-    with pytest.raises(ValueError, match="two-symbol"):
+    mat[0][LEAK_G], mat[1][LEAK_G], mat[2][LEAK_G], mat[3][LEAK_G] = 0.4, 0.3, 0.2, 0.1
+    model = leak_model(noncomp.Classifier(["0", "1", "2", "3"], mat))
+    with pytest.raises(ValueError, match="two- or three-symbol"):
         noncomp.sample("H 0\nS 0\nM 0\n", model, shots=8, seed=15)
+
+
+def _ternary_classifier(level: int, col: list[float]) -> noncomp.Classifier:
+    """Three-symbol classifier; `level`'s column is `col`, others read symbol 0."""
+    m = _zeros(3, 5)
+    for lvl in range(5):
+        m[0][lvl] = 1.0
+    m[0][level], m[1][level], m[2][level] = col
+    return noncomp.Classifier(["0", "1", "2"], m)
+
+
+def test_ternary_herald_rides_the_sidecar():
+    """A lost qubit's measurement heralds; the visible record stays binary."""
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transition_to(LOST)},
+        classifier=_ternary_classifier(LOST, [0.0, 0.0, 1.0]),
+    )
+    r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=4000, seed=21)
+    assert r.heralds.shape == (4000, 2)
+    assert np.all(r.heralds[:, 0] == 1)  # the lost qubit's slot heralds
+    assert np.all(r.heralds[:, 1] == 0)  # the survivor's does not
+    # The heralded slot's record bit is a uniform draw, not a pinned value.
+    assert abs(r.measurements[:, 0].mean() - 0.5) < 0.04
+    # symbols() folds the herald back in as a third value.
+    sym = r.symbols()
+    assert np.all(sym[:, 0] == 2)
+    assert np.array_equal(sym[:, 1], r.measurements[:, 1])
+
+
+def test_two_symbol_classifier_heralds_nothing():
+    model = leak_model(classifier_for(LEAK_G, [0.5, 0.5]))
+    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=64, seed=22)
+    assert r.heralds.shape == (64, 1)
+    assert not r.heralds.any()
+    assert np.array_equal(r.symbols(), r.measurements)
+
+
+def test_herald_deterministic_in_seed():
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transition_to(LOST)},
+        classifier=_ternary_classifier(LOST, [0.2, 0.1, 0.7]),
+    )
+    a = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
+    b = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
+    assert np.array_equal(a.heralds, b.heralds)
+    assert np.array_equal(a.measurements, b.measurements)
+    assert abs(a.heralds[:, 0].mean() - 0.7) < 0.15
 
 
 # --- 4. Record layout invariants -------------------------------------------

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -196,25 +196,102 @@ TEST_CASE("sample_noncomputational: a measurement on a leaked qubit without a cl
                         ContainsSubstring("requires a classifier"));
 }
 
-TEST_CASE("sample_noncomputational: a non-binary classifier rejects on injection") {
+TEST_CASE("sample_noncomputational: a four-symbol classifier rejects on injection") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("S", always_leaked(LevelSet::default_set()));
 
-    // Three symbols: no defined symbol-to-record-bit mapping for the binary record.
-    std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
+    // Four symbols: beyond bit-plus-herald there is no defined mapping onto
+    // the binary record and its herald sidecar.
+    std::vector<std::vector<double>> m(4, std::vector<double>(5, 0.0));
     for (size_t level = 0; level < 5; ++level) {
         m[0][level] = 1.0;
     }
-    m[0][kLeakG] = 0.5;
+    m[0][kLeakG] = 0.4;
     m[1][kLeakG] = 0.3;
     m[2][kLeakG] = 0.2;
-    MeasurementClassifier three =
-        MeasurementClassifier::from_matrix({"0", "1", "2"}, std::move(m), LevelSet::default_set());
-    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(three));
+    m[3][kLeakG] = 0.1;
+    MeasurementClassifier four = MeasurementClassifier::from_matrix(
+        {"0", "1", "2", "3"}, std::move(m), LevelSet::default_set());
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(four));
 
     REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 16, 1),
-                        ContainsSubstring("two-symbol classifier"));
+                        ContainsSubstring("two- or three-symbol classifier"));
+}
+
+namespace {
+
+// Three-symbol classifier whose column for `level` is `col`; every other
+// level is a deterministic symbol 0.
+MeasurementClassifier ternary_classifier_with(const LevelSet& levels, uint8_t level,
+                                              std::vector<double> col) {
+    std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    m[0][level] = col[0];
+    m[1][level] = col[1];
+    m[2][level] = col[2];
+    return MeasurementClassifier::from_matrix({"0", "1", "2"}, std::move(m), levels);
+}
+
+}  // namespace
+
+TEST_CASE("sample_noncomputational: the herald symbol fills the sidecar, not the record") {
+    // Qubit 1 leaks and its column always heralds; qubit 0 stays
+    // computational. The heralded slot's visible record bit is a uniform
+    // draw, so the record layout is unchanged and both values occur.
+    Circuit c = parse("H 1\nS 1\nM 1\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    MeasurementClassifier cl =
+        ternary_classifier_with(LevelSet::default_set(), kLeakG, {0.0, 0.0, 1.0});
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
+
+    constexpr uint32_t kShots = 256;
+    NonComputationalSample r = sample_noncomputational(c, model, kShots, 5);
+    REQUIRE(r.heralds.size() == kShots * 2);
+    size_t ones = 0;
+    for (uint32_t shot = 0; shot < kShots; ++shot) {
+        REQUIRE(r.heralds[shot * 2 + 0] == 1);  // leaked slot heralds
+        REQUIRE(r.heralds[shot * 2 + 1] == 0);  // computational slot does not
+        ones += r.measurements[shot * 2 + 0];
+    }
+    REQUIRE(ones > kShots * 30 / 100);  // heralded record bit is uniform
+    REQUIRE(ones < kShots * 70 / 100);
+}
+
+TEST_CASE("sample_noncomputational: a partial herald column matches its frequency") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    MeasurementClassifier cl =
+        ternary_classifier_with(LevelSet::default_set(), kLeakG, {0.3, 0.0, 0.7});
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
+
+    constexpr uint32_t kShots = 1000;
+    NonComputationalSample r = sample_noncomputational(c, model, kShots, 6);
+    size_t heralded = 0;
+    for (uint32_t shot = 0; shot < kShots; ++shot) {
+        heralded += r.heralds[shot];
+    }
+    REQUIRE(heralded > 630);
+    REQUIRE(heralded < 770);
+}
+
+TEST_CASE("sample_noncomputational: a two-symbol classifier leaves the herald sidecar zero") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    MeasurementClassifier cl = make_classifier(LevelSet::default_set(), {0.5, 0.5});
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
+
+    constexpr uint32_t kShots = 64;
+    NonComputationalSample r = sample_noncomputational(c, model, kShots, 7);
+    REQUIRE(r.heralds.size() == kShots);
+    for (uint8_t h : r.heralds) {
+        REQUIRE(h == 0);
+    }
 }
 
 TEST_CASE("sample_noncomputational: a circuit with EXP_VAL probes rejects") {


### PR DESCRIPTION
> [!NOTE]
> Prototype work on the `codex/noncomputational-structural-mvp` feature branch — less-strict review bar than `main`.

Work item 3 of the checkpoint plan: heralded-loss readout. A classifier may now carry a **third symbol that heralds the measurement** — e.g. a lost column `[0, 0, 1]` is a deterministic loss herald — closing the readout gap with ternary-outcome leakage simulators while preserving clifft's record invariants.

### Design

- Symbols 0/1 remain the visible record bit, exactly as before. The herald is reported per visible measurement slot in a new sidecar, `heralds` (row-major shots × num_measurements), alongside `final_status`.
- **The visible record stays binary.** A heralded slot carries a uniformly drawn bit: a heralded outcome has no preferred computational value, and a pinned bit would silently bias any detector referencing the slot. Record layout and `rec[-k]` references are unchanged.
- Alphabets beyond three symbols have no defined mapping onto (bit, herald) and reject at injection; substochastic (reject) columns remain rejected. A two-symbol draw consumes exactly one random number as before, so existing seeds reproduce bit-for-bit.
- Python: `NonComputationalSample.heralds`, plus a `symbols()` method giving the ternary per-slot view (the bit, or 2 where heralded) — the comparison adapter for simulators that carry the herald in-band as a third outcome value.
- Design doc §5.2 notes updated (herald semantics, uniform-bit rationale, >3-symbol rejection).

### Tests

- C++: herald fills the sidecar and not the record (uniform-bit check on the heralded slot, zero on computational slots), partial herald column matches its frequency, two-symbol classifier leaves the sidecar zero, four-symbol classifier rejects (repurposes the old three-symbol-rejects test).
- Python: end-to-end Bell-pair loss with deterministic herald + `symbols()` view, two-symbol no-op, seed determinism, four-symbol rejection.
- Debug and Release suites: 939 cases / 123,576 assertions green. Python: 583 green (qiskit-optional modules excluded as usual). Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)