### PR TITLE
feat(svm): instrument kernels for exact state-dependent jumps

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(clifft_core STATIC
     api/reference_syndrome.cc
     svm/svm.cc
     svm/svm_forced_kernels.cc
+    svm/svm_instrument_kernels.cc
     svm/svm_scalar.cc
     svm/svm_state.cc
     util/canonical_phase.cc

--- a/src/clifft/svm/svm_instrument_kernels.cc
+++ b/src/clifft/svm/svm_instrument_kernels.cc
@@ -1,0 +1,153 @@
+// Instrument kernel implementations. See svm_instrument_kernels.h for the
+// API contract.
+
+#include "clifft/svm/svm_instrument_kernels.h"
+
+#include "clifft/svm/svm_internal.h"
+#include "clifft/svm/svm_math.h"
+
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+
+namespace clifft {
+
+namespace {
+
+// Index of the ii-th amplitude pair's bit_v = 0 element: the k-1 loop bits
+// of ii spread around an inserted zero at position v (the portable twin of
+// the per-ISA kernels' scatter_bits_1).
+inline uint64_t pair_index(uint64_t ii, uint16_t v) {
+    const uint64_t low_mask = (1ULL << v) - 1;
+    return (ii & low_mask) | ((ii & ~low_mask) << 1);
+}
+
+}  // namespace
+
+InstrumentPopulations exec_instrument_damp_eval(SchrodingerState& state, uint16_t v, double r_g,
+                                                double r_e) {
+    assert(v < state.active_k && v < 64 && "instrument damp_eval: axis must be active");
+    assert(r_g > 0.0 && r_g <= 1.0 && r_e > 0.0 && r_e <= 1.0 &&
+           "instrument damp_eval: coefficients must be in (0, 1]; a p = 1 site lowers as "
+           "eval-only plus per-branch collapse");
+
+    const bool px_v = bit_get(state.p_x, v);
+    // Frame conjugation: X^px diag(r_g, r_e) X^px swaps the coefficients;
+    // Z^pz commutes with a real diagonal.
+    const double c0 = px_v ? r_e : r_g;
+    const double c1 = px_v ? r_g : r_e;
+
+    const uint64_t v_bit = 1ULL << v;
+    const uint64_t pairs = 1ULL << (state.active_k - 1);
+    auto* __restrict arr = state.v();
+
+    double pop0 = 0.0;
+    double pop1 = 0.0;
+    parallel_reduce(static_cast<int64_t>(pairs), state.active_k, pop0, pop1,
+                    [&](int64_t ii, double& acc0, double& acc1) {
+                        const uint64_t i0 = pair_index(static_cast<uint64_t>(ii), v);
+                        const uint64_t i1 = i0 | v_bit;
+                        acc0 += std::norm(arr[i0]);
+                        acc1 += std::norm(arr[i1]);
+                        arr[i0] *= c0;
+                        arr[i1] *= c1;
+                    });
+
+    return InstrumentPopulations{px_v ? pop1 : pop0, px_v ? pop0 : pop1};
+}
+
+void exec_instrument_collapse_active(SchrodingerState& state, uint16_t v, uint8_t source,
+                                     double target_norm2) {
+    assert(v < state.active_k && v < 64 && "instrument collapse: axis must be active");
+    assert(target_norm2 > 0.0 && "instrument collapse: target norm must be positive");
+
+    const bool px_v = bit_get(state.p_x, v);
+    // Frame conjugation maps the physical projector |s><s| onto array half
+    // s XOR p_x[v]; a projector is invariant under Z^pz, so unlike the
+    // frame-re-anchoring measurement kernels there is no phase to extract.
+    const uint8_t b = source ^ static_cast<uint8_t>(px_v);
+
+    const uint64_t v_bit = 1ULL << v;
+    const uint64_t pairs = 1ULL << (state.active_k - 1);
+    auto* __restrict arr = state.v();
+
+    double kept = 0.0;
+    double discarded = 0.0;
+    parallel_reduce(static_cast<int64_t>(pairs), state.active_k, kept, discarded,
+                    [&](int64_t ii, double& k_acc, double& d_acc) {
+                        const uint64_t i0 = pair_index(static_cast<uint64_t>(ii), v);
+                        const uint64_t i1 = i0 | v_bit;
+                        const uint64_t keep = (b == 0) ? i0 : i1;
+                        const uint64_t drop = (b == 0) ? i1 : i0;
+                        k_acc += std::norm(arr[keep]);
+                        d_acc += std::norm(arr[drop]);
+                        arr[drop] = {0.0, 0.0};
+                    });
+    (void)discarded;
+    assert(kept > kDustEpsilon * (kept + discarded) &&
+           "instrument collapse onto a zero-probability level");
+
+    state.scale_magnitude(std::sqrt(target_norm2 / kept));
+}
+
+void exec_instrument_expand_damp(SchrodingerState& state, uint16_t v, double r_g, double r_e) {
+    assert(v == state.active_k && "instrument expand_damp must target the next dormant axis");
+    assert(state.v_size() <= state.array_size() / 2 &&
+           "instrument expand_damp exceeded AOT peak_rank allocation");
+    assert(r_g > 0.0 && r_g <= 1.0 && r_e > 0.0 && r_e <= 1.0 &&
+           "instrument expand_damp: coefficients must be in (0, 1]; a p = 1 site lowers as "
+           "plain expansion plus per-branch collapse");
+
+    const bool px_v = bit_get(state.p_x, v);
+    const double c_lo = px_v ? r_e : r_g;
+    const double c_hi = px_v ? r_g : r_e;
+
+    const uint64_t half = 1ULL << state.active_k;
+    auto* __restrict arr = state.v();
+
+    parallel_for(static_cast<int64_t>(half), state.active_k, [&](int64_t ii) {
+        const uint64_t i = static_cast<uint64_t>(ii);
+        arr[i + half] = arr[i] * c_hi;
+        arr[i] *= c_lo;
+    });
+
+    state.active_k++;
+    state.scale_magnitude(1.0 / std::sqrt(2.0));
+}
+
+void exec_instrument_collapse_dormant(SchrodingerState& state, uint16_t v, uint8_t level) {
+    // Phase extraction and frame anchor, mirroring the dormant-random
+    // measurement kernel with the outcome forced and no record written.
+    if (bit_get(state.p_x, v) && level) {
+        state.multiply_phase({-1.0, 0.0});
+    }
+    bit_set(state.p_x, v, level != 0);
+    bit_set(state.p_z, v, false);
+}
+
+InstrumentBranch instrument_fire_branch(InstrumentPopulations pops, double p_g, double p_e,
+                                        double u) {
+    assert(u >= 0.0 && u < 1.0 && "instrument fire draw: variate out of [0, 1)");
+    assert(p_g >= 0.0 && p_g <= 1.0 && p_e >= 0.0 && p_e <= 1.0 &&
+           "instrument fire draw: probabilities out of [0, 1]");
+    const double total = pops.pop_g + pops.pop_e;
+    assert(total > 0.0 && "instrument fire draw on zero-norm populations");
+
+    const double eps = kDustEpsilon * total;
+    const double w_g = (pops.pop_g <= eps) ? 0.0 : p_g * pops.pop_g;
+    const double w_e = (pops.pop_e <= eps) ? 0.0 : p_e * pops.pop_e;
+
+    InstrumentBranch branch;
+    const double scaled = u * total;
+    if (scaled < w_g) {
+        branch.fired = true;
+        branch.source = 0;
+    } else if (scaled < w_g + w_e) {
+        branch.fired = true;
+        branch.source = 1;
+    }
+    return branch;
+}
+
+}  // namespace clifft

--- a/src/clifft/svm/svm_instrument_kernels.h
+++ b/src/clifft/svm/svm_instrument_kernels.h
@@ -1,0 +1,121 @@
+#pragma once
+
+// Instrument kernels: the array-level pieces of an exact state-dependent
+// jump site.
+//
+// A transition instrument attached to one qubit carries per-source jump
+// probabilities (p_g, p_e). The exact channel is the Kraus set
+//
+//   K_jump,s = sqrt(p_s) |dest_s><s|              (one per source s)
+//   K_stay   = r_g P_g + r_e P_e,  r_s = sqrt(1 - p_s)
+//
+// so the fire probability p_g<P_g> + p_e<P_e> is runtime state and the
+// no-fire branch applies the weak damping filter diag(r_g, r_e). These
+// kernels realize that channel per site classification -- the same
+// active/dormant, diagonal-basis classification that selects measurement
+// opcodes. A site whose localized basis is not Z-like on its axis is the
+// lowering's problem (basis-change sandwich), not a kernel variant.
+//
+// None of these kernels rolls the PRNG: instrument_fire_branch() turns one
+// caller-supplied uniform variate into the branch decision, so every
+// function here is deterministic and directly oracle-testable. The
+// destination fixup for a jump whose destination differs from its source
+// is a Pauli and is likewise the caller's, through the existing frame
+// machinery.
+//
+// Conventions shared with the measurement kernels: coefficients and levels
+// are physical -- the active-axis kernels read p_x[v] to map them onto
+// array halves, and p_z[v] commutes with every real diagonal here. A
+// compile-time localization sign is folded in by the caller before the
+// call. Renormalization goes through SchrodingerState::scale_magnitude.
+//
+// The kernels are declared in this internal header so both the dispatcher
+// and the test suite can call them. Implementations live in
+// svm_instrument_kernels.cc.
+
+#include "clifft/svm/svm.h"
+
+#include <cstdint>
+
+namespace clifft {
+
+// Populations of the two physical levels on one active-axis qubit,
+// accumulated before any damping. pop_g + pop_e is the array norm-squared
+// at site entry: the renormalization target for whichever branch follows.
+struct InstrumentPopulations {
+    double pop_g = 0.0;
+    double pop_e = 0.0;
+};
+
+// Branch decision for one instrument site.
+struct InstrumentBranch {
+    bool fired = false;
+    uint8_t source = 0;  // Physical source level; meaningful only when fired.
+};
+
+// Fused damp + evaluate on active axis v: one pass that accumulates the
+// pre-damp physical populations and multiplies the array halves by the
+// damp coefficients (r_g, r_e). No renormalization and no draw happen
+// here -- the caller draws the branch from the returned populations, then
+// either renormalizes the no-fire state by
+// scale_magnitude(sqrt((pop_g + pop_e) / (r_g^2 pop_g + r_e^2 pop_e)))
+// or collapses the fire state. Applying the damp before the draw is
+// exact: on fire, the pre-applied r_source is a scalar on the surviving
+// half and cancels in the collapse renormalization, while the fire
+// probability uses the pre-damp populations accumulated here.
+//
+// Precondition: r_g, r_e in (0, 1]. A p = 1 source (r = 0) would zero the
+// half a subsequent fire must renormalize, so an exact p = 1 site lowers
+// as the eval-only call (r_g = r_e = 1, array untouched) followed by a
+// collapse on every branch -- including no-fire, whose posterior excludes
+// the certain-fire source -- instead of the fused form.
+[[nodiscard]] InstrumentPopulations exec_instrument_damp_eval(SchrodingerState& state, uint16_t v,
+                                                              double r_g, double r_e);
+
+// Forced projection of active axis v onto physical level `source`, in
+// place: the discarded half is zeroed while the array layout, active_k,
+// and the Pauli frame all stay put, because downstream bytecode was
+// compiled for this layout. gamma absorbs sqrt(target_norm2 / kept),
+// preserving the physical norm across the site the same way the
+// measurement kernels do. `target_norm2` is the raw array norm-squared
+// at site entry: the populations total of the paired damp_eval call. A
+// standalone collapse obtains it from an eval-only call (it needs the
+// populations for its draw anyway); a stale total double-counts the
+// rescale. No measurement record is written: this is instrument
+// back-action, not a Born measurement.
+void exec_instrument_collapse_active(SchrodingerState& state, uint16_t v, uint8_t source,
+                                     double target_norm2);
+
+// Fused subspace expansion + damp for a dormant-random qubit: promotes
+// axis v (which must be the next dormant axis, v == active_k) exactly
+// like OP_EXPAND -- array doubles, gamma /= sqrt(2) -- while multiplying
+// the two halves by the damp coefficients (r_g, r_e) in the same pass.
+// With r_g = r_e = 1 this is exactly the plain expansion. No evaluation
+// is needed at such a site: a dormant-random qubit's level populations
+// are exactly half-half, so the caller draws from
+// pop_g = pop_e = (array norm-squared) / 2 and renormalizes the no-fire
+// branch by scale_magnitude(sqrt(2 / (r_g^2 + r_e^2))). The same
+// (0, 1] precondition and p = 1 lowering recipe as damp_eval apply.
+void exec_instrument_expand_damp(SchrodingerState& state, uint16_t v, double r_g, double r_e);
+
+// Frame-level forced collapse of a dormant-random qubit onto level
+// `level`, mirroring the state math of the dormant-random measurement
+// kernel with the outcome forced and no record written: extracts the
+// phase (-1)^(p_x[v] * level) into gamma and re-anchors the frame
+// (p_x[v] = level, p_z[v] = 0). Both levels of a dormant-random qubit
+// carry probability exactly one half, so no renormalization is needed.
+// Unlike the active-axis kernels, `level` is the localized (abstract)
+// outcome the frame anchors to, exactly as in the measurement kernel.
+void exec_instrument_collapse_dormant(SchrodingerState& state, uint16_t v, uint8_t level);
+
+// Turn one uniform variate u in [0, 1) into the branch decision for an
+// instrument site: fire-with-source-g occupies [0, p_g pop_g / N),
+// fire-with-source-e the next p_e pop_e / N, and no-fire the remainder,
+// where N = pop_g + pop_e. A population at or below the measurement
+// kernels' dust threshold (kDustEpsilon * N) is clamped to zero first, so
+// a source whose population is floating-point dust is never selected --
+// the collapse it would trigger has no ray left to renormalize.
+[[nodiscard]] InstrumentBranch instrument_fire_branch(InstrumentPopulations pops, double p_g,
+                                                      double p_e, double u);
+
+}  // namespace clifft

--- a/src/clifft/svm/svm_instrument_kernels.h
+++ b/src/clifft/svm/svm_instrument_kernels.h
@@ -6,10 +6,16 @@
 // A transition instrument attached to one qubit carries per-source jump
 // probabilities (p_g, p_e). The exact channel is the Kraus set
 //
-//   K_jump,s = sqrt(p_s) |dest_s><s|              (one per source s)
+//   K_jump,s = sqrt(p_s) |dest[s]><s|             (one per source s)
 //   K_stay   = r_g P_g + r_e P_e,  r_s = sqrt(1 - p_s)
 //
-// so the fire probability p_g<P_g> + p_e<P_e> is runtime state and the
+// where dest[s] is the destination level that source s's transition
+// column assigns -- any level, possibly several: a column spread over
+// multiple destinations changes nothing at this layer, because the
+// carrier physics depends only on the column sums p_s and picking the
+// destination is the caller's classical draw.
+//
+// So the fire probability p_g<P_g> + p_e<P_e> is runtime state and the
 // no-fire branch applies the weak damping filter diag(r_g, r_e). These
 // kernels realize that channel per site classification -- the same
 // active/dormant, diagonal-basis classification that selects measurement

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/record_probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_forced_kernels.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_instrument_kernels.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_scalar.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm_state.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/util/canonical_phase.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(clifft_tests
     test_svm.cc
     test_state_reset.cc
     test_forced_kernels.cc
+    test_instrument_kernels.cc
     test_execute_forced.cc
     test_svm_avx512_axis01.cc
     test_statevector.cc

--- a/tests/test_instrument_kernels.cc
+++ b/tests/test_instrument_kernels.cc
@@ -1,0 +1,473 @@
+// Directed and dense-oracle tests for the instrument kernels.
+//
+// The kernels are the array-level pieces of an exact state-dependent jump
+// site (design/state-dependent-jumps.md): fused damp+evaluate on an active
+// axis, in-place forced collapse of an active axis, fused expand+damp for
+// a dormant-random qubit, frame-level forced collapse of a dormant-random
+// qubit, and the pure fire-branch draw helper. None of them rolls the
+// PRNG, so every test is deterministic: the oracle is a dense reference
+// that applies the instrument's Kraus operators to a copy of the
+// gamma-scaled amplitudes.
+//
+// These tests exercise the kernels directly, without the dispatcher
+// (which is wired up in a separate step).
+
+#include "clifft/svm/svm.h"
+#include "clifft/svm/svm_instrument_kernels.h"
+#include "clifft/util/xoshiro.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+using Amps = std::vector<std::complex<double>>;
+
+constexpr double kTol = 1e-12;
+
+// Deterministic pseudo-random active state: k active axes, normalized
+// amplitudes with nonzero real and imaginary parts, cleared frame.
+SchrodingerState make_active_state(uint32_t peak_rank, uint32_t k, uint64_t seed) {
+    SchrodingerState state(peak_rank, /*num_measurements=*/1);
+    state.active_k = k;
+    Xoshiro256PlusPlus rng(seed);
+    double norm2 = 0.0;
+    for (uint64_t i = 0; i < (1ULL << k); ++i) {
+        const std::complex<double> a(rng.next_double() - 0.5, rng.next_double() - 0.5);
+        state.v()[i] = a;
+        norm2 += std::norm(a);
+    }
+    const double inv = 1.0 / std::sqrt(norm2);
+    for (uint64_t i = 0; i < (1ULL << k); ++i) {
+        state.v()[i] *= inv;
+    }
+    return state;
+}
+
+void set_frame_bit(std::vector<uint64_t>& words, uint16_t v, bool b) {
+    if (b) {
+        words[v >> 6] |= (1ULL << (v & 63));
+    } else {
+        words[v >> 6] &= ~(1ULL << (v & 63));
+    }
+}
+
+bool get_frame_bit(const std::vector<uint64_t>& words, uint16_t v) {
+    return (words[v >> 6] >> (v & 63)) & 1;
+}
+
+// Gamma-scaled amplitudes: the physically meaningful content of the array.
+Amps physical(const SchrodingerState& state) {
+    Amps out(state.v_size());
+    for (uint64_t i = 0; i < out.size(); ++i) {
+        out[i] = state.gamma() * state.v()[i];
+    }
+    return out;
+}
+
+double norm2(const Amps& a) {
+    double n = 0.0;
+    for (const auto& x : a) {
+        n += std::norm(x);
+    }
+    return n;
+}
+
+// Physical level of array index i on axis v under frame bit px.
+uint8_t level_of(uint64_t i, uint16_t v, bool px) {
+    return static_cast<uint8_t>(((i >> v) & 1) ^ static_cast<uint64_t>(px));
+}
+
+// Dense reference: population of physical level `lvl` on axis v.
+double ref_population(const Amps& a, uint16_t v, bool px, uint8_t lvl) {
+    double p = 0.0;
+    for (uint64_t i = 0; i < a.size(); ++i) {
+        if (level_of(i, v, px) == lvl) {
+            p += std::norm(a[i]);
+        }
+    }
+    return p;
+}
+
+// Dense reference: the damping filter K_stay = r_g P_g + r_e P_e.
+void ref_damp(Amps& a, uint16_t v, bool px, double r_g, double r_e) {
+    for (uint64_t i = 0; i < a.size(); ++i) {
+        a[i] *= (level_of(i, v, px) == 0) ? r_g : r_e;
+    }
+}
+
+// Dense reference: project onto physical level `lvl` on axis v.
+void ref_project(Amps& a, uint16_t v, bool px, uint8_t lvl) {
+    for (uint64_t i = 0; i < a.size(); ++i) {
+        if (level_of(i, v, px) != lvl) {
+            a[i] = {0.0, 0.0};
+        }
+    }
+}
+
+// Rescale so norm2(a) == target.
+void ref_rescale_to(Amps& a, double target_norm2) {
+    const double s = std::sqrt(target_norm2 / norm2(a));
+    for (auto& x : a) {
+        x *= s;
+    }
+}
+
+// Dense reference: Hadamard on axis v (frame-free; used with px = pz = 0).
+void ref_hadamard(Amps& a, uint16_t v) {
+    const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+    const uint64_t v_bit = 1ULL << v;
+    for (uint64_t i = 0; i < a.size(); ++i) {
+        if ((i & v_bit) == 0) {
+            const std::complex<double> lo = a[i];
+            const std::complex<double> hi = a[i | v_bit];
+            a[i] = (lo + hi) * inv_sqrt2;
+            a[i | v_bit] = (lo - hi) * inv_sqrt2;
+        }
+    }
+}
+
+void require_amps_match(const Amps& got, const Amps& want) {
+    REQUIRE(got.size() == want.size());
+    for (uint64_t i = 0; i < got.size(); ++i) {
+        REQUIRE_THAT(got[i].real(), WithinAbs(want[i].real(), kTol));
+        REQUIRE_THAT(got[i].imag(), WithinAbs(want[i].imag(), kTol));
+    }
+}
+
+}  // namespace
+
+// =============================================================================
+// damp_eval: fused damp + populations on an active axis
+// =============================================================================
+
+TEST_CASE("instrument damp_eval: populations and damped state match the dense reference") {
+    const struct {
+        double p_g, p_e;
+    } rates[] = {{0.0, 0.0}, {0.36, 0.0}, {0.0, 0.75}, {0.36, 0.75}};
+
+    uint64_t seed = 11;
+    for (uint32_t k = 1; k <= 3; ++k) {
+        for (uint16_t v = 0; v < k; ++v) {
+            for (int px = 0; px <= 1; ++px) {
+                for (int pz = 0; pz <= 1; ++pz) {
+                    for (const auto& rate : rates) {
+                        const double r_g = std::sqrt(1.0 - rate.p_g);
+                        const double r_e = std::sqrt(1.0 - rate.p_e);
+
+                        auto state = make_active_state(/*peak_rank=*/4, k, seed++);
+                        set_frame_bit(state.p_x, v, px != 0);
+                        set_frame_bit(state.p_z, v, pz != 0);
+                        const Amps before = physical(state);
+
+                        const InstrumentPopulations pops =
+                            exec_instrument_damp_eval(state, v, r_g, r_e);
+
+                        REQUIRE_THAT(pops.pop_g,
+                                     WithinAbs(ref_population(before, v, px != 0, 0), kTol));
+                        REQUIRE_THAT(pops.pop_e,
+                                     WithinAbs(ref_population(before, v, px != 0, 1), kTol));
+                        REQUIRE_THAT(pops.pop_g + pops.pop_e, WithinAbs(norm2(before), kTol));
+
+                        Amps want = before;
+                        ref_damp(want, v, px != 0, r_g, r_e);
+                        require_amps_match(physical(state), want);
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("instrument damp_eval: unit coefficients evaluate without touching the array") {
+    auto state = make_active_state(/*peak_rank=*/3, /*k=*/2, /*seed=*/7);
+    Amps before(state.v(), state.v() + state.v_size());
+    const auto gamma_before = state.gamma();
+
+    const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/1, 1.0, 1.0);
+
+    REQUIRE_THAT(pops.pop_g + pops.pop_e, WithinAbs(1.0, kTol));
+    REQUIRE(state.gamma() == gamma_before);
+    // Multiplication by exactly 1.0 must be bit-preserving.
+    for (uint64_t i = 0; i < state.v_size(); ++i) {
+        REQUIRE(state.v()[i] == before[i]);
+    }
+}
+
+TEST_CASE("instrument damp_eval + no-fire renormalization matches the normalized K_stay state") {
+    const double p_g = 0.2, p_e = 0.5;
+    const double r_g = std::sqrt(1.0 - p_g), r_e = std::sqrt(1.0 - p_e);
+
+    auto state = make_active_state(/*peak_rank=*/4, /*k=*/3, /*seed=*/23);
+    const Amps before = physical(state);
+
+    const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/1, r_g, r_e);
+    const double total = pops.pop_g + pops.pop_e;
+    const double no_fire = r_g * r_g * pops.pop_g + r_e * r_e * pops.pop_e;
+    state.scale_magnitude(std::sqrt(total / no_fire));
+
+    Amps want = before;
+    ref_damp(want, /*v=*/1, /*px=*/false, r_g, r_e);
+    ref_rescale_to(want, total);
+    require_amps_match(physical(state), want);
+}
+
+// =============================================================================
+// collapse_active: in-place forced projection
+// =============================================================================
+
+TEST_CASE("instrument fire path: collapse after damp recovers the pre-damp projection") {
+    // The fused pass damps before the branch is drawn. On fire the
+    // pre-applied r_source is a scalar on the surviving half, so the
+    // collapse renormalization must reproduce the projection of the
+    // *pre-damp* state exactly.
+    const double r_g = std::sqrt(1.0 - 0.3), r_e = std::sqrt(1.0 - 0.6);
+
+    for (int px = 0; px <= 1; ++px) {
+        for (uint8_t source = 0; source <= 1; ++source) {
+            auto state = make_active_state(/*peak_rank=*/4, /*k=*/3, /*seed=*/31 + px);
+            set_frame_bit(state.p_x, /*v=*/2, px != 0);
+            const Amps before = physical(state);
+            const uint32_t k_before = state.active_k;
+
+            const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/2, r_g, r_e);
+            const double total = pops.pop_g + pops.pop_e;
+            exec_instrument_collapse_active(state, /*v=*/2, source, total);
+
+            Amps want = before;
+            ref_project(want, /*v=*/2, px != 0, source);
+            ref_rescale_to(want, total);
+            require_amps_match(physical(state), want);
+
+            // Layout and frame are untouched; the discarded half is
+            // exactly zero.
+            REQUIRE(state.active_k == k_before);
+            REQUIRE(get_frame_bit(state.p_x, 2) == (px != 0));
+            for (uint64_t i = 0; i < state.v_size(); ++i) {
+                if (level_of(i, /*v=*/2, px != 0) != source) {
+                    REQUIRE(state.v()[i] == std::complex<double>{0.0, 0.0});
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("instrument collapse_active: collapsing an already-definite level is the identity") {
+    // Each site draws from its own evaluation, so the second collapse's
+    // target is the raw norm measured at the *second* site, not a stale
+    // total from the first.
+    auto state = make_active_state(/*peak_rank=*/4, /*k=*/2, /*seed=*/43);
+    const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/0, 0.9, 0.8);
+
+    exec_instrument_collapse_active(state, /*v=*/0, /*source=*/1, pops.pop_g + pops.pop_e);
+    const Amps once = physical(state);
+
+    const InstrumentPopulations again = exec_instrument_damp_eval(state, /*v=*/0, 1.0, 1.0);
+    REQUIRE_THAT(again.pop_e, WithinAbs(again.pop_g + again.pop_e, kTol));  // definite level
+    exec_instrument_collapse_active(state, /*v=*/0, /*source=*/1, again.pop_g + again.pop_e);
+    require_amps_match(physical(state), once);
+}
+
+// =============================================================================
+// fire_branch: the pure draw helper
+// =============================================================================
+
+TEST_CASE("instrument fire_branch: regions partition the variate by exact branch probability") {
+    const InstrumentPopulations pops{0.3, 0.7};
+    const double p_g = 0.5, p_e = 0.1;
+    // Region boundaries: fire-g on [0, 0.15), fire-e on [0.15, 0.22).
+    const double w_g = p_g * pops.pop_g, w_e = p_e * pops.pop_e;
+    REQUIRE_THAT(w_g, WithinAbs(0.15, kTol));
+    REQUIRE_THAT(w_g + w_e, WithinAbs(0.22, kTol));
+
+    auto branch = instrument_fire_branch(pops, p_g, p_e, 0.0);
+    REQUIRE((branch.fired && branch.source == 0));
+    branch = instrument_fire_branch(pops, p_g, p_e, 0.149999);
+    REQUIRE((branch.fired && branch.source == 0));
+    branch = instrument_fire_branch(pops, p_g, p_e, 0.150001);
+    REQUIRE((branch.fired && branch.source == 1));
+    branch = instrument_fire_branch(pops, p_g, p_e, 0.219999);
+    REQUIRE((branch.fired && branch.source == 1));
+    branch = instrument_fire_branch(pops, p_g, p_e, 0.220001);
+    REQUIRE(!branch.fired);
+    branch = instrument_fire_branch(pops, p_g, p_e, 0.999999);
+    REQUIRE(!branch.fired);
+}
+
+TEST_CASE("instrument fire_branch: a dust population is never selected as the source") {
+    // pop_e is floating-point dust: even a variate inside what would be
+    // its region must not select it (the collapse it would trigger has no
+    // ray to renormalize).
+    const InstrumentPopulations pops{1.0, 1e-25};
+    auto branch = instrument_fire_branch(pops, /*p_g=*/0.0, /*p_e=*/1.0, /*u=*/1e-26);
+    REQUIRE(!branch.fired);
+}
+
+// =============================================================================
+// expand_damp: dormant-random site under damping="exact"
+// =============================================================================
+
+TEST_CASE("instrument expand_damp: matches plain expansion followed by the damp") {
+    const double r_g = std::sqrt(1.0 - 0.4), r_e = std::sqrt(1.0 - 0.1);
+
+    for (int px = 0; px <= 1; ++px) {
+        auto state = make_active_state(/*peak_rank=*/3, /*k=*/1, /*seed=*/57);
+        const uint16_t v = 1;  // next dormant axis
+        set_frame_bit(state.p_x, v, px != 0);
+        const Amps before = physical(state);
+
+        exec_instrument_expand_damp(state, v, r_g, r_e);
+        REQUIRE(state.active_k == 2);
+
+        // Dense reference: |phi> (x) |+> on the new axis, then the damp.
+        Amps want(before.size() * 2);
+        const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+        for (uint64_t i = 0; i < before.size(); ++i) {
+            want[i] = before[i] * inv_sqrt2;
+            want[i + before.size()] = before[i] * inv_sqrt2;
+        }
+        ref_damp(want, v, px != 0, r_g, r_e);
+        require_amps_match(physical(state), want);
+    }
+}
+
+TEST_CASE("instrument expand_damp: unit coefficients reproduce the plain expansion") {
+    auto state = make_active_state(/*peak_rank=*/3, /*k=*/1, /*seed=*/61);
+    const Amps before = physical(state);
+
+    exec_instrument_expand_damp(state, /*v=*/1, 1.0, 1.0);
+
+    REQUIRE(state.active_k == 2);
+    const Amps after = physical(state);
+    REQUIRE_THAT(norm2(after), WithinAbs(norm2(before), kTol));
+    const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+    for (uint64_t i = 0; i < before.size(); ++i) {
+        REQUIRE_THAT(std::abs(after[i] - before[i] * inv_sqrt2), WithinAbs(0.0, kTol));
+        REQUIRE_THAT(std::abs(after[i + before.size()] - before[i] * inv_sqrt2),
+                     WithinAbs(0.0, kTol));
+    }
+}
+
+// =============================================================================
+// collapse_dormant: frame-level forced collapse
+// =============================================================================
+
+TEST_CASE("instrument collapse_dormant: anchors the frame and extracts the phase") {
+    for (int px = 0; px <= 1; ++px) {
+        for (uint8_t level = 0; level <= 1; ++level) {
+            SchrodingerState state(/*peak_rank=*/2, /*num_measurements=*/1);
+            const uint16_t v = 1;
+            set_frame_bit(state.p_x, v, px != 0);
+            set_frame_bit(state.p_z, v, true);  // must be cleared by the anchor
+
+            exec_instrument_collapse_dormant(state, v, level);
+
+            const double want_phase = (px != 0 && level != 0) ? -1.0 : 1.0;
+            REQUIRE_THAT(state.gamma().real(), WithinAbs(want_phase, kTol));
+            REQUIRE_THAT(state.gamma().imag(), WithinAbs(0.0, kTol));
+            REQUIRE(get_frame_bit(state.p_x, v) == (level != 0));
+            REQUIRE(get_frame_bit(state.p_z, v) == false);
+        }
+    }
+}
+
+// =============================================================================
+// Physics pins
+// =============================================================================
+
+TEST_CASE("instrument damp_eval: frame conjugation swaps the coefficients and populations") {
+    const double r_g = 0.6, r_e = 0.9;
+
+    auto with_px = make_active_state(/*peak_rank=*/3, /*k=*/2, /*seed=*/71);
+    auto without = make_active_state(/*peak_rank=*/3, /*k=*/2, /*seed=*/71);
+    set_frame_bit(with_px.p_x, /*v=*/0, true);
+
+    const auto pops_px = exec_instrument_damp_eval(with_px, /*v=*/0, r_g, r_e);
+    const auto pops_swapped = exec_instrument_damp_eval(without, /*v=*/0, r_e, r_g);
+
+    // Same array action either way; the population labels swap.
+    require_amps_match(physical(with_px), physical(without));
+    REQUIRE_THAT(pops_px.pop_g, WithinAbs(pops_swapped.pop_e, kTol));
+    REQUIRE_THAT(pops_px.pop_e, WithinAbs(pops_swapped.pop_g, kTol));
+}
+
+TEST_CASE("instrument no-fire back-action: the FAQ interference case has its closed form") {
+    // H; site; H on |0> with (p_g = p, p_e = 0): the no-fire damp tilts
+    // |+> and the second H converts the tilt into a |1> population. The
+    // joint probability of (no fire, measure 1) is exactly (1 - r_g)^2 / 4
+    // -- approximately p^2/16 at small p -- the leading-order interference
+    // error a collapse-at-site approximation would inflate to O(1).
+    const double p = 0.36;
+    const double r_g = std::sqrt(1.0 - p);
+
+    SchrodingerState state(/*peak_rank=*/2, /*num_measurements=*/1);
+    state.active_k = 1;
+    const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+    state.v()[0] = {inv_sqrt2, 0.0};  // H|0> = |+>
+    state.v()[1] = {inv_sqrt2, 0.0};
+
+    const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/0, r_g, 1.0);
+    REQUIRE_THAT(pops.pop_g, WithinAbs(0.5, kTol));
+    REQUIRE_THAT(pops.pop_e, WithinAbs(0.5, kTol));
+
+    const double total = pops.pop_g + pops.pop_e;
+    const double p_fire = p * pops.pop_g / total;
+    REQUIRE_THAT(p_fire, WithinAbs(p / 2.0, kTol));
+
+    const double no_fire = r_g * r_g * pops.pop_g + 1.0 * pops.pop_e;
+    state.scale_magnitude(std::sqrt(total / no_fire));
+
+    Amps amps = physical(state);
+    ref_hadamard(amps, /*v=*/0);
+    const double p_one_given_no_fire = std::norm(amps[1]) / norm2(amps);
+    const double joint = (1.0 - p_fire) * p_one_given_no_fire;
+    REQUIRE_THAT(joint, WithinAbs((1.0 - r_g) * (1.0 - r_g) / 4.0, kTol));
+}
+
+TEST_CASE("instrument p = 1 lowering recipe: eval-only plus per-branch collapse is exact") {
+    // A certain-fire source (p_g = 1, r_g = 0) cannot use the fused form:
+    // the damp would destroy the ray a fire must renormalize. The recipe
+    // is an eval-only pass, then a collapse on *every* branch -- on
+    // no-fire the posterior excludes the certain-fire source.
+    const double p_g = 1.0, p_e = 0.19;
+
+    auto reference_state = make_active_state(/*peak_rank=*/3, /*k=*/2, /*seed=*/83);
+    const Amps before = physical(reference_state);
+    const double pop_g = ref_population(before, /*v=*/1, false, 0);
+    const double pop_e = ref_population(before, /*v=*/1, false, 1);
+    const double total = pop_g + pop_e;
+
+    struct Branch {
+        double u;
+        bool want_fired;
+        uint8_t collapse_to;
+    };
+    const Branch branches[] = {
+        {0.5 * pop_g / total, true, 0},                    // fire from g
+        {(pop_g + 0.5 * p_e * pop_e) / total, true, 1},    // fire from e
+        {(pop_g + p_e * pop_e) / total + 1e-6, false, 1},  // no fire: source must be e
+    };
+
+    for (const Branch& b : branches) {
+        auto state = make_active_state(/*peak_rank=*/3, /*k=*/2, /*seed=*/83);
+        const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/1, 1.0, 1.0);
+        const InstrumentBranch drawn = instrument_fire_branch(pops, p_g, p_e, b.u);
+        REQUIRE(drawn.fired == b.want_fired);
+        if (drawn.fired) {
+            REQUIRE(drawn.source == b.collapse_to);
+        }
+
+        exec_instrument_collapse_active(state, /*v=*/1, b.collapse_to, pops.pop_g + pops.pop_e);
+        Amps want = before;
+        ref_project(want, /*v=*/1, false, b.collapse_to);
+        ref_rescale_to(want, total);
+        require_amps_match(physical(state), want);
+    }
+}

--- a/tests/test_instrument_kernels.cc
+++ b/tests/test_instrument_kernels.cc
@@ -13,14 +13,18 @@
 // (which is wired up in a separate step).
 
 #include "clifft/svm/svm.h"
+#include "clifft/svm/svm_forced_kernels.h"
 #include "clifft/svm/svm_instrument_kernels.h"
+#include "clifft/svm/svm_internal.h"
 #include "clifft/util/xoshiro.h"
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <span>
 #include <vector>
 
 using namespace clifft;
@@ -375,6 +379,126 @@ TEST_CASE("instrument collapse_dormant: anchors the frame and extracts the phase
             REQUIRE(get_frame_bit(state.p_x, v) == (level != 0));
             REQUIRE(get_frame_bit(state.p_z, v) == false);
         }
+    }
+}
+
+// =============================================================================
+// Cross-checks against production machinery and mid-shot state shapes
+// =============================================================================
+
+TEST_CASE(
+    "instrument damp_eval: populations match the forced measurement kernel's "
+    "branch probabilities") {
+    // The dense reference in this file shares its author's reading of the
+    // frame convention; the forced measurement kernel does not -- it is
+    // the production machinery behind exact record probabilities. An
+    // eval-only pass and a forced Z-measurement on the same axis must
+    // assign the same probability to each level.
+    for (int px = 0; px <= 1; ++px) {
+        for (uint8_t outcome = 0; outcome <= 1; ++outcome) {
+            auto state = make_active_state(/*peak_rank=*/3, /*k=*/3, /*seed=*/97 + px);
+            const uint16_t v = 2;  // the forced measurement requires the top axis
+            set_frame_bit(state.p_x, v, px != 0);
+
+            const InstrumentPopulations pops = exec_instrument_damp_eval(state, v, 1.0, 1.0);
+            const double total = pops.pop_g + pops.pop_e;
+            const double want = (outcome == 0 ? pops.pop_g : pops.pop_e) / total;
+
+            const std::vector<uint8_t> record{outcome};
+            state.forced_record = record;
+            REQUIRE(exec_meas_active_diagonal_forced(state, v, /*classical_idx=*/0,
+                                                     /*sign=*/false));
+            REQUIRE_THAT(std::exp(state.forced_log_probability), WithinAbs(want, kTol));
+        }
+    }
+}
+
+TEST_CASE("instrument kernels: fused pass and collapse above the OpenMP rank threshold") {
+    // The fused pass mutates the array inside parallel_reduce -- a pattern
+    // the pre-existing kernels do not use -- so exercise it and the
+    // collapse at the rank where the threaded path activates, on an
+    // interior (strided) axis. Comparisons aggregate to keep the
+    // assertion count independent of the array size.
+    const uint32_t k = kMinRankForThreads;
+    const double r_g = std::sqrt(1.0 - 0.3), r_e = std::sqrt(1.0 - 0.05);
+    const uint16_t v = 7;
+
+    auto state = make_active_state(/*peak_rank=*/k, k, /*seed=*/113);
+    set_frame_bit(state.p_x, v, true);
+    const Amps before = physical(state);
+
+    const InstrumentPopulations pops = exec_instrument_damp_eval(state, v, r_g, r_e);
+    REQUIRE_THAT(pops.pop_g, WithinAbs(ref_population(before, v, true, 0), 1e-9));
+    REQUIRE_THAT(pops.pop_e, WithinAbs(ref_population(before, v, true, 1), 1e-9));
+
+    Amps want = before;
+    ref_damp(want, v, true, r_g, r_e);
+    Amps got = physical(state);
+    double max_diff = 0.0;
+    for (uint64_t i = 0; i < got.size(); ++i) {
+        max_diff = std::max(max_diff, std::abs(got[i] - want[i]));
+    }
+    REQUIRE_THAT(max_diff, WithinAbs(0.0, 1e-10));
+
+    exec_instrument_collapse_active(state, v, /*source=*/1, pops.pop_g + pops.pop_e);
+    want = before;
+    ref_project(want, v, true, 1);
+    ref_rescale_to(want, pops.pop_g + pops.pop_e);
+    got = physical(state);
+    max_diff = 0.0;
+    for (uint64_t i = 0; i < got.size(); ++i) {
+        max_diff = std::max(max_diff, std::abs(got[i] - want[i]));
+    }
+    REQUIRE_THAT(max_diff, WithinAbs(0.0, 1e-10));
+}
+
+TEST_CASE("instrument kernels: unnormalized array and nonunit gamma") {
+    // Mid-shot states carry deferred normalization: the raw array norm
+    // and gamma both sit away from one. Populations are raw-array
+    // quantities, and both branch post-states must come out right through
+    // the gamma-carried rescales.
+    const double r_g = std::sqrt(1.0 - 0.25), r_e = std::sqrt(1.0 - 0.6);
+    const double array_scale = 0.35;
+    const std::complex<double> gamma{1.6, -0.9};
+
+    auto make_scaled = [&] {
+        auto state = make_active_state(/*peak_rank=*/3, /*k=*/2, /*seed=*/131);
+        for (uint64_t i = 0; i < state.v_size(); ++i) {
+            state.v()[i] *= array_scale;
+        }
+        state.set_gamma(gamma);
+        return state;
+    };
+
+    {  // No-fire branch: normalized K_stay at unchanged physical norm.
+        auto state = make_scaled();
+        const Amps before = physical(state);
+
+        const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/0, r_g, r_e);
+        // Populations are raw array quantities, not gamma-scaled ones.
+        REQUIRE_THAT(pops.pop_g + pops.pop_e, WithinAbs(array_scale * array_scale, kTol));
+
+        const double total = pops.pop_g + pops.pop_e;
+        const double no_fire = r_g * r_g * pops.pop_g + r_e * r_e * pops.pop_e;
+        state.scale_magnitude(std::sqrt(total / no_fire));
+
+        Amps want = before;
+        ref_damp(want, /*v=*/0, false, r_g, r_e);
+        ref_rescale_to(want, norm2(before));
+        require_amps_match(physical(state), want);
+    }
+
+    {  // Fire branch: pre-damp projection at unchanged physical norm.
+        auto state = make_scaled();
+        const Amps before = physical(state);
+
+        const InstrumentPopulations pops = exec_instrument_damp_eval(state, /*v=*/0, r_g, r_e);
+        exec_instrument_collapse_active(state, /*v=*/0, /*source=*/0, pops.pop_g + pops.pop_e);
+
+        Amps want = before;
+        ref_project(want, /*v=*/0, false, 0);
+        ref_rescale_to(want, norm2(before));
+        require_amps_match(physical(state), want);
     }
 }
 


### PR DESCRIPTION
> **Prototype note:** this PR targets the `codex/noncomputational-structural-mvp` feature branch (not `main`) and is part of the in-progress noncomputational MVP; a less strict review bar applies.

Step 3 of the exact state-dependent jumps plan (`design/state-dependent-jumps.md` §6): the SVM kernels. Standalone — no opcodes, no HIR, no user surface; the dispatcher wiring comes with step 4, following the same two-step landing the forced measurement kernels used.

## What's here

New single scalar TU `svm_instrument_kernels.{h,cc}` (forced-kernels packaging precedent: internal header callable from both the future dispatcher and the test suite; registered in **both** the core and wasm source lists), with four kernels plus one pure helper:

- **`exec_instrument_damp_eval`** — the main-line workhorse: one pass over any active axis that accumulates the **pre-damp** populations (⟨P_g⟩, ⟨P_e⟩) while applying `diag(r_g, r_e)`, frame-aware (`p_x[v]` swaps coefficients and population labels; `p_z` commutes with a real diagonal). Returns the populations; the caller draws and renormalizes.
- **`exec_instrument_collapse_active`** — in-place forced projection onto a physical level: zeros the discarded half, leaves layout/`active_k`/frame untouched (downstream bytecode was compiled for this layout), restores the physical norm via gamma. Works on any axis — unlike measurement collapse, no swap-to-top is needed since nothing compacts.
- **`exec_instrument_expand_damp`** — the `EXPAND_ROT` pattern with two real coefficients (`k → k+1` fused with the damp); `(1, 1)` reproduces plain expansion exactly.
- **`exec_instrument_collapse_dormant`** — frame-level forced collapse (the dormant-random measurement kernel's state math, outcome forced, no record); also the entire fire path under `damping="neglect"`.
- **`instrument_fire_branch`** — pure draw arithmetic from one uniform variate, with the measurement kernels' dust clamping so a dust population is never selected as a collapse source.

## The two correctness points worth checking

1. **Unconditional damp is exact.** The fused pass damps before the branch is drawn; on fire, the pre-applied `r_source` is a scalar on the surviving half that the collapse renormalization cancels exactly, and the fire probability uses the pre-damp populations accumulated in the same pass. Pinned by the fire-path oracle test (collapse-after-damp reproduces the projection of the *pre-damp* state).
2. **`p = 1` cannot use the fused form** (`r = 0` destroys the ray a fire must renormalize), so the kernels assert `r ∈ (0, 1]` and the header documents the exact lowering recipe: eval-only pass (`r_g = r_e = 1`) plus a collapse on *every* branch — on no-fire the posterior excludes the certain-fire source. Pinned by a dedicated oracle test.

## Tests

13 new cases (`test_instrument_kernels.cc`), all against a dense Kraus reference on gamma-scaled amplitudes over grids of k / axis / frame bits / rates including the edges: populations + damped state vs. dense; no-fire branch vs. normalized `K_stay`; fire path vs. pre-damp projection; frame-conjugation covariance; expand+damp vs. dense expansion-then-damp; dormant collapse phase/anchor table; fire-branch region partition + dust clamp; and the FAQ interference micro-case pinned to its closed form — P(no fire ∧ measure 1) = (1−r_g)²/4 ≈ p²/16, the quantity a collapse-at-site approximation would inflate to O(1).

Verified: Debug **1032** + Release **1032** (`~[bench]`) green; wasm module builds in the emsdk 3.1.74 docker image with the new TU linked; pre-commit `--all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Review round** (`4248752`): three test additions from the robustness discussion — (1) a cross-check that an eval-only pass assigns each level the same probability the **forced measurement kernel** computes on the same state, anchoring the frame convention to production machinery rather than the test file's own dense reference; (2) a case at the OpenMP rank threshold (k = 18) covering the fused pass's **mutate-inside-`parallel_reduce`** pattern, which no pre-existing kernel uses; (3) an **unnormalized-array / nonunit-gamma** case pinning that populations are raw-array quantities and both branch post-states survive deferred normalization. Plus a header notation clarification: `dest[s]` is the destination source `s`'s transition column assigns — multi-destination columns change nothing at this layer (carrier physics depends only on column sums; destination choice is the caller's classical draw). Debug **1035** + Release **1035** green; 16 instrument cases; the k = 18 case runs in ~0.1 s.
