### PR TITLE
feat(noncomp): draw classifier record bits at sample time in the VM

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -571,7 +571,12 @@ Notes:
   outcome carries no preferred computational value, and a pinned bit
   would silently bias detectors), so the record layout and every
   `rec[-k]` reference are unchanged. Alphabets beyond three symbols
-  have no defined mapping onto (bit, herald) and reject at injection.
+  have no defined mapping onto (bit, herald) and reject at rewrite.
+  Mechanically, the rewrite replaces the measurement with an `MPAD`
+  padding its visible slot; a stochastic column adds a
+  `READOUT_NOISE` on that slot so the bit is drawn at sample time
+  inside the VM, while a deterministic column pads the literal bit
+  with no draw.
 - "Apply, demote to Unknown" is the conservative default: we drop
   knownness on any quantum gate touching a `ComputationalKnown`
   qubit. This loses some optimization opportunity (X on a known qubit
@@ -669,8 +674,8 @@ A dropped operation has no physical effect, so a surviving operand's
 status keeps its entry value (it is not demoted), and attached
 transitions still fire on every operand from its entry-status column —
 the noise process is not gated by whether the intended gate could act.
-The sampler, the rewriter, and classifier injection all advance
-statuses through this same rule.
+The sampler and the rewriter advance statuses through this same
+rule.
 
 ### 5.3 Hidden carrier edits at transition jumps
 

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -1,24 +1,18 @@
 #include "clifft/noncomp/orchestrator.h"
 
 #include "clifft/backend/backend.h"
-#include "clifft/circuit/gate_data.h"
-#include "clifft/circuit/target.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
-#include "clifft/noncomp/numeric.h"
-#include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/sampler.h"
-#include "clifft/noncomp/status_step.h"
-#include "clifft/noncomp/transition_instrument.h"
 #include "clifft/optimizer/pass_factory.h"
 #include "clifft/svm/svm.h"
 #include "clifft/util/xoshiro.h"
 
+#include <cassert>
 #include <cstdint>
-#include <map>
 #include <stdexcept>
-#include <string>
 #include <vector>
 
 namespace clifft {
@@ -39,169 +33,25 @@ uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
     return z ^ (z >> 31);
 }
 
-// One sampled classifier outcome for a measurement on a noncomputational
-// qubit: the injected record bit, and whether the herald symbol fired.
-struct ClassifierDraw {
-    uint8_t bit;
-    bool herald;
-};
-
-// Sample a classifier outcome for a qubit at `level`. The classifier must
-// have two or three symbols and a stochastic column for this level. Symbols
-// 0 and 1 map directly to the record bit. A third symbol heralds the
-// measurement: the herald flag is reported in the sidecar and the record bit
-// is drawn uniformly -- the slot still feeds detectors, and a heralded
-// outcome carries no preferred computational value, so a uniform bit keeps
-// downstream detector statistics unbiased rather than silently pinning them.
-// A substochastic (reject) column is unsupported here.
-ClassifierDraw classifier_draw(const MeasurementClassifier& classifier, uint8_t level,
-                               Xoshiro256PlusPlus& rng, GateType gate, uint32_t op_index,
-                               uint32_t qubit) {
-    // Record injection writes one visible bit. Symbols 0/1 are that bit; a
-    // third symbol is the herald. A still-richer alphabet has no defined
-    // mapping onto (bit, herald) and is not representable.
-    if (classifier.num_symbols() != 2 && classifier.num_symbols() != 3) {
-        throw std::invalid_argument(
-            "sample_noncomputational: injecting a measurement on a noncomputational qubit "
-            "requires a two- or three-symbol classifier, but the model's has " +
-            std::to_string(classifier.num_symbols()) + " symbols (measurement '" +
-            std::string(gate_name(gate)) + "' on qubit " + std::to_string(qubit) + " at op " +
-            std::to_string(op_index) + ")");
-    }
-    // A substochastic column reserves probability for a reject (heralded abort)
-    // outcome that has no binary record bit. That path is not wired through this
-    // entry point yet, so the column must sum to one within tolerance; a reject
-    // column is an explicit error rather than a silently dropped or aborted shot.
-    const double reject = classifier.reject_probability(level);
-    if (reject > kProbTolerance) {
-        throw std::invalid_argument(
-            "sample_noncomputational: classifier reject columns are not supported yet; the column "
-            "for level " +
-            std::to_string(level) + " sums to less than one (reject probability " +
-            std::to_string(reject) + ", measurement '" + std::string(gate_name(gate)) +
-            "' on qubit " + std::to_string(qubit) + " at op " + std::to_string(op_index) + ")");
-    }
-    const double u = rng.next_double();
-    // The column sums to one (checked above): symbol 0 owns [0, prob0),
-    // symbol 1 the next interval, and the herald symbol (if any) the
-    // remainder. Any tolerance-sized rounding residual falls to the last
-    // symbol. A two-symbol draw consumes exactly one random number, so
-    // existing two-symbol seeds reproduce.
-    if (u < classifier.prob(0, level)) {
-        return {0, false};
-    }
-    if (classifier.num_symbols() == 2 ||
-        u < classifier.prob(0, level) + classifier.prob(1, level)) {
-        return {1, false};
-    }
-    return {static_cast<uint8_t>(rng.next_double() < 0.5 ? 0 : 1), true};
-}
-
-GateType reset_for(GateType measure_reset) {
-    switch (measure_reset) {
-        case GateType::MRX:
-            return GateType::RX;
-        case GateType::MRY:
-            return GateType::RY;
-        default:
-            return GateType::R;  // MR
-    }
-}
-
-AstNode single_target(GateType gate, uint32_t value) {
-    return AstNode{gate, {Target::qubit(value)}, {}, 0};
-}
-
-// Replay `original` + `history` to find each leaked/lost measurement's visible
-// record slot and its sampled classifier outcome, then swap those slots in
-// `rewritten`: M -> MPAD(bit); a measure-and-reset -> MPAD(bit) plus the
-// matching reset. Herald flags are written into `heralds` (pre-sized to the
-// visible measurement count, zero-filled) at the same slot indices. The
-// rewriter has already guaranteed only M / measure-reset measurements reach a
-// noncomputational operand.
-Circuit inject_classifier(const Circuit& original, const Circuit& rewritten,
-                          const NonComputationalHistory& history,
-                          const NonComputationalModel& model, Xoshiro256PlusPlus& rng,
-                          std::vector<uint8_t>& heralds) {
-    const LevelSet& levels = model.levels();
-    const NonComputationalPolicy& policy = model.policy();
-    const MeasurementClassifier* classifier = model.classifier();
-
-    std::map<uint32_t, ClassifierDraw> slot_to_bit;
-    std::vector<QubitStatus> status = history.initial_status;
-    size_t trans_cursor = 0;
-    uint32_t slot = 0;
-    for (uint32_t op_index = 0; op_index < original.nodes.size(); ++op_index) {
-        const AstNode& node = original.nodes[op_index];
-        const GateType gate = node.gate;
-        const TransitionInstrument* instrument = model.transition_for(gate);
-        const bool measurement = is_measurement(gate);
-        // Mirror the sampler/rewriter policy pre-scan so all three trajectory
-        // replays advance statuses identically when an operation is dropped.
-        bool drop_op = false;
-        for (const QubitOperand& operand : qubit_operands(node)) {
-            if (operand_action(gate, status[operand.qubit].kind(), policy) == OperandAction::Drop) {
-                drop_op = true;
-            }
-        }
-        for (const QubitOperand& operand : qubit_operands(node)) {
-            const uint32_t qubit = operand.qubit;
-            const QubitStatus pre = status[qubit];
-            TransitionOutcome outcome;
-            if (operand.role == OperandRole::Physical && instrument != nullptr) {
-                const TransitionRecord& record = history.transitions[trans_cursor++];
-                outcome.jumped = record.jumped;
-                outcome.destination_level = record.destination_level;
-            }
-            if (measurement &&
-                (pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost)) {
-                if (classifier == nullptr) {
-                    throw std::invalid_argument(
-                        "sample_noncomputational: measurement '" + std::string(gate_name(gate)) +
-                        "' on a noncomputational qubit " + std::to_string(qubit) + " at op " +
-                        std::to_string(op_index) +
-                        " requires a classifier, but the model has none");
-                }
-                const ClassifierDraw draw =
-                    classifier_draw(*classifier, pre.level_id(), rng, gate, op_index, qubit);
-                slot_to_bit[slot] = draw;
-                heralds[slot] = draw.herald ? 1 : 0;
-            }
-            status[qubit] = drop_op ? step_status_dropped(pre, outcome, levels)
-                                    : step_status(pre, gate, operand.role, outcome, policy, levels);
-        }
-        if (measurement) {
-            ++slot;
+// Herald pass for a three-symbol classifier: draw each classified slot's
+// herald flag and re-point the heralded slots' record-flip probability at one
+// half -- a heralded outcome carries no preferred computational value, so a
+// uniform bit keeps downstream detector statistics unbiased rather than
+// silently pinning them. Non-heralded slots keep the not-heralded conditional
+// probability the rewriter emitted. Herald flags land in `heralds` (pre-sized
+// to the visible measurement count, zero-filled).
+void apply_heralds(RewriteResult& rw, const MeasurementClassifier& classifier,
+                   Xoshiro256PlusPlus& rng, std::vector<uint8_t>& heralds) {
+    for (const ClassifiedMeasurement& m : rw.classified_measurements) {
+        const double p_herald = classifier.prob(2, m.level);
+        if (rng.next_double() < p_herald) {
+            heralds[m.slot] = 1;
+            // The rewriter always emits a READOUT_NOISE node for a ternary
+            // classifier's slots, so there is a node to patch.
+            assert(m.noise_node != SIZE_MAX);
+            rw.circuit.nodes[m.noise_node].args[0] = 0.5;
         }
     }
-
-    if (slot_to_bit.empty()) {
-        return rewritten;
-    }
-
-    Circuit out = rewritten;
-    out.nodes.clear();
-    out.nodes.reserve(rewritten.nodes.size() + slot_to_bit.size());
-    uint32_t out_slot = 0;
-    for (const AstNode& node : rewritten.nodes) {
-        if (!is_measurement(node.gate)) {
-            out.nodes.push_back(node);
-            continue;
-        }
-        auto it = slot_to_bit.find(out_slot);
-        ++out_slot;
-        if (it == slot_to_bit.end()) {
-            out.nodes.push_back(node);  // computational measurement, kept as-is
-            continue;
-        }
-        const uint8_t bit = it->second.bit;
-        const uint32_t qubit = qubit_operands(node).front().qubit;
-        out.nodes.push_back(single_target(GateType::MPAD, bit));
-        if (is_measure_reset(node.gate)) {
-            out.nodes.push_back(single_target(reset_for(node.gate), qubit));
-        }
-    }
-    return out;
 }
 
 CompiledModule compile_circuit(const Circuit& circuit) {
@@ -220,9 +70,8 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
-    // The visible record layout is invariant under rewriting and injection, so
-    // the record widths come straight from the circuit and hold even for zero
-    // shots.
+    // The visible record layout is invariant under rewriting, so the record
+    // widths come straight from the circuit and hold even for zero shots.
     result.num_measurements = circuit.num_measurements;
     result.num_detectors = circuit.num_detectors;
     result.num_observables = circuit.num_observables;
@@ -245,16 +94,20 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
         global_seed = entropy();
     }
 
+    const MeasurementClassifier* classifier = model.classifier();
+
     for (uint32_t shot = 0; shot < shots; ++shot) {
         HistorySample hs =
             sample_history(circuit, model, derive_seed(global_seed, shot, kHistoryDomain));
-        Circuit rw = rewrite(circuit, hs.history, model);
-        Xoshiro256PlusPlus classifier_rng(derive_seed(global_seed, shot, kClassifierDomain));
+        RewriteResult rw = rewrite(circuit, hs.history, model);
         std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
-        Circuit injected =
-            inject_classifier(circuit, rw, hs.history, model, classifier_rng, shot_heralds);
+        if (classifier != nullptr && classifier->num_symbols() == 3 &&
+            !rw.classified_measurements.empty()) {
+            Xoshiro256PlusPlus classifier_rng(derive_seed(global_seed, shot, kClassifierDomain));
+            apply_heralds(rw, *classifier, classifier_rng, shot_heralds);
+        }
 
-        CompiledModule program = compile_circuit(injected);
+        CompiledModule program = compile_circuit(rw.circuit);
         SampleResult sr = sample(program, 1, derive_seed(global_seed, shot, kSvmDomain));
 
         result.measurements.insert(result.measurements.end(), sr.measurements.begin(),

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -6,17 +6,20 @@
 // pipeline and returns the user-facing records plus a noncomputational
 // sidecar. For each shot it:
 //   1. samples a structural history (initial statuses + transition outcomes);
-//   2. rewrites the circuit for that history (X-prep, trace-out R, policy);
-//   3. injects the model classifier's outcome for each measurement on a
-//      leaked/lost qubit -- swapping M for MPAD(bit), and a measure-and-reset
-//      for MPAD(bit) plus the matching reset -- so the forced bit reaches the
-//      SVM's detector/observable evaluation, not just postprocessing;
+//   2. rewrites the circuit for that history (X-prep, trace-out R, policy,
+//      and the classifier record write for each measurement on a leaked/lost
+//      qubit: MPAD plus a READOUT_NOISE for a stochastic column, so the bit
+//      is drawn at sample time inside the VM and reaches its
+//      detector/observable evaluation, not just postprocessing);
+//   3. for a three-symbol classifier, draws each classified slot's herald
+//      flag and re-points heralded slots' record flip at one half;
 //   4. compiles the result through the ordinary pipeline and samples one shot.
 //
 // Randomness is deterministic in `seed`: each shot draws domain-separated
-// sub-seeds for the history sampler, the classifier, and the SVM, so the
-// three streams never coincide. With no seed, a global seed is drawn from OS
-// entropy and the run is non-reproducible.
+// sub-seeds for the history sampler, the herald pass, and the SVM, so the
+// three streams never coincide. Stochastic classifier bits are drawn by the
+// SVM's own stream at the injected READOUT_NOISE sites. With no seed, a
+// global seed is drawn from OS entropy and the run is non-reproducible.
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/model.h"

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -2,12 +2,16 @@
 
 #include "clifft/circuit/gate_data.h"
 #include "clifft/circuit/target.h"
+#include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
+#include "clifft/noncomp/numeric.h"
 #include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -20,6 +24,68 @@ AstNode single_qubit_op(GateType gate, uint32_t qubit) {
     return AstNode{gate, {Target::qubit(qubit)}, {}, 0};
 }
 
+// MPAD's target is the padded record bit itself (a 0/1 literal).
+AstNode mpad_op(uint8_t bit) {
+    return AstNode{GateType::MPAD, {Target::qubit(bit)}, {}, 0};
+}
+
+// Classical bit-flip on an absolute visible record slot, drawn at sample
+// time inside the VM.
+AstNode readout_noise_op(uint32_t slot, double prob) {
+    return AstNode{GateType::READOUT_NOISE, {Target::rec(slot)}, {prob}, 0};
+}
+
+GateType reset_for(GateType measure_reset) {
+    switch (measure_reset) {
+        case GateType::MRX:
+            return GateType::RX;
+        case GateType::MRY:
+            return GateType::RY;
+        default:
+            return GateType::R;  // MR
+    }
+}
+
+// Validate that the model's classifier can supply the record bit for a
+// measurement on a noncomputational qubit at `level`: it must exist, have
+// two or three symbols, and offer a stochastic (non-reject) column for the
+// level. Returns the classifier on success.
+const MeasurementClassifier& classifier_for(const NonComputationalModel& model, uint8_t level,
+                                            GateType gate, uint32_t op_index, uint32_t qubit) {
+    const MeasurementClassifier* classifier = model.classifier();
+    if (classifier == nullptr) {
+        throw std::invalid_argument("rewrite: measurement '" + std::string(gate_name(gate)) +
+                                    "' on a noncomputational qubit " + std::to_string(qubit) +
+                                    " at op " + std::to_string(op_index) +
+                                    " requires a classifier, but the model has none");
+    }
+    // The record write is one visible bit. Symbols 0/1 are that bit; a third
+    // symbol is the herald. A still-richer alphabet has no defined mapping
+    // onto (bit, herald) and is not representable.
+    if (classifier->num_symbols() != 2 && classifier->num_symbols() != 3) {
+        throw std::invalid_argument(
+            "rewrite: a measurement on a noncomputational qubit requires a two- or three-symbol "
+            "classifier, but the model's has " +
+            std::to_string(classifier->num_symbols()) + " symbols (measurement '" +
+            std::string(gate_name(gate)) + "' on qubit " + std::to_string(qubit) + " at op " +
+            std::to_string(op_index) + ")");
+    }
+    // A substochastic column reserves probability for a reject (heralded
+    // abort) outcome that has no binary record bit. That path is not wired
+    // through this entry point yet, so the column must sum to one within
+    // tolerance; a reject column is an explicit error rather than a silently
+    // dropped or aborted shot.
+    const double reject = classifier->reject_probability(level);
+    if (reject > kProbTolerance) {
+        throw std::invalid_argument(
+            "rewrite: classifier reject columns are not supported yet; the column for level " +
+            std::to_string(level) + " sums to less than one (reject probability " +
+            std::to_string(reject) + ", measurement '" + std::string(gate_name(gate)) +
+            "' on qubit " + std::to_string(qubit) + " at op " + std::to_string(op_index) + ")");
+    }
+    return *classifier;
+}
+
 // A hidden carrier edit appended after an op for one operand's jump: an R
 // collapses and rezeros the carrier, and an X then prepares |1> when the
 // jump lands on the |1> computational level.
@@ -30,8 +96,8 @@ struct CarrierEdit {
 
 }  // namespace
 
-Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
-                const NonComputationalModel& model) {
+RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& history,
+                      const NonComputationalModel& model) {
     const LevelSet& levels = model.levels();
     const NonComputationalPolicy& policy = model.policy();
 
@@ -45,8 +111,11 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
     // Copy so every circuit-level field carries over (and any field added to
     // Circuit later is not silently dropped); only the node list is rebuilt.
     // The inserted X-prep, hidden R, and destination-prep X ops are not
-    // visible measurements, so the record-layout counts stay valid.
-    Circuit out = original;
+    // visible measurements, and a classifier record write pads the same slot
+    // its measurement occupied, so the record-layout counts stay valid.
+    RewriteResult result;
+    Circuit& out = result.circuit;
+    out = original;
     out.nodes.clear();
     out.nodes.reserve(original.nodes.size() + original.num_qubits);
 
@@ -63,6 +132,7 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
     }
 
     size_t trans_cursor = 0;
+    uint32_t slot = 0;  // visible measurement record index
 
     for (uint32_t op_index = 0; op_index < original.nodes.size(); ++op_index) {
         const AstNode& node = original.nodes[op_index];
@@ -97,9 +167,18 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
 
         std::vector<CarrierEdit> carrier_edits;  // hidden edits appended after this op
 
+        // Set when this (single-qubit Z-basis) measurement reads a leaked or
+        // lost qubit: the classifier, not the SVM, defines its record bit.
+        std::optional<uint8_t> classified_level;
+
         for (const QubitOperand& operand : qubit_operands(node)) {
             const uint32_t qubit = operand.qubit;
             const QubitStatus pre = status[qubit];
+
+            if (is_measurement(gate) &&
+                (pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost)) {
+                classified_level = pre.level_id();
+            }
 
             // Replay the recorded transition for this operand, if the sampler
             // consulted one (a Physical operand of a gate declaring a
@@ -152,13 +231,58 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
         }
 
         if (!drop_op) {
-            out.nodes.push_back(node);
+            if (classified_level.has_value()) {
+                // The policy pre-scan admits only single-qubit Z-basis
+                // measurement forms here (M and the measure-and-resets);
+                // X/Y-basis and multi-target measurements on a
+                // noncomputational operand reject above.
+                const uint32_t qubit = qubit_operands(node).front().qubit;
+                const MeasurementClassifier& classifier =
+                    classifier_for(model, *classified_level, gate, op_index, qubit);
+                const bool ternary = classifier.num_symbols() == 3;
+
+                // The record bit's flip probability on top of MPAD 0:
+                // P(symbol 1 | level) for a two-symbol column; for a ternary
+                // column, the bit's not-heralded conditional -- the herald
+                // pass re-points heralded slots at one half. An always-herald
+                // column has no not-heralded conditional; one half stands in
+                // (every draw heralds, so the pass always overwrites it).
+                double flip;
+                if (ternary) {
+                    const double p_herald = classifier.prob(2, *classified_level);
+                    const double denom = 1.0 - p_herald;
+                    flip = denom > 0.0 ? classifier.prob(1, *classified_level) / denom : 0.5;
+                    flip = std::min(1.0, std::max(0.0, flip));
+                } else {
+                    flip = classifier.prob(1, *classified_level);
+                }
+
+                size_t noise_node = SIZE_MAX;
+                if (!ternary && (flip == 0.0 || flip == 1.0)) {
+                    // Deterministic column: the bit is the padding literal
+                    // itself, no sample-time draw.
+                    out.nodes.push_back(mpad_op(flip == 1.0 ? 1 : 0));
+                } else {
+                    out.nodes.push_back(mpad_op(0));
+                    out.nodes.push_back(readout_noise_op(slot, flip));
+                    noise_node = out.nodes.size() - 1;
+                }
+                if (is_measure_reset(gate)) {
+                    out.nodes.push_back(single_qubit_op(reset_for(gate), qubit));
+                }
+                result.classified_measurements.push_back({slot, *classified_level, noise_node});
+            } else {
+                out.nodes.push_back(node);
+            }
         }
         for (const CarrierEdit& edit : carrier_edits) {
             out.nodes.push_back(single_qubit_op(GateType::R, edit.qubit));
             if (edit.prepare_one) {
                 out.nodes.push_back(single_qubit_op(GateType::X, edit.qubit));
             }
+        }
+        if (is_measurement(gate)) {
+            ++slot;
         }
     }
 
@@ -168,7 +292,7 @@ Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
             "history does not describe this circuit");
     }
 
-    return out;
+    return result;
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -4,28 +4,40 @@
 //
 // rewrite(original, history, model) replays one sampled trajectory and
 // produces a new ordinary clifft::Circuit ready for the existing compile
-// pipeline -- it introduces no new instruction kinds. It does three things:
+// pipeline -- it introduces no new instruction kinds. It does five things:
 //
 //   1. Initial-state prep: prepend an X on each qubit whose sampled initial
 //      status is ComputationalKnown with the |1> level, so the
 //      SVM's |0...0> initial state matches the sampled known level.
 //   2. Per-op policy: replay each operation's per-qubit status through the
-//      shared status stepper and keep, drop, or reject the operation. A
-//      measurement is always kept so the visible measurement record (and
-//      every rec[-k] reference into it) is preserved; reinterpreting a
-//      measurement's outcome for a leaked or lost qubit is a sampling /
-//      sidecar concern for the orchestrator, not a circuit edit. An
+//      shared status stepper and keep, drop, or reject the operation. An
 //      ambiguous operation on a leaked or lost operand rejects by default;
 //      under LostLeakedOpsPolicy::Drop it is excised whole (identity on the
 //      surviving operands), whose statuses then keep their entry values.
-//   3. Hidden trace-out: when a coherent qubit jumps to a Leaked or Lost
+//   3. Classifier record write: a measurement on a leaked or lost qubit is
+//      not a physical Born measurement -- the model's classifier defines its
+//      record bit. The measurement node is replaced by an MPAD writing the
+//      same visible record slot, so the record layout and every rec[-k]
+//      reference are preserved and the bit reaches the SVM's
+//      detector/observable evaluation. A stochastic classifier column adds a
+//      READOUT_NOISE on that slot so the bit is drawn at sample time inside
+//      the VM; a deterministic column pads the literal bit with no draw. A
+//      measure-and-reset additionally keeps its reset as a separate node.
+//      Each such replacement is reported in the result's
+//      classified_measurements (in slot order) so callers can post-process
+//      per-slot classifier behavior -- e.g. the herald pass for three-symbol
+//      classifiers, which re-points a heralded slot's flip probability at
+//      one half. For a three-symbol column the emitted probability is the
+//      bit's not-heralded conditional, and a READOUT_NOISE node is always
+//      emitted so a heralded slot has a node to patch.
+//   4. Hidden trace-out: when a coherent qubit jumps to a Leaked or Lost
 //      level, insert an R on that qubit immediately after the operation.
 //      The existing reset lowering turns it into a hidden measurement plus a
 //      corrective Pauli; it adds no visible measurement and shifts no record
 //      index. "Coherent" means the carrier state the base operation would
 //      leave with no jump is ComputationalUnknown -- a qubit a gate has just
 //      made coherent still needs trace-out even if it entered known.
-//   4. Carrier materialization: when a jump lands on a computational level,
+//   5. Carrier materialization: when a jump lands on a computational level,
 //      insert an R (plus an X for the |1> level) immediately
 //      after the operation, so the SVM carrier is prepared at the definite
 //      destination level. This is done for every carrier state: it is the
@@ -43,20 +55,47 @@
 #include "clifft/noncomp/history.h"
 #include "clifft/noncomp/model.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
 namespace clifft {
+
+// One measurement the rewrite replaced with a classifier record write.
+struct ClassifiedMeasurement {
+    // Visible measurement record index of the replaced measurement.
+    uint32_t slot = 0;
+
+    // The measured qubit's level id at the measurement.
+    uint8_t level = 0;
+
+    // Index into the rewritten circuit's nodes of the READOUT_NOISE node
+    // drawing this slot's bit, or SIZE_MAX when the column is deterministic
+    // and the bit is the MPAD literal itself.
+    size_t noise_node = SIZE_MAX;
+};
+
+// Result of a rewrite: the circuit plus the classifier record writes it
+// contains, in ascending slot order.
+struct RewriteResult {
+    Circuit circuit;
+    std::vector<ClassifiedMeasurement> classified_measurements;
+};
 
 // Produce the rewritten circuit for `original` under `history` and `model`.
 // Throws std::invalid_argument when the trajectory policy rejects an
-// operation (naming the operation index, qubit, gate, and status) or when
-// `history` does not describe `original` (qubit count or transition count
-// mismatch).
+// operation (naming the operation index, qubit, gate, and status), when a
+// measurement on a leaked/lost qubit needs a classifier the model does not
+// provide (or one that is not a two- or three-symbol stochastic column), or
+// when `history` does not describe `original` (qubit count or transition
+// count mismatch).
 //
 // Precondition: `original` is a parser-normalized circuit -- each
 // single-qubit operation is a single-target node and each two-qubit
 // operation is a single pair. The keep / drop / reject decision is made per
 // node, so a hand-built node that packs several single-qubit operands would
 // be dropped or rejected as a whole rather than per operand.
-Circuit rewrite(const Circuit& original, const NonComputationalHistory& history,
-                const NonComputationalModel& model);
+RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& history,
+                      const NonComputationalModel& model);
 
 }  // namespace clifft

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -279,6 +279,37 @@ TEST_CASE("sample_noncomputational: a partial herald column matches its frequenc
     REQUIRE(heralded < 770);
 }
 
+TEST_CASE("sample_noncomputational: the record bit is uniform given a herald, pinned without") {
+    // Column {0.5, 0, 0.5}: a non-heralded draw is always symbol 0, while a
+    // heralded slot's bit is uniform. This pins the (herald, bit) joint: if
+    // heralded slots kept the not-heralded flip probability (0), their bits
+    // would all read 0.
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    MeasurementClassifier cl =
+        ternary_classifier_with(LevelSet::default_set(), kLeakG, {0.5, 0.0, 0.5});
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
+
+    constexpr uint32_t kShots = 2000;
+    NonComputationalSample r = sample_noncomputational(c, model, kShots, 13);
+    size_t heralded = 0;
+    size_t heralded_ones = 0;
+    for (uint32_t shot = 0; shot < kShots; ++shot) {
+        if (r.heralds[shot]) {
+            ++heralded;
+            heralded_ones += r.measurements[shot];
+        } else {
+            REQUIRE(r.measurements[shot] == 0);  // not-heralded bit is symbol 0
+        }
+    }
+    REQUIRE(heralded > 850);  // expected 1000; generous band
+    REQUIRE(heralded < 1150);
+    // Heralded bits are uniform: expected heralded/2, ~6 sigma band.
+    REQUIRE(heralded_ones > heralded * 35 / 100);
+    REQUIRE(heralded_ones < heralded * 65 / 100);
+}
+
 TEST_CASE("sample_noncomputational: a two-symbol classifier leaves the herald sidecar zero") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -3,6 +3,7 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
+#include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/policy.h"
@@ -12,24 +13,29 @@
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_factory.h"
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
 
 using Catch::Matchers::ContainsSubstring;
+using clifft::AstNode;
 using clifft::Circuit;
 using clifft::default_hir_pass_manager;
 using clifft::GateType;
 using clifft::HirModule;
 using clifft::HistorySample;
 using clifft::LevelSet;
+using clifft::MeasurementClassifier;
 using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
 using clifft::parse;
 using clifft::rewrite;
+using clifft::RewriteResult;
 using clifft::sample_history;
 using clifft::trace;
 using clifft::TransitionInstrument;
@@ -106,6 +112,29 @@ NonComputationalModel make_model(std::vector<double> initial_state,
                                  std::move(transitions), std::nullopt, policy);
 }
 
+// Classifier whose column for `level` is `col` (two or three symbols by
+// col's length); every other level is a deterministic symbol 0.
+MeasurementClassifier classifier_with(uint8_t level, std::vector<double> col) {
+    std::vector<std::vector<double>> m(col.size(), std::vector<double>(5, 0.0));
+    std::vector<std::string> symbols;
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    for (size_t s = 0; s < col.size(); ++s) {
+        m[s][level] = col[s];
+        symbols.push_back(std::to_string(s));
+    }
+    return MeasurementClassifier::from_matrix(std::move(symbols), std::move(m),
+                                              LevelSet::default_set());
+}
+
+NonComputationalModel make_model_with_classifier(
+    std::vector<double> initial_state, std::map<std::string, TransitionInstrument> transitions,
+    MeasurementClassifier classifier, NonComputationalPolicy policy = {}) {
+    return NonComputationalModel(LevelSet::default_set(), std::move(initial_state),
+                                 std::move(transitions), std::move(classifier), policy);
+}
+
 std::vector<double> all_g() {
     return {1.0, 0.0, 0.0, 0.0, 0.0};
 }
@@ -124,6 +153,12 @@ size_t count_gate(const Circuit& c, GateType gate) {
 }
 
 Circuit rewritten(const Circuit& c, const NonComputationalModel& model, uint64_t seed) {
+    HistorySample s = sample_history(c, model, seed);
+    return rewrite(c, s.history, model).circuit;
+}
+
+RewriteResult rewritten_result(const Circuit& c, const NonComputationalModel& model,
+                               uint64_t seed) {
     HistorySample s = sample_history(c, model, seed);
     return rewrite(c, s.history, model);
 }
@@ -275,15 +310,108 @@ TEST_CASE("rewrite: a lost-qubit reset rejects by default and restores under pol
     REQUIRE(count_gate(rw, GateType::R) == 2);
 }
 
-TEST_CASE("rewrite: a plain Z measurement on a lost qubit is kept") {
+TEST_CASE("rewrite: a lost-qubit measurement becomes a classifier record write") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model_with_classifier(all_g(), std::move(transitions),
+                                                             classifier_with(kLost, {0.5, 0.5}));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    // The M is replaced by an MPAD padding the same visible slot, plus a
+    // READOUT_NOISE drawing the stochastic classifier bit at sample time.
+    REQUIRE(count_gate(rw.circuit, GateType::M) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
+    REQUIRE(rw.circuit.num_measurements == 1);  // visible record preserved
+
+    REQUIRE(rw.classified_measurements.size() == 1);
+    REQUIRE(rw.classified_measurements[0].slot == 0);
+    REQUIRE(rw.classified_measurements[0].level == kLost);
+    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(noise.gate == GateType::READOUT_NOISE);
+    REQUIRE(noise.targets[0].is_rec());
+    REQUIRE(noise.targets[0].value() == 0);  // flips the padded slot
+    REQUIRE(noise.args[0] == 0.5);
+}
+
+TEST_CASE("rewrite: a deterministic classifier column pads the literal bit, no draw") {
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model_with_classifier(all_g(), std::move(transitions),
+                                                             classifier_with(kLost, {0.0, 1.0}));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
+    for (const AstNode& node : rw.circuit.nodes) {
+        if (node.gate == GateType::MPAD) {
+            REQUIRE(node.targets[0].value() == 1);  // the bit is the padding literal
+        }
+    }
+    REQUIRE(rw.classified_measurements.size() == 1);
+    REQUIRE(rw.classified_measurements[0].noise_node == SIZE_MAX);
+}
+
+TEST_CASE("rewrite: the record write flips its own slot, not an earlier one") {
+    // Slot 0 is a computational measurement; the lost qubit's measurement is
+    // slot 1, and its READOUT_NOISE must target slot 1.
+    Circuit c = parse("M 1\nH 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model_with_classifier(all_g(), std::move(transitions),
+                                                             classifier_with(kLost, {0.5, 0.5}));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(count_gate(rw.circuit, GateType::M) == 1);  // the computational one
+    REQUIRE(rw.classified_measurements.size() == 1);
+    REQUIRE(rw.classified_measurements[0].slot == 1);
+    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(noise.targets[0].value() == 1);
+}
+
+TEST_CASE("rewrite: a ternary column emits the not-heralded conditional flip") {
+    // Column {0.3, 0.1, 0.6}: conditioned on not heralding, the bit is
+    // 0.1 / (1 - 0.6) = 0.25. A ternary slot always gets a READOUT_NOISE so
+    // the herald pass has a node to re-point at one half.
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model_with_classifier(
+        all_g(), std::move(transitions), classifier_with(kLeakG, {0.3, 0.1, 0.6}));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(rw.classified_measurements.size() == 1);
+    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(noise.gate == GateType::READOUT_NOISE);
+    REQUIRE(noise.args[0] == Catch::Approx(0.25));
+}
+
+TEST_CASE("rewrite: an always-herald ternary column still emits a patchable node") {
+    // {0, 0, 1} has no not-heralded conditional; one half stands in, and the
+    // herald pass overwrites it on every (always-heralding) draw.
+    Circuit c = parse("H 0\nS 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_leaked(LevelSet::default_set()));
+    NonComputationalModel model = make_model_with_classifier(
+        all_g(), std::move(transitions), classifier_with(kLeakG, {0.0, 0.0, 1.0}));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(rw.classified_measurements.size() == 1);
+    REQUIRE(rw.classified_measurements[0].noise_node != SIZE_MAX);
+    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(noise.args[0] == 0.5);
+}
+
+TEST_CASE("rewrite: a noncomputational measurement without a classifier rejects") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("S", always_lost(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    Circuit rw = rewritten(c, model, 1);
-    REQUIRE(count_gate(rw, GateType::M) == 1);
-    REQUIRE(rw.num_measurements == 1);  // visible record preserved
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("requires a classifier"));
 }
 
 TEST_CASE("rewrite: an X/Y-basis or multi-qubit measurement on a lost qubit rejects") {
@@ -316,19 +444,29 @@ TEST_CASE("rewrite: a measure-and-reset on a lost qubit rejects by default, kept
 
     NonComputationalPolicy restore;
     restore.reset_restores_lost = true;
-    NonComputationalModel reload = make_model(all_g(), std::move(transitions), restore);
+    NonComputationalModel reload = make_model_with_classifier(
+        all_g(), std::move(transitions), classifier_with(kLost, {1.0, 0.0}), restore);
     Circuit rw = rewritten(c, reload, 1);
-    REQUIRE(count_gate(rw, GateType::MR) == 1);  // kept; orchestrator injects later
+    // The MR splits into the classifier record write plus its reset; with the
+    // trace-out of the lost coherent qubit that makes two Rs.
+    REQUIRE(count_gate(rw, GateType::MR) == 0);
+    REQUIRE(count_gate(rw, GateType::MPAD) == 1);
+    REQUIRE(count_gate(rw, GateType::R) == 2);
+    REQUIRE(rw.num_measurements == 1);  // visible record preserved
 }
 
-TEST_CASE("rewrite: a measure-and-reset on a leaked qubit is kept") {
+TEST_CASE("rewrite: a measure-and-reset on a leaked qubit records and resets") {
     Circuit c = parse("H 0\nS 0\nMR 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("S", always_leaked(LevelSet::default_set()));
-    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+    NonComputationalModel model = make_model_with_classifier(all_g(), std::move(transitions),
+                                                             classifier_with(kLeakG, {0.5, 0.5}));
 
     Circuit rw = rewritten(c, model, 1);
-    REQUIRE(count_gate(rw, GateType::MR) == 1);
+    REQUIRE(count_gate(rw, GateType::MR) == 0);
+    REQUIRE(count_gate(rw, GateType::MPAD) == 1);
+    REQUIRE(count_gate(rw, GateType::READOUT_NOISE) == 1);
+    REQUIRE(count_gate(rw, GateType::R) == 2);  // trace-out plus the MR's reset
 }
 
 TEST_CASE("rewrite: a jump to the |0> computational level inserts an R, no X") {
@@ -440,7 +578,7 @@ TEST_CASE("rewrite: a dropped gate leaves the surviving operand's status untouch
 
     HistorySample s = sample_history(c, model, 1);
     REQUIRE(s.final_status[1].kind() == clifft::QubitStatusKind::Lost);
-    Circuit rw = rewrite(c, s.history, model);
+    Circuit rw = rewrite(c, s.history, model).circuit;
     REQUIRE(count_gate(rw, GateType::CZ) == 0);
 }
 
@@ -491,7 +629,7 @@ TEST_CASE("rewrite: drop policy drops a non-restoring lost reset") {
 
     HistorySample s = sample_history(c, model, 1);
     REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
-    Circuit rw = rewrite(c, s.history, model);
+    Circuit rw = rewrite(c, s.history, model).circuit;
     REQUIRE(count_gate(rw, GateType::R) == 1);  // the trace-out only
 }
 
@@ -501,10 +639,13 @@ TEST_CASE("rewrite: drop policy keeps a measure-and-reset on a non-restoring los
     transitions.emplace("S", always_lost(LevelSet::default_set()));
     NonComputationalPolicy policy;
     policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
+    NonComputationalModel model = make_model_with_classifier(
+        all_g(), std::move(transitions), classifier_with(kLost, {1.0, 0.0}), policy);
 
     HistorySample s = sample_history(c, model, 1);
     REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
-    Circuit rw = rewrite(c, s.history, model);
-    REQUIRE(count_gate(rw, GateType::MR) == 1);  // record slot preserved
+    RewriteResult rw = rewrite(c, s.history, model);
+    REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);  // record slot preserved
+    REQUIRE(rw.circuit.num_measurements == 1);
 }

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -199,11 +199,13 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
     Circuit c = parse("H 0\nCX 0 1\nS 0\nM 0\nM 1\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("S", always_lost(LevelSet::default_set()));
-    NonComputationalModel model = make_model(std::move(transitions));  // rewrite ignores classifier
+    // The lost qubit's later M needs a classifier column for its record bit.
+    NonComputationalModel model =
+        make_model(std::move(transitions), lost_classifier(LevelSet::default_set(), {1.0, 0.0}));
 
     HistorySample hs =
         sample_history(c, model, 1);  // always_lost: qubit 0 is deterministically lost
-    Circuit rw = rewrite(c, hs.history, model);
+    Circuit rw = rewrite(c, hs.history, model).circuit;
 
     // The original circuit has no reset; the loss rewrite adds exactly one
     // trace-out R (and no X-prep, since both halves start in |0>).


### PR DESCRIPTION
> **Prototype / less-strict review.** Targets the `codex/noncomputational-structural-mvp` feature branch, not `main`.

Step 1 of the state-dependent-jumps implementation plan (`design/state-dependent-jumps.md` §6): move the classifier's record-bit draw from per-shot injection into the VM, and make the rewriter the single validated trajectory replay.

**What changes**

- **Rewriter absorbs classifier injection.** A measurement on a leaked/lost qubit now rewrites directly to `MPAD` (padding the same visible slot — record layout and every `rec[-k]` unchanged) plus, for a **stochastic** column, a `READOUT_NOISE(P(1|level)) rec[slot]` so the bit is drawn per shot inside the VM. A **deterministic** column pads the literal bit with no draw; a measure-and-reset keeps its reset as a separate node. `READOUT_NOISE rec[k]` is already a first-class circuit instruction (the `M(p)` decomposition emits it), so no new instruction surface.
- **`rewrite()` returns a `RewriteResult`** — the circuit plus a `classified_measurements` table (slot, level, noise-node index) in slot order.
- **`inject_classifier` is deleted.** Its separate, unvalidated replay of the transition record (the known validation gap) is gone by construction; the rewriter's validated replay is the only one left. The reason injection was a separate pass — "it needs RNG" — no longer holds for two-symbol columns.
- **Three-symbol (heralded) classifiers**: the rewriter emits the bit's *not-heralded* conditional flip (always with a `READOUT_NOISE` node, so there is something to patch), and a small orchestrator herald pass consumes the table — no circuit replay — drawing each classified slot's herald flag and re-pointing heralded slots at ½. This preserves the exact *(herald, bit)* joint: bit-given-herald uniform, bit-given-no-herald renormalized.
- Classifier validation (presence, 2-or-3 symbols, reject columns) moves into `rewrite()` with the same substantive messages, fired lazily at the consulting measurement as before.
- Design note: the lost-measurement bullet documents the new mechanism; the status-advance rule now names two replays, not three.

**Behavior**

Statistically identical everywhere. Draw order changes (stochastic classifier bits come from the SVM stream at the `READOUT_NOISE` sites; the classifier RNG domain is now consumed only by ternary herald flags), so fixed-seed outputs differ from prior versions — consistent with seeds not being stable across feature versions.

**Tests**

- New rewriter units pin the emission forms: MPAD+READOUT_NOISE for stochastic columns (with the rec target on the right slot among earlier measurements), literal-bit MPAD for deterministic columns, ternary not-heralded conditional (`{0.3,0.1,0.6}` → 0.25), always-herald placeholder, MR split, classifier-required error.
- New orchestrator test pins the *(herald, bit)* joint with a column where the patch is observable (`{0.5, 0, 0.5}`: non-heralded bits always 0, heralded bits uniform) — it fails if the herald re-point doesn't run.
- Existing e2e detector/observable/MR/recapture/drop tests pass unchanged.
- Debug **979** + Release **979** green (`~[bench]`); Python **732** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)