### PR TITLE
feat(noncomp): exact-mode driver, continuation cache, and correlated neglect

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(clifft_core STATIC
     noncomp/op_role.cc
     noncomp/sampler.cc
     noncomp/rewriter.cc
+    noncomp/exact_driver.cc
     noncomp/orchestrator.cc
 )
 

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -765,8 +765,14 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     site.neglect_damping = instruments->neglect_damping;
                     if (node.gate == GateType::LOSS) {
                         // Uniform loss: source-independent rate, destination
-                        // entirely the trap remainder.
-                        const double p = node.args.empty() ? 0.0 : node.args[0];
+                        // entirely the trap remainder. A missing argument is
+                        // a malformed node, not a zero-probability loss.
+                        if (node.args.size() != 1) {
+                            throw std::runtime_error(
+                                "trace: LOSS at line " + std::to_string(node.source_line) +
+                                " requires exactly one argument (the loss probability)");
+                        }
+                        const double p = node.args[0];
                         site.p_total[0] = p;
                         site.p_total[1] = p;
                     } else {

--- a/src/clifft/noncomp/classifier.h
+++ b/src/clifft/noncomp/classifier.h
@@ -10,6 +10,12 @@
 // a qubit at this level should produce, and the sampler raises
 // instead of silently picking a bit.
 //
+// Symbol indices are positional: index 0 and 1 are the recorded
+// measurement bit, and an optional third symbol (kHeraldSymbol) is the
+// herald -- "this readout is ambiguous", reported in the per-shot
+// herald sidecar rather than the record. The sampling paths accept
+// exactly two or three symbols and always read index 2 as the herald.
+//
 // Construction binds the classifier to a LevelSet so the per-level
 // column count matches the level table.
 
@@ -35,8 +41,15 @@ class MeasurementClassifier {
                                              std::vector<std::vector<double>> matrix,
                                              const LevelSet& levels);
 
+    // The positional index of the herald symbol, when one is present.
+    static constexpr uint8_t kHeraldSymbol = 2;
+
     size_t num_symbols() const { return symbols_.size(); }
     size_t num_levels() const { return reject_probs_.size(); }
+
+    // True when a third, herald symbol is present (see kHeraldSymbol).
+    bool has_herald() const { return symbols_.size() == 3; }
+
     const std::string& symbol_label(uint8_t symbol_idx) const;
 
     // P(symbol | level). Throws on out-of-range indices.

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -2,47 +2,44 @@
 // design/state-dependent-jumps.md holds the full design. The vocabulary
 // used throughout this file:
 //
-//   annotation   A LEVEL_TRANSITION[name] or LOSS(p) node in the user's
-//                circuit: the level-transition channel a physical
-//                operation applies to each of its qubits.
-//   target       One (op_index, qubit) pair of an annotation; a node
-//                with n qubit operands is n targets.
-//   consult      One target's per-shot draw against its channel: did it
-//                fire, and to which destination level. A *classical*
-//                consult is one whose qubit's level is definite at that
-//                point (known computational, leaked, or lost), so the
-//                driver draws it without touching quantum state.
-//   fire / jump  A consult that moved the qubit to another level.
-//   site         A target kept as a runtime INSTRUMENT barrier in the
-//                compiled module, consulted in-line by the VM;
-//                trace()'s materialization order assigns site ids.
-//   trap         A fire the VM cannot resolve in-line -- the qubit's
-//                level is not definite there -- so execution stops at
-//                the site and control returns to the driver.
-//   carrier      The simulated qubit cell that keeps holding a
-//                noncomputational population's correlations while the
-//                status ledger tracks its level classically.
-//   continuation The circuit rewritten under a shot's events (initial
-//                statuses, jumps so far, pre-drawn classical outcomes)
-//                and recompiled whole; execution resumes past the
-//                trapped site, the prefix guaranteed identical to what
-//                the shot already ran.
-//   main line    The continuation of "nothing happened": every shot
-//                starts in it unless an initial level is
-//                noncomputational.
-//   forced twin  The forced-outcome variant of a sampling measurement
-//                opcode: same record slot, outcome read from
-//                state.forced_record instead of drawn. Collapses a
-//                neglect-form trap's carrier to the source the trap
-//                reported.
-//   sidecar      The per-shot herald record: one flag per visible
-//                measurement slot, set when a ternary classifier drew
-//                its "ambiguous" symbol for that slot.
-//   driver draw  Randomness this file consumes between VM runs
-//                (initial levels, trap destinations, classical
-//                consults, herald flags): one stream per shot, every
-//                draw ordered before any cache lookup. The VM's own
-//                Born randomness is the separate SVM stream (seed.h).
+//   annotation         A LEVEL_TRANSITION[name] or LOSS(p) node in the
+//                      user's circuit: the level-transition channel a
+//                      physical operation applies to each of its qubits.
+//   annotation target  One (op_index, qubit) pair of an annotation; a
+//                      node with n qubit operands is n annotation
+//                      targets. (Bare "Target" is the AST operand type.)
+//   consult            One annotation target's per-shot draw against its
+//                      channel: did it fire, and to which destination
+//                      level. A *classical* consult is one whose qubit's
+//                      level is definite at that point (known
+//                      computational, leaked, or lost), so the driver
+//                      draws it without touching quantum state.
+//   fire               A consult that moves the qubit to another level:
+//                      the stochastic event itself.
+//   jump               A recorded fire -- the ResolvedJump entry in a
+//                      shot's events.
+//   site               An annotation target kept as a runtime INSTRUMENT
+//                      barrier in the compiled module, consulted in-line
+//                      by the VM; trace()'s materialization order
+//                      assigns site ids.
+//   trap               A fire the VM cannot resolve in-line -- the
+//                      qubit's level is not definite there -- so
+//                      execution stops at the site and control returns
+//                      to the driver.
+//   carrier            The simulated qubit cell that keeps holding a
+//                      noncomputational population's correlations while
+//                      the status ledger tracks its level classically.
+//   continuation       The circuit rewritten under a shot's events
+//                      (initial statuses, jumps so far, pre-drawn
+//                      classical outcomes) and recompiled whole;
+//                      execution resumes past the trapped site, the
+//                      prefix guaranteed identical to what the shot
+//                      already ran.
+//
+// The driver's own randomness (initial levels, trap destinations,
+// classical consults, herald flags) is one per-shot stream, every draw
+// ordered before any cache lookup; the VM's Born randomness is the
+// separate SVM stream (seed.h).
 
 #include "clifft/noncomp/exact_driver.h"
 
@@ -392,9 +389,10 @@ std::vector<uint32_t> record_sequence(const HirModule& hir) {
 }
 #endif
 
-// The forced-outcome twin of a sampling measurement opcode, or
-// NUM_OPCODES when the opcode is not a sampling measurement.
-Opcode forced_twin(Opcode op) {
+// The forced-outcome variant of a sampling measurement opcode -- same
+// record slot, outcome read from state.forced_record instead of drawn
+// -- or NUM_OPCODES when the opcode is not a sampling measurement.
+Opcode forced_opcode(Opcode op) {
     switch (op) {
         case Opcode::OP_MEAS_DORMANT_STATIC:
             return Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
@@ -411,7 +409,8 @@ Opcode forced_twin(Opcode op) {
     }
 }
 
-// Swap the trace-out's hidden measurement at `slot` to its forced twin,
+// Swap the trace-out's hidden measurement at `slot` to its forced
+// opcode,
 // so resume() collapses the trapped carrier to the source the trap
 // reported (read from state.forced_record[slot]) instead of redrawing.
 // Slot indices ride inside instruction payloads and are never renumbered
@@ -419,12 +418,12 @@ Opcode forced_twin(Opcode op) {
 void swap_traceout_to_forced(CompiledModule& module, size_t slot) {
     size_t found = 0;
     for (Instruction& instr : module.bytecode) {
-        const Opcode twin = forced_twin(instr.opcode);
-        if (twin == Opcode::NUM_OPCODES) {
+        const Opcode forced = forced_opcode(instr.opcode);
+        if (forced == Opcode::NUM_OPCODES) {
             continue;
         }
         if (instr.classical.classical_idx == slot) {
-            instr.opcode = twin;
+            instr.opcode = forced;
             ++found;
         }
     }
@@ -442,7 +441,7 @@ bool equal_modulo_forced_swap(const Instruction& fresh, const Instruction& execu
     if (std::memcmp(&fresh, &executed, sizeof(Instruction)) == 0) {
         return true;
     }
-    if (forced_twin(fresh.opcode) != executed.opcode) {
+    if (forced_opcode(fresh.opcode) != executed.opcode) {
         return false;
     }
     Instruction swapped = fresh;
@@ -471,6 +470,20 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     const bool ternary = classifier != nullptr && classifier->has_herald();
 
     const Circuit annotated = annotate(circuit, model);
+
+    // Validate every annotation up front -- tag resolution, LOSS shape --
+    // so a malformed node fails here, deterministically, rather than on
+    // whichever shot first traps or consults it classically: a live site
+    // rides through the rewrite verbatim, and trace() must never be the
+    // first to look at its arguments.
+    for (uint32_t op_index = 0; op_index < static_cast<uint32_t>(annotated.nodes.size());
+         ++op_index) {
+        const AstNode& node = annotated.nodes[op_index];
+        if (node.gate == GateType::LEVEL_TRANSITION || node.gate == GateType::LOSS) {
+            resolve_annotation(node, model, op_index);
+        }
+    }
+
     const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
 
     std::map<std::string, ContinuationEntry> cache;

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -10,6 +10,7 @@
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
 #include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/pass_registry.h"
 #include "clifft/svm/svm.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/xoshiro.h"
@@ -21,6 +22,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace clifft {
@@ -267,6 +269,83 @@ void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_ra
         "; consider damping=\"neglect\" for high-rate sites or a larger max_rank");
 }
 
+// The exact-mode HIR pipeline: the defaults minus the statevector
+// squeeze. Squeeze reorders commuting measurements, which is
+// exchangeable under sampling semantics but not once a continuation's
+// trace-out is forced -- an entangled partner must not measure before
+// the forced collapse it is correlated with. One pipeline serves every
+// module in the mode, so prefix identity is preserved; the squeezed
+// rank compaction is a performance loss the validation campaign's
+// table will quantify.
+HirPassManager exact_hir_pass_manager() {
+    HirPassManager pm;
+    for (const auto& info : kRegisteredPasses) {
+        if (info.kind == PassKind::HIR && info.default_enabled &&
+            std::string_view(info.name) != "StatevectorSqueezePass") {
+            pm.add_pass(info.make_hir());
+        }
+    }
+    return pm;
+}
+
+// The forced-outcome twin of a sampling measurement opcode, or
+// NUM_OPCODES when the opcode is not a sampling measurement.
+Opcode forced_twin(Opcode op) {
+    switch (op) {
+        case Opcode::OP_MEAS_DORMANT_STATIC:
+            return Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
+        case Opcode::OP_MEAS_DORMANT_RANDOM:
+            return Opcode::OP_MEAS_DORMANT_RANDOM_FORCED;
+        case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
+            return Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED;
+        case Opcode::OP_MEAS_ACTIVE_INTERFERE:
+            return Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED;
+        case Opcode::OP_SWAP_MEAS_INTERFERE:
+            return Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;
+        default:
+            return Opcode::NUM_OPCODES;
+    }
+}
+
+// Swap the trace-out's hidden measurement at `slot` to its forced twin,
+// so resume() collapses the trapped carrier to the source the trap
+// reported (read from state.forced_record[slot]) instead of redrawing.
+// Slot indices ride inside instruction payloads and are never renumbered
+// by bytecode passes, so the slot is the durable identity here.
+void swap_traceout_to_forced(CompiledModule& module, size_t slot) {
+    size_t found = 0;
+    for (Instruction& instr : module.bytecode) {
+        const Opcode twin = forced_twin(instr.opcode);
+        if (twin == Opcode::NUM_OPCODES) {
+            continue;
+        }
+        if (instr.classical.classical_idx == slot) {
+            instr.opcode = twin;
+            ++found;
+        }
+    }
+    if (found != 1) {
+        throw std::logic_error("sample_noncomputational: the forced trace-out slot matched " +
+                               std::to_string(found) +
+                               " measurement instructions; expected exactly one");
+    }
+}
+
+// Instructions equal up to the sampling <-> forced opcode swap: the one
+// sanctioned prefix difference between a continuation's fresh compile and
+// the executed module it must otherwise match byte for byte.
+bool equal_modulo_forced_swap(const Instruction& fresh, const Instruction& executed) {
+    if (std::memcmp(&fresh, &executed, sizeof(Instruction)) == 0) {
+        return true;
+    }
+    if (forced_twin(fresh.opcode) != executed.opcode) {
+        return false;
+    }
+    Instruction swapped = fresh;
+    swapped.opcode = executed.opcode;
+    return std::memcmp(&swapped, &executed, sizeof(Instruction)) == 0;
+}
+
 }  // namespace
 
 NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
@@ -326,10 +405,13 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                 }
             }
             HirModule hir = trace(patched, &instrument_options);
-            default_hir_pass_manager().run(hir);
+            exact_hir_pass_manager().run(hir);
             CompiledModule module = lower(hir);
             default_bytecode_pass_manager().run(module);
             check_max_rank(module, max_rank);
+            if (entry.rw.forced_traceout_slot != SIZE_MAX) {
+                swap_traceout_to_forced(module, entry.rw.forced_traceout_slot);
+            }
 #ifndef NDEBUG
             // Re-entry contract: the continuation's prefix must be
             // bit-identical to the code the shot already executed. A
@@ -339,8 +421,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                 assert(prefix_end <= module.bytecode.size() &&
                        prefix_end <= executed_prefix_module->bytecode.size());
                 for (uint32_t i = 0; i < prefix_end; ++i) {
-                    assert(std::memcmp(&module.bytecode[i], &executed_prefix_module->bytecode[i],
-                                       sizeof(Instruction)) == 0 &&
+                    assert(equal_modulo_forced_swap(module.bytecode[i],
+                                                    executed_prefix_module->bytecode[i]) &&
                            "continuation prefix diverged from the executed module");
                 }
             }
@@ -390,6 +472,11 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             const QubitStatusKind kind = events.initial_status.back().kind();
             any_noncomp_initial |= kind == QubitStatusKind::Leaked || kind == QubitStatusKind::Lost;
         }
+
+        // Forced-outcome buffer for neglect-form trace-outs, one entry
+        // per hidden slot the chain forces; reset() clears the state's
+        // span each shot.
+        std::vector<uint8_t> forced_buffer;
 
         // Herald flags accumulate per visible slot across the shot's
         // trap chain: a slot's flag is drawn once, when its classified
@@ -459,22 +546,19 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             const AstNode& node = annotated.nodes[op_index];
             const AnnotationChannel channel = resolve_annotation(node, model, op_index);
 
-            // The correlated continuation for a neglect-form trap (the
-            // forced-to-source trace-out) is not wired yet; the guard
-            // keeps the decorrelated behavior from running silently.
-            if (trap.destination_pending) {
-                throw std::invalid_argument(
-                    "sample_noncomputational: a neglect-form site fired; the correlated "
-                    "continuation for damping=\"neglect\" is not wired yet -- use "
-                    "damping=\"exact\" (the default)");
-            }
-
-            // Destination: the class is already drawn as leaked/lost, so
-            // only the level within the trap remainder remains. (A
-            // pending destination would draw over the full column.)
+            // Destination: at a neglect-form site nothing was drawn, so
+            // the host draws over the full column (computational
+            // destinations included); elsewhere the class is already
+            // leaked/lost and only the level within the trap remainder
+            // remains.
             uint8_t dest;
             if (channel.instrument == nullptr) {
                 dest = channel.lost_level;
+            } else if (trap.destination_pending) {
+                const double total = channel.instrument->column_sum(trap.source);
+                dest = draw_from_column(
+                    *channel.instrument, trap.source, total, host_rng, [](uint8_t) { return true; },
+                    levels.size());
             } else {
                 double remainder = 0.0;
                 for (uint8_t to = 0; to < levels.size(); ++to) {
@@ -493,10 +577,26 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             events.jumps.push_back({op_index, qubit, dest});
             final_status = extend_classical_outcomes(annotated, events, model, host_rng);
 
+            // A neglect-form trap hands its carrier over uncollapsed; the
+            // continuation's trace-out is forced to the reported source,
+            // read from forced_record at the slot the rewrite names. The
+            // forced value is per-shot runtime state, so the module stays
+            // source-independent.
+            const bool force = trap.destination_pending;
             const uint32_t prefix_end = module->instrument_offsets[trap.site_id] + 1;
-            ContinuationEntry& next_entry = get_entry(events, false);
+            ContinuationEntry& next_entry = get_entry(events, force);
             CompiledModule* next_module =
                 get_module(next_entry, flags_for(next_entry.rw), module, prefix_end);
+
+            if (force) {
+                const size_t slot = next_entry.rw.forced_traceout_slot;
+                if (forced_buffer.size() <= slot) {
+                    forced_buffer.resize(slot + 1, 0);
+                }
+                forced_buffer[slot] = trap.source;
+                // The span must be re-pointed after any resize.
+                state.forced_record = forced_buffer;
+            }
 
             entry = &next_entry;
             module = next_module;

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -93,7 +93,7 @@ AnnotationChannel resolve_annotation(const AstNode& node, const NonComputational
                 "sample_noncomputational: LOSS at op " + std::to_string(op_index) +
                 " requires a level table with exactly one Lost-category level");
         }
-        channel.loss_p = node.args.empty() ? 0.0 : node.args[0];
+        channel.loss_p = loss_probability(node.args, op_index, "sample_noncomputational");
         channel.lost_level = *lost;
         return channel;
     }
@@ -121,6 +121,14 @@ uint8_t draw_from_column(const TransitionInstrument& instrument, uint8_t source,
         if (admit(to)) {
             mass += instrument.prob(to, source);
         }
+    }
+    if (!(mass > 0.0)) {
+        // Unreachable through the current call sites, all of which fire
+        // only when the column's admitted mass is positive; a real error
+        // beats a Release-mode draw of level 255 surfacing downstream.
+        throw std::logic_error(
+            "sample_noncomputational: destination draw over an empty column (source level " +
+            std::to_string(source) + ")");
     }
     const double u = rng.next_double() * mass;
     double acc = 0.0;
@@ -192,6 +200,14 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                 }
                 const auto seen = drawn.find({op_index, qubit});
                 if (seen != drawn.end()) {
+                    if (seen->second.source_level != pre.level_id()) {
+                        throw std::logic_error(
+                            "sample_noncomputational: classical outcome reuse at op " +
+                            std::to_string(op_index) + ", qubit " + std::to_string(qubit) +
+                            " crossed a source-level change (drawn at level " +
+                            std::to_string(seen->second.source_level) + ", walk holds level " +
+                            std::to_string(pre.level_id()) + ")");
+                    }
                     ordered.push_back(seen->second);
                     if (seen->second.jumped) {
                         status[qubit] = levels.status_for(seen->second.destination_level);
@@ -199,7 +215,7 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                     continue;
                 }
                 const AnnotationChannel channel = resolve_annotation(node, model, op_index);
-                ClassicalOutcome outcome{op_index, qubit, false, 0};
+                ClassicalOutcome outcome{op_index, qubit, false, 0, pre.level_id()};
                 if (channel.instrument != nullptr) {
                     const uint8_t source = pre.level_id();
                     const double total = channel.instrument->column_sum(source);
@@ -252,7 +268,7 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
 // share one module.
 std::string cache_key(const ExactShotEvents& events, const LevelSet& levels) {
     std::string key;
-    key.reserve(events.initial_status.size() + events.jumps.size() * 9 +
+    key.reserve(events.initial_status.size() * 2 + 10 + events.jumps.size() * 9 +
                 events.classical_outcomes.size() * 10);
     for (const QubitStatus& s : events.initial_status) {
         key.push_back(static_cast<char>(s.kind()));
@@ -266,13 +282,18 @@ std::string cache_key(const ExactShotEvents& events, const LevelSet& levels) {
             key.push_back(static_cast<char>((v >> (8 * b)) & 0xFF));
         }
     };
+    // Each variable-length section is count-prefixed, so equal keys mean
+    // equal events by construction: the fixed-size records cannot be
+    // reparsed across a section boundary. The markers are readability.
     key.push_back('J');
+    push32(static_cast<uint32_t>(events.jumps.size()));
     for (const ResolvedJump& jump : events.jumps) {
         push32(jump.op_index);
         push32(jump.qubit);
         key.push_back(static_cast<char>(jump.destination_level));
     }
     key.push_back('C');
+    push32(static_cast<uint32_t>(events.classical_outcomes.size()));
     for (const ClassicalOutcome& outcome : events.classical_outcomes) {
         push32(outcome.op_index);
         push32(outcome.qubit);
@@ -447,7 +468,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
 
     const LevelSet& levels = model.levels();
     const MeasurementClassifier* classifier = model.classifier();
-    const bool ternary = classifier != nullptr && classifier->num_symbols() == 3;
+    const bool ternary = classifier != nullptr && classifier->has_herald();
 
     const Circuit annotated = annotate(circuit, model);
     const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
@@ -578,7 +599,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             for (const ClassifiedMeasurement& m : rw.classified_measurements) {
                 auto [it, inserted] = herald_flags.try_emplace(m.slot, 0);
                 if (inserted && ternary) {
-                    const double p_herald = classifier->prob(2, m.level);
+                    const double p_herald =
+                        classifier->prob(MeasurementClassifier::kHeraldSymbol, m.level);
                     it->second = driver_rng.next_double() < p_herald ? 1 : 0;
                 }
                 flags.push_back(it->second);

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -101,12 +101,19 @@ uint8_t draw_from_column(const TransitionInstrument& instrument, uint8_t source,
     return static_cast<uint8_t>(last_positive);
 }
 
-// Walk the annotated circuit's statuses under `events`, drawing and
-// appending any classical-source consult beyond the ones already
-// recorded. Returns the walk's final statuses (computed from the real,
-// uncanonicalized initials). The walk is the single source of truth for
-// which consults are classical, so the events stream always matches what
-// rewrite_continuation will validate.
+// Walk the annotated circuit's statuses under `events` and rebuild the
+// classical-outcome stream in the walk's own (circuit) order: outcomes
+// already drawn for a consult are reused by annotation target, and
+// consults seen for the first time are drawn. Rebuilding rather than
+// appending matters after a trap, which turns the trapped qubit's later
+// consults classical *between* previously recorded ones -- an
+// append-only stream would replay old outcomes at the wrong targets.
+// Reused outcomes keep the executed prefix's compilation stable;
+// first-seen consults live only in the not-yet-executed suffix, so a
+// fresh draw is unbiased. Returns the walk's final statuses (computed
+// from the real, uncanonicalized initials). The walk is the single
+// source of truth for which consults are classical, so the events
+// stream always matches what rewrite_continuation will validate.
 std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                                                    ExactShotEvents& events,
                                                    const NonComputationalModel& model,
@@ -117,8 +124,14 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
         jump_dest.emplace(std::make_pair(jump.op_index, jump.qubit), jump.destination_level);
     }
 
+    std::map<std::pair<uint32_t, uint32_t>, ClassicalOutcome> drawn;
+    for (const ClassicalOutcome& outcome : events.classical_outcomes) {
+        drawn.emplace(std::make_pair(outcome.op_index, outcome.qubit), outcome);
+    }
+    std::vector<ClassicalOutcome> ordered;
+    ordered.reserve(events.classical_outcomes.size());
+
     std::vector<QubitStatus> status = events.initial_status;
-    size_t cursor = 0;
 
     for (uint32_t op_index = 0; op_index < annotated.nodes.size(); ++op_index) {
         const AstNode& node = annotated.nodes[op_index];
@@ -136,14 +149,11 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                     }
                     continue;
                 }
-                if (cursor < events.classical_outcomes.size()) {
-                    // Already drawn when an earlier trap extended the
-                    // stream; replay it.
-                    const ClassicalOutcome& outcome = events.classical_outcomes[cursor++];
-                    assert(outcome.op_index == op_index && outcome.qubit == qubit &&
-                           "recorded classical outcomes drifted from the status walk");
-                    if (outcome.jumped) {
-                        status[qubit] = levels.status_for(outcome.destination_level);
+                const auto seen = drawn.find({op_index, qubit});
+                if (seen != drawn.end()) {
+                    ordered.push_back(seen->second);
+                    if (seen->second.jumped) {
+                        status[qubit] = levels.status_for(seen->second.destination_level);
                     }
                     continue;
                 }
@@ -166,8 +176,7 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                     outcome.jumped = true;
                     outcome.destination_level = channel.lost_level;
                 }
-                ++cursor;
-                events.classical_outcomes.push_back(outcome);
+                ordered.push_back(outcome);
                 if (outcome.jumped) {
                     status[qubit] = levels.status_for(outcome.destination_level);
                 }
@@ -191,6 +200,7 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                         : normal_post_op_status(pre, gate, operand.role, model.policy(), levels);
         }
     }
+    events.classical_outcomes = std::move(ordered);
     return status;
 }
 

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -1,3 +1,49 @@
+// Exact-mode driver implementation. exact_driver.h is the entry point;
+// design/state-dependent-jumps.md holds the full design. The vocabulary
+// used throughout this file:
+//
+//   annotation   A LEVEL_TRANSITION[name] or LOSS(p) node in the user's
+//                circuit: the level-transition channel a physical
+//                operation applies to each of its qubits.
+//   target       One (op_index, qubit) pair of an annotation; a node
+//                with n qubit operands is n targets.
+//   consult      One target's per-shot draw against its channel: did it
+//                fire, and to which destination level. A *classical*
+//                consult is one whose qubit's level is definite at that
+//                point (known computational, leaked, or lost), so the
+//                driver draws it without touching quantum state.
+//   fire / jump  A consult that moved the qubit to another level.
+//   site         A target kept as a runtime INSTRUMENT barrier in the
+//                compiled module, consulted in-line by the VM;
+//                trace()'s materialization order assigns site ids.
+//   trap         A fire the VM cannot resolve in-line -- the qubit's
+//                level is not definite there -- so execution stops at
+//                the site and control returns to the driver.
+//   carrier      The simulated qubit cell that keeps holding a
+//                noncomputational population's correlations while the
+//                status ledger tracks its level classically.
+//   continuation The circuit rewritten under a shot's events (initial
+//                statuses, jumps so far, pre-drawn classical outcomes)
+//                and recompiled whole; execution resumes past the
+//                trapped site, the prefix guaranteed identical to what
+//                the shot already ran.
+//   main line    The continuation of "nothing happened": every shot
+//                starts in it unless an initial level is
+//                noncomputational.
+//   forced twin  The forced-outcome variant of a sampling measurement
+//                opcode: same record slot, outcome read from
+//                state.forced_record instead of drawn. Collapses a
+//                neglect-form trap's carrier to the source the trap
+//                reported.
+//   sidecar      The per-shot herald record: one flag per visible
+//                measurement slot, set when a ternary classifier drew
+//                its "ambiguous" symbol for that slot.
+//   driver draw  Randomness this file consumes between VM runs
+//                (initial levels, trap destinations, classical
+//                consults, herald flags): one stream per shot, every
+//                draw ordered before any cache lookup. The VM's own
+//                Born randomness is the separate SVM stream (seed.h).
+
 #include "clifft/noncomp/exact_driver.h"
 
 #include "clifft/backend/backend.h"
@@ -7,9 +53,10 @@
 #include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/sampler.h"
+#include "clifft/noncomp/seed.h"
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
-#include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_registry.h"
 #include "clifft/svm/svm.h"
 #include "clifft/svm/svm_math.h"
@@ -22,27 +69,11 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace clifft {
 
 namespace {
-
-// Domain tags for the per-shot sub-seeds, disjoint from the AOT
-// orchestrator's history/classifier/SVM tags so the two modes never
-// correlate. One host stream serves every host-side draw in a shot
-// (initial levels, trap destinations, classical follow-ons, herald
-// flags), in a deterministic order that never depends on cache state.
-constexpr uint64_t kExactHostDomain = 0x11;
-constexpr uint64_t kExactSvmDomain = 0x12;
-
-uint64_t derive_exact_seed(uint64_t global, uint64_t shot, uint64_t domain) {
-    uint64_t z = global ^ (shot * 0x9E3779B97F4A7C15ULL) ^ (domain * 0xBF58476D1CE4E5B9ULL);
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
-    return z ^ (z >> 31);
-}
 
 // The transition consulted by one annotation node: a named instrument for
 // LEVEL_TRANSITION, a uniform all-lost rate for LOSS.
@@ -75,12 +106,22 @@ AnnotationChannel resolve_annotation(const AstNode& node, const NonComputational
     return channel;
 }
 
-// Draw a destination level from `column` restricted to `mass` (the sum of
-// the admitted entries), with the measurement kernels' last-positive
-// fallback for the floating-point tail. `admit` filters levels.
+// Draw a destination level from `source`'s column of the instrument,
+// restricted to the levels `admit` accepts. `admit` is a pure
+// level_id -> bool predicate naming which destinations participate; the
+// draw normalizes over the admitted entries' own mass, summed here so a
+// caller cannot supply a mismatched normalizer (which would silently
+// bias the draw). Uses the measurement kernels' last-positive fallback
+// for the floating-point tail, and consumes exactly one RNG draw.
 template <typename Admit>
-uint8_t draw_from_column(const TransitionInstrument& instrument, uint8_t source, double mass,
+uint8_t draw_from_column(const TransitionInstrument& instrument, uint8_t source,
                          Xoshiro256PlusPlus& rng, Admit&& admit, size_t num_levels) {
+    double mass = 0.0;
+    for (uint8_t to = 0; to < num_levels; ++to) {
+        if (admit(to)) {
+            mass += instrument.prob(to, source);
+        }
+    }
     const double u = rng.next_double() * mass;
     double acc = 0.0;
     int last_positive = -1;
@@ -165,7 +206,7 @@ std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
                     if (rng.next_double() < total) {
                         outcome.jumped = true;
                         outcome.destination_level = draw_from_column(
-                            *channel.instrument, source, total, rng, [](uint8_t) { return true; },
+                            *channel.instrument, source, rng, [](uint8_t) { return true; },
                             levels.size());
                     }
                 } else if (pre.kind() != QubitStatusKind::Lost &&
@@ -279,24 +320,56 @@ void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_ra
         "; consider damping=\"neglect\" for high-rate sites or a larger max_rank");
 }
 
-// The exact-mode HIR pipeline: the defaults minus the statevector
-// squeeze. Squeeze reorders commuting measurements, which is
-// exchangeable under sampling semantics but not once a continuation's
+// The exact-mode pipelines: the default-enabled passes that declare
+// record-order preservation (pass_registry.h). Forced-outcome execution
+// is why the property matters: reordering commuting measurements is
+// exchangeable under sampling semantics but wrong once a continuation's
 // trace-out is forced -- an entangled partner must not measure before
-// the forced collapse it is correlated with. One pipeline serves every
-// module in the mode, so prefix identity is preserved; the squeezed
-// rank compaction is a performance loss the validation campaign's
-// table will quantify.
+// the forced collapse it is correlated with. Today the filter excludes
+// exactly the statevector squeeze, whose rank compaction is a
+// performance loss to quantify; a future pass joins these pipelines
+// only by declaring itself order-preserving. One pipeline serves every
+// module in the mode, so prefix identity is preserved.
 HirPassManager exact_hir_pass_manager() {
     HirPassManager pm;
     for (const auto& info : kRegisteredPasses) {
-        if (info.kind == PassKind::HIR && info.default_enabled &&
-            std::string_view(info.name) != "StatevectorSqueezePass") {
+        if (info.kind == PassKind::HIR && info.default_enabled && info.record_order.preserved) {
             pm.add_pass(info.make_hir());
         }
     }
     return pm;
 }
+
+// Bytecode counterpart. Every current default bytecode pass preserves
+// the record sequence (they fuse contiguous instructions, and record
+// slots ride inside instruction payloads), so today this matches the
+// default pipeline; the filter is the standing contract.
+BytecodePassManager exact_bytecode_pass_manager() {
+    BytecodePassManager pm;
+    for (const auto& info : kRegisteredPasses) {
+        if (info.kind == PassKind::Bytecode && info.default_enabled &&
+            info.record_order.preserved) {
+            pm.add_pass(info.make_bc());
+        }
+    }
+    return pm;
+}
+
+#ifndef NDEBUG
+// The sequence the exact pipelines must preserve: every measurement
+// record index, visible and hidden alike, in program order. Audited
+// around each module compile so a pass misdeclared as order-preserving
+// fails loudly here instead of corrupting correlations.
+std::vector<uint32_t> record_sequence(const HirModule& hir) {
+    std::vector<uint32_t> seq;
+    for (const HeisenbergOp& op : hir.ops) {
+        if (op.op_type() == OpType::MEASURE) {
+            seq.push_back(static_cast<uint32_t>(op.meas_record_idx()));
+        }
+    }
+    return seq;
+}
+#endif
 
 // The forced-outcome twin of a sampling measurement opcode, or
 // NUM_OPCODES when the opcode is not a sampling measurement.
@@ -397,7 +470,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     };
 
     // Level two: the compiled module for one herald-flag assignment (one
-    // flag per classified slot, in slot order). Every host draw feeding
+    // flag per classified slot, in slot order). Every driver draw feeding
     // this call happens before it, so cache hits and misses sample
     // identically.
     auto get_module = [&](ContinuationEntry& entry, const std::vector<uint8_t>& flags,
@@ -415,9 +488,16 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                 }
             }
             HirModule hir = trace(patched, &instrument_options);
+#ifndef NDEBUG
+            const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
+#endif
             exact_hir_pass_manager().run(hir);
+#ifndef NDEBUG
+            assert(record_sequence(hir) == pre_pass_records &&
+                   "an exact-pipeline HIR pass reordered or removed a record op");
+#endif
             CompiledModule module = lower(hir);
-            default_bytecode_pass_manager().run(module);
+            exact_bytecode_pass_manager().run(module);
             check_max_rank(module, max_rank);
             if (entry.rw.forced_traceout_slot != SIZE_MAX) {
                 swap_traceout_to_forced(module, entry.rw.forced_traceout_slot);
@@ -471,13 +551,13 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     uint32_t state_slots = main_module->total_meas_slots;
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
-        Xoshiro256PlusPlus host_rng(derive_exact_seed(global_seed, shot, kExactHostDomain));
+        Xoshiro256PlusPlus driver_rng(derive_seed(global_seed, shot, kExactDriverDomain));
 
         ExactShotEvents events;
         events.initial_status.reserve(circuit.num_qubits);
         bool any_noncomp_initial = false;
         for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
-            const uint8_t level = draw_initial_level(model, host_rng);
+            const uint8_t level = draw_initial_level(model, driver_rng);
             events.initial_status.push_back(levels.status_for(level));
             const QubitStatusKind kind = events.initial_status.back().kind();
             any_noncomp_initial |= kind == QubitStatusKind::Leaked || kind == QubitStatusKind::Lost;
@@ -499,7 +579,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                 auto [it, inserted] = herald_flags.try_emplace(m.slot, 0);
                 if (inserted && ternary) {
                     const double p_herald = classifier->prob(2, m.level);
-                    it->second = host_rng.next_double() < p_herald ? 1 : 0;
+                    it->second = driver_rng.next_double() < p_herald ? 1 : 0;
                 }
                 flags.push_back(it->second);
             }
@@ -510,11 +590,11 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
         // (rare) compiles its own continuation-from-the-top; classical
         // consults over the whole circuit are pre-drawn for it. The
         // rewrite fetch consumes no randomness, so drawing the herald
-        // flags after it keeps every host draw ahead of module lookup.
+        // flags after it keeps every driver draw ahead of module lookup.
         ContinuationEntry* entry = &main_entry;
         CompiledModule* module = main_module;
         std::vector<QubitStatus> final_status =
-            extend_classical_outcomes(annotated, events, model, host_rng);
+            extend_classical_outcomes(annotated, events, model, driver_rng);
         if (any_noncomp_initial) {
             entry = &get_entry(events, false);
             module = get_module(*entry, flags_for(entry->rw), nullptr, 0);
@@ -528,7 +608,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             state_slots = std::max(state_slots, module->total_meas_slots);
             state = make_state(*module);
         }
-        state.reseed(derive_exact_seed(global_seed, shot, kExactSvmDomain));
+        state.reseed(derive_seed(global_seed, shot, kExactSvmDomain));
         if (state.meas_record.size() < module->total_meas_slots) {
             state.meas_record.resize(module->total_meas_slots, 0);
         }
@@ -557,7 +637,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             const AnnotationChannel channel = resolve_annotation(node, model, op_index);
 
             // Destination: at a neglect-form site nothing was drawn, so
-            // the host draws over the full column (computational
+            // the driver draws over the full column (computational
             // destinations included); elsewhere the class is already
             // leaked/lost and only the level within the trap remainder
             // remains.
@@ -565,19 +645,12 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             if (channel.instrument == nullptr) {
                 dest = channel.lost_level;
             } else if (trap.destination_pending) {
-                const double total = channel.instrument->column_sum(trap.source);
                 dest = draw_from_column(
-                    *channel.instrument, trap.source, total, host_rng, [](uint8_t) { return true; },
+                    *channel.instrument, trap.source, driver_rng, [](uint8_t) { return true; },
                     levels.size());
             } else {
-                double remainder = 0.0;
-                for (uint8_t to = 0; to < levels.size(); ++to) {
-                    if (levels.at(to).category != LevelCategory::Computational) {
-                        remainder += channel.instrument->prob(to, trap.source);
-                    }
-                }
                 dest = draw_from_column(
-                    *channel.instrument, trap.source, remainder, host_rng,
+                    *channel.instrument, trap.source, driver_rng,
                     [&](uint8_t to) {
                         return levels.at(to).category != LevelCategory::Computational;
                     },
@@ -585,7 +658,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             }
 
             events.jumps.push_back({op_index, qubit, dest});
-            final_status = extend_classical_outcomes(annotated, events, model, host_rng);
+            final_status = extend_classical_outcomes(annotated, events, model, driver_rng);
 
             // A neglect-form trap hands its carrier over uncollapsed; the
             // continuation's trace-out is forced to the reported source,

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -1,0 +1,526 @@
+#include "clifft/noncomp/exact_driver.h"
+
+#include "clifft/backend/backend.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/noncomp/annotate.h"
+#include "clifft/noncomp/instrument_options.h"
+#include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/rewriter.h"
+#include "clifft/noncomp/sampler.h"
+#include "clifft/noncomp/status_step.h"
+#include "clifft/noncomp/transition_instrument.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/svm/svm.h"
+#include "clifft/svm/svm_math.h"
+#include "clifft/util/xoshiro.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace clifft {
+
+namespace {
+
+// Domain tags for the per-shot sub-seeds, disjoint from the AOT
+// orchestrator's history/classifier/SVM tags so the two modes never
+// correlate. One host stream serves every host-side draw in a shot
+// (initial levels, trap destinations, classical follow-ons, herald
+// flags), in a deterministic order that never depends on cache state.
+constexpr uint64_t kExactHostDomain = 0x11;
+constexpr uint64_t kExactSvmDomain = 0x12;
+
+uint64_t derive_exact_seed(uint64_t global, uint64_t shot, uint64_t domain) {
+    uint64_t z = global ^ (shot * 0x9E3779B97F4A7C15ULL) ^ (domain * 0xBF58476D1CE4E5B9ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+// The transition consulted by one annotation node: a named instrument for
+// LEVEL_TRANSITION, a uniform all-lost rate for LOSS.
+struct AnnotationChannel {
+    const TransitionInstrument* instrument = nullptr;  // null for LOSS
+    double loss_p = 0.0;
+    uint8_t lost_level = 0;
+};
+
+AnnotationChannel resolve_annotation(const AstNode& node, const NonComputationalModel& model,
+                                     uint32_t op_index) {
+    AnnotationChannel channel;
+    if (node.gate == GateType::LOSS) {
+        const std::optional<uint8_t> lost = sole_lost_level(model.levels());
+        if (!lost.has_value()) {
+            throw std::invalid_argument(
+                "sample_noncomputational: LOSS at op " + std::to_string(op_index) +
+                " requires a level table with exactly one Lost-category level");
+        }
+        channel.loss_p = node.args.empty() ? 0.0 : node.args[0];
+        channel.lost_level = *lost;
+        return channel;
+    }
+    channel.instrument = model.transition_named(node.tag);
+    if (channel.instrument == nullptr) {
+        throw std::invalid_argument("sample_noncomputational: LEVEL_TRANSITION[" + node.tag +
+                                    "] at op " + std::to_string(op_index) +
+                                    " does not name a transition in the model");
+    }
+    return channel;
+}
+
+// Draw a destination level from `column` restricted to `mass` (the sum of
+// the admitted entries), with the measurement kernels' last-positive
+// fallback for the floating-point tail. `admit` filters levels.
+template <typename Admit>
+uint8_t draw_from_column(const TransitionInstrument& instrument, uint8_t source, double mass,
+                         Xoshiro256PlusPlus& rng, Admit&& admit, size_t num_levels) {
+    const double u = rng.next_double() * mass;
+    double acc = 0.0;
+    int last_positive = -1;
+    for (uint8_t to = 0; to < num_levels; ++to) {
+        if (!admit(to)) {
+            continue;
+        }
+        const double p = instrument.prob(to, source);
+        if (p > 0.0) {
+            last_positive = to;
+        }
+        acc += p;
+        if (u < acc) {
+            return to;
+        }
+    }
+    assert(last_positive >= 0 && "destination draw over an empty column");
+    return static_cast<uint8_t>(last_positive);
+}
+
+// Walk the annotated circuit's statuses under `events`, drawing and
+// appending any classical-source consult beyond the ones already
+// recorded. Returns the walk's final statuses (computed from the real,
+// uncanonicalized initials). The walk is the single source of truth for
+// which consults are classical, so the events stream always matches what
+// rewrite_continuation will validate.
+std::vector<QubitStatus> extend_classical_outcomes(const Circuit& annotated,
+                                                   ExactShotEvents& events,
+                                                   const NonComputationalModel& model,
+                                                   Xoshiro256PlusPlus& rng) {
+    const LevelSet& levels = model.levels();
+    std::map<std::pair<uint32_t, uint32_t>, uint8_t> jump_dest;
+    for (const ResolvedJump& jump : events.jumps) {
+        jump_dest.emplace(std::make_pair(jump.op_index, jump.qubit), jump.destination_level);
+    }
+
+    std::vector<QubitStatus> status = events.initial_status;
+    size_t cursor = 0;
+
+    for (uint32_t op_index = 0; op_index < annotated.nodes.size(); ++op_index) {
+        const AstNode& node = annotated.nodes[op_index];
+        const GateType gate = node.gate;
+        if (gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) {
+            for (const Target& target : node.targets) {
+                const uint32_t qubit = target.value();
+                const QubitStatus pre = status[qubit];
+                const bool classical =
+                    pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost;
+                if (!classical) {
+                    const auto jump = jump_dest.find({op_index, qubit});
+                    if (jump != jump_dest.end()) {
+                        status[qubit] = levels.status_for(jump->second);
+                    }
+                    continue;
+                }
+                if (cursor < events.classical_outcomes.size()) {
+                    // Already drawn when an earlier trap extended the
+                    // stream; replay it.
+                    const ClassicalOutcome& outcome = events.classical_outcomes[cursor++];
+                    assert(outcome.op_index == op_index && outcome.qubit == qubit &&
+                           "recorded classical outcomes drifted from the status walk");
+                    if (outcome.jumped) {
+                        status[qubit] = levels.status_for(outcome.destination_level);
+                    }
+                    continue;
+                }
+                const AnnotationChannel channel = resolve_annotation(node, model, op_index);
+                ClassicalOutcome outcome{op_index, qubit, false, 0};
+                if (channel.instrument != nullptr) {
+                    const uint8_t source = pre.level_id();
+                    const double total = channel.instrument->column_sum(source);
+                    if (rng.next_double() < total) {
+                        outcome.jumped = true;
+                        outcome.destination_level = draw_from_column(
+                            *channel.instrument, source, total, rng, [](uint8_t) { return true; },
+                            levels.size());
+                    }
+                } else if (pre.kind() != QubitStatusKind::Lost &&
+                           rng.next_double() < channel.loss_p) {
+                    // LOSS on a leaked (not lost) qubit can still vacate
+                    // it; an already-lost qubit records a no-op outcome
+                    // without spending a draw.
+                    outcome.jumped = true;
+                    outcome.destination_level = channel.lost_level;
+                }
+                ++cursor;
+                events.classical_outcomes.push_back(outcome);
+                if (outcome.jumped) {
+                    status[qubit] = levels.status_for(outcome.destination_level);
+                }
+            }
+            continue;
+        }
+        // Ordinary operations advance statuses exactly as the rewrite
+        // does; drops keep entry statuses, which the stepper handles via
+        // the shared policy scan semantics.
+        bool drop_op = false;
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            if (operand_action(gate, status[operand.qubit].kind(), model.policy()) ==
+                OperandAction::Drop) {
+                drop_op = true;
+            }
+        }
+        for (const QubitOperand& operand : qubit_operands(node)) {
+            const QubitStatus pre = status[operand.qubit];
+            status[operand.qubit] =
+                drop_op ? pre
+                        : normal_post_op_status(pre, gate, operand.role, model.policy(), levels);
+        }
+    }
+    return status;
+}
+
+// Cache key: the canonicalized status-outcome delta. Computational
+// initial levels canonicalize to the zero level -- the rewrite provably
+// depends on initial statuses only through their kinds (plus levels for
+// noncomputational initials) -- so shots differing only in |1> preloads
+// share one module.
+std::string cache_key(const ExactShotEvents& events, const LevelSet& levels) {
+    std::string key;
+    key.reserve(events.initial_status.size() + events.jumps.size() * 9 +
+                events.classical_outcomes.size() * 10);
+    for (const QubitStatus& s : events.initial_status) {
+        key.push_back(static_cast<char>(s.kind()));
+        const bool classical =
+            s.kind() == QubitStatusKind::Leaked || s.kind() == QubitStatusKind::Lost;
+        key.push_back(classical ? static_cast<char>(s.level_id())
+                                : static_cast<char>(levels.computational_zero_id()));
+    }
+    auto push32 = [&key](uint32_t v) {
+        for (int b = 0; b < 4; ++b) {
+            key.push_back(static_cast<char>((v >> (8 * b)) & 0xFF));
+        }
+    };
+    key.push_back('J');
+    for (const ResolvedJump& jump : events.jumps) {
+        push32(jump.op_index);
+        push32(jump.qubit);
+        key.push_back(static_cast<char>(jump.destination_level));
+    }
+    key.push_back('C');
+    for (const ClassicalOutcome& outcome : events.classical_outcomes) {
+        push32(outcome.op_index);
+        push32(outcome.qubit);
+        key.push_back(outcome.jumped ? 1 : 0);
+        key.push_back(static_cast<char>(outcome.destination_level));
+    }
+    return key;
+}
+
+ExactShotEvents canonicalize(const ExactShotEvents& events, const LevelSet& levels) {
+    ExactShotEvents canonical = events;
+    for (QubitStatus& s : canonical.initial_status) {
+        if (s.kind() == QubitStatusKind::ComputationalKnown) {
+            s = levels.status_for(levels.computational_zero_id());
+        }
+    }
+    return canonical;
+}
+
+// One rewritten continuation plus its per-herald-flag compiled modules.
+struct ContinuationEntry {
+    ContinuationRewrite rw;
+    std::map<std::vector<uint8_t>, CompiledModule> modules;
+};
+
+void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_rank) {
+    if (!max_rank.has_value() || module.peak_rank <= *max_rank) {
+        return;
+    }
+    // Name the first instruction whose active dimension exceeded the cap,
+    // through the compile's per-instruction k history.
+    std::string site;
+    for (size_t i = 0; i < module.source_map.size(); ++i) {
+        if (module.source_map.active_k_at(i) > *max_rank) {
+            const auto lines = module.source_map.lines_for(i);
+            if (!lines.empty()) {
+                site = " (first exceeded at circuit line " + std::to_string(lines[0]) + ")";
+            }
+            break;
+        }
+    }
+    throw std::invalid_argument(
+        "sample_noncomputational: compiled peak rank " + std::to_string(module.peak_rank) +
+        " exceeds max_rank " + std::to_string(*max_rank) + site +
+        "; consider damping=\"neglect\" for high-rate sites or a larger max_rank");
+}
+
+}  // namespace
+
+NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
+                                                     const NonComputationalModel& model,
+                                                     uint32_t shots, uint64_t global_seed,
+                                                     std::optional<uint32_t> max_rank) {
+    NonComputationalSample result;
+    result.shots = shots;
+    result.num_qubits = circuit.num_qubits;
+    result.num_measurements = circuit.num_measurements;
+    result.num_detectors = circuit.num_detectors;
+    result.num_observables = circuit.num_observables;
+    if (shots == 0) {
+        return result;
+    }
+
+    const LevelSet& levels = model.levels();
+    const MeasurementClassifier* classifier = model.classifier();
+    const bool ternary = classifier != nullptr && classifier->num_symbols() == 3;
+
+    const Circuit annotated = annotate(circuit, model);
+    const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
+
+    std::map<std::string, ContinuationEntry> cache;
+
+    // Level one: the rewrite for `events`, computed once per delta. It is
+    // deterministic in the events and consumes no randomness, so a fetch
+    // never perturbs sampling.
+    auto get_entry = [&](const ExactShotEvents& events, bool force_last) -> ContinuationEntry& {
+        const std::string key =
+            cache_key(events, levels) + static_cast<char>(force_last ? 'F' : 'f');
+        auto [it, inserted] = cache.try_emplace(key);
+        ContinuationEntry& entry = it->second;
+        if (inserted) {
+            entry.rw =
+                rewrite_continuation(annotated, canonicalize(events, levels), force_last, model);
+        }
+        return entry;
+    };
+
+    // Level two: the compiled module for one herald-flag assignment (one
+    // flag per classified slot, in slot order). Every host draw feeding
+    // this call happens before it, so cache hits and misses sample
+    // identically.
+    auto get_module = [&](ContinuationEntry& entry, const std::vector<uint8_t>& flags,
+                          const CompiledModule* executed_prefix_module,
+                          uint32_t prefix_end) -> CompiledModule* {
+        auto [mit, module_inserted] = entry.modules.try_emplace(flags);
+        if (module_inserted) {
+            Circuit patched = entry.rw.circuit;
+            assert(flags.size() == entry.rw.classified_measurements.size());
+            for (size_t i = 0; i < flags.size(); ++i) {
+                if (flags[i] != 0) {
+                    const ClassifiedMeasurement& m = entry.rw.classified_measurements[i];
+                    assert(m.noise_node != SIZE_MAX);
+                    patched.nodes[m.noise_node].args[0] = 0.5;
+                }
+            }
+            HirModule hir = trace(patched, &instrument_options);
+            default_hir_pass_manager().run(hir);
+            CompiledModule module = lower(hir);
+            default_bytecode_pass_manager().run(module);
+            check_max_rank(module, max_rank);
+#ifndef NDEBUG
+            // Re-entry contract: the continuation's prefix must be
+            // bit-identical to the code the shot already executed. A
+            // determinism regression shows up here, loudly, rather than
+            // as state corruption.
+            if (executed_prefix_module != nullptr) {
+                assert(prefix_end <= module.bytecode.size() &&
+                       prefix_end <= executed_prefix_module->bytecode.size());
+                for (uint32_t i = 0; i < prefix_end; ++i) {
+                    assert(std::memcmp(&module.bytecode[i], &executed_prefix_module->bytecode[i],
+                                       sizeof(Instruction)) == 0 &&
+                           "continuation prefix diverged from the executed module");
+                }
+            }
+#else
+            (void)executed_prefix_module;
+            (void)prefix_end;
+#endif
+            mit->second = std::move(module);
+        }
+        return &mit->second;
+    };
+
+    // The shared main line: the continuation of "nothing happened".
+    ExactShotEvents no_events;
+    no_events.initial_status.assign(circuit.num_qubits,
+                                    levels.status_for(levels.computational_zero_id()));
+    ContinuationEntry& main_entry = get_entry(no_events, false);
+    CompiledModule* main_module = get_module(
+        main_entry, std::vector<uint8_t>(main_entry.rw.classified_measurements.size(), 0), nullptr,
+        0);
+
+    // The state is reused across shots (growth from trap continuations
+    // amortizes to the chain maximum); a starting module that outgrows it
+    // -- a rare noncomputational-initial shot -- rebuilds it instead,
+    // since grow_for_continuation is trap-gated by design.
+    auto make_state = [&](const CompiledModule& module) {
+        return SchrodingerState(StateConfig{.peak_rank = module.peak_rank,
+                                            .num_measurements = module.total_meas_slots,
+                                            .num_qubits = module.num_qubits,
+                                            .num_detectors = module.num_detectors,
+                                            .num_observables = module.num_observables,
+                                            .seed = 0});
+    };
+    SchrodingerState state = make_state(*main_module);
+    uint32_t state_rank = main_module->peak_rank;
+    uint32_t state_slots = main_module->total_meas_slots;
+
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        Xoshiro256PlusPlus host_rng(derive_exact_seed(global_seed, shot, kExactHostDomain));
+
+        ExactShotEvents events;
+        events.initial_status.reserve(circuit.num_qubits);
+        bool any_noncomp_initial = false;
+        for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
+            const uint8_t level = draw_initial_level(model, host_rng);
+            events.initial_status.push_back(levels.status_for(level));
+            const QubitStatusKind kind = events.initial_status.back().kind();
+            any_noncomp_initial |= kind == QubitStatusKind::Leaked || kind == QubitStatusKind::Lost;
+        }
+
+        // Herald flags accumulate per visible slot across the shot's
+        // trap chain: a slot's flag is drawn once, when its classified
+        // measurement first appears in a continuation.
+        std::map<uint32_t, uint8_t> herald_flags;
+        auto flags_for = [&](const ContinuationRewrite& rw) {
+            std::vector<uint8_t> flags;
+            flags.reserve(rw.classified_measurements.size());
+            for (const ClassifiedMeasurement& m : rw.classified_measurements) {
+                auto [it, inserted] = herald_flags.try_emplace(m.slot, 0);
+                if (inserted && ternary) {
+                    const double p_herald = classifier->prob(2, m.level);
+                    it->second = host_rng.next_double() < p_herald ? 1 : 0;
+                }
+                flags.push_back(it->second);
+            }
+            return flags;
+        };
+
+        // Resolve the shot's starting module. A noncomputational initial
+        // (rare) compiles its own continuation-from-the-top; classical
+        // consults over the whole circuit are pre-drawn for it. The
+        // rewrite fetch consumes no randomness, so drawing the herald
+        // flags after it keeps every host draw ahead of module lookup.
+        ContinuationEntry* entry = &main_entry;
+        CompiledModule* module = main_module;
+        std::vector<QubitStatus> final_status =
+            extend_classical_outcomes(annotated, events, model, host_rng);
+        if (any_noncomp_initial) {
+            entry = &get_entry(events, false);
+            module = get_module(*entry, flags_for(entry->rw), nullptr, 0);
+        }
+
+        if (shot > 0) {
+            state.reset();
+        }
+        if (module->peak_rank > state_rank || module->total_meas_slots > state_slots) {
+            state_rank = std::max(state_rank, module->peak_rank);
+            state_slots = std::max(state_slots, module->total_meas_slots);
+            state = make_state(*module);
+        }
+        state.reseed(derive_exact_seed(global_seed, shot, kExactSvmDomain));
+        if (state.meas_record.size() < module->total_meas_slots) {
+            state.meas_record.resize(module->total_meas_slots, 0);
+        }
+        // Known |1> initial levels are an X at time zero: a Pauli, so a
+        // per-shot frame preload rather than a distinct module.
+        for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
+            const QubitStatus& s = events.initial_status[q];
+            if (s.kind() == QubitStatusKind::ComputationalKnown &&
+                s.level_id() == levels.computational_one_id()) {
+                bit_set(state.p_x, q, true);
+            }
+        }
+        state.next_noise_idx = 0;
+        state.draw_next_noise(module->constant_pool.noise_hazards);
+        execute(*module, state);
+
+        while (state.pending_trap.has_value()) {
+            const SchrodingerState::InstrumentTrap trap = *state.pending_trap;
+            if (trap.site_id >= entry->rw.site_targets.size()) {
+                throw std::logic_error(
+                    "sample_noncomputational: trap site id is out of range of the executing "
+                    "module's site table");
+            }
+            const auto [op_index, qubit] = entry->rw.site_targets[trap.site_id];
+            const AstNode& node = annotated.nodes[op_index];
+            const AnnotationChannel channel = resolve_annotation(node, model, op_index);
+
+            // The correlated continuation for a neglect-form trap (the
+            // forced-to-source trace-out) is not wired yet; the guard
+            // keeps the decorrelated behavior from running silently.
+            if (trap.destination_pending) {
+                throw std::invalid_argument(
+                    "sample_noncomputational: a neglect-form site fired; the correlated "
+                    "continuation for damping=\"neglect\" is not wired yet -- use "
+                    "damping=\"exact\" (the default)");
+            }
+
+            // Destination: the class is already drawn as leaked/lost, so
+            // only the level within the trap remainder remains. (A
+            // pending destination would draw over the full column.)
+            uint8_t dest;
+            if (channel.instrument == nullptr) {
+                dest = channel.lost_level;
+            } else {
+                double remainder = 0.0;
+                for (uint8_t to = 0; to < levels.size(); ++to) {
+                    if (levels.at(to).category != LevelCategory::Computational) {
+                        remainder += channel.instrument->prob(to, trap.source);
+                    }
+                }
+                dest = draw_from_column(
+                    *channel.instrument, trap.source, remainder, host_rng,
+                    [&](uint8_t to) {
+                        return levels.at(to).category != LevelCategory::Computational;
+                    },
+                    levels.size());
+            }
+
+            events.jumps.push_back({op_index, qubit, dest});
+            final_status = extend_classical_outcomes(annotated, events, model, host_rng);
+
+            const uint32_t prefix_end = module->instrument_offsets[trap.site_id] + 1;
+            ContinuationEntry& next_entry = get_entry(events, false);
+            CompiledModule* next_module =
+                get_module(next_entry, flags_for(next_entry.rw), module, prefix_end);
+
+            entry = &next_entry;
+            module = next_module;
+            resume(*module, state, module->instrument_offsets[trap.site_id] + 1);
+        }
+
+        // Emit the visible records. The noncomputational path never sets
+        // expected_observables, so no reference normalization applies.
+        result.measurements.insert(result.measurements.end(), state.meas_record.begin(),
+                                   state.meas_record.begin() + circuit.num_measurements);
+        result.detectors.insert(result.detectors.end(), state.det_record.begin(),
+                                state.det_record.end());
+        result.observables.insert(result.observables.end(), state.obs_record.begin(),
+                                  state.obs_record.end());
+        result.final_status.insert(result.final_status.end(), final_status.begin(),
+                                   final_status.end());
+        std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
+        for (const auto& [slot, flag] : herald_flags) {
+            shot_heralds[slot] = flag;
+        }
+        result.heralds.insert(result.heralds.end(), shot_heralds.begin(), shot_heralds.end());
+    }
+
+    return result;
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/exact_driver.h
+++ b/src/clifft/noncomp/exact_driver.h
@@ -1,16 +1,23 @@
 #pragma once
 
-// Exact-mode driver: the runtime half of exact state-dependent jumps.
+// Exact-mode driver: resolves level transitions (leak, loss, decay) at
+// sample time, with no sampling approximation.
 //
-// Under UnknownSourcePolicy::Exact, transition firing moves into the VM:
-// the annotated circuit compiles once as a shared main line with every
-// annotation materialized as an instrument site, each shot preloads its
-// sampled initial levels into the Pauli frame and executes, and a fire
-// that cannot resolve in-line traps back here. The driver resolves the
+// A transition whose outcome depends on a qubit's quantum state -- a
+// jump out of superposition, where which level the qubit leaves from is
+// not yet decided -- cannot be drawn before that state exists. Under
+// UnknownSourcePolicy::Exact the annotated circuit therefore compiles
+// once with every annotation kept as a runtime instrument site; each
+// shot preloads its sampled initial levels and executes; a fire the VM
+// cannot resolve in-line traps back to this driver, which draws the
 // destination, extends the shot's event record, fetches or compiles the
-// continuation (cached by the status-outcome delta plus herald flags),
-// and resumes past the site. sample_noncomputational() routes here; this
-// header is internal.
+// matching continuation (cached by the status-outcome delta plus herald
+// flags), and resumes past the site. DampingPolicy::Neglect also runs
+// through this driver: it changes how a trapped fire resolves (the
+// carrier hands over uncollapsed and the continuation's trace-out is
+// forced to the reported source), not whether the mode applies.
+// sample_noncomputational() routes here; this header is internal. The
+// driver's working vocabulary is defined at the top of exact_driver.cc.
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/model.h"

--- a/src/clifft/noncomp/exact_driver.h
+++ b/src/clifft/noncomp/exact_driver.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// Exact-mode driver: the runtime half of exact state-dependent jumps.
+//
+// Under UnknownSourcePolicy::Exact, transition firing moves into the VM:
+// the annotated circuit compiles once as a shared main line with every
+// annotation materialized as an instrument site, each shot preloads its
+// sampled initial levels into the Pauli frame and executes, and a fire
+// that cannot resolve in-line traps back here. The driver resolves the
+// destination, extends the shot's event record, fetches or compiles the
+// continuation (cached by the status-outcome delta plus herald flags),
+// and resumes past the site. sample_noncomputational() routes here; this
+// header is internal.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/orchestrator.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace clifft {
+
+NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
+                                                     const NonComputationalModel& model,
+                                                     uint32_t shots, uint64_t global_seed,
+                                                     std::optional<uint32_t> max_rank);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -152,6 +152,7 @@ NonComputationalModel::NonComputationalModel(
     switch (policy_.unknown_source_policy) {
         case UnknownSourcePolicy::Reject:
         case UnknownSourcePolicy::EqualizeRates:
+        case UnknownSourcePolicy::Exact:
             break;
         default:
             throw std::invalid_argument(

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -32,7 +32,7 @@ namespace {
 void apply_heralds(RewriteResult& rw, const MeasurementClassifier& classifier,
                    Xoshiro256PlusPlus& rng, std::vector<uint8_t>& heralds) {
     for (const ClassifiedMeasurement& m : rw.classified_measurements) {
-        const double p_herald = classifier.prob(2, m.level);
+        const double p_herald = classifier.prob(MeasurementClassifier::kHeraldSymbol, m.level);
         if (rng.next_double() < p_herald) {
             heralds[m.slot] = 1;
             // The rewriter always emits a READOUT_NOISE node for a ternary
@@ -99,7 +99,7 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
             sample_history(annotated, model, derive_seed(global_seed, shot, kHistoryDomain));
         RewriteResult rw = rewrite(annotated, hs.history, model);
         std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
-        if (classifier != nullptr && classifier->num_symbols() == 3 &&
+        if (classifier != nullptr && classifier->has_herald() &&
             !rw.classified_measurements.empty()) {
             Xoshiro256PlusPlus classifier_rng(derive_seed(global_seed, shot, kClassifierDomain));
             apply_heralds(rw, *classifier, classifier_rng, shot_heralds);

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -5,6 +5,7 @@
 #include "clifft/frontend/hir.h"
 #include "clifft/noncomp/annotate.h"
 #include "clifft/noncomp/classifier.h"
+#include "clifft/noncomp/exact_driver.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/sampler.h"
 #include "clifft/optimizer/pass_factory.h"
@@ -67,7 +68,8 @@ CompiledModule compile_circuit(const Circuit& circuit) {
 
 NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                const NonComputationalModel& model, uint32_t shots,
-                                               std::optional<uint64_t> seed) {
+                                               std::optional<uint64_t> seed,
+                                               std::optional<uint32_t> max_rank) {
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
@@ -93,6 +95,10 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
         Xoshiro256PlusPlus entropy;
         entropy.seed_from_entropy();
         global_seed = entropy();
+    }
+
+    if (model.policy().unknown_source_policy == UnknownSourcePolicy::Exact) {
+        return sample_noncomputational_exact(circuit, model, shots, global_seed, max_rank);
     }
 
     const MeasurementClassifier* classifier = model.classifier();

--- a/src/clifft/noncomp/orchestrator.cc
+++ b/src/clifft/noncomp/orchestrator.cc
@@ -8,6 +8,7 @@
 #include "clifft/noncomp/exact_driver.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/sampler.h"
+#include "clifft/noncomp/seed.h"
 #include "clifft/optimizer/pass_factory.h"
 #include "clifft/svm/svm.h"
 #include "clifft/util/xoshiro.h"
@@ -20,20 +21,6 @@
 namespace clifft {
 
 namespace {
-
-// Distinct domain tags so per-shot sub-seeds for the three RNG consumers
-// never coincide (seeding all from the same value would correlate them).
-constexpr uint64_t kHistoryDomain = 0x1;
-constexpr uint64_t kClassifierDomain = 0x2;
-constexpr uint64_t kSvmDomain = 0x3;
-
-// SplitMix64 finalizer over a mix of the global seed, shot, and domain.
-uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
-    uint64_t z = global ^ (shot * 0x9E3779B97F4A7C15ULL) ^ (domain * 0xBF58476D1CE4E5B9ULL);
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
-    return z ^ (z >> 31);
-}
 
 // Herald pass for a three-symbol classifier: draw each classified slot's
 // herald flag and re-point the heralded slots' record-flip probability at one

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -63,8 +63,15 @@ struct NonComputationalSample {
 // three-symbol stochastic column (a third symbol heralds the measurement).
 // Reject (substochastic) classifier columns model a heralded abort outcome
 // and are not supported by this entry point yet.
+// `max_rank` caps the compiled peak rank in exact mode
+// (unknown_source_policy = Exact): compilation fails with the first
+// offending circuit line named, before any state is allocated, instead
+// of attempting a 2^k allocation. Unlimited when unset; ignored by the
+// AOT policies, whose per-shot modules never exceed the annotated
+// circuit's own rank.
 NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                const NonComputationalModel& model, uint32_t shots,
-                                               std::optional<uint64_t> seed = std::nullopt);
+                                               std::optional<uint64_t> seed = std::nullopt,
+                                               std::optional<uint32_t> max_rank = std::nullopt);
 
 }  // namespace clifft

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -21,6 +21,15 @@ namespace clifft {
 enum class UnknownSourcePolicy : uint8_t {
     Reject = 0,
     EqualizeRates = 1,
+
+    // Exact: transition firing moves to runtime. The circuit compiles
+    // once with every annotation materialized as an instrument site; fire
+    // probabilities are evaluated on the live state, and a fire that
+    // cannot resolve in-line traps to the driver, which recompiles the
+    // remaining circuit under the now-known status and resumes. Exact for
+    // every source context; see DampingPolicy for the one knob that
+    // trades exactness for rank at dormant-random sites.
+    Exact = 2,
 };
 
 // Policy for operations touching a leaked or lost operand that have no

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -11,9 +11,11 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace clifft {
@@ -139,6 +141,118 @@ void append_computational_confusion(Circuit& out, const NonComputationalModel& m
     out.nodes.push_back(AstNode{GateType::READOUT_NOISE, {Target::rec(slot)}, {p01, p10}, 0});
 }
 
+// Shared per-node processing for every non-annotation operation: the
+// policy scan (drop/reject), classifier record writes for measurements on
+// leaked/lost qubits, computational readout confusion for kept Z-basis
+// measurements, status stepping, and the visible-slot cursor. Both the
+// AOT rewrite and the exact-mode continuation rewrite go through this, so
+// the two paths cannot drift.
+void process_ordinary_node(const AstNode& node, uint32_t op_index,
+                           const NonComputationalModel& model, std::vector<QubitStatus>& status,
+                           Circuit& out, uint32_t& slot,
+                           std::vector<ClassifiedMeasurement>& classified) {
+    const LevelSet& levels = model.levels();
+    const NonComputationalPolicy& policy = model.policy();
+    const GateType gate = node.gate;
+
+    // Policy pre-scan over entry statuses: any rejecting operand rejects
+    // the whole operation; otherwise any dropping operand drops it whole
+    // (identity on the surviving operands).
+    bool drop_op = false;
+    for (const QubitOperand& operand : qubit_operands(node)) {
+        const uint32_t qubit = operand.qubit;
+        if (qubit >= status.size()) {
+            throw std::invalid_argument("rewrite: operand qubit " + std::to_string(qubit) +
+                                        " is out of range at op " + std::to_string(op_index));
+        }
+        switch (operand_action(gate, status[qubit].kind(), policy)) {
+            case OperandAction::Reject:
+                throw std::invalid_argument(
+                    "rewrite: operation '" + std::string(gate_name(gate)) + "' on a " +
+                    kind_name(status[qubit].kind()) + " qubit " + std::to_string(qubit) +
+                    " at op " + std::to_string(op_index) + " is not representable; rejecting");
+            case OperandAction::Drop:
+                drop_op = true;
+                break;
+            case OperandAction::Apply:
+                break;
+        }
+    }
+
+    // Set when this (single-qubit Z-basis) measurement reads a leaked or
+    // lost qubit: the classifier, not the SVM, defines its record bit.
+    std::optional<uint8_t> classified_level;
+
+    for (const QubitOperand& operand : qubit_operands(node)) {
+        const uint32_t qubit = operand.qubit;
+        const QubitStatus pre = status[qubit];
+
+        if (is_measurement(gate) &&
+            (pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost)) {
+            classified_level = pre.level_id();
+        }
+
+        status[qubit] =
+            drop_op ? pre : normal_post_op_status(pre, gate, operand.role, policy, levels);
+    }
+
+    if (!drop_op) {
+        if (classified_level.has_value()) {
+            // The policy pre-scan admits only single-qubit Z-basis
+            // measurement forms here (M and the measure-and-resets);
+            // X/Y-basis and multi-target measurements on a
+            // noncomputational operand reject above.
+            const uint32_t qubit = qubit_operands(node).front().qubit;
+            const MeasurementClassifier& classifier =
+                classifier_for(model, *classified_level, gate, op_index, qubit);
+            const bool ternary = classifier.num_symbols() == 3;
+
+            // The record bit's flip probability on top of MPAD 0:
+            // P(symbol 1 | level) for a two-symbol column; for a ternary
+            // column, the bit's not-heralded conditional -- the herald
+            // pass re-points heralded slots at one half. An always-herald
+            // column has no not-heralded conditional; one half stands in
+            // (every draw heralds, so the pass always overwrites it).
+            double flip;
+            if (ternary) {
+                const double p_herald = classifier.prob(2, *classified_level);
+                const double denom = 1.0 - p_herald;
+                flip = denom > 0.0 ? classifier.prob(1, *classified_level) / denom : 0.5;
+                flip = std::min(1.0, std::max(0.0, flip));
+            } else {
+                flip = classifier.prob(1, *classified_level);
+            }
+
+            size_t noise_node = SIZE_MAX;
+            if (!ternary && (flip == 0.0 || flip == 1.0)) {
+                // Deterministic column: the bit is the padding literal
+                // itself, no sample-time draw.
+                out.nodes.push_back(mpad_op(flip == 1.0 ? 1 : 0));
+            } else {
+                out.nodes.push_back(mpad_op(0));
+                out.nodes.push_back(readout_noise_op(slot, flip));
+                noise_node = out.nodes.size() - 1;
+            }
+            if (is_measure_reset(gate)) {
+                out.nodes.push_back(single_qubit_op(reset_for(gate), qubit));
+            }
+            classified.push_back({slot, *classified_level, noise_node});
+        } else {
+            out.nodes.push_back(node);
+            // The classifier's computational columns apply to Z-basis
+            // level readouts (M, MR); other measurement bases are not
+            // level readouts and carry no confusion.
+            if (gate == GateType::M || gate == GateType::MR) {
+                append_computational_confusion(out, model, gate, node.targets.front().is_inverted(),
+                                               slot, op_index, qubit_operands(node).front().qubit);
+            }
+        }
+    }
+    if (is_measurement(gate)) {
+        ++slot;
+    }
+}
+
 }  // namespace
 
 RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& history,
@@ -239,111 +353,183 @@ RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& hi
             continue;
         }
 
-        // Policy pre-scan over entry statuses: any rejecting operand rejects
-        // the whole operation; otherwise any dropping operand drops it whole
-        // (identity on the surviving operands). The scan precedes the
-        // transition replay so a surviving operand's stepping can know the
-        // base operation is gone.
-        bool drop_op = false;
-        for (const QubitOperand& operand : qubit_operands(node)) {
-            const uint32_t qubit = operand.qubit;
-            if (qubit >= status.size()) {
-                throw std::invalid_argument("rewrite: operand qubit " + std::to_string(qubit) +
-                                            " is out of range at op " + std::to_string(op_index));
-            }
-            switch (operand_action(gate, status[qubit].kind(), policy)) {
-                case OperandAction::Reject:
-                    throw std::invalid_argument(
-                        "rewrite: operation '" + std::string(gate_name(gate)) + "' on a " +
-                        kind_name(status[qubit].kind()) + " qubit " + std::to_string(qubit) +
-                        " at op " + std::to_string(op_index) + " is not representable; rejecting");
-                case OperandAction::Drop:
-                    drop_op = true;
-                    break;
-                case OperandAction::Apply:
-                    break;
-            }
-        }
-
-        // Set when this (single-qubit Z-basis) measurement reads a leaked or
-        // lost qubit: the classifier, not the SVM, defines its record bit.
-        std::optional<uint8_t> classified_level;
-
-        for (const QubitOperand& operand : qubit_operands(node)) {
-            const uint32_t qubit = operand.qubit;
-            const QubitStatus pre = status[qubit];
-
-            if (is_measurement(gate) &&
-                (pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost)) {
-                classified_level = pre.level_id();
-            }
-
-            status[qubit] =
-                drop_op ? pre : normal_post_op_status(pre, gate, operand.role, policy, levels);
-        }
-
-        if (!drop_op) {
-            if (classified_level.has_value()) {
-                // The policy pre-scan admits only single-qubit Z-basis
-                // measurement forms here (M and the measure-and-resets);
-                // X/Y-basis and multi-target measurements on a
-                // noncomputational operand reject above.
-                const uint32_t qubit = qubit_operands(node).front().qubit;
-                const MeasurementClassifier& classifier =
-                    classifier_for(model, *classified_level, gate, op_index, qubit);
-                const bool ternary = classifier.num_symbols() == 3;
-
-                // The record bit's flip probability on top of MPAD 0:
-                // P(symbol 1 | level) for a two-symbol column; for a ternary
-                // column, the bit's not-heralded conditional -- the herald
-                // pass re-points heralded slots at one half. An always-herald
-                // column has no not-heralded conditional; one half stands in
-                // (every draw heralds, so the pass always overwrites it).
-                double flip;
-                if (ternary) {
-                    const double p_herald = classifier.prob(2, *classified_level);
-                    const double denom = 1.0 - p_herald;
-                    flip = denom > 0.0 ? classifier.prob(1, *classified_level) / denom : 0.5;
-                    flip = std::min(1.0, std::max(0.0, flip));
-                } else {
-                    flip = classifier.prob(1, *classified_level);
-                }
-
-                size_t noise_node = SIZE_MAX;
-                if (!ternary && (flip == 0.0 || flip == 1.0)) {
-                    // Deterministic column: the bit is the padding literal
-                    // itself, no sample-time draw.
-                    out.nodes.push_back(mpad_op(flip == 1.0 ? 1 : 0));
-                } else {
-                    out.nodes.push_back(mpad_op(0));
-                    out.nodes.push_back(readout_noise_op(slot, flip));
-                    noise_node = out.nodes.size() - 1;
-                }
-                if (is_measure_reset(gate)) {
-                    out.nodes.push_back(single_qubit_op(reset_for(gate), qubit));
-                }
-                result.classified_measurements.push_back({slot, *classified_level, noise_node});
-            } else {
-                out.nodes.push_back(node);
-                // The classifier's computational columns apply to Z-basis
-                // level readouts (M, MR); other measurement bases are not
-                // level readouts and carry no confusion.
-                if (gate == GateType::M || gate == GateType::MR) {
-                    append_computational_confusion(out, model, gate,
-                                                   node.targets.front().is_inverted(), slot,
-                                                   op_index, qubit_operands(node).front().qubit);
-                }
-            }
-        }
-        if (is_measurement(gate)) {
-            ++slot;
-        }
+        process_ordinary_node(node, op_index, model, status, out, slot,
+                              result.classified_measurements);
     }
 
     if (trans_cursor != history.transitions.size()) {
         throw std::invalid_argument(
             "rewrite: history records more transitions than the circuit consults; "
             "history does not describe this circuit");
+    }
+
+    return result;
+}
+
+ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,
+                                         bool force_last_traceout,
+                                         const NonComputationalModel& model) {
+    const LevelSet& levels = model.levels();
+
+    if (events.initial_status.size() != annotated.num_qubits) {
+        throw std::invalid_argument("rewrite_continuation: events carry " +
+                                    std::to_string(events.initial_status.size()) +
+                                    " initial statuses but circuit declares " +
+                                    std::to_string(annotated.num_qubits) + " qubits");
+    }
+    if (force_last_traceout && events.jumps.empty()) {
+        throw std::invalid_argument(
+            "rewrite_continuation: force_last_traceout requires at least one jump");
+    }
+
+    // Jumps index by their annotation target. The chain arrives in trap
+    // order, which is circuit order; visitation below validates coverage.
+    std::map<std::pair<uint32_t, uint32_t>, uint8_t> jump_dest;
+    for (const ResolvedJump& jump : events.jumps) {
+        if (!jump_dest.emplace(std::make_pair(jump.op_index, jump.qubit), jump.destination_level)
+                 .second) {
+            throw std::invalid_argument("rewrite_continuation: duplicate jump for op " +
+                                        std::to_string(jump.op_index) + ", qubit " +
+                                        std::to_string(jump.qubit));
+        }
+    }
+    size_t jumps_seen = 0;
+    size_t classical_cursor = 0;
+
+    ContinuationRewrite result;
+    Circuit& out = result.circuit;
+    out = annotated;
+    out.nodes.clear();
+    out.nodes.reserve(annotated.nodes.size() + events.jumps.size() * 2);
+
+    // No initial X-prep here: in exact mode a known |1> initial level is a
+    // per-shot Pauli-frame preload, so every module in a chain compiles
+    // from the same node stream regardless of the shot's initials.
+    std::vector<QubitStatus> status = events.initial_status;
+
+    // Node index (into `out`) of the last jump's trace-out R, when one is
+    // emitted; converted to a hidden record slot after the walk.
+    size_t traceout_node = SIZE_MAX;
+
+    uint32_t slot = 0;  // visible measurement record index
+
+    for (uint32_t op_index = 0; op_index < annotated.nodes.size(); ++op_index) {
+        const AstNode& node = annotated.nodes[op_index];
+        const GateType gate = node.gate;
+
+        if (gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) {
+            for (const Target& target : node.targets) {
+                const uint32_t qubit = target.value();
+                if (qubit >= status.size()) {
+                    throw std::invalid_argument("rewrite_continuation: operand qubit " +
+                                                std::to_string(qubit) + " is out of range at op " +
+                                                std::to_string(op_index));
+                }
+                const QubitStatus pre = status[qubit];
+                const bool classical_source =
+                    pre.kind() == QubitStatusKind::Leaked || pre.kind() == QubitStatusKind::Lost;
+
+                if (classical_source) {
+                    // Classical-source consult: no runtime instrument; the
+                    // host pre-drew the outcome. The annotation node is
+                    // consumed, exactly as in the AOT rewrite.
+                    if (classical_cursor >= events.classical_outcomes.size()) {
+                        throw std::invalid_argument(
+                            "rewrite_continuation: circuit consults more classical-source "
+                            "transitions than the events record (op " +
+                            std::to_string(op_index) + ", qubit " + std::to_string(qubit) + ")");
+                    }
+                    const ClassicalOutcome& outcome = events.classical_outcomes[classical_cursor++];
+                    if (outcome.op_index != op_index || outcome.qubit != qubit) {
+                        throw std::invalid_argument(
+                            "rewrite_continuation: classical outcome (op " +
+                            std::to_string(outcome.op_index) + ", qubit " +
+                            std::to_string(outcome.qubit) + ") does not match consult (op " +
+                            std::to_string(op_index) + ", qubit " + std::to_string(qubit) + ")");
+                    }
+                    if (!outcome.jumped) {
+                        continue;
+                    }
+                    const Level& dest = levels.at(outcome.destination_level);
+                    if (dest.category == LevelCategory::Computational) {
+                        // Recapture: materialize the carrier at the definite
+                        // destination level.
+                        out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+                        if (outcome.destination_level == levels.computational_one_id()) {
+                            out.nodes.push_back(single_qubit_op(GateType::X, qubit));
+                        }
+                    }
+                    status[qubit] = levels.status_for(outcome.destination_level);
+                    continue;
+                }
+
+                // Quantum source: the annotation stays a runtime instrument.
+                // Split multi-target nodes so a sibling target with a
+                // classical status is not re-materialized.
+                out.nodes.push_back(
+                    AstNode{gate, {Target::qubit(qubit)}, node.args, node.source_line, node.tag});
+
+                const auto jump = jump_dest.find({op_index, qubit});
+                if (jump == jump_dest.end()) {
+                    continue;  // no fire recorded here; the site runs live
+                }
+                ++jumps_seen;
+                const bool is_last = jumps_seen == events.jumps.size() &&
+                                     op_index == events.jumps.back().op_index &&
+                                     qubit == events.jumps.back().qubit;
+
+                const Level& dest = levels.at(jump->second);
+                size_t r_node = SIZE_MAX;
+                if (dest.category == LevelCategory::Computational) {
+                    r_node = out.nodes.size();
+                    out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+                    if (jump->second == levels.computational_one_id()) {
+                        out.nodes.push_back(single_qubit_op(GateType::X, qubit));
+                    }
+                } else if (pre.kind() == QubitStatusKind::ComputationalUnknown) {
+                    r_node = out.nodes.size();
+                    out.nodes.push_back(single_qubit_op(GateType::R, qubit));
+                }
+                if (is_last && force_last_traceout) {
+                    if (r_node == SIZE_MAX) {
+                        throw std::invalid_argument(
+                            "rewrite_continuation: force_last_traceout on a jump that emits no "
+                            "carrier reset (the qubit's level is already definite at op " +
+                            std::to_string(op_index) + ")");
+                    }
+                    traceout_node = r_node;
+                }
+                status[qubit] = levels.status_for(jump->second);
+            }
+            continue;
+        }
+
+        process_ordinary_node(node, op_index, model, status, out, slot,
+                              result.classified_measurements);
+    }
+
+    if (jumps_seen != events.jumps.size()) {
+        throw std::invalid_argument(
+            "rewrite_continuation: events record jumps the circuit never consults");
+    }
+    if (classical_cursor != events.classical_outcomes.size()) {
+        throw std::invalid_argument(
+            "rewrite_continuation: events record more classical outcomes than the circuit "
+            "consults");
+    }
+
+    if (traceout_node != SIZE_MAX) {
+        // The forced trace-out's hidden record slot. Hidden slots are
+        // assigned by trace() sequentially in circuit order, one per pure
+        // reset target, starting after the visible slots; mirror that count
+        // over the rewritten node stream.
+        uint32_t hidden_before = 0;
+        for (size_t i = 0; i < traceout_node; ++i) {
+            if (is_reset(out.nodes[i].gate)) {
+                hidden_before += static_cast<uint32_t>(out.nodes[i].targets.size());
+            }
+        }
+        result.forced_traceout_slot = annotated.num_measurements + hidden_before;
     }
 
     return result;

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -466,6 +466,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
                 // Quantum source: the annotation stays a runtime instrument.
                 // Split multi-target nodes so a sibling target with a
                 // classical status is not re-materialized.
+                result.site_targets.emplace_back(op_index, qubit);
                 out.nodes.push_back(
                     AstNode{gate, {Target::qubit(qubit)}, node.args, node.source_line, node.tag});
 
@@ -532,6 +533,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
         result.forced_traceout_slot = annotated.num_measurements + hidden_before;
     }
 
+    result.final_status = std::move(status);
     return result;
 }
 

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -205,7 +205,7 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
             const uint32_t qubit = qubit_operands(node).front().qubit;
             const MeasurementClassifier& classifier =
                 classifier_for(model, *classified_level, gate, op_index, qubit);
-            const bool ternary = classifier.num_symbols() == 3;
+            const bool ternary = classifier.has_herald();
 
             // The record bit's flip probability on top of MPAD 0:
             // P(symbol 1 | level) for a two-symbol column; for a ternary
@@ -215,7 +215,8 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
             // (every draw heralds, so the pass always overwrites it).
             double flip;
             if (ternary) {
-                const double p_herald = classifier.prob(2, *classified_level);
+                const double p_herald =
+                    classifier.prob(MeasurementClassifier::kHeraldSymbol, *classified_level);
                 const double denom = 1.0 - p_herald;
                 flip = denom > 0.0 ? classifier.prob(1, *classified_level) / denom : 0.5;
                 flip = std::min(1.0, std::max(0.0, flip));
@@ -446,6 +447,13 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
                             std::to_string(outcome.op_index) + ", qubit " +
                             std::to_string(outcome.qubit) + ") does not match consult (op " +
                             std::to_string(op_index) + ", qubit " + std::to_string(qubit) + ")");
+                    }
+                    if (outcome.source_level != pre.level_id()) {
+                        throw std::invalid_argument(
+                            "rewrite_continuation: classical outcome at op " +
+                            std::to_string(op_index) + ", qubit " + std::to_string(qubit) +
+                            " was drawn at level " + std::to_string(outcome.source_level) +
+                            " but the walk holds level " + std::to_string(pre.level_id()));
                     }
                     if (!outcome.jumped) {
                         continue;

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -153,7 +153,10 @@ struct ClassicalOutcome {
 // initial statuses, the trap chain so far, and the pre-drawn
 // classical-source outcomes for the remaining annotations. This struct is
 // also the continuation cache key's content: two shots with equal events
-// share one compiled module.
+// share one compiled module. The one field the key omits is
+// ClassicalOutcome::source_level -- it is derived from everything else
+// in the events and exists only to validate replays, so it cannot vary
+// within a key.
 struct ExactShotEvents {
     std::vector<QubitStatus> initial_status;
     std::vector<ResolvedJump> jumps;

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -155,15 +155,17 @@ struct ExactShotEvents {
 // A compiled-continuation rewrite: the circuit, the classifier record
 // writes in its suffix, and -- when the *last* jump in the chain traps at
 // a site whose collapse could not happen in-line (a neglect-form site on
-// a coherent carrier) -- the hidden measurement slot of that jump's
-// trace-out, which the driver forces to the trap's reported source.
+// a coherent carrier) -- the hidden record slot of that jump's carrier
+// reset, which the driver forces to the trap's reported source.
 struct ContinuationRewrite {
     Circuit circuit;
     std::vector<ClassifiedMeasurement> classified_measurements;
 
-    // Hidden record slot of the last jump's trace-out, or SIZE_MAX when
-    // no forcing is needed (the runtime already collapsed the carrier, or
-    // the jump landed computationally).
+    // Hidden record slot of the reset that collapses the last jump's
+    // carrier -- the trace-out R of a noncomputational destination, or
+    // the materializing R of a computational one -- or SIZE_MAX when the
+    // caller did not request forcing. Requesting forcing for a jump that
+    // emits no reset (the carrier's level was already definite) throws.
     size_t forced_traceout_slot = SIZE_MAX;
 
     // Annotation target of each kept (runtime-instrument) site, in

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -139,6 +139,14 @@ struct ClassicalOutcome {
     uint32_t qubit = 0;
     bool jumped = false;
     uint8_t destination_level = 0;
+    // The level the qubit held when the outcome was drawn. The emitted
+    // nodes do not depend on it; it exists so every reuse and
+    // consumption can check the outcome is not being replayed against a
+    // different source. Today a qubit's noncomputational level moves
+    // only through its own consults, so a mismatch is unreachable --
+    // this check is what keeps that invariant explicit, and loud if a
+    // future cross-qubit transition breaks it.
+    uint8_t source_level = 0;
 };
 
 // The status-outcome delta a continuation is compiled under: the shot's

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -104,4 +104,78 @@ struct RewriteResult {
 RewriteResult rewrite(const Circuit& original, const NonComputationalHistory& history,
                       const NonComputationalModel& model);
 
+// =============================================================================
+// Exact-mode continuation rewrite
+// =============================================================================
+//
+// In exact mode, transition firing happens at runtime and a fire that
+// cannot resolve in-line halts execution at its instrument site. The
+// continuation is the full circuit recompiled under the now-known status
+// outcomes: its prefix (everything up to and including the trapped
+// annotation) is emitted verbatim so it compiles bit-identically to the
+// code that already ran, and only the suffix is rewritten. Unlike the AOT
+// rewrite above, annotation nodes are kept wherever their qubit is still
+// computational -- they stay runtime instruments, including on a
+// recaptured qubit -- and are consumed only where the source is a
+// classical (leaked/lost) status, using outcomes the host pre-drew.
+
+// One resolved jump in a shot's trap chain, in circuit order. `op_index`
+// and `qubit` name the annotation target that trapped; the destination
+// level is the host's draw from the transition column.
+struct ResolvedJump {
+    uint32_t op_index = 0;
+    uint32_t qubit = 0;
+    uint8_t destination_level = 0;
+};
+
+// One pre-drawn outcome for an annotation target whose source status is
+// classical at that point (seepage, restore, lost-stays-lost). Records
+// no-jump outcomes too: the stream must cover every classical-source
+// consult after the last trap, in circuit order, so the rewrite can
+// validate it describes this circuit.
+struct ClassicalOutcome {
+    uint32_t op_index = 0;
+    uint32_t qubit = 0;
+    bool jumped = false;
+    uint8_t destination_level = 0;
+};
+
+// The status-outcome delta a continuation is compiled under: the shot's
+// initial statuses, the trap chain so far, and the pre-drawn
+// classical-source outcomes for the remaining annotations. This struct is
+// also the continuation cache key's content: two shots with equal events
+// share one compiled module.
+struct ExactShotEvents {
+    std::vector<QubitStatus> initial_status;
+    std::vector<ResolvedJump> jumps;
+    std::vector<ClassicalOutcome> classical_outcomes;
+};
+
+// A compiled-continuation rewrite: the circuit, the classifier record
+// writes in its suffix, and -- when the *last* jump in the chain traps at
+// a site whose collapse could not happen in-line (a neglect-form site on
+// a coherent carrier) -- the hidden measurement slot of that jump's
+// trace-out, which the driver forces to the trap's reported source.
+struct ContinuationRewrite {
+    Circuit circuit;
+    std::vector<ClassifiedMeasurement> classified_measurements;
+
+    // Hidden record slot of the last jump's trace-out, or SIZE_MAX when
+    // no forcing is needed (the runtime already collapsed the carrier, or
+    // the jump landed computationally).
+    size_t forced_traceout_slot = SIZE_MAX;
+};
+
+// Rewrite `annotated` (the hook-expanded circuit the main line was
+// compiled from) into the continuation for `events`. Every annotation
+// target before or at the last jump must be covered by the walk (no-fire
+// for targets not in `jumps`); classical_outcomes must list, in circuit
+// order, exactly the classical-source consults after the last jump.
+// `force_last_traceout` marks the last jump as a neglect-form trap whose
+// carrier arrives uncollapsed. Throws std::invalid_argument on policy
+// rejects and on events that do not describe this circuit.
+ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,
+                                         bool force_last_traceout,
+                                         const NonComputationalModel& model);
+
 }  // namespace clifft

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -63,6 +63,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 namespace clifft {
@@ -164,6 +165,16 @@ struct ContinuationRewrite {
     // no forcing is needed (the runtime already collapsed the carrier, or
     // the jump landed computationally).
     size_t forced_traceout_slot = SIZE_MAX;
+
+    // Annotation target of each kept (runtime-instrument) site, in
+    // emission order -- which is trace()'s materialization order, so the
+    // vector maps a trap's site_id to its (op_index, qubit) in the
+    // annotated circuit's coordinates.
+    std::vector<std::pair<uint32_t, uint32_t>> site_targets;
+
+    // Every qubit's status at the end of the walk: the shot's final
+    // statuses once execution reaches the end of this continuation.
+    std::vector<QubitStatus> final_status;
 };
 
 // Rewrite `annotated` (the hook-expanded circuit the main line was

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -219,7 +219,7 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
                     "sample_history: LOSS at op " + std::to_string(op_index) +
                     " requires a level table with exactly one Lost-category level");
             }
-            const double p = node.args.empty() ? 0.0 : node.args[0];
+            const double p = loss_probability(node.args, op_index, "sample_history");
             for (const Target& target : node.targets) {
                 const uint32_t qubit = target.value();
                 check_qubit(qubit, op_index);

--- a/src/clifft/noncomp/sampler.cc
+++ b/src/clifft/noncomp/sampler.cc
@@ -137,6 +137,24 @@ TransitionOutcome consult_transition(const TransitionInstrument& instrument,
 
 }  // namespace
 
+uint8_t draw_initial_level(const NonComputationalModel& model, Xoshiro256PlusPlus& rng) {
+    const size_t num_levels = model.levels().size();
+    const double u = rng.next_double();
+    double acc = 0.0;
+    int last_positive = 0;
+    for (uint8_t l = 0; l < num_levels; ++l) {
+        const double p = model.initial_probability(l);
+        if (p > 0.0) {
+            last_positive = l;
+        }
+        acc += p;
+        if (u < acc) {
+            return l;
+        }
+    }
+    return static_cast<uint8_t>(last_positive);
+}
+
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed) {
     const LevelSet& levels = model.levels();
@@ -149,29 +167,9 @@ HistorySample sample_history(const Circuit& circuit, const NonComputationalModel
     result.history.initial_status.reserve(circuit.num_qubits);
 
     // Sample each qubit's initial level independently from the shared
-    // initial-state distribution. The last level with positive probability
-    // catches any floating-point tail so a draw always resolves to a level
-    // the distribution can actually produce.
+    // initial-state distribution.
     for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
-        const double u = rng.next_double();
-        double acc = 0.0;
-        int last_positive = 0;
-        int chosen = -1;
-        for (uint8_t l = 0; l < num_levels; ++l) {
-            const double p = model.initial_probability(l);
-            if (p > 0.0) {
-                last_positive = l;
-            }
-            acc += p;
-            if (u < acc) {
-                chosen = l;
-                break;
-            }
-        }
-        if (chosen < 0) {
-            chosen = last_positive;
-        }
-        result.history.initial_status.push_back(levels.status_for(static_cast<uint8_t>(chosen)));
+        result.history.initial_status.push_back(levels.status_for(draw_initial_level(model, rng)));
     }
 
     std::vector<QubitStatus> status = result.history.initial_status;

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -32,12 +32,6 @@ struct HistorySample {
     std::vector<QubitStatus> final_status;
 };
 
-// Sample one trajectory over `circuit` under `model`, deterministic in
-// `seed`. Under UnknownSourcePolicy::Reject (the default), throws
-// std::invalid_argument on a source-context violation: a source-dependent
-// transition firing on a ComputationalUnknown qubit, naming the operation,
-// qubit, and gate. Under EqualizeRates that case is sampled with the
-// equalized-rates approximation instead (see policy.h).
 // Draw one qubit's initial level from the model's shared initial-state
 // distribution, with the last positive level catching the floating-point
 // tail so a draw always resolves to a level the distribution can produce.
@@ -45,6 +39,12 @@ struct HistorySample {
 // paths sample initials identically.
 uint8_t draw_initial_level(const NonComputationalModel& model, Xoshiro256PlusPlus& rng);
 
+// Sample one trajectory over `circuit` under `model`, deterministic in
+// `seed`. Under UnknownSourcePolicy::Reject (the default), throws
+// std::invalid_argument on a source-context violation: a source-dependent
+// transition firing on a ComputationalUnknown qubit, naming the operation,
+// qubit, and gate. Under EqualizeRates that case is sampled with the
+// equalized-rates approximation instead (see policy.h).
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed);
 

--- a/src/clifft/noncomp/sampler.h
+++ b/src/clifft/noncomp/sampler.h
@@ -18,6 +18,7 @@
 #include "clifft/noncomp/history.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/qubit_status.h"
+#include "clifft/util/xoshiro.h"
 
 #include <cstdint>
 #include <vector>
@@ -37,6 +38,13 @@ struct HistorySample {
 // transition firing on a ComputationalUnknown qubit, naming the operation,
 // qubit, and gate. Under EqualizeRates that case is sampled with the
 // equalized-rates approximation instead (see policy.h).
+// Draw one qubit's initial level from the model's shared initial-state
+// distribution, with the last positive level catching the floating-point
+// tail so a draw always resolves to a level the distribution can produce.
+// Shared by the AOT history sampler and the exact-mode driver so the two
+// paths sample initials identically.
+uint8_t draw_initial_level(const NonComputationalModel& model, Xoshiro256PlusPlus& rng);
+
 HistorySample sample_history(const Circuit& circuit, const NonComputationalModel& model,
                              uint64_t seed);
 

--- a/src/clifft/noncomp/seed.h
+++ b/src/clifft/noncomp/seed.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// Per-shot seed derivation shared by the noncomputational sampling
+// paths. One global seed fans out into independent sub-streams, one per
+// (shot, domain) pair; every domain tag lives here so their pairwise
+// distinctness is visible in one place.
+
+#include <cstdint>
+
+namespace clifft {
+
+// AOT orchestrator streams: trajectory pre-sampling, classifier draws,
+// and the in-VM measurement randomness of the compiled module.
+inline constexpr uint64_t kHistoryDomain = 0x1;
+inline constexpr uint64_t kClassifierDomain = 0x2;
+inline constexpr uint64_t kSvmDomain = 0x3;
+
+// Exact-driver streams: the driver's own draws between VM runs (initial
+// levels, trap destinations, classical consults, herald flags) and the
+// in-VM measurement randomness of the modules it executes.
+inline constexpr uint64_t kExactDriverDomain = 0x11;
+inline constexpr uint64_t kExactSvmDomain = 0x12;
+
+// SplitMix64 finalizer over a mix of the global seed, shot, and domain.
+// Full-avalanche mixing: adjacent shots and sibling domains land in
+// statistically unrelated generator states, which is the xoshiro
+// authors' recommended seeding procedure.
+inline uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
+    uint64_t z = global ^ (shot * 0x9E3779B97F4A7C15ULL) ^ (domain * 0xBF58476D1CE4E5B9ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -1,6 +1,29 @@
 #include "clifft/noncomp/status_step.h"
 
+#include "clifft/noncomp/numeric.h"
+
+#include <stdexcept>
+#include <string>
+
 namespace clifft {
+
+double loss_probability(const std::vector<double>& args, uint32_t op_index,
+                        std::string_view caller) {
+    if (args.size() != 1) {
+        throw std::invalid_argument(std::string(caller) + ": LOSS at op " +
+                                    std::to_string(op_index) +
+                                    " requires exactly one argument (the loss probability)");
+    }
+    const double p = args[0];
+    // is_finite_robust runs first because -ffast-math folds
+    // std::isfinite() / NaN-aware comparisons away.
+    if (!is_finite_robust(p) || p < 0.0 || p > 1.0) {
+        throw std::invalid_argument(std::string(caller) + ": LOSS probability at op " +
+                                    std::to_string(op_index) + " = " + std::to_string(p) +
+                                    " is not finite or is out of [0, 1]");
+    }
+    return p;
+}
 
 std::optional<uint8_t> sole_lost_level(const LevelSet& levels) {
     std::optional<uint8_t> found;

--- a/src/clifft/noncomp/status_step.h
+++ b/src/clifft/noncomp/status_step.h
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 #include <optional>
+#include <string_view>
+#include <vector>
 
 namespace clifft {
 
@@ -23,6 +25,14 @@ namespace clifft {
 // LOSS annotation resolves its destination through this; a table with no
 // or several Lost levels cannot host it.
 std::optional<uint8_t> sole_lost_level(const LevelSet& levels);
+
+// The validated loss probability of a LOSS annotation node's argument
+// list: exactly one argument, finite, in [0, 1]. The parser guarantees
+// this shape for parsed circuits; a hand-built node that violates it is
+// rejected here rather than silently defaulting to a no-op. `caller`
+// prefixes the error message.
+double loss_probability(const std::vector<double>& args, uint32_t op_index,
+                        std::string_view caller);
 
 // The role a qubit operand plays in an operation. The same GateType can
 // mean physically different things: a CX with two qubit operands is a

--- a/src/clifft/optimizer/pass_factory.cc
+++ b/src/clifft/optimizer/pass_factory.cc
@@ -57,6 +57,8 @@ std::string pass_registry_json() {
         out += (p.kind == PassKind::HIR) ? "hir" : "bytecode";
         out += "\",\"default\":";
         out += p.default_enabled ? "true" : "false";
+        out += ",\"preserves_record_order\":";
+        out += p.record_order.preserved ? "true" : "false";
         out += "}";
     }
     out += ']';

--- a/src/clifft/optimizer/pass_registry.h
+++ b/src/clifft/optimizer/pass_registry.h
@@ -25,10 +25,29 @@ enum class PassKind : uint8_t { HIR, Bytecode };
 using HirPassFactory = std::unique_ptr<HirPass> (*)();
 using BytecodePassFactory = std::unique_ptr<BytecodePass> (*)();
 
+// Whether a pass keeps every record-writing operation (visible and
+// hidden measurement records alike) in program order, neither
+// reordering nor removing one. Reordering commuting measurements is
+// sound under sampling semantics -- the outcomes are exchangeable --
+// but not under forced-outcome execution, where a forced collapse must
+// happen before the operations correlated with it; pipelines that
+// force outcomes run only passes declaring `preserved`. There is no
+// default: a newly registered pass that does not declare its behavior
+// fails to compile rather than silently joining (or silently breaking)
+// those pipelines.
+struct RecordOrder {
+    bool preserved;
+    constexpr explicit RecordOrder(bool preserved_in) : preserved(preserved_in) {}
+};
+
+inline constexpr RecordOrder kPreservesRecordOrder{true};
+inline constexpr RecordOrder kBreaksRecordOrder{false};
+
 struct PassInfo {
     std::string_view name;
     PassKind kind;
     bool default_enabled;
+    RecordOrder record_order;
     HirPassFactory make_hir = nullptr;
     BytecodePassFactory make_bc = nullptr;
 };
@@ -50,47 +69,58 @@ inline const PassInfo kRegisteredPasses[] = {
     {.name = "PeepholeFusionPass",
      .kind = PassKind::HIR,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_hir = make_hir<PeepholeFusionPass>},
     {.name = "StatevectorSqueezePass",
      .kind = PassKind::HIR,
      .default_enabled = true,
+     .record_order = kBreaksRecordOrder,
      .make_hir = make_hir<StatevectorSqueezePass>},
     {.name = "RemoveNoisePass",
      .kind = PassKind::HIR,
      .default_enabled = false,
+     .record_order = kPreservesRecordOrder,
      .make_hir = make_hir<RemoveNoisePass>},
     {.name = "DropNonUnitaryPass",
      .kind = PassKind::HIR,
      .default_enabled = false,
+     .record_order = kBreaksRecordOrder,
      .make_hir = make_hir<DropNonUnitaryPass>},
     // Bytecode passes
     {.name = "NoiseBlockPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<NoiseBlockPass>},
     {.name = "MultiGatePass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<MultiGatePass>},
     {.name = "ExpandTPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<ExpandTPass>},
     {.name = "ExpandRotPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<ExpandRotPass>},
     {.name = "SwapMeasPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<SwapMeasPass>},
     {.name = "TileAxisFusionPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<TileAxisFusionPass>},
     {.name = "SingleAxisFusionPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
+     .record_order = kPreservesRecordOrder,
      .make_bc = make_bc<SingleAxisFusionPass>},
 };
 

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -70,17 +70,19 @@ void register_noncomp(nb::module_& m) {
            std::optional<std::vector<std::string>> classifier_symbols,
            std::optional<std::vector<std::vector<double>>> classifier_matrix,
            bool reset_restores_lost, const std::string& unknown_source_policy,
-           const std::string& lost_leaked_ops) {
+           const std::string& lost_leaked_ops, const std::string& damping) {
             clifft::NonComputationalPolicy policy;
             policy.reset_restores_lost = reset_restores_lost;
             if (unknown_source_policy == "reject") {
                 policy.unknown_source_policy = clifft::UnknownSourcePolicy::Reject;
             } else if (unknown_source_policy == "equalize_rates") {
                 policy.unknown_source_policy = clifft::UnknownSourcePolicy::EqualizeRates;
+            } else if (unknown_source_policy == "exact") {
+                policy.unknown_source_policy = clifft::UnknownSourcePolicy::Exact;
             } else {
                 throw std::invalid_argument(
-                    "noncomp model: unknown_source_policy must be 'reject' or 'equalize_rates', "
-                    "got '" +
+                    "noncomp model: unknown_source_policy must be 'reject', 'equalize_rates', "
+                    "or 'exact', got '" +
                     unknown_source_policy + "'");
             }
             if (lost_leaked_ops == "reject") {
@@ -91,6 +93,14 @@ void register_noncomp(nb::module_& m) {
                 throw std::invalid_argument(
                     "noncomp model: lost_leaked_ops must be 'reject' or 'drop', got '" +
                     lost_leaked_ops + "'");
+            }
+            if (damping == "exact") {
+                policy.damping = clifft::DampingPolicy::Exact;
+            } else if (damping == "neglect") {
+                policy.damping = clifft::DampingPolicy::Neglect;
+            } else {
+                throw std::invalid_argument(
+                    "noncomp model: damping must be 'exact' or 'neglect', got '" + damping + "'");
             }
 
             std::optional<clifft::ClassifierSpec> spec;
@@ -110,18 +120,18 @@ void register_noncomp(nb::module_& m) {
         nb::arg("initial_state"), nb::arg("transitions"),
         nb::arg("classifier_symbols") = nb::none(), nb::arg("classifier_matrix") = nb::none(),
         nb::arg("reset_restores_lost") = false, nb::arg("unknown_source_policy") = "reject",
-        nb::arg("lost_leaked_ops") = "reject",
+        nb::arg("lost_leaked_ops") = "reject", nb::arg("damping") = "exact",
         "Build a default 5-level NonComputationalModel from raw matrices. See "
         "clifft.noncomp.Model.");
 
     m.def(
         "_sample_noncomputational",
         [](const clifft::Circuit& circuit, const clifft::NonComputationalModel& model,
-           uint32_t shots, std::optional<uint64_t> seed) {
+           uint32_t shots, std::optional<uint64_t> seed, std::optional<uint32_t> max_rank) {
             clifft::NonComputationalSample r;
             {
                 nb::gil_scoped_release release;
-                r = clifft::sample_noncomputational(circuit, model, shots, seed);
+                r = clifft::sample_noncomputational(circuit, model, shots, seed, max_rank);
             }
             // Collapse per-qubit final status to {0 computational, 1 leaked,
             // 2 lost}; the internal known/unknown computational split is not
@@ -149,6 +159,7 @@ void register_noncomp(nb::module_& m) {
                                   r.num_detectors, r.num_observables);
         },
         nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
+        nb::arg("max_rank") = nb::none(),
         "Sample a noncomputational model. Returns (measurements, detectors, observables, "
         "final_status, heralds, num_qubits, num_measurements, num_detectors, num_observables).");
 }

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -118,13 +118,18 @@ class Model:
         reset_restores_lost: if true, a reset on a lost qubit restores it.
         unknown_source_policy: how a source-dependent transition on a qubit
             whose computational state is unknown is handled. ``"reject"``
-            (the default) raises; ``"equalize_rates"`` opts into an
-            approximation that pads every computational column with a
-            diagonal pseudo-jump up to the maximum computational jump rate,
-            draws the source uniformly, and collapses the carrier on every
-            jump. The approximation matches unbiased unknown-source
-            marginals; deterministic-but-untracked states remain
-            approximate, and destination-collapse correlations are
+            (the default) raises; ``"exact"`` moves transition firing into
+            the runtime -- the circuit compiles once with every annotation
+            as an instrument site, fire probabilities are evaluated on the
+            live state, and rare fires recompile-and-resume -- exact for
+            every source context, at a cost exponential in the number of
+            expanded sites (see ``damping``); ``"equalize_rates"`` opts
+            into an approximation that pads every computational column
+            with a diagonal pseudo-jump up to the maximum computational
+            jump rate, draws the source uniformly, and collapses the
+            carrier on every jump. The approximation matches unbiased
+            unknown-source marginals; deterministic-but-untracked states
+            remain approximate, and destination-collapse correlations are
             discarded.
         lost_leaked_ops: how an operation with no representable effect on a
             leaked or lost operand is handled. ``"reject"`` (the default)
@@ -132,6 +137,14 @@ class Model:
             acting as the identity on the surviving operands. Measurements
             are never dropped; their record slot is kept and the classifier
             supplies the outcome.
+        damping: exact-mode handling of sites whose no-fire back-action is
+            genuinely non-Clifford (a source-dependent transition on a
+            coherent qubit outside the amplitude array). ``"exact"`` (the
+            default) expands the qubit into the array, adding one to the
+            circuit's rank at that site; ``"neglect"`` keeps the rank and
+            omits the no-fire back-action, a survivorship tilt of order
+            ``|p_g - p_e|`` with no effect on source-independent rates.
+            Only meaningful under ``unknown_source_policy="exact"``.
 
     Construction validates shapes, probabilities, gate keys, policy values,
     and level table consistency in C++, raising ``ValueError`` on any
@@ -148,6 +161,7 @@ class Model:
         reset_restores_lost: bool = False,
         unknown_source_policy: str = "reject",
         lost_leaked_ops: str = "reject",
+        damping: str = "exact",
     ) -> None:
         transition_matrices = {
             str(gate): _as_matrix(matrix) for gate, matrix in (transitions or {}).items()
@@ -162,6 +176,7 @@ class Model:
             bool(reset_restores_lost),
             str(unknown_source_policy),
             str(lost_leaked_ops),
+            str(damping),
         )
 
 
@@ -243,6 +258,7 @@ def sample(
     model: Model,
     shots: int,
     seed: int | None = None,
+    max_rank: int | None = None,
 ) -> NonComputationalSample:
     """Sample ``circuit`` under ``model`` for ``shots`` shots.
 
@@ -250,11 +266,16 @@ def sample(
     :class:`NonComputationalSample`. Raises ``ValueError`` when the trajectory
     policy rejects an operation, when a leaked/lost measurement needs a
     classifier the model lacks, or when a classifier column is unsupported.
+
+    ``max_rank`` caps the compiled peak rank under
+    ``unknown_source_policy="exact"``: compilation fails with the offending
+    circuit line named, before any state allocation, instead of attempting
+    a ``2**k`` allocation. Unlimited when ``None``.
     """
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)
     meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs = (
-        _clifft_core._sample_noncomputational(circuit, model._handle, shots, seed)
+        _clifft_core._sample_noncomputational(circuit, model._handle, shots, seed, max_rank)
     )
     return NonComputationalSample(
         meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(clifft_tests
     test_noncomp_op_role.cc
     test_noncomp_sampler.cc
     test_noncomp_rewriter.cc
+    test_noncomp_continuation.cc
     test_noncomp_orchestrator.cc
     test_noncomp_validation.cc
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(clifft_tests
     test_noncomp_sampler.cc
     test_noncomp_rewriter.cc
     test_noncomp_continuation.cc
+    test_exact_driver.cc
     test_noncomp_orchestrator.cc
     test_noncomp_validation.cc
 )

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -213,16 +213,64 @@ TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
         ContainsSubstring("exceeds max_rank 2") && ContainsSubstring("circuit line"));
 }
 
-TEST_CASE("exact: a neglect-form trap is guarded until the correlated continuation lands") {
+TEST_CASE("exact: a neglect-form trap keeps the fire-side correlation") {
+    // The decisive pin for the forced trace-out. Qubit 0 is Bell-entangled
+    // with qubit 1 and dormant-random at the site; under neglect the fire
+    // traps with the carrier uncollapsed. The channel is certain but
+    // source-dependent in its destination (g -> leak_g, e -> leak_e), and
+    // the classifier maps those levels to 0 and 1 -- so the classified
+    // M 0 *is* the reported source, and the partner's M 1 must equal it
+    // on every shot, because the continuation's trace-out is forced to
+    // that same source. Independent redraw would mismatch half the time.
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeakG][0] = 1.0;  // from g: leak_g, certainly
+    leak[kLeak][1] = 1.0;   // from e: leak_e, certainly
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1"};
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0},   // leak_g reads 0
+                         {0.0, 1.0, 0.0, 1.0, 0.0}};  // leak_e reads 1
+
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = UnknownSourcePolicy::Exact;
+    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
+    policy.damping = DampingPolicy::Neglect;
+    auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
+                                                  {{"leak", leak}}, classifier, policy);
+
+    auto circuit = parse("H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
+    auto result = sample_noncomputational(circuit, model, 100, 29);
+
+    bool saw_zero = false;
+    bool saw_one = false;
+    for (uint32_t shot = 0; shot < 100; ++shot) {
+        const uint8_t classified = result.measurements[shot * 2];
+        const uint8_t partner = result.measurements[shot * 2 + 1];
+        REQUIRE(classified == partner);
+        (classified == 0 ? saw_zero : saw_one) = true;
+    }
+    REQUIRE(saw_zero);
+    REQUIRE(saw_one);
+}
+
+TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
     ModelSpec spec;
-    spec.leak_from_e = 1.0;
-    spec.leak_from_g = 0.5;
+    spec.leak_from_e = 0.3;  // source-dependent: the damp is non-scalar
     spec.damping = DampingPolicy::Neglect;
     auto model = make_model(spec);
-    auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+    auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0");
 
-    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 20, 29),
-                        ContainsSubstring("neglect-form site fired"));
+    // max_rank 0 admits the neglect compile (no expansion) and would
+    // reject the exact-damping one (which adds one at the site).
+    auto result = sample_noncomputational(circuit, model, 50, 37, /*max_rank=*/0);
+    REQUIRE(result.measurements.size() == 50);
+
+    ModelSpec exact_spec = spec;
+    exact_spec.damping = DampingPolicy::Exact;
+    REQUIRE_THROWS_WITH(
+        sample_noncomputational(circuit, make_model(exact_spec), 50, 37, /*max_rank=*/0),
+        ContainsSubstring("exceeds max_rank 0"));
 }
 
 TEST_CASE("exact: ternary heralds ride the cache key") {

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -1,0 +1,258 @@
+// End-to-end tests for exact-mode sampling: the driver loop, continuation
+// cache, frame-preloaded initials, and trap resolution behind
+// sample_noncomputational with unknown_source_policy = Exact.
+//
+// Deterministic pins use certain (p = 1) channels; the exact-vs-AOT
+// agreement checks use source-independent rates, where both paths are
+// exact, with generous statistical margins (the full distributional
+// campaign is a later step).
+
+#include "clifft/circuit/parser.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/orchestrator.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+constexpr uint8_t kLeakG = 2;
+constexpr uint8_t kLeak = 3;
+constexpr uint8_t kLost = 4;
+
+struct ModelSpec {
+    double leak_from_g = 0.0;
+    double leak_from_e = 0.0;
+    double seep_to_e = 0.0;
+    std::vector<double> initial = {1.0, 0.0, 0.0, 0.0, 0.0};
+    DampingPolicy damping = DampingPolicy::Exact;
+    UnknownSourcePolicy source_policy = UnknownSourcePolicy::Exact;
+};
+
+NonComputationalModel make_model(const ModelSpec& spec) {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeak][0] = spec.leak_from_g;
+    leak[kLeak][1] = spec.leak_from_e;
+    leak[1][kLeak] = spec.seep_to_e;
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1"};
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = spec.source_policy;
+    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
+    policy.damping = spec.damping;
+    return NonComputationalModel::from_spec(levels, spec.initial, {{"leak", leak}}, classifier,
+                                            policy);
+}
+
+double mean_of(const std::vector<uint8_t>& bits, uint32_t stride, uint32_t index) {
+    double sum = 0.0;
+    size_t n = 0;
+    for (size_t i = index; i < bits.size(); i += stride) {
+        sum += bits[i];
+        ++n;
+    }
+    return n > 0 ? sum / static_cast<double>(n) : 0.0;
+}
+
+}  // namespace
+
+TEST_CASE("exact: an untrapped run reproduces plain sampling behavior") {
+    // No annotations at all: the exact path is one shared module executed
+    // per shot. A Bell pair's measurements must be perfectly correlated.
+    ModelSpec spec;
+    auto model = make_model(spec);
+    auto circuit = parse("H 0\nCX 0 1\nM 0\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 200, 7);
+    REQUIRE(result.measurements.size() == 400);
+    int ones = 0;
+    for (uint32_t shot = 0; shot < 200; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == result.measurements[shot * 2 + 1]);
+        ones += result.measurements[shot * 2];
+    }
+    REQUIRE(ones > 50);
+    REQUIRE(ones < 150);
+    for (const QubitStatus& s : result.final_status) {
+        REQUIRE(s.kind() != QubitStatusKind::Leaked);
+        REQUIRE(s.kind() != QubitStatusKind::Lost);
+    }
+}
+
+TEST_CASE("exact: a certain leak traps, classifies, and reports the status") {
+    // From |1> (X prep), the site fires every shot; the leaked qubit's
+    // measurement classifies (leaked column reads 1) and the sidecar
+    // carries the leaked status. Qubit 1 is untouched.
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;
+    auto model = make_model(spec);
+    auto circuit = parse("X 0\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 25, 3);
+    for (uint32_t shot = 0; shot < 25; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == 1);      // classifier: leaked reads 1
+        REQUIRE(result.measurements[shot * 2 + 1] == 0);  // spectator
+        REQUIRE(result.final_status[shot * 2].kind() == QubitStatusKind::Leaked);
+        REQUIRE(result.final_status[shot * 2 + 1].kind() == QubitStatusKind::ComputationalKnown);
+    }
+}
+
+TEST_CASE("exact: a known |1> initial preloads the frame without a distinct module") {
+    // Initial state entirely on e: every shot must measure 1 through the
+    // frame preload alone.
+    ModelSpec spec;
+    spec.initial = {0.0, 1.0, 0.0, 0.0, 0.0};
+    auto model = make_model(spec);
+    auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 25, 11);
+    for (uint32_t shot = 0; shot < 25; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);
+    }
+}
+
+TEST_CASE("exact: a noncomputational initial compiles its own continuation") {
+    // Initial state entirely on the lost level: no trap ever fires (the
+    // annotation is a classical consult), the measurement classifies from
+    // the lost column, and the final status stays Lost.
+    ModelSpec spec;
+    spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};
+    auto model = make_model(spec);
+    auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 10, 5);
+    for (uint32_t shot = 0; shot < 10; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);  // the fixture's lost column reads 0
+        REQUIRE(result.final_status[shot].kind() == QubitStatusKind::Lost);
+    }
+}
+
+TEST_CASE("exact: seepage after a trap recaptures through a classical consult") {
+    // Certain leak, then certain seepage back to e at the next site, then
+    // a measurement: every shot reads 1 with a computational final
+    // status. The recapture path exercises pre-drawn classical outcomes
+    // and the multi-annotation continuation.
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;
+    spec.seep_to_e = 1.0;
+    auto model = make_model(spec);
+    auto circuit = parse("X 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 20, 13);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);
+        REQUIRE(result.final_status[shot].kind() == QubitStatusKind::ComputationalKnown);
+    }
+}
+
+TEST_CASE("exact: agreement with the AOT path where both are exact") {
+    // A source-independent rate (p_g = p_e) is exact under the AOT
+    // sampler too. Compare the leaked-measurement marginal over many
+    // shots with a generous margin: p(leak) = 0.3, and a leaked qubit
+    // reads 1 while a computational |0> reads 0.
+    const uint32_t shots = 4000;
+    auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
+
+    ModelSpec exact_spec;
+    exact_spec.leak_from_g = 0.3;
+    exact_spec.leak_from_e = 0.3;
+    auto exact_result = sample_noncomputational(circuit, make_model(exact_spec), shots, 17);
+
+    ModelSpec aot_spec = exact_spec;
+    aot_spec.source_policy = UnknownSourcePolicy::Reject;  // AOT path, exact here
+    auto aot_result = sample_noncomputational(circuit, make_model(aot_spec), shots, 17);
+
+    const double exact_mean = mean_of(exact_result.measurements, 1, 0);
+    const double aot_mean = mean_of(aot_result.measurements, 1, 0);
+    // Binomial std at p = 0.3 over 4000 shots is ~0.007; allow 5 sigma
+    // between each mean and the true rate.
+    REQUIRE(std::abs(exact_mean - 0.3) < 0.04);
+    REQUIRE(std::abs(aot_mean - 0.3) < 0.04);
+}
+
+TEST_CASE("exact: same seed reproduces identical runs") {
+    ModelSpec spec;
+    spec.leak_from_e = 0.5;
+    spec.initial = {0.5, 0.5, 0.0, 0.0, 0.0};
+    auto model = make_model(spec);
+    auto circuit = parse("H 1\nCX 1 0\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
+
+    auto a = sample_noncomputational(circuit, model, 100, 23);
+    auto b = sample_noncomputational(circuit, model, 100, 23);
+    REQUIRE(a.measurements == b.measurements);
+    REQUIRE(a.heralds == b.heralds);
+    for (size_t i = 0; i < a.final_status.size(); ++i) {
+        REQUIRE(a.final_status[i].kind() == b.final_status[i].kind());
+    }
+}
+
+TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
+    // Each dormant-random exact site adds one to k: three H-prefixed
+    // sites push the peak to 3, over a cap of 2.
+    ModelSpec spec;
+    spec.leak_from_e = 0.2;
+    auto model = make_model(spec);
+    auto circuit = parse(
+        "H 0\nH 1\nH 2\n"
+        "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
+        "M 0\nM 1\nM 2");
+
+    REQUIRE_THROWS_WITH(
+        sample_noncomputational(circuit, model, 5, 1, /*max_rank=*/2),
+        ContainsSubstring("exceeds max_rank 2") && ContainsSubstring("circuit line"));
+}
+
+TEST_CASE("exact: a neglect-form trap is guarded until the correlated continuation lands") {
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;
+    spec.leak_from_g = 0.5;
+    spec.damping = DampingPolicy::Neglect;
+    auto model = make_model(spec);
+    auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 20, 29),
+                        ContainsSubstring("neglect-form site fired"));
+}
+
+TEST_CASE("exact: ternary heralds ride the cache key") {
+    // A three-symbol classifier whose leaked column always heralds: every
+    // trapped shot's classified slot reports a herald, and the record bit
+    // stays roughly fair across shots.
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeak][1] = 1.0;
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1", "herald"};
+    classifier.matrix = {
+        {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = UnknownSourcePolicy::Exact;
+    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
+    auto model = NonComputationalModel::from_spec(levels, {0.0, 1.0, 0.0, 0.0, 0.0},
+                                                  {{"leak", leak}}, classifier, policy);
+
+    auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
+    auto result = sample_noncomputational(circuit, model, 200, 31);
+
+    int ones = 0;
+    for (uint32_t shot = 0; shot < 200; ++shot) {
+        REQUIRE(result.heralds[shot] == 1);
+        ones += result.measurements[shot];
+    }
+    // Heralded slots carry a uniform bit.
+    REQUIRE(ones > 60);
+    REQUIRE(ones < 140);
+}

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -511,3 +511,26 @@ TEST_CASE("exact: ternary heralds ride the cache key") {
     REQUIRE(ones > 60);
     REQUIRE(ones < 140);
 }
+
+TEST_CASE("exact: a hand-built malformed LOSS rejects up front") {
+    // A live LOSS site rides through the continuation rewrite verbatim,
+    // and trace() must never be the first to look at its arguments (a
+    // missing one would read as probability zero). Every annotation
+    // validates before the first compile instead. The parser guarantees
+    // LOSS(p) for parsed circuits; these are programmatically built.
+    ModelSpec spec;
+    auto model = make_model(spec);
+    Circuit circuit = parse("H 0\nM 0");
+    SECTION("missing the probability argument") {
+        circuit.nodes.insert(circuit.nodes.begin() + 1,
+                             AstNode{GateType::LOSS, {Target::qubit(0)}, {}, 0});
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
+                            ContainsSubstring("exactly one argument"));
+    }
+    SECTION("probability outside [0, 1]") {
+        circuit.nodes.insert(circuit.nodes.begin() + 1,
+                             AstNode{GateType::LOSS, {Target::qubit(0)}, {7.0}, 0});
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
+                            ContainsSubstring("out of [0, 1]"));
+    }
+}

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -254,6 +254,106 @@ TEST_CASE("exact: a neglect-form trap keeps the fire-side correlation") {
     REQUIRE(saw_one);
 }
 
+TEST_CASE("exact: a trap may insert a classical consult between pre-drawn ones") {
+    // Both qubits start leaked; R 0; X 0 recaptures q0 to a definite |1>,
+    // so q0's first annotation is quantum and traps (certain leak from
+    // e), while q1's later annotation was already pre-drawn as a
+    // classical consult. The trap turns q0's *second* annotation
+    // classical at a position before q1's recorded outcome -- the shape
+    // that breaks an append-only outcome stream. Post-fix: both
+    // measurements classify as leaked (reads 1) on every shot.
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;
+    spec.initial = {0.0, 0.0, 0.0, 1.0, 0.0};  // all mass on the leaked level
+    auto model = make_model(spec);
+    auto circuit = parse(
+        "R 0\nX 0\n"
+        "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\n"
+        "M 0\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 25, 41);
+    for (uint32_t shot = 0; shot < 25; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == 1);
+        REQUIRE(result.measurements[shot * 2 + 1] == 1);
+        REQUIRE(result.final_status[shot * 2].kind() == QubitStatusKind::Leaked);
+        REQUIRE(result.final_status[shot * 2 + 1].kind() == QubitStatusKind::Leaked);
+    }
+}
+
+TEST_CASE("exact: a chain of two forced traps keeps both correlations") {
+    // Two independent Bell pairs, each with a certain source-dependent
+    // leak under neglect: every shot traps twice, forcing two trace-outs
+    // at two different hidden slots, and the second continuation's prefix
+    // contains the first's forced instruction (exercising the
+    // sampling/forced mask in the debug prefix comparison). Both
+    // partner correlations must survive.
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeakG][0] = 1.0;
+    leak[kLeak][1] = 1.0;
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1"};
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = UnknownSourcePolicy::Exact;
+    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
+    policy.damping = DampingPolicy::Neglect;
+    auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
+                                                  {{"leak", leak}}, classifier, policy);
+
+    auto circuit = parse(
+        "H 0\nCX 0 1\nH 2\nCX 2 3\n"
+        "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 2\n"
+        "M 0\nM 1\nM 2\nM 3");
+    auto result = sample_noncomputational(circuit, model, 60, 43);
+
+    for (uint32_t shot = 0; shot < 60; ++shot) {
+        const uint8_t* m = result.measurements.data() + shot * 4;
+        REQUIRE(m[0] == m[1]);
+        REQUIRE(m[2] == m[3]);
+    }
+}
+
+TEST_CASE("exact: a neglect fire onto a computational destination stays correlated") {
+    // Under neglect every fire traps, including computational
+    // destinations. A certain source-swap channel (g -> e, e -> g) on a
+    // Bell-entangled dormant-random qubit: the continuation's forced
+    // materialization collapses the partner to the source while the
+    // trapped qubit re-preps at the destination, so the two measurements
+    // must anti-correlate on every shot.
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> swap_ge(5, std::vector<double>(5, 0.0));
+    swap_ge[1][0] = 1.0;  // g -> e, certainly
+    swap_ge[0][1] = 1.0;  // e -> g, certainly
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1"};
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = UnknownSourcePolicy::Exact;
+    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
+    policy.damping = DampingPolicy::Neglect;
+    auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
+                                                  {{"swap", swap_ge}}, classifier, policy);
+
+    auto circuit = parse("H 0\nCX 0 1\nLEVEL_TRANSITION[swap] 0\nM 0\nM 1");
+    auto result = sample_noncomputational(circuit, model, 60, 47);
+
+    bool saw_zero = false;
+    bool saw_one = false;
+    for (uint32_t shot = 0; shot < 60; ++shot) {
+        const uint8_t trapped = result.measurements[shot * 2];
+        const uint8_t partner = result.measurements[shot * 2 + 1];
+        REQUIRE(trapped == 1 - partner);
+        (partner == 0 ? saw_zero : saw_one) = true;
+    }
+    REQUIRE(saw_zero);
+    REQUIRE(saw_one);
+}
+
 TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
     ModelSpec spec;
     spec.leak_from_e = 0.3;  // source-dependent: the damp is non-scalar

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -354,6 +354,113 @@ TEST_CASE("exact: a neglect fire onto a computational destination stays correlat
     REQUIRE(saw_one);
 }
 
+TEST_CASE("exact: herald flags drawn in one continuation are reused by the next") {
+    // The reuse invariant, made observable: with p_herald = 0.5 and a
+    // deterministic not-heralded bit (P(1 | leak, not heralded) = 1), a
+    // slot whose sidecar flag says not-heralded must always record 1 --
+    // the record was drawn under the same flag that the sidecar reports.
+    // If the second continuation redrew the flag independently, its patch
+    // could disagree with the sidecar and break the invariant half the
+    // time. The two-trap chain makes slot 0's flag be drawn while
+    // compiling continuation one and reused by continuation two, where
+    // the measurement actually executes.
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeak][1] = 1.0;  // certain leak from e
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1", "herald"};
+    classifier.matrix = {
+        {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.5, 0.0}, {0.0, 0.0, 0.0, 0.5, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.unknown_source_policy = UnknownSourcePolicy::Exact;
+    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
+    auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
+                                                  {{"leak", leak}}, classifier, policy);
+
+    auto circuit = parse("X 0\nX 1\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nM 0\nM 1");
+    auto result = sample_noncomputational(circuit, model, 200, 53);
+
+    int heralded = 0;
+    for (uint32_t shot = 0; shot < 200; ++shot) {
+        for (uint32_t slot = 0; slot < 2; ++slot) {
+            const uint8_t herald = result.heralds[shot * 2 + slot];
+            const uint8_t bit = result.measurements[shot * 2 + slot];
+            if (herald == 0) {
+                REQUIRE(bit == 1);  // the not-heralded conditional is deterministic
+            }
+            heralded += herald;
+        }
+    }
+    REQUIRE(heralded > 120);  // p_herald = 0.5 over 400 slots
+    REQUIRE(heralded < 280);
+}
+
+TEST_CASE("exact: spectator noise between two traps fires exactly once") {
+    // Certain X errors on a spectator qubit, one between the two traps
+    // and one after: the noise-gap cursor must fire each exactly once
+    // across the two re-anchors, flipping the spectator twice back to 0.
+    // A cursor that refires or skips across either resume flips the
+    // deterministic record.
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;
+    auto model = make_model(spec);
+    auto circuit = parse(
+        "X 0\nX 1\n"
+        "LEVEL_TRANSITION[leak] 0\nX_ERROR(1) 2\nLEVEL_TRANSITION[leak] 1\nX_ERROR(1) 2\n"
+        "M 2");
+
+    auto result = sample_noncomputational(circuit, model, 20, 59);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);
+        REQUIRE(result.final_status[shot * 3].kind() == QubitStatusKind::Leaked);
+        REQUIRE(result.final_status[shot * 3 + 1].kind() == QubitStatusKind::Leaked);
+    }
+}
+
+TEST_CASE("exact: a detector and observable span the trap boundary") {
+    // The detector compares a pre-trap measurement (executed on the main
+    // line) with a post-trap classified one (written by the
+    // continuation): both read 1, so the parity is 0 on every shot, and
+    // the observable carries the classified bit.
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;
+    auto model = make_model(spec);
+    auto circuit = parse(
+        "X 0\nM 0\nLEVEL_TRANSITION[leak] 0\nM 0\n"
+        "DETECTOR rec[-1] rec[-2]\nOBSERVABLE_INCLUDE(0) rec[-1]");
+
+    auto result = sample_noncomputational(circuit, model, 20, 61);
+    REQUIRE(result.num_detectors == 1);
+    REQUIRE(result.num_observables == 1);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == 1);      // pre-trap Born measurement
+        REQUIRE(result.measurements[shot * 2 + 1] == 1);  // post-trap classified bit
+        REQUIRE(result.detectors[shot] == 0);             // equal bits: parity 0
+        REQUIRE(result.observables[shot] == 1);
+    }
+}
+
+TEST_CASE("exact: a hand-written multi-target annotation traps on one target") {
+    // A single LEVEL_TRANSITION node with two targets materializes one
+    // site per target; the trap maps back through site_targets to the
+    // right (op, qubit), and the continuation's split keeps the sibling
+    // target's instrument live.
+    ModelSpec spec;
+    spec.leak_from_e = 1.0;  // fires from e only
+    auto model = make_model(spec);
+    auto circuit = parse("X 0\nLEVEL_TRANSITION[leak] 0 1\nM 0\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 20, 67);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == 1);      // q0 leaked, classified
+        REQUIRE(result.measurements[shot * 2 + 1] == 0);  // q1 in g: never fires
+        REQUIRE(result.final_status[shot * 2].kind() == QubitStatusKind::Leaked);
+        REQUIRE(result.final_status[shot * 2 + 1].kind() == QubitStatusKind::ComputationalKnown);
+    }
+}
+
 TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
     ModelSpec spec;
     spec.leak_from_e = 0.3;  // source-dependent: the damp is non-scalar

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -290,3 +290,13 @@ TEST_CASE("fences: an absorbed virtual S conjugates the side-table fixup mask to
     REQUIRE(fixup.x().bit_get(0));
     REQUIRE(fixup.z().bit_get(0));
 }
+
+TEST_CASE("trace: a hand-built LOSS without its argument rejects") {
+    // The parser guarantees LOSS(p); a programmatically built node with
+    // no argument must reject here rather than trace as a silent
+    // zero-probability site.
+    const InstrumentTraceOptions options;
+    Circuit c = parse("H 0");
+    c.nodes.push_back(AstNode{GateType::LOSS, {Target::qubit(0)}, {}, 0});
+    REQUIRE_THROWS_WITH(trace(c, &options), ContainsSubstring("exactly one argument"));
+}

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -18,6 +18,8 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <numbers>
 #include <span>
 #include <string>
@@ -131,6 +133,30 @@ inline std::pair<uint64_t, uint64_t> pauli_masks(const std::string& pauli) {
 inline uint64_t test_lcg(uint64_t& seed) {
     seed = seed * 6364136223846793005ULL + 1442695040888963407ULL;
     return seed;
+}
+
+// Nonfinite test inputs. Release builds use -ffast-math, under which a
+// nonfinite floating-point *constant* in an expression is undefined
+// behavior (Clang's -Wnan-infinity-disabled) and optimizers really do
+// fold such constants to arbitrary values. Assemble the IEEE 754 bit
+// pattern behind a volatile instead, so a genuine NaN or infinity
+// reaches the code under test at runtime.
+static_assert(std::numeric_limits<double>::is_iec559,
+              "nonfinite test helpers require IEEE 754 doubles");
+inline double opaque_nonfinite(uint64_t bits) {
+    volatile uint64_t opaque_bits = bits;
+    const uint64_t materialized = opaque_bits;
+    double value;
+    std::memcpy(&value, &materialized, sizeof(value));
+    return value;
+}
+
+inline double opaque_nan() {
+    return opaque_nonfinite(0x7FF8000000000000ULL);
+}
+
+inline double opaque_infinity() {
+    return opaque_nonfinite(0x7FF0000000000000ULL);
 }
 
 // Check if two complex numbers are close (uses Catch2 CHECK_THAT).

--- a/tests/test_noncomp_classifier.cc
+++ b/tests/test_noncomp_classifier.cc
@@ -1,12 +1,13 @@
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 
+#include "test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -15,6 +16,8 @@ using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
 using clifft::LevelSet;
 using clifft::MeasurementClassifier;
+using clifft::test::opaque_infinity;
+using clifft::test::opaque_nan;
 
 namespace {
 
@@ -124,7 +127,7 @@ TEST_CASE("MeasurementClassifier: rejects entry above 1") {
 TEST_CASE("MeasurementClassifier: rejects NaN entry") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = default_identity_matrix();
-    m[0][0] = std::numeric_limits<double>::quiet_NaN();
+    m[0][0] = opaque_nan();
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
                         ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
 }
@@ -132,7 +135,7 @@ TEST_CASE("MeasurementClassifier: rejects NaN entry") {
 TEST_CASE("MeasurementClassifier: rejects infinity entry") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = default_identity_matrix();
-    m[0][0] = std::numeric_limits<double>::infinity();
+    m[0][0] = opaque_infinity();
     REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix({"0", "1"}, std::move(m), levels),
                       std::invalid_argument);
 }

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -136,7 +136,7 @@ TEST_CASE("continuation: classical-source consults consume pre-drawn outcomes") 
     events.jumps.push_back({0, 0, kLeak});
     events.classical_outcomes.push_back(
         {/*op_index=*/1, /*qubit=*/0, /*jumped=*/true,
-         /*destination_level=*/model.levels().computational_one_id()});
+         /*destination_level=*/model.levels().computational_one_id(), /*source_level=*/kLeak});
 
     auto result = rewrite_continuation(annotated, events, false, model);
     const std::vector<GateType> want = {
@@ -185,6 +185,17 @@ TEST_CASE("continuation: events that do not describe the circuit reject") {
         events.classical_outcomes.push_back({0, 0, false, 0});
         REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
                             ContainsSubstring("more classical outcomes"));
+    }
+    SECTION("a classical outcome drawn at a different source level") {
+        // A leaked initial makes op 0 a classical consult; the recorded
+        // outcome claims it was drawn at a computational level.
+        ExactShotEvents events = base;
+        events.initial_status[0] = model.levels().status_for(kLeak);
+        events.classical_outcomes.push_back(
+            {/*op_index=*/0, /*qubit=*/0, /*jumped=*/false, /*destination_level=*/0,
+             /*source_level=*/model.levels().computational_zero_id()});
+        REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
+                            ContainsSubstring("was drawn at level"));
     }
     SECTION("forcing a trace-out the jump does not emit") {
         // A jump landing computationally from a *known* level emits R+X,

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -1,0 +1,201 @@
+// Exact-mode continuation rewrite: the circuit-level half of the trap
+// protocol. rewrite_continuation() rebuilds the full circuit under a
+// shot's resolved events -- prefix verbatim (bit-identical compilation is
+// what re-entry relies on), annotations kept wherever their qubit is
+// still computational, classical-source consults consumed with pre-drawn
+// outcomes, and the trapped jump's carrier edit inserted at the suffix
+// start, with its hidden trace-out slot reported when the driver must
+// force it.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/noncomp/annotate.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/rewriter.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <string>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+// Default 5-level set: two computational, then leak_g, leak_e, lost.
+constexpr uint8_t kLeak = 3;
+
+// A model with one named leak transition (e leaks at 0.4, g at 0.1),
+// seepage back from the leaked level (0.2 to e), and a faithful
+// two-symbol classifier whose leaked column reads 1.
+NonComputationalModel demo_model(LostLeakedOpsPolicy lost_leaked = LostLeakedOpsPolicy::Drop) {
+    LevelSet levels = LevelSet::default_set();
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeak][0] = 0.1;
+    leak[kLeak][1] = 0.4;
+    leak[1][kLeak] = 0.2;  // seepage: leaked -> e
+
+    ClassifierSpec classifier;
+    classifier.symbols = {"0", "1"};
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.lost_leaked_ops = lost_leaked;
+    return NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+                                            classifier, policy);
+}
+
+std::vector<QubitStatus> computational_initials(const NonComputationalModel& model, uint32_t n) {
+    return std::vector<QubitStatus>(n, model.levels().status_for(0));
+}
+
+std::vector<GateType> gate_sequence(const Circuit& circuit) {
+    std::vector<GateType> gates;
+    gates.reserve(circuit.nodes.size());
+    for (const AstNode& node : circuit.nodes) {
+        gates.push_back(node.gate);
+    }
+    return gates;
+}
+
+}  // namespace
+
+TEST_CASE("continuation: empty events reproduce the annotated circuit verbatim") {
+    // The main line is this rewrite with no jumps: every annotation stays
+    // a runtime instrument and (with identity computational classifier
+    // columns) no node is added or removed.
+    auto model = demo_model();
+    auto annotated = annotate(parse("H 0\nLEVEL_TRANSITION[leak] 0\nCX 0 1\nM 0\nM 1"), model);
+
+    ExactShotEvents events;
+    events.initial_status = computational_initials(model, 2);
+
+    auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/false, model);
+    REQUIRE(gate_sequence(result.circuit) == gate_sequence(annotated));
+    REQUIRE(result.forced_traceout_slot == SIZE_MAX);
+    REQUIRE(result.classified_measurements.empty());
+}
+
+TEST_CASE("continuation: a known |1> initial adds no X prep") {
+    // Exact mode preloads known initials into the Pauli frame per shot;
+    // the compiled node stream must not depend on them, or modules could
+    // not be shared across shots.
+    auto model = demo_model();
+    auto annotated = annotate(parse("LEVEL_TRANSITION[leak] 0\nM 0"), model);
+
+    ExactShotEvents events;
+    events.initial_status = computational_initials(model, 1);
+    events.initial_status[0] = model.levels().status_for(model.levels().computational_one_id());
+
+    auto result = rewrite_continuation(annotated, events, false, model);
+    REQUIRE(gate_sequence(result.circuit) == gate_sequence(annotated));
+}
+
+TEST_CASE("continuation: a trapped jump keeps its annotation and inserts the trace-out") {
+    // The trapped annotation already executed -- it stays in the node
+    // stream so the prefix compiles identically -- and the leaked
+    // carrier's trace-out R lands right after it. The downstream CX on
+    // the leaked qubit drops; the measurement classifies.
+    auto model = demo_model();
+    auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nCX 0 1\nM 0\nM 1");
+    auto annotated = annotate(circuit, model);
+
+    ExactShotEvents events;
+    events.initial_status = computational_initials(model, 2);
+    // The annotation is node 1 in the source; annotate() keeps positions.
+    events.jumps.push_back({/*op_index=*/1, /*qubit=*/0, /*destination_level=*/kLeak});
+
+    auto result = rewrite_continuation(annotated, events, false, model);
+    const auto gates = gate_sequence(result.circuit);
+    const std::vector<GateType> want = {
+        GateType::H,
+        GateType::LEVEL_TRANSITION,  // kept: the prefix must compile identically
+        GateType::R,                 // trace-out of the coherent leaked carrier
+        // CX dropped whole (leaked control, policy Drop)
+        GateType::MPAD,  // M 0 classified: leaked column reads 1 deterministically
+        GateType::M,     // M 1 untouched
+    };
+    REQUIRE(gates == want);
+    REQUIRE(result.classified_measurements.size() == 1);
+    REQUIRE(result.classified_measurements[0].slot == 0);
+    REQUIRE(result.classified_measurements[0].level == kLeak);
+}
+
+TEST_CASE("continuation: classical-source consults consume pre-drawn outcomes") {
+    // After the trap, the second annotation on the leaked qubit is a
+    // classical consult: a pre-drawn seepage jump back to e rematerializes
+    // the carrier (R + X) and the third annotation is quantum again.
+    auto model = demo_model();
+    auto circuit =
+        parse("LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+    auto annotated = annotate(circuit, model);
+
+    ExactShotEvents events;
+    events.initial_status = computational_initials(model, 1);
+    events.jumps.push_back({0, 0, kLeak});
+    events.classical_outcomes.push_back(
+        {/*op_index=*/1, /*qubit=*/0, /*jumped=*/true,
+         /*destination_level=*/model.levels().computational_one_id()});
+
+    auto result = rewrite_continuation(annotated, events, false, model);
+    const std::vector<GateType> want = {
+        GateType::LEVEL_TRANSITION,  // trapped site, kept; the carrier is
+                                     // Known |0> here, so no trace-out
+        // second annotation consumed (classical source), outcome: recapture
+        GateType::R,  // carrier materialization at |1>
+        GateType::X,
+        GateType::LEVEL_TRANSITION,  // third annotation: quantum again, kept
+        GateType::M,                 // computational again: ordinary measurement
+    };
+    REQUIRE(gate_sequence(result.circuit) == want);
+}
+
+TEST_CASE("continuation: the forced trace-out slot mirrors trace's hidden numbering") {
+    // Hidden slots are assigned per pure-reset target in circuit order,
+    // after the visible slots. With one visible measurement and one reset
+    // ahead of the trace-out, the trace-out owns hidden slot 2.
+    auto model = demo_model();
+    auto circuit = parse("R 1\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+    auto annotated = annotate(circuit, model);
+
+    ExactShotEvents events;
+    events.initial_status = computational_initials(model, 2);
+    events.jumps.push_back({2, 0, kLeak});
+
+    auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/true, model);
+    REQUIRE(result.forced_traceout_slot == 2);  // 1 visible + 1 hidden before it
+}
+
+TEST_CASE("continuation: events that do not describe the circuit reject") {
+    auto model = demo_model();
+    auto annotated = annotate(parse("LEVEL_TRANSITION[leak] 0\nM 0"), model);
+
+    ExactShotEvents base;
+    base.initial_status = computational_initials(model, 1);
+
+    SECTION("a jump at an op the circuit never consults") {
+        ExactShotEvents events = base;
+        events.jumps.push_back({5, 0, kLeak});
+        REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
+                            ContainsSubstring("never consults"));
+    }
+    SECTION("a classical outcome with no classical-source consult") {
+        ExactShotEvents events = base;
+        events.classical_outcomes.push_back({0, 0, false, 0});
+        REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
+                            ContainsSubstring("more classical outcomes"));
+    }
+    SECTION("forcing a trace-out the jump does not emit") {
+        // A jump landing computationally from a *known* level emits R+X,
+        // so build the definite-carrier case: initial |0> is Known, and
+        // the jump lands on the leaked level -- Known carriers need no
+        // trace-out, so forcing must reject.
+        ExactShotEvents events = base;
+        events.initial_status[0] =
+            model.levels().status_for(model.levels().computational_zero_id());
+        events.jumps.push_back({0, 0, kLeak});
+        REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, true, model),
+                            ContainsSubstring("no carrier reset"));
+    }
+}

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -5,12 +5,13 @@
 #include "clifft/noncomp/policy.h"
 #include "clifft/noncomp/transition_instrument.h"
 
+#include "test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
-#include <limits>
 #include <map>
 #include <optional>
 #include <stdexcept>
@@ -26,6 +27,7 @@ using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
 using clifft::TransitionInstrument;
 using clifft::UnknownSourcePolicy;
+using clifft::test::opaque_nan;
 
 namespace {
 
@@ -162,7 +164,7 @@ TEST_CASE("NonComputationalModel: rejects initial state entry out of [0, 1]") {
 }
 
 TEST_CASE("NonComputationalModel: rejects NaN initial state entry") {
-    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double nan = opaque_nan();
     REQUIRE_THROWS_WITH(NonComputationalModel(two_level_set(), {nan, 1.0}, {}, std::nullopt,
                                               NonComputationalPolicy{}),
                         ContainsSubstring("not finite"));

--- a/tests/test_noncomp_sampler.cc
+++ b/tests/test_noncomp_sampler.cc
@@ -530,3 +530,21 @@ TEST_CASE("sample_history: a gate-named but non-hookable key is referenceable") 
     HistorySample s = sample_history(c, model, 1);
     REQUIRE(s.final_status[0].kind() == QubitStatusKind::Lost);
 }
+
+TEST_CASE("sample_history: a hand-built LOSS node without its argument rejects") {
+    // The parser guarantees LOSS(p); a programmatically built node with no
+    // argument is invalid input, not a zero-probability loss.
+    NonComputationalModel model = make_model(all_g(), {});
+    Circuit c = parse("R 0");
+    c.nodes.push_back(op(GateType::LOSS, {0}));
+    REQUIRE_THROWS_WITH(sample_history(c, model, 1), ContainsSubstring("exactly one argument"));
+}
+
+TEST_CASE("sample_history: a hand-built LOSS probability outside [0, 1] rejects") {
+    NonComputationalModel model = make_model(all_g(), {});
+    Circuit c = parse("R 0");
+    AstNode loss = op(GateType::LOSS, {0});
+    loss.args = {7.0};
+    c.nodes.push_back(loss);
+    REQUIRE_THROWS_WITH(sample_history(c, model, 1), ContainsSubstring("out of [0, 1]"));
+}

--- a/tests/test_noncomp_transition_instrument.cc
+++ b/tests/test_noncomp_transition_instrument.cc
@@ -1,12 +1,13 @@
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/transition_instrument.h"
 
+#include "test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
-#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -14,6 +15,8 @@ using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
 using clifft::LevelSet;
 using clifft::TransitionInstrument;
+using clifft::test::opaque_infinity;
+using clifft::test::opaque_nan;
 
 namespace {
 
@@ -80,7 +83,7 @@ TEST_CASE("TransitionInstrument: rejects column sum above 1") {
 TEST_CASE("TransitionInstrument: rejects NaN entry") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = zero5();
-    m[1][0] = std::numeric_limits<double>::quiet_NaN();
+    m[1][0] = opaque_nan();
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(std::move(m), levels),
                         ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
 }
@@ -88,7 +91,7 @@ TEST_CASE("TransitionInstrument: rejects NaN entry") {
 TEST_CASE("TransitionInstrument: rejects positive infinity entry") {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> m = zero5();
-    m[1][0] = std::numeric_limits<double>::infinity();
+    m[1][0] = opaque_infinity();
     REQUIRE_THROWS_AS(TransitionInstrument::from_matrix(std::move(m), levels),
                       std::invalid_argument);
 }


### PR DESCRIPTION
> **Prototype note:** this PR targets the `codex/noncomputational-structural-mvp` feature branch (not `main`); a less strict review bar applies.

Step 6 of the exact state-dependent jumps plan (`design/state-dependent-jumps.md` §4.5/§6): **exact mode becomes usable end-to-end, C++ and Python.** `unknown_source_policy="exact"` routes `sample_noncomputational` to the new driver. Three commits.

## C1 — the continuation rewrite (`0b77fe5`)

`rewrite_continuation()` rebuilds the full annotated circuit under a shot's resolved events: prefix verbatim (bit-identical compilation is what re-entry relies on), annotations kept wherever the qubit is still computational (including after a recapture), classical-source consults consumed with host-pre-drawn outcomes, the trapped jump's carrier edits at the suffix start. The **main line is this rewrite with empty events** — which is what carries readout confusion onto kept measurements — and the ordinary-op path is one helper shared with the AOT rewrite, so the two cannot drift. The forced trace-out's hidden **record slot** is reported by mirroring `trace()`'s per-reset-target numbering: slot indices ride in instruction payloads and survive every bytecode pass, so the slot (not an instruction position) is the durable identity, per the review discussion.

## C2 — driver, cache, Python (`718639e`)

The §4.5 loop as amended: shared main line; per-shot host-drawn initials with `|1⟩` preloaded as Pauli-frame bits (no distinct modules; rare noncomputational initials get their own continuation-from-the-top); traps resolve their destination branching on `destination_pending`, extend the events with pre-drawn classical follow-ons, and resume past the site. **Two-level cache**: the rewrite per canonicalized status-delta (computational initial levels canonicalize to zero — the node stream provably depends only on status kinds), then one compiled module per herald-flag assignment (option (d): ternary classifiers ride the key, reusing the existing patch pass). Every host draw precedes cache lookup, so hits and misses sample identically. `max_rank` rejects over-budget compiles naming the first offending circuit line, plumbed to Python along with `unknown_source_policy="exact"` and the `damping` kwarg. Debug builds byte-compare every continuation prefix against the executed module on cache insertion.

## C3 — correlated neglect (`108cac8`)

The forced trace-out, as designed in review: at cache-compile time the trace-out's hidden measurement swaps to its **forced opcode twin** at the reported slot (`record_probabilities` precedent), and the driver threads the reported source through `state.forced_record` per resume — per-shot runtime data, so the module stays source-independent and the key needs nothing new. The prefix-identity comparison treats the sampling↔forced twin as equal, the one sanctioned prefix difference in a chain.

**Activating it surfaced a real ordering hazard, caught deterministically by the new correlation test**: the squeeze pass reorders *commuting* measurements — exchangeable under sampling semantics, wrong once one is forced. An entangled partner slid between the site and the trace-out and measured the uncollapsed carrier. Exact-mode modules therefore compile with the default pipeline **minus `StatevectorSqueezePass`**, uniformly (prefix identity preserved); the rank-compaction loss is step 7's performance table to quantify, and restoring squeeze via a pinned-measurement barrier flag is a known follow-up. The decisive pin: a Bell-entangled dormant-random qubit with certain source-dependent leak destinations — the classified slot reads back the source, and the partner must equal it on **every** shot (independent redraw would mismatch half the time).

## Tests

17 new cases across three files: continuation-rewrite units (verbatim main line, no X-prep, trace-out placement, classical-consult validation, forced-slot numbering); driver end-to-end (certain-leak trap+classify+sidecar, frame preload, noncomputational initials, seepage recapture, exact-vs-AOT agreement at source-independent rates, seed reproducibility, `max_rank` with line naming, ternary heralds through the cache key, the neglect correlation pin, neglect-vs-exact rank contrast under `max_rank=0`).

**Verified**: Debug **1101** + Release **1101** (`~[bench]`) green; Python **505** green plus an exact-mode smoke through the real wheel; pre-commit clean. (No wasm-list change: the noncomp sources aren't in the wasm build.)

**Deferred, flagged**: hazard-pooling, suffix-only compilation, LRU capping, trapped-shot batching (all step-7-arbitrated); squeeze restoration for exact mode via a pinned-measurement flag; runtime herald state as the clean successor to flags-in-key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Review fix** (see latest commit): **[P1]** the classical-outcome stream is now rebuilt by annotation target on every extension instead of appended — a trap can turn the trapped qubit's later consults classical *between* previously recorded positions, and the old cursor replay fed outcomes to the wrong targets. Reused outcomes keep the executed prefix stable; first-seen consults draw fresh (unbiased: they live only in the never-executed suffix). The reviewer's repro is the regression test, plus two same-class chain pins: a **two-forced-trap chain** (two forced slots per shot; the first forced instruction sits in the second continuation's prefix, exercising the sampling/forced mask) and a **neglect fire onto a computational destination** (forced materialization anti-correlates the trapped qubit with its Bell partner under a certain source-swap channel). Debug + Release **1104** green.


**Audit round** (see latest commit): the four remaining cases from the trap-chain consistency audit, all deterministic — **herald-flag reuse** across continuations (p_herald = ½ paired with a deterministic not-heralded bit makes an independent redraw break a per-shot invariant), **exactly-once noise** between two traps across both re-anchors, a **detector + observable spanning the trap boundary** (main-line Born bit vs continuation classified bit), and a **hand-written multi-target annotation** trapping on one target with the sibling's instrument surviving the split. Debug + Release **1108** green.



**Fast-math round** (see latest commits): **[P1]** the Release-only NaN/Inf rejection failures on macOS were tracked to the test *inputs*, not the validation: `-ffast-math` makes a nonfinite floating-point constant in an expression undefined behavior (Clang's `-Wnan-infinity-disabled`), and AppleClang 17 folds such constants to arbitrary finite values, so the tests handed `from_matrix` a perfectly valid matrix. GCC 13 / Clang 18 on Linux preserve the bits, which is why CI and local Release runs stayed green. New `opaque_nan()`/`opaque_infinity()` helpers in `test_helpers.h` assemble the IEEE 754 bit pattern behind a `volatile` at runtime — the write-side mirror of `is_finite_robust()` — and every nonfinite construction site now uses them, including the model initial-state NaN test that passed on AppleClang only by accident (a folded entry still trips the sum-to-1 check). Library validation is untouched: runtime nonfinite values, Python's included, were always rejected. Out of scope but noted: `test_svm.cc` has 20 `CHECK(std::isfinite(...))` assertions that fold to vacuously-true under any fast-math Release (they can never go red, and Debug CI checks them for real; filed as #174), and vendored stim triggers the same warning class internally. **[P3]** the `forced_traceout_slot` comment now says what the slot points at for both destination kinds — trace-out R or materializing R — with SIZE_MAX meaning forcing wasn't requested. Debug + Release **1108** green; the five hardened tests also pass a clang-18 `-ffast-math` Release build, which no longer emits the warning for them.


**Review round 2** (see latest commits): the inline-comment round, applied. **Structural**: `draw_from_column` now sums the admitted entries' mass itself — a caller can no longer hand in a mismatched normalizer that would silently bias the draw, and the remainder-restricted call site loses its duplicated loop. The exact pipelines filter on a new `RecordOrder` declaration every registered pass must carry (`PassInfo` field with no default constructor — an unclassified new pass is a compile error, not a silent exact-mode breakage), with a Debug tripwire asserting the measurement-record sequence survives the HIR pipeline of every compiled module, so even a *misdeclared* pass fails loudly. Seed derivation and all five domain tags now live in one `seed.h` (the AOT/exact disjointness is visible in one place; the duplicated SplitMix64 finalizer is gone). **Naming**: "host" → "driver" everywhere (stream, tag, RNG) — "host" is reserved territory once a GPU backend introduces a host/device split. **Docs**: a vocabulary block at the top of `exact_driver.cc` defines the driver's working terms once (annotation/target/consult/site/trap/carrier/continuation/main line/forced twin/sidecar/driver draw); the header now leads with what the driver is for and says explicitly that neglect damping also runs through it; `sampler.h`'s misplaced doc block is fixed. Debug + Release + clang-18 Release all **1108** green, Python **734** green.


**Audit fixes** (see latest commits): the design-audit findings, applied. **[1]** `ClassicalOutcome` now records the source level it was drawn at, validated on every reuse (driver) and consumption (`rewrite_continuation`) — reuse-by-target is sound today only because a qubit's noncomputational level moves solely through its own consults, and this makes that invariant explicit and loud instead of implicit; a future cross-qubit transition that breaks it throws rather than silently replaying outcomes from the wrong column. **[2]** cache keys count-prefix their variable-length sections: equal keys now mean equal events by construction, not by the improbability of marker-aligned collisions. **[3]** `draw_from_column` throws on an empty admitted column instead of falling through an assert to a Release draw of level 255. **[4]** malformed `LOSS` nodes (wrong arity, nonfinite or out-of-range probability) are rejected by a shared `loss_probability()` helper in both sampling paths instead of silently defaulting to a no-op — the parser guarantees the shape, this covers hand-built circuits. **[5]** the herald convention has one home: `classifier.h` states the positional contract, `MeasurementClassifier::kHeraldSymbol`/`has_herald()` replace the hardcoded `prob(2, …)` and `num_symbols() == 3` at all six call sites. The `memcmp`-padding observation from the audit stands as a note (no change; `Instruction`'s explicit pads + factory zero-init carry it). New tests: source-level-mismatch reject, LOSS arity + range rejects. Debug + Release + clang-18 Release **1110** green, Python **734** green.


**Review round 3** (see latest commit): **[P2]** closed — the previous round's LOSS validation covered classical consults and traps but not *live* quantum-source sites, which ride through the continuation rewrite verbatim into `trace()`'s silent default-to-zero. The exact driver now resolves every annotation up front (tag resolution + LOSS shape), so malformed nodes fail deterministically at entry instead of on whichever shot first consults them — this also makes unknown-tag errors deterministic rather than shot-dependent. `trace()` itself now rejects a LOSS without exactly one argument (minimal arity check; the frontend can't reach the shared noncomp helper without inverting layering). Negative tests land where the reviewer scoped them: the exact public entry point (missing arg + `{7.0}`, two sections of one case) and direct instrument tracing; the AOT public entry is covered transitively (it routes through `sample_history`, which validates via the shared helper). **Terminology**: the vocabulary block shrinks to the invariant-encoding terms (annotation, annotation target, consult, fire, jump, site, trap, carrier, continuation) — "annotation target" spelled out (bare `Target` is the AST type), "fire" = the stochastic event vs "jump" = the stored `ResolvedJump`, `forced_twin()` renamed `forced_opcode()`, and main line / sidecar / driver-draw slots dropped (defined inline where used). The `ExactShotEvents` comment now states the key deliberately omits the derived `source_level`. Debug + Release + clang-18 Release **1112** green, Python **734** green.