### PR TITLE
fix(backend): preserve global phase across virtual-frame composition

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(clifft_core STATIC
     svm/svm_forced_kernels.cc
     svm/svm_scalar.cc
     svm/svm_state.cc
+    util/canonical_phase.cc
     util/introspection.cc
 )
 

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -1,6 +1,7 @@
 #include "clifft/backend/backend.h"
 
 #include "clifft/backend/compiler_context.h"
+#include "clifft/util/canonical_phase.h"
 #include "clifft/util/mask_view.h"
 
 #include <algorithm>
@@ -516,6 +517,112 @@ LocalizationResult localize_pauli(CompilerContext& ctx,
     return {static_cast<uint16_t>(pivot), basis, sign};
 }
 
+namespace {
+
+/// Column-sparse evaluation of canonical(B) * u at the canonical anchor of
+/// tableau(B * u): every pending-gate canonical matrix has at most two
+/// nonzero entries per column. The anchor packs (row << n) | col, and the
+/// gate axes index column bits, so all reads stay in the low half.
+std::complex<double> gate_compose_phase(const ChoiSupport& old_support,
+                                        const ChoiSupport& new_support, const PendingGate& g) {
+    const ChoiIndex& anchor = new_support.anchor;
+    std::complex<double> w{0.0, 0.0};
+
+    switch (g.type) {
+        case PendingGateType::S:
+            // S[c, c] = i^{c_q}
+            w = kImagPow[choi_index_bit(anchor, g.axis_1) ? 1 : 0] *
+                choi_amplitude(old_support, anchor);
+            break;
+
+        case PendingGateType::CZ: {
+            // CZ[c, c] = (-1)^{c_a * c_b}
+            const bool minus = choi_index_bit(anchor, g.axis_1) && choi_index_bit(anchor, g.axis_2);
+            w = (minus ? -1.0 : 1.0) * choi_amplitude(old_support, anchor);
+            break;
+        }
+
+        case PendingGateType::CNOT: {
+            // Permutation: column c has its single 1 at row c ^ (c_a ? e_b : 0).
+            ChoiIndex idx = anchor;
+            if (choi_index_bit(idx, g.axis_1)) {
+                choi_index_flip_bit(idx, g.axis_2);
+            }
+            w = choi_amplitude(old_support, idx);
+            break;
+        }
+
+        case PendingGateType::SWAP: {
+            ChoiIndex idx = anchor;
+            if (choi_index_bit(idx, g.axis_1) != choi_index_bit(idx, g.axis_2)) {
+                choi_index_flip_bit(idx, g.axis_1);
+                choi_index_flip_bit(idx, g.axis_2);
+            }
+            w = choi_amplitude(old_support, idx);
+            break;
+        }
+
+        case PendingGateType::H: {
+            // H[k, c] = (-1)^{k_q * c_q} / sqrt(2) over the two rows
+            // differing at qubit q.
+            ChoiIndex k0 = anchor;
+            ChoiIndex k1 = anchor;
+            if (choi_index_bit(anchor, g.axis_1)) {
+                choi_index_flip_bit(k0, g.axis_1);
+            } else {
+                choi_index_flip_bit(k1, g.axis_1);
+            }
+            const double s1 = choi_index_bit(anchor, g.axis_1) ? -1.0 : 1.0;
+            w = (choi_amplitude(old_support, k0) + s1 * choi_amplitude(old_support, k1)) *
+                kInvSqrt2;
+            break;
+        }
+    }
+
+    const double mag = std::abs(w);
+    assert(mag > 0.25 && "canonical anchor outside expected support");
+    return w / mag;
+}
+
+}  // namespace
+
+std::complex<double> frame_composition_phase(stim::Tableau<kStimWidth> composed,
+                                             std::span<const PendingGate> gate_log,
+                                             const stim::Tableau<kStimWidth>& target) {
+    ChoiSupport old_support = build_choi_support(composed);
+    std::complex<double> total{1.0, 0.0};
+
+    // Peel gates from the left factor adjacent to canonical(composed):
+    // composed * u_J * ... * u_1 reconstructs the target tableau, so walk
+    // the log in reverse application order, prepending each gate.
+    for (auto it = gate_log.rbegin(); it != gate_log.rend(); ++it) {
+        switch (it->type) {
+            case PendingGateType::CNOT:
+                composed.prepend_ZCX(it->axis_1, it->axis_2);
+                break;
+            case PendingGateType::CZ:
+                composed.prepend_ZCZ(it->axis_1, it->axis_2);
+                break;
+            case PendingGateType::S:
+                composed.prepend_SQRT_Z(it->axis_1);
+                break;
+            case PendingGateType::H:
+                composed.prepend_H_XZ(it->axis_1);
+                break;
+            case PendingGateType::SWAP:
+                composed.prepend_SWAP(it->axis_1, it->axis_2);
+                break;
+        }
+        ChoiSupport new_support = build_choi_support(composed);
+        total *= gate_compose_phase(old_support, new_support, *it);
+        old_support = std::move(new_support);
+    }
+
+    assert(composed == target && "frame gate log does not reproduce the HIR tableau");
+    (void)target;
+    return total;
+}
+
 }  // namespace internal
 
 // =========================================================================
@@ -843,7 +950,31 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
     auto& final_v_cum = ctx.virtual_frame.mutable_materialized_tableau();
     if (hir.final_tableau.has_value()) {
         stim::Tableau<kStimWidth> v_cum_inv = final_v_cum.inverse();
-        ctx.constant_pool.final_tableau = v_cum_inv.then(*hir.final_tableau);
+        stim::Tableau<kStimWidth> composed = v_cum_inv.then(*hir.final_tableau);
+
+        // The runtime ops were rewritten through the virtual frame gates,
+        // but the composed tableau realizes those gates only up to stim's
+        // canonical matrix phase. Fold the per-gate canonical deltas into
+        // global_weight so the API-visible global phase survives the
+        // composition. Programs with measurements or noise skip this: their
+        // observable outputs are insensitive to a global phase, and their
+        // frame gate logs grow with every localized measurement.
+        const auto& gate_log = ctx.virtual_frame.gate_log();
+        bool deterministic = true;
+        for (const auto& op : hir.ops) {
+            const OpType type = op.op_type();
+            if (type == OpType::MEASURE || type == OpType::NOISE || type == OpType::READOUT_NOISE ||
+                type == OpType::CONDITIONAL_PAULI) {
+                deterministic = false;
+                break;
+            }
+        }
+        if (deterministic && !gate_log.empty()) {
+            ctx.constant_pool.global_weight *= std::conj(
+                internal::frame_composition_phase(composed, gate_log, *hir.final_tableau));
+        }
+
+        ctx.constant_pool.final_tableau = std::move(composed);
     }
 
     ctx.constant_pool.global_weight *= hir.global_weight;

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -12,7 +12,9 @@
 
 #include "stim.h"
 
+#include <complex>
 #include <cstdint>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -122,7 +124,16 @@ class VirtualFrame {
     [[nodiscard]] bool has_pending() const { return !pending_gates_.empty(); }
     [[nodiscard]] size_t pending_size() const { return pending_gates_.size(); }
 
-    void append_gate(PendingGate gate) { pending_gates_.push_back(gate); }
+    void append_gate(PendingGate gate) {
+        pending_gates_.push_back(gate);
+        gate_log_.push_back(gate);
+    }
+
+    /// Every gate ever appended, in application order. Flushing materializes
+    /// gates into the tableau but the log survives: the final tableau
+    /// composition needs the concrete gate sequence to track the canonical
+    /// global phase, which the materialized tableau alone cannot supply.
+    [[nodiscard]] const std::vector<PendingGate>& gate_log() const { return gate_log_; }
 
     // Flush all pending gates into the materialized tableau in a single
     // transposed scope. Call before operations that require direct tableau
@@ -316,6 +327,7 @@ class VirtualFrame {
 
     stim::Tableau<kStimWidth> materialized_;
     std::vector<PendingGate> pending_gates_;
+    std::vector<PendingGate> gate_log_;
     size_t flush_threshold_;
 
     // Per-instance scratch buffers reused across calls to map_noise_channel.
@@ -352,6 +364,15 @@ struct CompilerContext {
         emit_k_history.push_back(reg_manager.active_k());
     }
 };
+
+/// Phase factor relating stim's canonical unitaries across the deferred
+/// virtual-frame composition. With gates u_1..u_J taken from `gate_log` in
+/// application order and `composed` the tableau of target * (u_J...u_1)^{-1}:
+///   canonical(composed) * u_J * ... * u_1 == phase * canonical(target).
+/// `target` only validates the reconstruction in debug builds.
+[[nodiscard]] std::complex<double> frame_composition_phase(stim::Tableau<kStimWidth> composed,
+                                                           std::span<const PendingGate> gate_log,
+                                                           const stim::Tableau<kStimWidth>& target);
 
 // =============================================================================
 // Result of localize_pauli: identifies what the Pauli was localized to.

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -1,6 +1,7 @@
 #include "clifft/optimizer/peephole.h"
 
 #include "clifft/optimizer/commutation.h"
+#include "clifft/util/canonical_phase.h"
 #include "clifft/util/constants.h"
 
 #include <algorithm>
@@ -72,208 +73,6 @@ inline void conjugate_pauli_by_S(MaskView x_p, MaskView z_p, bool sign_p, Mutabl
     z_q.xor_with(z_p);
 }
 
-// =========================================================================
-// Canonical tableau phase tracking
-// =========================================================================
-//
-// A stim::Tableau fixes its Clifford only up to global phase;
-// to_flat_unitary_matrix() resolves the ambiguity by scaling the row-major
-// flat matrix so its first nonzero entry is real positive. Replacing the
-// physical fused rotation R = Pi_+ + (+-i) Pi_- (projector form, including
-// its intrinsic e^{+-i*pi/4} relative to the SU(2) rotation) with the
-// tableau update U_C' = U_C * S_P therefore shifts the API-visible global
-// phase: canonical(U_C') = canonical(U_C) * R holds only up to an eighth
-// root of unity. The helpers below compute that root so the pass can fold
-// it into hir.global_weight and keep get_statevector() exact.
-//
-// The flat matrix of a tableau is the Choi state of the Clifford: a
-// 2n-qubit stabilizer state whose flat index packs (row << n) | col with
-// qubit q <-> bit q, stabilized by X_k (x) U(X_k) and Z_k (x) U(Z_k) on
-// the (input, output) halves. The first nonzero flat-matrix entry sits at
-// the minimum-integer support index of that state, and entries relative
-// to it follow by walking support generators, so the whole computation is
-// polynomial in n.
-
-using ChoiRow = stim::PauliString<kStimWidth>;
-using ChoiIndex = std::vector<uint64_t>;
-
-/// Row-reduced description of a tableau's Choi state: support generators
-/// in descending-pivot order plus the minimum-integer support index, which
-/// stim's matrix canonicalization anchors at a positive real amplitude.
-struct ChoiSupport {
-    std::vector<ChoiRow> x_rows;
-    std::vector<uint32_t> pivots;
-    std::vector<ChoiIndex> x_masks;
-    ChoiIndex anchor;
-};
-
-std::vector<ChoiRow> choi_generators(const stim::Tableau<kStimWidth>& tab) {
-    const size_t n = tab.num_qubits;
-    std::vector<ChoiRow> gens;
-    gens.reserve(2 * n);
-    for (size_t k = 0; k < n; ++k) {
-        for (bool z_input : {false, true}) {
-            const auto image = z_input ? tab.zs[k] : tab.xs[k];
-            ChoiRow g(2 * n);
-            if (z_input) {
-                g.zs[k] = true;
-            } else {
-                g.xs[k] = true;
-            }
-            for (size_t q = 0; q < n; ++q) {
-                g.xs[n + q] = image.xs[q];
-                g.zs[n + q] = image.zs[q];
-            }
-            g.sign = image.sign;
-            gens.push_back(std::move(g));
-        }
-    }
-    return gens;
-}
-
-[[nodiscard]] ChoiIndex choi_x_mask(const ChoiRow& row, uint32_t words) {
-    ChoiIndex mask(words, 0);
-    for (uint32_t w = 0; w < words; ++w) {
-        mask[w] = row.xs.u64[w];
-    }
-    return mask;
-}
-
-[[nodiscard]] bool index_bit(const ChoiIndex& idx, uint32_t bit) {
-    return ((idx[bit / 64] >> (bit % 64)) & 1U) != 0;
-}
-
-void index_xor(ChoiIndex& dst, const ChoiIndex& src) {
-    for (size_t w = 0; w < dst.size(); ++w) {
-        dst[w] ^= src[w];
-    }
-}
-
-constexpr std::complex<double> kIPow[4] = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
-
-/// Phase of P|j> = i^{2*sign + #Y + 2*parity(j & z)} |j ^ x| for a
-/// Hermitian signed Pauli P = (-1)^sign X^x Z^z (Y contributing i each).
-[[nodiscard]] std::complex<double> pauli_ket_phase(const ChoiRow& p, const ChoiIndex& j) {
-    uint32_t phase_idx = p.sign ? 2U : 0U;
-    for (size_t w = 0; w < j.size(); ++w) {
-        phase_idx += static_cast<uint32_t>(std::popcount(p.xs.u64[w] & p.zs.u64[w]));
-        phase_idx += 2U * (static_cast<uint32_t>(std::popcount(p.zs.u64[w] & j[w])) & 1U);
-    }
-    return kIPow[phase_idx & 3U];
-}
-
-/// Gauss-Jordan reduce the Choi stabilizer group and locate the
-/// minimum-integer support index. Scanning columns from the most
-/// significant bit down guarantees each pivot row's leading X bit is its
-/// pivot, so clearing pivot bits greedily minimizes over the support coset.
-[[nodiscard]] ChoiSupport build_choi_support(std::vector<ChoiRow> rows, size_t num_choi_qubits) {
-    const auto m = static_cast<uint32_t>(num_choi_qubits);
-    const uint32_t words = (m + 63U) / 64U;
-
-    ChoiSupport s;
-
-    size_t rank_x = 0;
-    for (uint32_t col = m; col-- > 0;) {
-        size_t pivot = rows.size();
-        for (size_t r = rank_x; r < rows.size(); ++r) {
-            if (rows[r].xs[col]) {
-                pivot = r;
-                break;
-            }
-        }
-        if (pivot == rows.size()) {
-            continue;
-        }
-        std::swap(rows[rank_x], rows[pivot]);
-        for (size_t r = 0; r < rows.size(); ++r) {
-            if (r != rank_x && rows[r].xs[col]) {
-                rows[r].ref() *= rows[rank_x];
-            }
-        }
-        s.pivots.push_back(col);
-        ++rank_x;
-    }
-
-    // The remaining rows are pure-Z constraints. After Gauss-Jordan over
-    // their Z parts, each pivot equation fixes one bit of a particular
-    // support element (zero on all free columns). Signs must be read only
-    // after the reduction finishes: clearing a later column can multiply an
-    // earlier pivot row and flip its sign.
-    std::vector<uint32_t> z_pivots;
-    size_t rank_z = rank_x;
-    for (uint32_t col = m; col-- > 0;) {
-        size_t pivot = rows.size();
-        for (size_t r = rank_z; r < rows.size(); ++r) {
-            if (rows[r].zs[col]) {
-                pivot = r;
-                break;
-            }
-        }
-        if (pivot == rows.size()) {
-            continue;
-        }
-        std::swap(rows[rank_z], rows[pivot]);
-        for (size_t r = rank_x; r < rows.size(); ++r) {
-            if (r != rank_z && rows[r].zs[col]) {
-                rows[r].ref() *= rows[rank_z];
-            }
-        }
-        z_pivots.push_back(col);
-        ++rank_z;
-    }
-    ChoiIndex base(words, 0);
-    for (size_t i = 0; i < z_pivots.size(); ++i) {
-        if (rows[rank_x + i].sign) {
-            base[z_pivots[i] / 64] |= uint64_t{1} << (z_pivots[i] % 64);
-        }
-    }
-    // A full-rank tableau group leaves no inconsistent identity rows.
-    for (size_t r = rank_z; r < rows.size(); ++r) {
-        assert(!rows[r].sign && "inconsistent Choi stabilizer group");
-    }
-
-    s.x_rows.assign(std::make_move_iterator(rows.begin()),
-                    std::make_move_iterator(rows.begin() + static_cast<ptrdiff_t>(rank_x)));
-    s.x_masks.reserve(rank_x);
-    for (const auto& row : s.x_rows) {
-        s.x_masks.push_back(choi_x_mask(row, words));
-    }
-
-    for (size_t i = 0; i < s.x_rows.size(); ++i) {
-        if (index_bit(base, s.pivots[i])) {
-            index_xor(base, s.x_masks[i]);
-        }
-    }
-    s.anchor = std::move(base);
-    return s;
-}
-
-/// Amplitude of |index> in the Choi state, in units where the anchor
-/// (stim's positive-real first nonzero matrix entry) has amplitude 1.
-/// Returns 0 when the index lies outside the support.
-[[nodiscard]] std::complex<double> choi_amplitude(const ChoiSupport& s, const ChoiIndex& index) {
-    ChoiIndex residual = index;
-    index_xor(residual, s.anchor);
-    ChoiIndex current = s.anchor;
-    std::complex<double> amp{1.0, 0.0};
-
-    for (size_t i = 0; i < s.x_rows.size(); ++i) {
-        if (!index_bit(residual, s.pivots[i])) {
-            continue;
-        }
-        amp *= pauli_ket_phase(s.x_rows[i], current);
-        index_xor(current, s.x_masks[i]);
-        index_xor(residual, s.x_masks[i]);
-    }
-
-    for (uint64_t word : residual) {
-        if (word != 0) {
-            return {0.0, 0.0};
-        }
-    }
-    return amp;
-}
-
 }  // namespace
 
 namespace internal {
@@ -332,12 +131,16 @@ void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z
     }
 }
 
+// The fused rotation R = Pi_+ + (+-i) Pi_- (projector form, including its
+// intrinsic e^{+-i*pi/4} relative to the SU(2) rotation) was replaced by
+// the tableau update U_C' = U_C * S_P, so canonical(U_C') matches
+// canonical(U_C) * R only up to an eighth root of unity. Evaluate
+// canonical(U_C) * R at the new canonical anchor to recover that root.
 std::complex<double> s_absorption_phase(const stim::Tableau<kStimWidth>& original,
                                         const stim::Tableau<kStimWidth>& updated, MaskView x_v,
                                         MaskView z_v, bool sign_v, bool is_dagger) {
-    const size_t n = original.num_qubits;
-    const ChoiSupport old_support = build_choi_support(choi_generators(original), 2 * n);
-    const ChoiSupport new_support = build_choi_support(choi_generators(updated), 2 * n);
+    const ChoiSupport old_support = build_choi_support(original);
+    const ChoiSupport new_support = build_choi_support(updated);
 
     // R = a*I + b*P in matrix form, so column c of R has entries a at row c
     // and b * phase(P|c>) at row c ^ x. The new canonical anchor packs
@@ -361,7 +164,7 @@ std::complex<double> s_absorption_phase(const stim::Tableau<kStimWidth>& origina
         alpha_idx += 2U * (static_cast<uint32_t>(std::popcount(z_v.words[w] & anchor[w])) & 1U);
         x_is_zero &= (x_v.words[w] == 0);
     }
-    const std::complex<double> alpha = kIPow[alpha_idx & 3U];
+    const std::complex<double> alpha = kImagPow[alpha_idx & 3U];
 
     std::complex<double> w_entry;
     if (x_is_zero) {

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -158,25 +158,20 @@ std::complex<double> s_absorption_phase(const stim::Tableau<kStimWidth>& origina
     // phase(P|c>) for c = low half of the anchor. Mask words beyond the
     // input half never overlap z_v, whose bits above n are zero.
     uint32_t alpha_idx = sign_v ? 2U : 0U;
-    bool x_is_zero = true;
     for (uint32_t w = 0; w < mask_words; ++w) {
         alpha_idx += static_cast<uint32_t>(std::popcount(x_v.words[w] & z_v.words[w]));
         alpha_idx += 2U * (static_cast<uint32_t>(std::popcount(z_v.words[w] & anchor[w])) & 1U);
-        x_is_zero &= (x_v.words[w] == 0);
     }
     const std::complex<double> alpha = kImagPow[alpha_idx & 3U];
 
-    std::complex<double> w_entry;
-    if (x_is_zero) {
-        w_entry = (a + b * alpha) * choi_amplitude(old_support, anchor);
-    } else {
-        ChoiIndex partner = anchor;
-        for (uint32_t w = 0; w < mask_words; ++w) {
-            partner[w] ^= x_v.words[w];
-        }
-        w_entry = a * choi_amplitude(old_support, anchor) +
-                  b * alpha * choi_amplitude(old_support, partner);
+    // For a pure-Z Pauli the partner coincides with the anchor and the two
+    // terms add up to the diagonal entry (a + b * alpha).
+    ChoiIndex partner = anchor;
+    for (uint32_t w = 0; w < mask_words; ++w) {
+        partner[w] ^= x_v.words[w];
     }
+    const std::complex<double> w_entry =
+        a * choi_amplitude(old_support, anchor) + b * alpha * choi_amplitude(old_support, partner);
 
     const double mag = std::abs(w_entry);
     assert(mag > 0.25 && "canonical anchor outside expected support");

--- a/src/clifft/util/canonical_phase.cc
+++ b/src/clifft/util/canonical_phase.cc
@@ -1,0 +1,175 @@
+#include "clifft/util/canonical_phase.h"
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <utility>
+
+namespace clifft::internal {
+
+namespace {
+
+using ChoiRow = stim::PauliString<kStimWidth>;
+
+std::vector<ChoiRow> choi_generators(const stim::Tableau<kStimWidth>& tab) {
+    const size_t n = tab.num_qubits;
+    std::vector<ChoiRow> gens;
+    gens.reserve(2 * n);
+    for (size_t k = 0; k < n; ++k) {
+        for (bool z_input : {false, true}) {
+            const auto image = z_input ? tab.zs[k] : tab.xs[k];
+            ChoiRow g(2 * n);
+            if (z_input) {
+                g.zs[k] = true;
+            } else {
+                g.xs[k] = true;
+            }
+            for (size_t q = 0; q < n; ++q) {
+                g.xs[n + q] = image.xs[q];
+                g.zs[n + q] = image.zs[q];
+            }
+            g.sign = image.sign;
+            gens.push_back(std::move(g));
+        }
+    }
+    return gens;
+}
+
+[[nodiscard]] ChoiIndex choi_x_mask(const ChoiRow& row, uint32_t words) {
+    ChoiIndex mask(words, 0);
+    for (uint32_t w = 0; w < words; ++w) {
+        mask[w] = row.xs.u64[w];
+    }
+    return mask;
+}
+
+void index_xor(ChoiIndex& dst, const ChoiIndex& src) {
+    for (size_t w = 0; w < dst.size(); ++w) {
+        dst[w] ^= src[w];
+    }
+}
+
+/// Phase of P|j> = i^{2*sign + #Y + 2*parity(j & z)} |j ^ x| for a
+/// Hermitian signed Pauli P = (-1)^sign X^x Z^z (Y contributing i each).
+[[nodiscard]] std::complex<double> pauli_ket_phase(const ChoiRow& p, const ChoiIndex& j) {
+    uint32_t phase_idx = p.sign ? 2U : 0U;
+    for (size_t w = 0; w < j.size(); ++w) {
+        phase_idx += static_cast<uint32_t>(std::popcount(p.xs.u64[w] & p.zs.u64[w]));
+        phase_idx += 2U * (static_cast<uint32_t>(std::popcount(p.zs.u64[w] & j[w])) & 1U);
+    }
+    return kImagPow[phase_idx & 3U];
+}
+
+}  // namespace
+
+// Scanning columns from the most significant bit down guarantees each
+// pivot row's leading X bit is its pivot, so clearing pivot bits greedily
+// minimizes over the support coset.
+ChoiSupport build_choi_support(const stim::Tableau<kStimWidth>& tab) {
+    std::vector<ChoiRow> rows = choi_generators(tab);
+    const auto m = static_cast<uint32_t>(2 * tab.num_qubits);
+    const uint32_t words = (m + 63U) / 64U;
+
+    ChoiSupport s;
+
+    size_t rank_x = 0;
+    for (uint32_t col = m; col-- > 0;) {
+        size_t pivot = rows.size();
+        for (size_t r = rank_x; r < rows.size(); ++r) {
+            if (rows[r].xs[col]) {
+                pivot = r;
+                break;
+            }
+        }
+        if (pivot == rows.size()) {
+            continue;
+        }
+        std::swap(rows[rank_x], rows[pivot]);
+        for (size_t r = 0; r < rows.size(); ++r) {
+            if (r != rank_x && rows[r].xs[col]) {
+                rows[r].ref() *= rows[rank_x];
+            }
+        }
+        s.pivots.push_back(col);
+        ++rank_x;
+    }
+
+    // The remaining rows are pure-Z constraints. After Gauss-Jordan over
+    // their Z parts, each pivot equation fixes one bit of a particular
+    // support element (zero on all free columns). Signs must be read only
+    // after the reduction finishes: clearing a later column can multiply an
+    // earlier pivot row and flip its sign.
+    std::vector<uint32_t> z_pivots;
+    size_t rank_z = rank_x;
+    for (uint32_t col = m; col-- > 0;) {
+        size_t pivot = rows.size();
+        for (size_t r = rank_z; r < rows.size(); ++r) {
+            if (rows[r].zs[col]) {
+                pivot = r;
+                break;
+            }
+        }
+        if (pivot == rows.size()) {
+            continue;
+        }
+        std::swap(rows[rank_z], rows[pivot]);
+        for (size_t r = rank_x; r < rows.size(); ++r) {
+            if (r != rank_z && rows[r].zs[col]) {
+                rows[r].ref() *= rows[rank_z];
+            }
+        }
+        z_pivots.push_back(col);
+        ++rank_z;
+    }
+    ChoiIndex base(words, 0);
+    for (size_t i = 0; i < z_pivots.size(); ++i) {
+        if (rows[rank_x + i].sign) {
+            base[z_pivots[i] / 64] |= uint64_t{1} << (z_pivots[i] % 64);
+        }
+    }
+    // A full-rank tableau group leaves no inconsistent identity rows.
+    for (size_t r = rank_z; r < rows.size(); ++r) {
+        assert(!rows[r].sign && "inconsistent Choi stabilizer group");
+    }
+
+    s.x_rows.assign(std::make_move_iterator(rows.begin()),
+                    std::make_move_iterator(rows.begin() + static_cast<ptrdiff_t>(rank_x)));
+    s.x_masks.reserve(rank_x);
+    for (const auto& row : s.x_rows) {
+        s.x_masks.push_back(choi_x_mask(row, words));
+    }
+
+    for (size_t i = 0; i < s.x_rows.size(); ++i) {
+        if (choi_index_bit(base, s.pivots[i])) {
+            index_xor(base, s.x_masks[i]);
+        }
+    }
+    s.anchor = std::move(base);
+    return s;
+}
+
+std::complex<double> choi_amplitude(const ChoiSupport& s, const ChoiIndex& index) {
+    ChoiIndex residual = index;
+    index_xor(residual, s.anchor);
+    ChoiIndex current = s.anchor;
+    std::complex<double> amp{1.0, 0.0};
+
+    for (size_t i = 0; i < s.x_rows.size(); ++i) {
+        if (!choi_index_bit(residual, s.pivots[i])) {
+            continue;
+        }
+        amp *= pauli_ket_phase(s.x_rows[i], current);
+        index_xor(current, s.x_masks[i]);
+        index_xor(residual, s.x_masks[i]);
+    }
+
+    for (uint64_t word : residual) {
+        if (word != 0) {
+            return {0.0, 0.0};
+        }
+    }
+    return amp;
+}
+
+}  // namespace clifft::internal

--- a/src/clifft/util/canonical_phase.h
+++ b/src/clifft/util/canonical_phase.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// Canonical tableau phase tracking.
+//
+// A stim::Tableau fixes its Clifford only up to global phase;
+// to_flat_unitary_matrix() resolves the ambiguity by scaling the row-major
+// flat matrix so its first nonzero entry is real positive. Any rewrite
+// that replaces a physical unitary factor with a tableau update therefore
+// shifts the API-visible global phase, and the compiler must fold the
+// difference into global_weight to keep get_statevector() exact.
+//
+// The flat matrix of a tableau is the Choi state of the Clifford: a
+// 2n-qubit stabilizer state whose flat index packs (row << n) | col with
+// qubit q <-> bit q, stabilized by X_k (x) U(X_k) and Z_k (x) U(Z_k) on
+// the (input, output) halves. The first nonzero flat-matrix entry sits at
+// the minimum-integer support index of that state, and entries relative
+// to it follow by walking support generators, so phase deltas between
+// canonical forms are computable in polynomial time with no dense
+// matrices.
+
+#include "clifft/util/stim_mask.h"
+
+#include <complex>
+#include <cstdint>
+#include <vector>
+
+namespace clifft::internal {
+
+/// Flat Choi-state index, 2n bits packed little-endian into 64-bit words.
+using ChoiIndex = std::vector<uint64_t>;
+
+/// Row-reduced description of a tableau's Choi state: support generators
+/// in descending-pivot order plus the minimum-integer support index, which
+/// stim's matrix canonicalization anchors at a positive real amplitude.
+struct ChoiSupport {
+    std::vector<stim::PauliString<kStimWidth>> x_rows;
+    std::vector<uint32_t> pivots;
+    std::vector<ChoiIndex> x_masks;
+    ChoiIndex anchor;
+};
+
+/// Gauss-Jordan reduce the Choi stabilizer group of `tab` and locate the
+/// minimum-integer support index of its flat unitary matrix.
+[[nodiscard]] ChoiSupport build_choi_support(const stim::Tableau<kStimWidth>& tab);
+
+/// Amplitude of |index> in the Choi state, in units where the anchor
+/// (stim's positive-real first nonzero matrix entry) has amplitude 1.
+/// Returns 0 when the index lies outside the support.
+[[nodiscard]] std::complex<double> choi_amplitude(const ChoiSupport& s, const ChoiIndex& index);
+
+inline constexpr std::complex<double> kImagPow[4] = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+
+[[nodiscard]] inline bool choi_index_bit(const ChoiIndex& idx, uint32_t bit) {
+    return ((idx[bit / 64] >> (bit % 64)) & 1U) != 0;
+}
+
+inline void choi_index_flip_bit(ChoiIndex& idx, uint32_t bit) {
+    idx[bit / 64] ^= uint64_t{1} << (bit % 64);
+}
+
+}  // namespace clifft::internal

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_forced_kernels.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_scalar.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_state.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/util/canonical_phase.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/util/introspection.cc
 )
 

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -196,6 +196,12 @@ class TestPeepholeExactGlobalPhase:
         "H 0\nCX 0 1\nS 1\nT 1\nT 1\nH 1\nT 1\nT 1",
         "Y 0\nH 0\nT 0\nT 0\nT 0\nT 0",
         "H 1\nCX 1 0\nR_Z(0.75) 0\nR_Z(0.75) 0\nH 0",
+        # Absorptions that leave rotations needing virtual-frame routing at
+        # lowering; these exercise the frame composition phase tracking.
+        "H 0\nT 0\nT 0\nT 0\nH 0\nT 0",
+        "CX 0 1\nY 1\nH 0\nR_Z(0.5) 0\nX 0",
+        "CX 0 1\nY 1\nH 0\nT_DAG 0\nT_DAG 0\nX 0",
+        "S_DAG 0\nH 0\nCX 2 3\nT 0\nCX 3 1\nT 0\nH 1\nT 1",
     ]
 
     def test_h_t_t_h_exact_amplitudes(self) -> None:
@@ -212,6 +218,19 @@ class TestPeepholeExactGlobalPhase:
         sv_baseline = _clifft_statevector(circuit)
         sv_optimized = _clifft_statevector(circuit, optimize=True)
         np.testing.assert_allclose(sv_optimized, sv_baseline, atol=1e-6)
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_random_circuits_componentwise(self, seed: int) -> None:
+        """Random Clifford+T circuits agree componentwise, no phase alignment.
+
+        Unlike the fidelity-based equivalence tests above, this catches
+        global-phase drift from S absorption and from the virtual-frame
+        tableau composition at lowering.
+        """
+        circuit = random_clifford_t_circuit(5, depth=30, seed=seed)
+        sv_baseline = _clifft_statevector(circuit)
+        sv_optimized = _clifft_statevector(circuit, optimize=True)
+        np.testing.assert_allclose(sv_optimized, sv_baseline, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1565,16 +1565,9 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
 
 namespace {
 
-using DenseMatrix = std::vector<std::complex<double>>;
-
-DenseMatrix dense_tableau(const stim::Tableau<kStimWidth>& tab) {
-    auto flat = tab.to_flat_unitary_matrix(true);
-    DenseMatrix m(flat.size());
-    for (size_t i = 0; i < flat.size(); ++i) {
-        m[i] = {flat[i].real(), flat[i].imag()};
-    }
-    return m;
-}
+using clifft::test::dense_matmul;
+using clifft::test::dense_tableau_matrix;
+using clifft::test::DenseMatrix;
 
 // Canonical matrix of a single pending frame gate, little-endian basis.
 DenseMatrix dense_pending_gate(const PendingGate& g, size_t n) {
@@ -1614,18 +1607,6 @@ DenseMatrix dense_pending_gate(const PendingGate& g, size_t n) {
         }
     }
     return m;
-}
-
-DenseMatrix dense_mul(const DenseMatrix& a, const DenseMatrix& b, uint64_t dim) {
-    DenseMatrix r(dim * dim, {0.0, 0.0});
-    for (uint64_t i = 0; i < dim; ++i) {
-        for (uint64_t k = 0; k < dim; ++k) {
-            for (uint64_t j = 0; j < dim; ++j) {
-                r[i * dim + j] += a[i * dim + k] * b[k * dim + j];
-            }
-        }
-    }
-    return r;
 }
 
 }  // namespace
@@ -1669,11 +1650,11 @@ TEST_CASE("Backend: frame composition phase matches dense canonical oracle") {
         const auto phase = frame_composition_phase(composed, log, target);
 
         const uint64_t dim = uint64_t{1} << n;
-        DenseMatrix lhs = dense_tableau(composed);
+        DenseMatrix lhs = dense_tableau_matrix(composed);
         for (auto it = log.rbegin(); it != log.rend(); ++it) {
-            lhs = dense_mul(lhs, dense_pending_gate(*it, n), dim);
+            lhs = dense_matmul(lhs, dense_pending_gate(*it, n), dim);
         }
-        const DenseMatrix rhs = dense_tableau(target);
+        const DenseMatrix rhs = dense_tableau_matrix(target);
         for (uint64_t i = 0; i < dim * dim; ++i) {
             CAPTURE(i);
             const auto expected = phase * rhs[i];

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -12,8 +12,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
+#include <complex>
 #include <cstdint>
+#include <random>
 #include <string>
+#include <vector>
 
 using namespace clifft;
 using namespace clifft::internal;
@@ -1554,4 +1557,128 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
     CHECK(cv.x().is_zero());
     CHECK(cv.z() == Z(0));
     CHECK_THAT(ch.prob, Catch::Matchers::WithinAbs(0.25, 1e-12));
+}
+
+// =============================================================================
+// Frame composition canonical phase -- dense stim oracle
+// =============================================================================
+
+namespace {
+
+using DenseMatrix = std::vector<std::complex<double>>;
+
+DenseMatrix dense_tableau(const stim::Tableau<kStimWidth>& tab) {
+    auto flat = tab.to_flat_unitary_matrix(true);
+    DenseMatrix m(flat.size());
+    for (size_t i = 0; i < flat.size(); ++i) {
+        m[i] = {flat[i].real(), flat[i].imag()};
+    }
+    return m;
+}
+
+// Canonical matrix of a single pending frame gate, little-endian basis.
+DenseMatrix dense_pending_gate(const PendingGate& g, size_t n) {
+    const uint64_t dim = uint64_t{1} << n;
+    constexpr std::complex<double> kI{0.0, 1.0};
+    const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+
+    DenseMatrix m(dim * dim, {0.0, 0.0});
+    for (uint64_t c = 0; c < dim; ++c) {
+        const bool b1 = ((c >> g.axis_1) & 1) != 0;
+        const bool b2 = ((c >> g.axis_2) & 1) != 0;
+        switch (g.type) {
+            case PendingGateType::S:
+                m[c * dim + c] = b1 ? kI : 1.0;
+                break;
+            case PendingGateType::CZ:
+                m[c * dim + c] = (b1 && b2) ? -1.0 : 1.0;
+                break;
+            case PendingGateType::CNOT:
+                m[(b1 ? c ^ (uint64_t{1} << g.axis_2) : c) * dim + c] = 1.0;
+                break;
+            case PendingGateType::SWAP: {
+                uint64_t r = c;
+                if (b1 != b2) {
+                    r ^= (uint64_t{1} << g.axis_1) | (uint64_t{1} << g.axis_2);
+                }
+                m[r * dim + c] = 1.0;
+                break;
+            }
+            case PendingGateType::H: {
+                const uint64_t r0 = c & ~(uint64_t{1} << g.axis_1);
+                const uint64_t r1 = c | (uint64_t{1} << g.axis_1);
+                m[r0 * dim + c] = inv_sqrt2;
+                m[r1 * dim + c] = b1 ? -inv_sqrt2 : inv_sqrt2;
+                break;
+            }
+        }
+    }
+    return m;
+}
+
+DenseMatrix dense_mul(const DenseMatrix& a, const DenseMatrix& b, uint64_t dim) {
+    DenseMatrix r(dim * dim, {0.0, 0.0});
+    for (uint64_t i = 0; i < dim; ++i) {
+        for (uint64_t k = 0; k < dim; ++k) {
+            for (uint64_t j = 0; j < dim; ++j) {
+                r[i * dim + j] += a[i * dim + k] * b[k * dim + j];
+            }
+        }
+    }
+    return r;
+}
+
+}  // namespace
+
+TEST_CASE("Backend: frame composition phase matches dense canonical oracle") {
+    // For target tableau T and frame gates u_1..u_J (application order),
+    // composed = tableau(T * (u_J...u_1)^{-1}) is what lower() stores; the
+    // chained phase must satisfy
+    //   canonical(composed) * u_J * ... * u_1 == phase * canonical(T)
+    // componentwise against stim's dense matrices.
+    std::mt19937_64 rng(0x141);
+
+    for (int trial = 0; trial < 128; ++trial) {
+        CAPTURE(trial);
+        const size_t n = 2 + static_cast<size_t>(trial % 2);
+        const auto target = stim::Tableau<kStimWidth>::random(n, rng);
+
+        std::vector<PendingGate> log;
+        const size_t num_gates = 1 + rng() % 8;
+        for (size_t i = 0; i < num_gates; ++i) {
+            PendingGate g{};
+            g.type = static_cast<PendingGateType>(rng() % 5);
+            g.axis_1 = static_cast<uint16_t>(rng() % n);
+            g.axis_2 = static_cast<uint16_t>(rng() % n);
+            if ((g.type == PendingGateType::CNOT || g.type == PendingGateType::CZ ||
+                 g.type == PendingGateType::SWAP) &&
+                g.axis_2 == g.axis_1) {
+                g.axis_2 = static_cast<uint16_t>((g.axis_1 + 1) % n);
+            }
+            log.push_back(g);
+        }
+
+        // Reproduce lower()'s composition through the production frame.
+        VirtualFrame frame(static_cast<uint32_t>(n), 4);
+        for (const auto& g : log) {
+            frame.append_gate(g);
+        }
+        const stim::Tableau<kStimWidth> v_cum_inv = frame.mutable_materialized_tableau().inverse();
+        const stim::Tableau<kStimWidth> composed = v_cum_inv.then(target);
+
+        const auto phase = frame_composition_phase(composed, log, target);
+
+        const uint64_t dim = uint64_t{1} << n;
+        DenseMatrix lhs = dense_tableau(composed);
+        for (auto it = log.rbegin(); it != log.rend(); ++it) {
+            lhs = dense_mul(lhs, dense_pending_gate(*it, n), dim);
+        }
+        const DenseMatrix rhs = dense_tableau(target);
+        for (uint64_t i = 0; i < dim * dim; ++i) {
+            CAPTURE(i);
+            const auto expected = phase * rhs[i];
+            REQUIRE_THAT(lhs[i].real(), Catch::Matchers::WithinAbs(expected.real(), 1e-5));
+            REQUIRE_THAT(lhs[i].imag(), Catch::Matchers::WithinAbs(expected.imag(), 1e-5));
+        }
+    }
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -20,6 +20,7 @@
 #include <span>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace clifft {
 namespace test {
@@ -136,6 +137,31 @@ inline void check_complex(std::complex<double> actual, std::complex<double> expe
                           double tol = kDefaultTol) {
     CHECK_THAT(actual.real(), Catch::Matchers::WithinAbs(expected.real(), tol));
     CHECK_THAT(actual.imag(), Catch::Matchers::WithinAbs(expected.imag(), tol));
+}
+
+// Dense-matrix oracle helpers for canonical-phase tests. Row-major
+// dim x dim complex matrices in little-endian basis order.
+using DenseMatrix = std::vector<std::complex<double>>;
+
+inline DenseMatrix dense_tableau_matrix(const stim::Tableau<kStimWidth>& tab) {
+    auto flat = tab.to_flat_unitary_matrix(true);
+    DenseMatrix m(flat.size());
+    for (size_t i = 0; i < flat.size(); ++i) {
+        m[i] = {flat[i].real(), flat[i].imag()};
+    }
+    return m;
+}
+
+inline DenseMatrix dense_matmul(const DenseMatrix& a, const DenseMatrix& b, uint64_t dim) {
+    DenseMatrix r(dim * dim, {0.0, 0.0});
+    for (uint64_t i = 0; i < dim; ++i) {
+        for (uint64_t k = 0; k < dim; ++k) {
+            for (uint64_t j = 0; j < dim; ++j) {
+                r[i * dim + j] += a[i * dim + k] * b[k * dim + j];
+            }
+        }
+    }
+    return r;
 }
 
 }  // namespace test

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -720,7 +720,9 @@ TEST_CASE("Peephole: commuting NOISE does not bypass EXP_VAL barrier", "[optimiz
 
 namespace {
 
-using DenseMatrix = std::vector<std::complex<double>>;
+using clifft::test::dense_matmul;
+using clifft::test::dense_tableau_matrix;
+using clifft::test::DenseMatrix;
 
 // Dense matrix of the projector-form rotation Pi_+ + e^{i*alpha*pi} Pi_- on
 // the signed Pauli (x, z, sign) over n qubits, little-endian basis order.
@@ -739,27 +741,6 @@ DenseMatrix dense_axis_rotation(uint64_t x, uint64_t z, bool sign, double alpha,
         uint32_t phase_idx = (sign ? 2U : 0U) + static_cast<uint32_t>(std::popcount(x & z)) +
                              2U * (static_cast<uint32_t>(std::popcount(c & z)) & 1U);
         r[(c ^ x) * dim + c] += b * kIPow[phase_idx & 3U];
-    }
-    return r;
-}
-
-DenseMatrix dense_tableau_matrix(const stim::Tableau<kStimWidth>& tab) {
-    auto flat = tab.to_flat_unitary_matrix(true);
-    DenseMatrix m(flat.size());
-    for (size_t i = 0; i < flat.size(); ++i) {
-        m[i] = {flat[i].real(), flat[i].imag()};
-    }
-    return m;
-}
-
-DenseMatrix dense_matmul(const DenseMatrix& a, const DenseMatrix& b, uint64_t dim) {
-    DenseMatrix r(dim * dim, {0.0, 0.0});
-    for (uint64_t i = 0; i < dim; ++i) {
-        for (uint64_t k = 0; k < dim; ++k) {
-            for (uint64_t j = 0; j < dim; ++j) {
-                r[i * dim + j] += a[i * dim + k] * b[k * dim + j];
-            }
-        }
     }
     return r;
 }

--- a/tests/test_statevector.cc
+++ b/tests/test_statevector.cc
@@ -1008,6 +1008,12 @@ TEST_CASE("Peephole statevector: optimized equals unoptimized componentwise") {
         "H 0\nCX 0 1\nS 1\nT 1\nT 1\nH 1\nT 1\nT 1",
         "Y 0\nH 0\nT 0\nT 0\nT 0\nT 0",
         "H 1\nCX 1 0\nR_Z(0.75) 0\nR_Z(0.75) 0\nH 0",
+        // Absorptions that leave rotations needing virtual-frame routing at
+        // lowering; these exercise the frame composition phase tracking.
+        "H 0\nT 0\nT 0\nT 0\nH 0\nT 0",
+        "CX 0 1\nY 1\nH 0\nR_Z(0.5) 0\nX 0",
+        "CX 0 1\nY 1\nH 0\nT_DAG 0\nT_DAG 0\nX 0",
+        "S_DAG 0\nH 0\nCX 2 3\nT 0\nCX 3 1\nT 0\nH 1\nT 1",
     };
 
     for (const char* circuit : circuits) {


### PR DESCRIPTION
Fixes #141. Stacked on #140 — review and merge that first; this PR's base is its branch.

## Problem

`lower()` defers virtual frame gates symplectically and composes them into the constant-pool tableau (`v_cum_inv.then(*hir.final_tableau)`). The composed tableau realizes those gates only up to stim's canonical matrix phase, so `get_statevector()`'s global phase shifted whenever leftover rotations localized through frame routing. This error composed with the peephole absorption phase: on `H 0; T 0; T 0; T 0; H 0; T 0` the two bugs cancelled on main, #140 alone exposed the backend error (`e^{i*pi/4}`), and on most random circuits the composition broke agreement in the other direction.

## Fix

Track the phase explicitly instead of letting the composition re-anchor it:

- `VirtualFrame` keeps a log of every appended gate (flushing still materializes into the tableau; the log preserves the concrete sequence, which the materialized tableau alone cannot supply).
- `lower()` chains per-gate canonical deltas `canonical(B) * u == phase * canonical(tableau(B * u))` from the composed tableau back to the HIR tableau, walking the log in reverse application order, and folds the conjugate product into `global_weight`. Each pending-gate matrix (H, S, CNOT, CZ, SWAP) has at most two entries per column, so every link costs one Choi support reduction plus at most two amplitude walks.
- The Choi machinery moves from `peephole.cc` to a shared `util/canonical_phase.{h,cc}` (both `src/clifft` and `src/wasm` source lists updated); the peephole's `s_absorption_phase` now uses it.
- Programs with measurements or noise skip the correction: every observable output there is insensitive to global phase, and their frame logs grow with every localized measurement (QEC-scale compiles are unaffected — fixture compile times unchanged).

## Validation

- `frame_composition_phase` fuzzed against dense stim matrices through the production `VirtualFrame` composition path: 128 random tableau/gate-log combinations, componentwise (`test_backend.cc`).
- The #141 repro class is exact again: `H T T T H T` gives optimized == unoptimized == truth; the directed corpus in C++/Python now includes leftover-rotation circuits that were previously impossible to test componentwise.
- New randomized componentwise test: 20 random 5q/depth-30 Clifford+T circuits, optimized vs unoptimized with **no global-phase alignment** (`test_peephole_oracle.py`) — the test issue #139 originally asked for, now achievable.
- 192-circuit stress suite: 61 componentwise mismatches before #140, 10 after #140 alone, **0 with this PR**.
- Full suites: 769/769 C++ (Debug), 712/712 Python; pre-commit clean.

## Cost

Only measurement/noise-free programs with frame gates pay: one Choi reduction per frame gate at composition time (~0.35 ms/gate at n=100). The SVM rank cap (k < 63) bounds leftover activations, so the chain is bounded for any compilable unitary circuit; `qv10`/`cultivation_d5`/`target_qec` fixtures (all measured) are byte-identical in compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)