### PR TITLE
docs(design): driver pseudocode branches on destination_pending

### DIFF
--- a/design/state-dependent-jumps.md
+++ b/design/state-dependent-jumps.md
@@ -339,16 +339,21 @@ main = cache.main_line(model)                 # compiled once per model
 for shot:
     state = init(shot_seed)
     preload initial computational levels       # Pauli-frame preload, no recompile
-    result = execute(main, state)
-    while result is Trap(site, source):
-        dest    = draw destination from column(source)          # host RNG
+    execute(main, state)
+    while state.pending_trap is Trap(site, source, destination_pending):
+        if destination_pending:                # neglect-form site: the VM drew
+            dest = draw from column(source)    #   nothing; full column, computational
+        else:                                  #   destinations included (host RNG)
+            dest = draw from trap remainder    # class already drawn leaked/lost; only
+                   of column(source)           #   the level remains (host RNG)
         events  = sample classical-source follow-ons (seepage,  # host RNG,
                   restore) over the remaining ops               # existing sampler
         key     = (site, dest, events)
         module, offset = cache.get_or_compile(key)
             # rewrite(circuit, statuses) on ops after site  — existing rewriter:
-            # drops, trace-out R, carrier materialization, classifier handling
-        result = resume(module, state, offset)
+            # drops, trace-out R (forced to `source` at a neglect-form site),
+            # carrier materialization, classifier handling
+        resume(module, state, offset)          # offset follows the trapped site
     emit records + status sidecar (from the trap chain)
 ```
 


### PR DESCRIPTION
> **Prototype note:** this PR targets the `codex/noncomputational-structural-mvp` feature branch (not `main`); a less strict review bar applies.

Docs-only follow-up to #171, closing the review's remaining P3: the §4.5 driver pseudocode still drew the destination from the full column for **every** trap, which is only correct when the trap reports `destination_pending` (a neglect-form site, where the VM drew nothing). For the other forms the destination class is already drawn as leaked/lost and the host draws **only the level within the trap remainder** — drawing the full column there could select a computational destination after the VM already trapped.

The pseudocode now carries `destination_pending` and branches on it, matches the shipped `state.pending_trap` protocol (no return-value `Trap`), notes the forced-to-source trace-out on the rewrite line, and marks the resume offset as following the trapped site. This is the reference the step-6 driver PR will be written against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
