### PR TITLE
feat(noncomp): asymmetric readout noise honors classifier confusion

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -577,6 +577,15 @@ Notes:
   `READOUT_NOISE` on that slot so the bit is drawn at sample time
   inside the VM, while a deterministic column pads the literal bit
   with no draw.
+- **Computational-qubit Z measurements (`M`, `MR`) receive the
+  classifier's computational columns as readout confusion**: the true
+  outcome is misreported at the column's off-diagonal rate via an
+  asymmetric in-record flip (`READOUT_NOISE(p01, p10)` on the slot).
+  The qubit still collapses to its true state -- real readout error is
+  a misreport. X/Y-basis measurements are not level readouts and carry
+  no confusion. Identity computational columns add nothing, and a
+  computational column must place all its probability on the two
+  record symbols.
 - "Apply, demote to Unknown" is the conservative default: we drop
   knownness on any quantum gate touching a `ComputationalKnown`
   qubit. This loses some optimization opportunity (X on a known qubit

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -301,6 +301,12 @@ class Parser {
         if (gate == GateType::EXP_VAL && !args.empty()) {
             throw ParseError("EXP_VAL takes no arguments", line_num);
         }
+        if (gate == GateType::READOUT_NOISE && args.size() != 1 && args.size() != 2) {
+            throw ParseError(
+                "READOUT_NOISE requires 1 argument (symmetric flip probability) or 2 "
+                "arguments (0->1, 1->0 flip probabilities)",
+                line_num);
+        }
 
         // Parse based on gate type.
         switch (gate) {
@@ -616,13 +622,19 @@ class Parser {
                     line_num);
             }
 
-            // Validate rec targets are only used for CX/CZ feedback forms.
+            // Validate rec targets are only used for CX/CZ feedback forms
+            // and READOUT_NOISE record flips.
             bool is_rec_token = token.starts_with("rec[") || (token.size() > 1 && token[0] == '!' &&
                                                               token.substr(1).starts_with("rec["));
-            if (is_rec_token && gate != GateType::CX && gate != GateType::CZ) {
+            if (is_rec_token && gate != GateType::CX && gate != GateType::CZ &&
+                gate != GateType::READOUT_NOISE) {
                 throw ParseError(
-                    "rec targets are only supported as feedback controls for CX/CZ gates",
+                    "rec targets are only supported as feedback controls for CX/CZ gates "
+                    "and as READOUT_NOISE targets",
                     line_num);
+            }
+            if (!is_rec_token && gate == GateType::READOUT_NOISE) {
+                throw ParseError("READOUT_NOISE targets must be rec references", line_num);
             }
 
             Target target = parse_target(token, line_num, circuit);

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -636,6 +636,12 @@ class Parser {
             if (!is_rec_token && gate == GateType::READOUT_NOISE) {
                 throw ParseError("READOUT_NOISE targets must be rec references", line_num);
             }
+            if (is_rec_token && gate == GateType::READOUT_NOISE && token[0] == '!') {
+                throw ParseError(
+                    "READOUT_NOISE targets do not support inversion; swap the two flip "
+                    "probabilities instead",
+                    line_num);
+            }
 
             Target target = parse_target(token, line_num, circuit);
             targets.push_back(target);

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -902,6 +902,11 @@ HirModule trace(const Circuit& circuit) {
 
             case GateType::READOUT_NOISE: {
                 for (const auto& target : node.targets) {
+                    if (target.is_inverted()) {
+                        throw std::runtime_error(
+                            "READOUT_NOISE does not support inverted record targets; swap the "
+                            "two flip probabilities instead");
+                    }
                     uint32_t abs_meas_idx = target.value();
                     // One argument is a symmetric flip; a second argument
                     // splits it into (0->1, 1->0) conditioned on the bit.

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -733,7 +733,7 @@ HirModule trace(const Circuit& circuit) {
 
                     if (!hidden && target.is_inverted()) {
                         ReadoutNoiseIdx idx{static_cast<uint32_t>(hir.readout_noise.size())};
-                        hir.readout_noise.push_back({this_meas, 1.0});
+                        hir.readout_noise.push_back({this_meas, 1.0, 1.0});
                         hir.append_readout_noise(idx);
                     }
                 }
@@ -903,9 +903,12 @@ HirModule trace(const Circuit& circuit) {
             case GateType::READOUT_NOISE: {
                 for (const auto& target : node.targets) {
                     uint32_t abs_meas_idx = target.value();
-                    double prob = node.args.empty() ? 0.0 : node.args[0];
+                    // One argument is a symmetric flip; a second argument
+                    // splits it into (0->1, 1->0) conditioned on the bit.
+                    double p01 = node.args.empty() ? 0.0 : node.args[0];
+                    double p10 = node.args.size() > 1 ? node.args[1] : p01;
                     ReadoutNoiseIdx idx{static_cast<uint32_t>(hir.readout_noise.size())};
-                    hir.readout_noise.push_back({abs_meas_idx, prob});
+                    hir.readout_noise.push_back({abs_meas_idx, p01, p10});
                     hir.append_readout_noise(idx);
                 }
                 break;

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -74,10 +74,16 @@ struct NoiseSite {
     std::vector<NoiseChannel> channels;
 };
 
-/// Readout noise entry: classical bit-flip on a measurement result.
+/// Readout noise entry: classical bit-flip on a measurement result. The
+/// flip probability conditions on the recorded bit's value, so asymmetric
+/// readout confusion (0->1 vs 1->0 at different rates) is expressible;
+/// symmetric noise sets both probabilities equal.
 struct ReadoutNoiseEntry {
-    uint32_t meas_idx;  // Absolute measurement index to potentially flip
-    double prob;        // Flip probability
+    uint32_t meas_idx;        // Absolute measurement index to potentially flip
+    double prob_zero_to_one;  // Flip probability when the recorded bit is 0
+    double prob_one_to_zero;  // Flip probability when the recorded bit is 1
+
+    [[nodiscard]] bool is_symmetric() const { return prob_zero_to_one == prob_one_to_zero; }
 };
 
 /// Index into HirModule::readout_noise side-table

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -86,6 +86,59 @@ const MeasurementClassifier& classifier_for(const NonComputationalModel& model, 
     return *classifier;
 }
 
+// Classifier readout confusion for a kept computational Z-basis measurement.
+// The classifier's computational columns give the probability of misreporting
+// each true outcome, so the record bit gets an asymmetric flip conditioned on
+// its value: p01 = P(symbol 1 | zero level), p10 = P(symbol 0 | one level).
+// Real readout error is a misreport -- the qubit still collapses to its true
+// state -- so only the record slot is touched and the layout is unchanged.
+// Identity columns emit nothing. An inverted measurement target reports the
+// complement bit, and confusion physically precedes the reporting convention,
+// so the emitted probabilities are swapped for it.
+void append_computational_confusion(Circuit& out, const NonComputationalModel& model, GateType gate,
+                                    bool inverted, uint32_t slot, uint32_t op_index,
+                                    uint32_t qubit) {
+    const MeasurementClassifier* classifier = model.classifier();
+    if (classifier == nullptr) {
+        return;
+    }
+    const LevelSet& levels = model.levels();
+    const uint8_t zero_id = levels.computational_zero_id();
+    const uint8_t one_id = levels.computational_one_id();
+    for (uint8_t level : {zero_id, one_id}) {
+        const double reject = classifier->reject_probability(level);
+        if (reject > kProbTolerance) {
+            throw std::invalid_argument(
+                "rewrite: classifier reject columns are not supported yet; the column for "
+                "computational level " +
+                std::to_string(level) + " sums to less than one (reject probability " +
+                std::to_string(reject) + ", measurement '" + std::string(gate_name(gate)) +
+                "' on qubit " + std::to_string(qubit) + " at op " + std::to_string(op_index) + ")");
+        }
+        double beyond_bit = 0.0;
+        for (size_t symbol = 2; symbol < classifier->num_symbols(); ++symbol) {
+            beyond_bit += classifier->prob(static_cast<uint8_t>(symbol), level);
+        }
+        if (beyond_bit > kProbTolerance) {
+            throw std::invalid_argument(
+                "rewrite: a computational measurement's classifier column must place all its "
+                "probability on the record symbols 0 and 1; the column for level " +
+                std::to_string(level) + " puts " + std::to_string(beyond_bit) +
+                " beyond the bit (measurement '" + std::string(gate_name(gate)) + "' on qubit " +
+                std::to_string(qubit) + " at op " + std::to_string(op_index) + ")");
+        }
+    }
+    double p01 = classifier->prob(1, zero_id);  // true 0 misread as 1
+    double p10 = classifier->prob(0, one_id);   // true 1 misread as 0
+    if (inverted) {
+        std::swap(p01, p10);
+    }
+    if (p01 == 0.0 && p10 == 0.0) {
+        return;  // identity columns: no draw, no node
+    }
+    out.nodes.push_back(AstNode{GateType::READOUT_NOISE, {Target::rec(slot)}, {p01, p10}, 0});
+}
+
 // A hidden carrier edit appended after an op for one operand's jump: an R
 // collapses and rezeros the carrier, and an X then prepares |1> when the
 // jump lands on the |1> computational level.
@@ -273,6 +326,14 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
                 result.classified_measurements.push_back({slot, *classified_level, noise_node});
             } else {
                 out.nodes.push_back(node);
+                // The classifier's computational columns apply to Z-basis
+                // level readouts (M, MR); other measurement bases are not
+                // level readouts and carry no confusion.
+                if (gate == GateType::M || gate == GateType::MR) {
+                    append_computational_confusion(out, model, gate,
+                                                   node.targets.front().is_inverted(), slot,
+                                                   op_index, qubit_operands(node).front().qubit);
+                }
             }
         }
         for (const CarrierEdit& edit : carrier_edits) {

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -29,7 +29,11 @@
 //      classifiers, which re-points a heralded slot's flip probability at
 //      one half. For a three-symbol column the emitted probability is the
 //      bit's not-heralded conditional, and a READOUT_NOISE node is always
-//      emitted so a heralded slot has a node to patch.
+//      emitted so a heralded slot has a node to patch. A kept computational
+//      Z-basis measurement (M, MR) additionally receives the classifier's
+//      computational readout confusion as an asymmetric READOUT_NOISE on
+//      its slot -- the misreport probabilities P(1 | zero level) and
+//      P(0 | one level) -- when those columns are not the identity.
 //   4. Hidden trace-out: when a coherent qubit jumps to a Leaked or Lost
 //      level, insert an R on that qubit immediately after the operation.
 //      The existing reset lowering turns it into a hidden measurement plus a

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -364,7 +364,18 @@ std::vector<double> noise_site_probabilities(const CompiledModule& program) {
         probs.push_back(p);
     }
     for (const auto& entry : pool.readout_noise) {
-        probs.push_back(entry.prob);
+        // A bit-conditioned (asymmetric) flip has no single site probability:
+        // whether it can fire depends on the record value at runtime, which
+        // the static Poisson-Binomial conditioning cannot represent.
+        if (!entry.is_symmetric()) {
+            throw std::invalid_argument(
+                "k-fault conditioning does not support asymmetric readout noise; "
+                "measurement record index " +
+                std::to_string(entry.meas_idx) + " has probabilities (" +
+                std::to_string(entry.prob_zero_to_one) + ", " +
+                std::to_string(entry.prob_one_to_zero) + ")");
+        }
+        probs.push_back(entry.prob_zero_to_one);
     }
     return probs;
 }

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1931,13 +1931,16 @@ static inline void exec_noise_block(SchrodingerState& state, const ConstantPool&
     }
 }
 
-// READOUT_NOISE: classical bit-flip on a measurement result.
+// READOUT_NOISE: classical bit-flip on a measurement result, with the flip
+// probability conditioned on the recorded bit (asymmetric confusion).
 // In forced-fault mode, a two-pointer comparison replaces the PRNG roll:
-// the bit flips iff entry_idx matches the next forced readout index.
+// the bit flips iff entry_idx matches the next forced readout index
+// (asymmetric entries are rejected up front by the k-fault entry points).
 static inline void exec_readout_noise(SchrodingerState& state, const ConstantPool& pool,
                                       uint32_t entry_idx) {
     assert(entry_idx < pool.readout_noise.size());
     const auto& entry = pool.readout_noise[entry_idx];
+    assert(entry.meas_idx < state.meas_record.size());
 
     bool fire = false;
     if (state.forced_faults.active) {
@@ -1950,10 +1953,11 @@ static inline void exec_readout_noise(SchrodingerState& state, const ConstantPoo
             ff.readout_pos++;
         }
     } else {
-        fire = (state.random_double() < entry.prob);
+        const double prob =
+            state.meas_record[entry.meas_idx] ? entry.prob_one_to_zero : entry.prob_zero_to_one;
+        fire = (state.random_double() < prob);
     }
     if (fire) {
-        assert(entry.meas_idx < state.meas_record.size());
         state.meas_record[entry.meas_idx] ^= 1;
     }
 }

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -84,6 +84,13 @@ class Classifier:
     measurement -- typically the loss outcome -- reported per record slot in
     :attr:`NonComputationalSample.heralds` while the visible record keeps a
     uniformly drawn bit, so the record layout is unchanged.
+
+    The computational columns define readout confusion for Z-basis
+    measurements of computational qubits: the true outcome is misreported
+    with the column's off-diagonal probability, an asymmetric in-record
+    flip (the qubit still collapses to its true state). Identity
+    computational columns add nothing, and a computational column may not
+    place probability beyond the two record symbols.
     """
 
     __slots__ = ("symbols", "matrix")
@@ -99,7 +106,8 @@ class Model:
     Args:
         initial_state: probability per level, ``P(level)``, summing to one.
         transitions: maps a gate-name string to its ``T[to][from]`` matrix.
-        classifier: optional :class:`Classifier` for leaked/lost measurements.
+        classifier: optional :class:`Classifier` supplying leaked/lost
+            measurement outcomes and computational readout confusion.
         reset_restores_lost: if true, a reset on a lost qubit restores it.
         unknown_source_policy: how a source-dependent transition on a qubit
             whose computational state is unknown is handled. ``"reject"``

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -34,10 +34,13 @@ def transition_to(level: int) -> list[list[float]]:
 
 
 def classifier_for(level: int, col: list[float]) -> noncomp.Classifier:
-    """Binary classifier; `level`'s column is `col`, every other column is symbol 0."""
+    """Binary classifier; `level`'s column is `col`, computational levels read
+    out faithfully (no readout confusion), other columns are symbol 0."""
     m = _zeros(2, 5)
     for lvl in range(5):
         m[0][lvl] = 1.0
+    m[0][noncomp.Level.E] = 0.0
+    m[1][noncomp.Level.E] = 1.0
     m[0][level] = col[0]
     m[1][level] = col[1]
     return noncomp.Classifier(["0", "1"], m)
@@ -374,3 +377,27 @@ def test_drop_policy_runs_a_multi_round_circuit_through_loss():
     assert r.num_measurements == 3
     assert np.array_equal(r.measurements, np.tile([0, 0, 1], (16, 1)))
     assert np.all(r.final_status[:, 0] == LOST_KIND)
+
+
+def test_computational_readout_confusion_misreports_the_record():
+    """The classifier's computational columns act as asymmetric readout
+    confusion on Z measurements: the qubit collapses to its true state but
+    the record bit is misreported at the column's off-diagonal rate."""
+    m = _zeros(2, 5)
+    m[0][noncomp.Level.G] = 0.7  # true 0 misread as 1 with probability 0.3
+    m[1][noncomp.Level.G] = 0.3
+    m[0][noncomp.Level.E] = 0.2  # true 1 misread as 0 with probability 0.2
+    m[1][noncomp.Level.E] = 0.8
+    for lvl in (LEAK_G, LEAK_E, LOST):
+        m[0][lvl] = 1.0
+    model = noncomp.Model(
+        initial_state=ALL_G, transitions={}, classifier=noncomp.Classifier(["0", "1"], m)
+    )
+
+    zero = noncomp.sample("M 0", model, shots=4000, seed=11)
+    ones = int(zero.measurements[:, 0].sum())
+    assert 1020 <= ones <= 1380  # expected 1200; ~6 sigma band
+
+    one = noncomp.sample("X 0\nM 0", model, shots=4000, seed=12)
+    zeros = int((1 - one.measurements[:, 0]).sum())
+    assert 650 <= zeros <= 950  # expected 800; ~6 sigma band

--- a/tests/python/test_noncomp_divergence.py
+++ b/tests/python/test_noncomp_divergence.py
@@ -51,6 +51,8 @@ def _leak_classifier() -> noncomp.Classifier:
     m = [[0.0] * 5 for _ in range(2)]
     for lvl in range(5):
         m[0][lvl] = 1.0
+    # Computational levels read out faithfully (no readout confusion).
+    m[0][Level.E], m[1][Level.E] = 0.0, 1.0
     m[0][Level.LEAK_E], m[1][Level.LEAK_E] = 0.0, 1.0
     return noncomp.Classifier(["0", "1"], m)
 

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -42,6 +42,8 @@ def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
     m = [[0.0] * 5 for _ in range(2)]  # P[symbol][level], two symbols
     for lvl in range(5):
         m[0][lvl] = 1.0
+    # Computational levels read out faithfully (no readout confusion).
+    m[0][noncomp.Level.E], m[1][noncomp.Level.E] = 0.0, 1.0
     m[0][level], m[1][level] = col[0], col[1]
     return noncomp.Classifier(["0", "1"], m)
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1278,7 +1278,8 @@ TEST_CASE("Frontend: READOUT_NOISE emission", "[frontend][noise]") {
     REQUIRE(static_cast<uint32_t>(hir.ops[1].readout_noise_idx()) == 0);
     REQUIRE(hir.readout_noise.size() == 1);
     REQUIRE(hir.readout_noise[0].meas_idx == 0);
-    REQUIRE(hir.readout_noise[0].prob == Catch::Approx(0.005));
+    REQUIRE(hir.readout_noise[0].prob_zero_to_one == Catch::Approx(0.005));
+    REQUIRE(hir.readout_noise[0].prob_one_to_zero == Catch::Approx(0.005));
 }
 
 TEST_CASE("Frontend: DETECTOR emission", "[frontend][qec]") {
@@ -1814,4 +1815,18 @@ TEST_CASE("Frontend: R_Z global phase accumulation", "[frontend][rotation]") {
     double expected_im = std::sin(-0.5 * std::numbers::pi / 2.0);
     CHECK(hir.global_weight.real() == Catch::Approx(expected_re).epsilon(1e-12));
     CHECK(hir.global_weight.imag() == Catch::Approx(expected_im).epsilon(1e-12));
+}
+
+TEST_CASE("Standalone READOUT_NOISE lowers one- and two-argument forms") {
+    auto hir1 = trace(parse("M 0\nREADOUT_NOISE(0.25) rec[-1]\n"));
+    REQUIRE(hir1.readout_noise.size() == 1);
+    REQUIRE(hir1.readout_noise[0].prob_zero_to_one == Catch::Approx(0.25));
+    REQUIRE(hir1.readout_noise[0].prob_one_to_zero == Catch::Approx(0.25));
+    REQUIRE(hir1.readout_noise[0].is_symmetric());
+
+    auto hir2 = trace(parse("M 0\nREADOUT_NOISE(0.25, 0.5) rec[-1]\n"));
+    REQUIRE(hir2.readout_noise.size() == 1);
+    REQUIRE(hir2.readout_noise[0].prob_zero_to_one == Catch::Approx(0.25));
+    REQUIRE(hir2.readout_noise[0].prob_one_to_zero == Catch::Approx(0.5));
+    REQUIRE_FALSE(hir2.readout_noise[0].is_symmetric());
 }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -14,6 +14,8 @@
 #include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -1815,6 +1817,14 @@ TEST_CASE("Frontend: R_Z global phase accumulation", "[frontend][rotation]") {
     double expected_im = std::sin(-0.5 * std::numbers::pi / 2.0);
     CHECK(hir.global_weight.real() == Catch::Approx(expected_re).epsilon(1e-12));
     CHECK(hir.global_weight.imag() == Catch::Approx(expected_im).epsilon(1e-12));
+}
+
+TEST_CASE("Trace rejects a programmatic inverted READOUT_NOISE target") {
+    // The parser refuses inverted rec targets; a hand-built AST node must
+    // not slip past lowering with the inversion silently ignored.
+    Circuit c = parse("M 0\n");
+    c.nodes.push_back({GateType::READOUT_NOISE, {Target::rec(0).inverted()}, {0.1, 0.2}, 0});
+    REQUIRE_THROWS_WITH(trace(c), Catch::Matchers::ContainsSubstring("inverted record targets"));
 }
 
 TEST_CASE("Standalone READOUT_NOISE lowers one- and two-argument forms") {

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
 #include <numeric>
 #include <vector>
@@ -389,4 +390,12 @@ TEST_CASE("sample_k - deterministic with same seed") {
     CHECK(r1.measurements == r2.measurements);
     CHECK(r1.detectors == r2.detectors);
     CHECK(r1.observables == r2.observables);
+}
+
+TEST_CASE("k-fault conditioning rejects asymmetric readout noise") {
+    auto prog = compile_circuit("M 0\nREADOUT_NOISE(0.1, 0.2) rec[-1]\n");
+    CHECK_THROWS_WITH(clifft::noise_site_probabilities(prog),
+                      Catch::Matchers::ContainsSubstring("asymmetric"));
+    CHECK_THROWS_WITH(clifft::sample_k(prog, 8, 1, 0),
+                      Catch::Matchers::ContainsSubstring("asymmetric"));
 }

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -70,15 +70,19 @@ TransitionInstrument always_to_e(const LevelSet& levels) {
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
-// Two-symbol classifier whose column for `level` is `col`; every other level
-// is a deterministic symbol 0. Only noncomputational qubits are classified, so
-// the computational columns are never consulted in these tests.
+// Two-symbol classifier whose column for `level` is `col`; computational
+// levels read out faithfully (no readout confusion) and leaked/lost levels
+// default to a deterministic symbol 0.
 MeasurementClassifier classifier_with(const LevelSet& levels, uint8_t level,
                                       std::vector<double> col) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;  // symbol "0"
     }
+    // Computational levels read out faithfully (identity columns) so the
+    // classifier adds no readout confusion here.
+    m[0][1] = 0.0;
+    m[1][1] = 1.0;
     m[0][level] = col[0];
     m[1][level] = col[1];
     return MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);
@@ -221,14 +225,18 @@ TEST_CASE("sample_noncomputational: a four-symbol classifier rejects on injectio
 
 namespace {
 
-// Three-symbol classifier whose column for `level` is `col`; every other
-// level is a deterministic symbol 0.
+// Three-symbol classifier whose column for `level` is `col`; computational
+// levels read out faithfully and other levels default to symbol 0.
 MeasurementClassifier ternary_classifier_with(const LevelSet& levels, uint8_t level,
                                               std::vector<double> col) {
     std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
     }
+    // Computational levels read out faithfully (identity columns) so the
+    // classifier adds no readout confusion here.
+    m[0][1] = 0.0;
+    m[1][1] = 1.0;
     m[0][level] = col[0];
     m[1][level] = col[1];
     m[2][level] = col[2];
@@ -543,4 +551,51 @@ TEST_CASE("sample_noncomputational: drop policy runs a multi-round circuit throu
     NonComputationalModel reject_model = make_model(all_g(), std::move(transitions), cl);
     REQUIRE_THROWS_WITH(sample_noncomputational(c, reject_model, 1, 3),
                         ContainsSubstring("CX") && ContainsSubstring("Lost"));
+}
+
+namespace {
+
+// Classifier with confused computational columns; noncomputational levels
+// deterministically read symbol 0.
+MeasurementClassifier comp_confusion(double p01, double p10) {
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    m[0][0] = 1.0 - p01;
+    m[1][0] = p01;
+    m[0][1] = p10;
+    m[1][1] = 1.0 - p10;
+    return MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), LevelSet::default_set());
+}
+
+}  // namespace
+
+TEST_CASE("sample_noncomputational: computational confusion misreports into the detector") {
+    // A certain 0->1 misreport: the record and the detector read 1 on every
+    // shot even though the qubit is |0> -- the flip is in-circuit, not
+    // postprocessing.
+    Circuit c = parse("M 0\nDETECTOR rec[-1]\n");
+    NonComputationalModel model = make_model(all_g(), {}, comp_confusion(1.0, 0.0));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 64, 3);
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.measurements[shot] == 1);
+        REQUIRE(s.detectors[shot] == 1);
+    }
+}
+
+TEST_CASE("sample_noncomputational: asymmetric confusion matches its rates") {
+    // True bit is 1 (X-prepared); it is misread as 0 with probability 0.2.
+    Circuit c = parse("X 0\nM 0\n");
+    NonComputationalModel model = make_model(all_g(), {}, comp_confusion(0.0, 0.2));
+
+    constexpr uint32_t kShots = 4000;
+    NonComputationalSample s = sample_noncomputational(c, model, kShots, 9);
+    size_t zeros = 0;
+    for (uint8_t bit : s.measurements) {
+        zeros += bit == 0 ? 1 : 0;
+    }
+    REQUIRE(zeros > 650);  // expected 800; ~6 sigma band
+    REQUIRE(zeros < 950);
 }

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -113,13 +113,18 @@ NonComputationalModel make_model(std::vector<double> initial_state,
 }
 
 // Classifier whose column for `level` is `col` (two or three symbols by
-// col's length); every other level is a deterministic symbol 0.
+// col's length); computational levels read out faithfully and other levels
+// default to a deterministic symbol 0.
 MeasurementClassifier classifier_with(uint8_t level, std::vector<double> col) {
     std::vector<std::vector<double>> m(col.size(), std::vector<double>(5, 0.0));
     std::vector<std::string> symbols;
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
     }
+    // Computational levels read out faithfully (identity columns) so the
+    // classifier adds no readout confusion here.
+    m[0][1] = 0.0;
+    m[1][1] = 1.0;
     for (size_t s = 0; s < col.size(); ++s) {
         m[s][level] = col[s];
         symbols.push_back(std::to_string(s));
@@ -648,4 +653,114 @@ TEST_CASE("rewrite: drop policy keeps a measure-and-reset on a non-restoring los
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);  // record slot preserved
     REQUIRE(rw.circuit.num_measurements == 1);
+}
+
+namespace {
+
+// Classifier with confused computational columns: a true 0 is misread as 1
+// with probability p01, a true 1 as 0 with probability p10; noncomputational
+// levels deterministically read symbol 0.
+MeasurementClassifier confused_classifier(double p01, double p10) {
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    m[0][0] = 1.0 - p01;
+    m[1][0] = p01;
+    m[0][1] = p10;
+    m[1][1] = 1.0 - p10;
+    return MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), LevelSet::default_set());
+}
+
+}  // namespace
+
+TEST_CASE("rewrite: computational readout confusion appends an asymmetric flip") {
+    Circuit c = parse("H 0\nM 0\n");
+    NonComputationalModel model =
+        make_model_with_classifier(all_g(), {}, confused_classifier(0.1, 0.2));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(count_gate(rw.circuit, GateType::M) == 1);  // measurement kept
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
+    const AstNode& noise = rw.circuit.nodes.back();
+    REQUIRE(noise.gate == GateType::READOUT_NOISE);
+    REQUIRE(noise.targets[0].is_rec());
+    REQUIRE(noise.targets[0].value() == 0);
+    REQUIRE(noise.args.size() == 2);
+    REQUIRE(noise.args[0] == 0.1);                // P(symbol 1 | zero level)
+    REQUIRE(noise.args[1] == 0.2);                // P(symbol 0 | one level)
+    REQUIRE(rw.classified_measurements.empty());  // not a noncomp record write
+}
+
+TEST_CASE("rewrite: identity computational columns add no readout confusion") {
+    Circuit c = parse("H 0\nM 0\n");
+    NonComputationalModel model =
+        make_model_with_classifier(all_g(), {}, classifier_with(kLost, {0.5, 0.5}));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 0);
+}
+
+TEST_CASE("rewrite: an inverted measurement swaps the confusion probabilities") {
+    // Confusion physically precedes the reporting convention, and
+    // invert-after-flip(p01, p10) equals flip(p10, p01)-after-invert.
+    Circuit c = parse("H 0\nM !0\n");
+    NonComputationalModel model =
+        make_model_with_classifier(all_g(), {}, confused_classifier(0.1, 0.2));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    const AstNode& noise = rw.circuit.nodes.back();
+    REQUIRE(noise.gate == GateType::READOUT_NOISE);
+    REQUIRE(noise.args[0] == 0.2);
+    REQUIRE(noise.args[1] == 0.1);
+}
+
+TEST_CASE("rewrite: confusion applies to MR but not X-basis measurements") {
+    Circuit c = parse("MR 0\nMX 0\n");
+    NonComputationalModel model =
+        make_model_with_classifier(all_g(), {}, confused_classifier(0.1, 0.2));
+
+    RewriteResult rw = rewritten_result(c, model, 1);
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
+    for (const AstNode& node : rw.circuit.nodes) {
+        if (node.gate == GateType::READOUT_NOISE) {
+            REQUIRE(node.targets[0].value() == 0);  // the MR slot, not the MX slot
+        }
+    }
+}
+
+TEST_CASE("rewrite: a substochastic computational column rejects") {
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    m[0][0] = 0.6;  // g column sums to 0.8: reject mass on a computational level
+    m[1][0] = 0.2;
+    m[0][1] = 0.0;
+    m[1][1] = 1.0;
+    MeasurementClassifier cl =
+        MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), LevelSet::default_set());
+    NonComputationalModel model = make_model_with_classifier(all_g(), {}, std::move(cl));
+
+    Circuit c = parse("M 0\n");
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("computational level"));
+}
+
+TEST_CASE("rewrite: a computational column with herald mass rejects") {
+    std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
+    for (size_t l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    m[0][0] = 0.9;  // g column puts 0.1 on the herald symbol
+    m[2][0] = 0.1;
+    m[0][1] = 0.0;
+    m[1][1] = 1.0;
+    MeasurementClassifier cl =
+        MeasurementClassifier::from_matrix({"0", "1", "2"}, std::move(m), LevelSet::default_set());
+    NonComputationalModel model = make_model_with_classifier(all_g(), {}, std::move(cl));
+
+    Circuit c = parse("M 0\n");
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("beyond the bit"));
 }

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -74,13 +74,17 @@ TransitionInstrument always_lost(const LevelSet& levels) {
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
-// Two-symbol classifier whose lost column is `col` (the only column a lost
-// qubit consults here); every other level deterministically reads symbol 0.
+// Two-symbol classifier whose lost column is `col`; computational levels
+// read out faithfully and leaked levels deterministically read symbol 0.
 MeasurementClassifier lost_classifier(const LevelSet& levels, std::vector<double> col) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
     }
+    // Computational levels read out faithfully (identity columns) so the
+    // classifier adds no readout confusion here.
+    m[0][1] = 0.0;
+    m[1][1] = 1.0;
     m[0][kLost] = col[0];
     m[1][kLost] = col[1];
     return MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels);

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1916,3 +1916,10 @@ TEST_CASE("READOUT_NOISE rejects bad argument counts and non-rec targets") {
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(0.1, 0.2, 0.3) rec[-1]\n"), ParseError);
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(0.1) 0\n"), ParseError);
 }
+
+TEST_CASE("READOUT_NOISE rejects inverted rec targets") {
+    // An inverted record target has no distinct meaning for a conditional
+    // flip (it would only swap the two probabilities), so it is refused
+    // rather than silently ignored.
+    CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(1, 0) !rec[-1]\n"), ParseError);
+}

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1898,3 +1898,21 @@ TEST_CASE("GateTraits: rotation gate arities", "[gate_data][rotation]") {
     CHECK(!is_clifford(GateType::R_Z));
     CHECK(!is_measurement(GateType::R_Z));
 }
+
+TEST_CASE("READOUT_NOISE parses one- and two-argument forms on rec targets") {
+    auto one = parse("M 0\nREADOUT_NOISE(0.1) rec[-1]\n");
+    REQUIRE(one.nodes.size() == 2);
+    REQUIRE(one.nodes[1].gate == GateType::READOUT_NOISE);
+    REQUIRE(one.nodes[1].args == std::vector<double>{0.1});
+    REQUIRE(one.nodes[1].targets[0].is_rec());
+    REQUIRE(one.nodes[1].targets[0].value() == 0);
+
+    auto two = parse("M 0\nREADOUT_NOISE(0.1, 0.2) rec[-1]\n");
+    REQUIRE(two.nodes[1].args == (std::vector<double>{0.1, 0.2}));
+}
+
+TEST_CASE("READOUT_NOISE rejects bad argument counts and non-rec targets") {
+    CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE rec[-1]\n"), ParseError);
+    CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(0.1, 0.2, 0.3) rec[-1]\n"), ParseError);
+    CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(0.1) 0\n"), ParseError);
+}

--- a/tests/test_svm.cc
+++ b/tests/test_svm.cc
@@ -2149,3 +2149,42 @@ TEST_CASE("Observable normalization in sample_survivors") {
         CHECK(result.observables[i] == 0);
     }
 }
+
+namespace {
+CompiledModule compile_readout_text(const std::string& text) {
+    auto circuit = parse(text);
+    auto hir = trace(circuit);
+    return lower(hir);
+}
+}  // namespace
+
+TEST_CASE("Asymmetric READOUT_NOISE flips conditioned on the recorded bit") {
+    // True bit 0, flip 0->1 certain: every record reads 1.
+    auto up = compile_readout_text("M 0\nREADOUT_NOISE(1, 0) rec[-1]\n");
+    for (uint8_t bit : sample(up, 32, 1).measurements) {
+        REQUIRE(bit == 1);
+    }
+    // True bit 1, flip 0->1 certain but 1->0 never: records stay 1.
+    auto stay = compile_readout_text("X 0\nM 0\nREADOUT_NOISE(1, 0) rec[-1]\n");
+    for (uint8_t bit : sample(stay, 32, 2).measurements) {
+        REQUIRE(bit == 1);
+    }
+    // True bit 1, flip 1->0 certain: every record reads 0.
+    auto down = compile_readout_text("X 0\nM 0\nREADOUT_NOISE(0, 1) rec[-1]\n");
+    for (uint8_t bit : sample(down, 32, 3).measurements) {
+        REQUIRE(bit == 0);
+    }
+}
+
+TEST_CASE("Asymmetric READOUT_NOISE matches its rate on a random bit") {
+    // P(record 1) = P(true 1) * (1 - p10) + P(true 0) * p01
+    //             = 0.5 * 1.0 + 0.5 * 0.3 = 0.65.
+    auto mod = compile_readout_text("H 0\nM 0\nREADOUT_NOISE(0.3, 0) rec[-1]\n");
+    auto result = sample(mod, 4000, 5);
+    size_t ones = 0;
+    for (uint8_t bit : result.measurements) {
+        ones += bit;
+    }
+    REQUIRE(ones > 2419);  // expected 2600; ~6 sigma band
+    REQUIRE(ones < 2781);
+}


### PR DESCRIPTION
> **Prototype / less-strict review.** Targets the `codex/noncomputational-structural-mvp` feature branch, not `main`.

Bridge PR 1 of 2 (per the locked annotation-bridge design): the asymmetric readout primitive plus the **g/e confusion fix** — the classifier's computational columns were validated but silently ignored; a ported classifier carrying real computational readout error lost it without a peep. They are now honored.

**The primitive — `READOUT_NOISE(p01, p10) rec[k]`:**
- One argument stays the symmetric flip (unchanged semantics *and* unchanged fixed-seed outputs — the kernel draws once either way). Two arguments flip `0→1` w.p. `p01` and `1→0` w.p. `p10`, conditioned on the recorded bit.
- The instruction is now parseable on rec targets (previously only synthesized by the `M(p)`/`MPP(p)` decompositions), with 1-or-2 argument validation — so per-measurement asymmetric confusion is hand-writable in a circuit, per the bridge's noise-as-first-class-operations direction.
- `ReadoutNoiseEntry` carries both probabilities; no new opcode, no binding surface change.
- **k-fault conditioning (`sample_k`/`sample_k_survivors`/`noise_site_probabilities`) rejects asymmetric entries up front**: a bit-conditioned flip has no static site probability for the Poisson-Binomial machinery. (`record_probabilities` already rejects all readout noise; unchanged.)

**The g/e fix:** the rewriter (which owns record-writes since #164) appends the confusion to each kept computational **Z-basis** measurement (`M`, `MR`): `p01 = P(symbol 1 | zero level)`, `p10 = P(symbol 0 | one level)`, in circuit, so detectors/observables see the confused bit. Details:
- The qubit still collapses to its true state — real readout error is a misreport; only the record slot is touched, layout unchanged.
- X/Y-basis measurements are not level readouts and carry no confusion (documented).
- Identity columns emit nothing — classifier-free models and faithful classifiers compile identically to before.
- New validation: substochastic computational columns reject (same message family as the noncomp reject-column error); a computational column with probability beyond the two record symbols (e.g. herald mass) rejects.
- Inverted measurement targets (`M !0`) swap the two rates: confusion physically precedes the reporting convention.

**Behavior change, as agreed (no compat shims):** models whose classifiers carried non-identity computational columns previously got a silent no-op and now get the confusion. Several *test helpers* were in exactly that bucket — their "every other column reads symbol 0" fill made the e-column maximally confused (dead until now); they gained faithful computational columns, and the three tests that initially failed did so precisely because the fix started working.

**Tests** (14 new cases): parser forms + rejections; frontend lowering of both arities; VM deterministic flips (0→1 certain, 1→0 certain, stay) + rate band; k-fault rejection; rewriter units pinning the orientation (`p01`/`p10` mapping — easy to get backwards), identity elision, MR-yes/MX-no scoping, inverted-target swap, both new validation errors; orchestrator e2e (misreport reaches the detector; asymmetric rate band); Python e2e band test both directions.

Verified: Debug **993** + Release **993** (`~[bench]`) green; Python **733** green; pre-commit `--all-files` clean. Design note documents the semantics; the notebook's "asymmetric computational readout confusion is out of scope" note comes out in the docs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Review round** (`af8e6f6`): inverted record targets (`!rec[...]`) on `READOUT_NOISE` parsed but lowered with the inversion silently ignored. Now rejected at both layers — the parser refuses the token, and `trace()` refuses a hand-built AST node (inversion has no distinct meaning for a bit-conditioned flip beyond swapping the two probabilities, so it errors rather than aliasing the plain form). Debug **995** + Release **995** green.