### PR TITLE
chore: deduplicate Pauli parsing and noise rewind

### DIFF
--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -809,238 +809,9 @@ class Parser {
         return inverted ? result.inverted() : result;
     }
 
-    // Parse MPP instruction with multiple Pauli products.
-    void parse_mpp(std::string_view targets_str, uint32_t line_num, Circuit& circuit, double arg) {
-        std::string_view remaining = targets_str;
-        uint32_t product_count = 0;
-
-        while (true) {
-            std::string_view product_str = next_token(remaining);
-            if (product_str.empty())
-                break;
-
-            if (product_count >= kMaxTargetsPerInstruction) {
-                throw ParseError("Too many MPP products (limit: " +
-                                     std::to_string(kMaxTargetsPerInstruction) + ")",
-                                 line_num);
-            }
-            product_count++;
-
-            // Each product is like "X0*Z1*Y2".
-            std::vector<Target> pauli_targets;
-            std::unordered_set<uint32_t> seen_qubits;
-
-            size_t pos = 0;
-            while (pos < product_str.size()) {
-                // Handle '*' separator with validation.
-                if (product_str[pos] == '*') {
-                    // Disallow leading, trailing, or consecutive '*' characters.
-                    if (pos == 0 || pos + 1 >= product_str.size() || product_str[pos + 1] == '*') {
-                        throw ParseError("Malformed Pauli product in MPP: misplaced '*'", line_num);
-                    }
-                    pos++;
-                    continue;
-                }
-
-                // Parse Pauli letter.
-                char pauli_char = product_str[pos];
-                uint32_t pauli_flag;
-                switch (pauli_char) {
-                    case 'X':
-                        pauli_flag = Target::kPauliX;
-                        break;
-                    case 'Y':
-                        pauli_flag = Target::kPauliY;
-                        break;
-                    case 'Z':
-                        pauli_flag = Target::kPauliZ;
-                        break;
-                    default:
-                        throw ParseError("Invalid Pauli in MPP: " + std::string(1, pauli_char),
-                                         line_num);
-                }
-                pos++;
-
-                // Parse qubit index.
-                size_t num_start = pos;
-                while (pos < product_str.size() && std::isdigit(product_str[pos])) {
-                    pos++;
-                }
-
-                if (num_start == pos) {
-                    throw ParseError("Expected qubit index after Pauli letter", line_num);
-                }
-
-                uint32_t qubit;
-                if (!parse_uint(std::string_view(product_str).substr(num_start, pos - num_start),
-                                qubit)) {
-                    throw ParseError("Invalid qubit index in MPP", line_num);
-                }
-
-                // Validate qubit index fits in 28-bit encoding.
-                if (qubit >= (1u << 28)) {
-                    throw ParseError("Qubit index too large (must be < 2^28)", line_num);
-                }
-
-                if (!seen_qubits.insert(qubit).second) {
-                    throw ParseError("Duplicate qubit in MPP product", line_num);
-                }
-
-                if (pauli_targets.size() >= kMaxTargetsPerInstruction) {
-                    throw ParseError("Too many Pauli terms in product (limit: " +
-                                         std::to_string(kMaxTargetsPerInstruction) + ")",
-                                     line_num);
-                }
-
-                pauli_targets.push_back(Target::pauli(qubit, pauli_flag));
-
-                // Update max qubit.
-                circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
-            }
-
-            if (pauli_targets.empty()) {
-                throw ParseError("Empty Pauli product in MPP", line_num);
-            }
-
-            // Decompose noisy MPP: MPP(p) -> MPP + READOUT_NOISE
-            bool is_noisy_meas = arg > 0.0;
-
-            // Emit one AstNode per product.
-            // MPP is a visible measurement.
-            AstNode node{GateType::MPP, std::move(pauli_targets), {}, line_num};
-            circuit.num_measurements++;
-            circuit.nodes.push_back(std::move(node));
-
-            if (is_noisy_meas) {
-                uint32_t meas_idx = circuit.num_measurements - 1;
-                circuit.nodes.push_back(
-                    {GateType::READOUT_NOISE, {Target::rec(meas_idx)}, {arg}, line_num});
-            }
-        }
-
-        if (product_count == 0) {
-            throw ParseError("MPP requires at least one Pauli product", line_num);
-        }
-    }
-
-    // Parse EXP_VAL instruction with multiple Pauli products.
-    // Same Pauli product syntax as MPP but no noise argument.
-    // Increments num_exp_vals (not num_measurements).
-    void parse_exp_val(std::string_view targets_str, uint32_t line_num, Circuit& circuit) {
-        std::string_view remaining = targets_str;
-        uint32_t product_count = 0;
-
-        while (true) {
-            std::string_view product_str = next_token(remaining);
-            if (product_str.empty())
-                break;
-
-            if (product_count >= kMaxTargetsPerInstruction) {
-                throw ParseError("Too many EXP_VAL products (limit: " +
-                                     std::to_string(kMaxTargetsPerInstruction) + ")",
-                                 line_num);
-            }
-            product_count++;
-
-            // Each product is like "X0*Z1*Y2".
-            std::vector<Target> pauli_targets;
-            std::unordered_set<uint32_t> seen_qubits;
-
-            size_t pos = 0;
-            while (pos < product_str.size()) {
-                // Handle '*' separator with validation.
-                if (product_str[pos] == '*') {
-                    if (pos == 0 || pos + 1 >= product_str.size() || product_str[pos + 1] == '*') {
-                        throw ParseError("Malformed Pauli product in EXP_VAL: misplaced '*'",
-                                         line_num);
-                    }
-                    pos++;
-                    continue;
-                }
-
-                // Parse Pauli letter.
-                char pauli_char = product_str[pos];
-                uint32_t pauli_flag;
-                switch (pauli_char) {
-                    case 'X':
-                        pauli_flag = Target::kPauliX;
-                        break;
-                    case 'Y':
-                        pauli_flag = Target::kPauliY;
-                        break;
-                    case 'Z':
-                        pauli_flag = Target::kPauliZ;
-                        break;
-                    default:
-                        throw ParseError("Invalid Pauli in EXP_VAL: " + std::string(1, pauli_char),
-                                         line_num);
-                }
-                pos++;
-
-                // Parse qubit index.
-                size_t num_start = pos;
-                while (pos < product_str.size() && std::isdigit(product_str[pos])) {
-                    pos++;
-                }
-
-                if (num_start == pos) {
-                    throw ParseError("Expected qubit index after Pauli letter", line_num);
-                }
-
-                uint32_t qubit;
-                if (!parse_uint(std::string_view(product_str).substr(num_start, pos - num_start),
-                                qubit)) {
-                    throw ParseError("Invalid qubit index in EXP_VAL", line_num);
-                }
-
-                if (qubit >= (1u << 28)) {
-                    throw ParseError("Qubit index too large (must be < 2^28)", line_num);
-                }
-
-                if (!seen_qubits.insert(qubit).second) {
-                    throw ParseError("Duplicate qubit in EXP_VAL product", line_num);
-                }
-
-                if (pauli_targets.size() >= kMaxTargetsPerInstruction) {
-                    throw ParseError("Too many Pauli terms in product (limit: " +
-                                         std::to_string(kMaxTargetsPerInstruction) + ")",
-                                     line_num);
-                }
-
-                pauli_targets.push_back(Target::pauli(qubit, pauli_flag));
-                circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
-            }
-
-            if (pauli_targets.empty()) {
-                throw ParseError("Empty Pauli product in EXP_VAL", line_num);
-            }
-
-            // Emit one AstNode per product.
-            AstNode node{GateType::EXP_VAL, std::move(pauli_targets), {}, line_num};
-            circuit.num_exp_vals++;
-            circuit.nodes.push_back(std::move(node));
-        }
-
-        if (product_count == 0) {
-            throw ParseError("EXP_VAL requires at least one Pauli product", line_num);
-        }
-    }
-
-    // Parse R_PAULI instruction: R_PAULI(alpha) X0*Y1*Z2
-    // Exactly one Pauli product with the rotation angle from args[0].
-    void parse_r_pauli(std::string_view targets_str, uint32_t line_num, Circuit& circuit,
-                       const std::vector<double>& args) {
-        std::string_view product_str = next_token(targets_str);
-        if (product_str.empty()) {
-            throw ParseError("R_PAULI requires a Pauli product (e.g. X0*Y1*Z2)", line_num);
-        }
-
-        // Check no extra tokens.
-        std::string_view extra = next_token(targets_str);
-        if (!extra.empty()) {
-            throw ParseError("R_PAULI takes exactly one Pauli product", line_num);
-        }
-
+    std::vector<Target> parse_pauli_product(std::string_view product_str,
+                                            std::string_view gate_name, uint32_t line_num,
+                                            Circuit& circuit) {
         std::vector<Target> pauli_targets;
         std::unordered_set<uint32_t> seen_qubits;
 
@@ -1048,7 +819,9 @@ class Parser {
         while (pos < product_str.size()) {
             if (product_str[pos] == '*') {
                 if (pos == 0 || pos + 1 >= product_str.size() || product_str[pos + 1] == '*') {
-                    throw ParseError("Malformed Pauli product in R_PAULI: misplaced '*'", line_num);
+                    throw ParseError(
+                        "Malformed Pauli product in " + std::string(gate_name) + ": misplaced '*'",
+                        line_num);
                 }
                 pos++;
                 continue;
@@ -1067,24 +840,30 @@ class Parser {
                     pauli_flag = Target::kPauliZ;
                     break;
                 default:
-                    throw ParseError("Invalid Pauli in R_PAULI: " + std::string(1, pauli_char),
+                    throw ParseError("Invalid Pauli in " + std::string(gate_name) + ": " +
+                                         std::string(1, pauli_char),
                                      line_num);
             }
             pos++;
 
             size_t num_start = pos;
-            while (pos < product_str.size() && std::isdigit(product_str[pos])) {
+            while (pos < product_str.size() &&
+                   std::isdigit(static_cast<unsigned char>(product_str[pos]))) {
                 pos++;
             }
 
             if (num_start == pos) {
-                throw ParseError("Expected qubit index after Pauli letter in R_PAULI", line_num);
+                std::string msg = "Expected qubit index after Pauli letter";
+                if (gate_name == "R_PAULI") {
+                    msg += " in R_PAULI";
+                }
+                throw ParseError(msg, line_num);
             }
 
             uint32_t qubit;
             if (!parse_uint(std::string_view(product_str).substr(num_start, pos - num_start),
                             qubit)) {
-                throw ParseError("Invalid qubit index in R_PAULI", line_num);
+                throw ParseError("Invalid qubit index in " + std::string(gate_name), line_num);
             }
 
             if (qubit >= (1u << 28)) {
@@ -1092,19 +871,108 @@ class Parser {
             }
 
             if (!seen_qubits.insert(qubit).second) {
-                throw ParseError("Duplicate qubit in R_PAULI product", line_num);
+                throw ParseError("Duplicate qubit in " + std::string(gate_name) + " product",
+                                 line_num);
             }
 
             if (pauli_targets.size() >= kMaxTargetsPerInstruction) {
-                throw ParseError("Too many Pauli terms in R_PAULI product", line_num);
+                if (gate_name == "R_PAULI") {
+                    throw ParseError("Too many Pauli terms in R_PAULI product", line_num);
+                }
+                throw ParseError("Too many Pauli terms in product (limit: " +
+                                     std::to_string(kMaxTargetsPerInstruction) + ")",
+                                 line_num);
             }
+
             pauli_targets.push_back(Target::pauli(qubit, pauli_flag));
             circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
         }
 
         if (pauli_targets.empty()) {
-            throw ParseError("Empty Pauli product in R_PAULI", line_num);
+            throw ParseError("Empty Pauli product in " + std::string(gate_name), line_num);
         }
+
+        return pauli_targets;
+    }
+
+    std::vector<std::vector<Target>> parse_pauli_products(std::string_view targets_str,
+                                                          std::string_view gate_name,
+                                                          uint32_t line_num, Circuit& circuit) {
+        std::vector<std::vector<Target>> products;
+        std::string_view remaining = targets_str;
+
+        while (true) {
+            std::string_view product_str = next_token(remaining);
+            if (product_str.empty())
+                break;
+
+            if (products.size() >= kMaxTargetsPerInstruction) {
+                throw ParseError("Too many " + std::string(gate_name) + " products (limit: " +
+                                     std::to_string(kMaxTargetsPerInstruction) + ")",
+                                 line_num);
+            }
+
+            products.push_back(parse_pauli_product(product_str, gate_name, line_num, circuit));
+        }
+
+        if (products.empty()) {
+            throw ParseError(std::string(gate_name) + " requires at least one Pauli product",
+                             line_num);
+        }
+
+        return products;
+    }
+
+    // Parse MPP instruction with multiple Pauli products.
+    void parse_mpp(std::string_view targets_str, uint32_t line_num, Circuit& circuit, double arg) {
+        auto products = parse_pauli_products(targets_str, "MPP", line_num, circuit);
+        for (auto& pauli_targets : products) {
+            // Decompose noisy MPP: MPP(p) -> MPP + READOUT_NOISE
+            bool is_noisy_meas = arg > 0.0;
+
+            // Emit one AstNode per product.
+            // MPP is a visible measurement.
+            AstNode node{GateType::MPP, std::move(pauli_targets), {}, line_num};
+            circuit.num_measurements++;
+            circuit.nodes.push_back(std::move(node));
+
+            if (is_noisy_meas) {
+                uint32_t meas_idx = circuit.num_measurements - 1;
+                circuit.nodes.push_back(
+                    {GateType::READOUT_NOISE, {Target::rec(meas_idx)}, {arg}, line_num});
+            }
+        }
+    }
+
+    // Parse EXP_VAL instruction with multiple Pauli products.
+    // Same Pauli product syntax as MPP but no noise argument.
+    // Increments num_exp_vals (not num_measurements).
+    void parse_exp_val(std::string_view targets_str, uint32_t line_num, Circuit& circuit) {
+        auto products = parse_pauli_products(targets_str, "EXP_VAL", line_num, circuit);
+        for (auto& pauli_targets : products) {
+            // Emit one AstNode per product.
+            AstNode node{GateType::EXP_VAL, std::move(pauli_targets), {}, line_num};
+            circuit.num_exp_vals++;
+            circuit.nodes.push_back(std::move(node));
+        }
+    }
+
+    // Parse R_PAULI instruction: R_PAULI(alpha) X0*Y1*Z2
+    // Exactly one Pauli product with the rotation angle from args[0].
+    void parse_r_pauli(std::string_view targets_str, uint32_t line_num, Circuit& circuit,
+                       const std::vector<double>& args) {
+        std::string_view product_str = next_token(targets_str);
+        if (product_str.empty()) {
+            throw ParseError("R_PAULI requires a Pauli product (e.g. X0*Y1*Z2)", line_num);
+        }
+
+        // Check no extra tokens.
+        std::string_view extra = next_token(targets_str);
+        if (!extra.empty()) {
+            throw ParseError("R_PAULI takes exactly one Pauli product", line_num);
+        }
+
+        auto pauli_targets = parse_pauli_product(product_str, "R_PAULI", line_num, circuit);
 
         circuit.nodes.push_back({GateType::R_PAULI, std::move(pauli_targets), args, line_num});
     }

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -3,6 +3,7 @@
 #include "stim.h"
 
 #include <cmath>
+#include <initializer_list>
 #include <numbers>
 #include <random>
 #include <stdexcept>
@@ -134,50 +135,31 @@ void accumulate_pauli_row(const stim::Tableau<kStimWidth>& tab, uint32_t qubit, 
     }
 }
 
-/// Rewind a single-qubit Pauli (X, Y, or Z) through the tableau into a
-/// freshly claimed noise_channel_masks slot. Returns the channel.
-NoiseChannel rewind_single_pauli(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
-                                 uint32_t qubit, int pauli_type, double prob) {
-    auto h = hir.claim_empty_noise_channel_mask();
-    auto slot = hir.noise_channel_masks.mut_at(h);
-    slot.x().zero_out();
-    slot.z().zero_out();
-    accumulate_pauli_row(sim.inv_state, qubit, pauli_type, sim.inv_state.num_qubits, slot.x(),
-                         slot.z());
-    return NoiseChannel{h, prob};
-}
+struct PauliTerm {
+    uint32_t qubit;
+    int pauli_type;
+};
 
-/// Rewind a two-qubit Pauli through the tableau into a freshly claimed slot.
-NoiseChannel rewind_two_qubit_pauli(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
-                                    uint32_t q1, uint32_t q2, int pauli1, int pauli2, double prob) {
+/// Rewind a Pauli product through the tableau into a fresh noise-channel slot.
+NoiseChannel rewind_pauli_terms(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                std::initializer_list<PauliTerm> terms, double prob) {
     auto h = hir.claim_empty_noise_channel_mask();
     auto slot = hir.noise_channel_masks.mut_at(h);
     slot.x().zero_out();
     slot.z().zero_out();
     uint32_t n = sim.inv_state.num_qubits;
-    if (pauli1 != 0)
-        accumulate_pauli_row(sim.inv_state, q1, pauli1, n, slot.x(), slot.z());
-    if (pauli2 != 0)
-        accumulate_pauli_row(sim.inv_state, q2, pauli2, n, slot.x(), slot.z());
+    for (const auto& term : terms) {
+        if (term.pauli_type != 0) {
+            accumulate_pauli_row(sim.inv_state, term.qubit, term.pauli_type, n, slot.x(), slot.z());
+        }
+    }
     return NoiseChannel{h, prob};
 }
 
-/// Rewind a three-qubit Pauli through the tableau into a freshly claimed slot.
-NoiseChannel rewind_three_qubit_pauli(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
-                                      uint32_t q1, uint32_t q2, uint32_t q3, int pauli1, int pauli2,
-                                      int pauli3, double prob) {
-    auto h = hir.claim_empty_noise_channel_mask();
-    auto slot = hir.noise_channel_masks.mut_at(h);
-    slot.x().zero_out();
-    slot.z().zero_out();
-    uint32_t n = sim.inv_state.num_qubits;
-    if (pauli1 != 0)
-        accumulate_pauli_row(sim.inv_state, q1, pauli1, n, slot.x(), slot.z());
-    if (pauli2 != 0)
-        accumulate_pauli_row(sim.inv_state, q2, pauli2, n, slot.x(), slot.z());
-    if (pauli3 != 0)
-        accumulate_pauli_row(sim.inv_state, q3, pauli3, n, slot.x(), slot.z());
-    return NoiseChannel{h, prob};
+void append_noise_site(HirModule& hir, NoiseSite site) {
+    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
+    hir.noise_sites.push_back(std::move(site));
+    hir.append_noise(idx);
 }
 
 NoiseSite make_single_qubit_noise_site(HirModule& hir,
@@ -186,18 +168,18 @@ NoiseSite make_single_qubit_noise_site(HirModule& hir,
     NoiseSite site;
     switch (gate) {
         case GateType::X_ERROR:
-            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 1, prob));
+            site.channels.push_back(rewind_pauli_terms(hir, sim, {{qubit, 1}}, prob));
             break;
         case GateType::Y_ERROR:
-            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 2, prob));
+            site.channels.push_back(rewind_pauli_terms(hir, sim, {{qubit, 2}}, prob));
             break;
         case GateType::Z_ERROR:
-            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 3, prob));
+            site.channels.push_back(rewind_pauli_terms(hir, sim, {{qubit, 3}}, prob));
             break;
         case GateType::DEPOLARIZE1:
-            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 1, prob / 3.0));
-            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 2, prob / 3.0));
-            site.channels.push_back(rewind_single_pauli(hir, sim, qubit, 3, prob / 3.0));
+            site.channels.push_back(rewind_pauli_terms(hir, sim, {{qubit, 1}}, prob / 3.0));
+            site.channels.push_back(rewind_pauli_terms(hir, sim, {{qubit, 2}}, prob / 3.0));
+            site.channels.push_back(rewind_pauli_terms(hir, sim, {{qubit, 3}}, prob / 3.0));
             break;
         default:
             throw std::runtime_error("Not a single-qubit noise gate");
@@ -213,7 +195,8 @@ NoiseSite make_depolarize2_noise_site(HirModule& hir, const stim::TableauSimulat
         for (int p2 = 0; p2 <= 3; ++p2) {
             if (p1 == 0 && p2 == 0)
                 continue;
-            site.channels.push_back(rewind_two_qubit_pauli(hir, sim, q1, q2, p1, p2, channel_prob));
+            site.channels.push_back(
+                rewind_pauli_terms(hir, sim, {{q1, p1}, {q2, p2}}, channel_prob));
         }
     }
     return site;
@@ -229,7 +212,7 @@ NoiseSite make_depolarize3_noise_site(HirModule& hir, const stim::TableauSimulat
                 if (p1 == 0 && p2 == 0 && p3 == 0)
                     continue;
                 site.channels.push_back(
-                    rewind_three_qubit_pauli(hir, sim, q1, q2, q3, p1, p2, p3, channel_prob));
+                    rewind_pauli_terms(hir, sim, {{q1, p1}, {q2, p2}, {q3, p3}}, channel_prob));
             }
         }
     }
@@ -757,9 +740,7 @@ HirModule trace(const Circuit& circuit) {
                 for (const auto& target : node.targets) {
                     NoiseSite site =
                         make_single_qubit_noise_site(hir, sim, node.gate, target.value(), prob);
-                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
-                    hir.noise_sites.push_back(std::move(site));
-                    hir.append_noise(idx);
+                    append_noise_site(hir, std::move(site));
                 }
                 break;
             }
@@ -776,12 +757,10 @@ HirModule trace(const Circuit& circuit) {
                         double prob = node.args[static_cast<size_t>(p)];
                         if (prob > 0.0) {
                             site.channels.push_back(
-                                rewind_single_pauli(hir, sim, qubit, p + 1, prob));
+                                rewind_pauli_terms(hir, sim, {{qubit, p + 1}}, prob));
                         }
                     }
-                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
-                    hir.noise_sites.push_back(std::move(site));
-                    hir.append_noise(idx);
+                    append_noise_site(hir, std::move(site));
                 }
                 break;
             }
@@ -802,14 +781,12 @@ HirModule trace(const Circuit& circuit) {
                             double prob = node.args[arg_idx];
                             if (prob > 0.0) {
                                 site.channels.push_back(
-                                    rewind_two_qubit_pauli(hir, sim, q1, q2, p1, p2, prob));
+                                    rewind_pauli_terms(hir, sim, {{q1, p1}, {q2, p2}}, prob));
                             }
                             ++arg_idx;
                         }
                     }
-                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
-                    hir.noise_sites.push_back(std::move(site));
-                    hir.append_noise(idx);
+                    append_noise_site(hir, std::move(site));
                 }
                 break;
             }
@@ -831,16 +808,14 @@ HirModule trace(const Circuit& circuit) {
                                     continue;
                                 double prob = node.args[arg_idx];
                                 if (prob > 0.0) {
-                                    site.channels.push_back(rewind_three_qubit_pauli(
-                                        hir, sim, q1, q2, q3, p1, p2, p3, prob));
+                                    site.channels.push_back(rewind_pauli_terms(
+                                        hir, sim, {{q1, p1}, {q2, p2}, {q3, p3}}, prob));
                                 }
                                 ++arg_idx;
                             }
                         }
                     }
-                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
-                    hir.noise_sites.push_back(std::move(site));
-                    hir.append_noise(idx);
+                    append_noise_site(hir, std::move(site));
                 }
                 break;
             }
@@ -851,9 +826,7 @@ HirModule trace(const Circuit& circuit) {
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
                     NoiseSite site = make_depolarize2_noise_site(hir, sim, q1, q2, prob);
-                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
-                    hir.noise_sites.push_back(std::move(site));
-                    hir.append_noise(idx);
+                    append_noise_site(hir, std::move(site));
                 }
                 break;
             }
@@ -865,9 +838,7 @@ HirModule trace(const Circuit& circuit) {
                     uint32_t q2 = node.targets[i + 1].value();
                     uint32_t q3 = node.targets[i + 2].value();
                     NoiseSite site = make_depolarize3_noise_site(hir, sim, q1, q2, q3, prob);
-                    NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
-                    hir.noise_sites.push_back(std::move(site));
-                    hir.append_noise(idx);
+                    append_noise_site(hir, std::move(site));
                 }
                 break;
             }


### PR DESCRIPTION
## Summary

Refactors duplicated Pauli-product handling before adding correlated-noise syntax.

- Factor shared Pauli-product parsing for `MPP`, `EXP_VAL`, and `R_PAULI`
- Replace fixed single/two/three-qubit noise rewind helpers with one Pauli-term rewind helper
- Add a small helper for appending `NoiseSite` entries

## Test plan

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

Additional targeted checks run:

- [x] `ctest --test-dir build -R "(Parse|Parser|Frontend|frontend)" --output-on-failure`
- [x] `uv run pytest tests/python/test_api.py tests/python/test_exp_value.py tests/python/test_sample.py -q`

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
