### PR TITLE
docs(examples): leakage and loss notebook

### DIFF
--- a/examples/leakage_and_loss.ipynb
+++ b/examples/leakage_and_loss.ipynb
@@ -1,0 +1,944 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7db639eb",
+   "metadata": {},
+   "source": [
+    "# Simulating leakage and atom loss in clifft\n",
+    "\n",
+    "Real qubits do not stay in their two-dimensional computational subspace. An atom can be\n",
+    "excited into a state outside the qubit manifold (**leakage**) or disappear from its trap\n",
+    "entirely (**loss**). Both processes matter enormously for quantum error correction --\n",
+    "they produce errors that ordinary Pauli noise models cannot represent -- and both are\n",
+    "awkward for fast stabilizer simulators, whose formalism only knows about qubits.\n",
+    "\n",
+    "This notebook walks through clifft's *noncomputational* simulation path end to end:\n",
+    "\n",
+    "1. the physics being modeled, and where exact simulation ends and approximation begins;\n",
+    "2. the Python API, one physical scenario at a time, each paired with a check against a\n",
+    "   closed-form expectation;\n",
+    "3. a realistic neutral-atom-style noise model on a small error-correction circuit;\n",
+    "4. a summary of what noise modeling is possible, exactly or approximately, and what is\n",
+    "   deliberately out of scope.\n",
+    "\n",
+    "Everything here is self-contained: every quantitative claim is produced by the cell that\n",
+    "makes it, with fixed seeds."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bd50a64",
+   "metadata": {},
+   "source": [
+    "## 1. The physics: an extended state space\n",
+    "\n",
+    "Standard circuit simulation works in a computational subspace $\\mathcal{H}_C \\cong \\mathbb{C}^2$\n",
+    "per site. To model leakage and loss we extend each site:\n",
+    "\n",
+    "$$\\mathcal{H}_\\text{tot} = \\mathcal{H}_C \\oplus \\mathcal{H}_{NC}$$\n",
+    "\n",
+    "clifft's built-in model gives every qubit **five levels**:\n",
+    "\n",
+    "| index | name | category | meaning |\n",
+    "|---|---|---|---|\n",
+    "| 0 | `g` | computational | qubit $|0\\rangle$ |\n",
+    "| 1 | `e` | computational | qubit $|1\\rangle$ |\n",
+    "| 2 | `leak_g` | leaked | carrier present, outside the qubit manifold |\n",
+    "| 3 | `leak_e` | leaked | a second leaked level |\n",
+    "| 4 | `lost` | lost | carrier physically gone |\n",
+    "\n",
+    "The two noncomputational categories are physically distinct. A **leaked** atom is still\n",
+    "in the trap: later pulses address an empty transition (they do nothing to it), but the\n",
+    "site exists. A **lost** atom is structurally absent: any multi-qubit interaction with\n",
+    "that site simply does not happen. Occupation of the noncomputational levels is tracked\n",
+    "as *classical* per-qubit status -- the model deliberately does not keep coherences into\n",
+    "or inside $\\mathcal{H}_{NC}$ (that regime needs a full qudit simulation).\n",
+    "\n",
+    "**Transitions** between levels are specified per gate as a matrix $T[\\text{to},\\text{from}]$:\n",
+    "column $s$ gives the probabilities of jumping out of level $s$ when the gate fires, and the\n",
+    "column's deficit below one is the probability that nothing happens. In Kraus language each\n",
+    "entry is a jump operator $\\sqrt{p_{s\\to d}}\\,|d\\rangle\\langle s|$, with the no-jump\n",
+    "back-action as the complement. A **measurement classifier** maps the level at readout to\n",
+    "the recorded symbol -- including a third *herald* symbol for detected loss."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18505dd1",
+   "metadata": {},
+   "source": [
+    "### What samples exactly, and what cannot\n",
+    "\n",
+    "clifft compiles a circuit once and samples many shots. Loss and leakage are handled\n",
+    "*ahead of time*: each shot draws a classical trajectory (which transitions fired, where),\n",
+    "rewrites the circuit for that trajectory -- removing gates on lost sites, inserting the\n",
+    "hidden collapse operations that implement the partial trace -- and runs the rewritten\n",
+    "circuit through the ordinary exact simulator.\n",
+    "\n",
+    "Whether that classical pre-sampling is *exact* depends on one property of the transition\n",
+    "matrix. If the computational columns are equal (**state-independent** transitions), the\n",
+    "no-jump back-action is proportional to the identity, the jump probability does not depend\n",
+    "on the quantum amplitudes, and pre-sampling is exact. If they differ\n",
+    "(**state-dependent**, e.g. leakage only out of $|1\\rangle$), the jump probability depends\n",
+    "on the state, the no-jump branch filters amplitudes, and *no* classical pre-sampling can\n",
+    "be exact. For that case clifft offers an explicit, opt-in **equalized-rates\n",
+    "approximation** -- pad the lower-rate column with a \"pseudo-jump\" that only dephases, so\n",
+    "all computational columns share the maximum rate -- whose accuracy envelope is\n",
+    "demonstrated, not just stated, in section 2.5.\n",
+    "\n",
+    "One more piece of bookkeeping matters for those demos: clifft's trajectory sampler knows a\n",
+    "qubit's level only when an *instruction* pins it (after a reset, or before any gate). A\n",
+    "qubit that a sequence of gates happens to return to a definite state is still tracked as\n",
+    "\"unknown\". Where that distinction bites is also shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a90bbf55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:41.325799Z",
+     "iopub.status.busy": "2026-06-11T21:40:41.325531Z",
+     "iopub.status.idle": "2026-06-11T21:40:41.596598Z",
+     "shell.execute_reply": "2026-06-11T21:40:41.595638Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "clifft 0.4.2.dev17+ge9f424da4.d20260611\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import clifft\n",
+    "from clifft import noncomp, twirl\n",
+    "\n",
+    "Level = noncomp.Level\n",
+    "SHOTS = 20_000\n",
+    "\n",
+    "\n",
+    "# Build a 5x5 transition matrix T[to][from] from {(to, from): p}.\n",
+    "def T(entries: dict) -> list[list[float]]:\n",
+    "    m = [[0.0] * 5 for _ in range(5)]\n",
+    "    for (to, frm), p in entries.items():\n",
+    "        m[to][frm] = p\n",
+    "    return m\n",
+    "\n",
+    "\n",
+    "# Classifier: g/leak_g read 0, e/leak_e read 1 (with optional confusion), lost heralds.\n",
+    "def ternary_classifier(leak_confusion: float = 0.0) -> noncomp.Classifier:\n",
+    "    m = [[0.0] * 5 for _ in range(3)]\n",
+    "    m[0][Level.G] = m[1][Level.E] = 1.0\n",
+    "    m[0][Level.LEAK_G], m[1][Level.LEAK_G] = 1 - leak_confusion, leak_confusion\n",
+    "    m[1][Level.LEAK_E], m[0][Level.LEAK_E] = 1 - leak_confusion, leak_confusion\n",
+    "    m[2][Level.LOST] = 1.0\n",
+    "    return noncomp.Classifier([\"0\", \"1\", \"2\"], m)\n",
+    "\n",
+    "\n",
+    "print(\"clifft\", clifft.version())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd4ceda7",
+   "metadata": {},
+   "source": [
+    "## 2. The API, one physical scenario at a time\n",
+    "\n",
+    "### 2.1 Initial populations and the status sidecar\n",
+    "\n",
+    "A model is a per-level initial distribution, per-gate transition matrices, a classifier,\n",
+    "and policy knobs. `noncomp.sample` returns the usual records plus two sidecars: each\n",
+    "qubit's final status, and a per-measurement herald flag. `symbols()` folds the herald\n",
+    "back into a ternary per-slot view."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a9ca9057",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:41.599612Z",
+     "iopub.status.busy": "2026-06-11T21:40:41.599378Z",
+     "iopub.status.idle": "2026-06-11T21:40:41.734544Z",
+     "shell.execute_reply": "2026-06-11T21:40:41.733606Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "status fractions (computational, leaked, lost): [0.9513, 0.0297, 0.019]\n",
+      "expected:                                       [0.95, 0.03, 0.02]\n",
+      "ternary readout counts (0/1/2): [19430, 190, 380]\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = noncomp.Model(\n",
+    "    initial_state=[0.95, 0.00, 0.02, 0.01, 0.02],  # P(g, e, leak_g, leak_e, lost)\n",
+    "    classifier=ternary_classifier(),\n",
+    ")\n",
+    "r = noncomp.sample(\"M 0\\n\", model, shots=SHOTS, seed=1)\n",
+    "\n",
+    "status = r.final_status[:, 0]\n",
+    "print(\n",
+    "    \"status fractions (computational, leaked, lost):\",\n",
+    "    [round(float((status == k).mean()), 4) for k in range(3)],\n",
+    ")\n",
+    "print(\"expected:                                      \", [0.95, 0.03, 0.02])\n",
+    "print(\"ternary readout counts (0/1/2):\", [int((r.symbols()[:, 0] == v).sum()) for v in (0, 1, 2)])\n",
+    "assert abs((status == noncomp.QubitStatusKind.LOST).mean() - 0.02) < 0.005"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc8dd134",
+   "metadata": {},
+   "source": [
+    "### 2.2 Loss is a partial trace\n",
+    "\n",
+    "The first physics claim worth testing: when an entangled qubit is lost, the survivor must\n",
+    "be left in the reduced (partially traced) state. For a Bell pair that is the maximally\n",
+    "mixed state -- the survivor reads 0 or 1 with probability $\\tfrac12$, *uncorrelated* with\n",
+    "the lost atom's record. Internally the rewriter implements this with a hidden collapse\n",
+    "inserted at the loss event; nothing about it leaks into the visible record layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2fc475f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:41.736625Z",
+     "iopub.status.busy": "2026-06-11T21:40:41.736233Z",
+     "iopub.status.idle": "2026-06-11T21:40:41.977544Z",
+     "shell.execute_reply": "2026-06-11T21:40:41.976828Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "survivor P(1) = 0.5037  (partial trace: 0.5)\n",
+      "lost qubit heralds: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "lossy = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions={\"S\": T({(Level.LOST, Level.G): 1.0, (Level.LOST, Level.E): 1.0})},\n",
+    "    classifier=ternary_classifier(),\n",
+    ")\n",
+    "# Bell pair, then the hooked S loses qubit 0 with certainty.\n",
+    "r = noncomp.sample(\"H 0\\nCX 0 1\\nS 0\\nM 0\\nM 1\\n\", lossy, shots=SHOTS, seed=2)\n",
+    "\n",
+    "survivor = r.measurements[:, 1]\n",
+    "print(\"survivor P(1) =\", round(float(survivor.mean()), 4), \" (partial trace: 0.5)\")\n",
+    "print(\"lost qubit heralds:\", bool(np.all(r.heralds[:, 0] == 1)))\n",
+    "assert abs(survivor.mean() - 0.5) < 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfe95e6f",
+   "metadata": {},
+   "source": [
+    "### 2.3 Relaxation and recapture re-prepare the carrier\n",
+    "\n",
+    "Transition matrices may also have *computational* destinations: relaxation (any level\n",
+    "decaying back to `g`) or recapture of a lost atom. clifft materializes the carrier at the\n",
+    "destination -- the channel $\\rho \\mapsto |d\\rangle\\langle d| \\otimes \\mathrm{Tr}_q(\\rho)$ --\n",
+    "so a collapse-to-$g$ with probability $p$ on a $|+\\rangle$ state leaves\n",
+    "$P(M{=}1) = (1-p)\\cdot\\tfrac12$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "84881a49",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:41.979824Z",
+     "iopub.status.busy": "2026-06-11T21:40:41.979608Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.173388Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.172407Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P(M=1) = 0.3528   (analytic: 0.35)\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = 0.3\n",
+    "relax = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions={\"S\": T({(Level.G, Level.G): p, (Level.G, Level.E): p})},\n",
+    ")\n",
+    "r = noncomp.sample(\"H 0\\nS 0\\nM 0\\n\", relax, shots=SHOTS, seed=3)\n",
+    "print(f\"P(M=1) = {r.measurements[:, 0].mean():.4f}   (analytic: {(1 - p) / 2})\")\n",
+    "assert abs(r.measurements[:, 0].mean() - (1 - p) / 2) < 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de0240c8",
+   "metadata": {},
+   "source": [
+    "### 2.4 Readout: classifiers, heralds, and detectors\n",
+    "\n",
+    "The classifier's columns give $P(\\text{symbol} \\mid \\text{level})$ at measurement. A lost\n",
+    "site reads the herald symbol, reported in the `heralds` sidecar while the visible record\n",
+    "keeps a uniformly drawn bit -- so the record layout (and every `rec[-k]` reference) is\n",
+    "unchanged, and downstream `DETECTOR`s keep working. Crucially, the classifier's bit is\n",
+    "injected *before* detector evaluation inside the simulator, so leakage shows up as\n",
+    "detector events, which is the whole point for error correction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "83a06014",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.175470Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.175344Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.392715Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.391717Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P(detector fires) = 1.0  (leaked qubit always reads 1, reference always 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "leaky = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions={\"S\": T({(Level.LEAK_E, Level.G): 1.0, (Level.LEAK_E, Level.E): 1.0})},\n",
+    "    classifier=ternary_classifier(),  # leak_e reads 1\n",
+    ")\n",
+    "# A reference measurement, then the leaked one; the detector XORs them.\n",
+    "r = noncomp.sample(\"M 1\\nH 0\\nS 0\\nM 0\\nDETECTOR rec[-1] rec[-2]\\n\", leaky, shots=SHOTS, seed=4)\n",
+    "print(\n",
+    "    \"P(detector fires) =\",\n",
+    "    round(float(r.detectors[:, 0].mean()), 4),\n",
+    "    \" (leaked qubit always reads 1, reference always 0)\",\n",
+    ")\n",
+    "assert np.all(r.detectors[:, 0] == 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b08239b",
+   "metadata": {},
+   "source": [
+    "### 2.5 State-dependent transitions: the equalized-rates approximation, with its boundary\n",
+    "\n",
+    "Suppose only $|1\\rangle$ leaks (a state-dependent matrix) and the qubit is in\n",
+    "$|+\\rangle$. Exact treatment requires runtime access to amplitudes, so by default clifft\n",
+    "**refuses** -- approximation is never silent. Opting in to\n",
+    "`unknown_source_policy=\"equalize_rates\"` enables the standard fast-path approximation:\n",
+    "both computational columns are padded to the maximum rate $p$, the source is drawn\n",
+    "uniformly, and every fired jump collapses the carrier (the padding events are pure\n",
+    "dephasing). For a leak that reads 1, the analytic prediction on $|+\\rangle$ is\n",
+    "$P(M{=}1) = \\tfrac{p}{2} + \\tfrac{p}{2} + \\tfrac{1-p}{2} = \\tfrac12 + \\tfrac{p}{2}$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bc5026a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.395521Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.395388Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.575314Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.573920Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default policy refuses: sample_history: source-dependent transition on gate 'S' fired on ComputationalUn ...\n",
+      "P(M=1) = 0.6979   (analytic: 0.7)\n",
+      "P(leaked) = 0.1993   (analytic: 0.2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = 0.4\n",
+    "leak_from_g = {\"S\": T({(Level.LEAK_E, Level.G): p})}  # leaks only out of g\n",
+    "\n",
+    "strict = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0], transitions=leak_from_g, classifier=ternary_classifier()\n",
+    ")\n",
+    "try:\n",
+    "    noncomp.sample(\"H 0\\nS 0\\nM 0\\n\", strict, shots=4, seed=5)\n",
+    "except ValueError as err:\n",
+    "    print(\"default policy refuses:\", str(err)[:80], \"...\")\n",
+    "\n",
+    "approx = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions=leak_from_g,\n",
+    "    classifier=ternary_classifier(),\n",
+    "    unknown_source_policy=\"equalize_rates\",\n",
+    ")\n",
+    "r = noncomp.sample(\"H 0\\nS 0\\nM 0\\n\", approx, shots=SHOTS, seed=5)\n",
+    "print(f\"P(M=1) = {r.measurements[:, 0].mean():.4f}   (analytic: {0.5 + p / 2})\")\n",
+    "leaked = (r.final_status[:, 0] == noncomp.QubitStatusKind.LEAKED).mean()\n",
+    "print(f\"P(leaked) = {leaked:.4f}   (analytic: {p / 2})\")\n",
+    "assert abs(r.measurements[:, 0].mean() - (0.5 + p / 2)) < 0.01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aab034b2",
+   "metadata": {},
+   "source": [
+    "The approximation has a precisely characterized envelope. **Per-qubit marginals are exact\n",
+    "whenever the source is genuinely unbiased** (which a stabilizer state always is, when it\n",
+    "is not outright deterministic). What it gives up is twofold, and both halves can be shown\n",
+    "live rather than asserted.\n",
+    "\n",
+    "**(a) Joint correlations.** If the leak destination depends on the source level\n",
+    "($g \\to$ `leak_g` reads 0, $e \\to$ `leak_e` reads 1), an exact treatment of a Bell pair\n",
+    "would correlate the leaked atom's readout with its partner. The equalized draw picks the\n",
+    "source independently of the collapse, so the joint distribution factorizes -- every\n",
+    "marginal is right, the correlation is gone:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8a94885d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.578608Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.578444Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.797760Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.796927Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "marginals: 0.502 0.495  (exact treatment: 0.5, 0.5)\n",
+      "P(records equal) = 0.5  (exact treatment would give 1.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "pair_model = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions={\"S\": T({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_E, Level.E): 1.0})},\n",
+    "    classifier=ternary_classifier(),\n",
+    "    unknown_source_policy=\"equalize_rates\",\n",
+    ")\n",
+    "r = noncomp.sample(\"H 0\\nCX 0 1\\nS 0\\nM 0\\nM 1\\n\", pair_model, shots=SHOTS, seed=6)\n",
+    "m = r.measurements\n",
+    "print(\n",
+    "    \"marginals:\",\n",
+    "    round(float(m[:, 0].mean()), 3),\n",
+    "    round(float(m[:, 1].mean()), 3),\n",
+    "    \" (exact treatment: 0.5, 0.5)\",\n",
+    ")\n",
+    "print(\n",
+    "    \"P(records equal) =\",\n",
+    "    round(float((m[:, 0] == m[:, 1]).mean()), 3),\n",
+    "    \" (exact treatment would give 1.0)\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36daa0bf",
+   "metadata": {},
+   "source": [
+    "**(b) Gate-determined states.** Status tracking is instruction-known, so two Hadamards\n",
+    "return a qubit to $|0\\rangle$ physically while the tracker still says \"unknown\". The\n",
+    "exact channel below (leaking only out of $e$) could never fire on $|0\\rangle$; the\n",
+    "equalized draw still leaks half of its fires. This is deliberately pinned by a test in\n",
+    "the repository so the boundary cannot drift silently:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a62f26f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.800254Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.800001Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.972919Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.971860Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P(leaked) = 0.2944   (exact channel: 0.0; equalized: 0.3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = 0.6\n",
+    "gate_determined = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions={\"S\": T({(Level.LEAK_E, Level.E): p})},\n",
+    "    classifier=ternary_classifier(),\n",
+    "    unknown_source_policy=\"equalize_rates\",\n",
+    ")\n",
+    "r = noncomp.sample(\"H 0\\nH 0\\nS 0\\nM 0\\n\", gate_determined, shots=SHOTS, seed=7)\n",
+    "leaked = (r.final_status[:, 0] == noncomp.QubitStatusKind.LEAKED).mean()\n",
+    "print(f\"P(leaked) = {leaked:.4f}   (exact channel: 0.0; equalized: {p / 2})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08cd9ade",
+   "metadata": {},
+   "source": [
+    "### 2.6 What happens downstream of a leaked or lost site\n",
+    "\n",
+    "By default, an operation touching a leaked or lost operand that has no representable\n",
+    "effect there is **refused** -- again, no silent choices. Opting in to\n",
+    "`lost_leaked_ops=\"drop\"` excises such operations whole (identity on the surviving\n",
+    "operands): the physical interaction cannot happen at a vacated site. Measurements are\n",
+    "never dropped, so the record layout survives; transitions still fire (a lost atom's\n",
+    "neighbors keep their own noise). With both compatibility policies on, multi-round\n",
+    "error-correction circuits run through loss events end to end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a4f981d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.974953Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.974759Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.979467Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.978788Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default policy refuses: rewrite: operation 'CX' on a Lost qubit 0 at op 2 is not representable; rejectin ...\n",
+      "ternary records (ancilla, ancilla, data):\n",
+      "[[0 0 2]\n",
+      " [0 0 2]\n",
+      " [0 0 2]\n",
+      " [0 0 2]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "circuit = \"H 0\\nS 0\\nCX 0 1\\nMR 1\\nCX 0 1\\nMR 1\\nM 0\\n\"\n",
+    "lose_data = {\"S\": T({(Level.LOST, Level.G): 1.0, (Level.LOST, Level.E): 1.0})}\n",
+    "\n",
+    "strict = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0], transitions=lose_data, classifier=ternary_classifier()\n",
+    ")\n",
+    "try:\n",
+    "    noncomp.sample(circuit, strict, shots=4, seed=8)\n",
+    "except ValueError as err:\n",
+    "    print(\"default policy refuses:\", str(err)[:80], \"...\")\n",
+    "\n",
+    "compat = noncomp.Model(\n",
+    "    initial_state=[1, 0, 0, 0, 0],\n",
+    "    transitions=lose_data,\n",
+    "    classifier=ternary_classifier(),\n",
+    "    lost_leaked_ops=\"drop\",\n",
+    ")\n",
+    "r = noncomp.sample(circuit, compat, shots=8, seed=8)\n",
+    "print(\"ternary records (ancilla, ancilla, data):\")\n",
+    "print(r.symbols()[:4])  # both CXs dropped: ancilla stays 0; the lost data heralds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1da58844",
+   "metadata": {},
+   "source": [
+    "### 2.7 Coherent control errors: twirl them, or simulate them exactly\n",
+    "\n",
+    "Over-rotations and phase miscalibrations are unitaries, not status changes, so they stay\n",
+    "outside the noncomputational model. The `clifft.twirl` helpers convert them into the\n",
+    "standard Pauli-twirl channel $p_P = |\\mathrm{tr}(U P)|^2 / 4$, inserted as ordinary noise\n",
+    "instructions. The twirl preserves the Pauli-transfer-matrix diagonal -- *not* circuit\n",
+    "statistics. Sometimes that coincides with exact; in general it does not, and because\n",
+    "clifft simulates non-Clifford gates exactly (at active-rank cost), both sides of that\n",
+    "boundary can be measured in one place:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3c541e1a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.981000Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.980855Z",
+     "iopub.status.idle": "2026-06-11T21:40:42.989763Z",
+     "shell.execute_reply": "2026-06-11T21:40:42.988945Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "one S between Hadamards (twirl matches here):\n",
+      "   exact P(1) = 0.505   twirled P(1) = 0.500\n",
+      "two S = exact Z (coherent accumulation):\n",
+      "   exact P(1) = 1.000   twirled P(1) = 0.501\n",
+      "H then twirled H (a single application differs):\n",
+      "   exact P(1) = 0.000   twirled P(1) = 0.494\n"
+     ]
+    }
+   ],
+   "source": [
+    "S_MATRIX = np.array([[1, 0], [0, 1j]])\n",
+    "H_MATRIX = np.array([[1, 1], [1, -1]]) / np.sqrt(2)\n",
+    "pz = twirl.pauli_probabilities(S_MATRIX)[2]\n",
+    "px_h, py_h, pz_h = twirl.pauli_probabilities(H_MATRIX)\n",
+    "\n",
+    "\n",
+    "def p1(text: str) -> float:\n",
+    "    return float(clifft.sample(clifft.compile(text), SHOTS, 9).measurements[:, 0].mean())\n",
+    "\n",
+    "\n",
+    "cases = [\n",
+    "    (\n",
+    "        \"one S between Hadamards (twirl matches here)\",\n",
+    "        \"H 0\\nS 0\\nH 0\\nM 0\\n\",\n",
+    "        f\"H 0\\nZ_ERROR({pz}) 0\\nH 0\\nM 0\\n\",\n",
+    "    ),\n",
+    "    (\n",
+    "        \"two S = exact Z (coherent accumulation)\",\n",
+    "        \"H 0\\nS 0\\nS 0\\nH 0\\nM 0\\n\",\n",
+    "        f\"H 0\\nZ_ERROR({pz}) 0\\nZ_ERROR({pz}) 0\\nH 0\\nM 0\\n\",\n",
+    "    ),\n",
+    "    (\n",
+    "        \"H then twirled H (a single application differs)\",\n",
+    "        \"H 0\\nH 0\\nM 0\\n\",\n",
+    "        f\"H 0\\nPAULI_CHANNEL_1({px_h}, {py_h}, {pz_h}) 0\\nM 0\\n\",\n",
+    "    ),\n",
+    "]\n",
+    "for label, exact_text, twirled_text in cases:\n",
+    "    print(f\"{label}:\\n   exact P(1) = {p1(exact_text):.3f}   twirled P(1) = {p1(twirled_text):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec82a24b",
+   "metadata": {},
+   "source": [
+    "## 3. A realistic neutral-atom noise model, end to end\n",
+    "\n",
+    "Parameter magnitudes follow what Infleqtion reported for their cesium-atom platform in\n",
+    "the two-logical-qubit experiment ([arXiv:2412.07670](https://arxiv.org/abs/2412.07670)):\n",
+    "per-two-qubit-gate leakage out of the excited state at the $10^{-3}$ scale with a few\n",
+    "$10^{-3}$ atom loss, single-qubit-layer leakage near $10^{-3}$, readout confusion of\n",
+    "0.4--2.8%, and a ~1% relative over-rotation (twirled here; section 2.7 showed exactly\n",
+    "what that approximation costs).\n",
+    "\n",
+    "The circuit is a distance-5 repetition-code memory: data in superposition, five rounds of\n",
+    "CX syndrome extraction with measure-and-reset ancillas, a hooked single-qubit layer on\n",
+    "the data each round, and detectors comparing consecutive rounds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4e1e83ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:42.992362Z",
+     "iopub.status.busy": "2026-06-11T21:40:42.992215Z",
+     "iopub.status.idle": "2026-06-11T21:40:45.355904Z",
+     "shell.execute_reply": "2026-06-11T21:40:45.355204Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3kAAAE+CAYAAAAwMtkoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAjSVJREFUeJzs3XdYVMf6wPHv0os0QUAUBZXYFSvBEhsRSzTE5MaWqFxvml3sxpqoWKKisRBTNMmNscV4rSSKLUZiw94LikaqKCBI2z2/P4j7CwGVFXBheT/PwyM7O+ecd4/Lzr5nzsyoFEVREEIIIYQQQghhEIz0HYAQQgghhBBCiOIjSZ4QQgghhBBCGBBJ8oQQQgghhBDCgEiSJ4QQQgghhBAGRJI8IYQQQgghhDAgkuQJIYQQQgghhAGRJE8IIYQQQgghDIgkeUIIIYQQQghhQCTJE0IIIYQQQggDIkmeEEIUYMaMGahUKn2HUebs378flUrF/v37n1n35s2bqFQq1qxZU+Jx6YO8h4pf+/btad++vb7DEEKIUk+SPCGEKGEeHh6oVKp8Px9++KG+Q3tuK1asKHRytnbtWkJCQko0nvLMEN9fQgghisZE3wEIIUR54O3tzZgxY/KUvfTSS3qKpuhWrFiBk5MTgwYNylP+yiuv8OjRI8zMzLRla9eu5dy5c4waNSpP3erVq/Po0SNMTU1fQMSGzdDeX0IIIYpGkjwhhHgBqlSpwjvvvFMs+0pLS8Pa2rpY9lXcjIyMsLCwKFRdlUpV6Lri6crL+0sIIUThyO2aQohy79ChQ7Ro0QILCwtq1qzJF198USLHycrKIi0tTadt1qxZg0ql4sCBAwwZMgRnZ2eqVq2qfX7Xrl20bdsWa2trbGxs6N69O+fPn8+zj0GDBlGhQgVu3LiBv78/1tbWuLm58cknn6AoSp66Go2GkJAQ6tevj4WFBS4uLnzwwQfcv39fW8fDw4Pz589z4MAB7a2Bj8dJ/XNMXvv27dmxYwe3bt3S1vXw8ACePCZv79692tdkb2/P66+/zsWLF/PUeTze7dq1awwaNAh7e3vs7OwIDAwkPT29UOf2yJEjdOvWDQcHB6ytrWnUqBFLlizRORbQ7T303//+l2bNmmFpaUnFihXp06cPt2/fLlTMT1MS768VK1ZQv359zM3NcXNzY+jQoTx48CDPPjw8PPL16EL+8XOP3xsbNmxg9uzZVK1aFQsLCzp16sS1a9fybb9q1Spq1qyJpaUlLVu25LfffivwNXz++efUr18fKysrHBwcaN68OWvXrtXpPAghhKGRnjwhRLl29uxZOnfuTKVKlZgxYwY5OTlMnz4dFxeXfHWTk5PJzs5+5j4tLCyoUKFCnrK9e/diZWWFWq2mevXqjB49mpEjRxY6ziFDhlCpUiWmTZum/SL//fffM3DgQPz9/Zk3bx7p6emsXLmSNm3acPLkSW0yBaBWq+nSpQsvv/wy8+fPJywsjOnTp5OTk8Mnn3yirffBBx+wZs0aAgMDGTFiBFFRUSxbtoyTJ0/y+++/Y2pqSkhICMOHD6dChQp8/PHHAAWeL4CPP/6Y5ORk7ty5w+LFiwHynZu/27NnD127dqVGjRrMmDGDR48e8fnnn9O6dWsiIyPzvCaAt99+G09PT4KDg4mMjOSrr77C2dmZefPmPfV87t69m9dee43KlSszcuRIXF1duXjxItu3b9f+vxQ2Fl3eQ7Nnz2bq1Km8/fbb/Oc//yEhIYHPP/+cV155hZMnT2Jvb//UuJ+kJN5fM2bMYObMmfj5+fHRRx9x+fJlVq5cybFjx7Tvhecxd+5cjIyMGDt2LMnJycyfP5/+/ftz5MgRbZ2vv/6aDz74gFatWjFq1Chu3LhBz549qVixIu7u7tp6X375JSNGjOCtt95i5MiRZGRkcObMGY4cOUK/fv2eKz4hhDAIihBClGMBAQGKhYWFcuvWLW3ZhQsXFGNjY+WfH5Ht2rVTgGf+DBw4MM92PXr0UObNm6ds2bJF+frrr5W2bdsqgDJ+/Phnxrd69WoFUNq0aaPk5ORoy1NTUxV7e3vlvffey1M/NjZWsbOzy1M+cOBABVCGDx+uLdNoNEr37t0VMzMzJSEhQVEURfntt98UQPnhhx/y7DMsLCxfef369ZV27drli3ffvn0KoOzbt09b1r17d6V69er56kZFRSmAsnr1am2Zt7e34uzsrNy7d09bdvr0acXIyEgZMGCAtmz69OkKoPz73//Os8833nhDcXR0zHesv8vJyVE8PT2V6tWrK/fv38/znEaj0TmWwr6Hbt68qRgbGyuzZ8/Oc8yzZ88qJiYm+coLqyTeX/Hx8YqZmZnSuXNnRa1Wa8uXLVumAMo333yjLatevXq+97yi5P69/P098vi9UbduXSUzM1NbvmTJEgVQzp49qyiKomRlZSnOzs6Kt7d3nnqrVq1SgDz7fP3115X69es/83UKIUR5Iz15QohyS61W88svvxAQEEC1atW05XXr1sXf35+dO3fmqb9w4cI8ty0+iZubW57HW7duzfM4MDCQrl27smjRIoYPH57n9rgnee+99zA2NtY+3r17Nw8ePKBv374kJiZqy42NjfHx8WHfvn359jFs2DDt7yqVimHDhrFjxw727NlDnz592LhxI3Z2drz66qt59tmsWTMqVKjAvn37SrR3JCYmhlOnTjF+/HgqVqyoLW/UqBGvvvpqvv8PIN8Mkm3btuXnn38mJSUFW1vbAo9z8uRJoqKiWLx4cb6es8dLHhQ2Fl3eQ5s3b0aj0fD222/nOb+urq54eXmxb98+Jk+e/KzTlE9JvL/27NlDVlYWo0aNwsjIKE+9yZMns2PHDgIDA3WO9XF8f5+Yp23btgDcuHGDBg0acPz4ceLj4/nkk0/y1Bs0aBDjxo3Lsy97e3vu3LnDsWPHaNGixXPFI4QQhkiSPCFEuZWQkMCjR4/w8vLK91zt2rXzJRXNmjUrluOqVCpGjx7NL7/8wv79+ws1YYanp2eex1evXgWgY8eOBdb/Z4JjZGREjRo18pQ9nn3x5s2b2n0mJyfj7Oxc4D7j4+OfGWdR3Lp1C8g99/9Ut25dfvnll3yTgvw9sQJwcHAA4P79+09M8q5fvw5AgwYNihxLampqod9DV69eRVGUAusCxTbLaHG8v570+s3MzKhRo4b2+efxtP+zvx/7n+fJ1NQ033t4woQJ7Nmzh5YtW1KrVi06d+5Mv379aN269XPHJ4QQhkCSPCGEKKSkpCSysrKeWc/S0hI7O7un1nk8rigpKalQx7a0tMzzWKPRALnj8lxdXfPVNzHR/eNdo9Hg7OzMDz/8UODzlSpV0nmfJe3vvU9/p/xjQpnSQKPRoFKp2LVrV4FxP22soq6K+v7SxZMWfFer1QW+zuL8P6tbty6XL19m+/bthIWF8dNPP7FixQqmTZvGzJkzdd6fEEIYCknyhBDlVqVKlbC0tNT2iv3d5cuX85X16tWLAwcOPHO/AwcOfOZC4Tdu3NDG8Dxq1qwJgLOzM35+fs+sr9FouHHjRp61065cuQKgnUCkZs2a7Nmzh9atWz/zS/+TvtgXpW716tWBgs/9pUuXcHJyKpap/R+fu3Pnzj3x3BU2FgsLi0K/h2rWrImiKHh6epb4GnZFfX/9/fX/vfcsKyuLqKioPOfNwcEh34ybkNsj98+eN12OffXq1Tw91dnZ2URFRdG4ceM89a2trenduze9e/cmKyuLXr16MXv2bCZNmiRLdAghyi1ZQkEIUW4ZGxvj7+/Pli1biI6O1pZfvHiRX375JV/9hQsXsnv37mf+jB8/XrtNUlISarU6z36ys7OZO3cuZmZmdOjQ4bli9/f3x9bWljlz5hQ442dCQkK+smXLlml/VxSFZcuWYWpqSqdOnYDcmSrVajWffvppvm1zcnLyfJG3trYu8It9QaytrUlOTn5mvcqVK+Pt7c23336bZ9/nzp3j119/pVu3boU63rM0bdoUT09PQkJC8r2Gx71JhY1Fl/dQr169MDY2ZubMmfl6rRRF4d69ezq/lpJ6f/n5+WFmZsbSpUvzxPr111+TnJxM9+7dtWU1a9bkjz/+yNPLvX379udeFqJ58+ZUqlSJ0NDQPPtcs2ZNvv+vf54zMzMz6tWrh6IohZoJVwghDJX05AkhyrWZM2cSFhZG27ZtGTJkCDk5Odp1t86cOZOn7vOMydu6dSuzZs3irbfewtPTk6SkJNauXcu5c+eYM2dOgbdaFoatrS0rV67k3XffpWnTpvTp04dKlSoRHR3Njh07aN26dZ6kzsLCgrCwMAYOHIiPjw+7du1ix44dTJ48Wdvb065dOz744AOCg4M5deoUnTt3xtTUlKtXr7Jx40aWLFnCW2+9pT0XK1euZNasWdSqVQtnZ+cnjg9s1qwZ69evJygoiBYtWlChQgV69OhRYN0FCxbQtWtXfH19GTx4sHbZAjs7O2bMmPFc5+qfjIyMWLlyJT169MDb25vAwEAqV67MpUuXOH/+vDY5K2wshX0P1axZk1mzZjFp0iRu3rxJQEAANjY2REVF8fPPP/P+++8zduxYIHdNuQ4dOjB9+vSnvu6Sen9VqlSJSZMmMXPmTLp06ULPnj25fPkyK1asoEWLFnnG+f3nP/9h06ZNdOnShbfffpvr16/z3//+V9tjqitTU1NmzZrFBx98QMeOHenduzdRUVGsXr06X89g586dcXV1pXXr1ri4uHDx4kWWLVtG9+7dsbGxea7jCyGEQdDXtJ5CCFFaHDhwQGnWrJliZmam1KhRQwkNDdVO0V9Ux48fV3r06KFUqVJFMTMzUypUqKC0adNG2bBhQ6G2fzzF/bFjxwp8ft++fYq/v79iZ2enWFhYKDVr1lQGDRqkHD9+XFtn4MCBirW1tXL9+nWlc+fOipWVleLi4qJMnz49z/T4j61atUpp1qyZYmlpqdjY2CgNGzZUxo8fr9y9e1dbJzY2VunevbtiY2OTZ1r7gpZQePjwodKvXz/F3t5eAbTLKRS0hIKiKMqePXuU1q1bK5aWloqtra3So0cP5cKFC3nqPP7/ebz8wz/PV1RU1DPOrKIcOnRIefXVVxUbGxvF2tpaadSokfL555/rHIui6PYe+umnn5Q2bdoo1tbWirW1tVKnTh1l6NChyuXLl7V1tm3bpgBKaGjoU19DSb+/li1bptSpU0cxNTVVXFxclI8++ijfshOKoigLFy5UqlSpopibmyutW7dWjh8//sQlFDZu3Jhn2ye9D1asWKF4enoq5ubmSvPmzZWDBw/m2+cXX3yhvPLKK4qjo6Nibm6u1KxZUxk3bpySnJxcqNcvhBCGSqUopXB0uhBCiGIzaNAgNm3axMOHD/Udiiik8ePH8+OPP3Lt2jXMzc31HY4QQogyRsbkCSGEEKXMvn37mDp1qiR4QgghnouMyRNCCCFKmWPHjuk7BCGEEGWY9OQJIYQQQgghhAGRMXlCCCGEEEIIYUCkJ08IIYQQQgghDIgkeUIIIYQQQghhQCTJE0IIIYQQQggDIkmeEEIIIYQQQhgQSfKEEEIIIYQQwoBIkieEEEIIIYQQBkSSPCGEEEIIIYQwIJLkCSGEEEIIIYQBkSRPCCGEEEIIIQyIJHlCCCGEEEIIYUAkyRNCCCGEEEIIAyJJnhBCCCGEEEIYEEnyhBBCCCGEEMKASJInhBBCCCGEEAZEkjwhhBBCCCGEMCCS5AkhhBBCCCGEAZEkTwghhBBCCCEMiCR5QgghhBBCCGFAJMkTQgghhBBCCAMiSZ4QQgghhBBCGBBJ8oQQQgghhBDCgJjoO4DSSKPRcPfuXWxsbFCpVPoORwghBKAoCqmpqbi5uWFkJNcoS5q0hUIIUfoUti2UJK8Ad+/exd3dXd9hCCGEKMDt27epWrWqvsMweNIWCiFE6fWstlCSvALY2NgAuSfP1tZWz9EIIYQASElJwd3dXfsZLUqWtIVCCFH6FLYtlCSvAI9vS7G1tZWGTQghShm5dfDFkLZQCCFKr2e1hTKoQQghhBBCCCEMiCR5QgghhBBCCGFA5HZNIYQQJUqtUTgalUR8agbONha09KyIsZHccimEEKJ8yL57l5z795/4vImDA6ZubsV6TEnyhBBClJiwczHM3HaBmOQMbVllOwum96hHlwaV9RiZEEIIUfKy797lepeuKFlZT6yjMjOjZtiuYk305HZNIYQQJSLsXAwf/TcyT4IHEJucwUf/jSTsXIyeIhNCCCFejJz795+a4AEoWVlP7el7HpLkCSGEKHZqjcLMbRdQCnjucdnMbRdQawqqIYQQQoiikCRPCCFEsTsalZSvB+/vFCAmOYOjUUkvLighhBCinJAkTwghRLGLT31ygvc89YQQQoiyKOvWLb0cVyZeEUIIUayuxqWy+veoQtV1trEo4WiEEEKIFy87Lo6EJUtJ3rxZL8eXJE8IIUSxuPcwk5A9V1l7NPqZY+1UgKtd7nIKQgghhKFQP0zj3ldfkrTmW5QM/d2tIkmeEEKIIsnIVrPm8E2W771GamYOAJ3rudCqliMzt14AyDMBy+MV8qb3qCfr5QkhhDAISnY29zduJHHZctRJuePNLZs2xf5fbxEzafILj0eSPCGEEM9FURS2n4lhXtgl7tx/BECDKrZM6V6Pl2s4AuBqa5FvnTxXWSdPCCGEgVAUhYfh4cQvXERWVO5QBbPq1ak0dgw2fn7kxMSgMjN75jp5Jg4OxRqXJHlCCCF0Fhl9n1nbLxAZ/QDITebG+dfmjSZVMPpb71yXBpV5tZ4rR6OSiE/NwNkm9xZN6cETQghR1j06fZq4BQt4dPwEAMYVK+I0dAgOb7+NytQUAFM3N2qG7XrqOngmDg7FuhA6SJInhBBCB7eT0pn/y2W2nb4LgKWpMR+1r8l7bWtgaWZc4DbGRip8azq+yDCFEEKIEpN1+zYJixeTsnMXACpzcyoOGoTje//BuEKFfPVN3dyKPYl7FknyhBBCPFNKRjYr9l3nm9+jyMrRoFLBv5pVZUzn2rjYygyZQgghDF/O/fvcC/2CpLVrITsbVCrsAgKoNHIEpq6u+g4vD0nyhBBCPFGOWsO6Y7dZvPsK99JyxxO0qunIx93rUt/NTs/RCSGEECVPk5nJ/f/+QOIXX6BJSQHAunVrnMeNxaJOHT1HVzBJ8oQQQuSjKAr7ryQwZ8dFrsY/BKBGJWs+7laXjnWcUalkTJ0QQgjDpmg0pOzYScLixWTfzR2mYF67Ns7jxlGhTWs9R/d0kuQJIYTI41JsCrN3XOS3q4kAOFiZMvrVl+jbshqmxkZ6jk4IIYQoeWlHjhI/fz4Z588DYOLiQqWRI7F7vScq44LHoJcmkuQJIYQAID41g8W7r7D+2G00CpgZGzGotQdDO9TCztJU3+EJIYQQJS7z2jXiP1vIw/37ATCytsbxvfeoOHAARpaW+g1OB6Xikuzy5cvx8PDAwsICHx8fjh49+tT6GzdupE6dOlhYWNCwYUN27tyZ5/lBgwahUqny/HTp0qUkX4IQQpRZGdlqlu+7RocF+/nxaG6C162hK7uDXmFyt7qS4AkhhDB4OQkJxEybzo2er+cmeMbGOPTrR81ff8Hpww/KVIIHpSDJW79+PUFBQUyfPp3IyEgaN26Mv78/8fHxBdY/fPgwffv2ZfDgwZw8eZKAgAACAgI4d+5cnnpdunQhJiZG+/Pjjz++iJcjhBBlhkajsOXkn3T8bD8LfrlMWpaaxlXt2PihLyv6N6O6o7W+QzQYxX0xc/PmzXTu3BlHR0dUKhWnTp3Kt4/27dvnu+D54YcfFufLEkKIMk+TlkbCsuVc8+/Cgw0bQKPB5lU/amzbhuu0qZg4ls0lgPSe5C1atIj33nuPwMBA6tWrR2hoKFZWVnzzzTcF1l+yZAldunRh3Lhx1K1bl08//ZSmTZuybNmyPPXMzc1xdXXV/jgU8yryQghRlh27mcQbK35n1PpT3E3OwM3OgiV9vPl5SGtaeFTUd3gGpSQuZqalpdGmTRvmzZv31GO/9957eS54zp8/v1hfmxBClFVKTg73N2zgWpcuJC5bhpKejkXjRlT/4b9U/fxzzGt46jvEItHrmLysrCxOnDjBpEmTtGVGRkb4+fkRERFR4DYREREEBQXlKfP392fLli15yvbv34+zszMODg507NiRWbNm4fiETDwzM5PMzEzt45S/pkYVQghDc+teGnN3XWLXuVgArM2MGdKhFoPbeGJhWvoHkpdFf7+YCRAaGsqOHTv45ptvmDhxYr76f7+YCfDpp5+ye/duli1bRmhoKADvvvsuADdv3nzqsa2srHAtZWs3CSGEPimKwsMDB4j/7DOyrl0HwNTdHecxQdj4+xvM7NF67clLTExErVbj4uKSp9zFxYXY2NgCt4mNjX1m/S5duvDdd98RHh7OvHnzOHDgAF27dkWtVhe4z+DgYOzs7LQ/7u7uRXxlQghRuiSnZzN7xwX8Fh1g17lYjFTQt2U19o/rwNAOtSTBKyGPL2b6+flpywpzMfPv9SH3YuaT6j/NDz/8gJOTEw0aNGDSpEmkp6c/sW5mZiYpKSl5foQQwpA8On+e6EGB3PnwI7KuXcfYzg6XyZOouWM7tl26GEyCBwY6u2afPn20vzds2JBGjRpRs2ZN9u/fT6dOnfLVnzRpUp7ewZSUFEn0hBAGIVut4Yc/bhESfpUH6dkAtPVyYkr3etR2tdFzdIbvaRczL126VOA2hbmYWRj9+vWjevXquLm5cebMGSZMmMDly5fZvHlzgfWDg4OZOXOmTscQQoiyIPvPP4kPWULKtm0AqMzMcHj3HZw++ABjW1s9R1cy9JrkOTk5YWxsTFxcXJ7yuLi4J95e4urqqlN9gBo1auDk5MS1a9cKTPLMzc0xNzd/jlcghBClk6IohF+MZ86ui9xISAPAy7kCH3evS/vaznqOTrwI77//vvb3hg0bUrlyZTp16sT169epWbNmvvpywVMIYWjUKSkkfvEF97//L0pWFgC2PXvgPHIkplWq6Dm6kvVcSd7Vq1fZt28f8fHxaDSaPM9Nmzat0PsxMzOjWbNmhIeHExAQAIBGoyE8PJxhw4YVuI2vry/h4eGMGjVKW7Z79258fX2feJw7d+5w7949KleuXOjYhBCirDp/N5nZOy5y+Po9ABytzRj96kv0aeGOiSxm/kK9qIuZheHj4wPAtWvXCkzy5IKnEMJQKFlZ3P/xRxJXrESdnAyAlY8PzuPGYdmgvp6jezF0TvK+/PJLPvroI5ycnHB1dc1z76pKpdIpyQMICgpi4MCBNG/enJYtWxISEkJaWpp2gPqAAQOoUqUKwcHBAIwcOZJ27dqxcOFCunfvzrp16zh+/DirVq0C4OHDh8ycOZM333wTV1dXrl+/zvjx46lVqxb+/v66vlwhhCgz4lIy+OyXy2yKvIOigJmJEYPbeDKkfU1sLGStO314URczC+PxMgtywVMIYagURSE1LIz4RYvJvn0bALNaNXEeO5YK7doZ1Ji7Z9E5yZs1axazZ89mwoQJxRJA7969SUhIYNq0acTGxuLt7U1YWJh2PEJ0dDRGRv9/5blVq1asXbuWKVOmMHnyZLy8vNiyZQsNGjQAwNjYmDNnzvDtt9/y4MED3Nzc6Ny5M59++qlcoRRCGKT0rBy+PBhF6IHrPMrOnWCqZ2M3xvnXxr2ilZ6jE8V9MRMgKSmJ6Oho7t69C8Dly5cBtMsGXb9+nbVr19KtWzccHR05c+YMo0eP5pVXXqFRo0Yv+AwIIUTJSz9xgrj588k4fQYA40pOVBo+HPtevVCZGOQ0JE+lUhRF0WUDW1tbTp06RY0aNUoqJr1LSUnBzs6O5ORkbA10MKYQouzTaBQ2n/yTBb9cIi4ldxmYptXsmfJaPZpWM7y1QcvyZ/OyZctYsGCB9mLm0qVLtbdPtm/fHg8PD9asWaOtv3HjRqZMmcLNmzfx8vJi/vz5dOvWTfv8mjVrtEni302fPp0ZM2Zw+/Zt3nnnHc6dO0daWhru7u688cYbTJkypdDnriyfbyFE+ZEZFUXCokWk7t4DgMrKCsd//xvHwEEYWVvrObriV9jPZp2TvMGDB9OiRQs+/PDDIgdZWknDJoQo7SKu32P2zguc+zN3mvuqDpZM7FqH7g0rG+ztKPLZ/GLJ+RZClGY59+6RuHw599dvALUajIywf+stnIYNxdTZcCcYK+xns859l7Vq1WLq1Kn88ccfNGzYEFPTvOM8RowYoXu0QgghCuVGwkOCd11i94XciTlszE0Y1rEWA1t5yFp3QgghDJ7m0SOSvv2We19+hSYtd/boCu3b4zx2DOa1auk5utJD5548T0/PJ+9MpeLGjRtFDkrf5OqlEKK0eZCexZLwq3wfcYscjYKxkYr+PtUY2ckLxwrlY7yxfDa/WHK+hRCliaJWk/y/rSQsWULOXzMQW9Svj/P48Vj7tNRzdC9OifXkRUVFFSkwIYQQhZeVo+G7iJssDb9KSkYOAB3rODO5Wx1qOcti5kIIIQzfw0O/E79gAZl/TTJl6uZGpdGjse3eDZWRLA1UkCJNNfO4E9BQx38IIYS+KIrCL+fjmLvrIjfvpQNQx9WGKd3r0cbLSc/RCSGEECUv49Il4hd8RtrvvwNgZGuL0wcf4PBOf4xk1vyneq4k77vvvmPBggVcvXoVgJdeeolx48bx7rvvFmtwQghRHp2584BZ2y9y9GYSAJVszBnb+SXeauaOsZFcVBNCCGHYsmNjSViylOQtW0BRwNSUiv364fjhB5g4GN7s0SVB5yRv0aJFTJ06lWHDhtG6dWsADh06xIcffkhiYiKjR48u9iCFEKI8uPvgEZ/9cpnNJ/8EwMLUiPfb1uCDdjWxNi9/a/wIIYQoX9QPH3Lvy69I+vZblIwMAGy7daXS6NGYubvrObqyRedvDZ9//jkrV65kwIAB2rKePXtSv359ZsyYIUmeEELoKC0zh9AD11l18AaZORoAejWpwlj/2rjZW+o5OiGEEKJkKdnZ3N+wgcTlK1An5d7FYtm8GS7jxmHZuLGeoyubdE7yYmJiaNWqVb7yVq1aERMTUyxBCSFEeaDWKGw6cZvPfr1CQmruYuYtPSsypXtdGlW1129wQgghRAlTFIXUPXtIWLiIrJs3ATDz9MR57BgqdOwo834UwXOtk7dhwwYmT56cp3z9+vV4eXkVW2BCCGHIDl1NZNaOC1yKTQWguqMVk7rWxb++izRqeqZWq1mzZg3h4eHEx8ej0WjyPL937149RSaEEIbj0alTxC34jEcnTgBgXLEilYYPw/6tt1D9Yx1uoTudk7yZM2fSu3dvDh48qB2T9/vvvxMeHs6GDRuKPUAhhDAk1+JTmbPzEnsvxQNga2HCSL+XePfl6piZyDTQpcHIkSNZs2YN3bt3p0GDBpJ0CyFEMcqKjiZ+0WJSw8IAUFlYUHHQQBz/8x+MK1TQc3SGQ+ck78033+TIkSMsXryYLVu2AFC3bl2OHj1KkyZNijs+IYQwCPceZhKy5yprj0aj1iiYGKl417c6Izp64WBtpu/wxN+sW7eODRs20K1bN32HIoQQBiPn/n0SV67k/o/rIDsbVCrser1BpREjMHVx0Xd4Bue5pmtr1qwZ//3vf4s7FiGEMDgZ2Wq+PXyTZXuvkZqZu5h553ouTOxahxqV5IplaWRmZkatWrX0HYYQQhgETWYm97//nsQvVqFJzR2iYN2mDc7jxmJRu7aeozNchUryUlJSsLW11f7+NI/rCSFEeaYoCjvOxjB31yXu3H8EQH03W6Z0r4dvTUc9RyeeZsyYMSxZsoRly5bJrZpCCPGcFI2GlO3biQ8JIedu7uSM5nXq4DxuLBX+GvIlSk6hkjwHBwdiYmJwdnbG3t6+wEZPURRUKhVqtbrYgxRCiLIkMvo+s7ZfIDL6AQAutuaM869DryZVMJLFzEu9Q4cOsW/fPnbt2kX9+vUx/ccEAJs3b9ZTZEIIUTak/fEH8fMXkHHhAgAmrq5UGjkSu549UBkb6zm68qFQSd7evXupWLEiAPv27SvRgIQQoqy6nZTO/F8us+30XQAsTY35sF1N3nvFEyszWcy8rLC3t+eNN97QdxhCCFHmZF69Stxnn5F24CAARtbWOL7/PhUHDsDIwkLP0ZUvhfrW0a5dO+3vnp6euLu75+vNUxSF27dvF290QghRBqRmZLNi/3W+PhRFVo4GlQr+1awqYzrXxsVWGrWyZvXq1foOQQghypTs+HgSP/+cBz9tBo0GTExw6N0bp6FDMPmro0i8WDpfWvb09NTeuvl3SUlJeHp6yu2aQohyI0etYd2x2yzefYV7aVkAtKrpyMfd61LfzU7P0YmiSkhI4PLlywDUrl2bSpUq6TkiIYQoXTRpadz7+hvurV6N8ih3/LnNq69SKWg05p6eeo6ufNM5yXs89u6fHj58iIV0wwohyon9l+OZveMiV+MfAlCjkjWTu9alU11nmayjjEtLS2P48OF899132oXQjY2NGTBgAJ9//jlWVlZ6jlAIIfRLycnhwU+bSfj8c9SJiQBYenvjPH4cVk2b6jk6ATokeUFBQQCoVCqmTp2ap5FTq9UcOXIEb2/vYg9QCCFKk0uxKczecZHfruY2ag5Wpozye4l+PtUwNZbFzA1BUFAQBw4cYNu2bbT+awa4Q4cOMWLECMaMGcPKlSv1HKEQQuiHoig83L+f+M8WknX9OgCm1arhHBSEjX9nuchZihQ6yTt58iSQ+5979uxZzMz+f/FeMzMzGjduzNixY4s/QiGEKAUSUjNZtPsK649Fo1HA1FhFYGtPhnaohZ2l6bN3IMqMn376iU2bNtG+fXttWbdu3bC0tOTtt9+WJE8IUS49OnuO+AULSD96FABje3uchgzBoU9vVH/LC0TpUOgk7/GsmoGBgSxZskTWwxNClAsZ2Wq+PhTFin3XSMvKHXPcraErE7rUobqjtZ6jEyUhPT0dFxeXfOXOzs6kp6frISIhhNCfrDt/khASQsr27QCozMyoOHAAju+9h7HkA6WWzmPyQkJCyMnJyVeelJSEiYmJJH9CCIOg0ShsO3OXebsucTc5A4DGVe2Y8lo9WnjITGGGzNfXl+nTp/Pdd99px5o/evSImTNn4uvrq+fohBDixVAnJ5P4xSruf/89SnY2AHav96TSyJGYurnpOTrxLDoneX369KFHjx4MGTIkT/mGDRvYunUrO3fuLLbghBBCH47dTGLW9gucvpMMgJudBRO61qFHIzdZzLwcWLJkCf7+/lStWpXGjRsDcPr0aSwsLPjll1/0HJ0QQpQsTVYW99euJXFlKJrk3HbQyvdlXMaNw6JePT1HJwpL51kCjhw5QocOHfKVt2/fniNHjjxXEMuXL8fDwwMLCwt8fHw4+te9vk+yceNG6tSpg4WFBQ0bNnxqYvnhhx+iUqkICQl5rtiEEOVH9L10hvxwgn+FRnD6TjLWZsaM86/N3rHted27iiR45USDBg24evUqwcHBeHt74+3tzdy5c7l69Sr169fXd3hCCFEiFEUhZedObnTrTvzceWiSkzH38sJ91RdU++YbSfDKGJ178jIzMwu8XTM7O5tHf62PoYv169cTFBREaGgoPj4+hISE4O/vz+XLl/OtxQdw+PBh+vbtS3BwMK+99hpr164lICCAyMhIGjRokKfuzz//zB9//IGbdCkLIZ4i+VE2y/ddY83vN8lSazBSQe8W1Rj9qhfONrI0THlkZWXFe++9p+8whBDihUg/fpy4+QvIOHMGAJNKlag0cgR2b7yBythYz9GJ56FSFEXRZYMOHTrQoEEDPv/88zzlQ4cO5cyZM/z22286BeDj40OLFi1YtmwZABqNBnd3d4YPH87EiRPz1e/duzdpaWls/2vwJ8DLL7+Mt7c3oaGh2rI///wTHx8ffvnlF7p3786oUaMYNWpUoWJKSUnBzs6O5ORkGWMohAHLVmtYeySakD1XuJ+eO96grZcTH3evSx1X+dsvbUrys3nr1q107doVU1NTtm7d+tS6PXv2LNZjl1bSFgph+DJvRBG/cCEPw8MBUFlZ4fifwTgOGoSRrAlaKhX2s1nnnrxZs2bh5+fH6dOn6dSpEwDh4eEcO3aMX3/9Vad9ZWVlceLECSZNmqQtMzIyws/Pj4iIiAK3iYiI0K7Z95i/vz9btmzRPtZoNLz77ruMGzeuULfWZGZmkpmZqX2ckpKi0+sQQpQtiqKw91I8s3de5EZCGgBezhWY3L0u7V+qJOv8lEMBAQHExsbi7OxMQEDAE+upVCrUavWLC0wIIUpATmIiCcuX82DDRlCrwdgY+3+9RaVhwzBxctJ3eKIY6JzktW7dmoiICBYsWMCGDRuwtLSkUaNGfP3113h5eem0r8TERNRqdb6pql1cXLh06VKB28TGxhZYPzY2Vvt43rx5mJiYMGLEiELFERwczMyZM3WKXQhRNp2/m8zsHRc5fP0eAI7WZox+9SX6tHDHRBYzL7c0Gk2BvwshhCHRPHpE0po13PvyKzR/LQlToWNHnMcEYV6zpp6jE8VJ5yQPwNvbmx9++KG4YykWJ06cYMmSJURGRhb6avykSZPy9A6mpKTg7u5eUiEKIfQgLiWDhb9eZuOJOygKmJkY8e/WngzpUBNbC1nMXPy/7777jt69e2Nubp6nPCsri3Xr1jFgwAA9RSaEEM9HUatJ3rKFhCVLyYmPB8CiYUOcx43FumVLPUcnSsJzJXmPZWRkkJWVladMl/v2nZycMDY2Ji4uLk95XFwcrq6uBW7j6ur61Pq//fYb8fHxVKtWTfu8Wq1mzJgxhISEcPPmzXz7NDc3z9eYCyEMQ3pWDl8ejCL0wHUeZefeZtejsRvj/WvjXlHGG4j8AgMD6dKlS77Jv1JTUwkMDJQkTwhRZiiKQtqhQ8Qv+IzMK1cAMK1ShUqjR2PbrSsqI7mDxVDpnOSlp6czfvx4NmzYwL179/I9r8tYBTMzM5o1a0Z4eLh2DIRGoyE8PJxhw4YVuI2vry/h4eF5JlHZvXu3doHad999Fz8/vzzb+Pv78+677xIYGFjo2IQQZZtGo/DzyT9Z8MtlYlNyFzNvWs2eKa/Vo2k1Bz1HJ0ozRVEKvBPkzp072NnZ6SEiIYTQXcbFi8QvWEDa4dx5Lozs7HD68EMc+vfDyMxMz9GJkqZzkjdu3Dj27dvHypUreffdd1m+fDl//vknX3zxBXPnztU5gKCgIAYOHEjz5s1p2bIlISEhpKWlaROyAQMGUKVKFYKDgwEYOXIk7dq1Y+HChXTv3p1169Zx/PhxVq1aBYCjoyOOjo55jmFqaoqrqyu1a9fWOT4hRNkTcf0es3de4NyfuZMoVXWwZGLXOnRvWFkmVRFP1KRJE1QqFSqVik6dOmFi8v9NpFqtJioqii5duugxQiGEeLbsmBgSQpaQvHUrKAoqU1Mc+vfH6cMPMLa313d44gXROcnbtm0b3333He3btycwMJC2bdtSq1Ytqlevzg8//ED//v112l/v3r1JSEhg2rRpxMbG4u3tTVhYmHZylejoaIz+1pXcqlUr1q5dy5QpU5g8eTJeXl5s2bIl3xp5QojyJyoxjeCdF/n1Qu4t3TbmJgztWItBrTywMJV1fsTTPb6j5NSpU/j7+1OhQgXtc2ZmZnh4ePDmm2/qKTohhHg6dWoq91Z9SdJ336H8NWu8bbduVAoajVnVqnqOTrxoOq+TV6FCBS5cuEC1atWoWrUqmzdvpmXLlkRFRdGwYUMePnxYUrG+MLI2kBBly4P0LJaEX+X7iFvkaBSMjVT0a1mNUX5eOFaQ8baG4kV9Nn/77bf06dOn3I/VlrZQiLJByc7m/voNJC5fjvr+fQCsmjfHecJ4LBs21HN0oriV2Dp5NWrUICoqimrVqlGnTh02bNhAy5Yt2bZtG/bSBSyEeIGycjR8/8ctloZfJflR7mLmHes4M7lbHWo52+g5OlFW1atXj1OnTuHj45On/MiRIxgbG9O8eXM9RSaEEP9PURRSd+8mYeEism7dAsCsRg2cx46hQocOMjyhnNM5yQsMDOT06dO0a9eOiRMn0qNHD5YtW0Z2djaLFi0qiRiFECIPRVH45Xwcc3dd5Oa93HV+6rja8HH3urT1qqTn6ERZN3ToUMaPH58vyfvzzz+ZN28eR44c0VNkQgiRK/3kSeLnL+DRyZMAGDs6Umn4MOzfeguVSZEmzxcGQud3wejRo7W/+/n5cenSJU6cOEGtWrVo1KhRsQYnhBD/dPZOMp/uuMDRqCQAnCqYM7bzS/yruTvGRnLVUhTdhQsXaNq0ab7yJk2acOHCBT1EJIQQubJu3SJ+4SJSf/0VAJWlJY6Bg6j478EYV7DWc3SiNNEpycvOzqZLly6Ehobi5eUFQPXq1alevXqJBCeEEI/FJD9iQdhlNp/8EwBzEyPef6UGH7SrSQVzuWopio+5uTlxcXHUqFEjT3lMTEyeGTeFEOJFybl/n8QVK7n/44+QkwNGRtj1eoNKw0dg6uL87B2Icken1srU1JQzZ86UVCxCCJFPWmYOXxy4zqrfbpCRrQGgV5MqjPWvjZu9pZ6jE4aoc+fOTJo0if/973/adfEePHjA5MmTefXVV/UcnRCiPNFkZJD0/ffc+2IVmr8mN7R+pS3OY8di8dJLeo5OlGY6X5J85513+Prrr59rTTwhhCgstUZh04nbfPbrFRJSc6eCbulRkSmv1aVRVXv9BicM2meffcYrr7xC9erVadKkCZC7rIKLiwvff/+9nqMTQpQHikZDyrZtxIcsIScmBgDzunVxGT8Oa19fPUcnygKdk7ycnBy++eYb9uzZQ7NmzbC2znv/r0y+IoQoqkNXE5m14wKXYlMBqO5oxaSudfCv7yqzhYkSV6VKFc6cOcMPP/zA6dOnsbS0JDAwkL59+2Jqaqrv8IQQBi4tIoK4BQvIvHARAJPKlXEeNRLbHj1Q/W3taCGeRuck79y5c9oB6VeuXMnznHz5EkIUxbX4VObsvMTeS/EA2FqYMKKTFwN8PTAzkYZNvDjW1ta8//77+g5DCFGOZFy5Qvxnn5F28DcAjCpUwPGD96n47rsYWVjoOTpR1hQqyTtz5gwNGjTAyMiIffv2lXRMQohy5t7DTJaEX+WHI9GoNQomRire9a3OiI5eOFib6Ts8UU5duHCB6OhosrKy8pT37NlTTxEJIQxRdlw8CZ8vJXnzz6DRgIkJDn374jTkI0wcHPQdniijCpXkNWnShJiYGJydnalRowbHjh3D0dGxpGMTQhi4zBw1a36/ybK910jNzAHg1XouTOpahxqVKug5OlFe3bhxgzfeeIOzZ8+iUqlQFAX4/7tV1Gq1PsMTQhgI9cM0kr75mnur16A8egSAjb8/zkGjMZOZ60URFSrJs7e3JyoqCmdnZ27evIlGoynpuIQQBkxRFHaejWVu2EVuJ+U2bPXdbJnSvR6+NeUCktCvkSNH4unpSXh4OJ6enhw9epR79+4xZswYPvvsM32HJ4Qo45ScHB5s2kTCsuWoExMBsGzSBOfx47D6a7InIYqqUEnem2++Sbt27ahcuTIqlYrmzZtjbGxcYN0bN24Ua4BCCMNyMvo+s3Zc5MSt+wC42Jozzr8OvZpUwUgWMxelQEREBHv37sXJyQkjIyOMjIxo06YNwcHBjBgxgpMnT+o7RCFEGaQoCg/37SP+s4Vk/fV92bR6NZyDxmDT+VWZ20IUq0IleatWraJXr15cu3aNESNG8N5772FjY1PSsQkhDMid++nMD7vM1tN3AbA0NeaDdjV4/5UaWJnJAtOi9FCr1do2zsnJibt371K7dm2qV6/O5cuX9RydEKIsenT2LPHz5pN+/DgAxg4OOA0dikPvt1HJrL2iBBT6m1WXLl0AOHHiBCNHjpQkTwhRKKkZ2azYf52vD0WRlaNBpYK3mlZlrH9tXGxltjBR+jRo0IDTp0/j6emJj48P8+fPx8zMjFWrVlGjRg19hyeEKEOy7twhYdFiUnbuBEBlbk7FAQNwfP89jOW7tChBOs9Jvnr1aknwhBDPlKPW8MORW7RfsJ+V+6+TlaPBt4Yj24e3YcG/GkuCJ0qtKVOmaMeef/LJJ0RFRdG2bVt27tzJ0qVLn2ufy5cvx8PDAwsLC3x8fDh69OhT62/cuJE6depgYWFBw4YN2fnXF8THNm/eTOfOnXF0dESlUnHq1Kl8+8jIyGDo0KE4OjpSoUIF3nzzTeLi4p4rfiGEbtQPHhA3dx43unbLTfBUKuxef52aYbtwHhMkCZ4ocXKPlBCi2O2/HM/sHRe5Gv8QgBpO1kzuVpdOdZ1lzIEo9fz9/bW/16pVi0uXLpGUlISDg8NzvX/Xr19PUFAQoaGh+Pj4EBISgr+/P5cvX8bZ2Tlf/cOHD9O3b1+Cg4N57bXXWLt2LQEBAURGRtKgQQMA0tLSaNOmDW+//TbvvfdegccdPXo0O3bsYOPGjdjZ2TFs2DB69erF77//rvNrEEIUjiYri/v//YHEL75Ak5wMgHUrX5zHjcOibl09RyfKE5XyeG5ooZWSkoKdnR3JycnY2trqOxwhyozLsanM3nmRg1cSALC3MmVUJy/6v1wdU2NZzFwUzYv4bM7OzsbS0pJTp05pE6qi8vHxoUWLFixbtgwAjUaDu7s7w4cPZ+LEifnq9+7dm7S0NLZv364te/nll/H29iY0NDRP3Zs3b+Lp6cnJkyfx9vbWlicnJ1OpUiXWrl3LW2+9BcClS5eoW7cuERERvPzyy8+MW9pCIQpP0WhI2bmLhMWLyf7zTwDMX3oJ53FjsW7TRi5wimJT2M9m6ckTQhRZQmomi3ZfYf2xaDQKmBqrGNTKg2EdvLCzkgHlouwwNTWlWrVqxbYWXlZWFidOnGDSpEnaMiMjI/z8/IiIiChwm4iICIKCgvKU+fv7s2XLlkIf98SJE2RnZ+Pn56ctq1OnDtWqVXtikpeZmUlmZqb2cUpKSqGPJ0R5lnb0KPELPiPj7FkATJydqTRyBHYBAaieMBu9ECVN50vrBw8eJCcnJ195Tk4OBw8eLJaghBBlQ0a2muX7rtF+wT5+PJqb4HVr6MqeoHZ83L2eJHiiTPr444+ZPHkySUlJRd5XYmIiarUaFxeXPOUuLi7ExsYWuE1sbKxO9Z+0DzMzM+zt7Qu9n+DgYOzs7LQ/7u7uhT6eEOVR5vXr3P5oCNEDBpJx9ixGVlZUGjmCmmG7sH/zTUnwhF7p3JPXoUMHYmJi8o0jSE5OpkOHDsV29VMIUXopisLW03eZH3aZPx/kLmbeuKodU16rRwuPinqOToiiWbZsGdeuXcPNzY3q1atjbW2d5/nIyEg9RVayJk2alKcHMSUlRRI9IQqQk5hIwrJlPNi4CdRqMDbG/u1/UWnoUEycnPQdnhDAcyR5iqIUeF/xvXv38jWEQgjDc/xmEp/uuMjp2w8AcLOzYHyXOvRs7CaLmQuDEBAQUGz7cnJywtjYON+slnFxcbi6uha4jaurq071n7SPrKwsHjx4kKc372n7MTc3x9zcvNDHEKK80aSnc2/NGpK++hpNejoAFTp1wnlMEOayvIooZQqd5PXq1QsAlUrFoEGD8jQEarWaM2fO0KpVq+KPUAhRKkTfS2de2CV2nI0BwNrMmCEdajG4jScWpnJLiijbli5dyvvvv4+FhQWBgYFUrVoVI6OiTxZkZmZGs2bNCA8P1yaPGo2G8PBwhg0bVuA2vr6+hIeHM2rUKG3Z7t278fX1LfRxmzVrhqmpKeHh4bz55psAXL58mejoaJ32I4QARa3mwebNJC79nJyE3InFLBo1wmXcWKxatNBzdEIUrNBJnp2dHZDbk2djY4OlpaX2OTMzM15++eUnTuMshCi7kh9ls3zfNdb8fpMstQYjFfRuUY3Rr3rhbCNr3QnDEBQURJ8+fbCwsMDT07PAYQlF2ffAgQNp3rw5LVu2JCQkhLS0NAIDAwEYMGAAVapUITg4GICRI0fSrl07Fi5cSPfu3Vm3bh3Hjx9n1apV2n0mJSURHR3N3bt3gdwEDnJ78FxdXbGzs2Pw4MEEBQVRsWJFbG1tGT58OL6+voWaWVMIkfudN+2334hf8BmZV68CYFq1Ks5Bo7Hp2lVmzBSlWqGTvNWrVwPg4eHB2LFj5dZMIQxctlrDj0ejWbz7CvfTswFo6+XEx93rUsdVplMXhsXNzY2ffvqJbt26oSgKd+7cISMjo8C61apV02nfvXv3JiEhgWnTphEbG4u3tzdhYWHayVWio6Pz9Bq2atWKtWvXMmXKFCZPnoyXlxdbtmzJs6TD1q1btUkiQJ8+fQCYPn06M2bMAGDx4sUYGRnx5ptvkpmZib+/PytWrNApdiHKq4wLF4hbsID0iD8AMLKzw+mjD3Ho1w8jMzM9RyfEs8k6eQWQtYFEeaYoCnsvxTN750VuJKQB4OVcgcnd69L+pUpy5VLoTUl+Nq9atYrhw4cXOHv0Y4/HpJeXCcakLRTlUfbduyQsWULy1m2gKKhMTXF4912cPngf47/uahNCnwr72azzgIO4uDjeffdd3NzcMDExwdjYOM/P81i+fDkeHh5YWFjg4+PD0aNHn1p/48aN1KlTBwsLCxo2bMjOnTvzPD9jxgzq1KmDtbU1Dg4O+Pn5ceTIkeeKTYjy5MLdFN75+giDvz3OjYQ0HK3NmBXQgF0j29KhtrMkeMJgvf/++yQmJnL69GkURWH37t1ERkbm+Tl58qTBzqwpRHmnTk0lfuFCrnfpSvL/toKiYPvaa9TYtQuX8eMkwRNljs6zaw4aNIjo6GimTp1K5cqVi/ylb/369QQFBREaGoqPjw8hISH4+/tz+fLlAsdDHD58mL59+xIcHMxrr73G2rVrCQgIIDIyUnsry0svvcSyZcuoUaMGjx49YvHixXTu3Jlr165RqVKlIsUrhCGKT8ngs18vs/HEHRQFzIyN+HcbT4Z0qImthax1J8oHGxsbGjRowOrVq2ndurXMNClEOaBkZXF/3XoSV6xA/eABAFYtW+I8bhyWDRs8fWMhSjGdb9e0sbHht99+w9vbu1gC8PHxoUWLFixbtgzInXXM3d2d4cOHM3HixHz1e/fuTVpaGtu3b9eWvfzyy3h7exMaGlrgMR53a+7Zs4dOnTo9Mya5RUWUF4+y1Hz52w1CD1wnPSv3FrTXGlVmQpc6uFe00nN0QuQln80vlpxvUdZl371Lzv37BT+pwKOzZ0las5rsW9EAmNWsifPYMVRo317uXBGlVmE/m3XuyXN3d6e4hvFlZWVx4sQJJk2apC0zMjLCz8+PiIiIAreJiIjIs1grgL+/P1u2bHniMVatWoWdnR2NGzcusE5mZiaZmZnaxykpKTq+EiFKH7VG4WhUEvGpGTjbWNDSsyLGf61jp9Eo/HzyTxb8cpnYlNzJJZpUs2dK93o0q+6gz7CFEEKIIsu+e5frXbqiZGU9s66xkxOVhg/H/s1eqEx0/mosRKmk8zs5JCSEiRMn8sUXX+Dh4VGkgycmJqJWq7UzjD3m4uLCpUuXCtwmNja2wPqxsbF5yrZv306fPn1IT0+ncuXK7N69GycnpwL3GRwczMyZM4vwSoQoXcLOxTBz2wVikv9/dsDKdhZM71EPeyszZu24wLk/cy9mVHWwZEKXOrzWqOi3XwshhBClQc79+4VK8OzffhuXCeMxklnjhYHROcnr3bs36enp1KxZEysrK0xN847XSUpKKrbgiqJDhw6cOnWKxMREvvzyS95++22OHDlS4Di/SZMm5ekdTElJwd3d/UWGK0SxCTsXw0f/jeSf/e0xyRl8+N//nzTCxtyEoR1rMaiVhyxmLoQQolyy7/22JHjCID1XT15xcXJywtjYmLi4uDzlcXFxuLq6FriNq6troepbW1tTq1YtatWqxcsvv4yXlxdff/11nltDHzM3N5cB9sIgqDUKM7ddyJfg/VM/H3eCXq2NUwV53wshhBBCGBqdk7yBAwcW28HNzMxo1qwZ4eHhBAQEALkTr4SHhzNs2LACt/H19SU8PJxRo0Zpy3bv3o2vr+9Tj6XRaPKMuxPCEB2NSspzi+aT9GhURRI8If7mn2O9n2bRokUlGIkQojhoHj7UdwhC6NVzjS69fv06q1ev5vr16yxZsgRnZ2d27dpFtWrVqF+/vk77CgoKYuDAgTRv3pyWLVsSEhJCWloagYGBAAwYMIAqVaoQHBwMwMiRI2nXrh0LFy6ke/furFu3juPHj7Nq1SoA0tLSmD17Nj179qRy5cokJiayfPly/vzzT/71r389z8sVosyIT312gqdLPSHKi5MnT+Z5HBkZSU5ODrVr1wbgypUrGBsb06xZM32EJ4TQQerevcRM/ljfYQihVzoneQcOHKBr1660bt2agwcPMnv2bJydnTl9+jRff/01mzZt0ml/vXv3JiEhgWnTphEbG4u3tzdhYWHayVWio6MxMvr/NdtbtWrF2rVrmTJlCpMnT8bLy4stW7Zo18gzNjbm0qVLfPvttyQmJuLo6EiLFi347bffdE5AhShr7K0Kt6ads41FCUciRNmyb98+7e+LFi3CxsaGb7/9FgeH3Nlm79+/T2BgIG3bttVXiEKIZ8i5f5+4OcGkbNum71CE0Dud18nz9fXlX//6F0FBQdjY2HD69Glq1KjB0aNH6dWrF3fu3CmpWF8YWRtIlEV/3LjHpJ/OEHUv/Yl1VICrnQWHJnTULqcgRFnxoj6bq1Spwq+//prvwuC5c+fo3Lkzd+/eLbFjlybSFoqyJHXPHmJmzESdmAhGRtj17EHylv89czuPnzZhKZ0AogwpsXXyzp49y9q1a/OVOzs7k5iYqOvuhBBF9CA9i+Cdl1h//DYAthYmpGTkoII8E7A8Tumm96gnCZ4QT5GSkkJCQkK+8oSEBFJTU/UQkRDiSXLu3ydu1mxSduwAchc0d5szG5NKlUjZueupyyiozMwwcZC1YYVh0jnJs7e3JyYmBk9PzzzlJ0+epEqVKsUWmBDi6RRFYduZGD7Zdp7Eh7mN2DsvV2N8lzocvpaYb50817/WyevSoLK+QhaiTHjjjTcIDAxk4cKFtGzZEoAjR44wbtw4evXqpefohBCPpfzyK7GffIL63j0wMsLxP//BaegQjP6aMb1m2C5y7t9/4vYmDg6Yurm9qHCFeKF0TvL69OnDhAkT2LhxIyqVCo1Gw++//87YsWMZMGBAScQohPiH20npTP3fOfZfzu1tqOVcgbm9GtLcoyIAXRpU5tV6rhyNSiI+NQNnGwtaelaUHjwhCiE0NJSxY8fSr18/srOzATAxMWHw4MEsWLBAz9EJIXKSkoj99FNSd4UBYO5Vi8pz5mDZsGGeeqZubpLEiXJL5zF5WVlZDB06lDVr1qBWqzExMUGtVtOvXz/WrFmDsXHZX1RZxiGI0ipHrWHN4Zss/PUKj7LVmBkbMaxjLT5oVwNzk7L/tyfE07zoz+a0tDSuX78OQM2aNbEuZwsmS1soSqOUsDBiZ36C+v59MDbG8f33cProI4zMzPQdmhAvRGE/m3VO8h6Ljo7m3LlzPHz4kCZNmuDl5fXcwZY20rCJ0ujcn8lM2nyWs38mA9DSsyLBvRpSs1IFPUcmxIshn80vlpxvUZrkJCYS+8mnpP76KwDmtWtTec5smTRFlDslNvHKoUOHaNOmDdWqVaNatWpFClII8WzpWTmE7LnK14eiUGsUbC1MmNytLm83d8dIbr8UoljoMtZu8+bNJRiJEOLvFEUhZedO4j6dhfrBAzAxwemDD3D64H1U0nsnxBPpnOR17NiRKlWq0LdvX9555x3q1atXEnEJIYADVxKYsuUst5MeAfBao8pM61FP1rkTopjZ2dnpOwQhxD/kJCQQ+8knpO7eA4B5nTq4Bc/Bom5dPUcmROmnc5J39+5d1q1bx48//sjcuXNp1KgR/fv3p2/fvlStWrUkYhSi3El8mMms7RfYcip3Pa4q9pZ8GlCfjnVc9ByZEIZp9erV+g5BCPEXRVFI2b6duFmzUScng6kpTh9+gNP776MyNdV3eEKUCc89Jg8gKiqKtWvX8uOPP3Lp0iVeeeUV9u7dW5zx6YWMQxD6oigKm07cYfbOizxIz8ZIBYNaeTKm80tYm+t8TUYIgyKfzS+WnG+hD9nx8cTOmMnDv75PWtSrR+XgOVjUrq3nyIQoHUpsTN7feXp6MnHiRBo3bszUqVM5cOBAUXYnRLl2MzGNyT+f5fD1ewDUrWzL3F4Naexur9/AhCiHNm3axIYNG4iOjibrH4spR0ZG6ikqIQyXoiikbN1K7Ow5aFJSwNSUSkOH4Dh4sPTeCfEcjJ53w99//50hQ4ZQuXJl+vXrR4MGDdixY0dxxiZEuZCt1rB83zX8Qw5y+Po9LEyNmNS1DluHtZYETwg9WLp0KYGBgbi4uHDy5ElatmyJo6MjN27coGvXrvoOTwiDkx0Xx50PP+LuhIloUlKwqF8fz5824fThh5LgCfGcdO7JmzRpEuvWrePu3bu8+uqrLFmyhNdffx0rK6uSiE8IgxYZfZ/Jm89yKTYVgLZeTswKaEB1x/K1HpcQpcmKFStYtWoVffv2Zc2aNYwfP54aNWowbdo0kpKS9B2eEAZDURSSN/9M3Ny5aFJTUZma4jR8OI7/DkRlIkMUhCgKnf+CDh48yLhx43j77bdxcnIqiZiEMHipGdl89stlvvvjFooCFa3NmPpaXQK8q6BSybIIQuhTdHQ0rVq1AsDS0pLU1NyLMO+++y4vv/wyy5Yt02d4QhiE7JgYYqZNJ+233wCwaNQItzmzMa9VS8+RCWEYdE7yfv/995KIQ4hy49fzsUz733liUzIA6NW0ClO616Oitaz3I0Rp4OrqSlJSEtWrV6datWr88ccfNG7cmKioKIowV5kQgr967376ibi589A8fIjKzIxKI4ZTcdAg6b0Tohg911/T999/T2hoKFFRUURERFC9enVCQkLw9PTk9ddfL+4YhTAIcSkZzNh6nl3nYgGoVtGKOW80pI2X9IgLUZp07NiRrVu30qRJEwIDAxk9ejSbNm3i+PHjOi2aLoTIK/vuXWKmTiPtrw4Dy8aNqRw8B/MaNfQcmRCGR+ckb+XKlUybNo1Ro0Yxe/Zs1Go1APb29oSEhEiSJ8Q/aDQKa49GM2/XJVIzczA2UvH+KzUY0dELSzNjfYcnhPiHVatWodFoABg6dCiOjo4cPnyYnj178sEHH+g5OiHKHkVReLBhI/Hz56NJS0Nlbk6lkSOpOHAAKmNpB4UoCTqvk1evXj3mzJlDQEAANjY2nD59mho1anDu3Dnat29PYmJiScX6wsjaQKK4XI1LZdLmsxy/dR+Axu72zO3VkLqV5X0lhK5exGdzTk4Oc+bM4d///jdVq1YtkWOUFdIWiuKQdedPYqdNJe1wBACWTZpQefZszGt46jkyIcqmElsnLyoqiiZNmuQrNzc3Jy0tTdfdCWGQMrLVrNh/nZX7r5GtVrA2M2acf23e9fXA2EgmVhGitDIxMWH+/PkMGDBA36EIUaYpGg0P1q8nfsFnaNLTUVlY4Dx6FA7vvCO9d0K8ADoneZ6enpw6dYrq1avnKQ8LC6Nu3brFFpgQZdWRG/eY9PNZbiTkXvTwq+vMJ683wM3eUs+RCSEKo1OnThw4cAAPDw99hyJEmZR15w4xH08h/cgRACybNcNt9izM5G9KiBdG5yQvKCiIoUOHkpGRgaIoHD16lB9//JHg4GC++uqrkohRiDIhOT2b4F0XWXfsNgCVbMyZ2bM+XRu4yrIIQpQhXbt2ZeLEiZw9e5ZmzZphbZ133cqePXvqKTIhSjdFo+H+jz8Sv3ARSno6KktLnEePxuGd/qiMjPQdnhDlis5j8gB++OEHZsyYwfXr1wFwc3Nj5syZDB48uNgD1AcZhyB0oSgKO87GMGPrBRIfZgLQz6caE7rUwc7SVM/RCWE4XtRns9FTvoyqVCrthGOGTtpCoYus6Ojc3rtjxwCwatGCyrNnYVatmp4jE8KwlNiYPID+/fvTv39/0tPTefjwIc7Ozs8dqBBl2Z8PHjF1yzn2XooHoGYla4J7NaKlZ0U9RyaEeF6PZ9YUQjybotFw/78/EL94McqjR6isrHAeE4RD377SeyeEHhVp1UkrKyusrKyKKxYhygy1RmHN4Zss/PUy6VlqzIyNGNKhJh+1r4m5iQwoF8JQZGRkYGFhoe8whCiVsm7e5O6UKTw6fgIAKx+f3N67cj4zrRClQZGSPCHKo/N3k5m0+Sxn7iQD0MLDgeBeDanlbKPnyIQQxUGtVjNnzhxCQ0OJi4vjypUr1KhRg6lTp+Lh4WEwQxOEeF6KWk3S99+TELIEJSMDIysrnMePw/7tt6X3TohSQv4ShSikR1lqgnddpOey3zlzJxkbCxPmvNGQ9e/7SoInhAGZPXs2a9asYf78+ZiZmWnLGzRoIBOMiXIv80YUt955l/i581AyMrBu5UuNbVtx6NNHEjwhSpFS8de4fPlyPDw8sLCwwMfHh6NHjz61/saNG6lTpw4WFhY0bNiQnTt3ap/Lzs5mwoQJNGzYEGtra9zc3BgwYAB3794t6ZchDNjBKwl0DjnAFwduoNYodG9YmfCgdvTzqYaRrHsnhEH57rvvWLVqFf3798f4b+t5NW7cmEuXLukxMiH0R1GruffNaqLeeINHJ09iZG2N6yczcf/6a0yrVNF3eEKIf9ApycvOzqZTp05cvXq12AJYv349QUFBTJ8+ncjISBo3boy/vz/x8fEF1j98+DB9+/Zl8ODBnDx5koCAAAICAjh37hwA6enpREZGMnXqVCIjI9m8eTOXL1+WKa/Fc7n3MJPR608x4Juj3E56RGU7C74a0Jzl/ZvibCvjdIQwRH/++Se1atXKV67RaMjOztZDRELoV+aNG9zq15/4+fNRMjOxbt06t/fu7bdliSAhSimdl1CoVKkShw8fxsvLq1gC8PHxoUWLFixbtgzIbUTd3d0ZPnw4EydOzFe/d+/epKWlsX37dm3Zyy+/jLe3N6GhoQUe49ixY7Rs2ZJbt25RrRBT+cq00UJRFDZH/smsHRe4n56NSgUDfT0Y61+bCuYylFUIfXhRn83NmjVj9OjRvPPOO9jY2HD69Glq1KjBJ598wu7du/ntt99K7NilibSFQsnJIWnNGhKWfo6SlYVRhQq4TJqIXa9ektwJoScltoTCO++8w9dff83cuXOLFCBAVlYWJ06cYNKkSdoyIyMj/Pz8iIiIKHCbiIgIgoKC8pT5+/uzZcuWJx4nOTkZlUqFvb19gc9nZmaSmZmpfZySklL4FyEMzs3END7ecpbfr90DoI6rDXPfbIS3u71+AxNCvBDTpk1j4MCB/Pnnn2g0Gu0dId99912eC4xCGLLMa9e4O/ljMs6cAcD6lbZU/uQTTF1d9RyZEKIwdE7ycnJy+Oabb9izZw/NmjXD2to6z/OLFi0q9L4SExNRq9W4uLjkKXdxcXniuIfY2NgC68fGxhZYPyMjgwkTJtC3b98nZrvBwcHMnDmz0HELw5St1vDlbzdYsucqmTkazE2MGOX3Ev9p64mpcakYviqEeAFef/11tm3bxieffIK1tTXTpk2jadOmbNu2jVdffVXf4QlRopScHO59/Q2Jy5ahZGdjZGODy6RJ2L0RIL13QpQhOid5586do2nTpgBcuXIlz3Ol7Y8/Ozubt99+G0VRWLly5RPrTZo0KU/vYEpKCu7u7i8iRFFKnLr9gIk/neFSbCoAbWo5MfuNBlR3tH7GlkIIQ9S2bVt2796t7zCEeKEyLl8hZvJkMs6fB6BCu3a4fjIT039cXBdClH46J3n79u0rtoM7OTlhbGxMXFxcnvK4uDhcn3A7gKura6HqP07wbt26xd69e596z6q5uTnm5ubP+SpEWfYwM4fPfrnMtxE3URRwsDJl6mv1eKNJlVJ30UII8WJlZWURHx+PRqPJU16Ysd1ClCVKdjb3vvqKhBUrITsbI1tbXD+ejG3PntIWClFGFeketDt37nDnzp3n3t7MzIxmzZoRHh6uLdNoNISHh+Pr61vgNr6+vnnqA+zevTtP/ccJ3tWrV9mzZw+Ojo7PHaMwXHsuxPHqogOsOZyb4PVqUoU9Qe3o1bSqNGpClGNXr16lbdu2WFpaUr16dTw9PfH09MTDwwNPT099hydEscq4fJmo3r1JWLIUsrOp0LEjNbZvw+7116UtFKIM07knT6PRMGvWLBYuXMjDhw8BsLGxYcyYMXz88ccY6bgQZlBQEAMHDqR58+a0bNmSkJAQ0tLSCAwMBGDAgAFUqVKF4OBgAEaOHEm7du1YuHAh3bt3Z926dRw/fpxVq1YBuQneW2+9RWRkJNu3b0etVmvH61WsWDHPwraifIpPyWDmtgvsOBsDQLWKVsx+owFtvSrpOTIhRGkwaNAgTExM2L59O5UrV5YvusIgKVlZJK76ksTQUMjJwdjODpcpU7B9rbu854UwADoneR9//LF2ds3WrVsDcOjQIWbMmEFGRgazZ8/WaX+9e/cmISGBadOmERsbi7e3N2FhYdrJVaKjo/Mkjq1atWLt2rVMmTKFyZMn4+XlxZYtW2jQoAGQu77R1q1bAfD29s5zrH379tG+fXtdX7IwEBqNwrpjtwnedZHUjByMjVS817YGIzt5YWlm/OwdCCHKhVOnTnHixAnq1Kmj71CEKBEZFy9yd9JkMv+a5K6CXycqT5+OSSW52CmEodB5nTw3NzdCQ0PzLS7+v//9jyFDhvDnn38Wa4D6IGsDGZ5r8alM2nyWYzfvA9Coqh3BvRpS381Oz5EJIQrrRX02t2jRgsWLF9OmTZsSO0ZZIG2h4VGyskgM/YLEVatye+/s7XGZOgXbbt2k906IMqLE1slLSkoq8OpmnTp1SEpK0nV3QpSozBw1K/ZdZ8X+a2SrFazMjBnbuTYDW3lgbCQNmhAi19/XR503bx7jx49nzpw5NGzYEFNT0zx1JeERZdGj8+eJmTSZzL9mRrfp3BnXaVMxcXLSc2RCiJKg88QrjRs3ZtmyZfnKly1bRuPGjYslKCGKw9GoJLot+Y0l4VfJVit0rOPM7qB2/LuNpyR4Qog87O3tcXBwwMHBgVdffZU//viDTp064ezsrC1/XOd5LF++HA8PDywsLPDx8eHo0aNPrb9x40bq1KmDhYUFDRs2ZOfOnXmeVxSFadOmUblyZSwtLfHz8+Pq1at56nh4eKBSqfL8zJ0797niF2WXJiuL+JAQbr7dm8wrVzB2cKBKyGKqLl0iCZ4QBkznnrz58+fTvXt39uzZo53RMiIigtu3b+drhITQh+RH2czddYkfj0YD4FTBnBk969G9oUygIIQoWHEuD/RP69evJygoiNDQUHx8fAgJCcHf35/Lly/j7Oycr/7hw4fp27cvwcHBvPbaa6xdu5aAgAAiIyO148/nz5/P0qVL+fbbb/H09GTq1Kn4+/tz4cIFLCwstPv65JNPeO+997SPbWxsSux1itLn0dlzxEyeRObVawDYdO2C69SpmFSsqOfIhBAlTecxeQB3795l+fLlXPprwG7dunUZMmQIbm5uxR6gPsg4hLJJURR2no1lxrbzJKRmAtC3pTsTu9TFzsr0GVsLIUq7svrZ7OPjQ4sWLbR3wWg0Gtzd3Rk+fDgTJ07MV793796kpaWxfft2bdnLL7+Mt7c3oaGhKIqCm5sbY8aMYezYsQAkJyfj4uLCmjVr6NOnD5Dbkzdq1ChGjRr1XHGX1fMtQJOZSeKy5dz75htQqzF2dMR12jRs/TvrOzQhRBGV2Ji86Oho3N3dC5xFMzo6WhaJFXpx98Ejpm45R/ileABqVLIm+I2G+NSQNRKFEM/v8a2S7u7uz7V9VlYWJ06cYNKkSdoyIyMj/Pz8iIiIKHCbiIgIgoKC8pT5+/uzZcsWAKKiooiNjcXPz0/7vJ2dHT4+PkRERGiTPIC5c+fy6aefUq1aNfr168fo0aMxMSm46c/MzCQzM1P7+O/jFEXZ8ej0ae5O/pis69cBsO3eHZcpH2PynLcaCyHKJp2TPE9PT2JiYvLdYnLv3j08PT1Rq9XFFpwQz6LWKHwXcZPPfrlMWpYaU2MVH7WvxZD2NbEwlWURhBBFc/PmTbKzs597+8TERNRqtXZZoMdcXFy0d8P8U2xsbIH1H6/5+vjfp9UBGDFiBE2bNqVixYocPnyYSZMmERMTw6JFiwo8bnBwMDNnztTtBYpSQ5OZSeLnn3Pvm9Wg0WDs5ETlGdOx+dvFACFE+aFzkqcoSoHjmh4+fJhnHIAQJe3C3RQmbT7D6TvJADSv7kBwr4Z4uciYEyGE+HtvYKNGjTAzM+ODDz4gODgYc3PzfPUnTZqUZ5uUlJTn7sEUL1b6yZPEfDyFrBs3ALDt2QPXyZMxtrfXb2BCCL0pdJL3+INfpVIxdepUrKystM+p1WqOHDmSb/FxIUpCRraakD1X+fK3G6g1CjbmJkzoWod+LathJLNmCiGKUdu2bbG0tHzu7Z2cnDA2NiYuLi5PeVxcHK6urgVu4+rq+tT6j/+Ni4ujcuXKeeo8rR328fEhJyeHmzdvUrt27XzPm5ubF5j8idJLk5FBwpKlJK1ZA4qCSaVKuM6ciU3HDvoOTQihZ4VO8k6ePAnk9uSdPXsWMzMz7XNmZmY0btxYOwBciKJSaxSORiURn5qBs40FLT0rYmyk4tDVRD7ecpZb99IB6NrAlRk96+NiK73IQojiV9RZo83MzGjWrBnh4eEEBAQAuROvhIeHM2zYsAK38fX1JTw8PM+EKbt379bOaO3p6Ymrqyvh4eHapC4lJYUjR47w0UcfPTGWU6dOYWRkVOCMnqLsSY+MJGbyx2TdvAmAXUAALpMmYmxnp9/AhBClQqGTvMfTSwcGBrJkyRKZaUuUmLBzMczcdoGY5AxtmbONOZ5O1hyJSgLA1daCT16vT+f6BV8JF0KI5/Xtt9/i5ORE9+7dARg/fjyrVq2iXr16/Pjjj1SvXl2n/QUFBTFw4ECaN29Oy5YtCQkJIS0tjcDAQAAGDBhAlSpVCA4OBmDkyJG0a9eOhQsX0r17d9atW8fx48dZtWoVkHtHzahRo5g1axZeXl7aJRTc3Ny0iWRERARHjhyhQ4cO2NjYEBERwejRo3nnnXeee60/8eJk371Lzv37BT6nZGby4KefSN78c27vnbMzrp/MxKZ9+xcbpBCiVNN5TF5ISAg5OTn5ypOSkjAxMZHkTxRJ2LkYPvpvJP9c1yM+NZP4v5ZFGNTKgzGdX8LGQpZFEEIUvzlz5rBy5UogN1latmwZISEhbN++ndGjR7N582ad9te7d28SEhKYNm0asbGxeHt7ExYWpp04JTo6GiMjI239Vq1asXbtWqZMmcLkyZPx8vJiy5Yt2jXyIDfxTEtL4/333+fBgwe0adOGsLAw7dh4c3Nz1q1bx4wZM8jMzMTT05PRo0fnm7VTlD7Zd+9yvUtXlKysZ9a1e7MXLhMmYCzfvYQQ/6DzOnldu3alR48eDBkyJE95aGgoW7duNYgF0WVtIP1QaxTazNubpwfvn5wqmHFksh/GMvZOiHLnRX02W1lZcenSJapVq8aECROIiYnhu+++4/z587Rv356EhIQSO3ZpIm2hfjw6f56bb771zHouUz6m4jvvvICIhBClSWE/m42e+MwTPL7945/at2/PkSNHdN2dEFpHo5KemuABJD7M4uhft2wKIURJqFChAvfu3QPg119/5dVXXwXAwsKCR48e6TM0IbQsmzTRdwhCiFJM59s1MzMzC7xdMzs7Wxo/USTxqU9P8HStJ4QQz+PVV1/lP//5D02aNOHKlSt069YNgPPnz+Ph4aHf4IQQQohC0Lknr2XLltrB338XGhpKs2bNiiUoUf6oNQrHCtlD52wjM2kKIUrO8uXL8fX1JSEhgZ9++glHR0cATpw4Qd++ffUcnRBCCPFsOvfkzZo1Cz8/P06fPk2nTp0ACA8P59ixY/z666/FHqAwfNfiHzJu02lORj94aj0V4GqXu5yCEEKUFHt7e5YtW5avfObMmXqIRpQnmvR07n39jb7DEEIYAJ178lq3bk1ERARVq1Zlw4YNbNu2jVq1anHmzBnatm1bEjEKA5Wj1hB64Drdlv7GyegH2Jib8I5PNVTkJnR/9/jx9B71ZNIVIUSJCgsL49ChQ9rHy5cvx9vbm379+nH/CdPaC1FU6cePcyPgDVINYAI7IYT+6dyTB+Dt7c3atWuLOxZRjlyNS2XspjOcvv0AgHYvVSK4V0Pc7C1p4+WUb508VzsLpveoR5cGlfUUsRCivBg3bhzz5s0D4OzZs4wZM4agoCD27dtHUFAQq1ev1nOEwpBoHj0iISSEpO++B0XB2NER9V8T/wghxPN6riTv+vXrrF69mhs3bhASEoKzszO7du2iWrVq1K9fv7hjFAYkR63hi4M3WLLnKllqDTYWJkx7rR5vNauKSpXbQ9elQWVerefK0agk4lMzcLbJvUVTevCEEC9CVFQU9erVA+Cnn37itddeY86cOURGRmonYRGiOKRHRhIzaTJZt24BYPfWm1QcOJCbb7711HXyVGZmmMii9kKIp9A5yTtw4ABdu3aldevWHDx4kFmzZuHs7Mzp06f5+uuv2bRpU0nEKQzA5dhUxm06zZk7yQB0rOPMnDca4mqXfyIVYyMVvjUdX3SIQgiBmZkZ6enpAOzZs4cBAwYAULFiRVJSUvQZmjAQub13S0j67jtQFExcXKj86SdUeOUVAGqG7SLnKbcGmzg4YOrm9qLCFUKUQToneRMnTmTWrFkEBQVhY2OjLe/YsWOBA9WFyFZrCN1/naV7r5KtVrC1MGF6j/r0alpF23snhBClRZs2bQgKCqJ169YcPXqU9evXA3DlyhWqVq2q5+hEWZceeZKYSZP+v/euVy9cJk7A+G+LGpu6uUkSJ4QoEp2TvLNnzxY4Hs/Z2ZnExMRiCUoYjosxKYzdeJrzd3OvfvvVdWb2Gw1xsZVlEIQQpdOyZcsYMmQImzZtYuXKlVSpUgWAXbt20aVLFz1HJ8oqTUYGCUuWkrRmTW7vnbNzbu9du3b6Dk0IYYB0TvLs7e2JiYnB09MzT/nJkye1DaEQWTkaVuy/xrK918jRKNhbmTKjR31e93aT3jshRKlWrVo1tm/fnq988eLFeohGGIL0kyeJmfwxWVFRANgFBOAyaSLGdnZ6jkwIYah0TvL69OnDhAkT2LhxIyqVCo1Gw++//87YsWO14xZE+Xb+bjJjN57hYkxu713nei7MeqOBLGIuhCgz1Go1W7Zs4eLFiwDUr1+fnj17YmxsrOfIRFmiycggYennub13Gg0mlSrh+ukn2LRvr+/QhBAGTud18ubMmUOdOnVwd3fn4cOH1KtXj1deeYVWrVoxZcoUnQNYvnw5Hh4eWFhY4OPjw9GjR59af+PGjdSpUwcLCwsaNmzIzn+sJ7N582Y6d+6Mo6MjKpWKU6dO6RyTeD5ZORoW7b7C68t+52JMCg5Wpizt24Qv3m0mCZ4Qosy4du0adevWZcCAAWzevJnNmzfzzjvvUL9+fa5fv67v8EQZ8ej0aaJ6vUnSN9+ARoPd669TY/s2SfCEEC+EzkmemZkZX375JTdu3GD79u3897//5dKlS3z//fc6X+Fcv349QUFBTJ8+ncjISBo3boy/vz/x8fEF1j98+DB9+/Zl8ODBnDx5koCAAAICAjh37py2TlpaGm3atNGucSRejHN/JtNz2SGWhl8lR6PQtYErv45uR8/GcnumEKJsGTFiBDVr1uT27dtERkYSGRlJdHQ0np6ejBgxQt/hiVJOk5lJ/GefcbNvP7Ju3MC4khNVV6zAbd5cuT1TCPHCqBRFUXTZ4JNPPmHs2LFYWVnlKX/06BELFixg2rRphd6Xj48PLVq00M7KqdFocHd3Z/jw4UycODFf/d69e5OWlpZnrMTLL7+Mt7c3oaGheerevHkTT09PTp48ibe3tw6vEFJSUrCzsyM5ORnbv812JfLLzFHzefg1Vh64jlqjUNHajE9fb0D3RrJouRCieL2oz2Zra2v++OMPGjZsmKf89OnTtG7dmocPH5bYsUsTaQt19+jMGe5OmkzWXz2+tj174Dp5Msb29voNTAhhMAr72axzT97MmTMLbODS09OZOXNmofeTlZXFiRMn8PPz+/9gjIzw8/MjIiKiwG0iIiLy1Afw9/d/Yv3CyszMJCUlJc+PeLbTtx/Q4/NDLNt3DbVGoXujyuwe/YokeEKIMs3c3JzU1NR85Q8fPsTMzEwPEYnSTpOVRfzCRdzs05es69f/6r1bTpX58yXBE0Lohc5JnqIoBd5+d/r0aSpWrFjo/SQmJqJWq3FxcclT7uLiQmxsbIHbxMbG6lS/sIKDg7Gzs9P+uLu7F2l/hi4jW828sEu8seJ3rsQ9xKmCGSv7N2V5v6Y4VjDXd3hCCFEkr732Gu+//z5HjhxBURQUReGPP/7gww8/pGfPnvoOT5Qyj86eJapXL+59+SVoNNj26EHNbduw6dhR36EJIcqxQs+u6eDggEqlQqVS8dJLL+VJ9NRqNQ8fPuTDDz8skSBL2qRJkwgKCtI+TklJkUTvCU5G32fcpjNci8/tzX3d243pPepT0VqubgshDMPSpUsZOHAgvr6+mJqaApCTk0PPnj1ZsmSJnqMTpYUmK4vE5Su499VXoFZj7OhI5ZkzsPnHHUdCCKEPhU7yQkJCUBSFf//738ycORO7vw0eNjMzw8PDA19f30If2MnJCWNjY+Li4vKUx8XF4erqWuA2rq6uOtUvLHNzc8zNpQfqaTKy1SzefYUvf7uBRgGnCubMfqMB/vWLdu6FEKK0sbe353//+x9Xr17l0qVLANStW5datWrpOTJRWjw6d56YSZPIvHoVANvu3XGZ8jEmDg56jkwIIXIVOskbOHAgAJ6enrRu3RoTE52X2MvDzMyMZs2aER4eTkBAAJA78Up4eDjDhg0rcBtfX1/Cw8MZNWqUtmz37t06JZdCdydu3WfcptPcSEgD4I0mVZjeox72VtJ7J4QwXF5eXnh5eek7DFGKaLKySFyxgntf/n/vnev0adh27qzv0IQQIg+dM7V27dpx/fp1Vq9ezfXr11myZAnOzs7s2rWLatWqUb9+/ULvKygoiIEDB9K8eXNatmxJSEgIaWlpBAYGAjBgwACqVKlCcHAwACNHjqRdu3YsXLiQ7t27s27dOo4fP86qVau0+0xKSiI6Opq7d+8CcPnyZSC3F7CoPX7lzaMsNQt/vczXv0ehKOBsY86cNxriV8/l2RsLIUQZ8vdb9p9l0aJFJRiJKK0enT9PzMS/9d5164rL1KnSeyeEKJV0TvIOHDhA165dad26NQcPHmT27Nk4Oztz+vRpvv76azZt2lToffXu3ZuEhASmTZtGbGws3t7ehIWFaSdXiY6Oxsjo/+eGadWqFWvXrmXKlClMnjwZLy8vtmzZQoMGDbR1tm7dqk0SAfr06QPA9OnTmTFjhq4vt9w6djOJ8ZvOEJWY23v3ZtOqTHutHnZWpnqOTAghit/JkycLVU/W/Sx/lKwsEkNDSfxiVW7vXcWKuE6fjq2/9N4JIUovndfJ8/X15V//+hdBQUHY2Nhw+vRpatSowdGjR+nVqxd37twpqVhfmPK8NlB6Vg4LfrnMmsM3URRwtbUguFdDOtRx1ndoQohyrjx/NuuDnG/IuHCBu5Mmk/nXXUE2XbrgOm0qJjrMJi6EEMWpsJ/NOvfknT17lrVr1+Yrd3Z2JjExUdfdCT1QaxSORiURn5qBs40FLT0rYmyk4siNe4z/6Qy37qUD8HbzqnzcvR52ltJ7J4QQovzI7b37gsRVqyAnB2MHh9yxd1266Ds0IYQoFJ2TPHt7e2JiYvD09MxTfvLkSapUqVJsgYmSEXYuhpnbLhCTnKEtc7E1p66rLfuvJABQ2S639659bem9E0IIYViy794l5/79Jz6vTkoifuEiMv+aWdXG3z+3987R8UWFKIQQRaZzktenTx8mTJjAxo0bUalUaDQafv/9d8aOHcuAAQNKIkZRTMLOxfDRfyP55/25cSmZxKXkJnh9W7ozqVtdbC2k904IIYRhyb57l+tduqJkZT2zrrG9fW7vXdeuLyAyIYQoXkbPrpLXnDlzqFOnDu7u7jx8+JB69erxyiuv0KpVK6ZMmVISMYpioNYozNx2IV+C93cVrc2YFdBQEjwhhBAGKef+/UIleFY+PtTYvk0SPCFEmaVzT56ZmRlffvklU6dO5dy5czx8+JAmTZrIWkKl3NGopDy3aBYkKS2Lo1FJ+NaUW1KEEEKUX87jxmHi5KTvMIQQ4rk994rm1apVo1q1asUZiyhB8alPT/B0rSeEEEIYLFkpQwhRxhUqyZNFYsu25EfZ7DoXU6i6zjYWJRyNEEIIIYQQoiQVKsn75yKxkZGR5OTkULt2bQCuXLmCsbExzZo1K/4IxXPTaBQ2nbjD/F8ukfjw6WMQVICrXe5yCkIIIYShybl/n3tffqXvMIQQ4oUoVJK3b98+7e+LFi3CxsaGb7/9FgcHBwDu379PYGAgbdu2LZkohc5O337AtK3nOX37AQA1K1nTvVFlPg+/BpBnApbHd6VM71EPYyO5R0UIIYThULKySPphLYkrVqBJTdV3OEII8ULoPCZv4cKF/Prrr9oED8DBwYFZs2bRuXNnxowZU6wBCt0kPsxkQdhlNpy4jaJABXMTRnbyYmArD8xMjKhX2TbfOnmudhZM71GPLg0q6zFyIYQQovgoisLDvXuJmz+f7FvRAJh6eJB986Z+AxNCiBdA5yQvJSWFhISEfOUJCQmkyhUyvclRa/j+j1ss2n2F1IwcAHo1rcLELnVwtv3/cXZdGlTm1XquHI1KIj41A2eb3Fs0pQdPCCGEoci4dIm44LmkHzkCgLGTE86jRmLl8zI3und/6jIKKjMzTP52IVsIIcoinZO8N954g8DAQBYuXEjLli0BOHLkCOPGjaNXr17FHqB4tojr95ix9TyX43KT7Pputnzyen2aVS94fJ2xkUqWSRBCCGFwchISSFi6lAebfgJFQWVmRsXAQBzfew/jCtYA1AzbRc79+0/ch4mDA6Zubi8qZCGEKBE6J3mhoaGMHTuWfv36kZ2dnbsTExMGDx7MggULij1A8WR3Hzxi9s6L7DiTO3OmvZUp4/xr06dFNemZE0IIUW5oMjNJWvMt9774Ak16OgC23bpSKWgMZlWr5Klr6uYmSZwQwuDpnORZWVmxYsUKFixYwPXr1wGoWbMm1tbWxR6cKFhmjpqvfoti2d5rPMpWY6SC/j7VGdP5JeytzPQdnhBCCPFCKIpCalgY8Z8tJPvPPwGwaNQIl4kTsWraRM/RCSGE/jz3YujW1tY0atSoOGMRhRB+MY5Ptl/g1r3cK5UtPByY0bM+9d3s9ByZEEII8eI8OnuWuOC5PIqMBMDExQXnMUHYvvYaKiMjPUcnhBD69dxJnnixohLT+GTbefZdzp30xtnGnMnd6vK6txsqldyaKYQQonzIjo0lYfFikv+3FQCVpSWO/xmM47//jZGlpZ6jE0KI0kGSvFIuLTOH5fuu8dVvUWSpNZgaq/h3G0+Gd/Sigrn89wkhhCgfNOnp3PtmNfe++golI3cZILvXX6dS0GhMXVz0HJ0QQpQukiWUUoqisO1MDHN2XCQ2Jbcxa/dSJab1qEfNShX0HJ0QQgjxYigaDSnbthG/aDE5cXEAWDZrhsvEiVg2bKDn6IQQonSSJK8UuhiTwoyt5zkSlQSAe0VLpr1WH7+6znJrphBCiHIjPTKSuOC5ZJw9C4BplSo4jxuHjX9naQ+FEOIpJMkrRZLTs1m85wrfRdxEo4CFqRFD2tfi/VdqYGFqrO/whBBCiBci686fxC/8jNRdYQAYWVvj+OEHVBwwACNzcz1HJ4QQpZ8keaWARqOw4fht5v9ymaS0LAC6NXRlcre6VHWw0nN0QgghxIuhfpjGvVWrSFqzBiUrC4yMsH/zTSqNHIGJk5O+wxNCiDJDkjw9Oxl9n+lbz3PmTjIAXs4VmNGzPq1rSWMmhBCifFDUah5s3kzCkqWoExMBsPJ9GZeJE7GoXVvP0QkhRNkjSZ6eJKRmMi/sEptO3AHAxtyEkX5eDGzlgamxrO8jhBCifEj74whxc+eSeekSAGbVq+M8YTwVOnSQcXdCCPGcJMl7wbLVGr6LuEXI7iukZuYA8FazqkzoUodKNjLOQAghRPmQdfMmcQs+42F4OABGtrZUGjoEh759UZmZ6Tk6IYQo2yTJK2ZqjcLRqCTiUzNwtrGgpWdFjI1yr0QevpbI9K3nuRr/EIBGVe2Y0bM+Tas56DNkIYQQothk371Lzv37T3xeZWpK8uafSfrhB8jOBmNjHPr0wWnYUEwcpD0UQojiUCruC1y+fDkeHh5YWFjg4+PD0aNHn1p/48aN1KlTBwsLCxo2bMjOnTvzPK8oCtOmTaNy5cpYWlri5+fH1atXS/IlABB2LoY28/bS98s/GLnuFH2//IM28/byw5FbDPnhBP2+OsLV+IdUtDZjbq+GbBnSWhI8IYQoB/TRziUlJdG/f39sbW2xt7dn8ODBPHz4sNhf299l373L9S5dufnmW0/8ier5Oklr1kB2NtbtXqHG1v/hOnWKJHhCCFGM9J7krV+/nqCgIKZPn05kZCSNGzfG39+f+Pj4AusfPnyYvn37MnjwYE6ePElAQAABAQGcO3dOW2f+/PksXbqU0NBQjhw5grW1Nf7+/mRkZJTY6wg7F8NH/40kJjnvMWKSM/j453PsPBuLkQoG+lZn35j29GlZDSMjGWsghBCGTl/tXP/+/Tl//jy7d+9m+/btHDx4kPfff79EX2vO/fu5s2I+g0nVqrh/+SXVvvgC85o1SzQmIYQoj1SKoij6DMDHx4cWLVqwbNkyADQaDe7u7gwfPpyJEyfmq9+7d2/S0tLYvn27tuzll1/G29ub0NBQFEXBzc2NMWPGMHbsWACSk5NxcXFhzZo19OnT55kxpaSkYGdnR3JyMra2ts+sr9YotJm3N1+C93dmxio2D2lNgyp2z9yfEEKI/HT9bC4t9NHOXbx4kXr16nHs2DGaN28OQFhYGN26dePOnTu4ubk9M+7nOd+Pzp/n5ptvPbOex4b1WDZqVKh9CiGE+H+F/WzWa09eVlYWJ06cwM/PT1tmZGSEn58fERERBW4TERGRpz6Av7+/tn5UVBSxsbF56tjZ2eHj4/PEfWZmZpKSkpLnRxdHo5KemuABZKkVUjNydNqvEEKIsk1f7VxERAT29vbaBA/Az88PIyMjjhw5UuBxi9oW6sTYuOT2LYQQQr9JXmJiImq1GhcXlzzlLi4uxMbGFrhNbGzsU+s//leXfQYHB2NnZ6f9cXd31+l1xKcW7jbQwtYTQghhGPTVzsXGxuLs7JzneRMTEypWrFhibaEQQojSQ+9j8kqDSZMmkZycrP25ffu2Tts721gUaz0hhBDiRStqWyiEEKL00GuS5+TkhLGxMXFxcXnK4+LicHV1LXAbV1fXp9Z//K8u+zQ3N8fW1jbPjy5aelaksp0FT5pGRQVUtstdTkEIIUT5oa92ztXVNd/ELjk5OSQlJZVYWyiEEKL00GuSZ2ZmRrNmzQj/ayFUyB2QHh4ejq+vb4Hb+Pr65qkPsHv3bm19T09PXF1d89RJSUnhyJEjT9xnURkbqZjeox5AvkTv8ePpPepp18sTQghRPuirnfP19eXBgwecOHFCW2fv3r1oNBp8fHyK7fUJIYQonfS+GHpQUBADBw6kefPmtGzZkpCQENLS0ggMDARgwIABVKlSheDgYABGjhxJu3btWLhwId27d2fdunUcP36cVatWAaBSqRg1ahSzZs3Cy8sLT09Ppk6dipubGwEBASX2Oro0qMzKd5oyc9uFPJOwuNpZML1HPbo0qFxixxZCCFF66aOdq1u3Ll26dOG9994jNDSU7Oxshg0bRp8+fQo1s+bzMnFwQGVm9tRlFFRmZrImnhBClDC9J3m9e/cmISGBadOmERsbi7e3N2FhYdoB5dHR0RgZ/X+HY6tWrVi7di1Tpkxh8uTJeHl5sWXLFho0aKCtM378eNLS0nj//fd58OABbdq0ISwsDAuLkh0T16VBZV6t58rRqCTiUzNwtsm9RVN68IQQovzSVzv3ww8/MGzYMDp16oSRkRFvvvkmS5cuLdHXaurmRs2wXeTcv//EOiYODpiWYKIphBCiFKyTVxqV1bWYhBDCkMln84sl51sIIUqfMrFOnhBCCCGEEEKI4iVJnhBCCCGEEEIYEL2PySuNHt/BmpKSoudIhBBCPPb4M1lGGbwY0hYKIUTpU9i2UJK8AqSmpgLg7u6u50iEEEL8U2pqKnZ2dvoOw+BJWyiEEKXXs9pCmXilABqNhrt372JjY4NKpfvMmCkpKbi7u3P79m0ZrF4Ech6LTs5h8ZDzWHTFcQ4VRSE1NRU3N7c8s1GKklHUthDkb6c4yDksHnIei07OYfEo6nksbFsoPXkFMDIyomrVqkXej62trfwRFAM5j0Un57B4yHksuqKeQ+nBe3GKqy0E+dspDnIOi4ecx6KTc1g8inIeC9MWyqVQIYQQQgghhDAgkuQJIYQQQgghhAGRJK8EmJubM336dMzNzfUdSpkm57Ho5BwWDzmPRSfnsHyS//eik3NYPOQ8Fp2cw+Lxos6jTLwihBBCCCGEEAZEevKEEEIIIYQQwoBIkieEEEIIIYQQBkSSPCGEEEIIIYQwIJLkCSGEEEIIIYQBkSSvBCxfvhwPDw8sLCzw8fHh6NGj+g6pTDl48CA9evTAzc0NlUrFli1b9B1SmRMcHEyLFi2wsbHB2dmZgIAALl++rO+wypyVK1fSqFEj7YKlvr6+7Nq1S99hlWlz585FpVIxatQofYciSpi0hUUjbWHRSVtYPKQtLH4voi2UJK+YrV+/nqCgIKZPn05kZCSNGzfG39+f+Ph4fYdWZqSlpdG4cWOWL1+u71DKrAMHDjB06FD++OMPdu/eTXZ2Np07dyYtLU3foZUpVatWZe7cuZw4cYLjx4/TsWNHXn/9dc6fP6/v0MqkY8eO8cUXX9CoUSN9hyJKmLSFRSdtYdFJW1g8pC0sXi+sLVREsWrZsqUydOhQ7WO1Wq24ubkpwcHBeoyq7AKUn3/+Wd9hlHnx8fEKoBw4cEDfoZR5Dg4OyldffaXvMMqc1NRUxcvLS9m9e7fSrl07ZeTIkfoOSZQgaQuLl7SFxUPawuIjbeHzeZFtofTkFaOsrCxOnDiBn5+ftszIyAg/Pz8iIiL0GJko75KTkwGoWLGiniMpu9RqNevWrSMtLQ1fX199h1PmDB06lO7du+f5fBSGSdpCUVpJW1h00hYWzYtsC01K/AjlSGJiImq1GhcXlzzlLi4uXLp0SU9RifJOo9EwatQoWrduTYMGDfQdTplz9uxZfH19ycjIoEKFCvz888/Uq1dP32GVKevWrSMyMpJjx47pOxTxAkhbKEojaQuLRtrConvRbaEkeUIYuKFDh3Lu3DkOHTqk71DKpNq1a3Pq1CmSk5PZtGkTAwcO5MCBA9K4FdLt27cZOXIku3fvxsLCQt/hCCHKKWkLi0bawqLRR1soSV4xcnJywtjYmLi4uDzlcXFxuLq66ikqUZ4NGzaM7du3c/DgQapWrarvcMokMzMzatWqBUCzZs04duwYS5Ys4YsvvtBzZGXDiRMniI+Pp2nTptoytVrNwYMHWbZsGZmZmRgbG+sxQlHcpC0UpY20hUUnbWHR6KMtlDF5xcjMzIxmzZoRHh6uLdNoNISHh8t9y+KFUhSFYcOG8fPPP7N37148PT31HZLB0Gg0ZGZm6juMMqNTp06cPXuWU6dOaX+aN29O//79OXXqlCR4BkjaQlFaSFtYcqQt1I0+2kLpyStmQUFBDBw4kObNm9OyZUtCQkJIS0sjMDBQ36GVGQ8fPuTatWvax1FRUZw6dYqKFStSrVo1PUZWdgwdOpS1a9fyv//9DxsbG2JjYwGws7PD0tJSz9GVHZMmTaJr165Uq1aN1NRU1q5dy/79+/nll1/0HVqZYWNjk2/8i7W1NY6OjjIuxoBJW1h00hYWnbSFxUPawqLTR1soSV4x6927NwkJCUybNo3Y2Fi8vb0JCwvLNwBdPNnx48fp0KGD9nFQUBAAAwcOZM2aNXqKqmxZuXIlAO3bt89Tvnr1agYNGvTiAyqj4uPjGTBgADExMdjZ2dGoUSN++eUXXn31VX2HJkSpJm1h0UlbWHTSFhYPaQvLJpWiKIq+gxBCCCGEEEIIUTxkTJ4QQgghhBBCGBBJ8oQQQgghhBDCgEiSJ4QQQgghhBAGRJI8IYQQQgghhDAgkuQJIYQQQgghhAGRJE8IIYQQQgghDIgkeUIIIYQQQghhQCTJE0IIIYQQQggDIkleOTJjxgy8vb31HcZz2b9/PyqVigcPHhR5X6+88gpr164telBllEqlYsuWLU98/ubNm6hUKk6dOgXodu6L8//pn54Vd2lXkvF7eHgQEhJSLPsKCwvD29sbjUZTLPsTQojnId9ZhCgaSfLKkbFjxxIeHq7vMPRq69atxMXF0adPH23ZqlWraN++Pba2tjp9KC9fvhwPDw8sLCzw8fHh6NGjJRS1frVq1YqYmBjs7Oz0HUqZFhMTQ9euXYH8iXRp0qVLF0xNTfnhhx/0HYoQohyT7yxCFI0keeVIhQoVcHR01HcYerV06VICAwMxMvr/t356ejpdunRh8uTJhd7P+vXrCQoKYvr06URGRtK4cWP8/f2Jj48vibD1yszMDFdXV1Qqlb5DKdNcXV0xNzfXdxiFMmjQIJYuXarvMIQQ5Zh8ZxGiaCTJKyPat2/PiBEjGD9+PBUrVsTV1ZUZM2bkqRMdHc3rr79OhQoVsLW15e233yYuLk77/D9vfdi/fz8tW7bE2toae3t7Wrduza1bt7TP/+9//6Np06ZYWFhQo0YNZs6cSU5OzhNjfNb+tm3bRosWLbCwsMDJyYk33nhD+9z3339P8+bNsbGxwdXVlX79+j0zYTp06BBt27bF0tISd3d3RowYQVpa2hPrJyQksHfvXnr06JGnfNSoUUycOJGXX375qcf7u0WLFvHee+8RGBhIvXr1CA0NxcrKim+++abQ+9DVoEGDCAgIYObMmVSqVAlbW1s+/PBDsrKytHUKum3P29s733vlca+SpaUlNWrUYNOmTU887j9vO7l16xY9evTAwcEBa2tr6tevz86dO/Nsc+LECZo3b46VlRWtWrXi8uXLeZ5/1nvr6tWrvPLKK1hYWFCvXj127979zPPTvn17hg8fzqhRo3BwcMDFxYUvv/yStLQ0AgMDsbGxoVatWuzatUu7jVqtZvDgwXh6emJpaUnt2rVZsmRJnv3m5OQwYsQI7O3tcXR0ZMKECQwcOJCAgIA8x37W3+ffb9f09PQEoEmTJqhUKtq3b6/dz6hRo/JsFxAQwKBBg7SP4+Pj6dGjB5aWlnh6ehbY4/bgwQP+85//aN8nHTt25PTp09rnT58+TYcOHbCxscHW1pZmzZpx/Phx7fM9evTg+PHjXL9+/VmnXQgh8pHvLPnp+p1FiKKSJK8M+fbbb7G2tubIkSPMnz+fTz75RPvlV6PR8Prrr5OUlMSBAwfYvXs3N27coHfv3gXuKycnh4CAANq1a8eZM2eIiIjg/fff1/bW/PbbbwwYMICRI0dy4cIFvvjiC9asWcPs2bOfa387duzgjTfeoFu3bpw8eZLw8HBatmyp3T47O5tPP/2U06dPs2XLFm7evJnni+0/Xb9+nS5duvDmm29y5swZ1q9fz6FDhxg2bNgTtzl06BBWVlbUrVv3qef5WbKysjhx4gR+fn7aMiMjI/z8/IiIiHjidj/88AMVKlR46s9vv/321GOHh4dz8eJF9u/fz48//sjmzZuZOXOmzq9h6tSpvPnmm5w+fZr+/fvTp08fLl68WKhthw4dSmZmJgcPHuTs2bPMmzePChUq5Knz8ccfs3DhQo4fP46JiQn//ve/tc89672l0Wjo1asXZmZmHDlyhNDQUCZMmFCo2L799lucnJw4evQow4cP56OPPuJf//oXrVq1IjIyks6dO/Puu++Snp6uPVbVqlXZuHEjFy5cYNq0aUyePJkNGzZo9zlv3jx++OEHVq9eze+//05KSkqBY+ue9vf5T49v7d2zZw8xMTFs3ry5UK8PcpP927dvs2/fPjZt2sSKFSvyfbn417/+RXx8PLt27eLEiRM0bdqUTp06kZSUBED//v2pWrUqx44d48SJE0ycOBFTU1Pt9tWqVcPFxeWZ70chhHgS+c7y/57nO4sQRaaIMqFdu3ZKmzZt8pS1aNFCmTBhgqIoivLrr78qxsbGSnR0tPb58+fPK4By9OhRRVEUZfr06Urjxo0VRVGUe/fuKYCyf//+Ao/XqVMnZc6cOXnKvv/+e6Vy5coF1n/W/nx9fZX+/fs/+4X+5dixYwqgpKamKoqiKPv27VMA5f79+4qiKMrgwYOV999/P882v/32m2JkZKQ8evSowH0uXrxYqVGjxhOP+c9jPMmff/6pAMrhw4fzlI8bN05p2bLlE7dLSUlRrl69+tSf9PT0J24/cOBApWLFikpaWpq2bOXKlUqFChUUtVqtKIqiVK9eXVm8eHGe7Ro3bqxMnz5d+xhQPvzwwzx1fHx8/q+9+41p6nrjAP4d1FaEFkQQYbZg6qriQAsdWmJGpiVu0YEbomyGgREFtDhHdGhcwGUal5ksJuiWaRxEo5lZFpMlbshke7EQG/EPHQxscKuCG9WoVVIFEXl+L0zveikt7ermz+75JLy4/849PffccM695zyXysvLiYjIarUSALp48SIRuZdLSkoK7dixY9Q8Ovc9ffq0sO7kyZMEQLguY9WtU6dOkUQioT/++EPY/v333xMAOnHihMfyGXmPDA0NUXh4OBUWFgrrent7CQCdOXPGYzobNmygvLw8YTkuLo727NkjSlelUlFubq7HcxOJ708iEuV/ZBm7pvPuu++K1uXm5lJRUREREVksFtE9TUTU2dlJAITr/vPPP5NCoaCBgQFROmq1mr744gsiIpLL5VRfX++xDIiItFqtx+vMGGPecJsl8DYLY4GS/Iv9SRag1NRU0XJ8fLzwBL+zsxNKpRJKpVLYnpycjKioKHR2duKll14SHRsdHY3i4mIsXrwY2dnZMBgMWLFiBeLj4wE8Hs7V3Nwsegr26NEjDAwM4P79+5gwYYJf6bW2tmLt2rUef9v58+exY8cOmM1m2O12IbJfd3c3kpOT3fY3m8345ZdfREPViAjDw8OwWq2jvq3r7+/H+PHjPebhnyaXyyGXywNKY86cOaKy1+v1cDgc6OnpQWJios/p6PV6t2Vfg4Bs3LgR5eXlaGxshMFgQF5enlvddF121oEbN25ApVKNWbecdTkhIcFjfj1xPW9oaCgmTZqElJQUYV1cXJyQF6f9+/fjyy+/RHd3N/r7+zE4OCgMEbp79y6uX78ueoIbGhqK9PR0t+iT3u7PJ6WzsxMSiQTp6enCupkzZyIqKkpYNpvNcDgcbnNZ+vv7heGXlZWVKCkpwZEjR2AwGJCfnw+1Wi3aPywsTHjjyRhj/uI2y1/+TpuFsUDxcM1niOtwKuDxHJ9AwpzX1dXhzJkzyMzMxPHjx6HRaGAymQAADocDH374IVpbW4W/trY2dHV1eewoeUsvLCzMYz7u3buHxYsXQ6FQ4OjRo2hpacGJEycAQDTfzJXD4UBpaakof2azGV1dXW6NVaeYmBjY7Xafy8eTmJgYhIaGiuYOAMD169cxZcoUj8c9ieGaYwkJCQERidY9fPgwoDRHKikpwe+//47CwkK0tbVBp9OhtrZWtI9rXXUOf3HW1b9Tt3w12j3iLS9fffUVNm/ejDVr1qCxsRGtra1YvXq1x3rn77n9vT+fxPVzOByIj48XlW9rayssFgu2bNkC4PFcl19//RVLlizBjz/+iOTkZOGec7p9+zZiY2P9OjdjjDlxm+Uvf6fNwlig+E1ekJg1axZ6enrQ09MjPBnr6OjAnTt3Rn2q5KTVaqHVarFt2zbo9XocO3YM8+fPR1paGiwWC6ZPn+5XPjyll5qaiqamJqxevdrtmEuXLuHWrVv4+OOPhby7BoEYTVpaGjo6OvzKn1arhc1mg91ux8SJE/36Xa6kUinS09PR1NQkBN8YHh5GU1OT1/H1OTk5mDdvnte0n3/+ea/bzWYz+vv7hX9AJpMJERERQrnFxsait7dX2L+vrw9Wq9UtHZPJhHfeeUe0rNVqvZ7blVKpRFlZGcrKyrBt2zYcPHgQFRUVPh07Vt1y1uXe3l7hqarzH++T1tzcjMzMTKxfv15Y5xpsJDIyEnFxcWhpacHLL78M4PHT4QsXLgT0/SapVCqk5Wrk9Xv06BHa29vxyiuvAHj81m5oaAjnz58XnnRbLBbRZz/S0tJgs9kgkUiQlJTkMQ8ajQYajQbvvfce3nrrLdTV1QmBBQYGBvDbb7/5VScYY8xX3GZh7J/HnbwgYTAYkJKSglWrVmHv3r0YGhrC+vXrkZWVBZ1O57a/1WrFgQMHkJOTg4SEBFgsFnR1dQkN/+rqaixduhQqlQrLly9HSEgIzGYz2tvbsXPnTr/Tq6mpwaJFi6BWq1FQUIChoSF89913qKqqgkqlglQqRW1tLcrKytDe3o6PPvrI6++tqqrC/PnzYTQaUVJSgvDwcHR0dOCHH37Avn37Rj1Gq9UiJiYGzc3NWLp0qbDeZrPBZrPh8uXLAIC2tjbI5XKoVCpER0cDABYtWoQ33nhD6MRVVlaiqKgIOp0OGRkZ2Lt3rxDF0ZMnMVxzcHAQa9aswQcffIArV66gpqYGRqNR+CTEwoULUV9fj9dffx1RUVGorq5GaGioWzpff/01dDodFixYgKNHj+Ls2bM4dOiQT3nYtGkTXnvtNWg0Gtjtdvz0009+DTUZq24ZDAZoNBoUFRVhz5496Ovrw/bt231O3x8vvPACDh8+jFOnTmHatGk4cuQIWlpahOiXAFBRUYHdu3dj+vTpmDlzJmpra2G32wP6pMTkyZMRFhaGhoYGTJ06FePHj0dkZCQWLlyIyspKnDx5Emq1Gp9++qmoAzdjxgy8+uqrKC0txeeffw6JRIJNmzaJnjobDAbo9XosW7YMn3zyCTQaDf78808hkMDs2bOxZcsWLF++HNOmTcO1a9fQ0tKCvLw8IQ2TyQSZTObzMFnGGPMHt1nGbrMwFrCnOyWQ+WqsgAxERFevXqWcnBwKDw8nuVxO+fn5ZLPZhO2uk5htNhstW7aM4uPjSSqVUmJiIlVXVwsBPIiIGhoaKDMzk8LCwkihUFBGRgYdOHBg1Pz5kt4333xDc+fOJalUSjExMfTmm28K244dO0ZJSUkkk8lIr9fTt99+6zX4BxHR2bNnKTs7myIiIig8PJxSU1Np165dXsvx/fffp4KCAtG6mpoaAuD2V1dXJ+yTmJgoCl5CRFRbW0sqlYqkUillZGSQyWTyeu5AFRUVUW5uLlVXV9OkSZMoIiKC1q5dKwqwcffuXVq5ciUpFApSKpVUX18/auCV/fv3U3Z2NslkMkpKSqLjx48L28cKvGI0GkmtVpNMJqPY2FgqLCykmzdvjrovEdHFixcJAFmtVmHdWHXLYrHQggULSCqVkkajoYaGBp8Cr4y8R0YLROOazsDAABUXF1NkZCRFRUVReXk5bd26VbhPiIgePnxIRqORFAoFTZw4kaqqqig/P19Uj3y5P0fm/+DBg6RUKikkJISysrKIiGhwcJDKy8spOjqaJk+eTLt373ZLp7e3l5YsWUIymYxUKhUdPnzY7Xf29fVRRUUFJSQk0Lhx40ipVNKqVauou7ubHjx4QAUFBaRUKkkqlVJCQgIZjUbR5P9169ZRaWmpx7JmjDFvuM3yZNosjAXiOaIRE0AYC2I2mw2zZ8/GhQsX/ApU8v+guLgYd+7cGTV8P/v3DA8PY9asWVixYsWYT2+fRTdv3sSMGTNw7tw50RtNxhhjjD07eLgm+0+ZMmUKDh06hO7u7meuk8eejqtXr6KxsRFZWVl48OAB9u3bB6vVirfffvtpZ+0fceXKFXz22WfcwWOMMcaeYdzJY/85zmApjPkiJCQE9fX12Lx5M4gIL774Ik6fPh20Ia91Ot2oc2IYY4wx9uzg4ZqMMcYYY4wxFkT4O3mMMcYYY4wxFkS4k8cYY4wxxhhjQYQ7eYwxxhhjjDEWRLiTxxhjjDHGGGNBhDt5jDHGGGOMMRZEuJPHGGOMMcYYY0GEO3mMMcYYY4wxFkS4k8cYY4wxxhhjQeR/eej1HwZlOj4AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 900x320 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def rep_code(d: int, rounds: int, p_z: float) -> str:\n",
+    "    data = list(range(d))\n",
+    "    anc = list(range(d, 2 * d - 1))\n",
+    "    lines = [\"H \" + \" \".join(map(str, data))]\n",
+    "    for k in range(rounds):\n",
+    "        for i in range(d - 1):\n",
+    "            lines += [f\"CX {data[i]} {anc[i]}\", f\"CX {data[i + 1]} {anc[i]}\"]\n",
+    "        lines += [\n",
+    "            \"S \" + \" \".join(map(str, data)),\n",
+    "            f\"Z_ERROR({p_z}) \" + \" \".join(map(str, data)),\n",
+    "            \"MR \" + \" \".join(map(str, anc)),\n",
+    "        ]\n",
+    "        if k > 0:  # compare each ancilla with its previous round\n",
+    "            lines += [f\"DETECTOR rec[-{i + 1}] rec[-{i + 1 + (d - 1)}]\" for i in range(d - 1)]\n",
+    "    lines.append(\"M \" + \" \".join(map(str, data)))\n",
+    "    return \"\\n\".join(lines) + \"\\n\"\n",
+    "\n",
+    "\n",
+    "def atom_model(scale: float) -> noncomp.Model:\n",
+    "    leak_2q, loss_2q, leak_1q = 1.0e-3 * scale, 3.9e-3 * scale, 1.3e-3 * scale\n",
+    "    return noncomp.Model(\n",
+    "        initial_state=[1 - 0.0095 * scale, 0, 0.0065 * scale, 0.003 * scale, 0],\n",
+    "        transitions={\n",
+    "            \"CX\": T(\n",
+    "                {\n",
+    "                    (Level.LEAK_E, Level.E): leak_2q,\n",
+    "                    (Level.LOST, Level.E): loss_2q,\n",
+    "                    (Level.LEAK_G, Level.G): 1e-4 * scale,\n",
+    "                }\n",
+    "            ),\n",
+    "            \"S\": T({(Level.LEAK_E, Level.E): leak_1q}),\n",
+    "        },\n",
+    "        classifier=ternary_classifier(leak_confusion=0.028),\n",
+    "        reset_restores_lost=True,  # a fresh atom is loaded at ancilla reset\n",
+    "        unknown_source_policy=\"equalize_rates\",\n",
+    "        lost_leaked_ops=\"drop\",\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "P_Z_OVERROT = twirl.rotation(\"Z\", 0.012 * np.pi / 2)[2]\n",
+    "D, ROUNDS = 5, 5\n",
+    "text = rep_code(D, ROUNDS, P_Z_OVERROT)\n",
+    "\n",
+    "scales = [0.0, 0.5, 1.0, 2.0, 4.0]\n",
+    "det_rate, herald_rate = [], []\n",
+    "for s in scales:\n",
+    "    r = noncomp.sample(text, atom_model(s), shots=4000, seed=10)\n",
+    "    det_rate.append(float(r.detectors.mean()))\n",
+    "    herald_rate.append(float(r.heralds.mean()))\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 3.2))\n",
+    "ax1.plot(scales, det_rate, \"o-\")\n",
+    "ax1.set_xlabel(\"noise scale (1.0 = published magnitudes)\")\n",
+    "ax1.set_ylabel(\"detector event fraction\")\n",
+    "ax2.plot(scales, herald_rate, \"s-\", color=\"tab:red\")\n",
+    "ax2.set_xlabel(\"noise scale\")\n",
+    "ax2.set_ylabel(\"loss-herald fraction\")\n",
+    "fig.suptitle(f\"d={D} repetition code, {ROUNDS} rounds\")\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a031343a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:45.358362Z",
+     "iopub.status.busy": "2026-06-11T21:40:45.358217Z",
+     "iopub.status.idle": "2026-06-11T21:40:47.589303Z",
+     "shell.execute_reply": "2026-06-11T21:40:47.588678Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAEiCAYAAABkykQ1AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAP2hJREFUeJzt3XlclWX+//H3AQXEABWSRVG0cEuEFEHMRksS0jS0hZjGhRzb3Elzyd2ZSAtD0xm+OGPWPDLNMqcpo4wRWyAd95wUzVFxksVlhMQE5dy/P/x5Zk6icjzAEXw9H4/7Medc9+e+rs99vDtzPtz3dd8mwzAMAQAAAIAdnBydAAAAAIC6j8ICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0aODqBm5HZbNbx48fl4eEhk8nk6HQAAAAAhzAMQz/99JMCAgLk5HTtcxIUFpU4fvy4AgMDHZ0GAAAAcFM4duyYWrZsec0YCotKeHh4SLr0AXp6ejo4GwAAAMAxSkpKFBgYaPl9fC0UFpW4fPmTp6cnhQUAAABueVWZHsDkbQAAAAB2o7AAAAAAYDcKCwAAAAB2Y46FHSoqKnThwgVHp4E6qGHDhnJ2dnZ0GgAAANWGwuIGGIahgoICnTlzxtGpoA5r0qSJ/Pz8eFYKAACoFygsbsDloqJ58+Zyd3fnhyFsYhiGzp07p6KiIkmSv7+/gzMCAACwH4WFjSoqKixFhbe3t6PTQR3VqFEjSVJRUZGaN2/OZVEAAKDOY/K2jS7PqXB3d3dwJqjrLh9DzNMBAAD1AWcsbhCXP8FeHEMAANSefR06VnufHffvq/Y+6zLOWAAAAACwG4UFqk2fPn00YcIEy/ugoCClpqZa3ptMJq1fv77W86pJI0aMUFxcnKPTAAAAcLib4lKoZcuW6dVXX1VBQYFCQ0P1xhtvKCIi4qrxa9eu1cyZM3XkyBEFBwdrwYIF6t+/v2X91S4xWbhwoSZPnlzt+V8WNPWTGuv7l468MqDWxqqqdevWqWHDho5OAwAAAA7g8MJizZo1SkpKUlpamiIjI5WamqqYmBjl5uaqefPmV8RnZ2crISFBycnJeuihh7Rq1SrFxcVpx44d6ty5syQpPz/faptPP/1UI0eO1COPPFIr+3SratasWa2PeeHCBYoZAABqAHMSYCuHXwq1aNEijRo1SomJierUqZPS0tLk7u6uFStWVBq/ePFixcbGavLkyerYsaPmz5+vrl27aunSpZYYPz8/q+Wvf/2r7rvvPrVt27a2duumk5GRoV69eqlJkyby9vbWQw89pEOHDlnWHzlyRCaTSevWrdN9990nd3d3hYaGKicnx6qfb775Rn369JG7u7uaNm2qmJgY/ec//5F05aVQ1zNlyhS1a9dO7u7uatu2rWbOnHnNOyRdznHNmjXq3bu33Nzc9M4778hsNmvevHlq2bKlXF1dFRYWpoyMDMt2WVlZMplMVg803LVrl0wmk44cOSJJWrlypZo0aaLPPvtMHTt21G233abY2FirIrWiokJJSUmWz/DFF1+UYRhWOb7//vsKCQlRo0aN5O3trejoaJWWllb5MwEAAKirHFpYlJeXa/v27YqOjra0OTk5KTo6+ooftJfl5ORYxUtSTEzMVeMLCwv1ySefaOTIkdWXeB1UWlqqpKQkbdu2TZmZmXJyctLgwYNlNput4l566SVNmjRJu3btUrt27ZSQkKCLFy9KuvRjvG/fvurUqZNycnL09ddfa+DAgaqoqLihnDw8PLRy5Up9//33Wrx4sZYvX67XX3/9uttNnTpV48eP1759+xQTE6PFixcrJSVFr732mvbs2aOYmBgNGjRIBw8etCmfc+fO6bXXXtNf/vIXffnll8rLy9OkSZMs61NSUrRy5UqtWLFCX3/9tU6fPq0PP/zQsj4/P18JCQl66qmntG/fPmVlZWnIkCFXFB8AAAD1kUMvhTp58qQqKirk6+tr1e7r66v9+/dXuk1BQUGl8QUFBZXGv/XWW/Lw8NCQIUOumkdZWZnKysos70tKSqq6C3XGLy8DW7FihW6//XZ9//33lkvIJGnSpEkaMODS/I25c+fqrrvu0g8//KAOHTpo4cKFCg8P1x/+8AdL/F133XXDOc2YMcPyOigoSJMmTdLq1av14osvXnO7CRMmWP17vvbaa5oyZYqeeOIJSdKCBQu0adMmpaamatmyZVXO58KFC0pLS9Mdd9whSRozZozmzZtnWZ+amqpp06ZZxk5LS9Nnn31mWZ+fn6+LFy9qyJAhat26tSQpJCSkyuMDAADUZQ6fY1HTVqxYoSeffFJubm5XjUlOTtbcuXNrMavad/DgQc2aNUtbtmzRyZMnLWcq8vLyrAqLLl26WF77+/tLuvR06A4dOmjXrl167LHHqi2nNWvWaMmSJTp06JDOnj2rixcvytPT87rbhYeHW16XlJTo+PHjuueee6xi7rnnHu3evdumfNzd3S1FhXRp/4uKiiRJxcXFys/PV2RkpGV9gwYNFB4ebjkjERoaqr59+yokJEQxMTHq16+fHn30UTVt2tSmPAAAuJUwl6P+cOilUD4+PnJ2dlZhYaFVe2Fhofz8/Crdxs/Pr8rxX331lXJzc/Xb3/72mnlMmzZNxcXFluXYsWM27snNb+DAgTp9+rSWL1+uLVu2aMuWLZIuXY72v/53IvTlu2tdLkIaNWpUbfnk5OToySefVP/+/fXxxx9r586deumll67IpzKNGze2aSwnp0uH+f9eklTZXI5fTgI3mUw2Xcbk7OysjRs36tNPP1WnTp30xhtvqH379jp8+LBN+QIAANRFDi0sXFxc1K1bN2VmZlrazGazMjMzFRUVVek2UVFRVvGStHHjxkrj//znP6tbt24KDQ29Zh6urq7y9PS0WuqTU6dOKTc3VzNmzFDfvn3VsWNHy4RrW3Tp0uWKz/5GZWdnq3Xr1nrppZcUHh6u4OBgHT161OZ+PD09FRAQoG+++caq/ZtvvlGnTp0kSbfffrsk67uF7dq1y6ZxvLy85O/vbynIJOnixYvavn27VZzJZNI999yjuXPnaufOnXJxcbGahwEAAFBfOfxSqKSkJA0fPlzh4eGKiIhQamqqSktLlZiYKEkaNmyYWrRooeTkZEnS+PHj1bt3b6WkpGjAgAFavXq1tm3bpvT0dKt+S0pKtHbtWqWkpNT6Pt1smjZtKm9vb6Wnp8vf3195eXmaOnWqzf1MmzZNISEhev755/Xss8/KxcVFmzZt0mOPPSYfHx+b+goODlZeXp5Wr16t7t2765NPPrnhH+CTJ0/W7NmzdccddygsLExvvvmmdu3apXfeeUeSdOeddyowMFBz5szR73//ex04cOCGjovx48frlVdeUXBwsDp06KBFixZZ3Wlqy5YtyszMVL9+/dS8eXNt2bJFJ06cUMeO1X+KFwAA4Gbj8MIiPj5eJ06c0KxZs1RQUGC5VejlCdp5eXmWS1kkqWfPnlq1apVmzJih6dOnKzg4WOvXr7eaJyBJq1evlmEYSkhIqNX9uRk5OTlp9erVGjdunDp37qz27dtryZIl6tOnj039tGvXTp9//rmmT5+uiIgINWrUSJGRkTf0GQ8aNEgTJ07UmDFjVFZWpgEDBmjmzJmaM2eOzX2NGzdOxcXFeuGFF1RUVKROnTrpo48+UnBwsKRLlzi9++67eu6559SlSxd1795dv/vd72yeL/LCCy8oPz9fw4cPl5OTk5566ikNHjxYxcXFki6dPfnyyy+VmpqqkpIStW7dWikpKXrwwQdt3icAAIC6xmRwL8wrlJSUyMvLS8XFxVdcFnX+/HkdPnxYbdq0ueaEcOB6OJYAADez2ppUXd/GqW+u9bv4lxz+gDwAAAAAdR+FBQAAAAC7UVgAAAAAsBuFBQAAAAC7UVgAAAAAsBuFBQAAAAC7UVgAAAAAsBuFBQAAAAC7UVjcIgzD0NNPP61mzZrJZDJp165d6tOnjyZMmFCt48yZM0dhYWE2bZOVlSWTyaQzZ85Uay4AAACoPQ0cnQBqR0ZGhlauXKmsrCy1bdtWPj4+WrdunRo2bOjo1G5Inz59FBYWptTUVEenAgAAAFFYVKuaeFT81dj6CPlDhw7J399fPXv2tLQ1a9asutMCAADALYpLoW4BI0aM0NixY5WXlyeTyaSgoCBJuuJSqKCgIL388st66qmn5OHhoVatWik9Pd2qrylTpqhdu3Zyd3dX27ZtNXPmTF24cMGmfDZs2KB27dqpUaNGuu+++3TkyBGr9adOnVJCQoJatGghd3d3hYSE6N1337Xan82bN2vx4sUymUwymUw6cuSIKioqNHLkSLVp00aNGjVS+/bttXjxYptyAwAAwI2hsLgFLF68WPPmzVPLli2Vn5+vf/zjH1eNTUlJUXh4uHbu3Knnn39ezz33nHJzcy3rPTw8tHLlSn3//fdavHixli9frtdff73KuRw7dkxDhgzRwIEDtWvXLv32t7/V1KlTrWLOnz+vbt266ZNPPtHevXv19NNPa+jQodq6datlf6KiojRq1Cjl5+crPz9fgYGBMpvNatmypdauXavvv/9es2bN0vTp0/Xee+/Z+IkBAADAVlwKdQvw8vKSh4eHnJ2d5efnd83Y/v376/nnn5d06ezE66+/rk2bNql9+/aSpBkzZlhig4KCNGnSJK1evVovvvhilXL54x//qDvuuEMpKSmSpPbt2+u7777TggULLDEtWrTQpEmTLO/Hjh2rzz77TO+9954iIiLk5eUlFxcXubu7W+2Ps7Oz5s6da3nfpk0b5eTk6L333tPjjz9epfwAAABwYygsYKVLly6W1yaTSX5+fioqKrK0rVmzRkuWLNGhQ4d09uxZXbx4UZ6enlXuf9++fYqMjLRqi4qKsnpfUVGhl19+We+9955+/PFHlZeXq6ysTO7u7tftf9myZVqxYoXy8vL0888/q7y83Oa7VAEAAMB2XAoFK7+8S5TJZJLZbJYk5eTk6Mknn1T//v318ccfa+fOnXrppZdUXl5erTm8+uqrWrx4saZMmaJNmzZp165diomJue44q1ev1qRJkzRy5Eh9/vnn2rVrlxITE6s9PwAAAFyJMxaosuzsbLVu3VovvfSSpe3o0aM29dGxY0d99NFHVm3ffvut1ftvvvlGDz/8sH7zm99Iksxmsw4cOKBOnTpZYlxcXFRRUXHFdj179rRcyiVduhsWAAAAah5nLFBlwcHBysvL0+rVq3Xo0CEtWbJEH374oU19PPvsszp48KAmT56s3NxcrVq1SitXrrxinI0bNyo7O1v79u3TM888o8LCQquYoKAgbdmyRUeOHNHJkydlNpsVHBysbdu26bPPPtOBAwc0c+bMa05UBwAAQPWhsECVDRo0SBMnTtSYMWMUFham7OxszZw506Y+WrVqpQ8++EDr169XaGio0tLS9PLLL1vFzJgxQ127dlVMTIz69OkjPz8/xcXFWcVMmjRJzs7O6tSpk26//Xbl5eXpmWee0ZAhQxQfH6/IyEidOnXK6uwFAAAAao7JMAzDkQksW7ZMr776qgoKChQaGqo33nhDERERV41fu3atZs6cqSNHjig4OFgLFixQ//79rWL27dunKVOmaPPmzbp48aI6deqkDz74QK1atapSTiUlJfLy8lJxcfEVE5PPnz+vw4cPq02bNnJzc7N9h4H/j2MJAHAzq4kH/1b2gN/6Nk59c63fxb/k0DMWa9asUVJSkmbPnq0dO3YoNDRUMTExVnch+l/Z2dlKSEjQyJEjtXPnTsXFxSkuLk579+61xBw6dEi9evVShw4dlJWVpT179mjmzJn8cAMAAABqkEPPWERGRqp79+5aunSppEuTdAMDAzV27NgrHpomSfHx8SotLdXHH39saevRo4fCwsKUlpYmSXriiSfUsGFD/eUvf7nhvDhjgdrAsQQAuJnVtzMJnLG4MXXijEV5ebm2b9+u6Ojo/ybj5KTo6Gjl5ORUuk1OTo5VvCTFxMRY4s1msz755BO1a9dOMTExat68uSIjI7V+/fpr5lJWVqaSkhKrBQAAAEDVOaywOHnypCoqKuTr62vV7uvrq4KCgkq3KSgouGZ8UVGRzp49q1deeUWxsbH6/PPPNXjwYA0ZMkSbN2++ai7Jycny8vKyLIGBgXbuHQAAAHBrqVd3hbr8ILeHH35YEydOVFhYmKZOnaqHHnrIcqlUZaZNm6bi4mLLcuzYsdpKGQAAAKgXHPaAPB8fHzk7O1/xfILCwkL5+flVuo2fn9814318fNSgQQOrB6lJlx7K9vXXX181F1dXV7m6utqUv4NvpoV6gGMIAADUJw47Y+Hi4qJu3bopMzPT0mY2m5WZmamoqKhKt4mKirKKl6SNGzda4l1cXNS9e3fl5uZaxRw4cECtW7eulrwbNmwoSTp37ly19Idb1+Vj6PIxBQAAUJc57IyFJCUlJWn48OEKDw9XRESEUlNTVVpaqsTEREnSsGHD1KJFCyUnJ0uSxo8fr969eyslJUUDBgzQ6tWrtW3bNqWnp1v6nDx5suLj4/WrX/1K9913nzIyMvS3v/1NWVlZ1ZKzs7OzmjRpYrklrru7u0wmU7X0jVuDYRg6d+6cioqK1KRJEzk7Ozs6JQAAALs5tLCIj4/XiRMnNGvWLBUUFCgsLEwZGRmWCdp5eXlycvrvSZWePXtq1apVmjFjhqZPn67g4GCtX79enTt3tsQMHjxYaWlpSk5O1rhx49S+fXt98MEH6tWrV7XlffnSq6s9bwOoiiZNmlz1sj8AAIC6xuFP3r4ZVfV+vRUVFbpw4UItZob6omHDhpypAADc1Orb8yV4jsWNseU5Fg49Y1HXOTs78+MQAAAAUD273SwAAAAAx6CwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGA3CgsAAAAAdqOwAAAAAGC3m6KwWLZsmYKCguTm5qbIyEht3br1mvFr165Vhw4d5ObmppCQEG3YsMFq/YgRI2QymayW2NjYmtwFAAAA4Jbm8MJizZo1SkpK0uzZs7Vjxw6FhoYqJiZGRUVFlcZnZ2crISFBI0eO1M6dOxUXF6e4uDjt3bvXKi42Nlb5+fmW5d13362N3QEAAABuSTdUWFy8eFFffPGF/u///k8//fSTJOn48eM6e/aszX0tWrRIo0aNUmJiojp16qS0tDS5u7trxYoVlcYvXrxYsbGxmjx5sjp27Kj58+era9euWrp0qVWcq6ur/Pz8LEvTpk1t31EAAAAAVWJzYXH06FGFhITo4Ycf1ujRo3XixAlJ0oIFCzRp0iSb+iovL9f27dsVHR3934ScnBQdHa2cnJxKt8nJybGKl6SYmJgr4rOystS8eXO1b99ezz33nE6dOnXVPMrKylRSUmK1AAAAAKg6mwuL8ePHKzw8XP/5z3/UqFEjS/vgwYOVmZlpU18nT55URUWFfH19rdp9fX1VUFBQ6TYFBQXXjY+NjdXbb7+tzMxMLViwQJs3b9aDDz6oioqKSvtMTk6Wl5eXZQkMDLRpPwAAAIBbXQNbN/jqq6+UnZ0tFxcXq/agoCD9+OOP1ZaYPZ544gnL65CQEHXp0kV33HGHsrKy1Ldv3yvip02bpqSkJMv7kpISigsAAADABjafsTCbzZX+5f/f//63PDw8bOrLx8dHzs7OKiwstGovLCyUn59fpdv4+fnZFC9Jbdu2lY+Pj3744YdK17u6usrT09NqAQAAAFB1NhcW/fr1U2pqquW9yWTS2bNnNXv2bPXv39+mvlxcXNStWzerS6jMZrMyMzMVFRVV6TZRUVFXXHK1cePGq8ZLl4qeU6dOyd/f36b8AAAAAFSNzZdCpaSkKCYmRp06ddL58+f161//WgcPHpSPj88N3dI1KSlJw4cPV3h4uCIiIpSamqrS0lIlJiZKkoYNG6YWLVooOTlZ0qU5Hr1791ZKSooGDBig1atXa9u2bUpPT5cknT17VnPnztUjjzwiPz8/HTp0SC+++KLuvPNOxcTE2JwfAAAAgOuzubBo2bKldu/erTVr1mj37t06e/asRo4cqSeffNJqMndVxcfH68SJE5o1a5YKCgoUFhamjIwMywTtvLw8OTn998RKz549tWrVKs2YMUPTp09XcHCw1q9fr86dO0uSnJ2dtWfPHr311ls6c+aMAgIC1K9fP82fP1+urq425wcAAADg+kyGYRi2bPDll1+qZ8+eatDAuia5ePGisrOz9atf/apaE3SEkpISeXl5qbi4mPkWAADglrSvQ8dq77Pj/n31fpz6xpbfxTbPsbjvvvt0+vTpK9qLi4t133332dodAAAAgHrA5sLCMAyZTKYr2k+dOqXGjRtXS1IAAAAA6pYqz7EYMmSIpEt3gRoxYoTVfIWKigrt2bNHPXv2rP4MAQAAANz0qlxYeHl5Sbp0xsLDw8NqoraLi4t69OihUaNGVX+GAAAAAG56VS4s3nzzTUmXnrA9adIkLnsCAAAAYGHz7WZnz55dE3kAAAAAqMNsLiwk6f3339d7772nvLw8lZeXW63bsWNHtSQGAAAAoO6w+a5QS5YsUWJionx9fbVz505FRETI29tb//rXv/Tggw/WRI4AAAAAbnI2FxZ/+MMflJ6erjfeeEMuLi568cUXtXHjRo0bN07FxcU1kSMAAACAm5zNhUVeXp7ltrKNGjXSTz/9JEkaOnSo3n333erNDgAAAECdYHNh4efnZ3nydqtWrfTtt99Kkg4fPizDMKo3OwAAAAB1gs2Fxf3336+PPvpIkpSYmKiJEyfqgQceUHx8vAYPHlztCQIAAAC4+dl8V6j09HSZzWZJ0ujRo+Xt7a3s7GwNGjRIzzzzTLUnCAAAAODmZ1NhcfHiRb388st66qmn1LJlS0nSE088oSeeeKJGkgMAAABQN9h0KVSDBg20cOFCXbx4sabyAQAAAFAH2TzHom/fvtq8eXNN5AIAAACgjrJ5jsWDDz6oqVOn6rvvvlO3bt3UuHFjq/WDBg2qtuQAAAAA1A02FxbPP/+8JGnRokVXrDOZTKqoqLA/KwAAAAB1is2XQpnN5qsuN1pULFu2TEFBQXJzc1NkZKS2bt16zfi1a9eqQ4cOcnNzU0hIiDZs2HDV2GeffVYmk0mpqak3lBsAAACA67O5sKhua9asUVJSkmbPnq0dO3YoNDRUMTExKioqqjQ+OztbCQkJGjlypHbu3Km4uDjFxcVp7969V8R++OGH+vbbbxUQEFDTuwEAAADc0hxeWCxatEijRo1SYmKiOnXqpLS0NLm7u2vFihWVxi9evFixsbGaPHmyOnbsqPnz56tr165aunSpVdyPP/6osWPH6p133lHDhg1rY1cAAACAW5ZDC4vy8nJt375d0dHRljYnJydFR0crJyen0m1ycnKs4iUpJibGKt5sNmvo0KGaPHmy7rrrrppJHgAAAICFzZO3q9PJkydVUVEhX19fq3ZfX1/t37+/0m0KCgoqjS8oKLC8X7BggRo0aKBx48ZVKY+ysjKVlZVZ3peUlFR1FwAAAADoJrgUqrpt375dixcv1sqVK2Uymaq0TXJysry8vCxLYGBgDWcJAAAA1C9VKixKSkqqvNjCx8dHzs7OKiwstGovLCyUn59fpdv4+fldM/6rr75SUVGRWrVqpQYNGqhBgwY6evSoXnjhBQUFBVXa57Rp01RcXGxZjh07ZtN+AAAAALe6Kl0K1aRJkyr/9d+WW866uLioW7duyszMVFxcnKRL8yMyMzM1ZsyYSreJiopSZmamJkyYYGnbuHGjoqKiJElDhw6tdA7G0KFDlZiYWGmfrq6ucnV1rXLeAAAAAKxVqbDYtGmT5fWRI0c0depUjRgxwvJjPicnR2+99ZaSk5NtTiApKUnDhw9XeHi4IiIilJqaqtLSUksRMGzYMLVo0cLS9/jx49W7d2+lpKRowIABWr16tbZt26b09HRJkre3t7y9va3GaNiwofz8/NS+fXub8wMAAABwfVUqLHr37m15PW/ePC1atEgJCQmWtkGDBikkJETp6ekaPny4TQnEx8frxIkTmjVrlgoKChQWFqaMjAzLBO28vDw5Of33iq2ePXtq1apVmjFjhqZPn67g4GCtX79enTt3tmlcAAAAoLrt69Cx2vvsuH9ftfdZE0yGYRi2bODu7q7du3crODjYqv3AgQMKCwvTuXPnqjVBRygpKZGXl5eKi4vl6enp6HQAAABqXW39QGacGxunttjyu9jmu0IFBgZq+fLlV7T/6U9/4m5KAAAAwC3K5udYvP7663rkkUf06aefKjIyUpK0detWHTx4UB988EG1JwgAAADg5mfzGYv+/fvrwIEDGjhwoE6fPq3Tp09r4MCBOnDggPr3718TOQIAAAC4yd3Qk7cDAwP18ssvV3cuAAAAAOqoKhUWe/bsqXKHXbp0ueFkAAAAcG31bXIw6o8qFRZhYWEymUy63g2kTCaTTQ/IAwAAAFA/VKmwOHz4cE3nAQAAAKAOq1Jh0bp165rOAwAAAEAddkOTtyXp+++/V15ensrLy63aBw0aZHdSAAAAAOoWmwuLf/3rXxo8eLC+++47q3kXJpNJkphjAQAAANyCbH6Oxfjx49WmTRsVFRXJ3d1d//znP/Xll18qPDxcWVlZNZAiAAAAgJudzWcscnJy9Pe//10+Pj5ycnKSk5OTevXqpeTkZI0bN047d+6siTwBAAAA3MRsPmNRUVEhDw8PSZKPj4+OHz8u6dIE79zc3OrNDgAAAECdYPMZi86dO2v37t1q06aNIiMjtXDhQrm4uCg9PV1t27atiRwBAAAA3ORsLixmzJih0tJSSdK8efP00EMP6d5775W3t7fWrFlT7QkCAAAAuPnZXFjExMRYXt95553av3+/Tp8+raZNm1ruDAUAAADg1mLTHIsLFy6oQYMG2rt3r1V7s2bNKCoAAACAW5hNhUXDhg3VqlUrnlUBAAAAwIrNd4V66aWXNH36dJ0+fbom8gEAAABQB9lcWCxdulRffvmlAgIC1L59e3Xt2tVquRHLli1TUFCQ3NzcFBkZqa1bt14zfu3aterQoYPc3NwUEhKiDRs2WK2fM2eOOnTooMaNG6tp06aKjo7Wli1bbig3AAAAANdn8+TtuLi4ak1gzZo1SkpKUlpamiIjI5WamqqYmBjl5uaqefPmV8RnZ2crISFBycnJeuihh7Rq1SrFxcVpx44d6ty5sySpXbt2Wrp0qdq2bauff/5Zr7/+uvr166cffvhBt99+e7XmDwAAAEAyGYZhODKByMhIde/eXUuXLpUkmc1mBQYGauzYsZo6deoV8fHx8SotLdXHH39saevRo4fCwsKUlpZW6RglJSXy8vLSF198ob59+143p8vxxcXF8vT0vME9AwAAqH77OnSs9j477t/HOHVsnNpiy+9imy+FkqQzZ87oT3/6k6ZNm2aZa7Fjxw79+OOPNvVTXl6u7du3Kzo6+r8JOTkpOjpaOTk5lW6Tk5NjFS9dugXu1eLLy8uVnp4uLy8vhYaG2pQfAAAAgKqx+VKoPXv2KDo6Wl5eXjpy5IhGjRqlZs2aad26dcrLy9Pbb79d5b5OnjypiooK+fr6WrX7+vpq//79lW5TUFBQaXxBQYFV28cff6wnnnhC586dk7+/vzZu3CgfH59K+ywrK1NZWZnlfUlJSZX3AQAAAMANnLFISkrSiBEjdPDgQbm5uVna+/fvry+//LJak7PHfffdp127dik7O1uxsbF6/PHHVVRUVGlscnKyvLy8LEtgYGAtZwsAAADUbTYXFv/4xz/0zDPPXNHeokWLK84aXI+Pj4+cnZ1VWFho1V5YWCg/P79Kt/Hz86tSfOPGjXXnnXeqR48e+vOf/6wGDRroz3/+c6V9Tps2TcXFxZbl2LFjNu0HAAAAcKuzubBwdXWt9FKhAwcO2HzHJRcXF3Xr1k2ZmZmWNrPZrMzMTEVFRVW6TVRUlFW8JG3cuPGq8f/b7/9e7vS/XF1d5enpabUAAAAAqDqbC4tBgwZp3rx5unDhgiTJZDIpLy9PU6ZM0SOPPGJzAklJSVq+fLneeust7du3T88995xKS0uVmJgoSRo2bJimTZtmiR8/frwyMjKUkpKi/fv3a86cOdq2bZvGjBkjSSotLdX06dP17bff6ujRo9q+fbueeuop/fjjj3rsscdszg8AAADA9dk8eTslJUWPPvqomjdvrp9//lm9e/dWQUGBoqKi9Pvf/97mBOLj43XixAnNmjVLBQUFCgsLU0ZGhmWCdl5enpyc/lv/9OzZU6tWrdKMGTM0ffp0BQcHa/369ZZnWDg7O2v//v166623dPLkSXl7e6t79+766quvdNddd9mcHwAAAIDru+HnWHz99dfas2ePzp49q65du15xC9i6jOdYAACAm1V9ex4D49zYOLXFlt/FNp+xuKxXr17q1avXjW4OAAAAoB65ocIiMzNTmZmZKioqktlstlq3YsWKakkMAAAAQN1hc2Exd+5czZs3T+Hh4fL395fJZKqJvAAAAADUITYXFmlpaVq5cqWGDh1aE/kAAAAAqINsvt1seXm5evbsWRO5AAAAAKijbC4sfvvb32rVqlU1kQsAAACAOqpKl0IlJSVZXpvNZqWnp+uLL75Qly5d1LBhQ6vYRYsWVW+GAAAAAG56VSosdu7cafU+LCxMkrR3716rdiZyAwAAALemKhUWmzZtquk8AAAAANRhNs+xAAAAAIBforAAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYLeborBYtmyZgoKC5ObmpsjISG3duvWa8WvXrlWHDh3k5uamkJAQbdiwwbLuwoULmjJlikJCQtS4cWMFBARo2LBhOn78eE3vBgAAAHDLcnhhsWbNGiUlJWn27NnasWOHQkNDFRMTo6Kiokrjs7OzlZCQoJEjR2rnzp2Ki4tTXFyc9u7dK0k6d+6cduzYoZkzZ2rHjh1at26dcnNzNWjQoNrcLQAAAOCWYjIMw3BkApGRkerevbuWLl0qSTKbzQoMDNTYsWM1derUK+Lj4+NVWlqqjz/+2NLWo0cPhYWFKS0trdIx/vGPfygiIkJHjx5Vq1atrptTSUmJvLy8VFxcLE9PzxvcMwAAgOq3r0PHau+z4/59jFPHxqkttvwudugZi/Lycm3fvl3R0dGWNicnJ0VHRysnJ6fSbXJycqziJSkmJuaq8ZJUXFwsk8mkJk2aVLq+rKxMJSUlVgsAAACAqnNoYXHy5ElVVFTI19fXqt3X11cFBQWVblNQUGBT/Pnz5zVlyhQlJCRctcpKTk6Wl5eXZQkMDLyBvQEAAABuXQ6fY1GTLly4oMcff1yGYeiPf/zjVeOmTZum4uJiy3Ls2LFazBIAAACo+xo4cnAfHx85OzursLDQqr2wsFB+fn6VbuPn51el+MtFxdGjR/X3v//9mteEubq6ytXV9Qb3AgAAAIBDz1i4uLioW7duyszMtLSZzWZlZmYqKiqq0m2ioqKs4iVp48aNVvGXi4qDBw/qiy++kLe3d83sAAAAAABJDj5jIUlJSUkaPny4wsPDFRERodTUVJWWlioxMVGSNGzYMLVo0ULJycmSpPHjx6t3795KSUnRgAEDtHr1am3btk3p6emSLhUVjz76qHbs2KGPP/5YFRUVlvkXzZo1k4uLi2N2FAAAAKjHHF5YxMfH68SJE5o1a5YKCgoUFhamjIwMywTtvLw8OTn998RKz549tWrVKs2YMUPTp09XcHCw1q9fr86dO0uSfvzxR3300UeSpLCwMKuxNm3apD59+tTKfgEAAAC3EocXFpI0ZswYjRkzptJ1WVlZV7Q99thjeuyxxyqNDwoKkoMfzQEAAADccur1XaEAAAAA1A4KCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDcKCwAAAAB2o7AAAAAAYDeHFxbLli1TUFCQ3NzcFBkZqa1bt14zfu3aterQoYPc3NwUEhKiDRs2WK1ft26d+vXrJ29vb5lMJu3atasGswcAAAAgObiwWLNmjZKSkjR79mzt2LFDoaGhiomJUVFRUaXx2dnZSkhI0MiRI7Vz507FxcUpLi5Oe/futcSUlpaqV69eWrBgQW3tBgAAAHDLc2hhsWjRIo0aNUqJiYnq1KmT0tLS5O7urhUrVlQav3jxYsXGxmry5Mnq2LGj5s+fr65du2rp0qWWmKFDh2rWrFmKjo6urd0AAAAAbnkOKyzKy8u1fft2qwLAyclJ0dHRysnJqXSbnJycKwqGmJiYq8ZXVVlZmUpKSqwWAAAAAFXnsMLi5MmTqqiokK+vr1W7r6+vCgoKKt2moKDApviqSk5OlpeXl2UJDAy0qz8AAADgVuPwyds3g2nTpqm4uNiyHDt2zNEpAQAAAHVKA0cN7OPjI2dnZxUWFlq1FxYWys/Pr9Jt/Pz8bIqvKldXV7m6utrVBwAAAHArc9gZCxcXF3Xr1k2ZmZmWNrPZrMzMTEVFRVW6TVRUlFW8JG3cuPGq8QAAAABqh8POWEhSUlKShg8frvDwcEVERCg1NVWlpaVKTEyUJA0bNkwtWrRQcnKyJGn8+PHq3bu3UlJSNGDAAK1evVrbtm1Tenq6pc/Tp08rLy9Px48flyTl5uZKunS2w94zG7hxQVM/qfY+j7wyoNr7BAAAwI1xaGERHx+vEydOaNasWSooKFBYWJgyMjIsE7Tz8vLk5PTfkyo9e/bUqlWrNGPGDE2fPl3BwcFav369OnfubIn56KOPLIWJJD3xxBOSpNmzZ2vOnDm1s2MAAADALcahhYUkjRkzRmPGjKl0XVZW1hVtjz32mB577LGr9jdixAiNGDGimrIDKscZGAAAAGsOLyxQudr64coP5Jsb/z6obdV9zHG84Vr4jgPqFwoLAPyfO2pdfStg2J/rc/Q+Aah5FBaoV/g/w5tbffz3qW8/KHFzq4//DQGoPygsANRL9e0Hf33bHwBA/UNhAQCotyjIIDFvEagtDntAHgAAAID6g8ICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADY7aYoLJYtW6agoCC5ubkpMjJSW7duvWb82rVr1aFDB7m5uSkkJEQbNmywWm8YhmbNmiV/f381atRI0dHROnjwYE3uAgAAAHBLc3hhsWbNGiUlJWn27NnasWOHQkNDFRMTo6Kiokrjs7OzlZCQoJEjR2rnzp2Ki4tTXFyc9u7da4lZuHChlixZorS0NG3ZskWNGzdWTEyMzp8/X1u7BQAAANxSHF5YLFq0SKNGjVJiYqI6deqktLQ0ubu7a8WKFZXGL168WLGxsZo8ebI6duyo+fPnq2vXrlq6dKmkS2crUlNTNWPGDD388MPq0qWL3n77bR0/flzr16+vxT0DAAAAbh0OLSzKy8u1fft2RUdHW9qcnJwUHR2tnJycSrfJycmxipekmJgYS/zhw4dVUFBgFePl5aXIyMir9gkAAADAPg0cOfjJkydVUVEhX19fq3ZfX1/t37+/0m0KCgoqjS8oKLCsv9x2tZhfKisrU1lZmeV9cXGxJKmkpMSGvale5rJz1d5nZfvDOIxTH8epibEYh3Hq4zhXG4txbu5xzlZUMA7j1JrLYxuGcd1YhxYWN4vk5GTNnTv3ivbAwEAHZFNzvFIZh3EYh3EYh3EcMxbj3NzjyMuLcRjnmn766Sd5XScPhxYWPj4+cnZ2VmFhoVV7YWGh/Pz8Kt3Gz8/vmvGX/7ewsFD+/v5WMWFhYZX2OW3aNCUlJVnem81mnT59Wt7e3jKZTDbvV20qKSlRYGCgjh07Jk9PT0enAwfhOIDEcYBLOA4gcRzgkuo4DgzD0E8//aSAgIDrxjq0sHBxcVG3bt2UmZmpuLg4SZd+1GdmZmrMmDGVbhMVFaXMzExNmDDB0rZx40ZFRUVJktq0aSM/Pz9lZmZaComSkhJt2bJFzz33XKV9urq6ytXV1aqtSZMmdu1bbfP09OSLAxwHkMRxgEs4DiBxHOASe4+D652puMzhl0IlJSVp+PDhCg8PV0REhFJTU1VaWqrExERJ0rBhw9SiRQslJydLksaPH6/evXsrJSVFAwYM0OrVq7Vt2zalp6dLkkwmkyZMmKDf/e53Cg4OVps2bTRz5kwFBARYihcAAAAA1cvhhUV8fLxOnDihWbNmqaCgQGFhYcrIyLBMvs7Ly5OT039vXtWzZ0+tWrVKM2bM0PTp0xUcHKz169erc+fOlpgXX3xRpaWlevrpp3XmzBn16tVLGRkZcnNzq/X9AwAAAG4FJqMqU7xx0yorK1NycrKmTZt2xeVcuHVwHEDiOMAlHAeQOA5wSW0fBxQWAAAAAOzm8CdvAwAAAKj7KCwAAAAA2I3CAgAAAIDdKCzqsGXLlikoKEhubm6KjIzU1q1bHZ0SatmcOXNkMpmslg4dOjg6LdSwL7/8UgMHDlRAQIBMJpPWr19vtd4wDM2aNUv+/v5q1KiRoqOjdfDgQcckixpzveNgxIgRV3w/xMbGOiZZ1Ijk5GR1795dHh4eat68ueLi4pSbm2sVc/78eY0ePVre3t667bbb9Mgjj1zxoGHUfVU5Fvr06XPFd8Kzzz5brXlQWNRRa9asUVJSkmbPnq0dO3YoNDRUMTExKioqcnRqqGV33XWX8vPzLcvXX3/t6JRQw0pLSxUaGqply5ZVun7hwoVasmSJ0tLStGXLFjVu3FgxMTE6f/58LWeKmnS940CSYmNjrb4f3n333VrMEDVt8+bNGj16tL799ltt3LhRFy5cUL9+/VRaWmqJmThxov72t79p7dq12rx5s44fP64hQ4Y4MGvUhKocC5I0atQoq++EhQsXVm8iBuqkiIgIY/To0Zb3FRUVRkBAgJGcnOzArFDbZs+ebYSGhjo6DTiQJOPDDz+0vDebzYafn5/x6quvWtrOnDljuLq6Gu+++64DMkRt+OVxYBiGMXz4cOPhhx92SD5wjKKiIkOSsXnzZsMwLv2337BhQ2Pt2rWWmH379hmSjJycHEeliVrwy2PBMAyjd+/exvjx42t0XM5Y1EHl5eXavn27oqOjLW1OTk6Kjo5WTk6OAzODIxw8eFABAQFq27atnnzySeXl5Tk6JTjQ4cOHVVBQYPX94OXlpcjISL4fbkFZWVlq3ry52rdvr+eee06nTp1ydEqoQcXFxZKkZs2aSZK2b9+uCxcuWH0fdOjQQa1ateL7oJ775bFw2TvvvCMfHx917txZ06ZN07lz56p1XIc/eRu2O3nypCoqKixPJ7/M19dX+/fvd1BWcITIyEitXLlS7du3V35+vubOnat7771Xe/fulYeHh6PTgwMUFBRIUqXfD5fX4dYQGxurIUOGqE2bNjp06JCmT5+uBx98UDk5OXJ2dnZ0eqhmZrNZEyZM0D333KPOnTtLuvR94OLioiZNmljF8n1Qv1V2LEjSr3/9a7Vu3VoBAQHas2ePpkyZotzcXK1bt67axqawAOqwBx980PK6S5cuioyMVOvWrfXee+9p5MiRDswMgKM98cQTltchISHq0qWL7rjjDmVlZalv374OzAw1YfTo0dq7dy/z7HDVY+Hpp5+2vA4JCZG/v7/69u2rQ4cO6Y477qiWsbkUqg7y8fGRs7PzFXd1KCwslJ+fn4Oyws2gSZMmateunX744QdHpwIHufwdwPcDfqlt27by8fHh+6EeGjNmjD7++GNt2rRJLVu2tLT7+fmpvLxcZ86csYrn+6D+utqxUJnIyEhJqtbvBAqLOsjFxUXdunVTZmampc1sNiszM1NRUVEOzAyOdvbsWR06dEj+/v6OTgUO0qZNG/n5+Vl9P5SUlGjLli18P9zi/v3vf+vUqVN8P9QjhmFozJgx+vDDD/X3v/9dbdq0sVrfrVs3NWzY0Or7IDc3V3l5eXwf1DPXOxYqs2vXLkmq1u8ELoWqo5KSkjR8+HCFh4crIiJCqampKi0tVWJioqNTQy2aNGmSBg4cqNatW+v48eOaPXu2nJ2dlZCQ4OjUUIPOnj1r9Remw4cPa9euXWrWrJlatWqlCRMm6He/+52Cg4PVpk0bzZw5UwEBAYqLi3Nc0qh21zoOmjVrprlz5+qRRx6Rn5+fDh06pBdffFF33nmnYmJiHJg1qtPo0aO1atUq/fWvf5WHh4dl3oSXl5caNWokLy8vjRw5UklJSWrWrJk8PT01duxYRUVFqUePHg7OHtXpesfCoUOHtGrVKvXv31/e3t7as2ePJk6cqF/96lfq0qVL9SVSo/ecQo164403jFatWhkuLi5GRESE8e233zo6JdSy+Ph4w9/f33BxcTFatGhhxMfHGz/88IOj00IN27RpkyHpimX48OGGYVy65ezMmTMNX19fw9XV1ejbt6+Rm5vr2KRR7a51HJw7d87o16+fcfvttxsNGzY0WrdubYwaNcooKChwdNqoRpX9+0sy3nzzTUvMzz//bDz//PNG06ZNDXd3d2Pw4MFGfn6+45JGjbjesZCXl2f86le/Mpo1a2a4uroad955pzF58mSjuLi4WvMw/f9kAAAAAOCGMccCAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAIBqNmfOHIWFhTk6DQCoVRQWAAD8D0cUBUeOHJHJZNKuXbtqdVwAqE4UFgCAWmMYhi5evOjoNAAANYDCAgDqgD59+mjs2LGaMGGCmjZtKl9fXy1fvlylpaVKTEyUh4eH7rzzTn366adW2+3du1cPPvigbrvtNvn6+mro0KE6efKkZX1GRoZ69eqlJk2ayNvbWw899JAOHTpkWV9eXq4xY8bI399fbm5uat26tZKTkyVV/lf2M2fOyGQyKSsrS5KUlZUlk8mkTz/9VN26dZOrq6u+/vprmc1mJScnq02bNmrUqJFCQ0P1/vvvW/q5vN1nn32mu+++W40aNdL999+voqIiffrpp+rYsaM8PT3161//WufOnbNsV9V+MzMzFR4eLnd3d/Xs2VO5ubmSpJUrV2ru3LnavXu3TCaTTCaTVq5cWem/SVZWliIiItS4cWM1adJE99xzj44ePVpprNls1rx589SyZUu5uroqLCxMGRkZlvVt2rSRJN19990ymUzq06dPpf0AwM2MwgIA6oi33npLPj4+2rp1q8aOHavnnntOjz32mHr27KkdO3aoX79+Gjp0qOWH9pkzZ3T//ffr7rvv1rZt25SRkaHCwkI9/vjjlj5LS0uVlJSkbdu2KTMzU05OTho8eLDMZrMkacmSJfroo4/03nvvKTc3V++8846CgoJszn3q1Kl65ZVXtG/fPnXp0kXJycl6++23lZaWpn/+85+aOHGifvOb32jz5s1W282ZM0dLly5Vdna2jh07pscff1ypqalatWqVPvnkE33++ed64403LPFV7fell15SSkqKtm3bpgYNGuipp56SJMXHx+uFF17QXXfdpfz8fOXn5ys+Pv6K/bl48aLi4uLUu3dv7dmzRzk5OXr66adlMpkq3f/FixcrJSVFr732mvbs2aOYmBgNGjRIBw8elCRt3bpVkvTFF18oPz9f69ats/kzBgCHMwAAN73evXsbvXr1sry/ePGi0bhxY2Po0KGWtvz8fEOSkZOTYxiGYcyfP9/o16+fVT/Hjh0zJBm5ubmVjnPixAlDkvHdd98ZhmEYY8eONe6//37DbDZfEXv48GFDkrFz505L23/+8x9DkrFp0ybDMAxj06ZNhiRj/fr1lpjz588b7u7uRnZ2tlV/I0eONBISEqy2++KLLyzrk5OTDUnGoUOHLG3PPPOMERMTY1e/n3zyiSHJ+Pnnnw3DMIzZs2cboaGhlX4+l506dcqQZGRlZVW6/pd9BAQEGL///e+tYrp37248//zzhmFU/lkCQF3TwDHlDADAVl26dLG8dnZ2lre3t0JCQixtvr6+kqSioiJJ0u7du7Vp0ybddtttV/R16NAhtWvXTgcPHtSsWbO0ZcsWnTx50nKmIi8vT507d9aIESP0wAMPqH379oqNjdVDDz2kfv362Zx7eHi45fUPP/ygc+fO6YEHHrCKKS8v1913333Vffb19ZW7u7vatm1r1Xb5r/032q+/v7+kS59bq1atqrQ/zZo104gRIxQTE6MHHnhA0dHRevzxxy19/a+SkhIdP35c99xzj1X7Pffco927d1dpPACoCygsAKCOaNiwodV7k8lk1Xb5MpzLxcHZs2c1cOBALViw4Iq+Lv8AHjhwoFq3bq3ly5crICBAZrNZnTt3Vnl5uSSpa9euOnz4sD799FN98cUXevzxxxUdHa33339fTk6XrqY1DMPS74ULFyrNvXHjxpbXZ8+elSR98sknatGihVWcq6vrVff5l/t7ue1/9/dG+5X++7lV1Ztvvqlx48YpIyNDa9as0YwZM7Rx40b16NHDpn4AoL6gsACAeqpr16764IMPFBQUpAYNrvy6P3XqlHJzc7V8+XLde++9kqSvv/76ijhPT0/Fx8crPj5ejz76qGJjY3X69GndfvvtkqT8/HzLGYGq3C61U6dOcnV1VV5ennr37m3HHtZMvy4uLqqoqKhS7N133627775b06ZNU1RUlFatWnVFYeHp6amAgAB98803Vnl98803ioiIsIwpqcrjAsDNiMICAOqp0aNHa/ny5UpISNCLL76oZs2a6YcfftDq1av1pz/9SU2bNpW3t7fS09Pl7++vvLw8TZ061aqPRYsWyd/fX3fffbecnJy0du1a+fn5qUmTJnJyclKPHj30yiuvqE2bNioqKtKMGTOum5eHh4cmTZqkiRMnymw2q1evXiouLtY333wjT09PDR8+/Ib2t7r6DQoK0uHDh7Vr1y61bNlSHh4eV5zxOHz4sNLT0zVo0CAFBAQoNzdXBw8e1LBhwyrtc/LkyZo9e7buuOMOhYWF6c0339SuXbv0zjvvSJKaN2+uRo0aKSMjQy1btpSbm5u8vLxu6HMAAEehsACAeuryX8mnTJmifv36qaysTK1bt1ZsbKycnJxkMpm0evVqjRs3Tp07d1b79u21ZMkSq1udenh4aOHChTp48KCcnZ3VvXt3bdiwwXIZ1IoVKzRy5Eh169ZN7du318KFC6s0B2P+/Pm6/fbblZycrH/9619q0qSJunbtqunTp9u1z9XR7yOPPKJ169bpvvvu05kzZ/Tmm29qxIgRVjHu7u7av3+/3nrrLZ06dUr+/v4aPXq0nnnmmUr7HDdunIqLi/XCCy+oqKhInTp10kcffaTg4GBJUoMGDbRkyRLNmzdPs2bN0r333mu5ZS8A1BUm438vjgUAAACAG8BzLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN0oLAAAAADYjcICAAAAgN3+H+Ts3v/07r1nAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Where do the heralds land? Data qubits accumulate loss across rounds (no reset);\n",
+    "# ancillas are reloaded each round, so their herald rate stays flat.\n",
+    "r = noncomp.sample(text, atom_model(4.0), shots=20000, seed=11)\n",
+    "n_anc_slots = (D - 1) * ROUNDS\n",
+    "slot_rate = r.heralds.mean(axis=0)\n",
+    "fig, ax = plt.subplots(figsize=(8, 3))\n",
+    "ax.bar(range(n_anc_slots), slot_rate[:n_anc_slots], label=\"ancilla rounds\")\n",
+    "ax.bar(\n",
+    "    range(n_anc_slots, n_anc_slots + D),\n",
+    "    slot_rate[n_anc_slots:],\n",
+    "    color=\"tab:red\",\n",
+    "    label=\"final data\",\n",
+    ")\n",
+    "ax.set_xlabel(\"measurement slot\")\n",
+    "ax.set_ylabel(\"herald rate\")\n",
+    "ax.legend()\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a70c00be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-11T21:40:47.591094Z",
+     "iopub.status.busy": "2026-06-11T21:40:47.590911Z",
+     "iopub.status.idle": "2026-06-11T21:40:47.676652Z",
+     "shell.execute_reply": "2026-06-11T21:40:47.675868Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plain sampling:        0.0004 ms/shot\n",
+      "noncomputational:      0.1590 ms/shot  (per-shot rewrite + compile)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cost of the noncomputational path: the trajectory is resolved before compilation,\n",
+    "# so each shot pays a rewrite + recompile. (Tracked over time in the repository's\n",
+    "# nightly benchmark suite.)\n",
+    "import time\n",
+    "\n",
+    "plain = clifft.compile(text)\n",
+    "t0 = time.perf_counter()\n",
+    "clifft.sample(plain, 2000, 1)\n",
+    "t_plain = time.perf_counter() - t0\n",
+    "\n",
+    "model = atom_model(1.0)\n",
+    "noncomp.sample(text, model, shots=2, seed=1)  # warm\n",
+    "t0 = time.perf_counter()\n",
+    "noncomp.sample(text, model, shots=500, seed=1)\n",
+    "t_nc = time.perf_counter() - t0\n",
+    "print(f\"plain sampling:      {t_plain / 2000 * 1e3:8.4f} ms/shot\")\n",
+    "print(f\"noncomputational:    {t_nc / 500 * 1e3:8.4f} ms/shot  (per-shot rewrite + compile)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daa70188",
+   "metadata": {},
+   "source": [
+    "## 4. How this is validated\n",
+    "\n",
+    "The checks in this notebook are the demonstration layer of a larger ladder in the\n",
+    "repository's test suite:\n",
+    "\n",
+    "- **lossless-limit equivalence** -- a zero-noise model reproduces plain sampling and the\n",
+    "  exact record layout;\n",
+    "- **analytic micro-cases** -- the Bell-pair partial trace, relaxation mixtures, and\n",
+    "  classifier distributions asserted against closed forms (several reproduced above);\n",
+    "- **an independent density-matrix oracle** -- a tiny first-principles simulator, written\n",
+    "  against none of clifft's internals, that cross-checks output distributions on the\n",
+    "  supported subset in CI;\n",
+    "- **divergence probes** -- the two documented approximations of section 2.5 are pinned\n",
+    "  quantitatively (the Bell-pair joint gap, the gate-determined miss) so they can never\n",
+    "  soften without a test changing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41b14a9f",
+   "metadata": {},
+   "source": [
+    "## 5. Capability summary\n",
+    "\n",
+    "**Exact today** (within clifft's exact near-Clifford simulation):\n",
+    "\n",
+    "| mechanism | section |\n",
+    "|---|---|\n",
+    "| initial level populations | 2.1 |\n",
+    "| loss with partial-trace back-action; gates dropped at lost sites | 2.2, 2.6 |\n",
+    "| state-independent leakage/loss transitions on any state | 2.2 |\n",
+    "| state-dependent transitions on instruction-known states | -- |\n",
+    "| computational destinations: relaxation, recapture, re-preparation | 2.3 |\n",
+    "| measurement classifiers, confusion, ternary loss herald, detector wiring | 2.4 |\n",
+    "| Pauli/readout noise alongside the above | 2.7 |\n",
+    "| coherent control errors simulated exactly (active-rank cost) | 2.7 |\n",
+    "\n",
+    "**Approximate, by explicit opt-in, with the approximation characterized:**\n",
+    "\n",
+    "| mechanism | nature of the approximation |\n",
+    "|---|---|\n",
+    "| state-dependent transitions on unknown states (`equalize_rates`) | marginals exact for unbiased sources; destination-collapse correlations discarded (2.5a); gate-determined-but-untracked states take the approximate path (2.5b) |\n",
+    "| coherent errors as twirled Pauli channels (`clifft.twirl`) | preserves the Pauli-transfer-matrix diagonal, not circuit statistics (2.7) |\n",
+    "\n",
+    "**Out of scope** (and why):\n",
+    "\n",
+    "- *Exact state-dependent jumps on unknown states* -- requires the destination to depend\n",
+    "  on a runtime measurement outcome; the designated successor is a segmented execution\n",
+    "  tier where precompiled continuations are selected at runtime, which would also restore\n",
+    "  the correlations of 2.5a and remove the equalization dephasing entirely.\n",
+    "- *Movement / atom-site semantics, correlated multi-qubit leakage instruments* -- per-qubit\n",
+    "  marginal transition matrices only, today.\n",
+    "- *Asymmetric computational readout confusion* -- symmetric flips via noise instructions,\n",
+    "  or classical post-processing for terminal measurements.\n",
+    "\n",
+    "The pattern throughout: anything clifft cannot do exactly is **refused by default** and\n",
+    "available only behind a named policy knob whose approximation is documented and pinned by\n",
+    "tests -- so a simulation either is exact, or says precisely how it is not."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/leakage_and_loss.ipynb
+++ b/examples/leakage_and_loss.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7db639eb",
+   "id": "7ca4bd4f",
    "metadata": {},
    "source": [
     "# Simulating leakage and atom loss in clifft\n",
@@ -23,12 +23,16 @@
     "   deliberately out of scope.\n",
     "\n",
     "Everything here is self-contained: every quantitative claim is produced by the cell that\n",
-    "makes it, with fixed seeds."
+    "makes it, with fixed seeds.\n",
+    "\n",
+    "If you already work with a transition-matrix leakage simulator (for example the one in\n",
+    "cirq-superstaq), the **appendix** maps each of its concepts onto this API directly, and\n",
+    "section 1 will read as familiar ground."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4bd50a64",
+   "id": "bab54e3a",
    "metadata": {},
    "source": [
     "## 1. The physics: an extended state space\n",
@@ -42,8 +46,8 @@
     "\n",
     "| index | name | category | meaning |\n",
     "|---|---|---|---|\n",
-    "| 0 | `g` | computational | qubit $|0\\rangle$ |\n",
-    "| 1 | `e` | computational | qubit $|1\\rangle$ |\n",
+    "| 0 | `g` | computational | the qubit state $\\lvert 0\\rangle$ |\n",
+    "| 1 | `e` | computational | the qubit state $\\lvert 1\\rangle$ |\n",
     "| 2 | `leak_g` | leaked | carrier present, outside the qubit manifold |\n",
     "| 3 | `leak_e` | leaked | a second leaked level |\n",
     "| 4 | `lost` | lost | carrier physically gone |\n",
@@ -65,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18505dd1",
+   "id": "66477c81",
    "metadata": {},
    "source": [
     "### What samples exactly, and what cannot\n",
@@ -96,13 +100,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a90bbf55",
+   "id": "79c03a97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:41.325799Z",
-     "iopub.status.busy": "2026-06-11T21:40:41.325531Z",
-     "iopub.status.idle": "2026-06-11T21:40:41.596598Z",
-     "shell.execute_reply": "2026-06-11T21:40:41.595638Z"
+     "iopub.execute_input": "2026-06-12T00:57:40.187588Z",
+     "iopub.status.busy": "2026-06-12T00:57:40.187466Z",
+     "iopub.status.idle": "2026-06-12T00:57:40.435668Z",
+     "shell.execute_reply": "2026-06-12T00:57:40.435086Z"
     }
    },
    "outputs": [
@@ -148,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd4ceda7",
+   "id": "7a96f816",
    "metadata": {},
    "source": [
     "## 2. The API, one physical scenario at a time\n",
@@ -164,13 +168,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a9ca9057",
+   "id": "1bbc2172",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:41.599612Z",
-     "iopub.status.busy": "2026-06-11T21:40:41.599378Z",
-     "iopub.status.idle": "2026-06-11T21:40:41.734544Z",
-     "shell.execute_reply": "2026-06-11T21:40:41.733606Z"
+     "iopub.execute_input": "2026-06-12T00:57:40.437700Z",
+     "iopub.status.busy": "2026-06-12T00:57:40.437485Z",
+     "iopub.status.idle": "2026-06-12T00:57:40.605792Z",
+     "shell.execute_reply": "2026-06-12T00:57:40.605157Z"
     }
    },
    "outputs": [
@@ -203,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc8dd134",
+   "id": "a415d245",
    "metadata": {},
    "source": [
     "### 2.2 Loss is a partial trace\n",
@@ -218,13 +222,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2fc475f5",
+   "id": "b569f9c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:41.736625Z",
-     "iopub.status.busy": "2026-06-11T21:40:41.736233Z",
-     "iopub.status.idle": "2026-06-11T21:40:41.977544Z",
-     "shell.execute_reply": "2026-06-11T21:40:41.976828Z"
+     "iopub.execute_input": "2026-06-12T00:57:40.606988Z",
+     "iopub.status.busy": "2026-06-12T00:57:40.606850Z",
+     "iopub.status.idle": "2026-06-12T00:57:40.852269Z",
+     "shell.execute_reply": "2026-06-12T00:57:40.851500Z"
     }
    },
    "outputs": [
@@ -254,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfe95e6f",
+   "id": "f4b9e0dc",
    "metadata": {},
    "source": [
     "### 2.3 Relaxation and recapture re-prepare the carrier\n",
@@ -269,13 +273,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "84881a49",
+   "id": "24d39b04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:41.979824Z",
-     "iopub.status.busy": "2026-06-11T21:40:41.979608Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.173388Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.172407Z"
+     "iopub.execute_input": "2026-06-12T00:57:40.853797Z",
+     "iopub.status.busy": "2026-06-12T00:57:40.853675Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.046510Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.045415Z"
     }
    },
    "outputs": [
@@ -300,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de0240c8",
+   "id": "b1f1254a",
    "metadata": {},
    "source": [
     "### 2.4 Readout: classifiers, heralds, and detectors\n",
@@ -316,13 +320,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "83a06014",
+   "id": "edf54d09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.175470Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.175344Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.392715Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.391717Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.048719Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.048586Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.288671Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.287574Z"
     }
    },
    "outputs": [
@@ -352,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b08239b",
+   "id": "1b84e892",
    "metadata": {},
    "source": [
     "### 2.5 State-dependent transitions: the equalized-rates approximation, with its boundary\n",
@@ -370,13 +374,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "bc5026a1",
+   "id": "1e248d32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.395521Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.395388Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.575314Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.573920Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.291025Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.290899Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.485087Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.483996Z"
     }
    },
    "outputs": [
@@ -417,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aab034b2",
+   "id": "494d2031",
    "metadata": {},
    "source": [
     "The approximation has a precisely characterized envelope. **Per-qubit marginals are exact\n",
@@ -435,13 +439,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "8a94885d",
+   "id": "60ceacc2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.578608Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.578444Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.797760Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.796927Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.487653Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.487537Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.730700Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.729828Z"
     }
    },
    "outputs": [
@@ -478,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36daa0bf",
+   "id": "f00b32b5",
    "metadata": {},
    "source": [
     "**(b) Gate-determined states.** Status tracking is instruction-known, so two Hadamards\n",
@@ -491,13 +495,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "a62f26f6",
+   "id": "9bc2079b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.800254Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.800001Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.972919Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.971860Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.732657Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.732545Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.916890Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.916418Z"
     }
    },
    "outputs": [
@@ -524,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08cd9ade",
+   "id": "f03bc8f2",
    "metadata": {},
    "source": [
     "### 2.6 What happens downstream of a leaked or lost site\n",
@@ -541,13 +545,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "a4f981d9",
+   "id": "de6bec3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.974953Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.974759Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.979467Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.978788Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.919544Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.919432Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.923513Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.922909Z"
     }
    },
    "outputs": [
@@ -589,7 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1da58844",
+   "id": "3ed47bae",
    "metadata": {},
    "source": [
     "### 2.7 Coherent control errors: twirl them, or simulate them exactly\n",
@@ -606,13 +610,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3c541e1a",
+   "id": "c99a4575",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.981000Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.980855Z",
-     "iopub.status.idle": "2026-06-11T21:40:42.989763Z",
-     "shell.execute_reply": "2026-06-11T21:40:42.988945Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.925595Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.925488Z",
+     "iopub.status.idle": "2026-06-12T00:57:41.933392Z",
+     "shell.execute_reply": "2026-06-12T00:57:41.932898Z"
     }
    },
    "outputs": [
@@ -663,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec82a24b",
+   "id": "7f4854fc",
    "metadata": {},
    "source": [
     "## 3. A realistic neutral-atom noise model, end to end\n",
@@ -683,13 +687,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "4e1e83ca",
+   "id": "d4e9c1f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:42.992362Z",
-     "iopub.status.busy": "2026-06-11T21:40:42.992215Z",
-     "iopub.status.idle": "2026-06-11T21:40:45.355904Z",
-     "shell.execute_reply": "2026-06-11T21:40:45.355204Z"
+     "iopub.execute_input": "2026-06-12T00:57:41.935478Z",
+     "iopub.status.busy": "2026-06-12T00:57:41.935377Z",
+     "iopub.status.idle": "2026-06-12T00:57:44.315957Z",
+     "shell.execute_reply": "2026-06-12T00:57:44.315294Z"
     }
    },
    "outputs": [
@@ -770,13 +774,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a031343a",
+   "id": "e9081e88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:45.358362Z",
-     "iopub.status.busy": "2026-06-11T21:40:45.358217Z",
-     "iopub.status.idle": "2026-06-11T21:40:47.589303Z",
-     "shell.execute_reply": "2026-06-11T21:40:47.588678Z"
+     "iopub.execute_input": "2026-06-12T00:57:44.317423Z",
+     "iopub.status.busy": "2026-06-12T00:57:44.317294Z",
+     "iopub.status.idle": "2026-06-12T00:57:46.786135Z",
+     "shell.execute_reply": "2026-06-12T00:57:46.785302Z"
     }
    },
    "outputs": [
@@ -815,13 +819,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "a70c00be",
+   "id": "764d5658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-11T21:40:47.591094Z",
-     "iopub.status.busy": "2026-06-11T21:40:47.590911Z",
-     "iopub.status.idle": "2026-06-11T21:40:47.676652Z",
-     "shell.execute_reply": "2026-06-11T21:40:47.675868Z"
+     "iopub.execute_input": "2026-06-12T00:57:46.788276Z",
+     "iopub.status.busy": "2026-06-12T00:57:46.788162Z",
+     "iopub.status.idle": "2026-06-12T00:57:46.847362Z",
+     "shell.execute_reply": "2026-06-12T00:57:46.846695Z"
     }
    },
    "outputs": [
@@ -829,8 +833,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plain sampling:        0.0004 ms/shot\n",
-      "noncomputational:      0.1590 ms/shot  (per-shot rewrite + compile)\n"
+      "plain sampling:        0.0002 ms/shot\n",
+      "noncomputational:      0.1085 ms/shot  (per-shot rewrite + compile)\n"
      ]
     }
    ],
@@ -856,7 +860,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daa70188",
+   "id": "40f8dce7",
    "metadata": {},
    "source": [
     "## 4. How this is validated\n",
@@ -878,7 +882,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41b14a9f",
+   "id": "22a10059",
    "metadata": {},
    "source": [
     "## 5. Capability summary\n",
@@ -917,6 +921,46 @@
     "The pattern throughout: anything clifft cannot do exactly is **refused by default** and\n",
     "available only behind a named policy knob whose approximation is documented and pinned by\n",
     "tests -- so a simulation either is exact, or says precisely how it is not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4df9e08",
+   "metadata": {},
+   "source": [
+    "## Appendix: translating from cirq-superstaq's leakage simulator\n",
+    "\n",
+    "For readers coming from the transition-matrix leakage simulator in cirq-superstaq, the\n",
+    "two models share their core structure -- a stabilizer-class quantum core plus a\n",
+    "classical per-qubit level tracker -- and most concepts carry over one to one:\n",
+    "\n",
+    "| there | here | section |\n",
+    "|---|---|---|\n",
+    "| five-level qudit, indices 0--4 | the same five levels, named by `noncomp.Level` | 1 |\n",
+    "| `JumpChannel` matrix, entry = P(from column to row), column deficit = no jump | identical convention: `transitions={\"GATE\": T}` | 1 |\n",
+    "| channels attached to CZ / Z-rotations | any gate name can carry a matrix (`\"CZ\"`, `\"S\"`, `\"CX\"`, ...) | 3 |\n",
+    "| initial-state preparation channel | `initial_state=[...]` | 2.1 |\n",
+    "| classifier errors with ternary readout (0 / 1 / loss) | three-symbol `Classifier`; the visible record stays binary and the loss symbol arrives in the `heralds` sidecar; `symbols()` reconstructs the ternary view | 2.4 |\n",
+    "| equalize-and-collapse for jumps on superposed qubits | `unknown_source_policy=\"equalize_rates\"` -- refused by default, opt-in, with the approximation characterized | 2.5 |\n",
+    "| gates skipped on leaked or lost atoms | `lost_leaked_ops=\"drop\"` -- refused by default, opt-in | 2.6 |\n",
+    "| reset reloads a lost atom | `reset_restores_lost=True` | 2.6, 3 |\n",
+    "| over-rotations twirled onto the stabilizer sampler | `clifft.twirl` produces the same Pauli channel as explicit noise instructions -- or simulate the rotation exactly | 2.7 |\n",
+    "| `cirq.Circuit` input | Stim-format text (or a parsed `clifft.Circuit`); measurement keys become record slots, and `DETECTOR` / `OBSERVABLE_INCLUDE` are evaluated in-circuit | 2.4, 3 |\n",
+    "\n",
+    "Section 3's `atom_model` is exactly this translation applied to published neutral-atom\n",
+    "parameter magnitudes.\n",
+    "\n",
+    "**Differences to plan around, in both directions.** Not available here: oversampling\n",
+    "amortization (clifft's per-shot pipeline cost is low enough not to need it -- see the\n",
+    "timing cell in section 3); noise hooks on global-rotation or atom-movement operations\n",
+    "(no atom-site semantics); asymmetric readout confusion on *computational* levels\n",
+    "(symmetric flips via noise instructions, or classical post-processing for terminal\n",
+    "measurements); and a readout that collapses the level register -- the classifier here is\n",
+    "record-only, the tracked status is unchanged by measurement. Available here that has no\n",
+    "direct counterpart there: detectors and observables computed in-circuit from classifier\n",
+    "outcomes, a record layout that is invariant under every loss/leakage event (decoder\n",
+    "inputs never reshape), per-qubit final-status and per-slot herald sidecars, exact\n",
+    "simulation of non-Clifford and coherent-error gates, and reproducible per-shot seeding."
    ]
   }
  ],


### PR DESCRIPTION
> [!NOTE]
> Prototype work on the `codex/noncomputational-structural-mvp` feature branch — less-strict review bar than `main`.

The final checkpoint work item: `examples/leakage_and_loss.ipynb`, committed **with executed outputs** (viewable on GitHub), fixed seeds, ~30s runtime, dependencies = clifft + numpy + matplotlib only. Fully **self-contained**: every quantitative claim is produced by the cell that makes it; no cross-simulator dependencies or numbers.

### Contents

1. **Physics framing** — extended state space, leakage vs. loss as distinct processes, transition matrices as instruments, and the load-bearing dichotomy: state-independent transitions pre-sample exactly, state-dependent ones cannot, and what clifft does about each.
2. **API tour by scenario**, each demo asserted against a closed form: initial populations + sidecars; **loss = partial trace** (Bell pair → 50/50 survivor); relaxation/recapture mixture; classifier/herald/detector wiring (the classifier bit demonstrably feeds a `DETECTOR`); **equalized rates with both documented divergences shown live** (the refusal-by-default first, then the joint decorrelation and the gate-determined miss as honest-boundary demos); drop policy on a multi-round circuit through loss; twirl helpers with the selected match, the single-application counterexample, and exact coherent simulation alongside.
3. **A realistic neutral-atom model** at published magnitudes (cited to [arXiv:2412.07670](https://arxiv.org/abs/2412.07670)) on a d=5 repetition code: detector-rate and herald-rate sweeps vs. noise scale, herald-by-slot structure (sticky data loss vs. reloaded ancillas), and a brief on-machine perf cell framing the per-shot rewrite+compile cost.
4. **Validation note** — the test-suite ladder behind the notebook's asserts.
5. **Capability summary** — exact today / approximate by explicit opt-in (with the characterized envelopes) / out of scope (with the segmented-execution successor named). Closing principle: anything not exact is refused by default and available only behind a documented policy knob.

Notebook executes clean (0 errors), pre-commit clean (ruff runs on notebooks here).

### Revision

- Tables now render on GitHub's notebook viewer (the pipe inside in-table math was parsed as a column separator; switched to `\lvert` notation).
- **New appendix: "Translating from cirq-superstaq's leakage simulator"** — a knob-for-knob mapping table (matrix convention, classifier/ternary readout → herald sidecar, equalize/drop/reset policies, circuit input) plus the differences to plan around in both directions. This is the entry point for a reader who already uses a transition-matrix leakage model: section 3's `atom_model` is the worked version of that translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
