### PR TITLE
feat(noncomp): transitions as first-class circuit annotations

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -586,12 +586,11 @@ Notes:
   no confusion. Identity computational columns add nothing, and a
   computational column must place all its probability on the two
   record symbols.
-- "Apply, demote to Unknown" is the conservative default: we drop
-  knownness on any quantum gate touching a `ComputationalKnown`
-  qubit. This loses some optimization opportunity (X on a known qubit
-  could keep knownness with a flipped value; Z/S/T preserve it as a
-  phase), but the conservative rule sidesteps gate-by-gate
-  classification in MVP. Refinement is a later pass.
+- "Apply, demote to Unknown" is the conservative default for
+  basis-mixing gates. Z-diagonal gates preserve a known level and
+  X-type gates flip it (the gate classification lives in the status
+  stepper and defaults to demotion for anything unclassified), so the
+  exact known-source path survives diagonal circuits.
 
 ### 5.2.1 QubitStatusKind transitions
 
@@ -603,7 +602,9 @@ sampling:
 | Initial-state sample (Computational level)       | `ComputationalKnown(level_id)`                                          |
 | Initial-state sample (Leaked level)              | `Leaked(level_id)`                                                      |
 | Initial-state sample (Lost level)                | `Lost(level_id)`                                                        |
-| Any quantum gate touching qubit, kind == Known   | demote to `ComputationalUnknown`                                        |
+| Z-diagonal gate (`Z`/`S`/`T`/`CZ`/`R_Z`...), kind == Known | level preserved: `ComputationalKnown(level)`                  |
+| X-type gate (`X`/`Y`), kind == Known             | level flipped: `ComputationalKnown(other level)`                        |
+| Any other quantum gate touching qubit, kind == Known | demote to `ComputationalUnknown`                                    |
 | Z-basis measurement `M`                          | `ComputationalKnown(g)` or `ComputationalKnown(e)` per outcome          |
 | Z-basis measurement-and-reset `MR`               | `ComputationalKnown(g)` (post-op state is reset, regardless of outcome) |
 | X- or Y-basis measurement (`MX`/`MY`/`MRX`/`MRY`)| post-state is in X/Y basis, not energy basis: `ComputationalUnknown`    |

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -490,6 +490,44 @@ that only ever fires on known-or-classical sources runs fine in MVP.
 
 ## 5. Sampling, rewrite, and policy table
 
+### 5.0 Transitions are circuit annotations
+
+Transition consult points are first-class circuit instructions:
+
+- `TRANSITION[name] q...` applies the model transition matrix stored
+  under `name` to each target independently. Any key in the model's
+  `transitions` map is referenceable; a key that names a gate (e.g.
+  `"CZ"`) additionally acts as a *hook*, expanded by the annotation
+  layer into a `TRANSITION[key]` annotation after every occurrence of
+  that gate (one single-target annotation per Physical operand, in
+  operand order). Feedback operands are virtual and get none.
+- `LOSS(p) q...` applies a uniform loss with probability `p` inline; it
+  requires a level table with exactly one Lost-category level.
+
+**A transition fires at its circuit position, and the source column is
+the qubit's status there.** This is the standard noise-follows-the-
+ideal-operation convention; the annotation carries no reference to any
+gate, and placement is meaning: putting an annotation before or after
+an operation selects which state it consults. Consequences relative to
+attaching transitions to gates with entry-status sources:
+
+- A hook on a Z-diagonal gate (`CZ`, `S`, ...) consults the same
+  definite level the gate entered with (the status stepper tracks
+  knownness through diagonal and X-type gates), so the exact
+  known-source path survives where it physically should.
+- A hook on a basis-mixing gate (`H`, ...) consults a genuine
+  superposition: a source-dependent matrix there is an unknown-source
+  consult (reject or equalize per policy). The old entry-status column
+  choice was an artifact of attachment, not physics.
+- A hook on a measure-and-reset consults the post-reset state. A
+  transition acting on the pre-reset level -- readout-induced loss --
+  is written explicitly as `M q`, `TRANSITION[name] q`, `R q`.
+
+Annotations are consumed by the trajectory layer: the sampler draws one
+outcome per annotation target, and the rewriter replays those outcomes
+and emits only the carrier edits. `clifft.compile()` rejects circuits
+containing them.
+
 ### 5.1 Pipeline
 
 For each shot:
@@ -507,14 +545,15 @@ For each shot:
    `Leaked`/`Lost` initial qubits need no quantum prep (their
    computational amplitude is irrelevant); the lost/leaked policy
    gates downstream ops on them from op 0.
-3. **Walk the circuit ops in order, sampling transitions and updating
-   statuses.** For each op, consult the model's transitions and the
-   per-qubit statuses. Apply the §4.2 sample-time check on the source
-   context (per qubit operand, since transitions are per-qubit
-   marginals). Sample any per-qubit branches. Record the resulting
+3. **Expand gate hooks and walk the annotated circuit.** The
+   annotation layer inserts a `TRANSITION[key]` after each hooked
+   operation (once per sampling call); the sampler then walks the
+   operations, advancing statuses, and samples an outcome at each
+   TRANSITION/LOSS annotation target with the source taken from the
+   qubit's status at the annotation (§5.0). Apply the §4.2 sample-time
+   check on that source context. Record the resulting
    `NonComputationalHistory` (sequence of (op-index, qubit, sampled
-   branch, status-update, optional herald)). Update the status `kind`
-   per §5.2.1 below.
+   branch)). Update the status `kind` per §5.2.1 below.
 4. **Rewrite the original circuit using the history.** Produce a new
    ordinary clifft circuit (no new instructions). Drop, keep, or
    replace ops per the policy table. Insert an `R` op at structural
@@ -681,11 +720,10 @@ leaked site does not happen:
   faithful.
 
 A dropped operation has no physical effect, so a surviving operand's
-status keeps its entry value (it is not demoted), and attached
-transitions still fire on every operand from its entry-status column —
-the noise process is not gated by whether the intended gate could act.
-The sampler and the rewriter advance statuses through this same
-rule.
+status keeps its entry value (it is not demoted). Transition
+annotations are separate instructions and are never policy-gated: the
+noise process fires whether or not the intended gate could act. The
+sampler and the rewriter advance statuses through this same rule.
 
 ### 5.3 Hidden carrier edits at transition jumps
 

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -494,11 +494,11 @@ that only ever fires on known-or-classical sources runs fine in MVP.
 
 Transition consult points are first-class circuit instructions:
 
-- `TRANSITION[name] q...` applies the model transition matrix stored
+- `LEVEL_TRANSITION[name] q...` applies the model transition matrix stored
   under `name` to each target independently. Any key in the model's
   `transitions` map is referenceable; a key that names a gate (e.g.
   `"CZ"`) additionally acts as a *hook*, expanded by the annotation
-  layer into a `TRANSITION[key]` annotation after every occurrence of
+  layer into a `LEVEL_TRANSITION[key]` annotation after every occurrence of
   that gate (one single-target annotation per Physical operand, in
   operand order). Feedback operands are virtual and get none.
 - `LOSS(p) q...` applies a uniform loss with probability `p` inline; it
@@ -521,7 +521,7 @@ attaching transitions to gates with entry-status sources:
   choice was an artifact of attachment, not physics.
 - A hook on a measure-and-reset consults the post-reset state. A
   transition acting on the pre-reset level -- readout-induced loss --
-  is written explicitly as `M q`, `TRANSITION[name] q`, `R q`.
+  is written explicitly as `M q`, `LEVEL_TRANSITION[name] q`, `R q`.
 
 Annotations are consumed by the trajectory layer: the sampler draws one
 outcome per annotation target, and the rewriter replays those outcomes
@@ -546,10 +546,10 @@ For each shot:
    computational amplitude is irrelevant); the lost/leaked policy
    gates downstream ops on them from op 0.
 3. **Expand gate hooks and walk the annotated circuit.** The
-   annotation layer inserts a `TRANSITION[key]` after each hooked
+   annotation layer inserts a `LEVEL_TRANSITION[key]` after each hooked
    operation (once per sampling call); the sampler then walks the
    operations, advancing statuses, and samples an outcome at each
-   TRANSITION/LOSS annotation target with the source taken from the
+   LEVEL_TRANSITION/LOSS annotation target with the source taken from the
    qubit's status at the annotation (§5.0). Apply the §4.2 sample-time
    check on that source context. Record the resulting
    `NonComputationalHistory` (sequence of (op-index, qubit, sampled

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -391,9 +391,9 @@ Plan: add a spec-based `NonComputationalModel` builder (raw
 in Python. At that point decide whether the compositional constructor
 stays public or becomes an internal/test-only entry. Fingerprints
 must not leak into the Python API or user docs. Transition keys are
-accepted as gate-name strings but canonicalized to `GateType`
-internally; only hookable physical gates are allowed (no annotations,
-identity no-ops, `MPAD`, `EXP_VAL`, or noise channels in the MVP).
+arbitrary names, stored verbatim and resolved by exact key from
+`LEVEL_TRANSITION[key]` annotations; a key that names a hookable
+physical gate additionally registers a gate hook (§5.0).
 
 ## 4. Validation: construction-time vs. sample-time
 
@@ -424,8 +424,11 @@ representable in the MVP.
    `P(reject | level)`.
 6. **Policy values are well-formed** (enum values, not free strings on
    the C++ side; Python sugar translates).
-7. **Transition keys reference known gate names** in clifft's circuit
-   vocabulary; unknown keys reject.
+7. **Transition keys are tag-safe names**: nonempty, with no `]` or
+   newline, so a `LEVEL_TRANSITION[key]` annotation can reference them.
+   A key that names a hookable gate registers a gate hook, and two keys
+   resolving to the same gate reject; any other key is a named-only
+   reference, not an error.
 
 Each `TransitionInstrument` also computes and caches a derived flag
 at construction:

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(clifft_core STATIC
     util/introspection.cc
     util/xoshiro.cc
     noncomp/transition_instrument.cc
+    noncomp/annotate.cc
     noncomp/classifier.cc
     noncomp/model.cc
     noncomp/status_step.cc

--- a/src/clifft/circuit/circuit.h
+++ b/src/clifft/circuit/circuit.h
@@ -42,7 +42,7 @@ struct AstNode {
     // 0 means no source line information available.
     uint32_t source_line = 0;
 
-    // Bracket tag from `NAME[tag] targets` syntax. TRANSITION uses it to
+    // Bracket tag from `NAME[tag] targets` syntax. LEVEL_TRANSITION uses it to
     // reference a model transition matrix by name; no other instruction
     // accepts one. Empty when absent.
     std::string tag;

--- a/src/clifft/circuit/circuit.h
+++ b/src/clifft/circuit/circuit.h
@@ -15,6 +15,7 @@
 #include "clifft/circuit/target.h"
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace clifft {
@@ -40,6 +41,11 @@ struct AstNode {
     // Source line number in the original input text (1-based).
     // 0 means no source line information available.
     uint32_t source_line = 0;
+
+    // Bracket tag from `NAME[tag] targets` syntax. TRANSITION uses it to
+    // reference a model transition matrix by name; no other instruction
+    // accepts one. Empty when absent.
+    std::string tag;
 };
 
 // A parsed circuit ready for compilation.

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -131,6 +131,11 @@ enum class GateType : uint16_t {
     // Annotations
     TICK,  // Timing layer marker (no-op)
 
+    // Noncomputational trajectory annotations (consumed by the
+    // noncomputational sampling layer; trace() rejects them)
+    TRANSITION,  // Per-site level transition; the tag names a model matrix
+    LOSS,        // Per-site uniform loss with an inline probability
+
     // Simulation-only probes
     EXP_VAL,  // Non-destructive expectation value
 
@@ -267,6 +272,9 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = A, .name = "DETECTOR"},
     {.arity = A, .name = "OBSERVABLE_INCLUDE"},
     {.arity = A, .name = "TICK"},
+    // Noncomputational trajectory annotations
+    {.arity = S, .name = "TRANSITION"},
+    {.arity = S, .name = "LOSS"},
     // Simulation-only probes
     {.arity = ML, .name = "EXP_VAL"},
     // Sentinel

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -133,8 +133,8 @@ enum class GateType : uint16_t {
 
     // Noncomputational trajectory annotations (consumed by the
     // noncomputational sampling layer; trace() rejects them)
-    TRANSITION,  // Per-site level transition; the tag names a model matrix
-    LOSS,        // Per-site uniform loss with an inline probability
+    LEVEL_TRANSITION,  // Per-site level transition; the tag names a model matrix
+    LOSS,              // Per-site uniform loss with an inline probability
 
     // Simulation-only probes
     EXP_VAL,  // Non-destructive expectation value
@@ -273,7 +273,7 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = A, .name = "OBSERVABLE_INCLUDE"},
     {.arity = A, .name = "TICK"},
     // Noncomputational trajectory annotations
-    {.arity = S, .name = "TRANSITION"},
+    {.arity = S, .name = "LEVEL_TRANSITION"},
     {.arity = S, .name = "LOSS"},
     // Simulation-only probes
     {.arity = ML, .name = "EXP_VAL"},

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -212,6 +212,11 @@ class Parser {
             }
             rest = trim(rest.substr(close_bracket + 1));
         }
+        // Restricted here, before the discarded-annotation and parser-rewrite
+        // paths return, so no instruction can silently drop a tag.
+        if (!tag.empty() && gate_name != "TRANSITION") {
+            throw ParseError("Tags are only supported on TRANSITION", line_num);
+        }
 
         // Parse optional parenthesized arguments (comma-separated floats).
         std::vector<double> args;
@@ -324,8 +329,6 @@ class Parser {
                 throw ParseError("TRANSITION takes no arguments (the tag names the matrix)",
                                  line_num);
             }
-        } else if (!tag.empty()) {
-            throw ParseError("Tags are only supported on TRANSITION", line_num);
         }
         if (gate == GateType::LOSS) {
             if (args.size() != 1) {

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -214,8 +214,8 @@ class Parser {
         }
         // Restricted here, before the discarded-annotation and parser-rewrite
         // paths return, so no instruction can silently drop a tag.
-        if (!tag.empty() && gate_name != "TRANSITION") {
-            throw ParseError("Tags are only supported on TRANSITION", line_num);
+        if (!tag.empty() && gate_name != "LEVEL_TRANSITION") {
+            throw ParseError("Tags are only supported on LEVEL_TRANSITION", line_num);
         }
 
         // Parse optional parenthesized arguments (comma-separated floats).
@@ -320,13 +320,13 @@ class Parser {
         if (gate == GateType::EXP_VAL && !args.empty()) {
             throw ParseError("EXP_VAL takes no arguments", line_num);
         }
-        if (gate == GateType::TRANSITION) {
+        if (gate == GateType::LEVEL_TRANSITION) {
             if (tag.empty()) {
-                throw ParseError("TRANSITION requires a [tag] naming a transition in the model",
-                                 line_num);
+                throw ParseError(
+                    "LEVEL_TRANSITION requires a [tag] naming a transition in the model", line_num);
             }
             if (!args.empty()) {
-                throw ParseError("TRANSITION takes no arguments (the tag names the matrix)",
+                throw ParseError("LEVEL_TRANSITION takes no arguments (the tag names the matrix)",
                                  line_num);
             }
         }
@@ -675,7 +675,7 @@ class Parser {
             if (!is_rec_token && gate == GateType::READOUT_NOISE) {
                 throw ParseError("READOUT_NOISE targets must be rec references", line_num);
             }
-            if ((gate == GateType::TRANSITION || gate == GateType::LOSS) &&
+            if ((gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) &&
                 (is_rec_token || token[0] == '!')) {
                 throw ParseError(
                     std::string(clifft::gate_name(gate)) + " targets must be plain qubit indices",

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -199,6 +199,20 @@ class Parser {
         std::string_view gate_name = line.substr(0, name_end);
         std::string_view rest = trim(line.substr(name_end));
 
+        // Parse an optional bracket tag: NAME[tag](args) targets.
+        std::string tag;
+        if (!rest.empty() && rest[0] == '[') {
+            auto close_bracket = rest.find(']');
+            if (close_bracket == std::string_view::npos) {
+                throw ParseError("Unclosed tag bracket", line_num);
+            }
+            tag = std::string(trim(rest.substr(1, close_bracket - 1)));
+            if (tag.empty()) {
+                throw ParseError("Empty tag", line_num);
+            }
+            rest = trim(rest.substr(close_bracket + 1));
+        }
+
         // Parse optional parenthesized arguments (comma-separated floats).
         std::vector<double> args;
         if (!rest.empty() && rest[0] == '(') {
@@ -301,6 +315,27 @@ class Parser {
         if (gate == GateType::EXP_VAL && !args.empty()) {
             throw ParseError("EXP_VAL takes no arguments", line_num);
         }
+        if (gate == GateType::TRANSITION) {
+            if (tag.empty()) {
+                throw ParseError("TRANSITION requires a [tag] naming a transition in the model",
+                                 line_num);
+            }
+            if (!args.empty()) {
+                throw ParseError("TRANSITION takes no arguments (the tag names the matrix)",
+                                 line_num);
+            }
+        } else if (!tag.empty()) {
+            throw ParseError("Tags are only supported on TRANSITION", line_num);
+        }
+        if (gate == GateType::LOSS) {
+            if (args.size() != 1) {
+                throw ParseError("LOSS requires exactly 1 argument (the loss probability)",
+                                 line_num);
+            }
+            if (!(args[0] >= 0.0 && args[0] <= 1.0)) {
+                throw ParseError("LOSS probability must lie in [0, 1]", line_num);
+            }
+        }
         if (gate == GateType::READOUT_NOISE && args.size() != 1 && args.size() != 2) {
             throw ParseError(
                 "READOUT_NOISE requires 1 argument (symmetric flip probability) or 2 "
@@ -336,7 +371,7 @@ class Parser {
                 circuit.nodes.push_back({GateType::TICK, {}, args, line_num});
                 break;
             default:
-                parse_standard_gate(gate, rest, line_num, circuit, arg, args);
+                parse_standard_gate(gate, rest, line_num, circuit, arg, args, tag);
                 break;
         }
     }
@@ -600,7 +635,8 @@ class Parser {
 
     // Parse a standard gate with qubit targets (possibly with rec references).
     void parse_standard_gate(GateType gate, std::string_view targets_str, uint32_t line_num,
-                             Circuit& circuit, double arg, const std::vector<double>& args) {
+                             Circuit& circuit, double arg, const std::vector<double>& args,
+                             const std::string& tag = {}) {
         // Resets (R, RX) don't accept noise arguments.
         if (is_reset(gate) && arg != 0.0) {
             throw ParseError("Reset gates do not accept arguments", line_num);
@@ -635,6 +671,12 @@ class Parser {
             }
             if (!is_rec_token && gate == GateType::READOUT_NOISE) {
                 throw ParseError("READOUT_NOISE targets must be rec references", line_num);
+            }
+            if ((gate == GateType::TRANSITION || gate == GateType::LOSS) &&
+                (is_rec_token || token[0] == '!')) {
+                throw ParseError(
+                    std::string(clifft::gate_name(gate)) + " targets must be plain qubit indices",
+                    line_num);
             }
             if (is_rec_token && gate == GateType::READOUT_NOISE && token[0] == '!') {
                 throw ParseError(
@@ -691,6 +733,7 @@ class Parser {
                     }
 
                     AstNode node{gate, {t}, std::move(node_args), line_num};
+                    node.tag = tag;
                     update_circuit_stats(node, circuit);
                     circuit.nodes.push_back(std::move(node));
 

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -740,6 +740,13 @@ HirModule trace(const Circuit& circuit) {
                 break;
             }
 
+            case GateType::TRANSITION:
+            case GateType::LOSS:
+                throw std::runtime_error(
+                    std::string(gate_name(node.gate)) +
+                    " is a noncomputational annotation; run the circuit through "
+                    "sample_noncomputational instead of compiling it directly");
+
             case GateType::MPAD: {
                 for (const auto& target : node.targets) {
                     bool sign = (target.value() != 0) ^ target.is_inverted();

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -740,7 +740,7 @@ HirModule trace(const Circuit& circuit) {
                 break;
             }
 
-            case GateType::TRANSITION:
+            case GateType::LEVEL_TRANSITION:
             case GateType::LOSS:
                 throw std::runtime_error(
                     std::string(gate_name(node.gate)) +

--- a/src/clifft/noncomp/annotate.cc
+++ b/src/clifft/noncomp/annotate.cc
@@ -25,7 +25,7 @@ Circuit annotate(const Circuit& circuit, const NonComputationalModel& model) {
             if (operand.role != OperandRole::Physical) {
                 continue;
             }
-            out.nodes.push_back(AstNode{GateType::TRANSITION,
+            out.nodes.push_back(AstNode{GateType::LEVEL_TRANSITION,
                                         {Target::qubit(operand.qubit)},
                                         {},
                                         node.source_line,

--- a/src/clifft/noncomp/annotate.cc
+++ b/src/clifft/noncomp/annotate.cc
@@ -1,0 +1,38 @@
+#include "clifft/noncomp/annotate.h"
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+#include "clifft/noncomp/op_role.h"
+
+namespace clifft {
+
+Circuit annotate(const Circuit& circuit, const NonComputationalModel& model) {
+    const auto& hooks = model.transition_hooks();
+
+    Circuit out = circuit;
+    out.nodes.clear();
+    out.nodes.reserve(circuit.nodes.size() * 2);
+
+    for (const AstNode& node : circuit.nodes) {
+        out.nodes.push_back(node);
+        const auto hook = hooks.find(node.gate);
+        if (hook == hooks.end()) {
+            continue;
+        }
+        // One annotation per Physical operand: feedback corrections are
+        // virtual and fire no transition.
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            if (operand.role != OperandRole::Physical) {
+                continue;
+            }
+            out.nodes.push_back(AstNode{GateType::TRANSITION,
+                                        {Target::qubit(operand.qubit)},
+                                        {},
+                                        node.source_line,
+                                        hook->second});
+        }
+    }
+    return out;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/annotate.h
+++ b/src/clifft/noncomp/annotate.h
@@ -3,13 +3,13 @@
 // Annotation expansion for the noncomputational trajectory layer.
 //
 // annotate(circuit, model) expands the model's gate hooks -- transition
-// keys that name a gate -- into explicit TRANSITION[key] annotations in the
+// keys that name a gate -- into explicit LEVEL_TRANSITION[key] annotations in the
 // circuit: one single-target annotation per Physical qubit operand,
 // inserted immediately after each hooked operation, in operand order. The
 // result carries every transition consult point as a first-class
 // instruction, positioned where it fires, so the sampler and rewriter
 // consume only annotations and the expanded circuit is a complete audit of
-// the applied noise model. Circuits may also carry hand-written TRANSITION
+// the applied noise model. Circuits may also carry hand-written LEVEL_TRANSITION
 // and LOSS annotations; expansion leaves them where they are.
 
 #include "clifft/circuit/circuit.h"

--- a/src/clifft/noncomp/annotate.h
+++ b/src/clifft/noncomp/annotate.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// Annotation expansion for the noncomputational trajectory layer.
+//
+// annotate(circuit, model) expands the model's gate hooks -- transition
+// keys that name a gate -- into explicit TRANSITION[key] annotations in the
+// circuit: one single-target annotation per Physical qubit operand,
+// inserted immediately after each hooked operation, in operand order. The
+// result carries every transition consult point as a first-class
+// instruction, positioned where it fires, so the sampler and rewriter
+// consume only annotations and the expanded circuit is a complete audit of
+// the applied noise model. Circuits may also carry hand-written TRANSITION
+// and LOSS annotations; expansion leaves them where they are.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/model.h"
+
+namespace clifft {
+
+Circuit annotate(const Circuit& circuit, const NonComputationalModel& model);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -91,21 +91,34 @@ NonComputationalModel::NonComputationalModel(
         p /= sum;
     }
 
-    // Transition keys must name hookable physical gates, canonicalized to
-    // GateType so the sampler resolves them against the parsed circuit
-    // and no two spellings of one gate shadow each other. Each instrument
-    // must have been built against this model's level table.
-    std::map<GateType, std::string> first_spelling;
+    // A transition key is referenced from circuits by TRANSITION[key]
+    // annotations, so it must survive the tag syntax; a key that names a
+    // hookable physical gate additionally registers a gate hook,
+    // canonicalized to GateType so no two spellings of one gate shadow
+    // each other. Each instrument must have been built against this
+    // model's level table.
     for (auto& [name, instrument] : transitions) {
-        const GateType gate = parse_gate_name(name);
-        if (gate == GateType::UNKNOWN) {
-            throw std::invalid_argument("NonComputationalModel: transition key '" + name +
-                                        "' is not a recognized gate name");
+        if (name.empty()) {
+            throw std::invalid_argument("NonComputationalModel: transition keys must be nonempty");
         }
-        if (!supports_transition(gate)) {
-            throw std::invalid_argument("NonComputationalModel: transition key '" + name + "' (" +
-                                        std::string(gate_name(gate)) +
-                                        ") does not support a transition instrument");
+        if (name.find(']') != std::string::npos || name.find('\n') != std::string::npos) {
+            throw std::invalid_argument(
+                "NonComputationalModel: transition key '" + name +
+                "' contains ']' or a newline and cannot be referenced by a TRANSITION tag");
+        }
+        const GateType gate = parse_gate_name(name);
+        if (gate != GateType::UNKNOWN) {
+            if (!supports_transition(gate)) {
+                throw std::invalid_argument("NonComputationalModel: transition key '" + name +
+                                            "' (" + std::string(gate_name(gate)) +
+                                            ") does not support a transition instrument");
+            }
+            auto [it, inserted] = hooks_.emplace(gate, name);
+            if (!inserted) {
+                throw std::invalid_argument(
+                    "NonComputationalModel: transition keys '" + it->second + "' and '" + name +
+                    "' both resolve to gate '" + std::string(gate_name(gate)) + "'");
+            }
         }
         if (instrument.num_levels() != n) {
             throw std::invalid_argument("NonComputationalModel: transition '" + name + "' spans " +
@@ -117,13 +130,7 @@ NonComputationalModel::NonComputationalModel(
             throw std::invalid_argument("NonComputationalModel: transition '" + name +
                                         "' was built against a different level table");
         }
-        auto [it, inserted] = transitions_.emplace(gate, std::move(instrument));
-        if (!inserted) {
-            throw std::invalid_argument(
-                "NonComputationalModel: transition keys '" + first_spelling.at(gate) + "' and '" +
-                name + "' both resolve to gate '" + std::string(gate_name(gate)) + "'");
-        }
-        first_spelling.emplace(gate, name);
+        transitions_.emplace(name, std::move(instrument));
     }
 
     // The classifier, if present, must have been built against the same
@@ -192,16 +199,13 @@ double NonComputationalModel::initial_probability(uint8_t level_id) const {
 }
 
 const TransitionInstrument* NonComputationalModel::transition_for(GateType gate) const {
-    const auto it = transitions_.find(gate);
-    return it == transitions_.end() ? nullptr : &it->second;
+    const auto it = hooks_.find(gate);
+    return it == hooks_.end() ? nullptr : transition_named(it->second);
 }
 
-const TransitionInstrument* NonComputationalModel::transition_for(std::string_view gate) const {
-    const GateType type = parse_gate_name(gate);
-    if (type == GateType::UNKNOWN) {
-        return nullptr;
-    }
-    return transition_for(type);
+const TransitionInstrument* NonComputationalModel::transition_named(std::string_view name) const {
+    const auto it = transitions_.find(name);
+    return it == transitions_.end() ? nullptr : &it->second;
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -106,13 +106,13 @@ NonComputationalModel::NonComputationalModel(
                 "NonComputationalModel: transition key '" + name +
                 "' contains ']' or a newline and cannot be referenced by a TRANSITION tag");
         }
+        // Only a key naming a hookable physical gate registers a hook. Any
+        // other key -- an arbitrary name, or one naming a non-hookable
+        // instruction such as LOSS or a noise channel -- is a named-only
+        // transition: referenceable from TRANSITION[key], expanded onto
+        // nothing.
         const GateType gate = parse_gate_name(name);
-        if (gate != GateType::UNKNOWN) {
-            if (!supports_transition(gate)) {
-                throw std::invalid_argument("NonComputationalModel: transition key '" + name +
-                                            "' (" + std::string(gate_name(gate)) +
-                                            ") does not support a transition instrument");
-            }
+        if (gate != GateType::UNKNOWN && supports_transition(gate)) {
             auto [it, inserted] = hooks_.emplace(gate, name);
             if (!inserted) {
                 throw std::invalid_argument(

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -91,7 +91,7 @@ NonComputationalModel::NonComputationalModel(
         p /= sum;
     }
 
-    // A transition key is referenced from circuits by TRANSITION[key]
+    // A transition key is referenced from circuits by LEVEL_TRANSITION[key]
     // annotations, so it must survive the tag syntax; a key that names a
     // hookable physical gate additionally registers a gate hook,
     // canonicalized to GateType so no two spellings of one gate shadow
@@ -104,12 +104,12 @@ NonComputationalModel::NonComputationalModel(
         if (name.find(']') != std::string::npos || name.find('\n') != std::string::npos) {
             throw std::invalid_argument(
                 "NonComputationalModel: transition key '" + name +
-                "' contains ']' or a newline and cannot be referenced by a TRANSITION tag");
+                "' contains ']' or a newline and cannot be referenced by a LEVEL_TRANSITION tag");
         }
         // Only a key naming a hookable physical gate registers a hook. Any
         // other key -- an arbitrary name, or one naming a non-hookable
         // instruction such as LOSS or a noise channel -- is a named-only
-        // transition: referenceable from TRANSITION[key], expanded onto
+        // transition: referenceable from LEVEL_TRANSITION[key], expanded onto
         // nothing.
         const GateType gate = parse_gate_name(name);
         if (gate != GateType::UNKNOWN && supports_transition(gate)) {

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -85,15 +85,25 @@ class NonComputationalModel {
     double initial_probability(uint8_t level_id) const;
     const std::vector<double>& initial_state() const { return initial_state_; }
 
-    const std::map<GateType, TransitionInstrument>& transitions() const { return transitions_; }
+    // Every declared transition by its original key. A key that names a
+    // hookable gate additionally registers a gate hook (see
+    // transition_hooks); any key can be referenced from a circuit by a
+    // TRANSITION[key] annotation.
+    const std::map<std::string, TransitionInstrument, std::less<>>& transitions() const {
+        return transitions_;
+    }
 
-    // Transition instrument declared for a gate, or nullptr if the model
-    // declares none. The GateType overload is what the sampler uses; the
-    // string overload canonicalizes the name first (returning nullptr
-    // for an unrecognized name) and is a convenience for callers holding
-    // a gate-name string.
+    // Gate hooks: the gate-named subset of the transition keys, mapping
+    // each hooked gate to its key. The annotation layer expands these
+    // into explicit TRANSITION annotations after each hooked operation.
+    const std::map<GateType, std::string>& transition_hooks() const { return hooks_; }
+
+    // Transition instrument hooked on a gate, or nullptr if none.
     const TransitionInstrument* transition_for(GateType gate) const;
-    const TransitionInstrument* transition_for(std::string_view gate) const;
+
+    // Transition instrument by exact key, or nullptr if none. This is the
+    // lookup a TRANSITION[name] annotation resolves through.
+    const TransitionInstrument* transition_named(std::string_view name) const;
 
     // The classifier, or nullptr if the model has none.
     const MeasurementClassifier* classifier() const {
@@ -105,7 +115,8 @@ class NonComputationalModel {
   private:
     LevelSet levels_;
     std::vector<double> initial_state_;
-    std::map<GateType, TransitionInstrument> transitions_;
+    std::map<std::string, TransitionInstrument, std::less<>> transitions_;
+    std::map<GateType, std::string> hooks_;
     std::optional<MeasurementClassifier> classifier_;
     NonComputationalPolicy policy_;
 };

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -88,21 +88,21 @@ class NonComputationalModel {
     // Every declared transition by its original key. A key that names a
     // hookable gate additionally registers a gate hook (see
     // transition_hooks); any key can be referenced from a circuit by a
-    // TRANSITION[key] annotation.
+    // LEVEL_TRANSITION[key] annotation.
     const std::map<std::string, TransitionInstrument, std::less<>>& transitions() const {
         return transitions_;
     }
 
     // Gate hooks: the gate-named subset of the transition keys, mapping
     // each hooked gate to its key. The annotation layer expands these
-    // into explicit TRANSITION annotations after each hooked operation.
+    // into explicit LEVEL_TRANSITION annotations after each hooked operation.
     const std::map<GateType, std::string>& transition_hooks() const { return hooks_; }
 
     // Transition instrument hooked on a gate, or nullptr if none.
     const TransitionInstrument* transition_for(GateType gate) const;
 
     // Transition instrument by exact key, or nullptr if none. This is the
-    // lookup a TRANSITION[name] annotation resolves through.
+    // lookup a LEVEL_TRANSITION[name] annotation resolves through.
     const TransitionInstrument* transition_named(std::string_view name) const;
 
     // The classifier, or nullptr if the model has none.

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -3,21 +3,24 @@
 // NonComputationalModel: the assembled, validated trajectory model.
 //
 // Ties together a LevelSet, a per-level initial-state distribution, a
-// gate-keyed table of TransitionInstruments, an optional
+// name-keyed table of TransitionInstruments, an optional
 // MeasurementClassifier, and the NonComputationalPolicy knobs.
 //
 // Construction runs the model-wide consistency checks (initial state is
 // a probability vector over the levels; every instrument and the
 // classifier were built against this model's level table; transition
-// keys name hookable physical gates; policy values are recognized) and
-// throws std::invalid_argument on failure. Whether a transition's
-// source context is representable is a sample-time concern enforced by
-// the sampler against the target qubit's QubitStatusKind, not here.
+// keys survive the LEVEL_TRANSITION tag syntax; policy values are
+// recognized) and throws std::invalid_argument on failure. Whether a
+// transition's source context is representable is a sample-time concern
+// enforced by the sampler against the target qubit's QubitStatusKind,
+// not here.
 //
-// Transition keys are supplied as gate-name strings (Stim aliases such
-// as "CNOT" are accepted) but stored canonicalized to GateType, so the
-// sampler resolves them against the parsed circuit's GateType directly
-// and two spellings of the same gate cannot silently shadow each other.
+// Transition keys are arbitrary names, stored verbatim; a circuit
+// references any of them by exact key with a LEVEL_TRANSITION[key]
+// annotation. A key that names a hookable physical gate (Stim aliases
+// such as "CNOT" are accepted) additionally registers a gate hook,
+// keyed by GateType so two spellings of one gate cannot register
+// competing hooks.
 
 #include "clifft/circuit/gate_data.h"
 #include "clifft/noncomp/classifier.h"
@@ -49,9 +52,9 @@ class NonComputationalModel {
     //   - initial_state has one entry per level, each finite and in
     //     [0, 1]; the distribution is normalized to sum to exactly 1
     //     after checking it sums to 1 within tolerance;
-    //   - every transition key names a hookable physical gate (no
-    //     annotations, identity no-ops, noise channels, or synthetic
-    //     gates), and no two keys canonicalize to the same gate;
+    //   - every transition key is nonempty and free of ']' and newline
+    //     (so a LEVEL_TRANSITION[key] tag can reference it), and no two
+    //     hook-registering keys resolve to the same gate;
     //   - every TransitionInstrument and the classifier, if present,
     //     were built against this model's level table (fingerprint
     //     match);
@@ -69,7 +72,7 @@ class NonComputationalModel {
     // classifier against `levels` from raw matrices, then assemble. Because all
     // components are built against the one LevelSet, callers never construct
     // those objects or deal with level fingerprints. `transition_matrices` maps
-    // a gate-name string to its T[to][from] matrix; `classifier_spec` is
+    // a transition key to its T[to][from] matrix; `classifier_spec` is
     // optional. Validation and throwing match the component from_matrix
     // factories and the constructor.
     static NonComputationalModel from_spec(

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -3,6 +3,7 @@
 #include "clifft/backend/backend.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
+#include "clifft/noncomp/annotate.h"
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/sampler.h"
@@ -96,10 +97,14 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
 
     const MeasurementClassifier* classifier = model.classifier();
 
+    // Expand the model's gate hooks into explicit TRANSITION annotations
+    // once: the per-shot layers below consume only annotations.
+    const Circuit annotated = annotate(circuit, model);
+
     for (uint32_t shot = 0; shot < shots; ++shot) {
         HistorySample hs =
-            sample_history(circuit, model, derive_seed(global_seed, shot, kHistoryDomain));
-        RewriteResult rw = rewrite(circuit, hs.history, model);
+            sample_history(annotated, model, derive_seed(global_seed, shot, kHistoryDomain));
+        RewriteResult rw = rewrite(annotated, hs.history, model);
         std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
         if (classifier != nullptr && classifier->num_symbols() == 3 &&
             !rw.classified_measurements.empty()) {

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -97,7 +97,7 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
 
     const MeasurementClassifier* classifier = model.classifier();
 
-    // Expand the model's gate hooks into explicit TRANSITION annotations
+    // Expand the model's gate hooks into explicit LEVEL_TRANSITION annotations
     // once: the per-shot layers below consume only annotations.
     const Circuit annotated = annotate(circuit, model);
 

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -2,10 +2,12 @@
 
 // Orchestrator: the top-level noncomputational sampling entry point.
 //
-// sample_noncomputational(circuit, model, shots, seed) runs the full per-shot
-// pipeline and returns the user-facing records plus a noncomputational
-// sidecar. For each shot it:
-//   1. samples a structural history (initial statuses + transition outcomes);
+// sample_noncomputational(circuit, model, shots, seed) expands the model's
+// gate hooks into explicit TRANSITION annotations once, then runs the full
+// per-shot pipeline and returns the user-facing records plus a
+// noncomputational sidecar. For each shot it:
+//   1. samples a structural history (initial statuses + an outcome per
+//      TRANSITION/LOSS annotation target);
 //   2. rewrites the circuit for that history (X-prep, trace-out R, policy,
 //      and the classifier record write for each measurement on a leaked/lost
 //      qubit: MPAD plus a READOUT_NOISE for a stochastic column, so the bit

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -3,11 +3,11 @@
 // Orchestrator: the top-level noncomputational sampling entry point.
 //
 // sample_noncomputational(circuit, model, shots, seed) expands the model's
-// gate hooks into explicit TRANSITION annotations once, then runs the full
+// gate hooks into explicit LEVEL_TRANSITION annotations once, then runs the full
 // per-shot pipeline and returns the user-facing records plus a
 // noncomputational sidecar. For each shot it:
 //   1. samples a structural history (initial statuses + an outcome per
-//      TRANSITION/LOSS annotation target);
+//      LEVEL_TRANSITION/LOSS annotation target);
 //   2. rewrites the circuit for that history (X-prep, trace-out R, policy,
 //      and the classifier record write for each measurement on a leaked/lost
 //      qubit: MPAD plus a READOUT_NOISE for a stochastic column, so the bit

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -205,14 +205,14 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
         const AstNode& node = original.nodes[op_index];
         const GateType gate = node.gate;
 
-        // TRANSITION and LOSS annotations are the transition consult
+        // LEVEL_TRANSITION and LOSS annotations are the transition consult
         // points. They are consumed here -- the rewritten circuit carries
         // only their carrier edits -- with the same jump semantics an
         // operation-attached transition had: a jump into the computational
         // subspace materializes the carrier at the destination, and a jump
         // out of it needs the hidden trace-out exactly when the carrier at
         // the annotation's position is coherent.
-        if (gate == GateType::TRANSITION || gate == GateType::LOSS) {
+        if (gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) {
             for (const Target& target : node.targets) {
                 const uint32_t qubit = target.value();
                 if (qubit >= status.size()) {

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -139,14 +139,6 @@ void append_computational_confusion(Circuit& out, const NonComputationalModel& m
     out.nodes.push_back(AstNode{GateType::READOUT_NOISE, {Target::rec(slot)}, {p01, p10}, 0});
 }
 
-// A hidden carrier edit appended after an op for one operand's jump: an R
-// collapses and rezeros the carrier, and an X then prepares |1> when the
-// jump lands on the |1> computational level.
-struct CarrierEdit {
-    uint32_t qubit;
-    bool prepare_one;
-};
-
 }  // namespace
 
 RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& history,
@@ -187,10 +179,65 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
     size_t trans_cursor = 0;
     uint32_t slot = 0;  // visible measurement record index
 
+    // Consume one recorded transition outcome for (op_index, qubit),
+    // validating that the record stream describes this circuit.
+    auto replay_transition = [&](uint32_t op_index, uint32_t qubit) -> TransitionOutcome {
+        if (trans_cursor >= history.transitions.size()) {
+            throw std::invalid_argument(
+                "rewrite: circuit consults more transitions than the history records; "
+                "history does not describe this circuit");
+        }
+        const TransitionRecord& record = history.transitions[trans_cursor++];
+        if (record.op_index != op_index || record.qubit != qubit) {
+            throw std::invalid_argument(
+                "rewrite: transition record (op " + std::to_string(record.op_index) + ", qubit " +
+                std::to_string(record.qubit) + ") does not match consult (op " +
+                std::to_string(op_index) + ", qubit " + std::to_string(qubit) +
+                "); history does not describe this circuit");
+        }
+        TransitionOutcome outcome;
+        outcome.jumped = record.jumped;
+        outcome.destination_level = record.destination_level;
+        return outcome;
+    };
+
     for (uint32_t op_index = 0; op_index < original.nodes.size(); ++op_index) {
         const AstNode& node = original.nodes[op_index];
         const GateType gate = node.gate;
-        const TransitionInstrument* instrument = model.transition_for(gate);
+
+        // TRANSITION and LOSS annotations are the transition consult
+        // points. They are consumed here -- the rewritten circuit carries
+        // only their carrier edits -- with the same jump semantics an
+        // operation-attached transition had: a jump into the computational
+        // subspace materializes the carrier at the destination, and a jump
+        // out of it needs the hidden trace-out exactly when the carrier at
+        // the annotation's position is coherent.
+        if (gate == GateType::TRANSITION || gate == GateType::LOSS) {
+            for (const Target& target : node.targets) {
+                const uint32_t qubit = target.value();
+                if (qubit >= status.size()) {
+                    throw std::invalid_argument("rewrite: operand qubit " + std::to_string(qubit) +
+                                                " is out of range at op " +
+                                                std::to_string(op_index));
+                }
+                const QubitStatus pre = status[qubit];
+                const TransitionOutcome outcome = replay_transition(op_index, qubit);
+                if (!outcome.jumped) {
+                    continue;
+                }
+                const Level& dest = levels.at(outcome.destination_level);
+                if (dest.category == LevelCategory::Computational) {
+                    out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+                    if (outcome.destination_level == levels.computational_one_id()) {
+                        out.nodes.push_back(single_qubit_op(GateType::X, qubit));
+                    }
+                } else if (pre.kind() == QubitStatusKind::ComputationalUnknown) {
+                    out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+                }
+                status[qubit] = levels.status_for(outcome.destination_level);
+            }
+            continue;
+        }
 
         // Policy pre-scan over entry statuses: any rejecting operand rejects
         // the whole operation; otherwise any dropping operand drops it whole
@@ -218,8 +265,6 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
             }
         }
 
-        std::vector<CarrierEdit> carrier_edits;  // hidden edits appended after this op
-
         // Set when this (single-qubit Z-basis) measurement reads a leaked or
         // lost qubit: the classifier, not the SVM, defines its record bit.
         std::optional<uint8_t> classified_level;
@@ -233,54 +278,8 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
                 classified_level = pre.level_id();
             }
 
-            // Replay the recorded transition for this operand, if the sampler
-            // consulted one (a Physical operand of a gate declaring a
-            // transition). Records are consumed in sampler order.
-            TransitionOutcome outcome;
-            if (operand.role == OperandRole::Physical && instrument != nullptr) {
-                if (trans_cursor >= history.transitions.size()) {
-                    throw std::invalid_argument(
-                        "rewrite: circuit consults more transitions than the history records; "
-                        "history does not describe this circuit");
-                }
-                const TransitionRecord& record = history.transitions[trans_cursor++];
-                if (record.op_index != op_index || record.qubit != qubit) {
-                    throw std::invalid_argument(
-                        "rewrite: transition record (op " + std::to_string(record.op_index) +
-                        ", qubit " + std::to_string(record.qubit) +
-                        ") does not match consult (op " + std::to_string(op_index) + ", qubit " +
-                        std::to_string(qubit) + "); history does not describe this circuit");
-                }
-                outcome.jumped = record.jumped;
-                outcome.destination_level = record.destination_level;
-            }
-
-            // Carrier-edit decision for a jump. A jump into the computational
-            // subspace materializes the carrier at the destination level: the
-            // R collapses whatever the base op left -- a coherent
-            // superposition, a definite level, or a stale residual on a
-            // recaptured leaked/lost qubit -- and the X then prepares |1> for
-            // a One-level destination. A jump out of the computational
-            // subspace needs a hidden Z-basis unraveling (trace-out) only
-            // when the carrier the base op would leave with no jump is
-            // coherent; a dropped operation leaves the entry carrier.
-            if (outcome.jumped) {
-                const Level& dest = levels.at(outcome.destination_level);
-                if (dest.category == LevelCategory::Computational) {
-                    carrier_edits.push_back(
-                        {qubit, outcome.destination_level == levels.computational_one_id()});
-                } else {
-                    const QubitStatus post_if_no_jump =
-                        drop_op ? pre
-                                : normal_post_op_status(pre, gate, operand.role, policy, levels);
-                    if (post_if_no_jump.kind() == QubitStatusKind::ComputationalUnknown) {
-                        carrier_edits.push_back({qubit, false});
-                    }
-                }
-            }
-
-            status[qubit] = drop_op ? step_status_dropped(pre, outcome, levels)
-                                    : step_status(pre, gate, operand.role, outcome, policy, levels);
+            status[qubit] =
+                drop_op ? pre : normal_post_op_status(pre, gate, operand.role, policy, levels);
         }
 
         if (!drop_op) {
@@ -334,12 +333,6 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
                                                    node.targets.front().is_inverted(), slot,
                                                    op_index, qubit_operands(node).front().qubit);
                 }
-            }
-        }
-        for (const CarrierEdit& edit : carrier_edits) {
-            out.nodes.push_back(single_qubit_op(GateType::R, edit.qubit));
-            if (edit.prepare_one) {
-                out.nodes.push_back(single_qubit_op(GateType::X, edit.qubit));
             }
         }
         if (is_measurement(gate)) {

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -35,25 +35,27 @@
 //      its slot -- the misreport probabilities P(1 | zero level) and
 //      P(0 | one level) -- when those columns are not the identity.
 //   4. Hidden trace-out: when a coherent qubit jumps to a Leaked or Lost
-//      level, insert an R on that qubit immediately after the operation.
+//      level, insert an R on that qubit at the annotation's position.
 //      The existing reset lowering turns it into a hidden measurement plus a
 //      corrective Pauli; it adds no visible measurement and shifts no record
-//      index. "Coherent" means the carrier state the base operation would
-//      leave with no jump is ComputationalUnknown -- a qubit a gate has just
-//      made coherent still needs trace-out even if it entered known.
+//      index. "Coherent" means the qubit's status at the annotation's
+//      position is ComputationalUnknown; a definite atom needs no
+//      unraveling.
 //   5. Carrier materialization: when a jump lands on a computational level,
-//      insert an R (plus an X for the |1> level) immediately
-//      after the operation, so the SVM carrier is prepared at the definite
+//      insert an R (plus an X for the |1> level) at the annotation's
+//      position, so the SVM carrier is prepared at the definite
 //      destination level. This is done for every carrier state: it is the
 //      collapse unraveling for a coherent carrier, a deterministic re-prep
 //      for a known one, and it rezeros a stale residual when a leaked or
 //      lost qubit is recaptured. Like the trace-out, it shifts no record
 //      index.
 //
-// Transition outcomes are consumed from history.transitions in the same
-// order the sampler produced them (one record per Physical operand of a gate
-// that declares a transition). The rewriter does not sample, compile, or run
-// the SVM.
+// Transition consults happen only at TRANSITION and LOSS annotations
+// (gate hooks are expanded by annotate() before sampling and rewriting).
+// The rewriter consumes those annotations -- replaying outcomes from
+// history.transitions in sampler order, one record per annotation target --
+// and emits only their carrier edits; annotation nodes never reach the
+// rewritten circuit. It does not sample, compile, or run the SVM.
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/history.h"

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -50,7 +50,7 @@
 //      lost qubit is recaptured. Like the trace-out, it shifts no record
 //      index.
 //
-// Transition consults happen only at TRANSITION and LOSS annotations
+// Transition consults happen only at LEVEL_TRANSITION and LOSS annotations
 // (gate hooks are expanded by annotate() before sampling and rewriting).
 // The rewriter consumes those annotations -- replaying outcomes from
 // history.transitions in sampler order, one record per annotation target --

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -12,6 +12,131 @@
 
 namespace clifft {
 
+namespace {
+
+// Consult one transition instrument for one qubit at an annotation site:
+// pick the source column from the qubit's status at the site (the
+// positional convention), apply the unknown-source policy, and sample the
+// outcome. `site` names the annotation in error messages.
+TransitionOutcome consult_transition(const TransitionInstrument& instrument,
+                                     const QubitStatus& s_in, const LevelSet& levels,
+                                     const NonComputationalPolicy& policy, Xoshiro256PlusPlus& rng,
+                                     const std::string& site, uint32_t qubit, uint32_t op_index) {
+    const size_t num_levels = levels.size();
+
+    // Source-context check and column selection: an unknown computational
+    // source has no definite level, so a source-dependent instrument
+    // cannot pick a column for it exactly. The policy chooses between
+    // rejecting and the equalized-rates approximation.
+    bool equalize = false;
+    uint8_t source_col = 0;
+    if (s_in.kind() == QubitStatusKind::ComputationalUnknown) {
+        if (instrument.is_source_independent_on_computational()) {
+            // Computational columns are identical here, so any one
+            // serves; use g.
+            source_col = levels.computational_zero_id();
+        } else if (policy.unknown_source_policy == UnknownSourcePolicy::EqualizeRates) {
+            equalize = true;
+        } else {
+            throw std::invalid_argument(
+                "sample_history: source-dependent transition '" + site +
+                "' fired on ComputationalUnknown qubit " + std::to_string(qubit) + " at op " +
+                std::to_string(op_index) +
+                "; a source-dependent instrument cannot be applied to a qubit whose "
+                "computational state is unknown");
+        }
+    } else {
+        source_col = s_in.level_id();
+    }
+
+    TransitionOutcome outcome;
+    if (equalize) {
+        // Equalized-rates draw: every computational column is padded
+        // with a diagonal pseudo-jump up to the maximum computational
+        // jump rate p_max, so firing is source-independent and can be
+        // drawn here. On fire the source is drawn uniformly over the
+        // computational levels and the destination from that padded,
+        // renormalized column. A pseudo-jump lands on the source
+        // level itself: a transition event whose only effect is the
+        // carrier collapse the rewriter materializes.
+        double p_max = 0.0;
+        uint8_t num_comp = 0;
+        for (uint8_t l = 0; l < num_levels; ++l) {
+            if (levels.at(l).category == LevelCategory::Computational) {
+                ++num_comp;
+                const double s = instrument.column_sum(l);
+                if (s > p_max) {
+                    p_max = s;
+                }
+            }
+        }
+        const double u = rng.next_double();
+        if (u >= 1.0 - p_max) {
+            uint8_t source = levels.computational_zero_id();
+            uint8_t seen = 0;
+            const double pick = rng.next_double() * num_comp;
+            for (uint8_t l = 0; l < num_levels; ++l) {
+                if (levels.at(l).category != LevelCategory::Computational) {
+                    continue;
+                }
+                source = l;
+                if (pick < ++seen) {
+                    break;
+                }
+            }
+            const double deficit = p_max - instrument.column_sum(source);
+            const double v = rng.next_double() * p_max;
+            double acc = 0.0;
+            int last_positive = -1;
+            for (uint8_t to = 0; to < num_levels; ++to) {
+                const double p = instrument.prob(to, source) + (to == source ? deficit : 0.0);
+                if (p > 0.0) {
+                    last_positive = to;
+                }
+                acc += p;
+                if (v < acc) {
+                    outcome.jumped = true;
+                    outcome.destination_level = to;
+                    break;
+                }
+            }
+            if (!outcome.jumped && last_positive >= 0) {
+                outcome.jumped = true;
+                outcome.destination_level = static_cast<uint8_t>(last_positive);
+            }
+        }
+    } else {
+        // Sample the outcome: the no-jump weight occupies [0, w), the
+        // jump targets partition [w, 1). last_positive catches a
+        // floating-point tail so u >= w always resolves to a jump.
+        const double u = rng.next_double();
+        const double no_jump = instrument.no_jump_weight(source_col);
+        if (u >= no_jump) {
+            double acc = no_jump;
+            int last_positive = -1;
+            for (uint8_t to = 0; to < num_levels; ++to) {
+                const double p = instrument.prob(to, source_col);
+                if (p > 0.0) {
+                    last_positive = to;
+                }
+                acc += p;
+                if (u < acc) {
+                    outcome.jumped = true;
+                    outcome.destination_level = to;
+                    break;
+                }
+            }
+            if (!outcome.jumped && last_positive >= 0) {
+                outcome.jumped = true;
+                outcome.destination_level = static_cast<uint8_t>(last_positive);
+            }
+        }
+    }
+    return outcome;
+}
+
+}  // namespace
+
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed) {
     const LevelSet& levels = model.levels();
@@ -51,12 +176,69 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
 
     std::vector<QubitStatus> status = result.history.initial_status;
 
-    // Walk the operations, sampling attached transitions per qubit
-    // operand and advancing each qubit's status.
+    auto check_qubit = [&](uint32_t qubit, uint32_t op_index) {
+        if (qubit >= status.size()) {
+            throw std::invalid_argument("sample_history: operand qubit " + std::to_string(qubit) +
+                                        " is out of range (circuit declares " +
+                                        std::to_string(status.size()) + " qubits) at op " +
+                                        std::to_string(op_index));
+        }
+    };
+
+    // Walk the operations. Transition consults happen only at TRANSITION
+    // and LOSS annotations -- positioned where they fire, with the source
+    // taken from the qubit's status there -- while every other operation
+    // just advances statuses through its normal effect.
     for (uint32_t op_index = 0; op_index < circuit.nodes.size(); ++op_index) {
         const AstNode& node = circuit.nodes[op_index];
         const GateType gate = node.gate;
-        const TransitionInstrument* instrument = model.transition_for(gate);
+
+        if (gate == GateType::TRANSITION) {
+            const TransitionInstrument* instrument = model.transition_named(node.tag);
+            if (instrument == nullptr) {
+                throw std::invalid_argument("sample_history: TRANSITION[" + node.tag + "] at op " +
+                                            std::to_string(op_index) +
+                                            " does not name a transition in the model");
+            }
+            for (const Target& target : node.targets) {
+                const uint32_t qubit = target.value();
+                check_qubit(qubit, op_index);
+                const TransitionOutcome outcome = consult_transition(
+                    *instrument, status[qubit], levels, policy, rng, node.tag, qubit, op_index);
+                result.history.transitions.push_back(
+                    TransitionRecord{op_index, qubit, outcome.jumped,
+                                     outcome.jumped ? outcome.destination_level : kInvalidLevel});
+                if (outcome.jumped) {
+                    status[qubit] = levels.status_for(outcome.destination_level);
+                }
+            }
+            continue;
+        }
+        if (gate == GateType::LOSS) {
+            const std::optional<uint8_t> lost = sole_lost_level(levels);
+            if (!lost.has_value()) {
+                throw std::invalid_argument(
+                    "sample_history: LOSS at op " + std::to_string(op_index) +
+                    " requires a level table with exactly one Lost-category level");
+            }
+            const double p = node.args.empty() ? 0.0 : node.args[0];
+            for (const Target& target : node.targets) {
+                const uint32_t qubit = target.value();
+                check_qubit(qubit, op_index);
+                TransitionOutcome outcome;
+                if (rng.next_double() < p) {
+                    outcome.jumped = true;
+                    outcome.destination_level = *lost;
+                }
+                result.history.transitions.push_back(
+                    TransitionRecord{op_index, qubit, outcome.jumped,
+                                     outcome.jumped ? outcome.destination_level : kInvalidLevel});
+                if (outcome.jumped) {
+                    status[qubit] = levels.status_for(outcome.destination_level);
+                }
+            }
+            continue;
+        }
 
         // Policy pre-scan over entry statuses, mirroring the rewriter: when
         // the policy drops the operation whole, a surviving operand's
@@ -65,14 +247,8 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
         // as applied, which is moot once the rewrite throws.
         bool drop_op = false;
         for (const QubitOperand& operand : qubit_operands(node)) {
-            const uint32_t qubit = operand.qubit;
-            if (qubit >= status.size()) {
-                throw std::invalid_argument(
-                    "sample_history: operand qubit " + std::to_string(qubit) +
-                    " is out of range (circuit declares " + std::to_string(status.size()) +
-                    " qubits) at op " + std::to_string(op_index));
-            }
-            if (operand_action(gate, status[qubit].kind(), policy) == OperandAction::Drop) {
+            check_qubit(operand.qubit, op_index);
+            if (operand_action(gate, status[operand.qubit].kind(), policy) == OperandAction::Drop) {
                 drop_op = true;
             }
         }
@@ -80,135 +256,8 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
         for (const QubitOperand& operand : qubit_operands(node)) {
             const uint32_t qubit = operand.qubit;
             const QubitStatus s_in = status[qubit];
-
-            // Feedback corrections are virtual: they never fire a
-            // transition. Physical operands consult the instrument (if
-            // any) for this gate.
-            if (operand.role != OperandRole::Physical || instrument == nullptr) {
-                status[qubit] =
-                    drop_op ? s_in
-                            : normal_post_op_status(s_in, gate, operand.role, policy, levels);
-                continue;
-            }
-
-            // Source-context check and column selection: an unknown
-            // computational source has no definite level, so a
-            // source-dependent instrument cannot pick a column for it
-            // exactly. The policy chooses between rejecting and the
-            // equalized-rates approximation.
-            bool equalize = false;
-            uint8_t source_col = 0;
-            if (s_in.kind() == QubitStatusKind::ComputationalUnknown) {
-                if (instrument->is_source_independent_on_computational()) {
-                    // Computational columns are identical here, so any one
-                    // serves; use g.
-                    source_col = levels.computational_zero_id();
-                } else if (policy.unknown_source_policy == UnknownSourcePolicy::EqualizeRates) {
-                    equalize = true;
-                } else {
-                    throw std::invalid_argument(
-                        "sample_history: source-dependent transition on gate '" +
-                        std::string(gate_name(gate)) + "' fired on ComputationalUnknown qubit " +
-                        std::to_string(qubit) + " at op " + std::to_string(op_index) +
-                        "; a source-dependent instrument cannot be applied to a qubit whose "
-                        "computational state is unknown");
-                }
-            } else {
-                source_col = s_in.level_id();
-            }
-
-            TransitionOutcome outcome;
-            if (equalize) {
-                // Equalized-rates draw: every computational column is padded
-                // with a diagonal pseudo-jump up to the maximum computational
-                // jump rate p_max, so firing is source-independent and can be
-                // drawn here. On fire the source is drawn uniformly over the
-                // computational levels and the destination from that padded,
-                // renormalized column. A pseudo-jump lands on the source
-                // level itself: a transition event whose only effect is the
-                // carrier collapse the rewriter materializes.
-                double p_max = 0.0;
-                uint8_t num_comp = 0;
-                for (uint8_t l = 0; l < num_levels; ++l) {
-                    if (levels.at(l).category == LevelCategory::Computational) {
-                        ++num_comp;
-                        const double s = instrument->column_sum(l);
-                        if (s > p_max) {
-                            p_max = s;
-                        }
-                    }
-                }
-                const double u = rng.next_double();
-                if (u >= 1.0 - p_max) {
-                    uint8_t source = levels.computational_zero_id();
-                    uint8_t seen = 0;
-                    const double pick = rng.next_double() * num_comp;
-                    for (uint8_t l = 0; l < num_levels; ++l) {
-                        if (levels.at(l).category != LevelCategory::Computational) {
-                            continue;
-                        }
-                        source = l;
-                        if (pick < ++seen) {
-                            break;
-                        }
-                    }
-                    const double deficit = p_max - instrument->column_sum(source);
-                    const double v = rng.next_double() * p_max;
-                    double acc = 0.0;
-                    int last_positive = -1;
-                    for (uint8_t to = 0; to < num_levels; ++to) {
-                        const double p =
-                            instrument->prob(to, source) + (to == source ? deficit : 0.0);
-                        if (p > 0.0) {
-                            last_positive = to;
-                        }
-                        acc += p;
-                        if (v < acc) {
-                            outcome.jumped = true;
-                            outcome.destination_level = to;
-                            break;
-                        }
-                    }
-                    if (!outcome.jumped && last_positive >= 0) {
-                        outcome.jumped = true;
-                        outcome.destination_level = static_cast<uint8_t>(last_positive);
-                    }
-                }
-            } else {
-                // Sample the outcome: the no-jump weight occupies [0, w), the
-                // jump targets partition [w, 1). last_positive catches a
-                // floating-point tail so u >= w always resolves to a jump.
-                const double u = rng.next_double();
-                const double no_jump = instrument->no_jump_weight(source_col);
-                if (u >= no_jump) {
-                    double acc = no_jump;
-                    int last_positive = -1;
-                    for (uint8_t to = 0; to < num_levels; ++to) {
-                        const double p = instrument->prob(to, source_col);
-                        if (p > 0.0) {
-                            last_positive = to;
-                        }
-                        acc += p;
-                        if (u < acc) {
-                            outcome.jumped = true;
-                            outcome.destination_level = to;
-                            break;
-                        }
-                    }
-                    if (!outcome.jumped && last_positive >= 0) {
-                        outcome.jumped = true;
-                        outcome.destination_level = static_cast<uint8_t>(last_positive);
-                    }
-                }
-            }
-
-            result.history.transitions.push_back(
-                TransitionRecord{op_index, qubit, outcome.jumped,
-                                 outcome.jumped ? outcome.destination_level : kInvalidLevel});
-
             status[qubit] =
-                drop_op ? step_status_dropped(s_in, outcome, levels)
-                        : step_status(s_in, gate, OperandRole::Physical, outcome, policy, levels);
+                drop_op ? s_in : normal_post_op_status(s_in, gate, operand.role, policy, levels);
         }
     }
 

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -185,7 +185,7 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
         }
     };
 
-    // Walk the operations. Transition consults happen only at TRANSITION
+    // Walk the operations. Transition consults happen only at LEVEL_TRANSITION
     // and LOSS annotations -- positioned where they fire, with the source
     // taken from the qubit's status there -- while every other operation
     // just advances statuses through its normal effect.
@@ -193,11 +193,11 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
         const AstNode& node = circuit.nodes[op_index];
         const GateType gate = node.gate;
 
-        if (gate == GateType::TRANSITION) {
+        if (gate == GateType::LEVEL_TRANSITION) {
             const TransitionInstrument* instrument = model.transition_named(node.tag);
             if (instrument == nullptr) {
-                throw std::invalid_argument("sample_history: TRANSITION[" + node.tag + "] at op " +
-                                            std::to_string(op_index) +
+                throw std::invalid_argument("sample_history: LEVEL_TRANSITION[" + node.tag +
+                                            "] at op " + std::to_string(op_index) +
                                             " does not name a transition in the model");
             }
             for (const Target& target : node.targets) {

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -5,7 +5,7 @@
 //
 // It performs the sampling pass only: sample initial statuses, walk the
 // operations advancing each qubit's status, and sample an outcome at each
-// TRANSITION or LOSS annotation -- the only transition consult points.
+// LEVEL_TRANSITION or LOSS annotation -- the only transition consult points.
 // A consult is positional: the source is the qubit's status at the
 // annotation's place in the circuit (gate hooks are expanded to
 // annotations by annotate() before sampling). It does not rewrite,

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -3,13 +3,16 @@
 // History sampler: walks a parsed circuit once and samples a single
 // noncomputational trajectory under a model.
 //
-// It performs the sampling pass only: sample initial statuses, then per
-// operation sample any attached transition and advance each qubit's
-// status. It does not rewrite, compile, or run the SVM, and it never
-// consults a measurement outcome -- the status it tracks is what is
-// classically known before the simulation runs (a Z-basis measurement on
-// an unknown qubit does not pin a value here). Sampling is deterministic
-// in the seed.
+// It performs the sampling pass only: sample initial statuses, walk the
+// operations advancing each qubit's status, and sample an outcome at each
+// TRANSITION or LOSS annotation -- the only transition consult points.
+// A consult is positional: the source is the qubit's status at the
+// annotation's place in the circuit (gate hooks are expanded to
+// annotations by annotate() before sampling). It does not rewrite,
+// compile, or run the SVM, and it never consults a measurement outcome --
+// the status it tracks is what is classically known before the simulation
+// runs (a Z-basis measurement on an unknown qubit does not pin a value
+// here). Sampling is deterministic in the seed.
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/history.h"

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -2,6 +2,35 @@
 
 namespace clifft {
 
+namespace {
+
+// Z-diagonal operations preserve computational-basis populations, so a
+// known energy level survives them unchanged; X-type operations flip the
+// populations, mapping each known level to the other one. Everything
+// else mixes the basis and demotes knownness. Conservative by default: a
+// newly added gate demotes until it is deliberately classified here.
+bool preserves_known_level(GateType g) {
+    switch (g) {
+        case GateType::Z:
+        case GateType::S:
+        case GateType::S_DAG:
+        case GateType::T:
+        case GateType::T_DAG:
+        case GateType::R_Z:
+        case GateType::CZ:
+        case GateType::R_ZZ:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool flips_known_level(GateType g) {
+    return g == GateType::X || g == GateType::Y;
+}
+
+}  // namespace
+
 OperandAction operand_action(GateType gate, QubitStatusKind kind,
                              const NonComputationalPolicy& policy) {
     if (kind == QubitStatusKind::ComputationalKnown ||
@@ -126,9 +155,22 @@ QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, Opera
     if (gate == GateType::EXP_VAL || gate == GateType::MPAD) {
         return entry;  // non-destructive probe / classical measurement pad
     }
-    // Any other quantum operation -- a gate, Pauli noise, or an X/Y or
-    // multi-qubit measurement -- collapses a definite energy level, so a
-    // known computational qubit demotes to unknown.
+    if (kind == QubitStatusKind::ComputationalKnown) {
+        // Z-diagonal gates leave a definite energy level definite; X-type
+        // gates map it to the other level, still definite.
+        if (preserves_known_level(gate)) {
+            return entry;
+        }
+        if (flips_known_level(gate)) {
+            const uint8_t flipped = entry.level_id() == levels.computational_zero_id()
+                                        ? levels.computational_one_id()
+                                        : levels.computational_zero_id();
+            return levels.computational_known(flipped);
+        }
+    }
+    // Any other quantum operation -- a basis-mixing gate, Pauli noise, or
+    // an X/Y or multi-qubit measurement -- makes the energy level
+    // indefinite, so a known computational qubit demotes to unknown.
     return QubitStatus::computational_unknown();
 }
 

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -2,6 +2,19 @@
 
 namespace clifft {
 
+std::optional<uint8_t> sole_lost_level(const LevelSet& levels) {
+    std::optional<uint8_t> found;
+    for (uint8_t l = 0; l < levels.size(); ++l) {
+        if (levels.at(l).category == LevelCategory::Lost) {
+            if (found.has_value()) {
+                return std::nullopt;
+            }
+            found = l;
+        }
+    }
+    return found;
+}
+
 namespace {
 
 // Z-diagonal operations preserve computational-basis populations, so a

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -57,12 +57,13 @@ OperandAction operand_action(GateType gate, QubitStatusKind kind,
 // normal status effect (no transition fired). For a Physical operand:
 // Z-basis reset -> Known(g); X/Y reset -> Unknown; Z-basis measurement
 // preserves the pre-SVM-known status; non-destructive probes preserve
-// status; every other quantum operation demotes a computational qubit to
-// Unknown; a Leaked/Lost qubit is only changed by a reset that restores
-// it. A feedback operand never leaks (the correction is virtual): a
-// FeedbackX may flip g<->e on a control bit unknown before SVM execution,
-// so it demotes a known computational qubit; a FeedbackZ is phase-only and
-// leaves the status untouched.
+// status; a Z-diagonal gate (Z/S/T/CZ...) preserves a known level and an
+// X-type gate (X/Y) flips it to the other known level; every other
+// quantum operation demotes a computational qubit to Unknown; a
+// Leaked/Lost qubit is only changed by a reset that restores it. A feedback operand never leaks
+// (the correction is virtual): a FeedbackX may flip g<->e on a control bit unknown before SVM
+// execution, so it demotes a known computational qubit; a FeedbackZ is phase-only and leaves the
+// status untouched.
 QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, OperandRole role,
                                   const NonComputationalPolicy& policy, const LevelSet& levels);
 

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -15,8 +15,14 @@
 #include "clifft/noncomp/qubit_status.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace clifft {
+
+// The unique Lost-category level id, if the table has exactly one. The
+// LOSS annotation resolves its destination through this; a table with no
+// or several Lost levels cannot host it.
+std::optional<uint8_t> sole_lost_level(const LevelSet& levels);
 
 // The role a qubit operand plays in an operation. The same GateType can
 // mean physically different things: a CX with two qubit operands is a

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -107,9 +107,9 @@ class Model:
         initial_state: probability per level, ``P(level)``, summing to one.
         transitions: maps a name to its ``T[to][from]`` matrix. A key that
             names a gate (e.g. ``"CZ"``) is a *hook*: it expands to a
-            ``TRANSITION[key]`` annotation after every occurrence of that
+            ``LEVEL_TRANSITION[key]`` annotation after every occurrence of that
             gate. Any key -- gate-named or not -- can be referenced
-            directly from the circuit with ``TRANSITION[key] q``, and
+            directly from the circuit with ``LEVEL_TRANSITION[key] q``, and
             ``LOSS(p) q`` applies a uniform loss inline. A transition
             fires at its circuit position, with the source taken from the
             qubit's state there.

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -105,7 +105,14 @@ class Model:
 
     Args:
         initial_state: probability per level, ``P(level)``, summing to one.
-        transitions: maps a gate-name string to its ``T[to][from]`` matrix.
+        transitions: maps a name to its ``T[to][from]`` matrix. A key that
+            names a gate (e.g. ``"CZ"``) is a *hook*: it expands to a
+            ``TRANSITION[key]`` annotation after every occurrence of that
+            gate. Any key -- gate-named or not -- can be referenced
+            directly from the circuit with ``TRANSITION[key] q``, and
+            ``LOSS(p) q`` applies a uniform loss inline. A transition
+            fires at its circuit position, with the source taken from the
+            qubit's state there.
         classifier: optional :class:`Classifier` supplying leaked/lost
             measurement outcomes and computational readout confusion.
         reset_restores_lost: if true, a reset on a lost qubit restores it.

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -86,9 +86,29 @@ def test_initial_state_out_of_range_probability_raises():
         noncomp.Model(initial_state=[2.0, -1.0, 0.0, 0.0, 0.0])
 
 
-def test_unknown_gate_key_raises():
-    with pytest.raises(ValueError, match="transition key"):
-        noncomp.Model(initial_state=ALL_G, transitions={"NOTAGATE": transition_to(LEAK_G)})
+def test_non_gate_key_is_a_named_transition():
+    """A key that names no gate is a named transition: referenceable from a
+    TRANSITION[key] annotation, hooked on nothing."""
+    model = noncomp.Model(initial_state=ALL_G, transitions={"my_leak": transition_to(LEAK_G)})
+    r = noncomp.sample("H 0\nS 0\nM 0", model, shots=8, seed=1)
+    assert r.final_status.shape == (8, 1)  # no hook fired; plain sampling ran
+
+
+def test_local_annotations_run_end_to_end():
+    """Hand-written LOSS and TRANSITION annotations drive the trajectory."""
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"leak": transition_to(LEAK_G)},
+        classifier=classifier_for(LEAK_G, [0.0, 1.0]),
+    )
+    r = noncomp.sample("H 0\nTRANSITION[leak] 0\nM 0", model, shots=32, seed=2)
+    assert np.all(r.measurements[:, 0] == 1)  # leaked slot takes the classifier bit
+
+    lossy = noncomp.Model(
+        initial_state=ALL_G, transitions={}, classifier=classifier_for(LOST, [1.0, 0.0])
+    )
+    s = noncomp.sample("H 0\nLOSS(1) 0\nM 0", lossy, shots=32, seed=3)
+    assert np.all(s.measurements[:, 0] == 0)  # lost slot pinned by the classifier
 
 
 def test_transition_wrong_shape_raises():

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -88,20 +88,20 @@ def test_initial_state_out_of_range_probability_raises():
 
 def test_non_gate_key_is_a_named_transition():
     """A key that names no gate is a named transition: referenceable from a
-    TRANSITION[key] annotation, hooked on nothing."""
+    LEVEL_TRANSITION[key] annotation, hooked on nothing."""
     model = noncomp.Model(initial_state=ALL_G, transitions={"my_leak": transition_to(LEAK_G)})
     r = noncomp.sample("H 0\nS 0\nM 0", model, shots=8, seed=1)
     assert r.final_status.shape == (8, 1)  # no hook fired; plain sampling ran
 
 
 def test_local_annotations_run_end_to_end():
-    """Hand-written LOSS and TRANSITION annotations drive the trajectory."""
+    """Hand-written LOSS and LEVEL_TRANSITION annotations drive the trajectory."""
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"leak": transition_to(LEAK_G)},
         classifier=classifier_for(LEAK_G, [0.0, 1.0]),
     )
-    r = noncomp.sample("H 0\nTRANSITION[leak] 0\nM 0", model, shots=32, seed=2)
+    r = noncomp.sample("H 0\nLEVEL_TRANSITION[leak] 0\nM 0", model, shots=32, seed=2)
     assert np.all(r.measurements[:, 0] == 1)  # leaked slot takes the classifier bit
 
     lossy = noncomp.Model(

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1840,3 +1840,10 @@ TEST_CASE("Standalone READOUT_NOISE lowers one- and two-argument forms") {
     REQUIRE(hir2.readout_noise[0].prob_one_to_zero == Catch::Approx(0.5));
     REQUIRE_FALSE(hir2.readout_noise[0].is_symmetric());
 }
+
+TEST_CASE("Trace rejects noncomputational annotations with a pointer to the entry point") {
+    REQUIRE_THROWS_WITH(trace(parse("TRANSITION[t] 0\n")),
+                        Catch::Matchers::ContainsSubstring("sample_noncomputational"));
+    REQUIRE_THROWS_WITH(trace(parse("LOSS(0.1) 0\n")),
+                        Catch::Matchers::ContainsSubstring("sample_noncomputational"));
+}

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1842,7 +1842,7 @@ TEST_CASE("Standalone READOUT_NOISE lowers one- and two-argument forms") {
 }
 
 TEST_CASE("Trace rejects noncomputational annotations with a pointer to the entry point") {
-    REQUIRE_THROWS_WITH(trace(parse("TRANSITION[t] 0\n")),
+    REQUIRE_THROWS_WITH(trace(parse("LEVEL_TRANSITION[t] 0\n")),
                         Catch::Matchers::ContainsSubstring("sample_noncomputational"));
     REQUIRE_THROWS_WITH(trace(parse("LOSS(0.1) 0\n")),
                         Catch::Matchers::ContainsSubstring("sample_noncomputational"));

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -135,11 +135,12 @@ TEST_CASE("NonComputationalModel: canonicalizes alias transition keys to GateTyp
     transitions.emplace("CNOT", zero_transition(levels));  // alias for CX
     NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
                                 std::move(transitions), std::nullopt, NonComputationalPolicy{});
-    // Stored and resolvable under the canonical gate, not the alias spelling.
-    REQUIRE(model.transitions().count(GateType::CX) == 1);
+    // Stored under the original key; the hook resolves the canonical gate.
+    REQUIRE(model.transitions().count("CNOT") == 1);
     REQUIRE(model.transition_for(GateType::CX) != nullptr);
-    REQUIRE(model.transition_for("CX") != nullptr);
-    REQUIRE(model.transition_for("CNOT") != nullptr);
+    REQUIRE(model.transition_named("CNOT") != nullptr);
+    // Named lookup is exact-key: the canonical spelling is not a key here.
+    REQUIRE(model.transition_named("CX") == nullptr);
 }
 
 // =========================================================================
@@ -177,14 +178,24 @@ TEST_CASE("NonComputationalModel: rejects initial state that does not sum to 1")
 // Construction: transition validation
 // =========================================================================
 
-TEST_CASE("NonComputationalModel: rejects an unknown transition gate key") {
+TEST_CASE("NonComputationalModel: a non-gate transition key is a named transition, not a hook") {
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
-    transitions.emplace("NOT_A_GATE", zero_transition(levels));
+    transitions.emplace("my_leak", zero_transition(levels));
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
+                                std::move(transitions), std::nullopt, NonComputationalPolicy{});
+    REQUIRE(model.transition_named("my_leak") != nullptr);
+    REQUIRE(model.transition_hooks().empty());
+}
+
+TEST_CASE("NonComputationalModel: rejects a transition key a TRANSITION tag cannot reference") {
+    LevelSet levels = LevelSet::default_set();
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("bad]key", zero_transition(levels));
     REQUIRE_THROWS_WITH(
         NonComputationalModel(LevelSet::default_set(), default_initial_state(),
                               std::move(transitions), std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("NOT_A_GATE") && ContainsSubstring("not a recognized gate name"));
+        ContainsSubstring("bad]key") && ContainsSubstring("cannot be referenced"));
 }
 
 TEST_CASE("NonComputationalModel: rejects a non-hookable noise-channel transition key") {
@@ -292,11 +303,10 @@ TEST_CASE("NonComputationalModel: transition_for resolves known gates and misses
     NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
                                 std::move(transitions), std::nullopt, NonComputationalPolicy{});
     REQUIRE(model.transition_for(GateType::H) != nullptr);
-    REQUIRE(model.transition_for("H") != nullptr);
+    REQUIRE(model.transition_named("H") != nullptr);
     REQUIRE(model.transition_for(GateType::CX) == nullptr);
-    REQUIRE(model.transition_for("CX") == nullptr);
-    // An unrecognized name canonicalizes to nothing rather than throwing.
-    REQUIRE(model.transition_for("NOT_A_GATE") == nullptr);
+    // Named lookup misses absent keys rather than throwing.
+    REQUIRE(model.transition_named("NOT_A_KEY") == nullptr);
 }
 
 TEST_CASE("NonComputationalModel: policy accessor reflects the constructed policy") {

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -198,25 +198,21 @@ TEST_CASE("NonComputationalModel: rejects a transition key a TRANSITION tag cann
         ContainsSubstring("bad]key") && ContainsSubstring("cannot be referenced"));
 }
 
-TEST_CASE("NonComputationalModel: rejects a non-hookable noise-channel transition key") {
+TEST_CASE("NonComputationalModel: a non-hookable gate-named key is a named-only transition") {
+    // Keys naming non-hookable instructions (noise channels, annotations,
+    // LOSS itself) register no hook, but stay referenceable from a
+    // TRANSITION[key] annotation like any other name.
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("DEPOLARIZE1", zero_transition(levels));
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
-                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("DEPOLARIZE1") &&
-            ContainsSubstring("does not support a transition instrument"));
-}
-
-TEST_CASE("NonComputationalModel: rejects a non-hookable annotation transition key") {
-    LevelSet levels = LevelSet::default_set();
-    std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("TICK", zero_transition(levels));
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel(LevelSet::default_set(), default_initial_state(),
-                              std::move(transitions), std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("does not support a transition instrument"));
+    transitions.emplace("LOSS", zero_transition(levels));
+    NonComputationalModel model(LevelSet::default_set(), default_initial_state(),
+                                std::move(transitions), std::nullopt, NonComputationalPolicy{});
+    REQUIRE(model.transition_named("DEPOLARIZE1") != nullptr);
+    REQUIRE(model.transition_named("TICK") != nullptr);
+    REQUIRE(model.transition_named("LOSS") != nullptr);
+    REQUIRE(model.transition_hooks().empty());
 }
 
 TEST_CASE("NonComputationalModel: rejects two keys resolving to the same gate") {

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -129,7 +129,7 @@ TEST_CASE("NonComputationalModel: normalizes the stored initial state") {
     REQUIRE_THAT(sum(model.initial_state()), WithinAbs(1.0, 1e-15));
 }
 
-TEST_CASE("NonComputationalModel: canonicalizes alias transition keys to GateType") {
+TEST_CASE("NonComputationalModel: alias key is stored verbatim and hooks the canonical gate") {
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("CNOT", zero_transition(levels));  // alias for CX

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -188,7 +188,8 @@ TEST_CASE("NonComputationalModel: a non-gate transition key is a named transitio
     REQUIRE(model.transition_hooks().empty());
 }
 
-TEST_CASE("NonComputationalModel: rejects a transition key a TRANSITION tag cannot reference") {
+TEST_CASE(
+    "NonComputationalModel: rejects a transition key a LEVEL_TRANSITION tag cannot reference") {
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("bad]key", zero_transition(levels));
@@ -201,7 +202,7 @@ TEST_CASE("NonComputationalModel: rejects a transition key a TRANSITION tag cann
 TEST_CASE("NonComputationalModel: a non-hookable gate-named key is a named-only transition") {
     // Keys naming non-hookable instructions (noise channels, annotations,
     // LOSS itself) register no hook, but stay referenceable from a
-    // TRANSITION[key] annotation like any other name.
+    // LEVEL_TRANSITION[key] annotation like any other name.
     LevelSet levels = LevelSet::default_set();
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("DEPOLARIZE1", zero_transition(levels));

--- a/tests/test_noncomp_model_builder.cc
+++ b/tests/test_noncomp_model_builder.cc
@@ -80,11 +80,12 @@ TEST_CASE("from_spec: a Stim gate alias resolves to the canonical transition key
     REQUIRE(model.transition_for(GateType::CX) != nullptr);
 }
 
-TEST_CASE("from_spec: an unknown gate key raises") {
-    REQUIRE_THROWS_WITH(
+TEST_CASE("from_spec: a non-gate key builds a named transition without a hook") {
+    NonComputationalModel model =
         NonComputationalModel::from_spec(LevelSet::default_set(), all_g(), lost_on("NOTAGATE"),
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("transition key"));
+                                         std::nullopt, NonComputationalPolicy{});
+    REQUIRE(model.transition_named("NOTAGATE") != nullptr);
+    REQUIRE(model.transition_hooks().empty());
 }
 
 TEST_CASE("from_spec: a classifier matrix with the wrong level count raises") {

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -600,11 +600,11 @@ TEST_CASE("sample_noncomputational: asymmetric confusion matches its rates") {
     REQUIRE(zeros < 950);
 }
 
-TEST_CASE("sample_noncomputational: hand-written LOSS and TRANSITION run end to end") {
+TEST_CASE("sample_noncomputational: hand-written LOSS and LEVEL_TRANSITION run end to end") {
     // Qubit 0 is lost by a local LOSS; its measurement takes the classifier's
-    // lost bit. Qubit 1 leaks via a local named TRANSITION; its measurement
+    // lost bit. Qubit 1 leaks via a local named LEVEL_TRANSITION; its measurement
     // takes the leak_g bit.
-    Circuit c = parse("H 0\nH 1\nLOSS(1) 0\nTRANSITION[leak] 1\nM 0\nM 1\n");
+    Circuit c = parse("H 0\nH 1\nLOSS(1) 0\nLEVEL_TRANSITION[leak] 1\nM 0\nM 1\n");
     auto leak = zeros5();
     leak[kLeakG][0] = 1.0;
     leak[kLeakG][1] = 1.0;

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -599,3 +599,33 @@ TEST_CASE("sample_noncomputational: asymmetric confusion matches its rates") {
     REQUIRE(zeros > 650);  // expected 800; ~6 sigma band
     REQUIRE(zeros < 950);
 }
+
+TEST_CASE("sample_noncomputational: hand-written LOSS and TRANSITION run end to end") {
+    // Qubit 0 is lost by a local LOSS; its measurement takes the classifier's
+    // lost bit. Qubit 1 leaks via a local named TRANSITION; its measurement
+    // takes the leak_g bit.
+    Circuit c = parse("H 0\nH 1\nLOSS(1) 0\nTRANSITION[leak] 1\nM 0\nM 1\n");
+    auto leak = zeros5();
+    leak[kLeakG][0] = 1.0;
+    leak[kLeakG][1] = 1.0;
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace(
+        "leak", TransitionInstrument::from_matrix(std::move(leak), LevelSet::default_set()));
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    m[0][0] = 1.0;
+    m[1][1] = 1.0;
+    m[1][kLeakG] = 1.0;  // leaked reads 1
+    m[0][kLost] = 1.0;   // lost reads 0
+    m[0][3] = 1.0;
+    MeasurementClassifier cl =
+        MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), LevelSet::default_set());
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
+
+    NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
+    for (uint32_t shot = 0; shot < s.shots; ++shot) {
+        REQUIRE(s.measurements[shot * 2 + 0] == 0);  // lost slot: classifier bit 0
+        REQUIRE(s.measurements[shot * 2 + 1] == 1);  // leaked slot: classifier bit 1
+        REQUIRE(s.final_status[shot * 2 + 0].kind() == QubitStatusKind::Lost);
+        REQUIRE(s.final_status[shot * 2 + 1].kind() == QubitStatusKind::Leaked);
+    }
+}

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -3,6 +3,7 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
+#include "clifft/noncomp/annotate.h"
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
@@ -23,6 +24,7 @@
 #include <vector>
 
 using Catch::Matchers::ContainsSubstring;
+using clifft::annotate;
 using clifft::AstNode;
 using clifft::Circuit;
 using clifft::default_hir_pass_manager;
@@ -97,6 +99,11 @@ TransitionInstrument relax_e_to_g(const LevelSet& levels) {
     return TransitionInstrument::from_matrix(std::move(m), levels);
 }
 
+// Source-independent: all columns zero, so a consult never fires.
+TransitionInstrument never_fires(const LevelSet& levels) {
+    return TransitionInstrument::from_matrix(zeros5(), levels);
+}
+
 // Source-independent on computational (both columns zero): only a lost
 // qubit jumps, back to the computational g level (recapture).
 TransitionInstrument recapture_lost_to_g(const LevelSet& levels) {
@@ -157,15 +164,19 @@ size_t count_gate(const Circuit& c, GateType gate) {
     return n;
 }
 
+// Expand the model's gate hooks, sample, and rewrite: the pipeline the
+// orchestrator runs, for tests written against gate-hooked models.
 Circuit rewritten(const Circuit& c, const NonComputationalModel& model, uint64_t seed) {
-    HistorySample s = sample_history(c, model, seed);
-    return rewrite(c, s.history, model).circuit;
+    Circuit annotated = annotate(c, model);
+    HistorySample s = sample_history(annotated, model, seed);
+    return rewrite(annotated, s.history, model).circuit;
 }
 
 RewriteResult rewritten_result(const Circuit& c, const NonComputationalModel& model,
                                uint64_t seed) {
-    HistorySample s = sample_history(c, model, seed);
-    return rewrite(c, s.history, model);
+    Circuit annotated = annotate(c, model);
+    HistorySample s = sample_history(annotated, model, seed);
+    return rewrite(annotated, s.history, model);
 }
 
 }  // namespace
@@ -196,19 +207,31 @@ TEST_CASE("rewrite: a coherent qubit that jumps to lost gets a trace-out R") {
     REQUIRE(rw.nodes[2].targets[0].value() == 0);
 }
 
-TEST_CASE("rewrite: an op that demotes a known qubit before a jump still inserts the R") {
-    // Qubit 0 enters H as Known(g); H demotes it to coherent Unknown and the
-    // attached transition then leaks it. The carrier is coherent at jump time,
-    // so a trace-out R is required even though the entry status was Known.
+TEST_CASE("rewrite: a source-dependent hook on a just-demoted qubit rejects") {
+    // Qubit 0 enters H as Known(g), but the expanded annotation consults the
+    // state at its own position -- after the H -- where the qubit is an
+    // unknown superposition. A source-dependent matrix therefore rejects
+    // under the default policy: the hooked gate's entry status no longer
+    // selects the column.
     Circuit c = parse("H 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("H", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
+    REQUIRE_THROWS_WITH(rewritten(c, model, 1), ContainsSubstring("ComputationalUnknown"));
+}
+
+TEST_CASE("rewrite: a definite atom lost at a diagonal gate needs no trace-out") {
+    // S preserves Known(g), so the qubit is a definite atom where the
+    // annotation loses it: no entanglement to unravel, no hidden R.
+    Circuit c = parse("S 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
     Circuit rw = rewritten(c, model, 1);
-    REQUIRE(rw.nodes.size() == 2);
-    REQUIRE(rw.nodes[1].gate == GateType::R);
-    REQUIRE(rw.nodes[1].targets[0].value() == 0);
+    REQUIRE(count_gate(rw, GateType::R) == 0);
+    REQUIRE(count_gate(rw, GateType::S) == 1);
 }
 
 TEST_CASE("rewrite: a still-known atom that is lost gets no trace-out R") {
@@ -268,10 +291,11 @@ TEST_CASE("rewrite: a two-qubit gate on a lost qubit rejects by default") {
     transitions.emplace("S", always_lost(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);  // sampler does not enforce policy
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("CZ") &&
-                                                          ContainsSubstring("Lost") &&
-                                                          ContainsSubstring("qubit 0"));
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);  // sampler does not enforce policy
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, model), ContainsSubstring("CZ") &&
+                                                              ContainsSubstring("Lost") &&
+                                                              ContainsSubstring("qubit 0"));
 }
 
 TEST_CASE("rewrite: a single-qubit gate on a leaked qubit rejects by default") {
@@ -280,8 +304,9 @@ TEST_CASE("rewrite: a single-qubit gate on a leaked qubit rejects by default") {
     transitions.emplace("S", always_leaked(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, model),
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, model),
                         ContainsSubstring("Leaked") && ContainsSubstring("qubit 0"));
 }
 
@@ -303,8 +328,9 @@ TEST_CASE("rewrite: a lost-qubit reset rejects by default and restores under pol
     transitions.emplace("S", always_lost(LevelSet::default_set()));
 
     NonComputationalModel reject = make_model(all_g(), transitions);
-    HistorySample s = sample_history(c, reject, 1);
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, reject),
+    Circuit c_ann = annotate(c, reject);
+    HistorySample s = sample_history(c_ann, reject, 1);
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, reject),
                         ContainsSubstring("Lost") && ContainsSubstring("qubit 0"));
 
     NonComputationalPolicy restore;
@@ -415,8 +441,10 @@ TEST_CASE("rewrite: a noncomputational measurement without a classifier rejects"
     transitions.emplace("S", always_lost(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("requires a classifier"));
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, model),
+                        ContainsSubstring("requires a classifier"));
 }
 
 TEST_CASE("rewrite: an X/Y-basis or multi-qubit measurement on a lost qubit rejects") {
@@ -424,16 +452,18 @@ TEST_CASE("rewrite: an X/Y-basis or multi-qubit measurement on a lost qubit reje
     mx.emplace("S", always_lost(LevelSet::default_set()));
     NonComputationalModel m_mx = make_model(all_g(), std::move(mx));
     Circuit cx = parse("H 0\nS 0\nMX 0\n");
-    HistorySample sx = sample_history(cx, m_mx, 1);
-    REQUIRE_THROWS_WITH(rewrite(cx, sx.history, m_mx),
+    Circuit cx_ann = annotate(cx, m_mx);
+    HistorySample sx = sample_history(cx_ann, m_mx, 1);
+    REQUIRE_THROWS_WITH(rewrite(cx_ann, sx.history, m_mx),
                         ContainsSubstring("MX") && ContainsSubstring("Lost"));
 
     std::map<std::string, TransitionInstrument> mp;
     mp.emplace("S", always_lost(LevelSet::default_set()));
     NonComputationalModel m_mp = make_model(all_g(), std::move(mp));
     Circuit cp = parse("H 0\nS 0\nMPP X0\n");
-    HistorySample sp = sample_history(cp, m_mp, 1);
-    REQUIRE_THROWS_WITH(rewrite(cp, sp.history, m_mp),
+    Circuit cp_ann = annotate(cp, m_mp);
+    HistorySample sp = sample_history(cp_ann, m_mp, 1);
+    REQUIRE_THROWS_WITH(rewrite(cp_ann, sp.history, m_mp),
                         ContainsSubstring("MPP") && ContainsSubstring("Lost"));
 }
 
@@ -443,8 +473,9 @@ TEST_CASE("rewrite: a measure-and-reset on a lost qubit rejects by default, kept
     transitions.emplace("S", always_lost(LevelSet::default_set()));
 
     NonComputationalModel reject = make_model(all_g(), transitions);
-    HistorySample s = sample_history(c, reject, 1);
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, reject),
+    Circuit c_ann = annotate(c, reject);
+    HistorySample s = sample_history(c_ann, reject, 1);
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, reject),
                         ContainsSubstring("MR") && ContainsSubstring("Lost"));
 
     NonComputationalPolicy restore;
@@ -581,9 +612,10 @@ TEST_CASE("rewrite: a dropped gate leaves the surviving operand's status untouch
     policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
     NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
 
-    HistorySample s = sample_history(c, model, 1);
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
     REQUIRE(s.final_status[1].kind() == clifft::QubitStatusKind::Lost);
-    Circuit rw = rewrite(c, s.history, model).circuit;
+    Circuit rw = rewrite(c_ann, s.history, model).circuit;
     REQUIRE(count_gate(rw, GateType::CZ) == 0);
 }
 
@@ -632,9 +664,10 @@ TEST_CASE("rewrite: drop policy drops a non-restoring lost reset") {
     policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
     NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
 
-    HistorySample s = sample_history(c, model, 1);
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
     REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
-    Circuit rw = rewrite(c, s.history, model).circuit;
+    Circuit rw = rewrite(c_ann, s.history, model).circuit;
     REQUIRE(count_gate(rw, GateType::R) == 1);  // the trace-out only
 }
 
@@ -647,9 +680,10 @@ TEST_CASE("rewrite: drop policy keeps a measure-and-reset on a non-restoring los
     NonComputationalModel model = make_model_with_classifier(
         all_g(), std::move(transitions), classifier_with(kLost, {1.0, 0.0}), policy);
 
-    HistorySample s = sample_history(c, model, 1);
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
     REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
-    RewriteResult rw = rewrite(c, s.history, model);
+    RewriteResult rw = rewrite(c_ann, s.history, model);
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);  // record slot preserved
     REQUIRE(rw.circuit.num_measurements == 1);
@@ -743,8 +777,9 @@ TEST_CASE("rewrite: a substochastic computational column rejects") {
     NonComputationalModel model = make_model_with_classifier(all_g(), {}, std::move(cl));
 
     Circuit c = parse("M 0\n");
-    HistorySample s = sample_history(c, model, 1);
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("computational level"));
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, model), ContainsSubstring("computational level"));
 }
 
 TEST_CASE("rewrite: a computational column with herald mass rejects") {
@@ -761,6 +796,94 @@ TEST_CASE("rewrite: a computational column with herald mass rejects") {
     NonComputationalModel model = make_model_with_classifier(all_g(), {}, std::move(cl));
 
     Circuit c = parse("M 0\n");
+    Circuit c_ann = annotate(c, model);
+    HistorySample s = sample_history(c_ann, model, 1);
+    REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, model), ContainsSubstring("beyond the bit"));
+}
+
+TEST_CASE("annotate: gate hooks expand to per-operand TRANSITION annotations") {
+    Circuit c = parse("H 0\nCZ 0 1\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CZ", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit ann = annotate(c, model);
+    // H, CZ, TRANSITION(0), TRANSITION(1), M.
+    REQUIRE(ann.nodes.size() == 5);
+    REQUIRE(ann.nodes[2].gate == GateType::TRANSITION);
+    REQUIRE(ann.nodes[2].tag == "CZ");
+    REQUIRE(ann.nodes[2].targets[0].value() == 0);
+    REQUIRE(ann.nodes[3].gate == GateType::TRANSITION);
+    REQUIRE(ann.nodes[3].targets[0].value() == 1);
+    REQUIRE(ann.num_measurements == c.num_measurements);  // layout untouched
+}
+
+TEST_CASE("annotate: feedback operands get no annotation") {
+    Circuit c = parse("M 0\nCX rec[-1] 1\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("CX", always_lost(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit ann = annotate(c, model);
+    REQUIRE(ann.nodes.size() == c.nodes.size());  // virtual correction: no consult point
+}
+
+TEST_CASE("annotate: an unhooked model leaves the circuit unchanged") {
+    Circuit c = parse("H 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("my_leak", always_lost(LevelSet::default_set()));  // named, no hook
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    Circuit ann = annotate(c, model);
+    REQUIRE(ann.nodes.size() == c.nodes.size());
+}
+
+TEST_CASE("rewrite: annotations are consumed, not emitted") {
+    Circuit c = parse("S 0\nTRANSITION[jump] 0\nM 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("jump", never_fires(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
     HistorySample s = sample_history(c, model, 1);
-    REQUIRE_THROWS_WITH(rewrite(c, s.history, model), ContainsSubstring("beyond the bit"));
+    Circuit rw = rewrite(c, s.history, model).circuit;
+    REQUIRE(count_gate(rw, GateType::TRANSITION) == 0);
+    REQUIRE(count_gate(rw, GateType::S) == 1);
+    REQUIRE(count_gate(rw, GateType::M) == 1);
+}
+
+TEST_CASE("rewrite: a LOSS jump on a coherent carrier inserts the trace-out R") {
+    Circuit c = parse("H 0\nLOSS(1) 0\n");
+    NonComputationalModel model = make_model(all_g(), {});
+
+    HistorySample s = sample_history(c, model, 1);
+    Circuit rw = rewrite(c, s.history, model).circuit;
+    REQUIRE(count_gate(rw, GateType::LOSS) == 0);  // consumed
+    REQUIRE(count_gate(rw, GateType::R) == 1);     // coherent carrier traced out
+}
+
+TEST_CASE("rewrite: a LOSS jump on a definite atom needs no trace-out") {
+    Circuit c = parse("LOSS(1) 0\n");  // Known(g) at the annotation
+    NonComputationalModel model = make_model(all_g(), {});
+
+    HistorySample s = sample_history(c, model, 1);
+    Circuit rw = rewrite(c, s.history, model).circuit;
+    REQUIRE(count_gate(rw, GateType::R) == 0);
+    REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);
+}
+
+TEST_CASE("rewrite: a TRANSITION jump to a computational level materializes the carrier") {
+    // Recapture a lost qubit at e: R rezeros the stale carrier, X prepares |1>.
+    Circuit c = parse("LOSS(1) 0\nTRANSITION[recapture] 0\n");
+    auto m = zeros5();
+    m[1][4] = 1.0;  // lost -> e with certainty
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("recapture",
+                        TransitionInstrument::from_matrix(std::move(m), LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::ComputationalKnown);
+    Circuit rw = rewrite(c, s.history, model).circuit;
+    REQUIRE(count_gate(rw, GateType::R) == 1);
+    REQUIRE(count_gate(rw, GateType::X) == 1);
 }

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -801,19 +801,19 @@ TEST_CASE("rewrite: a computational column with herald mass rejects") {
     REQUIRE_THROWS_WITH(rewrite(c_ann, s.history, model), ContainsSubstring("beyond the bit"));
 }
 
-TEST_CASE("annotate: gate hooks expand to per-operand TRANSITION annotations") {
+TEST_CASE("annotate: gate hooks expand to per-operand LEVEL_TRANSITION annotations") {
     Circuit c = parse("H 0\nCZ 0 1\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("CZ", always_lost(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
     Circuit ann = annotate(c, model);
-    // H, CZ, TRANSITION(0), TRANSITION(1), M.
+    // H, CZ, LEVEL_TRANSITION(0), LEVEL_TRANSITION(1), M.
     REQUIRE(ann.nodes.size() == 5);
-    REQUIRE(ann.nodes[2].gate == GateType::TRANSITION);
+    REQUIRE(ann.nodes[2].gate == GateType::LEVEL_TRANSITION);
     REQUIRE(ann.nodes[2].tag == "CZ");
     REQUIRE(ann.nodes[2].targets[0].value() == 0);
-    REQUIRE(ann.nodes[3].gate == GateType::TRANSITION);
+    REQUIRE(ann.nodes[3].gate == GateType::LEVEL_TRANSITION);
     REQUIRE(ann.nodes[3].targets[0].value() == 1);
     REQUIRE(ann.num_measurements == c.num_measurements);  // layout untouched
 }
@@ -839,14 +839,14 @@ TEST_CASE("annotate: an unhooked model leaves the circuit unchanged") {
 }
 
 TEST_CASE("rewrite: annotations are consumed, not emitted") {
-    Circuit c = parse("S 0\nTRANSITION[jump] 0\nM 0\n");
+    Circuit c = parse("S 0\nLEVEL_TRANSITION[jump] 0\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("jump", never_fires(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
     HistorySample s = sample_history(c, model, 1);
     Circuit rw = rewrite(c, s.history, model).circuit;
-    REQUIRE(count_gate(rw, GateType::TRANSITION) == 0);
+    REQUIRE(count_gate(rw, GateType::LEVEL_TRANSITION) == 0);
     REQUIRE(count_gate(rw, GateType::S) == 1);
     REQUIRE(count_gate(rw, GateType::M) == 1);
 }
@@ -871,9 +871,9 @@ TEST_CASE("rewrite: a LOSS jump on a definite atom needs no trace-out") {
     REQUIRE(s.final_status[0].kind() == clifft::QubitStatusKind::Lost);
 }
 
-TEST_CASE("rewrite: a TRANSITION jump to a computational level materializes the carrier") {
+TEST_CASE("rewrite: a LEVEL_TRANSITION jump to a computational level materializes the carrier") {
     // Recapture a lost qubit at e: R rezeros the stale carrier, X prepares |1>.
-    Circuit c = parse("LOSS(1) 0\nTRANSITION[recapture] 0\n");
+    Circuit c = parse("LOSS(1) 0\nLEVEL_TRANSITION[recapture] 0\n");
     auto m = zeros5();
     m[1][4] = 1.0;  // lost -> e with certainty
     std::map<std::string, TransitionInstrument> transitions;

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -138,7 +138,7 @@ TEST_CASE("sample_history: a transition on a known source fires and updates the 
 
     HistorySample s = sample_hooked(c, model, 1);
     REQUIRE(s.history.transitions.size() == 1);
-    REQUIRE(s.history.transitions[0].op_index == 1);  // the TRANSITION annotation
+    REQUIRE(s.history.transitions[0].op_index == 1);  // the LEVEL_TRANSITION annotation
     REQUIRE(s.history.transitions[0].qubit == 0);
     REQUIRE(s.history.transitions[0].jumped);
     REQUIRE(s.history.transitions[0].destination_level == kLost);
@@ -292,7 +292,7 @@ TEST_CASE("sample_history: source-dependent transition on an unknown qubit rejec
     transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    // The annotated circuit is [H, CZ, TRANSITION(0), TRANSITION(1)]; the
+    // The annotated circuit is [H, CZ, LEVEL_TRANSITION(0), LEVEL_TRANSITION(1)]; the
     // failing consult is the qubit-0 annotation at op 2.
     REQUIRE_THROWS_WITH(sample_hooked(c, model, 1),
                         ContainsSubstring("CZ") && ContainsSubstring("qubit 0") &&
@@ -454,8 +454,8 @@ TEST_CASE("sample_history: equalize_rates known divergence on a gate-determined 
     REQUIRE(lost < kN * 65 / 100);
 }
 
-TEST_CASE("sample_history: a hand-written TRANSITION consults the named matrix") {
-    Circuit c = parse("S 0\nTRANSITION[my_leak] 0\n");
+TEST_CASE("sample_history: a hand-written LEVEL_TRANSITION consults the named matrix") {
+    Circuit c = parse("S 0\nLEVEL_TRANSITION[my_leak] 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("my_leak", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
@@ -467,14 +467,14 @@ TEST_CASE("sample_history: a hand-written TRANSITION consults the named matrix")
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
 }
 
-TEST_CASE("sample_history: an unknown TRANSITION tag rejects") {
-    Circuit c = parse("TRANSITION[nope] 0\n");
+TEST_CASE("sample_history: an unknown LEVEL_TRANSITION tag rejects") {
+    Circuit c = parse("LEVEL_TRANSITION[nope] 0\n");
     NonComputationalModel model = make_model(all_g(), {});
     REQUIRE_THROWS_WITH(sample_history(c, model, 1),
                         ContainsSubstring("nope") && ContainsSubstring("does not name"));
 }
 
-TEST_CASE("sample_history: TRANSITION placement selects the source state") {
+TEST_CASE("sample_history: LEVEL_TRANSITION placement selects the source state") {
     // Before the H the qubit is Known(g): the g column fires. After the H
     // it is unknown: the same source-dependent matrix rejects. The consult
     // is positional, not attached to any gate.
@@ -482,11 +482,11 @@ TEST_CASE("sample_history: TRANSITION placement selects the source state") {
     t1.emplace("jump", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(t1));
 
-    Circuit before = parse("TRANSITION[jump] 0\nH 0\n");
+    Circuit before = parse("LEVEL_TRANSITION[jump] 0\nH 0\n");
     HistorySample s = sample_history(before, model, 1);
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
 
-    Circuit after = parse("H 0\nTRANSITION[jump] 0\n");
+    Circuit after = parse("H 0\nLEVEL_TRANSITION[jump] 0\n");
     REQUIRE_THROWS_WITH(sample_history(after, model, 1), ContainsSubstring("ComputationalUnknown"));
 }
 
@@ -522,7 +522,7 @@ TEST_CASE("sample_history: LOSS frequency matches its probability") {
 }
 
 TEST_CASE("sample_history: a gate-named but non-hookable key is referenceable") {
-    Circuit c = parse("TRANSITION[LOSS] 0\n");
+    Circuit c = parse("LEVEL_TRANSITION[LOSS] 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("LOSS", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -520,3 +520,13 @@ TEST_CASE("sample_history: LOSS frequency matches its probability") {
     REQUIRE(lost > 480);  // expected 600; ~7 sigma band
     REQUIRE(lost < 720);
 }
+
+TEST_CASE("sample_history: a gate-named but non-hookable key is referenceable") {
+    Circuit c = parse("TRANSITION[LOSS] 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("LOSS", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+}

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -2,6 +2,7 @@
 #include "clifft/circuit/gate_data.h"
 #include "clifft/circuit/parser.h"
 #include "clifft/circuit/target.h"
+#include "clifft/noncomp/annotate.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/policy.h"
@@ -18,6 +19,7 @@
 #include <vector>
 
 using Catch::Matchers::ContainsSubstring;
+using clifft::annotate;
 using clifft::AstNode;
 using clifft::Circuit;
 using clifft::GateType;
@@ -82,6 +84,12 @@ AstNode op(GateType gate, std::vector<uint32_t> qubits) {
     return AstNode{gate, std::move(targets), {}, 0};
 }
 
+// Expand the model's gate hooks and sample: the pipeline the orchestrator
+// runs, for tests written against gate-hooked models.
+HistorySample sample_hooked(const Circuit& c, const NonComputationalModel& model, uint64_t seed) {
+    return sample_history(annotate(c, model), model, seed);
+}
+
 }  // namespace
 
 TEST_CASE("sample_history: a fixed seed produces an identical history") {
@@ -118,6 +126,30 @@ TEST_CASE("sample_history: initial-state marginals match the distribution") {
 }
 
 TEST_CASE("sample_history: a transition on a known source fires and updates the status") {
+    // The hooked S is Z-diagonal, so the qubit is still Known(g) where the
+    // expanded annotation consults it; the g column jumps to lost with
+    // certainty. The record's op index names the annotation node.
+    Circuit c;
+    c.num_qubits = 1;
+    c.nodes.push_back(op(GateType::S, {0}));
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("S", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_hooked(c, model, 1);
+    REQUIRE(s.history.transitions.size() == 1);
+    REQUIRE(s.history.transitions[0].op_index == 1);  // the TRANSITION annotation
+    REQUIRE(s.history.transitions[0].qubit == 0);
+    REQUIRE(s.history.transitions[0].jumped);
+    REQUIRE(s.history.transitions[0].destination_level == kLost);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+}
+
+TEST_CASE("sample_history: a hooked basis-mixing gate leaves an unknown source") {
+    // H demotes its qubit before the expanded annotation consults it, so a
+    // source-dependent hook on H is an unknown-source consult and rejects
+    // under the default policy. The transition fires where it is positioned,
+    // on the state there -- not on the hooked gate's entry state.
     Circuit c;
     c.num_qubits = 1;
     c.nodes.push_back(op(GateType::H, {0}));
@@ -125,15 +157,7 @@ TEST_CASE("sample_history: a transition on a known source fires and updates the 
     transitions.emplace("H", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
-    // g jumps to lost with certainty, so the jump destination wins over
-    // H's normal demotion.
-    REQUIRE(s.history.transitions.size() == 1);
-    REQUIRE(s.history.transitions[0].op_index == 0);
-    REQUIRE(s.history.transitions[0].qubit == 0);
-    REQUIRE(s.history.transitions[0].jumped);
-    REQUIRE(s.history.transitions[0].destination_level == kLost);
-    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+    REQUIRE_THROWS_WITH(sample_hooked(c, model, 1), ContainsSubstring("ComputationalUnknown"));
 }
 
 TEST_CASE("sample_history: source-dependent transition on a known qubit is allowed") {
@@ -144,12 +168,12 @@ TEST_CASE("sample_history: source-dependent transition on a known qubit is allow
     transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
-    // One record per operand, in target order.
+    HistorySample s = sample_hooked(c, model, 1);
+    // One annotation (and record) per operand, in operand order.
     REQUIRE(s.history.transitions.size() == 2);
-    REQUIRE(s.history.transitions[0].op_index == 0);
+    REQUIRE(s.history.transitions[0].op_index == 1);
     REQUIRE(s.history.transitions[0].qubit == 0);
-    REQUIRE(s.history.transitions[1].op_index == 0);
+    REQUIRE(s.history.transitions[1].op_index == 2);
     REQUIRE(s.history.transitions[1].qubit == 1);
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
     REQUIRE(s.final_status[1].kind() == QubitStatusKind::Lost);
@@ -163,7 +187,7 @@ TEST_CASE("sample_history: classical feedback fires no transition and demotes th
     transitions.emplace("CX", lose_from_g(LevelSet::default_set()));  // would jump g->lost
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
+    HistorySample s = sample_hooked(c, model, 1);
     // The CX is virtual feedback, so no transition is consulted; qubit 1 is
     // demoted, not lost. (M has no transition; qubit 0 stays Known(g).)
     REQUIRE(s.history.transitions.empty());
@@ -177,7 +201,7 @@ TEST_CASE("sample_history: conditional-Z feedback preserves a known target and f
     transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));  // would jump g->lost
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
+    HistorySample s = sample_hooked(c, model, 1);
     // Conditional Z is phase-only: qubit 1 stays Known(g), and no
     // transition is consulted on the virtual correction.
     REQUIRE(s.history.transitions.empty());
@@ -203,7 +227,7 @@ TEST_CASE("sample_history: M on Unknown then a source-dependent transition rejec
     transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    REQUIRE_THROWS_WITH(sample_history(c, model, 1),
+    REQUIRE_THROWS_WITH(sample_hooked(c, model, 1),
                         ContainsSubstring("CZ") && ContainsSubstring("ComputationalUnknown"));
 }
 
@@ -213,24 +237,25 @@ TEST_CASE("sample_history: reset before a source-dependent transition is allowed
     transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);               // no throw: source is Known(g)
+    HistorySample s = sample_hooked(c, model, 1);                // no throw: source is Known(g)
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);  // g -> lost
 }
 
 TEST_CASE("sample_history: a partial jump probability matches its frequency") {
-    // 2000 independent qubits, each a single H carrying a g->lost(0.3)
-    // transition; all start Known(g). Tests probabilistic sampling and the
-    // T[to, from] orientation (a transposed matrix would never fire).
+    // 2000 independent qubits, each a single S carrying a g->lost(0.3)
+    // transition; S is Z-diagonal so every qubit is still Known(g) at its
+    // annotation. Tests probabilistic sampling and the T[to, from]
+    // orientation (a transposed matrix would never fire).
     Circuit c;
     c.num_qubits = 2000;
     for (uint32_t q = 0; q < c.num_qubits; ++q) {
-        c.nodes.push_back(op(GateType::H, {q}));
+        c.nodes.push_back(op(GateType::S, {q}));
     }
     std::map<std::string, TransitionInstrument> transitions;
-    transitions.emplace("H", lose_from_g_30pct(LevelSet::default_set()));
+    transitions.emplace("S", lose_from_g_30pct(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 99);
+    HistorySample s = sample_hooked(c, model, 99);
     size_t lost = 0;
     for (const auto& status : s.final_status) {
         if (status.kind() == QubitStatusKind::Lost) {
@@ -267,9 +292,11 @@ TEST_CASE("sample_history: source-dependent transition on an unknown qubit rejec
     transitions.emplace("CZ", lose_from_g(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    REQUIRE_THROWS_WITH(sample_history(c, model, 1),
+    // The annotated circuit is [H, CZ, TRANSITION(0), TRANSITION(1)]; the
+    // failing consult is the qubit-0 annotation at op 2.
+    REQUIRE_THROWS_WITH(sample_hooked(c, model, 1),
                         ContainsSubstring("CZ") && ContainsSubstring("qubit 0") &&
-                            ContainsSubstring("op 1") && ContainsSubstring("ComputationalUnknown"));
+                            ContainsSubstring("op 2") && ContainsSubstring("ComputationalUnknown"));
 }
 
 TEST_CASE("sample_history: source-independent transition on an unknown qubit is allowed") {
@@ -281,7 +308,7 @@ TEST_CASE("sample_history: source-independent transition on an unknown qubit is 
     transitions.emplace("H", never_jumps(LevelSet::default_set()));
     NonComputationalModel model = make_model(all_g(), std::move(transitions));
 
-    HistorySample s = sample_history(c, model, 1);
+    HistorySample s = sample_hooked(c, model, 1);
     REQUIRE(s.history.transitions.size() == 2);
     REQUIRE_FALSE(s.history.transitions[0].jumped);
     REQUIRE_FALSE(s.history.transitions[1].jumped);
@@ -309,7 +336,7 @@ TEST_CASE("sample_history: equalize_rates samples an unknown source instead of t
     policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
     NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
 
-    HistorySample s = sample_history(c, model, 7);
+    HistorySample s = sample_hooked(c, model, 7);
 
     size_t lost = 0;
     size_t known_e = 0;
@@ -349,7 +376,7 @@ TEST_CASE("sample_history: equalize_rates fires at the maximum computational rat
     policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
     NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
 
-    HistorySample s = sample_history(c, model, 11);
+    HistorySample s = sample_hooked(c, model, 11);
 
     size_t fired = 0;
     for (const auto& rec : s.history.transitions) {
@@ -381,7 +408,7 @@ TEST_CASE("sample_history: equalize_rates keeps a known source exact") {
         NonComputationalPolicy policy;
         policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
         NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
-        HistorySample s = sample_history(c, model, seed);
+        HistorySample s = sample_hooked(c, model, seed);
         REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
     }
 }
@@ -415,7 +442,7 @@ TEST_CASE("sample_history: equalize_rates known divergence on a gate-determined 
     policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
     NonComputationalModel model = make_model(all_g(), std::move(transitions), policy);
 
-    HistorySample s = sample_history(c, model, 13);
+    HistorySample s = sample_hooked(c, model, 13);
 
     size_t lost = 0;
     for (const auto& st : s.final_status) {
@@ -425,4 +452,71 @@ TEST_CASE("sample_history: equalize_rates known divergence on a gate-determined 
     }
     REQUIRE(lost > kN * 35 / 100);
     REQUIRE(lost < kN * 65 / 100);
+}
+
+TEST_CASE("sample_history: a hand-written TRANSITION consults the named matrix") {
+    Circuit c = parse("S 0\nTRANSITION[my_leak] 0\n");
+    std::map<std::string, TransitionInstrument> transitions;
+    transitions.emplace("my_leak", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(transitions));
+
+    HistorySample s = sample_history(c, model, 1);
+    REQUIRE(s.history.transitions.size() == 1);
+    REQUIRE(s.history.transitions[0].op_index == 1);
+    REQUIRE(s.history.transitions[0].jumped);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+}
+
+TEST_CASE("sample_history: an unknown TRANSITION tag rejects") {
+    Circuit c = parse("TRANSITION[nope] 0\n");
+    NonComputationalModel model = make_model(all_g(), {});
+    REQUIRE_THROWS_WITH(sample_history(c, model, 1),
+                        ContainsSubstring("nope") && ContainsSubstring("does not name"));
+}
+
+TEST_CASE("sample_history: TRANSITION placement selects the source state") {
+    // Before the H the qubit is Known(g): the g column fires. After the H
+    // it is unknown: the same source-dependent matrix rejects. The consult
+    // is positional, not attached to any gate.
+    std::map<std::string, TransitionInstrument> t1;
+    t1.emplace("jump", lose_from_g(LevelSet::default_set()));
+    NonComputationalModel model = make_model(all_g(), std::move(t1));
+
+    Circuit before = parse("TRANSITION[jump] 0\nH 0\n");
+    HistorySample s = sample_history(before, model, 1);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+
+    Circuit after = parse("H 0\nTRANSITION[jump] 0\n");
+    REQUIRE_THROWS_WITH(sample_history(after, model, 1), ContainsSubstring("ComputationalUnknown"));
+}
+
+TEST_CASE("sample_history: LOSS fires at its probability") {
+    Circuit certain = parse("LOSS(1) 0\n");
+    NonComputationalModel model = make_model(all_g(), {});
+    HistorySample s = sample_history(certain, model, 1);
+    REQUIRE(s.history.transitions.size() == 1);
+    REQUIRE(s.history.transitions[0].jumped);
+    REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
+
+    Circuit never = parse("LOSS(0) 0\n");
+    HistorySample n = sample_history(never, model, 2);
+    REQUIRE_FALSE(n.history.transitions[0].jumped);
+    REQUIRE(n.final_status[0].kind() == QubitStatusKind::ComputationalKnown);
+}
+
+TEST_CASE("sample_history: LOSS frequency matches its probability") {
+    Circuit c;
+    c.num_qubits = 2000;
+    for (uint32_t q = 0; q < c.num_qubits; ++q) {
+        c.nodes.push_back(op(GateType::LOSS, {q}));
+        c.nodes.back().args = {0.3};
+    }
+    NonComputationalModel model = make_model(all_g(), {});
+    HistorySample s = sample_history(c, model, 21);
+    size_t lost = 0;
+    for (const auto& st : s.final_status) {
+        lost += st.kind() == QubitStatusKind::Lost ? 1 : 0;
+    }
+    REQUIRE(lost > 480);  // expected 600; ~7 sigma band
+    REQUIRE(lost < 720);
 }

--- a/tests/test_noncomp_status_step.cc
+++ b/tests/test_noncomp_status_step.cc
@@ -38,6 +38,42 @@ TEST_CASE("normal_post_op_status: a quantum gate demotes a known computational q
     REQUIRE(out.kind() == QubitStatusKind::ComputationalUnknown);
 }
 
+TEST_CASE("normal_post_op_status: a Z-diagonal gate preserves a known level") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    for (GateType gate : {GateType::Z, GateType::S, GateType::S_DAG, GateType::T, GateType::T_DAG,
+                          GateType::R_Z, GateType::CZ, GateType::R_ZZ}) {
+        QubitStatus out =
+            normal_post_op_status(levels.computational_known(kE), gate, kPhysical, policy, levels);
+        REQUIRE(out.kind() == QubitStatusKind::ComputationalKnown);
+        REQUIRE(out.level_id() == kE);
+    }
+}
+
+TEST_CASE("normal_post_op_status: an X-type gate flips a known level") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    for (GateType gate : {GateType::X, GateType::Y}) {
+        QubitStatus from_g =
+            normal_post_op_status(levels.computational_known(kG), gate, kPhysical, policy, levels);
+        REQUIRE(from_g.kind() == QubitStatusKind::ComputationalKnown);
+        REQUIRE(from_g.level_id() == kE);
+        QubitStatus from_e =
+            normal_post_op_status(levels.computational_known(kE), gate, kPhysical, policy, levels);
+        REQUIRE(from_e.level_id() == kG);
+    }
+}
+
+TEST_CASE("normal_post_op_status: diagonal and flip gates leave Unknown unknown") {
+    LevelSet levels = LevelSet::default_set();
+    NonComputationalPolicy policy;
+    for (GateType gate : {GateType::Z, GateType::X, GateType::CZ}) {
+        QubitStatus out = normal_post_op_status(QubitStatus::computational_unknown(), gate,
+                                                kPhysical, policy, levels);
+        REQUIRE(out.kind() == QubitStatusKind::ComputationalUnknown);
+    }
+}
+
 TEST_CASE("normal_post_op_status: a Z-basis M preserves the pre-SVM-known status") {
     LevelSet levels = LevelSet::default_set();
     NonComputationalPolicy policy;

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -21,6 +21,7 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
+#include "clifft/noncomp/annotate.h"
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
@@ -40,6 +41,7 @@
 #include <string>
 #include <vector>
 
+using clifft::annotate;
 using clifft::Circuit;
 using clifft::default_hir_pass_manager;
 using clifft::GateType;
@@ -207,9 +209,10 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
     NonComputationalModel model =
         make_model(std::move(transitions), lost_classifier(LevelSet::default_set(), {1.0, 0.0}));
 
+    Circuit annotated = annotate(c, model);
     HistorySample hs =
-        sample_history(c, model, 1);  // always_lost: qubit 0 is deterministically lost
-    Circuit rw = rewrite(c, hs.history, model).circuit;
+        sample_history(annotated, model, 1);  // always_lost: qubit 0 is deterministically lost
+    Circuit rw = rewrite(annotated, hs.history, model).circuit;
 
     // The original circuit has no reset; the loss rewrite adds exactly one
     // trace-out R (and no X-prep, since both halves start in |0>).

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1923,3 +1923,39 @@ TEST_CASE("READOUT_NOISE rejects inverted rec targets") {
     // rather than silently ignored.
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(1, 0) !rec[-1]\n"), ParseError);
 }
+
+TEST_CASE("TRANSITION parses a tag and plain qubit targets") {
+    auto c = parse("TRANSITION[cz_leak] 0 1\n");
+    REQUIRE(c.nodes.size() == 2);  // single-arity: one node per target
+    for (size_t i = 0; i < 2; ++i) {
+        REQUIRE(c.nodes[i].gate == GateType::TRANSITION);
+        REQUIRE(c.nodes[i].tag == "cz_leak");
+        REQUIRE(c.nodes[i].targets[0].value() == i);
+    }
+    REQUIRE(c.num_qubits == 2);
+    REQUIRE(c.num_measurements == 0);
+}
+
+TEST_CASE("TRANSITION rejects malformed tags, args, and targets") {
+    CHECK_THROWS_AS(parse("TRANSITION 0\n"), ParseError);                // missing tag
+    CHECK_THROWS_AS(parse("TRANSITION[] 0\n"), ParseError);              // empty tag
+    CHECK_THROWS_AS(parse("TRANSITION[open 0\n"), ParseError);           // unclosed bracket
+    CHECK_THROWS_AS(parse("TRANSITION[t](0.1) 0\n"), ParseError);        // args not allowed
+    CHECK_THROWS_AS(parse("M 0\nTRANSITION[t] rec[-1]\n"), ParseError);  // rec target
+    CHECK_THROWS_AS(parse("TRANSITION[t] !0\n"), ParseError);            // inverted target
+}
+
+TEST_CASE("Tags are rejected on instructions other than TRANSITION") {
+    CHECK_THROWS_AS(parse("H[t] 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("X_ERROR[t](0.1) 0\n"), ParseError);
+}
+
+TEST_CASE("LOSS parses its probability and rejects bad forms") {
+    auto c = parse("LOSS(0.25) 0 1\n");
+    REQUIRE(c.nodes.size() == 2);
+    REQUIRE(c.nodes[0].gate == GateType::LOSS);
+    REQUIRE(c.nodes[0].args == std::vector<double>{0.25});
+    CHECK_THROWS_AS(parse("LOSS 0\n"), ParseError);       // missing probability
+    CHECK_THROWS_AS(parse("LOSS(1.5) 0\n"), ParseError);  // out of range
+    CHECK_THROWS_AS(parse("LOSS(0.1, 0.2) 0\n"), ParseError);
+}

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1948,6 +1948,11 @@ TEST_CASE("TRANSITION rejects malformed tags, args, and targets") {
 TEST_CASE("Tags are rejected on instructions other than TRANSITION") {
     CHECK_THROWS_AS(parse("H[t] 0\n"), ParseError);
     CHECK_THROWS_AS(parse("X_ERROR[t](0.1) 0\n"), ParseError);
+    // Including instructions handled before the main gate dispatch: the
+    // discarded coordinate annotations and the parser-rewrite gates.
+    CHECK_THROWS_AS(parse("QUBIT_COORDS[t](0, 0) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("CH[t] 0 1\n"), ParseError);
+    CHECK_THROWS_AS(parse("CCZ[t] 0 1 2\n"), ParseError);
 }
 
 TEST_CASE("LOSS parses its probability and rejects bad forms") {

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1924,11 +1924,11 @@ TEST_CASE("READOUT_NOISE rejects inverted rec targets") {
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(1, 0) !rec[-1]\n"), ParseError);
 }
 
-TEST_CASE("TRANSITION parses a tag and plain qubit targets") {
-    auto c = parse("TRANSITION[cz_leak] 0 1\n");
+TEST_CASE("LEVEL_TRANSITION parses a tag and plain qubit targets") {
+    auto c = parse("LEVEL_TRANSITION[cz_leak] 0 1\n");
     REQUIRE(c.nodes.size() == 2);  // single-arity: one node per target
     for (size_t i = 0; i < 2; ++i) {
-        REQUIRE(c.nodes[i].gate == GateType::TRANSITION);
+        REQUIRE(c.nodes[i].gate == GateType::LEVEL_TRANSITION);
         REQUIRE(c.nodes[i].tag == "cz_leak");
         REQUIRE(c.nodes[i].targets[0].value() == i);
     }
@@ -1936,16 +1936,16 @@ TEST_CASE("TRANSITION parses a tag and plain qubit targets") {
     REQUIRE(c.num_measurements == 0);
 }
 
-TEST_CASE("TRANSITION rejects malformed tags, args, and targets") {
-    CHECK_THROWS_AS(parse("TRANSITION 0\n"), ParseError);                // missing tag
-    CHECK_THROWS_AS(parse("TRANSITION[] 0\n"), ParseError);              // empty tag
-    CHECK_THROWS_AS(parse("TRANSITION[open 0\n"), ParseError);           // unclosed bracket
-    CHECK_THROWS_AS(parse("TRANSITION[t](0.1) 0\n"), ParseError);        // args not allowed
-    CHECK_THROWS_AS(parse("M 0\nTRANSITION[t] rec[-1]\n"), ParseError);  // rec target
-    CHECK_THROWS_AS(parse("TRANSITION[t] !0\n"), ParseError);            // inverted target
+TEST_CASE("LEVEL_TRANSITION rejects malformed tags, args, and targets") {
+    CHECK_THROWS_AS(parse("LEVEL_TRANSITION 0\n"), ParseError);                // missing tag
+    CHECK_THROWS_AS(parse("LEVEL_TRANSITION[] 0\n"), ParseError);              // empty tag
+    CHECK_THROWS_AS(parse("LEVEL_TRANSITION[open 0\n"), ParseError);           // unclosed bracket
+    CHECK_THROWS_AS(parse("LEVEL_TRANSITION[t](0.1) 0\n"), ParseError);        // args not allowed
+    CHECK_THROWS_AS(parse("M 0\nLEVEL_TRANSITION[t] rec[-1]\n"), ParseError);  // rec target
+    CHECK_THROWS_AS(parse("LEVEL_TRANSITION[t] !0\n"), ParseError);            // inverted target
 }
 
-TEST_CASE("Tags are rejected on instructions other than TRANSITION") {
+TEST_CASE("Tags are rejected on instructions other than LEVEL_TRANSITION") {
     CHECK_THROWS_AS(parse("H[t] 0\n"), ParseError);
     CHECK_THROWS_AS(parse("X_ERROR[t](0.1) 0\n"), ParseError);
     // Including instructions handled before the main gate dispatch: the


### PR DESCRIPTION
> **Prototype / less-strict review.** Targets the `codex/noncomputational-structural-mvp` feature branch, not `main`.

Bridge PR 2 of 2 — the annotation carrier, in two commits for commit-by-commit review:

**Commit 1 — known-level tracking through diagonal and X-type gates.** The status stepper's conservative demote-on-any-gate rule is refined: Z-diagonal operations (`Z`, `S`, `S_DAG`, `T`, `T_DAG`, `R_Z`, `CZ`, `R_ZZ`) preserve a `ComputationalKnown` level; `X`/`Y` flip it to the other known level; anything unclassified still demotes (conservative for future gates). This is the MVP note's earmarked "refinement is a later pass," pulled in so the exact known-source path survives positional placement.

**Commit 2 — the carrier.**
- **`LEVEL_TRANSITION[name] q…`** — the bracket tag (real Stim ≥1.13 tag syntax, accepted only on `LEVEL_TRANSITION`) references any key in the model's `transitions` map. Keys generalize from gate names to arbitrary names; gate-named keys additionally register **hooks**, which `annotate()` expands into per-Physical-operand `LEVEL_TRANSITION[key]` annotations after each hooked operation — the auditable form of the applied model. Feedback operands get none.
- **`LOSS(p) q…`** — Discussion #62's instruction, finally: inline uniform loss (needs exactly one Lost-category level).
- **Consumption**: sampler and rewriter consult *only* annotations (one record per annotation target; the rewriter emits just the carrier edits — trace-out `R` when the carrier at the annotation is coherent, `R`(+`X`) materialization for computational destinations). The orchestrator annotates once per call. `trace()` rejects annotation instructions with a pointer to `sample_noncomputational`.
- **Positional semantics**: *a transition fires at its circuit position; the source is the qubit's status there* — the noise-follows-the-ideal-op convention, replacing the two-time entry-status/post-op-apply attached semantics. Placement is meaning: a new test pins that the same annotation before vs. after an `H` selects Known-vs-unknown source.

**The conscious behavior deltas** (as agreed in the design round; pinned tests updated deliberately):
1. Hooks on **Z-diagonal gates keep their exact known-source path** (via commit 1) — e.g. the known-source-fires tests now hook `S`/`CZ` and pass exactly.
2. A source-dependent hook on a **basis-mixing gate** (`H`) is now an unknown-source consult (reject/equalize per policy) — the old entry-status column was an artifact of attachment, not physics; repurposed test pins the reject. A new positive pin: a definite atom lost at a diagonal gate needs **no trace-out `R`**.
3. An **`MR` hook consults the post-reset state**; pre-reset (readout-induced) transitions are now *expressible* as `M q; LEVEL_TRANSITION[name] q; R q`.
The equalize-rates statistics and the pinned divergence probes are unchanged (verified — the H-based unknown-source paths behave identically).

Also: `Model.transitions` docs updated (Python + C++), `transition_named()` replaces the string overload of `transition_for()`, keys that can't round-trip through tag syntax (`]`, newline) reject, and the design note gains §5.0 ("Transitions are circuit annotations") with the pipeline/policy-table text updated. `annotate.cc` is orchestrator-layer only, so no wasm source-list change is needed (the wasm build carries no noncomp sources).

**Record `op_index` values now name annotation nodes** in the annotated circuit — direct `sample_history`/`rewrite` users (tests) annotate first; the orchestrator API is unchanged.

Verified: Debug **1019** + Release **1019** (`~[bench]`) green; Python **734** green (one conscious flip: arbitrary transition keys are now named transitions, not errors); pre-commit `--all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Review round** (`8442931`): two fixes from external review — (1) transition keys naming recognized but non-hookable instructions (`LOSS`, noise channels, annotations) are now **named-only transitions** instead of rejecting, honoring the any-key-referenceable contract while the hookable allowlist still guards hook registration; (2) the tags-only-on-`TRANSITION` restriction is hoisted above the discarded-annotation and parser-rewrite early returns, so `QUBIT_COORDS[t]`/`CH[t]`/`CCZ[t]` reject rather than silently dropping the tag. Debug **1019** + Release **1019** + Python **734** green.

**Naming round** (`1036632`): the instruction is renamed **`TRANSITION` → `LEVEL_TRANSITION`** — a reader coming from Stim sees the annotation without knowing about the classical level sidecar, and `LEVEL_` says what it transitions. Instruction name, gate enumerator, messages, docs, and tests move together; `LOSS` unchanged. Debug **1019** + Release **1019** + Python **734** green.

**Doc-sync round** (`efa1c7b`): follow-up review caught that the `model.h` header comment, the constructor contract, and two design-note clauses still described the pre-review key contract (keys must name hookable gates, canonicalized to `GateType`). All now state the current one: keys are arbitrary tag-safe names stored verbatim, resolved by exact key from `LEVEL_TRANSITION[key]`, with gate-named keys additionally registering a `GateType`-keyed hook. The alias-key test is renamed to match what it asserts. Comments/docs only; Debug **1019** green, pre-commit clean.
