### PR TITLE
feat: add parser rewrites for controlled gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ sampling, and stratified importance sampling for rare-event estimation.
 
 ## Installation
 
+<!--pytest.mark.skip-->
+
 ```bash
 pip install clifft
 ```

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -39,6 +39,18 @@ Clifft extends Stim with discrete and arbitrary-angle non-Clifford gates. These 
 | `T` | $\pi/8$ gate |
 | `T_DAG` | Inverse $\pi/8$ gate |
 
+### Rewrite Gates
+
+These gate names are accepted by the parser as fixed rewrite rules into
+Clifft-native gates. They are rewritten during parsing and do not appear as
+distinct frontend, backend, or VM gate types.
+
+| Gate | Syntax | Notes |
+|------|--------|-------|
+| `CH` | `CH c t` | Controlled-Hadamard; rewritten to `R_Y(0.25) t; CX c t; R_Y(-0.25) t` |
+| `CCZ` | `CCZ a b c` | Controlled-controlled-Z; rewritten to 7 `T`/`T_DAG` gates and 6 `CX` gates |
+| `CCX` | `CCX a b t` | Toffoli gate; rewritten as `H t; CCZ a b t; H t` |
+
 ### Continuous Rotations
 
 Clifft extends the Stim gate set with arbitrary-angle rotation gates. All angle

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -222,6 +222,23 @@ class Parser {
             return;
         }
 
+        // Parser-only rewrite gates. They are lowered immediately so the
+        // AST never contains frontend/backend-visible CH, CCZ, or CCX nodes.
+        if (gate_name == "CH") {
+            if (!args.empty()) {
+                throw ParseError("CH takes no arguments", line_num);
+            }
+            parse_ch_rewrite(rest, line_num, circuit);
+            return;
+        }
+        if (gate_name == "CCZ" || gate_name == "CCX") {
+            if (!args.empty()) {
+                throw ParseError(std::string(gate_name) + " takes no arguments", line_num);
+            }
+            parse_three_qubit_rewrite(gate_name, rest, line_num, circuit);
+            return;
+        }
+
         // Look up gate type.
         GateType gate = find_gate(gate_name);
         if (gate == GateType::UNKNOWN) {
@@ -281,6 +298,122 @@ class Parser {
             default:
                 parse_standard_gate(gate, rest, line_num, circuit, arg, args);
                 break;
+        }
+    }
+
+    void append_rewrite_single(GateType gate, uint32_t qubit, uint32_t line_num, Circuit& circuit,
+                               std::vector<double> args = {}) {
+        AstNode node{gate, {Target::qubit(qubit)}, std::move(args), line_num};
+        update_circuit_stats(node, circuit);
+        circuit.nodes.push_back(std::move(node));
+    }
+
+    void append_rewrite_pair(GateType gate, uint32_t q0, uint32_t q1, uint32_t line_num,
+                             Circuit& circuit) {
+        AstNode node{gate, {Target::qubit(q0), Target::qubit(q1)}, {}, line_num};
+        update_circuit_stats(node, circuit);
+        circuit.nodes.push_back(std::move(node));
+    }
+
+    void append_ccz_decomposition(uint32_t a, uint32_t b, uint32_t c, uint32_t line_num,
+                                  Circuit& circuit) {
+        // Phase polynomial:
+        // 4abc = a + b + c - (a^b) - (a^c) - (b^c) + (a^b^c).
+        append_rewrite_single(GateType::T, a, line_num, circuit);
+        append_rewrite_single(GateType::T, b, line_num, circuit);
+        append_rewrite_single(GateType::T, c, line_num, circuit);
+        append_rewrite_pair(GateType::CX, a, b, line_num, circuit);
+        append_rewrite_single(GateType::T_DAG, b, line_num, circuit);
+        append_rewrite_pair(GateType::CX, a, b, line_num, circuit);
+        append_rewrite_pair(GateType::CX, a, c, line_num, circuit);
+        append_rewrite_single(GateType::T_DAG, c, line_num, circuit);
+        append_rewrite_pair(GateType::CX, b, c, line_num, circuit);
+        append_rewrite_single(GateType::T, c, line_num, circuit);
+        append_rewrite_pair(GateType::CX, a, c, line_num, circuit);
+        append_rewrite_single(GateType::T_DAG, c, line_num, circuit);
+        append_rewrite_pair(GateType::CX, b, c, line_num, circuit);
+    }
+
+    std::vector<Target> parse_plain_qubit_targets(std::string_view gate_name,
+                                                  std::string_view targets_str, uint32_t line_num,
+                                                  Circuit& circuit) {
+        std::vector<Target> targets;
+        std::string_view remaining = targets_str;
+
+        while (true) {
+            std::string_view token = next_token(remaining);
+            if (token.empty())
+                break;
+
+            if (targets.size() >= kMaxTargetsPerInstruction) {
+                throw ParseError(
+                    "Too many targets (limit: " + std::to_string(kMaxTargetsPerInstruction) + ")",
+                    line_num);
+            }
+
+            Target target = parse_target(token, line_num, circuit);
+            if (target.is_rec()) {
+                throw ParseError("Gate " + std::string(gate_name) + " does not accept rec targets",
+                                 line_num);
+            }
+            if (target.is_inverted()) {
+                throw ParseError(
+                    "Gate " + std::string(gate_name) + " does not accept inverted targets",
+                    line_num);
+            }
+            targets.push_back(target);
+        }
+        return targets;
+    }
+
+    void parse_ch_rewrite(std::string_view targets_str, uint32_t line_num, Circuit& circuit) {
+        std::vector<Target> targets =
+            parse_plain_qubit_targets("CH", targets_str, line_num, circuit);
+
+        if (targets.empty() || targets.size() % 2 != 0) {
+            throw ParseError("Gate CH requires pairs of targets", line_num);
+        }
+
+        for (size_t i = 0; i < targets.size(); i += 2) {
+            uint32_t control = targets[i].value();
+            uint32_t target = targets[i + 1].value();
+            if (control == target) {
+                throw ParseError("Gate CH requires distinct qubit targets", line_num);
+            }
+
+            append_rewrite_single(GateType::R_Y, target, line_num, circuit, {0.25});
+            append_rewrite_pair(GateType::CX, control, target, line_num, circuit);
+            append_rewrite_single(GateType::R_Y, target, line_num, circuit, {-0.25});
+        }
+    }
+
+    void parse_three_qubit_rewrite(std::string_view gate_name, std::string_view targets_str,
+                                   uint32_t line_num, Circuit& circuit) {
+        std::vector<Target> targets =
+            parse_plain_qubit_targets(gate_name, targets_str, line_num, circuit);
+
+        if (targets.empty() || targets.size() % 3 != 0) {
+            throw ParseError("Gate " + std::string(gate_name) + " requires triples of targets",
+                             line_num);
+        }
+
+        for (size_t i = 0; i < targets.size(); i += 3) {
+            uint32_t a = targets[i].value();
+            uint32_t b = targets[i + 1].value();
+            uint32_t c = targets[i + 2].value();
+            if (a == b || a == c || b == c) {
+                throw ParseError(
+                    "Gate " + std::string(gate_name) + " requires distinct qubit targets",
+                    line_num);
+            }
+
+            if (gate_name == "CCX") {
+                append_rewrite_single(GateType::H, c, line_num, circuit);
+            }
+            append_ccz_decomposition(a, b, c, line_num, circuit);
+            if (gate_name == "CCX") {
+                append_rewrite_single(GateType::H, c, line_num, circuit);
+            }
         }
     }
 

--- a/src/clifft/circuit/parser.h
+++ b/src/clifft/circuit/parser.h
@@ -11,6 +11,9 @@
 //
 // Parser transformations:
 // - MPP X0*Z1 X2 -> two separate AstNodes (unrolling)
+// - CH c t -> R_Y(0.25) t, CX c t, R_Y(-0.25) t
+// - CCZ a b c -> 7 T/T_DAG gates + 6 CX gates
+// - CCX a b t -> H t, CCZ a b t, H t
 //
 // REPEAT handling:
 // - REPEAT N { ... } blocks are unrolled at parse time via text-level replay.

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -122,6 +122,30 @@ class TestQiskitStatevectorOracle:
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equal(clifft_sv, qiskit_sv)
 
+    def test_ch_gate(self) -> None:
+        """CH parser rewrite matches Qiskit."""
+        circuit = "H 0\nCH 0 1"
+        clifft_sv = _clifft_statevector(circuit)
+        qc = stim_to_qiskit_noiseless(circuit)
+        qiskit_sv = qiskit_statevector(qc)
+        assert_statevectors_equal(clifft_sv, qiskit_sv)
+
+    def test_ccz_gate(self) -> None:
+        """CCZ parser rewrite matches Qiskit."""
+        circuit = "H 0\nH 1\nH 2\nCCZ 0 1 2"
+        clifft_sv = _clifft_statevector(circuit)
+        qc = stim_to_qiskit_noiseless(circuit)
+        qiskit_sv = qiskit_statevector(qc)
+        assert_statevectors_equal(clifft_sv, qiskit_sv)
+
+    def test_ccx_gate(self) -> None:
+        """CCX parser rewrite matches Qiskit."""
+        circuit = "H 0\nH 1\nCCX 0 1 2"
+        clifft_sv = _clifft_statevector(circuit)
+        qc = stim_to_qiskit_noiseless(circuit)
+        qiskit_sv = qiskit_statevector(qc)
+        assert_statevectors_equal(clifft_sv, qiskit_sv)
+
     def test_deep_t_circuit(self) -> None:
         """Deep circuit with many T gates tests accumulation accuracy."""
         lines = ["H 0", "H 1"]

--- a/tests/python/utils_qiskit.py
+++ b/tests/python/utils_qiskit.py
@@ -4,8 +4,9 @@ Translates noiseless Clifford+T circuits from .stim text format into
 Qiskit QuantumCircuit objects. Used as an independent oracle for
 statevector validation against Clifft.
 
-Supported gates: H, S, S_DAG, T, T_DAG, X, Y, Z, CX, CY, CZ, M, MX, MY, R, RX, MR, MRX,
-R_X, R_Y, R_Z, U3, R_XX, R_YY, R_ZZ, R_PAULI.
+Supported gates: H, S, S_DAG, T, T_DAG, X, Y, Z, CX, CY, CZ, CH, CCZ, CCX,
+M, MX, MY, R, RX, MR, MRX, R_X, R_Y, R_Z, U3, R_XX, R_YY, R_ZZ,
+R_PAULI.
 All rotation angles use half-turn units (alpha * pi = radians).
 Noise instructions and annotations (TICK, DETECTOR, etc.) are skipped.
 """
@@ -278,6 +279,33 @@ def _apply_gate(
             raise ValueError(f"CZ requires even number of targets, got {len(targets)}")
         for i in range(0, len(targets), 2):
             qc.cz(targets[i], targets[i + 1])
+    elif gate == "CH":
+        if len(targets) % 2 != 0:
+            raise ValueError(f"CH requires even number of targets, got {len(targets)}")
+        for i in range(0, len(targets), 2):
+            control = targets[i]
+            target = targets[i + 1]
+            # Aer does not assemble opaque CH instructions in all supported
+            # versions, so use Qiskit's CHGate definition in basis gates.
+            qc.s(target)
+            qc.h(target)
+            qc.t(target)
+            qc.cx(control, target)
+            qc.tdg(target)
+            qc.h(target)
+            qc.sdg(target)
+    elif gate == "CCZ":
+        if len(targets) % 3 != 0:
+            raise ValueError(f"CCZ requires multiple of 3 targets, got {len(targets)}")
+        for i in range(0, len(targets), 3):
+            qc.h(targets[i + 2])
+            qc.ccx(targets[i], targets[i + 1], targets[i + 2])
+            qc.h(targets[i + 2])
+    elif gate == "CCX":
+        if len(targets) % 3 != 0:
+            raise ValueError(f"CCX requires multiple of 3 targets, got {len(targets)}")
+        for i in range(0, len(targets), 3):
+            qc.ccx(targets[i], targets[i + 1], targets[i + 2])
     elif gate == "M":
         for q in targets:
             qc.measure(q, clbit_idx)

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -16,6 +16,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <string>
+#include <vector>
 
 using namespace clifft;
 
@@ -136,6 +137,138 @@ TEST_CASE("Parse CNOT alias", "[parser]") {
 
     REQUIRE(circuit.nodes.size() == 1);
     REQUIRE(circuit.nodes[0].gate == GateType::CX);
+}
+
+TEST_CASE("Parse CH rewrites to RY CX RY sequence", "[parser]") {
+    auto circuit = parse("CH 0 1");
+
+    REQUIRE(circuit.nodes.size() == 3);
+    CHECK(circuit.num_qubits == 2);
+    CHECK(circuit.num_measurements == 0);
+
+    CHECK(circuit.nodes[0].gate == GateType::R_Y);
+    REQUIRE(circuit.nodes[0].args.size() == 1);
+    CHECK(circuit.nodes[0].args[0] == Catch::Approx(0.25));
+    CHECK(circuit.nodes[0].targets[0].value() == 1);
+
+    CHECK(circuit.nodes[1].gate == GateType::CX);
+    CHECK(circuit.nodes[1].targets[0].value() == 0);
+    CHECK(circuit.nodes[1].targets[1].value() == 1);
+
+    CHECK(circuit.nodes[2].gate == GateType::R_Y);
+    REQUIRE(circuit.nodes[2].args.size() == 1);
+    CHECK(circuit.nodes[2].args[0] == Catch::Approx(-0.25));
+    CHECK(circuit.nodes[2].targets[0].value() == 1);
+
+    for (const auto& node : circuit.nodes) {
+        CHECK(node.source_line == 1);
+    }
+}
+
+TEST_CASE("Parse CH supports multiple pairs", "[parser]") {
+    auto circuit = parse("CH 0 1 2 3");
+
+    REQUIRE(circuit.nodes.size() == 6);
+    CHECK(circuit.num_qubits == 4);
+    CHECK(circuit.nodes[0].targets[0].value() == 1);
+    CHECK(circuit.nodes[3].targets[0].value() == 3);
+}
+
+TEST_CASE("Parse CH rejects malformed targets", "[parser]") {
+    CHECK_THROWS_AS(parse("CH 0"), ParseError);
+    CHECK_THROWS_AS(parse("CH(0.1) 0 1"), ParseError);
+    CHECK_THROWS_AS(parse("M 0\nCH rec[-1] 1"), ParseError);
+    CHECK_THROWS_AS(parse("CH !0 1"), ParseError);
+    CHECK_THROWS_AS(parse("CH 0 0"), ParseError);
+    CHECK_THROWS_AS(parse("CH 0 1", 2), ParseError);
+}
+
+TEST_CASE("Parse CCZ rewrites to Clifford T sequence", "[parser]") {
+    auto circuit = parse("CCZ 0 1 2");
+
+    struct ExpectedNode {
+        GateType gate;
+        std::vector<uint32_t> targets;
+    };
+
+    const std::vector<ExpectedNode> expected = {
+        {GateType::T, {0}},     {GateType::T, {1}},     {GateType::T, {2}},
+        {GateType::CX, {0, 1}}, {GateType::T_DAG, {1}}, {GateType::CX, {0, 1}},
+        {GateType::CX, {0, 2}}, {GateType::T_DAG, {2}}, {GateType::CX, {1, 2}},
+        {GateType::T, {2}},     {GateType::CX, {0, 2}}, {GateType::T_DAG, {2}},
+        {GateType::CX, {1, 2}},
+    };
+
+    REQUIRE(circuit.nodes.size() == expected.size());
+    CHECK(circuit.num_qubits == 3);
+    CHECK(circuit.num_measurements == 0);
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        const auto& node = circuit.nodes[i];
+        CHECK(node.gate == expected[i].gate);
+        REQUIRE(node.targets.size() == expected[i].targets.size());
+        for (size_t j = 0; j < expected[i].targets.size(); ++j) {
+            CHECK(node.targets[j].value() == expected[i].targets[j]);
+        }
+        CHECK(node.args.empty());
+        CHECK(node.source_line == 1);
+    }
+}
+
+TEST_CASE("Parse CCX wraps CCZ rewrite in H gates", "[parser]") {
+    auto circuit = parse("CCX 0 1 2");
+
+    REQUIRE(circuit.nodes.size() == 15);
+    CHECK(circuit.num_qubits == 3);
+    CHECK(circuit.num_measurements == 0);
+
+    CHECK(circuit.nodes.front().gate == GateType::H);
+    CHECK(circuit.nodes.front().targets[0].value() == 2);
+    CHECK(circuit.nodes.back().gate == GateType::H);
+    CHECK(circuit.nodes.back().targets[0].value() == 2);
+
+    size_t h_count = 0;
+    size_t t_count = 0;
+    size_t t_dag_count = 0;
+    size_t cx_count = 0;
+    for (const auto& node : circuit.nodes) {
+        if (node.gate == GateType::H)
+            h_count++;
+        if (node.gate == GateType::T)
+            t_count++;
+        if (node.gate == GateType::T_DAG)
+            t_dag_count++;
+        if (node.gate == GateType::CX)
+            cx_count++;
+        CHECK(node.source_line == 1);
+    }
+
+    CHECK(h_count == 2);
+    CHECK(t_count == 4);
+    CHECK(t_dag_count == 3);
+    CHECK(cx_count == 6);
+}
+
+TEST_CASE("Parse CCZ supports multiple triples", "[parser]") {
+    auto circuit = parse("CCZ 0 1 2 3 4 5");
+
+    REQUIRE(circuit.nodes.size() == 26);
+    CHECK(circuit.num_qubits == 6);
+    CHECK(circuit.nodes[0].gate == GateType::T);
+    CHECK(circuit.nodes[0].targets[0].value() == 0);
+    CHECK(circuit.nodes[13].gate == GateType::T);
+    CHECK(circuit.nodes[13].targets[0].value() == 3);
+}
+
+TEST_CASE("Parse CCZ and CCX reject malformed targets", "[parser]") {
+    CHECK_THROWS_AS(parse("CCZ 0 1"), ParseError);
+    CHECK_THROWS_AS(parse("CCX 0 1 2 3"), ParseError);
+    CHECK_THROWS_AS(parse("CCZ(0.1) 0 1 2"), ParseError);
+    CHECK_THROWS_AS(parse("M 0\nCCZ rec[-1] 1 2"), ParseError);
+    CHECK_THROWS_AS(parse("CCX !0 1 2"), ParseError);
+    CHECK_THROWS_AS(parse("CCZ 0 0 1"), ParseError);
+    CHECK_THROWS_AS(parse("CCX 0 1 1"), ParseError);
+    CHECK_THROWS_AS(parse("CCZ 0 1 2", 12), ParseError);
 }
 
 TEST_CASE("Parse measurements", "[parser]") {

--- a/tests/test_statevector.cc
+++ b/tests/test_statevector.cc
@@ -631,6 +631,50 @@ TEST_CASE("E2E: GHZ state on 3 qubits") {
     check_normalized(sv, kFloatTol);
 }
 
+TEST_CASE("E2E: CH applies Hadamard only when control is one") {
+    auto sv = pipeline_statevector("X 0\nCH 0 1");
+    REQUIRE(sv.size() == 4);
+
+    check_complex(sv[0], {0.0, 0.0}, kFloatTol);
+    check_complex(sv[1], {kInvSqrt2, 0.0}, kFloatTol);
+    check_complex(sv[2], {0.0, 0.0}, kFloatTol);
+    check_complex(sv[3], {kInvSqrt2, 0.0}, kFloatTol);
+    check_normalized(sv, kFloatTol);
+
+    auto sv_control_off = pipeline_statevector("X 1\nCH 0 1");
+    REQUIRE(sv_control_off.size() == 4);
+    check_complex(sv_control_off[0], {0.0, 0.0}, kFloatTol);
+    check_complex(sv_control_off[1], {0.0, 0.0}, kFloatTol);
+    check_complex(sv_control_off[2], {1.0, 0.0}, kFloatTol);
+    check_complex(sv_control_off[3], {0.0, 0.0}, kFloatTol);
+    check_normalized(sv_control_off, kFloatTol);
+}
+
+TEST_CASE("E2E: CCZ flips only all ones phase") {
+    auto sv = pipeline_statevector("H 0\nH 1\nH 2\nCCZ 0 1 2");
+    REQUIRE(sv.size() == 8);
+
+    double amp = 1.0 / std::sqrt(8.0);
+    for (size_t i = 0; i < sv.size(); ++i) {
+        check_complex(sv[i],
+                      i == 7 ? std::complex<double>{-amp, 0.0} : std::complex<double>{amp, 0.0},
+                      kFloatTol);
+    }
+    check_normalized(sv, kFloatTol);
+}
+
+TEST_CASE("E2E: CCX flips target when both controls are one") {
+    auto sv = pipeline_statevector("X 0\nX 1\nCCX 0 1 2");
+    REQUIRE(sv.size() == 8);
+
+    for (size_t i = 0; i < sv.size(); ++i) {
+        check_complex(sv[i],
+                      i == 7 ? std::complex<double>{1.0, 0.0} : std::complex<double>{0.0, 0.0},
+                      kFloatTol);
+    }
+    check_normalized(sv, kFloatTol);
+}
+
 TEST_CASE("E2E: dense Clifford plus T on 4 qubits") {
     // A non-trivial 4-qubit circuit with entanglement and T gates.
     // We verify normalization and that the state is non-trivial (not all-zero


### PR DESCRIPTION
## Summary

Adds parser-only rewrite gates for controlled gates using existing Clifft gate support:

- `CH c t` rewrites to `R_Y(0.25) t; CX c t; R_Y(-0.25) t`.
- `CCZ a b c` rewrites to the textbook 7-T / 6-CX sequence.
- `CCX a b t` rewrites to `H t; CCZ a b t; H t`.

The PR also documents these rewrite gates and adds C++ parser/statevector coverage plus Qiskit-Aer oracle coverage for CH, CCZ, and CCX.

Closes #150.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

Additional focused checks:

- `cmake --build build`
- `build/tests/clifft_tests "Parse CH rewrites to RY CX RY sequence"`
- `build/tests/clifft_tests "Parse CCZ rewrites to Clifford T sequence"`
- `uv run pytest tests/python/test_qiskit_aer.py::TestQiskitStatevectorOracle::test_ch_gate tests/python/test_qiskit_aer.py::TestQiskitStatevectorOracle::test_ccz_gate tests/python/test_qiskit_aer.py::TestQiskitStatevectorOracle::test_ccx_gate -q`

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project Apache-2.0 license.
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.