### PR TITLE
feat: add correlated Pauli noise channels

### DIFF
--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -144,6 +144,8 @@ Two-qubit Cliffords are also absorbed at compile time.
 | `PAULI_CHANNEL_1(px,py,pz)` | General single-qubit Pauli channel |
 | `PAULI_CHANNEL_2(...)` | General two-qubit Pauli channel (15 params) |
 | `PAULI_CHANNEL_3(...)` | General three-qubit Pauli channel (63 params) |
+| `CORRELATED_ERROR(p)` / `E(p)` | Correlated Pauli product error |
+| `ELSE_CORRELATED_ERROR(p)` | Else-branch in a correlated-error chain |
 
 Noisy measurements (e.g., `M(0.01) 0`) are decomposed by the parser into a
 clean measurement followed by an internal `READOUT_NOISE` instruction that
@@ -154,6 +156,17 @@ models classical bit-flip errors on the measurement result.
 `PAULI_CHANNEL_3` uses the same lexicographic Pauli order as
 `PAULI_CHANNEL_2`, extended to three qubits: `IIX`, `IIY`, `IIZ`, `IXI`,
 `IXX`, ..., `ZZZ`.
+
+`CORRELATED_ERROR(p) X0 Z1` applies the listed Pauli product with probability
+`p`. Pauli terms may be whitespace-separated or combined with `*`; all Pauli
+targets on the instruction form one product. Repeated terms on the same qubit
+multiply modulo Pauli phase, so `E(1) X0 Z0` is equivalent to a Y error and
+`E(1) X0 X0` is an identity event.
+
+`ELSE_CORRELATED_ERROR(p)` must immediately follow `CORRELATED_ERROR` or another
+`ELSE_CORRELATED_ERROR`. Its `p` is conditional on no earlier link in the chain
+firing. Clifft lowers each contiguous chain to one noise site with absolute
+channel probabilities.
 
 ## Identity Gates
 
@@ -210,8 +223,6 @@ Results are available via `SampleResult.exp_vals` (shape `(shots, num_exp_vals)`
 
 | Gate | Category | Reason |
 |------|----------|--------|
-| `CORRELATED_ERROR` / `E` | Noise | Correlated multi-qubit error model |
-| `ELSE_CORRELATED_ERROR` | Noise | Depends on `CORRELATED_ERROR` |
 | `HERALDED_ERASE` | Noise | Heralded erasure not modeled |
 | `HERALDED_PAULI_CHANNEL_1` | Noise | Heralded channel not modeled |
 | `SPP`, `SPP_DAG` | Pauli product phase | Generalized S/S_DAG gate over Pauli products |

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -115,9 +115,11 @@ enum class GateType : uint16_t {
     DEPOLARIZE3,  // Three-qubit depolarizing channel
 
     // Multi-parameter noise channels
-    PAULI_CHANNEL_1,  // 3-arg: P(X), P(Y), P(Z)
-    PAULI_CHANNEL_2,  // 15-arg: P(IX), P(IY), ..., P(ZZ)
-    PAULI_CHANNEL_3,  // 63-arg: P(IIX), P(IIY), ..., P(ZZZ)
+    PAULI_CHANNEL_1,        // 3-arg: P(X), P(Y), P(Z)
+    PAULI_CHANNEL_2,        // 15-arg: P(IX), P(IY), ..., P(ZZ)
+    PAULI_CHANNEL_3,        // 63-arg: P(IIX), P(IIY), ..., P(ZZZ)
+    CORRELATED_ERROR,       // E(p): correlated Pauli product error
+    ELSE_CORRELATED_ERROR,  // Else-branch in a correlated error chain
 
     // Synthetic gates (emitted by parser, not in input syntax)
     READOUT_NOISE,  // Classical bit-flip on measurement result
@@ -258,6 +260,8 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = S, .noise = true, .name = "PAULI_CHANNEL_1"},
     {.arity = P, .noise = true, .name = "PAULI_CHANNEL_2"},
     {.arity = T, .noise = true, .name = "PAULI_CHANNEL_3"},
+    {.arity = ML, .noise = true, .name = "CORRELATED_ERROR"},
+    {.arity = ML, .noise = true, .name = "ELSE_CORRELATED_ERROR"},
     {.arity = S, .noise = true, .name = "READOUT_NOISE"},
     // QEC annotations
     {.arity = A, .name = "DETECTOR"},

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -22,13 +23,21 @@ namespace {
 // Alternate gate names (Stim compatibility, shorthand, Z-basis synonyms).
 // Only aliases live here; canonical names come from kGateTraitsData in gate_data.h.
 constexpr std::pair<std::string_view, GateType> kGateAliases[] = {
-    {"CNOT", GateType::CX},       {"H_XZ", GateType::H},
-    {"MRZ", GateType::MR},        {"MZ", GateType::M},
-    {"RXX", GateType::R_XX},      {"RYY", GateType::R_YY},
-    {"RZ", GateType::R},          {"RZZ", GateType::R_ZZ},
-    {"SQRT_Z", GateType::S},      {"SQRT_Z_DAG", GateType::S_DAG},
-    {"SWAPCZ", GateType::CZSWAP}, {"U", GateType::U3},
-    {"ZCX", GateType::CX},        {"ZCY", GateType::CY},
+    {"CNOT", GateType::CX},
+    {"H_XZ", GateType::H},
+    {"E", GateType::CORRELATED_ERROR},
+    {"MRZ", GateType::MR},
+    {"MZ", GateType::M},
+    {"RXX", GateType::R_XX},
+    {"RYY", GateType::R_YY},
+    {"RZ", GateType::R},
+    {"RZZ", GateType::R_ZZ},
+    {"SQRT_Z", GateType::S},
+    {"SQRT_Z_DAG", GateType::S_DAG},
+    {"SWAPCZ", GateType::CZSWAP},
+    {"U", GateType::U3},
+    {"ZCX", GateType::CX},
+    {"ZCY", GateType::CY},
     {"ZCZ", GateType::CZ},
 };
 
@@ -151,6 +160,7 @@ class Parser {
     static constexpr uint32_t kMaxRecursionDepth = 100;
     std::string_view text_;
     size_t max_ops_;
+    bool previous_correlated_error_link_ = false;
 
     void parse_line(std::string_view line, uint32_t& line_num, Circuit& circuit,
                     std::string_view& remaining, uint32_t depth) {
@@ -171,7 +181,9 @@ class Parser {
 
         // Handle REPEAT N { ... } blocks.
         if (line.starts_with("REPEAT") && (line.size() == 6 || !is_gate_char(line[6]))) {
+            previous_correlated_error_link_ = false;
             parse_repeat(line, line_num, circuit, remaining, depth);
+            previous_correlated_error_link_ = false;
             return;
         }
 
@@ -219,6 +231,7 @@ class Parser {
 
         // Silently discard coordinate annotations (no AST nodes emitted).
         if (is_discarded_annotation(gate_name)) {
+            previous_correlated_error_link_ = false;
             return;
         }
 
@@ -228,6 +241,7 @@ class Parser {
             if (!args.empty()) {
                 throw ParseError("CH takes no arguments", line_num);
             }
+            previous_correlated_error_link_ = false;
             parse_ch_rewrite(rest, line_num, circuit);
             return;
         }
@@ -235,6 +249,7 @@ class Parser {
             if (!args.empty()) {
                 throw ParseError(std::string(gate_name) + " takes no arguments", line_num);
             }
+            previous_correlated_error_link_ = false;
             parse_three_qubit_rewrite(gate_name, rest, line_num, circuit);
             return;
         }
@@ -245,6 +260,15 @@ class Parser {
             throw ParseError("Unknown gate: " + std::string(gate_name), line_num);
         }
 
+        if (gate == GateType::ELSE_CORRELATED_ERROR && !previous_correlated_error_link_) {
+            throw ParseError(
+                "ELSE_CORRELATED_ERROR must immediately follow CORRELATED_ERROR or "
+                "ELSE_CORRELATED_ERROR",
+                line_num);
+        }
+        previous_correlated_error_link_ =
+            gate == GateType::CORRELATED_ERROR || gate == GateType::ELSE_CORRELATED_ERROR;
+
         // Validate argument counts for multi-probability channels.
         if (gate == GateType::PAULI_CHANNEL_1 && args.size() != 3) {
             throw ParseError("PAULI_CHANNEL_1 requires exactly 3 arguments", line_num);
@@ -254,6 +278,12 @@ class Parser {
         }
         if (gate == GateType::PAULI_CHANNEL_3 && args.size() != 63) {
             throw ParseError("PAULI_CHANNEL_3 requires exactly 63 arguments", line_num);
+        }
+        if ((gate == GateType::CORRELATED_ERROR || gate == GateType::ELSE_CORRELATED_ERROR) &&
+            args.size() != 1) {
+            throw ParseError(
+                std::string(clifft::gate_name(gate)) + " requires exactly 1 probability argument",
+                line_num);
         }
 
         // Validate argument counts for parameterized rotations.
@@ -282,6 +312,10 @@ class Parser {
                 break;
             case GateType::R_PAULI:
                 parse_r_pauli(rest, line_num, circuit, args);
+                break;
+            case GateType::CORRELATED_ERROR:
+            case GateType::ELSE_CORRELATED_ERROR:
+                parse_correlated_error(gate, rest, line_num, circuit, args);
                 break;
             case GateType::DETECTOR:
                 parse_detector(rest, line_num, circuit);
@@ -921,6 +955,138 @@ class Parser {
         }
 
         return products;
+    }
+
+    std::vector<Target> parse_correlated_pauli_targets(std::string_view targets_str,
+                                                       std::string_view gate_name,
+                                                       uint32_t line_num, Circuit& circuit) {
+        struct FoldedTerm {
+            uint32_t qubit;
+            uint8_t xz_bits;
+            bool inverted;
+        };
+
+        std::vector<FoldedTerm> terms;
+        std::unordered_map<uint32_t, size_t> term_index;
+
+        size_t pos = 0;
+        while (pos < targets_str.size()) {
+            while (pos < targets_str.size() &&
+                   std::isspace(static_cast<unsigned char>(targets_str[pos]))) {
+                ++pos;
+            }
+            while (pos < targets_str.size() && targets_str[pos] == '*') {
+                ++pos;
+                while (pos < targets_str.size() &&
+                       std::isspace(static_cast<unsigned char>(targets_str[pos]))) {
+                    ++pos;
+                }
+            }
+            if (pos >= targets_str.size()) {
+                break;
+            }
+
+            bool inverted = false;
+            if (targets_str[pos] == '!') {
+                inverted = true;
+                ++pos;
+                if (pos >= targets_str.size()) {
+                    throw ParseError("Expected Pauli target after '!'", line_num);
+                }
+            }
+
+            char pauli_char = targets_str[pos];
+            uint8_t xz_bits;
+            switch (pauli_char) {
+                case 'X':
+                    xz_bits = 1;
+                    break;
+                case 'Y':
+                    xz_bits = 3;
+                    break;
+                case 'Z':
+                    xz_bits = 2;
+                    break;
+                default:
+                    throw ParseError(
+                        "Gate " + std::string(gate_name) + " only accepts Pauli targets", line_num);
+            }
+            ++pos;
+
+            size_t num_start = pos;
+            while (pos < targets_str.size() &&
+                   std::isdigit(static_cast<unsigned char>(targets_str[pos]))) {
+                ++pos;
+            }
+            if (num_start == pos) {
+                throw ParseError(
+                    "Expected qubit index after Pauli letter in " + std::string(gate_name),
+                    line_num);
+            }
+
+            uint32_t qubit;
+            if (!parse_uint(targets_str.substr(num_start, pos - num_start), qubit)) {
+                throw ParseError("Invalid qubit index in " + std::string(gate_name), line_num);
+            }
+            if (qubit >= (1u << 28)) {
+                throw ParseError("Qubit index too large (must be < 2^28)", line_num);
+            }
+
+            if (pos < targets_str.size() &&
+                !std::isspace(static_cast<unsigned char>(targets_str[pos])) &&
+                targets_str[pos] != '*') {
+                throw ParseError("Targets in " + std::string(gate_name) +
+                                     " must be separated by whitespace or '*'",
+                                 line_num);
+            }
+
+            auto [it, inserted] = term_index.emplace(qubit, terms.size());
+            if (inserted) {
+                if (terms.size() >= kMaxTargetsPerInstruction) {
+                    throw ParseError(
+                        "Too many Pauli terms in " + std::string(gate_name) + " product", line_num);
+                }
+                terms.push_back({qubit, 0, false});
+            }
+            FoldedTerm& term = terms[it->second];
+            term.xz_bits ^= xz_bits;
+            term.inverted ^= inverted;
+            circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
+        }
+
+        std::vector<Target> targets;
+        targets.reserve(terms.size());
+        for (const auto& term : terms) {
+            uint32_t pauli_flag;
+            switch (term.xz_bits) {
+                case 1:
+                    pauli_flag = Target::kPauliX;
+                    break;
+                case 2:
+                    pauli_flag = Target::kPauliZ;
+                    break;
+                case 3:
+                    pauli_flag = Target::kPauliY;
+                    break;
+                default:
+                    continue;
+            }
+
+            Target target = Target::pauli(term.qubit, pauli_flag);
+            if (term.inverted) {
+                target = target.inverted();
+            }
+            targets.push_back(target);
+        }
+
+        return targets;
+    }
+
+    void parse_correlated_error(GateType gate, std::string_view targets_str, uint32_t line_num,
+                                Circuit& circuit, const std::vector<double>& args) {
+        auto targets =
+            parse_correlated_pauli_targets(targets_str, clifft::gate_name(gate), line_num, circuit);
+        circuit.nodes.push_back({gate, std::move(targets), args, line_num});
     }
 
     // Parse MPP instruction with multiple Pauli products.

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -156,6 +156,24 @@ NoiseChannel rewind_pauli_terms(HirModule& hir, const stim::TableauSimulator<kSt
     return NoiseChannel{h, prob};
 }
 
+/// Rewind a Pauli product stored as Pauli-tagged targets into a fresh noise slot.
+NoiseChannel rewind_pauli_targets(HirModule& hir, const stim::TableauSimulator<kStimWidth>& sim,
+                                  const std::vector<Target>& targets, double prob) {
+    auto h = hir.claim_empty_noise_channel_mask();
+    auto slot = hir.noise_channel_masks.mut_at(h);
+    slot.x().zero_out();
+    slot.z().zero_out();
+    uint32_t n = sim.inv_state.num_qubits;
+    for (const auto& target : targets) {
+        if (!target.has_pauli()) {
+            throw std::runtime_error("Expected Pauli target");
+        }
+        auto pauli_type = static_cast<int>(target.pauli() >> Target::kPauliShift);
+        accumulate_pauli_row(sim.inv_state, target.value(), pauli_type, n, slot.x(), slot.z());
+    }
+    return NoiseChannel{h, prob};
+}
+
 void append_noise_site(HirModule& hir, NoiseSite site) {
     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
     hir.noise_sites.push_back(std::move(site));
@@ -308,6 +326,10 @@ size_t count_noise_channels(const Circuit& circuit) {
             case GateType::PAULI_CHANNEL_3:
                 count += 63 * (n_targets / 3);
                 break;
+            case GateType::CORRELATED_ERROR:
+            case GateType::ELSE_CORRELATED_ERROR:
+                count += 1;
+                break;
             default:
                 break;
         }
@@ -392,7 +414,8 @@ HirModule trace(const Circuit& circuit) {
     uint32_t hidden_meas_idx = circuit.num_measurements;
     ExpValIdx exp_val_idx{0};
 
-    for (const auto& node : circuit.nodes) {
+    for (size_t node_index = 0; node_index < circuit.nodes.size(); ++node_index) {
+        const auto& node = circuit.nodes[node_index];
         const size_t ops_before = hir.ops.size();
 
         switch (node.gate) {
@@ -819,6 +842,40 @@ HirModule trace(const Circuit& circuit) {
                 }
                 break;
             }
+
+            case GateType::CORRELATED_ERROR: {
+                NoiseSite site;
+                double remaining = 1.0;
+                size_t chain_end = node_index;
+                while (true) {
+                    const auto& link = circuit.nodes[chain_end];
+                    if (link.args.empty()) {
+                        throw std::runtime_error(
+                            "CORRELATED_ERROR requires a probability argument");
+                    }
+
+                    double abs_prob = link.args[0] * remaining;
+                    if (abs_prob > 0.0 && !link.targets.empty()) {
+                        site.channels.push_back(
+                            rewind_pauli_targets(hir, sim, link.targets, abs_prob));
+                    }
+                    remaining *= 1.0 - link.args[0];
+
+                    size_t next = chain_end + 1;
+                    if (next >= circuit.nodes.size() ||
+                        circuit.nodes[next].gate != GateType::ELSE_CORRELATED_ERROR) {
+                        break;
+                    }
+                    chain_end = next;
+                }
+                append_noise_site(hir, std::move(site));
+                node_index = chain_end;
+                break;
+            }
+
+            case GateType::ELSE_CORRELATED_ERROR:
+                throw std::runtime_error(
+                    "ELSE_CORRELATED_ERROR must follow CORRELATED_ERROR in the same chain");
 
             case GateType::DEPOLARIZE2: {
                 double prob = node.args.empty() ? 0.0 : node.args[0];

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -198,6 +198,8 @@ NB_MODULE(_clifft_core, m) {
         .value("PAULI_CHANNEL_1", clifft::GateType::PAULI_CHANNEL_1)
         .value("PAULI_CHANNEL_2", clifft::GateType::PAULI_CHANNEL_2)
         .value("PAULI_CHANNEL_3", clifft::GateType::PAULI_CHANNEL_3)
+        .value("CORRELATED_ERROR", clifft::GateType::CORRELATED_ERROR)
+        .value("ELSE_CORRELATED_ERROR", clifft::GateType::ELSE_CORRELATED_ERROR)
         .value("READOUT_NOISE", clifft::GateType::READOUT_NOISE)
         // Annotations
         .value("DETECTOR", clifft::GateType::DETECTOR)

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -74,6 +74,16 @@ def test_parse_mpp() -> None:
     assert t1.value == 1
 
 
+def test_parse_correlated_error() -> None:
+    """Test parsing correlated Pauli noise."""
+    circuit = clifft.parse("E(0.1) X0*Z1\nELSE_CORRELATED_ERROR(0.25) Y2")
+    assert len(circuit) == 2
+    assert circuit.nodes[0].gate == clifft.GateType.CORRELATED_ERROR
+    assert circuit.nodes[1].gate == clifft.GateType.ELSE_CORRELATED_ERROR
+    assert circuit.nodes[0].args == [0.1]
+    assert [t.pauli_char for t in circuit.nodes[0].targets] == ["X", "Z"]
+
+
 def test_parse_feedback() -> None:
     """Test parsing classical feedback with rec targets."""
     circuit = clifft.parse("M 0\nCX rec[-1] 1")

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -596,6 +596,35 @@ class TestNoiseAndQEC:
         # X flips |0> to |1>
         assert np.all(result.measurements == 1)
 
+    def test_correlated_error_else_branch(self) -> None:
+        """ELSE_CORRELATED_ERROR fires when the earlier link does not."""
+        prog = clifft.compile("""
+            E(0.0) X0
+            ELSE_CORRELATED_ERROR(1.0) X1
+            M 0 1
+        """)
+        result = clifft.sample(prog, 100, seed=42)
+        assert np.all(result.measurements[:, 0] == 0)
+        assert np.all(result.measurements[:, 1] == 1)
+
+    def test_correlated_error_chain_probabilistic(self) -> None:
+        """Correlated-error chains convert conditional probabilities correctly."""
+        prog = clifft.compile("""
+            E(0.5) X0
+            ELSE_CORRELATED_ERROR(0.5) X1
+            M 0 1
+        """)
+        shots = 5000
+        result = clifft.sample(prog, shots, seed=42)
+        q0 = result.measurements[:, 0]
+        q1 = result.measurements[:, 1]
+
+        q0_rate = float(np.mean(q0))
+        q1_rate = float(np.mean(q1))
+        assert abs(q0_rate - 0.5) < binomial_tolerance(0.5, shots)
+        assert abs(q1_rate - 0.25) < binomial_tolerance(0.25, shots)
+        assert not np.any(q0 & q1)
+
     def test_pauli_noise_z_error(self) -> None:
         """Z_ERROR doesn't affect computational basis measurement."""
         prog = clifft.compile("""

--- a/tests/python/utils_qiskit.py
+++ b/tests/python/utils_qiskit.py
@@ -126,6 +126,7 @@ _SKIP_GATES = frozenset(
         "Z_ERROR",
         "DEPOLARIZE1",
         "DEPOLARIZE2",
+        "CORRELATED_ERROR",
         "E",
         "ELSE_CORRELATED_ERROR",
         "MPP",  # Pauli product measurements need special handling

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1647,6 +1647,77 @@ TEST_CASE("Frontend: PAULI_CHANNEL_3 emits selected channels", "[frontend]") {
     CHECK(mask.z() == 7);
 }
 
+TEST_CASE("Frontend: correlated error emits one noise channel", "[frontend][noise]") {
+    auto circuit = parse("E(0.25) X0 Z1");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    CHECK(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.noise_sites.size() == 1);
+
+    const auto& site = hir.noise_sites[0];
+    REQUIRE(site.channels.size() == 1);
+    CHECK(site.channels[0].prob == Catch::Approx(0.25));
+
+    auto mask = hir.noise_channel_masks.at(site.channels[0].mask);
+    CHECK(mask.x() == 1);
+    CHECK(mask.z() == 2);
+}
+
+TEST_CASE("Frontend: correlated error chain is one noise site", "[frontend][noise]") {
+    auto circuit = parse(
+        "E(0.2) X0\n"
+        "ELSE_CORRELATED_ERROR(0.25) Z1\n"
+        "ELSE_CORRELATED_ERROR(0.3333333333333333) X0 Z1");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    CHECK(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.noise_sites.size() == 1);
+
+    const auto& site = hir.noise_sites[0];
+    REQUIRE(site.channels.size() == 3);
+    CHECK(site.channels[0].prob == Catch::Approx(0.2));
+    CHECK(site.channels[1].prob == Catch::Approx(0.2));
+    CHECK(site.channels[2].prob == Catch::Approx(0.2));
+
+    auto first = hir.noise_channel_masks.at(site.channels[0].mask);
+    CHECK(first.x() == 1);
+    CHECK(first.z() == 0);
+
+    auto second = hir.noise_channel_masks.at(site.channels[1].mask);
+    CHECK(second.x() == 0);
+    CHECK(second.z() == 2);
+
+    auto third = hir.noise_channel_masks.at(site.channels[2].mask);
+    CHECK(third.x() == 1);
+    CHECK(third.z() == 2);
+}
+
+TEST_CASE("Frontend: correlated identity link consumes chain probability", "[frontend][noise]") {
+    auto circuit = parse("E(0.5) X0 X0\nELSE_CORRELATED_ERROR(1.0) X0");
+    auto hir = trace(circuit);
+
+    REQUIRE(hir.num_ops() == 1);
+    REQUIRE(hir.noise_sites.size() == 1);
+    const auto& site = hir.noise_sites[0];
+    REQUIRE(site.channels.size() == 1);
+    CHECK(site.channels[0].prob == Catch::Approx(0.5));
+
+    auto mask = hir.noise_channel_masks.at(site.channels[0].mask);
+    CHECK(mask.x() == 1);
+    CHECK(mask.z() == 0);
+}
+
+TEST_CASE("Frontend: stray else correlated error is rejected", "[frontend][noise]") {
+    Circuit circuit;
+    circuit.num_qubits = 1;
+    circuit.nodes.push_back(
+        {GateType::ELSE_CORRELATED_ERROR, {Target::pauli(0, Target::kPauliX)}, {0.1}, 1});
+
+    REQUIRE_THROWS_AS(trace(circuit), std::runtime_error);
+}
+
 // =============================================================================
 // Phase rotation tracing tests
 // =============================================================================

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1434,6 +1434,100 @@ TEST_CASE("Parse PAULI_CHANNEL_1 broadcasts to multiple targets", "[parser]") {
     }
 }
 
+TEST_CASE("Parse correlated error product", "[parser][noise]") {
+    auto circuit = parse("CORRELATED_ERROR(0.1) X0 Y2 Z5");
+    REQUIRE(circuit.nodes.size() == 1);
+    CHECK(circuit.nodes[0].gate == GateType::CORRELATED_ERROR);
+    REQUIRE(circuit.nodes[0].args.size() == 1);
+    CHECK(circuit.nodes[0].args[0] == Catch::Approx(0.1));
+    REQUIRE(circuit.nodes[0].targets.size() == 3);
+    CHECK(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    CHECK(circuit.nodes[0].targets[0].value() == 0);
+    CHECK(circuit.nodes[0].targets[1].pauli() == Target::kPauliY);
+    CHECK(circuit.nodes[0].targets[1].value() == 2);
+    CHECK(circuit.nodes[0].targets[2].pauli() == Target::kPauliZ);
+    CHECK(circuit.nodes[0].targets[2].value() == 5);
+    CHECK(circuit.num_qubits == 6);
+    CHECK(circuit.num_measurements == 0);
+}
+
+TEST_CASE("Parse correlated error alias and combiner", "[parser][noise]") {
+    auto circuit = parse("E(0.25) X0*Z1");
+    REQUIRE(circuit.nodes.size() == 1);
+    CHECK(circuit.nodes[0].gate == GateType::CORRELATED_ERROR);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    CHECK(circuit.nodes[0].targets[0].pauli() == Target::kPauliX);
+    CHECK(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
+}
+
+TEST_CASE("Parse correlated error chain", "[parser][noise]") {
+    auto circuit = parse(
+        "E(0.1) X0\n"
+        "ELSE_CORRELATED_ERROR(0.2) Z1\n"
+        "ELSE_CORRELATED_ERROR(0.3) X2");
+    REQUIRE(circuit.nodes.size() == 3);
+    CHECK(circuit.nodes[0].gate == GateType::CORRELATED_ERROR);
+    CHECK(circuit.nodes[1].gate == GateType::ELSE_CORRELATED_ERROR);
+    CHECK(circuit.nodes[2].gate == GateType::ELSE_CORRELATED_ERROR);
+}
+
+TEST_CASE("Parse correlated error chain permits blank and comment lines", "[parser][noise]") {
+    auto circuit = parse(R"(
+        E(0.1) X0
+        # This line is ignored.
+
+        ELSE_CORRELATED_ERROR(0.2) Z1
+        # This line is also ignored.
+        ELSE_CORRELATED_ERROR(0.3) X2
+    )");
+
+    REQUIRE(circuit.nodes.size() == 3);
+    CHECK(circuit.nodes[0].gate == GateType::CORRELATED_ERROR);
+    CHECK(circuit.nodes[1].gate == GateType::ELSE_CORRELATED_ERROR);
+    CHECK(circuit.nodes[2].gate == GateType::ELSE_CORRELATED_ERROR);
+}
+
+TEST_CASE("Parse correlated error folds duplicate terms", "[parser][noise]") {
+    auto circuit = parse("E(1) X0 Z0 X1 X1 !Z2");
+    REQUIRE(circuit.nodes.size() == 1);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    CHECK(circuit.nodes[0].targets[0].pauli() == Target::kPauliY);
+    CHECK(circuit.nodes[0].targets[0].value() == 0);
+    CHECK(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
+    CHECK(circuit.nodes[0].targets[1].value() == 2);
+    CHECK(circuit.nodes[0].targets[1].is_inverted());
+}
+
+TEST_CASE("Parse correlated error accepts empty product", "[parser][noise]") {
+    auto circuit = parse("E(0.1)\nELSE_CORRELATED_ERROR(0.2) X0");
+    REQUIRE(circuit.nodes.size() == 2);
+    CHECK(circuit.nodes[0].targets.empty());
+    REQUIRE(circuit.nodes[1].targets.size() == 1);
+}
+
+TEST_CASE("Parse correlated error rejects stray else", "[parser][noise]") {
+    REQUIRE_THROWS_AS(parse("ELSE_CORRELATED_ERROR(0.1) X0"), ParseError);
+}
+
+TEST_CASE("Parse correlated error requires contiguous else", "[parser][noise]") {
+    REQUIRE_THROWS_AS(parse("E(0.1) X0\nTICK\nELSE_CORRELATED_ERROR(0.2) Z0"), ParseError);
+    REQUIRE_THROWS_AS(parse("E(0.1) X0\nQUBIT_COORDS(0, 0) 0\nELSE_CORRELATED_ERROR(0.2) Z0"),
+                      ParseError);
+    REQUIRE_THROWS_AS(parse("E(0.1) X0\nI 0\nELSE_CORRELATED_ERROR(0.2) Z0"), ParseError);
+    REQUIRE_THROWS_AS(parse("E(0.1) X0\nREPEAT 1 {\nELSE_CORRELATED_ERROR(0.2) Z0\n}"), ParseError);
+}
+
+TEST_CASE("Parse correlated error rejects malformed targets", "[parser][noise]") {
+    REQUIRE_THROWS_AS(parse("E(0.1) X0Y1"), ParseError);
+    REQUIRE_THROWS_AS(parse("E(0.1) rec[-1]"), ParseError);
+}
+
+TEST_CASE("Parse correlated error rejects wrong arg count", "[parser][noise]") {
+    REQUIRE_THROWS_AS(parse("E X0"), ParseError);
+    REQUIRE_THROWS_AS(parse("E(0.1, 0.2) X0"), ParseError);
+    REQUIRE_THROWS_AS(parse("E(0.1) X0\nELSE_CORRELATED_ERROR(0.1, 0.2) X0"), ParseError);
+}
+
 // --- Review Round 2 edge cases ---
 
 TEST_CASE("REPEAT opening brace in comment is ignored", "[parser]") {
@@ -1663,12 +1757,16 @@ TEST_CASE("GateTraits: noise channels", "[gate_data]") {
     CHECK(is_noise_gate(GateType::PAULI_CHANNEL_1));
     CHECK(is_noise_gate(GateType::PAULI_CHANNEL_2));
     CHECK(is_noise_gate(GateType::PAULI_CHANNEL_3));
+    CHECK(is_noise_gate(GateType::CORRELATED_ERROR));
+    CHECK(is_noise_gate(GateType::ELSE_CORRELATED_ERROR));
     CHECK(is_noise_gate(GateType::READOUT_NOISE));
     CHECK(!is_noise_gate(GateType::M));
     CHECK(gate_arity(GateType::DEPOLARIZE2) == GateArity::PAIR);
     CHECK(gate_arity(GateType::PAULI_CHANNEL_2) == GateArity::PAIR);
     CHECK(gate_arity(GateType::DEPOLARIZE3) == GateArity::TRIPLE);
     CHECK(gate_arity(GateType::PAULI_CHANNEL_3) == GateArity::TRIPLE);
+    CHECK(gate_arity(GateType::CORRELATED_ERROR) == GateArity::MULTI);
+    CHECK(gate_arity(GateType::ELSE_CORRELATED_ERROR) == GateArity::MULTI);
 }
 
 TEST_CASE("GateTraits: annotations are ANNOTATION arity", "[gate_data]") {


### PR DESCRIPTION
## Summary

- Adds Stim-compatible `CORRELATED_ERROR` / `E` and `ELSE_CORRELATED_ERROR` parsing.
- Lowers each contiguous correlated-error chain to one HIR noise site with absolute channel probabilities.
- Exposes the new gates to Python and documents supported syntax.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

Focused checks run:

- [x] `cmake --build build -j`
- [x] `ctest --test-dir build --output-on-failure -R "Parse correlated error|Frontend: correlated|Frontend: stray else correlated error|GateTraits: noise channels"`
- [x] `uv run pytest tests/python/test_sample.py::TestNoiseAndQEC::test_correlated_error_else_branch tests/python/test_sample.py::TestNoiseAndQEC::test_correlated_error_chain_probabilistic -q`

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
