### PR TITLE
test: widen componentwise global-phase coverage

### DIFF
--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -219,7 +219,7 @@ class TestPeepholeExactGlobalPhase:
         sv_optimized = _clifft_statevector(circuit, optimize=True)
         np.testing.assert_allclose(sv_optimized, sv_baseline, atol=1e-6)
 
-    @pytest.mark.parametrize("seed", range(20))
+    @pytest.mark.parametrize("seed", range(100))
     def test_random_circuits_componentwise(self, seed: int) -> None:
         """Random Clifford+T circuits agree componentwise, no phase alignment.
 
@@ -228,6 +228,15 @@ class TestPeepholeExactGlobalPhase:
         tableau composition at lowering.
         """
         circuit = random_clifford_t_circuit(5, depth=30, seed=seed)
+        sv_baseline = _clifft_statevector(circuit)
+        sv_optimized = _clifft_statevector(circuit, optimize=True)
+        np.testing.assert_allclose(sv_optimized, sv_baseline, atol=1e-5)
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_random_deep_8q_componentwise(self, seed: int) -> None:
+        """Deeper 8-qubit circuits accumulate long virtual-frame gate logs,
+        stressing the chained composition phase across many links."""
+        circuit = random_clifford_t_circuit(8, depth=60, seed=seed)
         sv_baseline = _clifft_statevector(circuit)
         sv_optimized = _clifft_statevector(circuit, optimize=True)
         np.testing.assert_allclose(sv_optimized, sv_baseline, atol=1e-5)


### PR DESCRIPTION
Follow-up to #140. The end-to-end componentwise optimized-vs-unoptimized comparison is the only model-free check on the canonical phase tracking, so its breadth is what future changes to frame routing or the phase machinery get caught by.

- Random 5q/depth-30 sweep: 20 -> 100 seeds.
- New 20-seed 8q/depth-60 set: deeper circuits accumulate long virtual-frame gate logs, stressing the chained composition phase across many links — a class the suite did not previously cover componentwise.

Adds ~4 s to the Python suite. All 120 circuits pass on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)