### PR TITLE
feat: add DEPOLARIZE3 and PAULI_CHANNEL_3 support

### DIFF
--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -125,15 +125,23 @@ Two-qubit Cliffords are also absorbed at compile time.
 |-------------|-------|
 | `DEPOLARIZE1(p)` | Single-qubit depolarizing noise |
 | `DEPOLARIZE2(p)` | Two-qubit depolarizing noise |
+| `DEPOLARIZE3(p)` | Three-qubit depolarizing noise over triples of targets |
 | `X_ERROR(p)` | Single-qubit X error |
 | `Y_ERROR(p)` | Single-qubit Y error |
 | `Z_ERROR(p)` | Single-qubit Z error |
 | `PAULI_CHANNEL_1(px,py,pz)` | General single-qubit Pauli channel |
 | `PAULI_CHANNEL_2(...)` | General two-qubit Pauli channel (15 params) |
+| `PAULI_CHANNEL_3(...)` | General three-qubit Pauli channel (63 params) |
 
 Noisy measurements (e.g., `M(0.01) 0`) are decomposed by the parser into a
 clean measurement followed by an internal `READOUT_NOISE` instruction that
 models classical bit-flip errors on the measurement result.
+
+`DEPOLARIZE3(p) a b c` applies one of the 63 non-identity Pauli products on
+`a,b,c` with probability `p/63` each, and identity with probability `1-p`.
+`PAULI_CHANNEL_3` uses the same lexicographic Pauli order as
+`PAULI_CHANNEL_2`, extended to three qubits: `IIX`, `IIY`, `IIZ`, `IXI`,
+`IXX`, ..., `ZZZ`.
 
 ## Identity Gates
 

--- a/src/clifft/circuit/circuit.h
+++ b/src/clifft/circuit/circuit.h
@@ -33,7 +33,8 @@ struct AstNode {
 
     // Gate arguments (e.g., noise probabilities).
     // Most gates use args[0] for a single parameter.
-    // PAULI_CHANNEL_1 uses 3 args, PAULI_CHANNEL_2 uses 15 args.
+    // PAULI_CHANNEL_1 uses 3 args, PAULI_CHANNEL_2 uses 15 args,
+    // PAULI_CHANNEL_3 uses 63 args.
     std::vector<double> args;
 
     // Source line number in the original input text (1-based).

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -112,10 +112,12 @@ enum class GateType : uint16_t {
     Z_ERROR,      // Single-qubit Z error
     DEPOLARIZE1,  // Single-qubit depolarizing channel
     DEPOLARIZE2,  // Two-qubit depolarizing channel
+    DEPOLARIZE3,  // Three-qubit depolarizing channel
 
     // Multi-parameter noise channels
     PAULI_CHANNEL_1,  // 3-arg: P(X), P(Y), P(Z)
     PAULI_CHANNEL_2,  // 15-arg: P(IX), P(IY), ..., P(ZZ)
+    PAULI_CHANNEL_3,  // 63-arg: P(IIX), P(IIY), ..., P(ZZZ)
 
     // Synthetic gates (emitted by parser, not in input syntax)
     READOUT_NOISE,  // Classical bit-flip on measurement result
@@ -138,6 +140,7 @@ enum class GateType : uint16_t {
 enum class GateArity : uint8_t {
     SINGLE,      // Single qubit (H, S, X, T, M, etc.)
     PAIR,        // Two qubits consumed in pairs (CX, CY, CZ)
+    TRIPLE,      // Three qubits consumed in triples (3-qubit noise channels)
     MULTI,       // Variable targets (MPP)
     ANNOTATION,  // No qubit targets (TICK)
 };
@@ -159,6 +162,7 @@ namespace detail {
 
 constexpr auto S = GateArity::SINGLE;
 constexpr auto P = GateArity::PAIR;
+constexpr auto T = GateArity::TRIPLE;
 constexpr auto ML = GateArity::MULTI;
 constexpr auto A = GateArity::ANNOTATION;
 
@@ -250,8 +254,10 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = S, .noise = true, .name = "Z_ERROR"},
     {.arity = S, .noise = true, .name = "DEPOLARIZE1"},
     {.arity = P, .noise = true, .name = "DEPOLARIZE2"},
+    {.arity = T, .noise = true, .name = "DEPOLARIZE3"},
     {.arity = S, .noise = true, .name = "PAULI_CHANNEL_1"},
     {.arity = P, .noise = true, .name = "PAULI_CHANNEL_2"},
+    {.arity = T, .noise = true, .name = "PAULI_CHANNEL_3"},
     {.arity = S, .noise = true, .name = "READOUT_NOISE"},
     // QEC annotations
     {.arity = A, .name = "DETECTOR"},

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -235,6 +235,9 @@ class Parser {
         if (gate == GateType::PAULI_CHANNEL_2 && args.size() != 15) {
             throw ParseError("PAULI_CHANNEL_2 requires exactly 15 arguments", line_num);
         }
+        if (gate == GateType::PAULI_CHANNEL_3 && args.size() != 63) {
+            throw ParseError("PAULI_CHANNEL_3 requires exactly 63 arguments", line_num);
+        }
 
         // Validate argument counts for parameterized rotations.
         if ((gate == GateType::R_X || gate == GateType::R_Y || gate == GateType::R_Z ||
@@ -576,6 +579,20 @@ class Parser {
                     }
 
                     AstNode node{gate, {t0, t1}, args, line_num};
+                    update_circuit_stats(node, circuit);
+                    circuit.nodes.push_back(std::move(node));
+                }
+                break;
+
+            case GateArity::TRIPLE:
+                if (targets.size() % 3 != 0) {
+                    throw ParseError(
+                        "Gate " + std::string(gate_name(gate)) + " requires triples of targets",
+                        line_num);
+                }
+                for (size_t i = 0; i < targets.size(); i += 3) {
+                    AstNode node{
+                        gate, {targets[i], targets[i + 1], targets[i + 2]}, args, line_num};
                     update_circuit_stats(node, circuit);
                     circuit.nodes.push_back(std::move(node));
                 }

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -162,6 +162,24 @@ NoiseChannel rewind_two_qubit_pauli(HirModule& hir, const stim::TableauSimulator
     return NoiseChannel{h, prob};
 }
 
+/// Rewind a three-qubit Pauli through the tableau into a freshly claimed slot.
+NoiseChannel rewind_three_qubit_pauli(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                      uint32_t q1, uint32_t q2, uint32_t q3, int pauli1, int pauli2,
+                                      int pauli3, double prob) {
+    auto h = hir.claim_empty_noise_channel_mask();
+    auto slot = hir.noise_channel_masks.mut_at(h);
+    slot.x().zero_out();
+    slot.z().zero_out();
+    uint32_t n = sim.inv_state.num_qubits;
+    if (pauli1 != 0)
+        accumulate_pauli_row(sim.inv_state, q1, pauli1, n, slot.x(), slot.z());
+    if (pauli2 != 0)
+        accumulate_pauli_row(sim.inv_state, q2, pauli2, n, slot.x(), slot.z());
+    if (pauli3 != 0)
+        accumulate_pauli_row(sim.inv_state, q3, pauli3, n, slot.x(), slot.z());
+    return NoiseChannel{h, prob};
+}
+
 NoiseSite make_single_qubit_noise_site(HirModule& hir,
                                        const stim::TableauSimulator<kStimWidth>& sim, GateType gate,
                                        uint32_t qubit, double prob) {
@@ -196,6 +214,23 @@ NoiseSite make_depolarize2_noise_site(HirModule& hir, const stim::TableauSimulat
             if (p1 == 0 && p2 == 0)
                 continue;
             site.channels.push_back(rewind_two_qubit_pauli(hir, sim, q1, q2, p1, p2, channel_prob));
+        }
+    }
+    return site;
+}
+
+NoiseSite make_depolarize3_noise_site(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                      uint32_t q1, uint32_t q2, uint32_t q3, double prob) {
+    NoiseSite site;
+    double channel_prob = prob / 63.0;
+    for (int p1 = 0; p1 <= 3; ++p1) {
+        for (int p2 = 0; p2 <= 3; ++p2) {
+            for (int p3 = 0; p3 <= 3; ++p3) {
+                if (p1 == 0 && p2 == 0 && p3 == 0)
+                    continue;
+                site.channels.push_back(
+                    rewind_three_qubit_pauli(hir, sim, q1, q2, q3, p1, p2, p3, channel_prob));
+            }
         }
     }
     return site;
@@ -285,6 +320,10 @@ size_t count_noise_channels(const Circuit& circuit) {
             case GateType::DEPOLARIZE2:
             case GateType::PAULI_CHANNEL_2:
                 count += 15 * (n_targets / 2);
+                break;
+            case GateType::DEPOLARIZE3:
+            case GateType::PAULI_CHANNEL_3:
+                count += 63 * (n_targets / 3);
                 break;
             default:
                 break;
@@ -775,12 +814,57 @@ HirModule trace(const Circuit& circuit) {
                 break;
             }
 
+            case GateType::PAULI_CHANNEL_3: {
+                if (node.args.size() < 63) {
+                    throw std::runtime_error("PAULI_CHANNEL_3 requires 63 arguments");
+                }
+                for (size_t i = 0; i + 2 < node.targets.size(); i += 3) {
+                    uint32_t q1 = node.targets[i].value();
+                    uint32_t q2 = node.targets[i + 1].value();
+                    uint32_t q3 = node.targets[i + 2].value();
+                    NoiseSite site;
+                    size_t arg_idx = 0;
+                    for (int p1 = 0; p1 <= 3; ++p1) {
+                        for (int p2 = 0; p2 <= 3; ++p2) {
+                            for (int p3 = 0; p3 <= 3; ++p3) {
+                                if (p1 == 0 && p2 == 0 && p3 == 0)
+                                    continue;
+                                double prob = node.args[arg_idx];
+                                if (prob > 0.0) {
+                                    site.channels.push_back(rewind_three_qubit_pauli(
+                                        hir, sim, q1, q2, q3, p1, p2, p3, prob));
+                                }
+                                ++arg_idx;
+                            }
+                        }
+                    }
+                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
+                    hir.noise_sites.push_back(std::move(site));
+                    hir.append_noise(idx);
+                }
+                break;
+            }
+
             case GateType::DEPOLARIZE2: {
                 double prob = node.args.empty() ? 0.0 : node.args[0];
                 for (size_t i = 0; i + 1 < node.targets.size(); i += 2) {
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
                     NoiseSite site = make_depolarize2_noise_site(hir, sim, q1, q2, prob);
+                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
+                    hir.noise_sites.push_back(std::move(site));
+                    hir.append_noise(idx);
+                }
+                break;
+            }
+
+            case GateType::DEPOLARIZE3: {
+                double prob = node.args.empty() ? 0.0 : node.args[0];
+                for (size_t i = 0; i + 2 < node.targets.size(); i += 3) {
+                    uint32_t q1 = node.targets[i].value();
+                    uint32_t q2 = node.targets[i + 1].value();
+                    uint32_t q3 = node.targets[i + 2].value();
+                    NoiseSite site = make_depolarize3_noise_site(hir, sim, q1, q2, q3, prob);
                     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
                     hir.noise_sites.push_back(std::move(site));
                     hir.append_noise(idx);

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -194,8 +194,10 @@ NB_MODULE(_clifft_core, m) {
         .value("Z_ERROR", clifft::GateType::Z_ERROR)
         .value("DEPOLARIZE1", clifft::GateType::DEPOLARIZE1)
         .value("DEPOLARIZE2", clifft::GateType::DEPOLARIZE2)
+        .value("DEPOLARIZE3", clifft::GateType::DEPOLARIZE3)
         .value("PAULI_CHANNEL_1", clifft::GateType::PAULI_CHANNEL_1)
         .value("PAULI_CHANNEL_2", clifft::GateType::PAULI_CHANNEL_2)
+        .value("PAULI_CHANNEL_3", clifft::GateType::PAULI_CHANNEL_3)
         .value("READOUT_NOISE", clifft::GateType::READOUT_NOISE)
         // Annotations
         .value("DETECTOR", clifft::GateType::DETECTOR)

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -16,6 +16,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <random>
 #include <stdexcept>
+#include <string>
 
 using namespace clifft;
 using clifft::test::X;
@@ -29,6 +30,17 @@ struct NoiseChannelMasks {
     uint64_t stab_mask;
     double prob;
 };
+
+static std::string make_pauli_channel3_args(size_t nonzero_idx, double prob) {
+    std::string args;
+    for (size_t k = 0; k < 63; ++k) {
+        if (!args.empty()) {
+            args += ", ";
+        }
+        args += std::to_string(k == nonzero_idx ? prob : 0.0);
+    }
+    return args;
+}
 
 static NoiseChannelMasks rewind_single_pauli_reference(
     const stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit, int pauli_type, double prob) {
@@ -1130,6 +1142,29 @@ TEST_CASE("Frontend: DEPOLARIZE2 produces 15 channels", "[frontend][noise]") {
     }
 }
 
+TEST_CASE("Frontend: DEPOLARIZE3 produces 63 channels", "[frontend][noise]") {
+    auto circuit = parse("DEPOLARIZE3(0.63) 0 1 2");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    CHECK(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.noise_sites.size() == 1);
+    const auto& site = hir.noise_sites[0];
+    REQUIRE(site.channels.size() == 63);
+
+    for (const auto& ch : site.channels) {
+        CHECK(ch.prob == Catch::Approx(0.01));
+    }
+
+    auto first = hir.noise_channel_masks.at(site.channels[0].mask);
+    CHECK(first.x() == 4);
+    CHECK(first.z() == 0);
+
+    auto last = hir.noise_channel_masks.at(site.channels.back().mask);
+    CHECK(last.x() == 0);
+    CHECK(last.z() == 7);
+}
+
 TEST_CASE("Frontend: noise rewinding through H gate", "[frontend][noise]") {
     // H 0, X_ERROR 0
     // X after H becomes Z (at t=0, the error manifests as Z)
@@ -1596,6 +1631,20 @@ TEST_CASE("Frontend: PAULI_CHANNEL_2 emits noise with up to 15 channels", "[fron
     REQUIRE(hir.noise_sites.size() == 1);
     // 4 nonzero channels: IX(0.01), XI(0.02), ZI(0.03), ZZ(0.04)
     CHECK(hir.noise_sites[0].channels.size() == 4);
+}
+
+TEST_CASE("Frontend: PAULI_CHANNEL_3 emits selected channels", "[frontend]") {
+    auto circuit = parse("PAULI_CHANNEL_3(" + make_pauli_channel3_args(62, 0.07) + ") 0 1 2");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.noise_sites.size() == 1);
+    REQUIRE(hir.noise_sites[0].channels.size() == 1);
+    CHECK(hir.noise_sites[0].channels[0].prob == Catch::Approx(0.07));
+
+    auto mask = hir.noise_channel_masks.at(hir.noise_sites[0].channels[0].mask);
+    CHECK(mask.x() == 0);
+    CHECK(mask.z() == 7);
 }
 
 // =============================================================================

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -15,8 +15,20 @@
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <string>
 
 using namespace clifft;
+
+static std::string make_pauli_channel3_args(double default_prob = 0.0) {
+    std::string args;
+    for (size_t k = 0; k < 63; ++k) {
+        if (!args.empty()) {
+            args += ", ";
+        }
+        args += std::to_string(default_prob);
+    }
+    return args;
+}
 
 TEST_CASE("Parse empty circuit", "[parser]") {
     auto circuit = parse("");
@@ -785,6 +797,26 @@ TEST_CASE("Parse noise gates: DEPOLARIZE1 DEPOLARIZE2", "[parser][noise]") {
     REQUIRE(circuit.nodes[2].targets[1].value() == 3);
 }
 
+TEST_CASE("Parse noise gates: DEPOLARIZE3 consumes triples", "[parser][noise]") {
+    auto circuit = parse("DEPOLARIZE3(0.03) 0 1 2 3 4 5");
+
+    REQUIRE(circuit.nodes.size() == 2);
+    REQUIRE(circuit.num_qubits == 6);
+    REQUIRE(circuit.nodes[0].gate == GateType::DEPOLARIZE3);
+    REQUIRE(circuit.nodes[0].args[0] == Catch::Approx(0.03));
+    REQUIRE(circuit.nodes[0].targets.size() == 3);
+    CHECK(circuit.nodes[0].targets[0].value() == 0);
+    CHECK(circuit.nodes[0].targets[1].value() == 1);
+    CHECK(circuit.nodes[0].targets[2].value() == 2);
+    CHECK(circuit.nodes[1].targets[0].value() == 3);
+    CHECK(circuit.nodes[1].targets[1].value() == 4);
+    CHECK(circuit.nodes[1].targets[2].value() == 5);
+}
+
+TEST_CASE("DEPOLARIZE3 rejects incomplete triples", "[parser][noise]") {
+    REQUIRE_THROWS_AS(parse("DEPOLARIZE3(0.03) 0 1 2 3"), ParseError);
+}
+
 TEST_CASE("Parse noisy measurement: M with readout noise decomposes", "[parser][noise]") {
     auto circuit = parse("M(0.001) 0");
 
@@ -1231,6 +1263,35 @@ TEST_CASE("Parse PAULI_CHANNEL_2 with 15 args", "[parser]") {
     CHECK(circuit.num_qubits == 2);
 }
 
+TEST_CASE("Parse PAULI_CHANNEL_3 with 63 args", "[parser]") {
+    auto circuit = parse("PAULI_CHANNEL_3(" + make_pauli_channel3_args(0.0) + ") 0 1 2");
+    REQUIRE(circuit.nodes.size() == 1);
+    CHECK(circuit.nodes[0].gate == GateType::PAULI_CHANNEL_3);
+    REQUIRE(circuit.nodes[0].args.size() == 63);
+    CHECK(circuit.num_qubits == 3);
+}
+
+TEST_CASE("Parse PAULI_CHANNEL_3 broadcasts over triples", "[parser]") {
+    auto circuit = parse("PAULI_CHANNEL_3(" + make_pauli_channel3_args(0.01) + ") 0 1 2 3 4 5");
+    REQUIRE(circuit.nodes.size() == 2);
+    CHECK(circuit.num_qubits == 6);
+
+    for (const auto& node : circuit.nodes) {
+        CHECK(node.gate == GateType::PAULI_CHANNEL_3);
+        REQUIRE(node.targets.size() == 3);
+        REQUIRE(node.args.size() == 63);
+        CHECK(node.args[0] == Catch::Approx(0.01));
+        CHECK(node.args[62] == Catch::Approx(0.01));
+    }
+
+    CHECK(circuit.nodes[0].targets[0].value() == 0);
+    CHECK(circuit.nodes[0].targets[1].value() == 1);
+    CHECK(circuit.nodes[0].targets[2].value() == 2);
+    CHECK(circuit.nodes[1].targets[0].value() == 3);
+    CHECK(circuit.nodes[1].targets[1].value() == 4);
+    CHECK(circuit.nodes[1].targets[2].value() == 5);
+}
+
 TEST_CASE("Parse PAULI_CHANNEL_1 broadcasts to multiple targets", "[parser]") {
     auto circuit = parse("PAULI_CHANNEL_1(0.1, 0.2, 0.3) 0 1 2");
     REQUIRE(circuit.nodes.size() == 3);
@@ -1286,6 +1347,10 @@ TEST_CASE("PAULI_CHANNEL_1 rejects wrong arg count", "[parser]") {
 
 TEST_CASE("PAULI_CHANNEL_2 rejects wrong arg count", "[parser]") {
     REQUIRE_THROWS_AS(parse("PAULI_CHANNEL_2(0.01, 0.02, 0.03) 0 1"), ParseError);
+}
+
+TEST_CASE("PAULI_CHANNEL_3 rejects wrong arg count", "[parser]") {
+    REQUIRE_THROWS_AS(parse("PAULI_CHANNEL_3(0.01, 0.02, 0.03) 0 1 2"), ParseError);
 }
 
 // =============================================================================
@@ -1461,12 +1526,16 @@ TEST_CASE("GateTraits: noise channels", "[gate_data]") {
     CHECK(is_noise_gate(GateType::Z_ERROR));
     CHECK(is_noise_gate(GateType::DEPOLARIZE1));
     CHECK(is_noise_gate(GateType::DEPOLARIZE2));
+    CHECK(is_noise_gate(GateType::DEPOLARIZE3));
     CHECK(is_noise_gate(GateType::PAULI_CHANNEL_1));
     CHECK(is_noise_gate(GateType::PAULI_CHANNEL_2));
+    CHECK(is_noise_gate(GateType::PAULI_CHANNEL_3));
     CHECK(is_noise_gate(GateType::READOUT_NOISE));
     CHECK(!is_noise_gate(GateType::M));
     CHECK(gate_arity(GateType::DEPOLARIZE2) == GateArity::PAIR);
     CHECK(gate_arity(GateType::PAULI_CHANNEL_2) == GateArity::PAIR);
+    CHECK(gate_arity(GateType::DEPOLARIZE3) == GateArity::TRIPLE);
+    CHECK(gate_arity(GateType::PAULI_CHANNEL_3) == GateArity::TRIPLE);
 }
 
 TEST_CASE("GateTraits: annotations are ANNOTATION arity", "[gate_data]") {


### PR DESCRIPTION
## Summary

Adds native support for three-qubit Pauli noise channels:

- `DEPOLARIZE3(p)` over target triples, lowered as one 63-channel noise site.
- `PAULI_CHANNEL_3(...)` with 63 disjoint non-identity Pauli alternatives in documented order.
- Python enum exposure, gate reference docs, and focused parser/frontend coverage.

Closes #148

## Test plan

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

Additional targeted checks run:

- `cmake --build build -j`
- `./build/tests/clifft_tests "*DEPOLARIZE3*"`
- `./build/tests/clifft_tests "*PAULI_CHANNEL_3*"`
- `./build/tests/clifft_tests "[parser]"`
- `./build/tests/clifft_tests "[frontend]"`
- Python smoke compile/sample with `DEPOLARIZE3`

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project Apache-2.0 license.
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.