### PR TITLE
feat(python): Pauli-twirl helpers for coherent control errors

### DIFF
--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -54,7 +54,7 @@ def _check_multiprocessing_omp() -> None:
 _check_multiprocessing_omp()
 del _check_multiprocessing_omp
 
-from clifft import noncomp
+from clifft import noncomp, twirl
 from clifft._clifft_core import (
     AstNode,
     BytecodePass,
@@ -425,6 +425,7 @@ __all__ = [
     "set_num_threads",
     "svm_backend",
     "trace",
+    "twirl",
     "version",
 ]
 

--- a/src/python/clifft/twirl.py
+++ b/src/python/clifft/twirl.py
@@ -20,6 +20,12 @@ These helpers only compute probabilities. Insert them into circuits as
 ordinary noise instructions (``Z_ERROR(p)``, ``PAULI_CHANNEL_1(px, py, pz)``),
 which both the plain sampler and the noncomputational path treat like any
 other Pauli noise.
+
+This module is experimental. It operates on one unitary at a time and leaves
+the circuit editing to the caller; a more robust interface -- a circuit
+annotated with the sites to twirl, with the noise nodes substituted
+internally -- may supersede these free functions, changing or removing this
+surface.
 """
 
 from __future__ import annotations

--- a/src/python/clifft/twirl.py
+++ b/src/python/clifft/twirl.py
@@ -1,0 +1,73 @@
+"""Pauli-twirling helpers for coherent control errors.
+
+A coherent control error -- an over-rotation, a phase miscalibration -- is a
+unitary, not a noncomputational status change. Clifft can simulate a coherent
+error exactly at the usual active-rank cost; the standard fast-path
+alternative is to *twirl* it: replace the error unitary ``U`` with the Pauli
+channel whose probabilities are
+
+    p_P = |tr(U P)|^2 / 4,    P in {I, X, Y, Z}.
+
+A single twirled error reproduces the exact computational-basis statistics of
+one application; errors that interfere across several gates (echo sequences,
+coherent accumulation) do not twirl faithfully -- that is the approximation.
+
+These helpers only compute probabilities. Insert them into circuits as
+ordinary noise instructions (``Z_ERROR(p)``, ``PAULI_CHANNEL_1(px, py, pz)``),
+which both the plain sampler and the noncomputational path treat like any
+other Pauli noise.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import numpy.typing as npt
+
+__all__ = [
+    "pauli_probabilities",
+    "rotation",
+]
+
+_PAULIS = (
+    np.array([[0, 1], [1, 0]], dtype=complex),
+    np.array([[0, -1j], [1j, 0]], dtype=complex),
+    np.array([[1, 0], [0, -1]], dtype=complex),
+)
+
+
+def pauli_probabilities(unitary: npt.ArrayLike) -> tuple[float, float, float]:
+    """Twirl a single-qubit unitary into Pauli probabilities ``(p_x, p_y, p_z)``.
+
+    The identity probability is the complement ``1 - p_x - p_y - p_z``. The
+    result is insensitive to the unitary's global phase. Suitable as the
+    arguments of a ``PAULI_CHANNEL_1`` instruction (or a single ``*_ERROR``
+    when only one component is nonzero).
+
+    Raises:
+        ValueError: if ``unitary`` is not a 2x2 unitary matrix.
+    """
+    u = np.asarray(unitary, dtype=complex)
+    if u.shape != (2, 2):
+        raise ValueError(f"pauli_probabilities: expected a 2x2 matrix, got shape {u.shape}")
+    if not np.allclose(u @ u.conj().T, np.eye(2), atol=1e-9):
+        raise ValueError("pauli_probabilities: matrix is not unitary")
+    return tuple(float(abs(np.trace(u @ p)) ** 2 / 4.0) for p in _PAULIS)  # type: ignore[return-value]
+
+
+def rotation(axis: str, radians: float) -> tuple[float, float, float]:
+    """Twirl of the rotation ``exp(-i * radians/2 * P_axis)``.
+
+    Closed form: probability ``sin^2(radians / 2)`` on the rotation axis and
+    zero elsewhere. This is the per-gate channel for an over-rotation by
+    ``radians`` about ``axis`` ("X", "Y", or "Z").
+    """
+    p = math.sin(radians / 2.0) ** 2
+    try:
+        index = ("X", "Y", "Z").index(axis.upper())
+    except ValueError:
+        raise ValueError(f"rotation: axis must be 'X', 'Y', or 'Z', got {axis!r}") from None
+    out = [0.0, 0.0, 0.0]
+    out[index] = p
+    return (out[0], out[1], out[2])

--- a/src/python/clifft/twirl.py
+++ b/src/python/clifft/twirl.py
@@ -8,9 +8,13 @@ channel whose probabilities are
 
     p_P = |tr(U P)|^2 / 4,    P in {I, X, Y, Z}.
 
-A single twirled error reproduces the exact computational-basis statistics of
-one application; errors that interfere across several gates (echo sequences,
-coherent accumulation) do not twirl faithfully -- that is the approximation.
+The twirled channel preserves the diagonal of ``U``'s Pauli transfer matrix
+and discards the coherences between Pauli components. That is an
+approximation, not an equivalence: circuit statistics under the twirled
+channel generally differ from the exact unitary even for a single
+application (twirling one Hadamard turns a deterministic H-H identity into a
+coin flip), and they coincide only in selected configurations where the
+discarded coherences never reach a measurement.
 
 These helpers only compute probabilities. Insert them into circuits as
 ordinary noise instructions (``Z_ERROR(p)``, ``PAULI_CHANNEL_1(px, py, pz)``),

--- a/tests/python/test_twirl.py
+++ b/tests/python/test_twirl.py
@@ -1,0 +1,123 @@
+"""Tests for the Pauli-twirl helpers and Pauli-noise passthrough.
+
+The helper math is checked against closed forms and against clifft's own
+exact near-Clifford simulation: a single twirled error reproduces the exact
+computational-basis statistics of one application, while coherently
+accumulating errors do not -- the second half is asserted too, so the
+approximation boundary is pinned rather than implied.
+
+The passthrough tests confirm ordinary Pauli noise instructions behave
+identically through the noncomputational path: statistically unchanged on
+computational qubits, dropped on leaked/lost operands.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import clifft
+from clifft import noncomp, twirl
+
+BAND = 0.04  # ~7 sigma at 8000 shots for p near 0.5
+SHOTS = 8000
+
+S_MATRIX = np.array([[1, 0], [0, 1j]], dtype=complex)
+
+
+def _p1(text: str, slot: int = 0, seed: int = 1) -> float:
+    meas = np.asarray(clifft.sample(clifft.compile(text), SHOTS, seed).measurements)
+    return float(meas[:, slot].mean())
+
+
+# --- Helper math -------------------------------------------------------------
+
+
+def test_rotation_closed_form():
+    theta = 0.37
+    p = np.sin(theta / 2) ** 2
+    assert twirl.rotation("Z", theta) == pytest.approx((0.0, 0.0, p))
+    assert twirl.rotation("X", theta) == pytest.approx((p, 0.0, 0.0))
+    assert twirl.rotation("y", theta) == pytest.approx((0.0, p, 0.0))
+    with pytest.raises(ValueError, match="axis"):
+        twirl.rotation("Q", theta)
+
+
+def test_pauli_probabilities_matches_rotation():
+    theta = 0.81
+    rz = np.array([[np.exp(-1j * theta / 2), 0], [0, np.exp(1j * theta / 2)]])
+    assert twirl.pauli_probabilities(rz) == pytest.approx(twirl.rotation("Z", theta))
+
+
+def test_pauli_probabilities_known_cases():
+    # X twirls to a certain X flip; H splits evenly between X and Z; the
+    # result ignores global phase (S equals RZ(pi/2) up to one).
+    x = np.array([[0, 1], [1, 0]], dtype=complex)
+    h = np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2)
+    assert twirl.pauli_probabilities(x) == pytest.approx((1.0, 0.0, 0.0))
+    assert twirl.pauli_probabilities(h) == pytest.approx((0.5, 0.0, 0.5))
+    assert twirl.pauli_probabilities(S_MATRIX) == pytest.approx((0.0, 0.0, 0.5))
+
+
+def test_pauli_probabilities_validates_input():
+    with pytest.raises(ValueError, match="2x2"):
+        twirl.pauli_probabilities(np.eye(3))
+    with pytest.raises(ValueError, match="unitary"):
+        twirl.pauli_probabilities([[1, 0], [0, 2]])
+
+
+# --- Single use is exact; coherent accumulation is not ------------------------
+
+
+def test_single_twirled_error_matches_exact_statistics():
+    # One S between Hadamards: exact coherent simulation and the twirled
+    # Z_ERROR(0.5) channel give the same computational-basis marginal.
+    (_, _, p_z) = twirl.pauli_probabilities(S_MATRIX)
+    exact = _p1("H 0\nS 0\nH 0\nM 0\n")
+    twirled = _p1(f"H 0\nZ_ERROR({p_z}) 0\nH 0\nM 0\n")
+    assert abs(exact - twirled) < BAND
+
+
+def test_coherent_accumulation_does_not_twirl_faithfully():
+    # Two S gates compose to an exact Z (P(M=1) = 1 between Hadamards); two
+    # independent twirled channels only flip with probability 1/2. This is
+    # the approximation the twirl makes, asserted so it cannot be mistaken
+    # for an equivalence.
+    (_, _, p_z) = twirl.pauli_probabilities(S_MATRIX)
+    exact = _p1("H 0\nS 0\nS 0\nH 0\nM 0\n")
+    twirled = _p1(f"H 0\nZ_ERROR({p_z}) 0\nZ_ERROR({p_z}) 0\nH 0\nM 0\n")
+    assert exact == pytest.approx(1.0)
+    assert abs(twirled - 0.5) < BAND
+
+
+# --- Pauli noise passes through the noncomputational path ---------------------
+
+
+def test_pauli_noise_unchanged_through_noncomp_path():
+    lossless = noncomp.Model(initial_state=[1.0, 0.0, 0.0, 0.0, 0.0])
+    r = noncomp.sample("H 0\nZ_ERROR(0.3) 0\nH 0\nM 0\n", lossless, shots=SHOTS, seed=2)
+    assert abs(np.asarray(r.measurements)[:, 0].mean() - 0.3) < BAND
+
+    (px, py, pz) = twirl.pauli_probabilities(S_MATRIX)
+    r = noncomp.sample(
+        f"H 0\nPAULI_CHANNEL_1({px}, {py}, {pz}) 0\nH 0\nM 0\n", lossless, shots=SHOTS, seed=3
+    )
+    assert abs(np.asarray(r.measurements)[:, 0].mean() - 0.5) < BAND
+
+
+def test_pauli_noise_dropped_on_a_lost_qubit():
+    # The X_ERROR lands after the loss, so it is dropped and the record is
+    # whatever the classifier pins for the lost level.
+    lost_col = [[0.0] * 5 for _ in range(2)]
+    for lvl in range(5):
+        lost_col[0][lvl] = 1.0
+    to_lost = [[0.0] * 5 for _ in range(5)]
+    to_lost[noncomp.Level.LOST][noncomp.Level.G] = 1.0
+    to_lost[noncomp.Level.LOST][noncomp.Level.E] = 1.0
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={"S": to_lost},
+        classifier=noncomp.Classifier(["0", "1"], lost_col),
+    )
+    r = noncomp.sample("H 0\nS 0\nX_ERROR(1) 0\nM 0\n", model, shots=64, seed=4)
+    assert not np.asarray(r.measurements).any()

--- a/tests/python/test_twirl.py
+++ b/tests/python/test_twirl.py
@@ -1,10 +1,12 @@
 """Tests for the Pauli-twirl helpers and Pauli-noise passthrough.
 
-The helper math is checked against closed forms and against clifft's own
-exact near-Clifford simulation: a single twirled error reproduces the exact
-computational-basis statistics of one application, while coherently
-accumulating errors do not -- the second half is asserted too, so the
-approximation boundary is pinned rather than implied.
+The helper math is checked against closed forms. The twirl is an
+approximation -- it preserves the Pauli-transfer-matrix diagonal, not circuit
+statistics -- so the integration tests pin both sides of that contract
+against clifft's exact near-Clifford simulation: one selected configuration
+where the twirled channel and the exact unitary coincide, and two
+counterexamples (a single twirled Hadamard, and coherent accumulation of two
+S gates) where they measurably do not.
 
 The passthrough tests confirm ordinary Pauli noise instructions behave
 identically through the noncomputational path: statistically unchanged on
@@ -66,23 +68,36 @@ def test_pauli_probabilities_validates_input():
         twirl.pauli_probabilities([[1, 0], [0, 2]])
 
 
-# --- Single use is exact; coherent accumulation is not ------------------------
+# --- The twirl is an approximation: one matching case, two counterexamples ----
 
 
-def test_single_twirled_error_matches_exact_statistics():
-    # One S between Hadamards: exact coherent simulation and the twirled
-    # Z_ERROR(0.5) channel give the same computational-basis marginal.
+def test_selected_case_where_twirl_matches_exact():
+    # One S between Hadamards happens to coincide: the coherence the twirl
+    # discards does not reach this measurement, so the exact simulation and
+    # the twirled Z_ERROR(0.5) give the same marginal. A selected case, not
+    # a general single-use property -- see the counterexamples below.
     (_, _, p_z) = twirl.pauli_probabilities(S_MATRIX)
     exact = _p1("H 0\nS 0\nH 0\nM 0\n")
     twirled = _p1(f"H 0\nZ_ERROR({p_z}) 0\nH 0\nM 0\n")
     assert abs(exact - twirled) < BAND
 
 
-def test_coherent_accumulation_does_not_twirl_faithfully():
+def test_single_application_counterexample():
+    # Twirling even one application can be wrong: exact H H is the identity
+    # (P(M=1) = 0), while twirling the second H into its Pauli channel
+    # (0.5, 0, 0.5) scrambles the |+> state into a coin flip.
+    (px, py, pz) = twirl.pauli_probabilities(
+        np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2)
+    )
+    exact = _p1("H 0\nH 0\nM 0\n")
+    twirled = _p1(f"H 0\nPAULI_CHANNEL_1({px}, {py}, {pz}) 0\nM 0\n")
+    assert exact == pytest.approx(0.0)
+    assert abs(twirled - 0.5) < BAND
+
+
+def test_coherent_accumulation_counterexample():
     # Two S gates compose to an exact Z (P(M=1) = 1 between Hadamards); two
-    # independent twirled channels only flip with probability 1/2. This is
-    # the approximation the twirl makes, asserted so it cannot be mistaken
-    # for an equivalence.
+    # independent twirled channels only flip with probability 1/2.
     (_, _, p_z) = twirl.pauli_probabilities(S_MATRIX)
     exact = _p1("H 0\nS 0\nS 0\nH 0\nM 0\n")
     twirled = _p1(f"H 0\nZ_ERROR({p_z}) 0\nZ_ERROR({p_z}) 0\nH 0\nM 0\n")


### PR DESCRIPTION
> [!NOTE]
> Prototype work on the `codex/noncomputational-structural-mvp` feature branch — less-strict review bar than `main`.

Work item 4 of the checkpoint plan: coherent-error compatibility. Python-only.

### `clifft.twirl`

Two helpers, deliberately kept **outside** the noncomputational model surface — coherent control errors are unitaries, not status changes, and they enter circuits as ordinary noise instructions:

- `pauli_probabilities(unitary)` — the standard twirl `p_P = |tr(U·P)|²/4` of a 2×2 unitary into `(p_x, p_y, p_z)`, global-phase-invariant, validated (shape/unitarity). Maps directly onto `PAULI_CHANNEL_1(px, py, pz)` or a single `*_ERROR` when one component is nonzero.
- `rotation(axis, radians)` — the closed form `sin²(θ/2)` on the rotation axis, for over-rotation parameters.

The module docstring states the contract precisely: the twirl preserves the diagonal of the unitary's Pauli transfer matrix and discards the coherences between Pauli components — circuit statistics generally differ from the exact unitary even for a single application.

### Tests (8 new)

- Helper math vs closed forms (rotations, X/H/S known cases, validation errors).
- **Exact-vs-twirl through clifft itself**: one *selected* matching case (one S between Hadamards, where the discarded coherence never reaches the measurement) and two counterexamples — a **single** twirled Hadamard (exact H·H is the identity, the twirled channel gives a coin flip) and coherent accumulation of two S gates (1.0 vs 0.5) — all asserted, so the contract cannot regress into "twirl equals exact unless repeated".
- Passthrough: `Z_ERROR` and `PAULI_CHANNEL_1` are statistically unchanged through the noncomputational path on computational qubits, and Pauli noise on a lost operand is dropped.

Python suite: 592 green (583 + 9 new; qiskit-optional modules excluded as usual). Pre-commit clean. No C++ changes.

### Review round

Reworded the twirl contract per review (it preserves the Pauli-transfer-matrix diagonal, not single-use circuit statistics — the H·H counterexample is now a committed test) and reframed the S-between-Hadamards test as a selected matching case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
