### PR TITLE
refactor(noncomp): API pre-cleanup — keep ComputationalKnown, drop BasisBit

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -111,37 +111,28 @@ simulation:
   coherent return from a leaked level back into a superposition with
   `g`/`e`.
 
-A `Computational`-category level must also declare a `basis_bit`
-(`Zero` or `One`, exposed as a `BasisBit` enum) identifying which
-computational basis state it represents. The rewriter uses this to
-prepend a preparation gate when an initial sample places the qubit
-in `ComputationalKnown` with a level whose `basis_bit` is `One`
-(the SVM default initialization is `|0...0>`).
+A level table must contain exactly two `Computational` levels; in table
+order the first is the `|0>` state and the second is `|1>`. The rewriter
+uses `computational_one_id()` to prepend a preparation gate when an
+initial sample places the qubit in `ComputationalKnown` with the `|1>`
+level, or when a transition materializes the carrier at the `|1>` level
+(the SVM default initialization is `|0...0>`). `Leaked` and `Lost` levels
+carry no basis information — "lost from `|1>`" provenance, if ever needed,
+belongs in an event record or in distinct levels, not in the level tag.
 
-`Leaked`-category levels may optionally carry a `basis_bit` as
-origin metadata (e.g., to record that the atom leaked from `|1>`).
-No current code path consumes it; consumers that want to integrate
-classifier or decoder metadata can read it directly. `Lost`-category
-levels must leave `basis_bit` empty — "lost from `|1>`" provenance,
-if ever needed, belongs in an event record or in distinct lost
-levels, not in the default lost level.
+`LevelSet` validation rejects any table without exactly two `Computational`
+levels; downstream paths (visible Z-basis measurement, Z-basis reset,
+initial prep, classifier defaults) need unambiguous `g`/`e` ids.
 
-`LevelSet` validation also requires the level table to contain
-exactly one `Computational` level with `basis_bit == Zero` and
-exactly one with `basis_bit == One`. Downstream paths (visible
-Z-basis measurement, Z-basis reset, initial prep, classifier
-defaults) need unambiguous `g`/`e` ids; duplicates or missing
-canonical levels reject at `LevelSet` construction.
+Default level set for the MVP:
 
-Default level set for the MVP (sqale-aligned):
-
-| id | label    | category      | basis_bit | notes                          |
-|----|----------|---------------|-----------|--------------------------------|
-| 0  | `g`      | Computational | 0         | logical 0                      |
-| 1  | `e`      | Computational | 1         | logical 1                      |
-| 2  | `leak_g` | Leaked        | —         | metastable / Rydberg "leak g"  |
-| 3  | `leak_e` | Leaked        | —         | metastable / Rydberg "leak e"  |
-| 4  | `lost`   | Lost          | —         | empty trap / vacuum            |
+| id | label    | category      | notes                          |
+|----|----------|---------------|--------------------------------|
+| 0  | `g`      | Computational | logical 0                      |
+| 1  | `e`      | Computational | logical 1                      |
+| 2  | `leak_g` | Leaked        | metastable / Rydberg "leak g"  |
+| 3  | `leak_e` | Leaked        | metastable / Rydberg "leak e"  |
+| 4  | `lost`   | Lost          | empty trap / vacuum            |
 
 Users may construct a `NonComputationalModel` with a different level
 set, but the default ships unchanged.
@@ -224,8 +215,8 @@ import clifft
 model = clifft.NonComputationalModel(
     # Optional; defaults to the sqale-aligned 5-level set above.
     levels=[
-        clifft.Level("g",      category="computational", basis_bit=0),
-        clifft.Level("e",      category="computational", basis_bit=1),
+        clifft.Level("g",      category="computational"),
+        clifft.Level("e",      category="computational"),
         clifft.Level("leak_g", category="leaked"),
         clifft.Level("leak_e", category="leaked"),
         clifft.Level("lost",   category="lost"),
@@ -303,12 +294,9 @@ invariant; the runtime sampler uses it as the §4.2 gate.
 ```cpp
 namespace clifft {
 
-enum class BasisBit : uint8_t { Zero = 0, One = 1 };
-
 struct Level {
     std::string label;
     LevelCategory category;
-    std::optional<BasisBit> basis_bit;
 };
 
 // Validated level table. Construction runs the section 4.1 level-set
@@ -387,8 +375,8 @@ independently constructible and testable, but it admits a misuse a
 level-count check cannot catch — a component built against a
 different but same-sized `LevelSet` would bind its columns to the
 wrong level ids. To close that, each instrument and classifier records
-a deterministic `LevelSet::fingerprint()` (over each level's label,
-category, and basis_bit, in order) at construction, and the model
+a deterministic `LevelSet::fingerprint()` (over each level's label
+and category, in order) at construction, and the model
 rejects any component whose fingerprint does not match its own table.
 
 The fingerprint exists *only* to guard the compositional path. The
@@ -417,13 +405,9 @@ representable in the MVP.
 
 1. **Level set well-formed.** Every level id in `[0, len(levels))`,
    categories all in `LevelCategory` (unrecognized enum values reject).
-   Every `Computational`-category level declares a `basis_bit` (the
-   `BasisBit` enum restricts the value to `Zero` or `One`
-   structurally). `Leaked` levels may carry a `basis_bit` as
-   optional metadata; `Lost` levels must not. The table must contain
-   exactly one Computational level with `basis_bit == Zero` and
-   exactly one with `basis_bit == One` (downstream code needs
-   unambiguous `g`/`e` ids).
+   The table must contain exactly two `Computational` levels; in table
+   order the first is the `|0>` (g) state and the second is `|1>` (e).
+   Downstream code needs unambiguous `g`/`e` ids.
 2. **Initial state is a probability vector** over `levels`. Sums to 1
    within tolerance.
 3. **Transition matrices are square**, of size `len(levels)`, entries
@@ -516,10 +500,10 @@ For each shot:
    if the level's category is `Computational`, else `Leaked` or
    `Lost` (with the sampled level id) per the level's category.
 2. **Translate known computational initial levels into prep gates.**
-   For every qubit whose initial sample is `ComputationalKnown` with
-   a level whose `basis_bit == 1`, the rewriter prepends an `X` on
-   that qubit so the SVM's `|0...0>` initial state matches the
-   sampled known level. `basis_bit == 0` requires no prep.
+   For every qubit whose initial sample is `ComputationalKnown` at
+   the `|1>` level, the rewriter prepends an `X` on that qubit so the
+   SVM's `|0...0>` initial state matches the sampled known level. The
+   `|0>` level requires no prep.
    `Leaked`/`Lost` initial qubits need no quantum prep (their
    computational amplitude is irrelevant); the lost/leaked policy
    gates downstream ops on them from op 0.
@@ -775,8 +759,8 @@ collapses and rezeros the carrier to `|0>`. So the rewriter inserts,
 immediately after the base op:
 
 - an `R` on the qubit, always; and
-- an `X` after it when the destination is the `basis_bit == One`
-  computational level.
+- an `X` after it when the destination is the `|1>` computational
+  level.
 
 The edit is deliberately uniform over the carrier state the base op
 would leave:
@@ -823,7 +807,7 @@ Proposed layout under `src/clifft/noncomp/` (new directory):
    with `computational_unknown()` factory and accessors
    (`is_unknown_computational`, `known_source_level`,
    `require_classical_source_level`). Zero clifft-internal deps.
-2. `level.h` — `LevelCategory` enum, `BasisBit` enum, `Level` struct,
+2. `level.h` — `LevelCategory` enum, `Level` struct,
    `LevelSet` (validated table that owns the `QubitStatus` factories
    `computational_known` / `leaked` / `lost`). Depends on (1).
 3. `transition_instrument.h/.cc` — `TransitionInstrument`,
@@ -843,14 +827,14 @@ Proposed layout under `src/clifft/noncomp/` (new directory):
    (1)-(7), `clifft::Circuit`, `clifft::AstNode`.
 9. `rewriter.h/.cc` — produces a new `clifft::Circuit` from
    `(original, history, model)`, inserting `R` at coherent-qubit loss
-   points and `X` prep for `basis_bit == One` initial samples.
+   points and `X` prep for known-|1> initial samples.
    Depends on (1)-(8) and `clifft::Circuit`.
 10. `orchestrator.h/.cc` — top-level `sample_noncomputational` entry
     point that runs the full pipeline. Depends on (1)-(9), the
     existing compile pipeline, and the SVM.
 
 Python bindings in `src/python/bindings.cc` expose: `Level`,
-`BasisBit`, `LevelSet`, `TransitionInstrument`,
+`LevelSet`, `TransitionInstrument`,
 `MeasurementClassifier`, `NonComputationalPolicy`,
 `NonComputationalModel`,
 `sample_noncomputational(circuit_text, model, shots, seed=None)`.
@@ -869,10 +853,9 @@ tests under `tests/test_noncomp_*.cc`; Python tests under
 
 1. **`qubit_status`, `level`, `transition_instrument`, `classifier`
    unit tests.**
-   - `LevelSet::default_set()` validates; missing `basis_bit` on a
-     Computational level rejects; unrecognized `LevelCategory` enum
-     value rejects; oversized level set rejects. Leaked-with-`basis_bit`
-     is accepted as optional metadata.
+   - `LevelSet::default_set()` validates; a table without exactly two
+     Computational levels rejects; unrecognized `LevelCategory` enum
+     value rejects; oversized level set rejects.
    - Matrix orientation: `T[to, from]` matches a known per-column
      no-jump weight.
    - `is_source_independent_on_computational` is true for identical

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -81,6 +81,15 @@ encode "computational but unknown" as a kind that *cannot* carry a
 specific level id, enforcing the source-resolved invariant
 structurally rather than by convention. See §2.3.
 
+`ComputationalKnown` earns its place as a kind distinct from an opaque
+`Computational`: three code paths branch on it. The sampler takes the
+*exact* known-source column for a state-dependent transition on a
+`ComputationalKnown` qubit and only rejects (or approximates) on
+`ComputationalUnknown` (§4.2); the rewriter prepends an `X` prep for a
+qubit whose sampled initial level is the known `|1>` state; and a
+classically-controlled `X` demotes `Known → Unknown` while leaving an
+already-`Unknown` qubit untouched (§5.2.1).
+
 ### 2.2 Levels (model-defined)
 
 A `Level` is a model-defined tag with a stable integer id, a label, and

--- a/src/clifft/noncomp/level.h
+++ b/src/clifft/noncomp/level.h
@@ -3,25 +3,15 @@
 // Level definitions and the validated level table.
 //
 // A Level is a model-defined tag with a stable integer id (its index
-// into the level table), a human-readable label, a LevelCategory, and
-// an optional basis_bit:
+// into the level table), a human-readable label, and a LevelCategory.
 //
-//   - For LevelCategory::Computational, basis_bit is REQUIRED and
-//     identifies which computational basis state (|0> or |1>) the
-//     level represents. The rewriter uses it to prepend an X prep
-//     for basis_bit == One initial samples.
-//   - For LevelCategory::Leaked, basis_bit is optional metadata
-//     (origin / classifier hint). No current code path consumes it.
-//   - For LevelCategory::Lost, basis_bit MUST be empty. "Lost from
-//     |1>" provenance, if ever needed, belongs in an event record or
-//     in distinct lost levels — not the default lost level.
-//
-// LevelSet validation also enforces that the level table contains
-// exactly one Computational level with basis_bit == Zero and exactly
-// one with basis_bit == One. Downstream paths (visible Z-basis
-// measurement, Z-basis reset, initial prep, classifier defaults)
-// need unambiguous g/e ids; duplicates or missing canonical levels
-// reject at LevelSet construction.
+// A level table must contain exactly two Computational levels; in table
+// order the first is the |0> state and the second is |1>. The rewriter
+// uses computational_one_id() to prepend an X prep for a sampled known-|1>
+// initial level, or when a transition materializes the carrier at the |1>
+// level (the SVM default initialization is |0...0>). Leaked and Lost levels
+// carry no basis information -- "lost from |1>" provenance, if ever needed,
+// belongs in an event record or in distinct levels, not in the level tag.
 //
 // LevelSet wraps a std::vector<Level>, runs validation in its ctor,
 // and owns the QubitStatus factories that bind a level id to this
@@ -33,7 +23,6 @@
 #include "clifft/noncomp/qubit_status.h"
 
 #include <cstdint>
-#include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -48,15 +37,9 @@ enum class LevelCategory : uint8_t {
     Lost = 2,
 };
 
-enum class BasisBit : uint8_t {
-    Zero = 0,
-    One = 1,
-};
-
 struct Level {
     std::string label;
     LevelCategory category;
-    std::optional<BasisBit> basis_bit;
 };
 
 class LevelSet {
@@ -66,31 +49,30 @@ class LevelSet {
     explicit LevelSet(std::vector<Level> levels) : levels_(std::move(levels)) {
         validate();
         fingerprint_ = compute_fingerprint();
-        computational_zero_id_ = find_computational_id(BasisBit::Zero);
-        computational_one_id_ = find_computational_id(BasisBit::One);
+        assign_computational_ids();
     }
 
     // Default level set: g, e, leak_g, leak_e, lost.
-    // Stable order; the integer ids are positional.
+    // Stable order; the integer ids are positional (g = |0>, e = |1>).
     static LevelSet default_set() {
         return LevelSet({
-            Level{"g", LevelCategory::Computational, BasisBit::Zero},
-            Level{"e", LevelCategory::Computational, BasisBit::One},
-            Level{"leak_g", LevelCategory::Leaked, std::nullopt},
-            Level{"leak_e", LevelCategory::Leaked, std::nullopt},
-            Level{"lost", LevelCategory::Lost, std::nullopt},
+            Level{"g", LevelCategory::Computational},
+            Level{"e", LevelCategory::Computational},
+            Level{"leak_g", LevelCategory::Leaked},
+            Level{"leak_e", LevelCategory::Leaked},
+            Level{"lost", LevelCategory::Lost},
         });
     }
 
     std::span<const Level> levels() const { return levels_; }
     size_t size() const { return levels_.size(); }
 
-    // Deterministic schema signature over (label, category, basis_bit)
-    // per level, in order. Two tables that agree on every level's
-    // identity share a fingerprint; any difference in labels, order,
-    // categories, or basis bits changes it. Instruments and classifiers
-    // record the fingerprint of the table they were built against so a
-    // model can reject a component bound to a different table.
+    // Deterministic schema signature over (label, category) per level, in
+    // order. Two tables that agree on every level's identity share a
+    // fingerprint; any difference in labels, order, or categories changes
+    // it. Instruments and classifiers record the fingerprint of the table
+    // they were built against so a model can reject a component bound to a
+    // different table.
     uint64_t fingerprint() const { return fingerprint_; }
 
     const Level& at(uint8_t level_id) const {
@@ -115,9 +97,9 @@ class LevelSet {
         return QubitStatus::lost_unchecked(level_id);
     }
 
-    // Ids of the unique Computational levels with basis_bit == Zero (g)
-    // and == One (e). Validation guarantees exactly one of each, so
-    // these always refer to real levels in this table.
+    // Ids of the two Computational levels in table order: the first is the
+    // |0> state (g), the second is |1> (e). Validation guarantees exactly
+    // two Computational levels, so these always refer to real levels.
     uint8_t computational_zero_id() const { return computational_zero_id_; }
     uint8_t computational_one_id() const { return computational_one_id_; }
 
@@ -144,21 +126,28 @@ class LevelSet {
     uint8_t computational_zero_id_ = kInvalidLevel;
     uint8_t computational_one_id_ = kInvalidLevel;
 
-    uint8_t find_computational_id(BasisBit bit) const {
+    // validate() guarantees exactly two Computational levels; the first in
+    // table order is |0>, the second is |1>.
+    void assign_computational_ids() {
+        bool have_zero = false;
         for (size_t i = 0; i < levels_.size(); ++i) {
-            if (levels_[i].category == LevelCategory::Computational &&
-                levels_[i].basis_bit == bit) {
-                return static_cast<uint8_t>(i);
+            if (levels_[i].category != LevelCategory::Computational) {
+                continue;
+            }
+            if (!have_zero) {
+                computational_zero_id_ = static_cast<uint8_t>(i);
+                have_zero = true;
+            } else {
+                computational_one_id_ = static_cast<uint8_t>(i);
+                return;
             }
         }
-        return kInvalidLevel;  // unreachable: validate() guarantees one of each
     }
 
     // FNV-1a over a canonical byte serialization of each level. The
     // label is length-prefixed so that, e.g., {"ab", "c"} and {"a",
-    // "bc"} do not collide; the basis_bit absence is encoded with a
-    // sentinel distinct from its Zero/One values. Hand-rolled (not
-    // std::hash) so the value is stable across platforms and runs.
+    // "bc"} do not collide. Hand-rolled (not std::hash) so the value is
+    // stable across platforms and runs.
     uint64_t compute_fingerprint() const {
         constexpr uint64_t kOffsetBasis = 1469598103934665603ULL;
         constexpr uint64_t kPrime = 1099511628211ULL;
@@ -176,7 +165,6 @@ class LevelSet {
                 mix(static_cast<uint8_t>(c));
             }
             mix(static_cast<uint8_t>(lv.category));
-            mix(lv.basis_bit.has_value() ? static_cast<uint8_t>(*lv.basis_bit) : 0xFFu);
         }
         return h;
     }
@@ -190,32 +178,15 @@ class LevelSet {
                                         std::to_string(levels_.size()) +
                                         " entries; max supported is 128");
         }
-        size_t computational_zero_count = 0;
-        size_t computational_one_count = 0;
+        size_t computational_count = 0;
         for (size_t i = 0; i < levels_.size(); ++i) {
             const Level& lv = levels_[i];
             switch (lv.category) {
                 case LevelCategory::Computational:
-                    if (!lv.basis_bit.has_value()) {
-                        throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
-                                                    std::to_string(i) +
-                                                    ") is Computational but has no basis_bit");
-                    }
-                    if (*lv.basis_bit == BasisBit::Zero) {
-                        ++computational_zero_count;
-                    } else {
-                        ++computational_one_count;
-                    }
+                    ++computational_count;
                     break;
                 case LevelCategory::Leaked:
-                    // basis_bit allowed as optional origin metadata.
-                    break;
                 case LevelCategory::Lost:
-                    if (lv.basis_bit.has_value()) {
-                        throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
-                                                    std::to_string(i) +
-                                                    ") is Lost and must not carry basis_bit");
-                    }
                     break;
                 default:
                     throw std::invalid_argument("LevelSet: level '" + lv.label + "' (id " +
@@ -223,17 +194,11 @@ class LevelSet {
                                                 ") has an unrecognized LevelCategory value");
             }
         }
-        if (computational_zero_count != 1) {
+        if (computational_count != 2) {
             throw std::invalid_argument(
-                "LevelSet: expected exactly one Computational level with basis_bit == Zero, "
-                "got " +
-                std::to_string(computational_zero_count));
-        }
-        if (computational_one_count != 1) {
-            throw std::invalid_argument(
-                "LevelSet: expected exactly one Computational level with basis_bit == One, "
-                "got " +
-                std::to_string(computational_one_count));
+                "LevelSet: expected exactly two Computational levels (the first is |0>, the "
+                "second |1>), got " +
+                std::to_string(computational_count));
         }
     }
 

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -22,7 +22,7 @@ AstNode single_qubit_op(GateType gate, uint32_t qubit) {
 
 // A hidden carrier edit appended after an op for one operand's jump: an R
 // collapses and rezeros the carrier, and an X then prepares |1> when the
-// jump lands on the basis_bit == One computational level.
+// jump lands on the |1> computational level.
 struct CarrierEdit {
     uint32_t qubit;
     bool prepare_one;
@@ -57,7 +57,7 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
     for (uint32_t q = 0; q < original.num_qubits; ++q) {
         const QubitStatus& s = status[q];
         if (s.kind() == QubitStatusKind::ComputationalKnown &&
-            levels.at(s.level_id()).basis_bit == BasisBit::One) {
+            s.level_id() == levels.computational_one_id()) {
             out.nodes.push_back(single_qubit_op(GateType::X, q));
         }
     }
@@ -135,7 +135,8 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
             if (outcome.jumped) {
                 const Level& dest = levels.at(outcome.destination_level);
                 if (dest.category == LevelCategory::Computational) {
-                    carrier_edits.push_back({qubit, dest.basis_bit == BasisBit::One});
+                    carrier_edits.push_back(
+                        {qubit, outcome.destination_level == levels.computational_one_id()});
                 } else {
                     const QubitStatus post_if_no_jump =
                         drop_op ? pre

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -7,7 +7,7 @@
 // pipeline -- it introduces no new instruction kinds. It does three things:
 //
 //   1. Initial-state prep: prepend an X on each qubit whose sampled initial
-//      status is ComputationalKnown with a basis_bit == One level, so the
+//      status is ComputationalKnown with the |1> level, so the
 //      SVM's |0...0> initial state matches the sampled known level.
 //   2. Per-op policy: replay each operation's per-qubit status through the
 //      shared status stepper and keep, drop, or reject the operation. A
@@ -26,7 +26,7 @@
 //      leave with no jump is ComputationalUnknown -- a qubit a gate has just
 //      made coherent still needs trace-out even if it entered known.
 //   4. Carrier materialization: when a jump lands on a computational level,
-//      insert an R (plus an X for the basis_bit == One level) immediately
+//      insert an R (plus an X for the |1> level) immediately
 //      after the operation, so the SVM carrier is prepared at the definite
 //      destination level. This is done for every carrier state: it is the
 //      collapse unraveling for a coherent carrier, a deterministic re-prep

--- a/src/clifft/noncomp/transition_instrument.cc
+++ b/src/clifft/noncomp/transition_instrument.cc
@@ -65,8 +65,7 @@ TransitionInstrument TransitionInstrument::from_matrix(std::vector<std::vector<d
     // is_source_independent_on_computational: every column whose source
     // level has category Computational must equal the first such column
     // within tolerance. Vacuously true if there are fewer than two
-    // Computational levels (LevelSet validation guarantees exactly two:
-    // basis_bit == Zero and basis_bit == One).
+    // Computational levels (LevelSet validation guarantees exactly two).
     bool flag = true;
     const auto levels_span = levels.levels();
     uint8_t first_comp = 0xFF;

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -54,27 +54,25 @@ std::vector<double> default_initial_state() {
 
 // A two-level set (g, e), distinct in size from the default 5-level set.
 LevelSet two_level_set() {
-    using clifft::BasisBit;
     using clifft::Level;
     using clifft::LevelCategory;
     return LevelSet({
-        Level{"g", LevelCategory::Computational, BasisBit::Zero},
-        Level{"e", LevelCategory::Computational, BasisBit::One},
+        Level{"g", LevelCategory::Computational},
+        Level{"e", LevelCategory::Computational},
     });
 }
 
 // A second valid 5-level set with different labels: same size as
 // default_set but a distinct fingerprint.
 LevelSet relabeled_five_level_set() {
-    using clifft::BasisBit;
     using clifft::Level;
     using clifft::LevelCategory;
     return LevelSet({
-        Level{"zero", LevelCategory::Computational, BasisBit::Zero},
-        Level{"one", LevelCategory::Computational, BasisBit::One},
-        Level{"leak0", LevelCategory::Leaked, std::nullopt},
-        Level{"leak1", LevelCategory::Leaked, std::nullopt},
-        Level{"gone", LevelCategory::Lost, std::nullopt},
+        Level{"zero", LevelCategory::Computational},
+        Level{"one", LevelCategory::Computational},
+        Level{"leak0", LevelCategory::Leaked},
+        Level{"leak1", LevelCategory::Leaked},
+        Level{"gone", LevelCategory::Lost},
     });
 }
 

--- a/tests/test_noncomp_value_types.cc
+++ b/tests/test_noncomp_value_types.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 using Catch::Matchers::ContainsSubstring;
-using clifft::BasisBit;
 using clifft::kInvalidLevel;
 using clifft::Level;
 using clifft::LevelCategory;
@@ -27,9 +26,9 @@ TEST_CASE("LevelSet: default_set validates and exposes the expected levels") {
     LevelSet set = LevelSet::default_set();
     REQUIRE(set.size() == 5);
     REQUIRE(set.at(0).category == LevelCategory::Computational);
-    REQUIRE(set.at(0).basis_bit == BasisBit::Zero);
+    REQUIRE(set.computational_zero_id() == 0);
     REQUIRE(set.at(1).category == LevelCategory::Computational);
-    REQUIRE(set.at(1).basis_bit == BasisBit::One);
+    REQUIRE(set.computational_one_id() == 1);
     REQUIRE(set.at(2).category == LevelCategory::Leaked);
     REQUIRE(set.at(4).category == LevelCategory::Lost);
 }
@@ -38,88 +37,52 @@ TEST_CASE("LevelSet: rejects empty level set") {
     REQUIRE_THROWS_AS(LevelSet(std::vector<Level>{}), std::invalid_argument);
 }
 
-TEST_CASE("LevelSet: rejects Computational level missing basis_bit") {
+TEST_CASE("LevelSet: accepts a custom set with exactly two Computational levels") {
     std::vector<Level> levels = {
-        Level{"g", LevelCategory::Computational, std::nullopt},
-        Level{"e", LevelCategory::Computational, BasisBit::One},
+        Level{"g", LevelCategory::Computational},
+        Level{"e", LevelCategory::Computational},
+        Level{"leak", LevelCategory::Leaked},
+        Level{"lost", LevelCategory::Lost},
     };
-    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
-                        ContainsSubstring("Computational") && ContainsSubstring("basis_bit"));
-}
-
-TEST_CASE("LevelSet: accepts Leaked level carrying optional basis_bit metadata") {
-    std::vector<Level> levels = {
-        Level{"g", LevelCategory::Computational, BasisBit::Zero},
-        Level{"e", LevelCategory::Computational, BasisBit::One},
-        // Single Leaked level with origin metadata.
-        Level{"leak", LevelCategory::Leaked, BasisBit::One},
-        Level{"lost", LevelCategory::Lost, std::nullopt},
-    };
-    REQUIRE_NOTHROW(LevelSet(std::move(levels)));
-}
-
-TEST_CASE("LevelSet: rejects Lost level carrying basis_bit") {
-    std::vector<Level> levels = {
-        Level{"g", LevelCategory::Computational, BasisBit::Zero},
-        Level{"e", LevelCategory::Computational, BasisBit::One},
-        Level{"lost", LevelCategory::Lost, BasisBit::One},
-    };
-    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
-                        ContainsSubstring("Lost") && ContainsSubstring("basis_bit"));
+    LevelSet set(std::move(levels));
+    REQUIRE(set.computational_zero_id() == 0);
+    REQUIRE(set.computational_one_id() == 1);
 }
 
 TEST_CASE("LevelSet: rejects level set above the 128-entry cap") {
     std::vector<Level> levels;
     levels.reserve(129);
     for (size_t i = 0; i < 129; ++i) {
-        levels.push_back(
-            Level{"L" + std::to_string(i), LevelCategory::Computational, BasisBit::Zero});
+        levels.push_back(Level{"L" + std::to_string(i), LevelCategory::Computational});
     }
     REQUIRE_THROWS_WITH(LevelSet(std::move(levels)), ContainsSubstring("128"));
 }
 
 TEST_CASE("LevelSet: rejects unrecognized LevelCategory enum value") {
     std::vector<Level> levels = {
-        Level{"weird", static_cast<LevelCategory>(99), std::nullopt},
+        Level{"weird", static_cast<LevelCategory>(99)},
     };
     REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
                         ContainsSubstring("unrecognized LevelCategory"));
 }
 
-TEST_CASE("LevelSet: rejects two Computational/Zero levels") {
+TEST_CASE("LevelSet: rejects more than two Computational levels") {
     std::vector<Level> levels = {
-        Level{"g1", LevelCategory::Computational, BasisBit::Zero},
-        Level{"g2", LevelCategory::Computational, BasisBit::Zero},
-        Level{"e", LevelCategory::Computational, BasisBit::One},
+        Level{"g", LevelCategory::Computational},
+        Level{"e", LevelCategory::Computational},
+        Level{"x", LevelCategory::Computational},
     };
     REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
-                        ContainsSubstring("Zero") && ContainsSubstring("got 2"));
+                        ContainsSubstring("two Computational") && ContainsSubstring("got 3"));
 }
 
-TEST_CASE("LevelSet: rejects missing Computational/Zero level") {
+TEST_CASE("LevelSet: rejects fewer than two Computational levels") {
     std::vector<Level> levels = {
-        Level{"e", LevelCategory::Computational, BasisBit::One},
+        Level{"g", LevelCategory::Computational},
+        Level{"lost", LevelCategory::Lost},
     };
     REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
-                        ContainsSubstring("Zero") && ContainsSubstring("got 0"));
-}
-
-TEST_CASE("LevelSet: rejects two Computational/One levels") {
-    std::vector<Level> levels = {
-        Level{"g", LevelCategory::Computational, BasisBit::Zero},
-        Level{"e1", LevelCategory::Computational, BasisBit::One},
-        Level{"e2", LevelCategory::Computational, BasisBit::One},
-    };
-    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
-                        ContainsSubstring("One") && ContainsSubstring("got 2"));
-}
-
-TEST_CASE("LevelSet: rejects missing Computational/One level") {
-    std::vector<Level> levels = {
-        Level{"g", LevelCategory::Computational, BasisBit::Zero},
-    };
-    REQUIRE_THROWS_WITH(LevelSet(std::move(levels)),
-                        ContainsSubstring("One") && ContainsSubstring("got 0"));
+                        ContainsSubstring("two Computational") && ContainsSubstring("got 1"));
 }
 
 // =========================================================================


### PR DESCRIPTION
> **Prototype / less-strict review.** Targets the `codex/noncomputational-structural-mvp` feature branch, not `main`.

Item #1 of the path-to-main roadmap — the two "revisit when concrete code exists" API-shape questions from PR #106, resolved against actual usage on the merged branch.

**#8 — keep `ComputationalKnown` (commit 1, doc-only).** Auditing the code, the Known/Unknown split is load-bearing: the sampler takes the *exact* known-source column for a state-dependent transition on a Known qubit (only Unknown rejects/approximates), the rewriter uses it for `|1>` X-prep, and a classically-controlled X demotes Known→Unknown. So it stays; the design note now records why.

**#9 — eliminate per-level `BasisBit` (commit 2).** The `optional<BasisBit>` on `Level` was only meaningful for the two Computational levels and never read on Leaked/Lost (the default set left them `nullopt`) — "optional for everyone, meaningful for two" was the awkward part. Removed: `Level` is now `{label, category}`; the `LevelSet` identifies its `|0>`/`|1>` levels positionally (first/second Computational in table order) via `computational_zero_id()` / `computational_one_id()`, which the rewriter's two consumers compare against. Validation tightens to "exactly two Computational levels"; the fingerprint drops the `basis_bit` byte (all components recompute against the same table, so consistency holds).

No Python surface change (the Python `Level` is a separate index enum). Verified: Debug **973** + Release **973** C++ tests, **877** Python tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
