### PR TITLE
feat(svm): resumable instrument traps and cross-module resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,12 @@ These constraints must not be violated:
   bytes (`static_assert(sizeof(Instruction) == 32)`).
 - **Stim is Immutable:** Fetch Stim via CMake `FetchContent`. Do not fork,
   vendor, or patch Stim source.
-- **Single Memory Allocation:** The VM's `ShotState` must allocate its
-  coefficient array exactly once based on `peak_rank`.
+- **Single Memory Allocation:** The VM's `SchrodingerState` allocates its
+  coefficient array once at construction, sized by `peak_rank`. The one
+  sanctioned exception is the trap boundary: `resume()` may grow (never
+  shrink) the array before re-entering the dispatch, when a trap
+  continuation was compiled with a larger peak rank. No allocation ever
+  happens inside the dispatch loop or a kernel.
 - **Deterministic RNG:** Do not use `std::uniform_real_distribution` (it is
   implementation-defined). Use `(rng() >> 11) * 0x1.0p-53` for `[0, 1)`.
 - **No Global Topology in the VM:** All multi-qubit Pauli interference must

--- a/design/state-dependent-jumps.md
+++ b/design/state-dependent-jumps.md
@@ -307,7 +307,15 @@ coordinate-aligning virtual Hadamard for an anchor that only happens on a
 runtime-conditional branch (a measurement's anchor is unconditional, so
 its compile-time alignment is sound). The trap's suffix rewrite handles
 the collapse at source level instead; fires are rare, so the cost is a
-cached continuation, not a hot path.
+cached continuation, not a hot path. The same obstruction gives
+`neglect` a second approximation clause on the *fire* side: the carrier
+hands over uncollapsed, so the continuation's trace-out draws its
+unraveling independently of the reported source, decorrelating the
+fired qubit's entangled partners from its source-dependent downstream
+effects. Everywhere the collapse *can* happen in-line (active, expand,
+and dormant-deterministic forms), the runtime collapses onto the drawn
+source *before* trapping, which makes the continuation's trace-out
+deterministic and keeps the correlation exact.
 
 New opcodes land in the shared kernel include and are compiled per-ISA like
 every other opcode; the instruction's 24-byte payload carries the axis, the

--- a/design/state-dependent-jumps.md
+++ b/design/state-dependent-jumps.md
@@ -307,15 +307,22 @@ coordinate-aligning virtual Hadamard for an anchor that only happens on a
 runtime-conditional branch (a measurement's anchor is unconditional, so
 its compile-time alignment is sound). The trap's suffix rewrite handles
 the collapse at source level instead; fires are rare, so the cost is a
-cached continuation, not a hot path. The same obstruction gives
-`neglect` a second approximation clause on the *fire* side: the carrier
-hands over uncollapsed, so the continuation's trace-out draws its
-unraveling independently of the reported source, decorrelating the
-fired qubit's entangled partners from its source-dependent downstream
-effects. Everywhere the collapse *can* happen in-line (active, expand,
-and dormant-deterministic forms), the runtime collapses onto the drawn
+cached continuation, not a hot path.
+
+The uncollapsed handover costs no correlation, because past the trap
+the continuation is fire-branch-only and the conditional convention
+shift becomes unconditional there: the driver's suffix rewrite emits
+the leaked qubit's trace-out as a hidden measurement **forced to the
+reported source**, so entangled partners collapse consistently with the
+destination-side effects. (A bare frame anchor at trap time would be
+wrong — after `H 0`, anchoring the dormant representation to `|s⟩`
+yields the physical state `H|s⟩`, not `|s⟩`; the collapse must execute
+inside compiled code that carries the basis alignment.) With that,
+`neglect`'s only approximation is the omitted no-fire back-action.
+Everywhere the collapse *can* happen in-line (active, expand, and
+dormant-deterministic forms), the runtime collapses onto the drawn
 source *before* trapping, which makes the continuation's trace-out
-deterministic and keeps the correlation exact.
+deterministic and keeps the correlation exact with no forcing needed.
 
 New opcodes land in the shared kernel include and are compiled per-ISA like
 every other opcode; the instruction's 24-byte payload carries the axis, the

--- a/design/state-dependent-jumps.md
+++ b/design/state-dependent-jumps.md
@@ -291,7 +291,11 @@ Per instrument instruction:
   with the `SchrodingerState` intact. A new `resume(module, state, offset)`
   entry point continues execution; measurement records, detector/observable
   records, frame bits, gamma, and the RNG all already live in the state
-  object and survive the module switch.
+  object and survive the module switch. A continuation compiled with a
+  larger peak rank grows the state's amplitude array at that boundary —
+  the single sanctioned exception to the VM's allocate-once invariant,
+  host-side between dispatch entries, never inside a kernel; a driver
+  reusing one state across shots amortizes growth to the chain maximum.
 
 Dormant-random sites are handled per the damping policy (§4.6): under
 `exact`, the compiler emits an expansion before the instrument (the fused

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -38,11 +38,15 @@ enum class LostLeakedOpsPolicy : uint8_t {
 // back-action is genuinely non-Clifford (a source-dependent transition on
 // a dormant qubit with a random outcome). Exact expands the qubit into
 // the amplitude array (+1 to the circuit's k at that site) and applies
-// the damp there. Neglect keeps only the site's exact ingredients -- the
-// state-independent fire draw and the on-fire collapse -- and omits the
-// no-fire back-action, a pure survivorship tilt of order |p_g - p_e|
-// with no effect at all on source-independent sites. Sites where the
-// qubit is active or deterministic are exact under both settings.
+// the damp there. Neglect keeps the state-independent fire draw but makes
+// two approximations at such sites: it omits the no-fire back-action (a
+// pure survivorship tilt of order |p_g - p_e|, no effect at all on
+// source-independent rates), and on a leaked/lost fire it hands the
+// carrier over uncollapsed, so its unraveling in the continuation is
+// drawn independently of the reported source -- washing out correlations
+// between the fired qubit's entangled partners and its source-dependent
+// downstream effects. Sites where the qubit is active or deterministic
+// are exact under both settings.
 enum class DampingPolicy : uint8_t {
     Exact = 0,
     Neglect = 1,

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -38,15 +38,14 @@ enum class LostLeakedOpsPolicy : uint8_t {
 // back-action is genuinely non-Clifford (a source-dependent transition on
 // a dormant qubit with a random outcome). Exact expands the qubit into
 // the amplitude array (+1 to the circuit's k at that site) and applies
-// the damp there. Neglect keeps the state-independent fire draw but makes
-// two approximations at such sites: it omits the no-fire back-action (a
-// pure survivorship tilt of order |p_g - p_e|, no effect at all on
-// source-independent rates), and on a leaked/lost fire it hands the
-// carrier over uncollapsed, so its unraveling in the continuation is
-// drawn independently of the reported source -- washing out correlations
-// between the fired qubit's entangled partners and its source-dependent
-// downstream effects. Sites where the qubit is active or deterministic
-// are exact under both settings.
+// the damp there. Neglect keeps k stable by omitting the no-fire
+// back-action -- a pure survivorship tilt of order |p_g - p_e|, with no
+// effect at all on source-independent rates -- and that omission is its
+// only approximation. A leaked/lost fire at such a site traps with the
+// drawn source recorded, and the exact-mode driver's continuation
+// collapses the carrier onto that source (a trace-out forced to the
+// reported outcome), keeping fire-side correlations exact. Sites where
+// the qubit is active or deterministic are exact under both settings.
 enum class DampingPolicy : uint8_t {
     Exact = 0,
     Neglect = 1,

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -41,11 +41,13 @@ enum class LostLeakedOpsPolicy : uint8_t {
 // the damp there. Neglect keeps k stable by omitting the no-fire
 // back-action -- a pure survivorship tilt of order |p_g - p_e|, with no
 // effect at all on source-independent rates -- and that omission is its
-// only approximation. A leaked/lost fire at such a site traps with the
-// drawn source recorded, and the exact-mode driver's continuation
-// collapses the carrier onto that source (a trace-out forced to the
-// reported outcome), keeping fire-side correlations exact. Sites where
-// the qubit is active or deterministic are exact under both settings.
+// only approximation. Every fire at such a site traps with the drawn
+// source recorded and its destination still undrawn, and the exact-mode
+// driver's continuation collapses the carrier onto that source (a
+// trace-out forced to the reported outcome) before applying the drawn
+// destination's effects, keeping fire-side correlations exact. Sites
+// where the qubit is active or deterministic are exact under both
+// settings.
 enum class DampingPolicy : uint8_t {
     Exact = 0,
     Neglect = 1,

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -7,6 +7,7 @@
 #include <bit>
 #include <cctype>
 #include <cstdlib>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <string>
@@ -181,6 +182,24 @@ void resume(const CompiledModule& program, SchrodingerState& state, uint32_t off
         throw std::invalid_argument(
             "resume(): continuation module's detector/observable/exp-val counts do not match "
             "the state; the visible structure of a continuation must equal the original's");
+    }
+
+    // The only valid re-entry point is the instruction after the trapped
+    // site. A stale or miscomputed driver offset would silently skip or
+    // re-run bytecode, so it is rejected against the continuation's own
+    // offset table.
+    const uint32_t site_id = state.pending_trap->site_id;
+    if (site_id >= program.instrument_offsets.size() ||
+        program.instrument_offsets[site_id] == std::numeric_limits<uint32_t>::max()) {
+        throw std::invalid_argument(
+            "resume(): the continuation module has no instrument at the trapped site id " +
+            std::to_string(site_id) + "; its prefix does not match the executed module");
+    }
+    if (offset != program.instrument_offsets[site_id] + 1) {
+        throw std::invalid_argument("resume(): offset " + std::to_string(offset) +
+                                    " does not follow the trapped site (expected " +
+                                    std::to_string(program.instrument_offsets[site_id] + 1) +
+                                    " for site " + std::to_string(site_id) + ")");
     }
 
     // A suffix rewrite can raise the continuation's peak rank and its

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -165,6 +165,11 @@ void execute(const CompiledModule& program, SchrodingerState& state) {
 
 void resume(const CompiledModule& program, SchrodingerState& state, uint32_t offset) {
     assert_arena_widths_match(program.num_qubits, program.constant_pool);
+    if (!state.pending_trap.has_value()) {
+        throw std::invalid_argument(
+            "resume(): the state has no pending trap; resume() only continues a shot that "
+            "execute() halted at an instrument trap");
+    }
     if (program.num_qubits != state.num_qubits) {
         throw std::invalid_argument(
             "resume(): continuation module declares " + std::to_string(program.num_qubits) +
@@ -182,7 +187,7 @@ void resume(const CompiledModule& program, SchrodingerState& state, uint32_t off
     // hidden-measurement count beyond what the original module needed;
     // visible slots are layout-stable, so growth never disturbs written
     // records.
-    state.ensure_array_capacity(program.peak_rank);
+    state.grow_for_continuation(program.peak_rank);
     if (state.meas_record.size() < program.total_meas_slots) {
         state.meas_record.resize(program.total_meas_slots, 0);
     }
@@ -235,9 +240,8 @@ const char* svm_backend() {
 static void throw_on_pending_trap(const SchrodingerState& state) {
     if (state.pending_trap.has_value()) {
         throw std::runtime_error(
-            "a shot fired an instrument to a leaked/lost destination; instrument programs "
-            "require the exact-mode driver (execute/resume), not the plain sampling entry "
-            "points");
+            "a shot halted at a resumable instrument trap; instrument programs require the "
+            "exact-mode driver (execute/resume), not the plain sampling entry points");
     }
 }
 

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -18,15 +18,15 @@ namespace clifft {
 // =============================================================================
 
 namespace scalar {
-void execute_internal(const CompiledModule& program, SchrodingerState& state);
+void execute_internal(const CompiledModule& program, SchrodingerState& state, size_t start_offset);
 }  // namespace scalar
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
 namespace avx2 {
-void execute_internal(const CompiledModule& program, SchrodingerState& state);
+void execute_internal(const CompiledModule& program, SchrodingerState& state, size_t start_offset);
 }  // namespace avx2
 namespace avx512 {
-void execute_internal(const CompiledModule& program, SchrodingerState& state);
+void execute_internal(const CompiledModule& program, SchrodingerState& state, size_t start_offset);
 }  // namespace avx512
 #endif
 
@@ -34,7 +34,7 @@ void execute_internal(const CompiledModule& program, SchrodingerState& state);
 // CPUID Runtime Dispatcher
 // =============================================================================
 
-using DispatchFn = void (*)(const CompiledModule&, SchrodingerState&);
+using DispatchFn = void (*)(const CompiledModule&, SchrodingerState&, size_t);
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
 
@@ -77,21 +77,21 @@ static bool host_supports_avx512_kernel() {
 // first execute() call -- throwing during static init would terminate
 // the entire process (no Python catch is in scope yet) and turn a clear
 // runtime error into a hard crash at import.
-[[noreturn]] static void trap_force_isa_avx2(const CompiledModule&, SchrodingerState&) {
+[[noreturn]] static void trap_force_isa_avx2(const CompiledModule&, SchrodingerState&, size_t) {
     throw std::runtime_error(
         "CLIFFT_FORCE_ISA=avx2 requested but host CPU lacks one or more required "
         "features (avx2, bmi2, fma). Unset CLIFFT_FORCE_ISA to use the auto-detected "
         "fallback, or set it to 'scalar' explicitly.");
 }
 
-[[noreturn]] static void trap_force_isa_avx512(const CompiledModule&, SchrodingerState&) {
+[[noreturn]] static void trap_force_isa_avx512(const CompiledModule&, SchrodingerState&, size_t) {
     throw std::runtime_error(
         "CLIFFT_FORCE_ISA=avx512 requested but host CPU lacks one or more required "
         "features (avx2, bmi2, fma, avx512f, avx512dq). Unset CLIFFT_FORCE_ISA to use "
         "the auto-detected fallback, or set it to 'avx2' or 'scalar' explicitly.");
 }
 
-[[noreturn]] static void trap_force_isa_unknown(const CompiledModule&, SchrodingerState&) {
+[[noreturn]] static void trap_force_isa_unknown(const CompiledModule&, SchrodingerState&, size_t) {
     throw std::runtime_error(
         "CLIFFT_FORCE_ISA is set to an unrecognized value. Accepted values are "
         "'avx512', 'avx2', 'scalar' (case-insensitive). Unset CLIFFT_FORCE_ISA to "
@@ -157,9 +157,55 @@ static DispatchFn resolved_fn = resolve_dispatcher();
 
 void execute(const CompiledModule& program, SchrodingerState& state) {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    resolved_fn(program, state);
+    resolved_fn(program, state, 0);
 #else
-    scalar::execute_internal(program, state);
+    scalar::execute_internal(program, state, 0);
+#endif
+}
+
+void resume(const CompiledModule& program, SchrodingerState& state, uint32_t offset) {
+    assert_arena_widths_match(program.num_qubits, program.constant_pool);
+    if (program.num_qubits != state.num_qubits) {
+        throw std::invalid_argument(
+            "resume(): continuation module declares " + std::to_string(program.num_qubits) +
+            " qubits but the state was built for " + std::to_string(state.num_qubits));
+    }
+    if (program.num_detectors != state.det_record.size() ||
+        program.num_observables != state.obs_record.size() ||
+        program.num_exp_vals != state.exp_vals.size()) {
+        throw std::invalid_argument(
+            "resume(): continuation module's detector/observable/exp-val counts do not match "
+            "the state; the visible structure of a continuation must equal the original's");
+    }
+
+    // A suffix rewrite can raise the continuation's peak rank and its
+    // hidden-measurement count beyond what the original module needed;
+    // visible slots are layout-stable, so growth never disturbs written
+    // records.
+    state.ensure_array_capacity(program.peak_rank);
+    if (state.meas_record.size() < program.total_meas_slots) {
+        state.meas_record.resize(program.total_meas_slots, 0);
+    }
+
+    // Re-anchor the noise-gap cursor at the entry offset: position it on
+    // the first noise site at or after the offset and redraw the gap from
+    // that hazard base. Exact, because exponential gaps are memoryless.
+    state.next_noise_idx = static_cast<uint32_t>(program.constant_pool.noise_sites.size());
+    for (size_t i = offset; i < program.bytecode.size(); ++i) {
+        const Instruction& instr = program.bytecode[i];
+        if (instr.opcode == Opcode::OP_NOISE || instr.opcode == Opcode::OP_NOISE_BLOCK) {
+            state.next_noise_idx = instr.pauli.cp_mask_idx;
+            break;
+        }
+    }
+    state.draw_next_noise(program.constant_pool.noise_hazards);
+
+    state.pending_trap.reset();
+
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    resolved_fn(program, state, offset);
+#else
+    scalar::execute_internal(program, state, offset);
 #endif
 }
 
@@ -182,6 +228,17 @@ const char* svm_backend() {
         return "trap:unknown";
 #endif
     return "scalar";
+}
+
+// A shot that halts at an instrument trap has no complete record; the
+// plain sampling entry points do not implement the trap protocol.
+static void throw_on_pending_trap(const SchrodingerState& state) {
+    if (state.pending_trap.has_value()) {
+        throw std::runtime_error(
+            "a shot fired an instrument to a leaked/lost destination; instrument programs "
+            "require the exact-mode driver (execute/resume), not the plain sampling entry "
+            "points");
+    }
 }
 
 // =============================================================================
@@ -224,6 +281,7 @@ SampleResult sample(const CompiledModule& program, uint32_t shots, std::optional
         state.draw_next_noise(program.constant_pool.noise_hazards);
 
         execute(program, state);
+        throw_on_pending_trap(state);
 
         // Copy only visible measurements (first num_vis entries)
         std::copy(state.meas_record.begin(), state.meas_record.begin() + num_vis,
@@ -305,6 +363,7 @@ SurvivorResult sample_survivors(const CompiledModule& program, uint32_t shots,
         state.draw_next_noise(program.constant_pool.noise_hazards);
 
         execute(program, state);
+        throw_on_pending_trap(state);
 
         if (state.discarded) {
             continue;
@@ -605,6 +664,7 @@ SampleResult sample_k(const CompiledModule& program, uint32_t shots, uint32_t k,
 
         prepare_forced_shot(state, w, dp, k, n_q, uniform_mode, uniform_pool);
         execute(program, state);
+        throw_on_pending_trap(state);
 
         std::copy(state.meas_record.begin(), state.meas_record.begin() + num_vis,
                   result.measurements.begin() +
@@ -684,6 +744,7 @@ SurvivorResult sample_k_survivors(const CompiledModule& program, uint32_t shots,
 
         prepare_forced_shot(state, w, dp, k, n_q, uniform_mode, uniform_pool);
         execute(program, state);
+        throw_on_pending_trap(state);
 
         if (state.discarded)
             continue;

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -189,6 +189,15 @@ class SchrodingerState {
     void allocate_array(uint32_t peak_rank);
     void free_array() noexcept;
 
+    /// Grow the amplitude array to hold 2^peak_rank entries, preserving
+    /// the live 2^active_k amplitudes (the region above stays zero); no-op
+    /// when the allocation already suffices. This is the single sanctioned
+    /// exception to the allocate-once invariant, so it is reachable only
+    /// from resume(), only between dispatch entries, and only while a trap
+    /// is pending (asserted). Never shrinks.
+    void grow_for_continuation(uint32_t peak_rank);
+    friend void resume(const CompiledModule& program, SchrodingerState& state, uint32_t offset);
+
     std::complex<double> gamma_ = {1.0, 0.0};
     std::complex<double>* v_ = nullptr;  // page-aligned
     uint64_t array_size_ = 0;            // 2^peak_rank (allocated capacity)
@@ -206,7 +215,9 @@ class SchrodingerState {
 
     // --- Resumable trap state ---
     //
-    // Set when an instrument fires to a leaked or lost destination:
+    // Set when an instrument fire cannot be resolved in-line: any form
+    // firing to a leaked/lost destination, or any fire at a neglect-mode
+    // dormant-random site (whose collapse belongs to the continuation).
     // execute() halts at the site with the state intact (the carrier
     // already collapsed onto the drawn source where the form allows it)
     // and the host continues via resume() in a recompiled module. Dormant
@@ -214,15 +225,16 @@ class SchrodingerState {
     struct InstrumentTrap {
         uint32_t site_id = 0;  // CompiledInstrumentSite::site_id
         uint8_t source = 0;    // Drawn physical source level (0 = |0>)
+
+        // True at a neglect-form site: no destination has been drawn at
+        // all, so the host draws from the site's full column --
+        // computational destinations included -- and the continuation
+        // performs the collapse. False elsewhere: the destination class
+        // is already drawn as leaked/lost, and the host draws only which
+        // noncomputational level from the trap remainder.
+        bool destination_pending = false;
     };
     std::optional<InstrumentTrap> pending_trap;
-
-    /// Grow the amplitude array to hold 2^peak_rank entries, preserving
-    /// the live 2^active_k amplitudes (the region above stays zero). No-op
-    /// when the current allocation already suffices. Used by resume() when
-    /// a continuation module was compiled with a larger peak rank than the
-    /// module this state was built for.
-    void ensure_array_capacity(uint32_t peak_rank);
 
     // --- Forced-execution state ---
     //
@@ -249,20 +261,25 @@ class SchrodingerState {
 // =============================================================================
 
 /// Execute a compiled program for one shot, populating state with results.
-/// If an instrument fires to a leaked/lost destination, execution halts at
-/// the site with state.pending_trap set; continue via resume().
+/// If an instrument fire cannot be resolved in-line (a leaked/lost
+/// destination on any form, or any fire at a neglect-form site),
+/// execution halts at the site with state.pending_trap set; continue via
+/// resume().
 void execute(const CompiledModule& program, SchrodingerState& state);
 
 /// Continue a trapped shot in `program` starting at bytecode index
 /// `offset` (for a trap at site s, program.instrument_offsets[s] + 1).
-/// The program's bytecode before `offset` must be bit-identical to the
-/// code the state already executed -- the compiler's determinism plus the
-/// instrument barrier contract guarantee this for a recompiled
-/// continuation of the same circuit prefix. Clears pending_trap, grows
-/// the amplitude array and measurement-record buffer if the continuation
-/// needs more than the state was built with, and re-anchors the noise-gap
-/// cursor at the entry offset (exact, because exponential gaps are
-/// memoryless). May itself halt on a later trap.
+/// Requires state.pending_trap to be set and clears it. The program's
+/// bytecode before `offset` must be bit-identical to the code the state
+/// already executed -- the compiler's determinism plus the instrument
+/// barrier contract guarantee this for a recompiled continuation of the
+/// same circuit prefix. Grows the amplitude array and measurement-record
+/// buffer if the continuation needs more than the state was built with
+/// (the sanctioned trap-boundary exception to the allocate-once
+/// invariant; a driver reusing one state across shots amortizes growth to
+/// the chain maximum), and re-anchors the noise-gap cursor at the entry
+/// offset (exact, because exponential gaps are memoryless). May itself
+/// halt on a later trap.
 void resume(const CompiledModule& program, SchrodingerState& state, uint32_t offset);
 
 /// Return the name of the active SVM dispatch backend. Reflects the

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -184,6 +184,11 @@ class SchrodingerState {
     uint64_t dust_clamps = 0;
 
   private:
+    /// Allocate a zero-filled amplitude array for 2^peak_rank entries,
+    /// setting v_, array_size_, v_alloc_bytes_, v_is_mmap_, peak_rank_.
+    void allocate_array(uint32_t peak_rank);
+    void free_array() noexcept;
+
     std::complex<double> gamma_ = {1.0, 0.0};
     std::complex<double>* v_ = nullptr;  // page-aligned
     uint64_t array_size_ = 0;            // 2^peak_rank (allocated capacity)
@@ -198,6 +203,26 @@ class SchrodingerState {
   public:
     // Expectation value record: one double per EXP_VAL probe per shot.
     std::vector<double> exp_vals;
+
+    // --- Resumable trap state ---
+    //
+    // Set when an instrument fires to a leaked or lost destination:
+    // execute() halts at the site with the state intact (the carrier
+    // already collapsed onto the drawn source where the form allows it)
+    // and the host continues via resume() in a recompiled module. Dormant
+    // in ordinary sampling; reset() clears it.
+    struct InstrumentTrap {
+        uint32_t site_id = 0;  // CompiledInstrumentSite::site_id
+        uint8_t source = 0;    // Drawn physical source level (0 = |0>)
+    };
+    std::optional<InstrumentTrap> pending_trap;
+
+    /// Grow the amplitude array to hold 2^peak_rank entries, preserving
+    /// the live 2^active_k amplitudes (the region above stays zero). No-op
+    /// when the current allocation already suffices. Used by resume() when
+    /// a continuation module was compiled with a larger peak rank than the
+    /// module this state was built for.
+    void ensure_array_capacity(uint32_t peak_rank);
 
     // --- Forced-execution state ---
     //
@@ -224,7 +249,21 @@ class SchrodingerState {
 // =============================================================================
 
 /// Execute a compiled program for one shot, populating state with results.
+/// If an instrument fires to a leaked/lost destination, execution halts at
+/// the site with state.pending_trap set; continue via resume().
 void execute(const CompiledModule& program, SchrodingerState& state);
+
+/// Continue a trapped shot in `program` starting at bytecode index
+/// `offset` (for a trap at site s, program.instrument_offsets[s] + 1).
+/// The program's bytecode before `offset` must be bit-identical to the
+/// code the state already executed -- the compiler's determinism plus the
+/// instrument barrier contract guarantee this for a recompiled
+/// continuation of the same circuit prefix. Clears pending_trap, grows
+/// the amplitude array and measurement-record buffer if the continuation
+/// needs more than the state was built with, and re-anchors the noise-gap
+/// cursor at the entry offset (exact, because exponential gaps are
+/// memoryless). May itself halt on a later trap.
+void resume(const CompiledModule& program, SchrodingerState& state, uint32_t offset);
 
 /// Return the name of the active SVM dispatch backend. Reflects the
 /// resolved CPUID path or the CLIFFT_FORCE_ISA environment override.

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1996,8 +1996,9 @@ static inline int draw_instrument_destination(SchrodingerState& state,
 // circuit at source level under the now-known status, recompiles, and
 // resume()s past the site.
 static inline bool instrument_trap(SchrodingerState& state, const CompiledInstrumentSite& site,
-                                   uint8_t source) {
-    state.pending_trap = SchrodingerState::InstrumentTrap{site.site_id, source};
+                                   uint8_t source, bool destination_pending) {
+    state.pending_trap =
+        SchrodingerState::InstrumentTrap{site.site_id, source, destination_pending};
     return false;
 }
 
@@ -2010,11 +2011,12 @@ static inline void apply_instrument_fixup(SchrodingerState& state, const Constan
     apply_pauli_to_frame(state, mask.x(), mask.z(), mask.sign());
 }
 
-// Returns false when the shot halts at a resumable trap. On a fire to a
-// leaked/lost destination the carrier is collapsed onto the drawn source
-// *before* trapping wherever the form allows it, so the continuation's
-// trace-out measures an already-definite carrier and the unraveling stays
-// correlated with the reported source.
+// Returns false when the shot halts at a resumable trap: a fire to a
+// leaked/lost destination on any form, or any fire at a neglect-form
+// site. The carrier is collapsed onto the drawn source *before* trapping
+// wherever the form allows it, so the continuation's trace-out measures
+// an already-definite carrier and the unraveling stays correlated with
+// the reported source.
 static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& pool,
                                    const Instruction& instr) {
     const CompiledInstrumentSite& site = pool.instrument_sites[instr.instrument.cp_site_idx];
@@ -2031,7 +2033,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         if (dest < 0) {
             // The carrier is already definite at the source; no collapse
             // is needed before handing over.
-            return instrument_trap(state, site, source);
+            return instrument_trap(state, site, source, /*destination_pending=*/false);
         }
         if (dest != source) {
             apply_instrument_fixup(state, pool, site);
@@ -2055,7 +2057,8 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
             return true;
         }
         const double w = state.random_double() * mass;
-        return instrument_trap(state, site, w < site.p_total[0] ? 0 : 1);
+        return instrument_trap(state, site, w < site.p_total[0] ? 0 : 1,
+                               /*destination_pending=*/true);
     }
 
     // Active-array forms. The instruction's damp coefficients are
@@ -2102,7 +2105,8 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         exec_instrument_collapse_active(state, v, static_cast<uint8_t>(branch.source ^ sign),
                                         pops.pop_g + pops.pop_e);
         if (dest < 0) {
-            return instrument_trap(state, site, branch.source);
+            return instrument_trap(state, site, branch.source,
+                                   /*destination_pending=*/false);
         }
         if (dest != branch.source) {
             apply_instrument_fixup(state, pool, site);
@@ -2132,7 +2136,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
     const int dest = draw_instrument_destination(state, site, branch.source);
     exec_instrument_collapse_active(state, v, static_cast<uint8_t>(branch.source ^ sign), total);
     if (dest < 0) {
-        return instrument_trap(state, site, branch.source);
+        return instrument_trap(state, site, branch.source, /*destination_pending=*/false);
     }
     if (dest != branch.source) {
         apply_instrument_fixup(state, pool, site);

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -2045,10 +2045,11 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         // defining approximation is omitting the no-fire back-action.
         // Every fire traps: an in-line collapse would re-anchor the frame
         // conditionally, which compiled downstream code cannot account
-        // for. The carrier therefore hands over uncollapsed, and the
-        // continuation's trace-out draws its unraveling independently of
-        // the source reported here -- neglect's second approximation
-        // clause (see DampingPolicy in noncomp/policy.h).
+        // for. The carrier hands over uncollapsed with the drawn source
+        // recorded; the exact-mode driver's continuation performs the
+        // collapse as a trace-out forced to that source, keeping the
+        // fire-side correlations exact (see DampingPolicy in
+        // noncomp/policy.h).
         const double mass = site.p_total[0] + site.p_total[1];
         if (state.random_double() * 2.0 >= mass) {
             return true;

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1972,8 +1972,9 @@ static inline void exec_readout_noise(SchrodingerState& state, const ConstantPoo
 // the draw-free kernels from svm_instrument_kernels.h with the fire draws.
 // Physical source/destination indices (0 = |0> level) map to localized
 // levels through FLAG_SIGN here; the kernels handle p_x[v] themselves. A
-// leaked/lost destination is a resumable trap -- until the trap protocol
-// lands, it throws.
+// fire that cannot resolve in-line -- a leaked/lost destination on any
+// form, or any fire at a neglect-form site -- is a resumable trap: the
+// dispatch halts with state.pending_trap set.
 
 // Destination of a fire from physical source s: a computational level d
 // in {0, 1} with probability p_dest[s][d] / p_total[s] -- d != s is a

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1991,13 +1991,14 @@ static inline int draw_instrument_destination(SchrodingerState& state,
     return -1;
 }
 
-[[noreturn]] static inline void instrument_trap(const CompiledInstrumentSite& site,
-                                                uint8_t source) {
-    throw std::runtime_error("instrument site " + std::to_string(site.site_id) + " (circuit line " +
-                             std::to_string(site.source_line) + ") fired from source " +
-                             std::to_string(source) +
-                             " to a leaked/lost destination; resumable traps are not "
-                             "implemented yet");
+// Halt at a resumable trap: record the site and drawn source on the
+// state and stop the dispatch loop. The host rewrites the remaining
+// circuit at source level under the now-known status, recompiles, and
+// resume()s past the site.
+static inline bool instrument_trap(SchrodingerState& state, const CompiledInstrumentSite& site,
+                                   uint8_t source) {
+    state.pending_trap = SchrodingerState::InstrumentTrap{site.site_id, source};
+    return false;
 }
 
 // Destination fixup for an in-line computational fire whose destination
@@ -2009,7 +2010,12 @@ static inline void apply_instrument_fixup(SchrodingerState& state, const Constan
     apply_pauli_to_frame(state, mask.x(), mask.z(), mask.sign());
 }
 
-static inline void exec_instrument(SchrodingerState& state, const ConstantPool& pool,
+// Returns false when the shot halts at a resumable trap. On a fire to a
+// leaked/lost destination the carrier is collapsed onto the drawn source
+// *before* trapping wherever the form allows it, so the continuation's
+// trace-out measures an already-definite carrier and the unraveling stays
+// correlated with the reported source.
+static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& pool,
                                    const Instruction& instr) {
     const CompiledInstrumentSite& site = pool.instrument_sites[instr.instrument.cp_site_idx];
     const bool sign = (instr.flags & Instruction::FLAG_SIGN) != 0;
@@ -2019,16 +2025,18 @@ static inline void exec_instrument(SchrodingerState& state, const ConstantPool& 
         const auto source = static_cast<uint8_t>(static_cast<uint8_t>(bit_get(state.p_x, v)) ^
                                                  static_cast<uint8_t>(sign));
         if (state.random_double() >= site.p_total[source]) {
-            return;  // no fire; the definite-source damp is a scalar
+            return true;  // no fire; the definite-source damp is a scalar
         }
         const int dest = draw_instrument_destination(state, site, source);
         if (dest < 0) {
-            instrument_trap(site, source);
+            // The carrier is already definite at the source; no collapse
+            // is needed before handing over.
+            return instrument_trap(state, site, source);
         }
         if (dest != source) {
             apply_instrument_fixup(state, pool, site);
         }
-        return;
+        return true;
     }
 
     if (instr.opcode == Opcode::OP_INSTRUMENT_DORMANT_NEGLECT) {
@@ -2037,13 +2045,16 @@ static inline void exec_instrument(SchrodingerState& state, const ConstantPool& 
         // defining approximation is omitting the no-fire back-action.
         // Every fire traps: an in-line collapse would re-anchor the frame
         // conditionally, which compiled downstream code cannot account
-        // for; the source draw (weights p_g : p_e) rides along.
+        // for. The carrier therefore hands over uncollapsed, and the
+        // continuation's trace-out draws its unraveling independently of
+        // the source reported here -- neglect's second approximation
+        // clause (see DampingPolicy in noncomp/policy.h).
         const double mass = site.p_total[0] + site.p_total[1];
         if (state.random_double() * 2.0 >= mass) {
-            return;
+            return true;
         }
         const double w = state.random_double() * mass;
-        instrument_trap(site, w < site.p_total[0] ? 0 : 1);
+        return instrument_trap(state, site, w < site.p_total[0] ? 0 : 1);
     }
 
     // Active-array forms. The instruction's damp coefficients are
@@ -2078,23 +2089,24 @@ static inline void exec_instrument(SchrodingerState& state, const ConstantPool& 
                 exec_instrument_collapse_active(state, v, static_cast<uint8_t>(survivor ^ sign),
                                                 pops.pop_g + pops.pop_e);
             }
-            return;
+            return true;
         }
         const int dest = draw_instrument_destination(state, site, branch.source);
-        if (dest < 0) {
-            instrument_trap(site, branch.source);
-        }
         // Materialize the expansion the compiled layout expects, then
         // collapse onto the source: the eval-only-plus-collapse recipe,
-        // exact for every rate.
+        // exact for every rate, on the trap path as much as the in-line
+        // one.
         exec_instrument_expand_damp(state, v, 1.0, 1.0);
         const InstrumentPopulations pops = exec_instrument_damp_eval(state, v, 1.0, 1.0);
         exec_instrument_collapse_active(state, v, static_cast<uint8_t>(branch.source ^ sign),
                                         pops.pop_g + pops.pop_e);
+        if (dest < 0) {
+            return instrument_trap(state, site, branch.source);
+        }
         if (dest != branch.source) {
             apply_instrument_fixup(state, pool, site);
         }
-        return;
+        return true;
     }
 
     // OP_INSTRUMENT_ACTIVE
@@ -2114,16 +2126,17 @@ static inline void exec_instrument(SchrodingerState& state, const ConstantPool& 
             const uint8_t survivor = site.p_total[0] >= 1.0 ? 1 : 0;
             exec_instrument_collapse_active(state, v, static_cast<uint8_t>(survivor ^ sign), total);
         }
-        return;
+        return true;
     }
     const int dest = draw_instrument_destination(state, site, branch.source);
-    if (dest < 0) {
-        instrument_trap(site, branch.source);
-    }
     exec_instrument_collapse_active(state, v, static_cast<uint8_t>(branch.source ^ sign), total);
+    if (dest < 0) {
+        return instrument_trap(state, site, branch.source);
+    }
     if (dest != branch.source) {
         apply_instrument_fixup(state, pool, site);
     }
+    return true;
 }
 
 // DETECTOR: computes the XOR parity of a list of measurement record entries.
@@ -2346,12 +2359,12 @@ exec_exp_val(SchrodingerState& state, const ConstantPool& pool, uint32_t cp_exp_
 // SVM Execution
 // =============================================================================
 
-void execute_internal(const CompiledModule& program, SchrodingerState& state);
+void execute_internal(const CompiledModule& program, SchrodingerState& state, size_t start_offset);
 
-void execute_internal(const CompiledModule& program, SchrodingerState& state) {
+void execute_internal(const CompiledModule& program, SchrodingerState& state, size_t start_offset) {
     assert(program.peak_rank < 64 && "peak_rank >= 64 would cause UB in bit shifts");
 
-    if (program.bytecode.empty()) {
+    if (start_offset >= program.bytecode.size()) {
         return;
     }
 
@@ -2427,8 +2440,8 @@ void execute_internal(const CompiledModule& program, SchrodingerState& state) {
         [static_cast<uint8_t>(Opcode::OP_EXP_VAL)] = &&L_OP_EXP_VAL,
     };
 
-    const Instruction* pc = program.bytecode.data();
-    const Instruction* end = pc + program.bytecode.size();
+    const Instruction* pc = program.bytecode.data() + start_offset;
+    const Instruction* end = program.bytecode.data() + program.bytecode.size();
 
 #define DISPATCH()                                              \
     do {                                                        \
@@ -2597,7 +2610,9 @@ L_OP_EXP_VAL:
     DISPATCH();
 
 L_OP_INSTRUMENT:
-    exec_instrument(state, program.constant_pool, *pc);
+    if (!exec_instrument(state, program.constant_pool, *pc)) {
+        return;  // resumable trap: state.pending_trap is set
+    }
     DISPATCH();
 
 L_OP_MEAS_DORMANT_STATIC_FORCED: {
@@ -2645,7 +2660,8 @@ L_OP_SWAP_MEAS_INTERFERE_FORCED:
 #undef DISPATCH
 #else
     // Fallback standard C++ switch loop for MSVC and non-GNU compilers
-    for (const auto& instr : program.bytecode) {
+    for (size_t instr_idx = start_offset; instr_idx < program.bytecode.size(); ++instr_idx) {
+        const auto& instr = program.bytecode[instr_idx];
         switch (instr.opcode) {
             case Opcode::OP_FRAME_CNOT:
                 exec_frame_cnot(state, instr.axis_1, instr.axis_2);
@@ -2822,7 +2838,9 @@ L_OP_SWAP_MEAS_INTERFERE_FORCED:
             case Opcode::OP_INSTRUMENT_DORMANT_STATIC:
             case Opcode::OP_INSTRUMENT_EXPAND:
             case Opcode::OP_INSTRUMENT_DORMANT_NEGLECT:
-                exec_instrument(state, program.constant_pool, instr);
+                if (!exec_instrument(state, program.constant_pool, instr)) {
+                    return;  // resumable trap: state.pending_trap is set
+                }
                 break;
         }
     }

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -125,7 +125,9 @@ void SchrodingerState::free_array() noexcept {
     aligned_free_portable(v_);
 }
 
-void SchrodingerState::ensure_array_capacity(uint32_t peak_rank) {
+void SchrodingerState::grow_for_continuation(uint32_t peak_rank) {
+    assert(pending_trap.has_value() &&
+           "the amplitude array may grow only at the trap boundary, under a pending trap");
     if (peak_rank >= 63) {
         throw std::invalid_argument(
             "peak_rank >= 63 would cause undefined behavior in 1ULL << peak_rank");

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -42,6 +42,14 @@ SchrodingerState::SchrodingerState(StateConfig cfg) : peak_rank_(cfg.peak_rank),
     p_x.assign(num_words, 0);
     p_z.assign(num_words, 0);
 
+    allocate_array(peak_rank);
+    v_[0] = {1.0, 0.0};
+}
+
+void SchrodingerState::allocate_array(uint32_t peak_rank) {
+    peak_rank_ = peak_rank;
+    v_ = nullptr;
+    v_is_mmap_ = false;
     array_size_ = 1ULL << peak_rank;
     size_t bytes = array_size_ * sizeof(std::complex<double>);
     // Round up to page boundary for mmap/aligned_alloc compatibility.
@@ -105,10 +113,9 @@ SchrodingerState::SchrodingerState(StateConfig cfg) : peak_rank_(cfg.peak_rank),
             }
         }
     }
-    v_[0] = {1.0, 0.0};
 }
 
-SchrodingerState::~SchrodingerState() {
+void SchrodingerState::free_array() noexcept {
 #if defined(__linux__)
     if (v_is_mmap_) {
         munmap(v_, v_alloc_bytes_);
@@ -116,6 +123,39 @@ SchrodingerState::~SchrodingerState() {
     }
 #endif
     aligned_free_portable(v_);
+}
+
+void SchrodingerState::ensure_array_capacity(uint32_t peak_rank) {
+    if (peak_rank >= 63) {
+        throw std::invalid_argument(
+            "peak_rank >= 63 would cause undefined behavior in 1ULL << peak_rank");
+    }
+    if ((1ULL << peak_rank) <= array_size_) {
+        return;
+    }
+
+    std::complex<double>* old_v = v_;
+    const size_t old_bytes = v_alloc_bytes_;
+    const bool old_mmap = v_is_mmap_;
+    const uint64_t live = v_size();
+
+    allocate_array(peak_rank);
+    std::memcpy(v_, old_v, live * sizeof(std::complex<double>));
+
+#if defined(__linux__)
+    if (old_mmap) {
+        munmap(old_v, old_bytes);
+    } else {
+        aligned_free_portable(old_v);
+    }
+#else
+    (void)old_bytes;
+    aligned_free_portable(old_v);
+#endif
+}
+
+SchrodingerState::~SchrodingerState() {
+    free_array();
 }
 
 SchrodingerState::SchrodingerState(SchrodingerState&& other) noexcept
@@ -139,6 +179,7 @@ SchrodingerState::SchrodingerState(SchrodingerState&& other) noexcept
       v_is_mmap_(other.v_is_mmap_),
       rng_(std::move(other.rng_)),
       exp_vals(std::move(other.exp_vals)),
+      pending_trap(other.pending_trap),
       forced_record(other.forced_record),
       forced_log_probability(other.forced_log_probability),
       forced_reachable(other.forced_reachable) {
@@ -148,6 +189,7 @@ SchrodingerState::SchrodingerState(SchrodingerState&& other) noexcept
     other.v_is_mmap_ = false;
     other.active_k = 0;
     other.peak_rank_ = 0;
+    other.pending_trap.reset();
     other.forced_record = {};
     other.forced_log_probability = 0.0;
     other.forced_reachable = true;
@@ -184,6 +226,7 @@ SchrodingerState& SchrodingerState::operator=(SchrodingerState&& other) noexcept
         det_record = std::move(other.det_record);
         obs_record = std::move(other.obs_record);
         exp_vals = std::move(other.exp_vals);
+        pending_trap = other.pending_trap;
         forced_record = other.forced_record;
         forced_log_probability = other.forced_log_probability;
         forced_reachable = other.forced_reachable;
@@ -193,6 +236,7 @@ SchrodingerState& SchrodingerState::operator=(SchrodingerState&& other) noexcept
         other.v_is_mmap_ = false;
         other.active_k = 0;
         other.peak_rank_ = 0;
+        other.pending_trap.reset();
         other.forced_record = {};
         other.forced_log_probability = 0.0;
         other.forced_reachable = true;
@@ -219,14 +263,16 @@ void SchrodingerState::reset() {
     gamma_ = {1.0, 0.0};
     active_k = 0;
 
-    // If the previous shot was discarded by OP_POSTSELECT, the bytecode
-    // loop exited early, leaving meas_record and det_record with stale
-    // data from the aborted shot. Zero them out to avoid garbage.
-    if (discarded) {
+    // If the previous shot was discarded by OP_POSTSELECT or halted at a
+    // resumable trap, the bytecode loop exited early, leaving meas_record
+    // and det_record with stale data from the aborted shot. Zero them out
+    // to avoid garbage.
+    if (discarded || pending_trap.has_value()) {
         std::fill(meas_record.begin(), meas_record.end(), 0);
         std::fill(det_record.begin(), det_record.end(), 0);
     }
     discarded = false;
+    pending_trap.reset();
 
     // obs_record uses ^= accumulation and must always be cleared.
     std::fill(obs_record.begin(), obs_record.end(), 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(clifft_tests
     test_frontend_instruments.cc
     test_backend_instruments.cc
     test_execute_instruments.cc
+    test_trap_resume.cc
     test_backend.cc
     test_svm.cc
     test_state_reset.cc

--- a/tests/test_execute_instruments.cc
+++ b/tests/test_execute_instruments.cc
@@ -74,9 +74,8 @@ std::vector<uint8_t> run_shot(const CompiledModule& module, uint64_t seed) {
 // probe, a trapped shot returns nullopt.
 std::optional<double> run_shot_exp_val(const CompiledModule& module, uint64_t seed) {
     auto state = make_shot_state(module, seed);
-    try {
-        execute(module, state);
-    } catch (const std::runtime_error&) {
+    execute(module, state);
+    if (state.pending_trap.has_value()) {
         return std::nullopt;
     }
     return state.exp_vals.at(0);
@@ -156,18 +155,17 @@ TEST_CASE("execute: the no-fire path of a weak site leaves a definite carrier al
     REQUIRE(ones > 30);  // p = 0.05: overwhelmingly no-fire
 }
 
-TEST_CASE("execute: a leaked/lost fire names the site and line in the trap error") {
+TEST_CASE("execute: a leaked/lost fire halts with the trap recorded") {
     InstrumentTraceOptions options;  // LOSS needs no spec
     auto module = compile_raw("H 1\nLOSS(1.0) 0\nM 0", options);
 
-    SchrodingerState state(StateConfig{.peak_rank = module.peak_rank,
-                                       .num_measurements = module.total_meas_slots,
-                                       .num_qubits = module.num_qubits,
-                                       .seed = 7});
-    REQUIRE_THROWS_WITH(execute(module, state),
-                        ContainsSubstring("instrument site 0") &&
-                            ContainsSubstring("circuit line 2") &&
-                            ContainsSubstring("resumable traps are not implemented yet"));
+    auto state = make_shot_state(module, /*seed=*/7);
+    execute(module, state);
+
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.pending_trap->site_id == 0);
+    // The measurement after the site never ran.
+    REQUIRE(state.meas_record == std::vector<uint8_t>{0});
 }
 
 TEST_CASE("execute: the no-fire back-action matches its closed form through the pipeline") {
@@ -295,15 +293,12 @@ TEST_CASE("execute: a neglect-mode dormant-random site is silent until it fires"
     int traps = 0;
     int completed = 0;
     for (uint64_t seed = 1; seed <= 40; ++seed) {
-        SchrodingerState state(StateConfig{.peak_rank = module.peak_rank,
-                                           .num_measurements = module.total_meas_slots,
-                                           .num_qubits = module.num_qubits,
-                                           .seed = seed});
-        try {
-            execute(module, state);
-            ++completed;
-        } catch (const std::runtime_error&) {
+        auto state = make_shot_state(module, seed);
+        execute(module, state);
+        if (state.pending_trap.has_value()) {
             ++traps;
+        } else {
+            ++completed;
         }
     }
     REQUIRE(traps > 0);

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -1,0 +1,256 @@
+// Trap and resume: the runtime half of the exact-jump protocol.
+//
+// execute() halts at a leaked/lost instrument fire with state.pending_trap
+// set and the carrier collapsed onto the drawn source wherever the form
+// allows; resume() continues the state in a (possibly different) module at
+// a bytecode offset, growing the amplitude array and record buffer when
+// the continuation needs more, and re-anchoring the noise-gap cursor at
+// the entry offset. The orchestrator driver and continuation cache are a
+// separate step; these tests hand-build their continuations, leaning on
+// the prefix-identity contract that makes cross-module re-entry sound.
+
+#include "clifft/backend/backend.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/svm/svm.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cmath>
+#include <complex>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+// A transition whose entire fire mass is leaked/lost, with per-source
+// rates (p_g, p_e).
+InstrumentSpec leak(double p_g, double p_e) {
+    InstrumentSpec spec;
+    spec.p_total[0] = p_g;
+    spec.p_total[1] = p_e;
+    return spec;
+}
+
+CompiledModule compile_raw(const char* text, const InstrumentTraceOptions& options) {
+    auto hir = trace(parse(text), &options);
+    return lower(hir);
+}
+
+SchrodingerState make_shot_state(const CompiledModule& module, uint64_t seed) {
+    return SchrodingerState(StateConfig{.peak_rank = module.peak_rank,
+                                        .num_measurements = module.total_meas_slots,
+                                        .num_qubits = module.num_qubits,
+                                        .num_detectors = module.num_detectors,
+                                        .num_observables = module.num_observables,
+                                        .num_exp_vals = module.num_exp_vals,
+                                        .seed = seed});
+}
+
+// Resume a trapped state past its trap site in `continuation`.
+void resume_past_trap(const CompiledModule& continuation, SchrodingerState& state) {
+    REQUIRE(state.pending_trap.has_value());
+    const uint32_t offset = continuation.instrument_offsets.at(state.pending_trap->site_id);
+    resume(continuation, state, offset + 1);
+}
+
+}  // namespace
+
+TEST_CASE("trap+resume: a spectator loss resumes in the same module and completes") {
+    // The lost qubit has no downstream operations, so the original module
+    // is its own valid continuation. H;T ... T_DAG;H on qubit 0 composes
+    // to the identity: the record is deterministically 0, trap or no trap.
+    InstrumentTraceOptions options;
+    auto module = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nM 0", options);
+
+    for (uint64_t seed = 1; seed <= 20; ++seed) {
+        auto state = make_shot_state(module, seed);
+        execute(module, state);
+
+        REQUIRE(state.pending_trap.has_value());
+        REQUIRE(state.pending_trap->site_id == 0);
+
+        resume_past_trap(module, state);
+        REQUIRE(!state.pending_trap.has_value());
+        REQUIRE(state.meas_record == std::vector<uint8_t>{0});
+    }
+}
+
+TEST_CASE("trap+resume: the continuation's suffix governs the outcome") {
+    // Two modules share the trapping prefix bit-for-bit (the barrier
+    // contract); their suffixes differ. Resuming the same trapped state
+    // into each must produce that module's suffix behavior: the original
+    // undoes the H (measures 0), the continuation adds an X (measures 1).
+    InstrumentTraceOptions options;
+    auto original = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nM 0", options);
+    auto continuation = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nX 0\nM 0", options);
+
+    const uint32_t offset = original.instrument_offsets.at(0);
+    REQUIRE(continuation.instrument_offsets.at(0) == offset);
+    for (uint32_t i = 0; i <= offset; ++i) {
+        REQUIRE(std::memcmp(&original.bytecode[i], &continuation.bytecode[i],
+                            sizeof(Instruction)) == 0);
+    }
+
+    for (uint64_t seed = 1; seed <= 10; ++seed) {
+        auto state = make_shot_state(original, seed);
+        execute(original, state);
+        REQUIRE(state.pending_trap.has_value());
+        resume_past_trap(continuation, state);
+        REQUIRE(state.meas_record == std::vector<uint8_t>{1});
+    }
+}
+
+TEST_CASE("trap+resume: an active-site trap hands over a collapsed carrier") {
+    // A certain leak on an active superposed qubit: the fire draws a
+    // source from the populations, and the carrier must arrive at the
+    // trap collapsed onto exactly that source -- the discarded half is
+    // zero and the surviving half matches the reported source.
+    InstrumentTraceOptions options;
+    options.transitions.emplace("leak", leak(1.0, 1.0));
+    auto module = compile_raw("H 0\nT 0\nLEVEL_TRANSITION[leak] 0\nM 0", options);
+
+    bool saw_g = false;
+    bool saw_e = false;
+    for (uint64_t seed = 1; seed <= 30; ++seed) {
+        auto state = make_shot_state(module, seed);
+        execute(module, state);
+
+        REQUIRE(state.pending_trap.has_value());
+        const uint8_t source = state.pending_trap->source;
+        (source == 0 ? saw_g : saw_e) = true;
+
+        // Axis 0 is the active axis; with no localization sign or frame
+        // bit in play here, array half `source` survives.
+        REQUIRE(state.active_k == 1);
+        const std::complex<double> discarded = state.v()[1 - source];
+        REQUIRE(discarded == std::complex<double>{0.0, 0.0});
+        REQUIRE(std::abs(state.v()[source]) > 0.5);
+    }
+    REQUIRE(saw_g);
+    REQUIRE(saw_e);
+}
+
+TEST_CASE("trap+resume: the record buffer grows for a continuation with more hidden slots") {
+    // The continuation replaces the suffix with one containing a reset,
+    // whose lowering adds a hidden measurement slot beyond what the
+    // original module allocated. Visible slots stay layout-stable.
+    InstrumentTraceOptions options;
+    auto original = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nM 0", options);
+    auto continuation = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nR 1\nM 0", options);
+    REQUIRE(continuation.total_meas_slots > original.total_meas_slots);
+
+    auto state = make_shot_state(original, /*seed=*/5);
+    execute(original, state);
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.meas_record.size() == original.total_meas_slots);
+
+    resume_past_trap(continuation, state);
+    REQUIRE(state.meas_record.size() == continuation.total_meas_slots);
+    REQUIRE(state.meas_record.at(0) == 0);  // H;T;T_DAG;H = identity
+}
+
+TEST_CASE("trap+resume: the amplitude array grows for a higher-rank continuation") {
+    // The original needs k = 0; the continuation's suffix activates two
+    // qubits (k = 2), exceeding the state's original allocation.
+    InstrumentTraceOptions options;
+    auto original = compile_raw("LOSS(1.0) 2\nM 0", options);
+    auto continuation = compile_raw("LOSS(1.0) 2\nH 0\nT 0\nH 1\nT 1\nCX 0 1\nM 0\nM 1", options);
+    REQUIRE(original.peak_rank == 0);
+    REQUIRE(continuation.peak_rank == 2);
+    REQUIRE(continuation.num_measurements == original.num_measurements + 1);
+
+    auto state = make_shot_state(original, /*seed=*/3);
+    execute(original, state);
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.array_size() == 1);
+
+    // The continuation also carries one more visible measurement, so
+    // grow the record buffer expectation accordingly.
+    resume_past_trap(continuation, state);
+    REQUIRE(state.array_size() >= 4);
+    REQUIRE(!state.pending_trap.has_value());
+    REQUIRE(state.meas_record.size() == continuation.total_meas_slots);
+}
+
+TEST_CASE("trap+resume: suffix noise fires after re-anchoring, prefix noise does not refire") {
+    // Both errors are certain (p = 1). The prefix error flips qubit 0
+    // before the trap; the suffix error flips it again after resume. A
+    // broken cursor either refires the prefix site (record 0) or skips
+    // the suffix site (record 0); only fire-each-exactly-once gives 0
+    // flipped twice -- M reads 0 -- wait: two X flips restore |0>, so the
+    // deterministic record is 0, and a single miss or double-fire yields
+    // 1 instead.
+    InstrumentTraceOptions options;
+    auto module = compile_raw("X_ERROR(1) 0\nLOSS(1.0) 1\nX_ERROR(1) 0\nM 0", options);
+
+    for (uint64_t seed = 1; seed <= 10; ++seed) {
+        auto state = make_shot_state(module, seed);
+        // Mirror sample()'s per-shot noise-cursor setup.
+        state.next_noise_idx = 0;
+        state.draw_next_noise(module.constant_pool.noise_hazards);
+
+        execute(module, state);
+        REQUIRE(state.pending_trap.has_value());
+
+        resume_past_trap(module, state);
+        REQUIRE(state.meas_record == std::vector<uint8_t>{0});
+    }
+}
+
+TEST_CASE("trap+resume: a chain of traps resumes one site at a time") {
+    InstrumentTraceOptions options;
+    auto module = compile_raw("LOSS(1.0) 1\nX 0\nLOSS(1.0) 2\nX 0\nM 0", options);
+
+    auto state = make_shot_state(module, /*seed=*/11);
+    execute(module, state);
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.pending_trap->site_id == 0);
+
+    resume_past_trap(module, state);
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.pending_trap->site_id == 1);
+
+    resume_past_trap(module, state);
+    REQUIRE(!state.pending_trap.has_value());
+    REQUIRE(state.meas_record == std::vector<uint8_t>{0});  // X twice
+}
+
+TEST_CASE("trap+resume: reset clears a pending trap and its partial records") {
+    InstrumentTraceOptions options;
+    auto module = compile_raw("X 0\nM 0\nLOSS(1.0) 1\nM 0", options);
+
+    auto state = make_shot_state(module, /*seed=*/2);
+    execute(module, state);
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.meas_record.at(0) == 1);  // written before the trap
+
+    state.reset();
+    REQUIRE(!state.pending_trap.has_value());
+    REQUIRE(state.meas_record.at(0) == 0);
+}
+
+TEST_CASE("trap+resume: plain sampling rejects a shot that traps") {
+    InstrumentTraceOptions options;
+    auto module = compile_raw("LOSS(1.0) 0\nM 0", options);
+    REQUIRE_THROWS_WITH(sample(module, /*shots=*/4, /*seed=*/9),
+                        ContainsSubstring("exact-mode driver"));
+}
+
+TEST_CASE("trap+resume: resume validates the handoff") {
+    InstrumentTraceOptions options;
+    auto module = compile_raw("LOSS(1.0) 0\nM 0", options);
+    auto other_qubits = compile_raw("LOSS(1.0) 0\nM 0\nM 1", options);
+
+    auto state = make_shot_state(module, /*seed=*/4);
+    execute(module, state);
+    REQUIRE(state.pending_trap.has_value());
+
+    REQUIRE_THROWS_WITH(resume(other_qubits, state, 1), ContainsSubstring("qubits"));
+}

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -113,6 +113,27 @@ TEST_CASE("trap+resume: resume refuses a state with no pending trap") {
     REQUIRE_THROWS_WITH(resume(module, state, 1), ContainsSubstring("no pending trap"));
 }
 
+TEST_CASE("trap+resume: resume rejects an offset that does not follow the trapped site") {
+    // A stale or miscomputed driver offset must not silently skip or
+    // re-run bytecode; only the instruction after the trapped site is a
+    // valid entry. Rejected attempts leave the trap pending, so the
+    // correct offset still works afterward.
+    InstrumentTraceOptions options;
+    auto module = compile_raw("LOSS(1.0) 0\nX 0\nM 0", options);
+    auto state = make_shot_state(module, /*seed=*/12);
+    execute(module, state);
+    REQUIRE(state.pending_trap.has_value());
+
+    const uint32_t good = module.instrument_offsets.at(0) + 1;
+    REQUIRE_THROWS_WITH(resume(module, state, good + 1), ContainsSubstring("does not follow"));
+    REQUIRE_THROWS_WITH(resume(module, state, good - 1), ContainsSubstring("does not follow"));
+    REQUIRE(state.pending_trap.has_value());
+
+    resume(module, state, good);
+    REQUIRE(!state.pending_trap.has_value());
+    REQUIRE(state.meas_record == std::vector<uint8_t>{1});
+}
+
 TEST_CASE("trap+resume: the continuation's suffix governs the outcome") {
     // Two modules share the trapping prefix bit-for-bit (the barrier
     // contract); their suffixes differ. Resuming the same trapped state

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -75,11 +75,42 @@ TEST_CASE("trap+resume: a spectator loss resumes in the same module and complete
 
         REQUIRE(state.pending_trap.has_value());
         REQUIRE(state.pending_trap->site_id == 0);
+        // The destination class is already drawn (leaked/lost); only the
+        // level within the trap remainder is the host's to pick.
+        REQUIRE(!state.pending_trap->destination_pending);
 
         resume_past_trap(module, state);
         REQUIRE(!state.pending_trap.has_value());
         REQUIRE(state.meas_record == std::vector<uint8_t>{0});
     }
+}
+
+TEST_CASE("trap+resume: a neglect-form trap reports its destination as pending") {
+    InstrumentTraceOptions options;
+    options.transitions.emplace("jump", [] {
+        InstrumentSpec spec;
+        spec.p_total[0] = 1.0;
+        spec.p_total[1] = 1.0;
+        spec.p_dest[0][1] = 0.5;  // half the column is computational:
+        spec.p_dest[1][0] = 0.5;  // the host must draw over all of it
+        return spec;
+    }());
+    options.neglect_damping = true;
+
+    auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0\nM 0", options);
+    auto state = make_shot_state(module, /*seed=*/6);
+    execute(module, state);
+
+    REQUIRE(state.pending_trap.has_value());
+    REQUIRE(state.pending_trap->destination_pending);
+    REQUIRE(state.active_k == 0);  // no expansion, carrier untouched
+}
+
+TEST_CASE("trap+resume: resume refuses a state with no pending trap") {
+    InstrumentTraceOptions options;
+    auto module = compile_raw("LOSS(1.0) 0\nM 0", options);
+    auto state = make_shot_state(module, /*seed=*/8);
+    REQUIRE_THROWS_WITH(resume(module, state, 1), ContainsSubstring("no pending trap"));
 }
 
 TEST_CASE("trap+resume: the continuation's suffix governs the outcome") {


### PR DESCRIPTION
> **Prototype note:** this PR targets the `codex/noncomputational-structural-mvp` feature branch (not `main`) and is part of the in-progress noncomputational MVP; a less strict review bar applies.

Step 5 of the exact state-dependent jumps plan (`design/state-dependent-jumps.md` §6): the trap return path and `resume()`. The orchestrator driver and continuation cache are step 6; everything here is exercisable with hand-built continuations.

## The trap

A leaked/lost instrument fire now **halts instead of throwing**: `execute()` returns with `state.pending_trap = {site_id, source}`, following the codebase's halt precedents (postselect's `discarded`, the forced path's early return). `exec_instrument` returns `bool` like the forced kernels; both dispatch paths early-return; `reset()` clears the trap and its partial records.

**Collapse before handover** (§4.4): on the active and expand forms the carrier collapses onto the drawn source *before* trapping — so the continuation's trace-out measures an already-definite carrier and the unraveling stays exactly correlated with the reported source. The dormant-deterministic form needs no collapse. The one form that can't collapse in-line (neglect-mode dormant-random, same virtual-H obstruction as step 4) hands the carrier over uncollapsed **with the drawn source recorded** — and per the review discussion, that costs no correlation: the step-6 driver's continuation will perform the collapse as a trace-out *forced to the reported source* (past the trap the continuation is fire-branch-only, so the conditional convention shift becomes unconditional). `policy.h` and the design note state that contract; neglect's only approximation is the omitted no-fire back-action, and exact mode (the default) has none.

## Resume

`resume(program, state, offset)` continues a trapped shot in a recompiled continuation, entering the shared per-ISA dispatch at `offset` (the caller passes `instrument_offsets[site] + 1`):

- **Handoff validation**: qubit count and detector/observable/exp-val structure must match (visible structure is rewrite-invariant); violations throw.
- **Growth**: a suffix rewrite can raise the continuation's `peak_rank` (new `ensure_array_capacity`, preserving the live `2^k` amplitudes) and its hidden-measurement count (`meas_record` grows; visible slots are layout-stable, so written records are undisturbed).
- **Noise-gap re-anchor**: the cursor lands on the first noise site at or after the entry offset and the exponential gap redraws from that hazard base — exact, because exponential gaps are memoryless.
- The plain sampling entry points (`sample`, `sample_survivors`, `sample_k`, `sample_k_survivors`) now **reject shots that trap** with a pointer to the exact-mode driver, instead of silently emitting a half-executed record.

## Tests

10 new cases (`test_trap_resume.cc`) plus the step-4 throw pins converted to trap assertions: a deterministic same-module spectator-loss round trip; **cross-module resume** where the continuation's differing suffix governs the outcome (with the shared prefix byte-compared, leaning on the barrier contract); the collapsed-carrier handoff (discarded half exactly zero, surviving half matches the reported source, both sources observed across seeds); both growth paths; **exactly-once noise firing across the trap boundary** (certain errors on both sides of the site — a cursor that refires the prefix or skips the suffix flips the deterministic record); a two-trap chain; reset hygiene; and the sampling-entry-point rejection.

**Verified**: Debug **1081** + Release **1081** (`~[bench]`) green; wasm module builds clean in the emsdk image (the per-ISA dispatch signature changed); pre-commit `--all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Contract update** (`d5f47c0`): external review overturned the two-clause neglect contract — the trap boundary makes the basis-convention shift unconditional in the continuation, so the fire-side correlation is restorable without expansion. The driver (step 6) will emit the leaked qubit's trace-out as a hidden measurement **forced to the trap's reported source**; a bare frame anchor at trap time would be wrong (after `H`, anchoring the dormant representation to `|s⟩` yields the physical state `H|s⟩`). `policy.h`, the design note §4.4, and the dispatch comment now state the target contract; runtime behavior is unchanged in this PR.


**Review round** (`374325c`): the two findings. **[P1]** The allocate-once invariant is now refined explicitly instead of silently violated: `AGENTS.md` names the single sanctioned exception — `resume()` may grow (never shrink) the array *between* dispatch entries for a larger-peak continuation; no allocation ever happens inside the dispatch or a kernel. The code enforces the boundary structurally: the growth method is private and reachable only through `resume()` (friend), asserts a pending trap, and `resume()` refuses an untrapped state. Rationale for growth over up-front sizing: continuations are compiled lazily, so no chain bound exists short of 2^n; a driver reusing one state across shots amortizes growth to the chain maximum. **[P2]** `pending_trap` gains **`destination_pending`** — true at neglect-form sites (no destination drawn at all; the host draws over the full column, computational destinations included), false elsewhere (class already drawn as leaked/lost; only the level within the remainder remains) — with the `execute()`/sampling wording generalized to match, and pins for both values. Debug **1083** + Release **1083** green.


**Review round two** (`904efef`): **[P2]** `resume()` now validates the re-entry offset against the continuation's own offset table — anything other than the-instruction-after-the-trapped-site is rejected (with a distinct error when the table has no entry for the trapped site id, i.e. a prefix mismatch), and rejected attempts leave the trap pending, so a corrected offset still works. Previously a stale driver offset silently skipped/re-ran bytecode, and one past EOF cleared the trap and returned as if completed. **[P3]** Scrubbed the two stale contract sentences (dispatch banner "throws"; policy.h "leaked/lost fire at such a site"). Debug **1084** + Release **1084** green.
