### PR TITLE
test(noncomp): validation campaign for the exact mode

### DIFF
--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -571,18 +571,21 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     // The state is reused across shots (growth from trap continuations
     // amortizes to the chain maximum); a starting module that outgrows it
     // -- a rare noncomputational-initial shot -- rebuilds it instead,
-    // since grow_for_continuation is trap-gated by design.
-    auto make_state = [&](const CompiledModule& module) {
-        return SchrodingerState(StateConfig{.peak_rank = module.peak_rank,
-                                            .num_measurements = module.total_meas_slots,
-                                            .num_qubits = module.num_qubits,
-                                            .num_detectors = module.num_detectors,
-                                            .num_observables = module.num_observables,
+    // since grow_for_continuation is trap-gated by design. Rebuilds size
+    // to the running maxima, never to the triggering module: a starting
+    // module can exceed on one axis (say, hidden record slots) while
+    // being smaller on the other, and later shots reuse the state.
+    auto make_state = [&](uint32_t peak_rank, uint32_t total_meas_slots) {
+        return SchrodingerState(StateConfig{.peak_rank = peak_rank,
+                                            .num_measurements = total_meas_slots,
+                                            .num_qubits = main_module->num_qubits,
+                                            .num_detectors = main_module->num_detectors,
+                                            .num_observables = main_module->num_observables,
                                             .seed = 0});
     };
-    SchrodingerState state = make_state(*main_module);
     uint32_t state_rank = main_module->peak_rank;
     uint32_t state_slots = main_module->total_meas_slots;
+    SchrodingerState state = make_state(state_rank, state_slots);
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
         Xoshiro256PlusPlus driver_rng(derive_seed(global_seed, shot, kExactDriverDomain));
@@ -641,7 +644,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
         if (module->peak_rank > state_rank || module->total_meas_slots > state_slots) {
             state_rank = std::max(state_rank, module->peak_rank);
             state_slots = std::max(state_slots, module->total_meas_slots);
-            state = make_state(*module);
+            state = make_state(state_rank, state_slots);
         }
         state.reseed(derive_seed(global_seed, shot, kExactSvmDomain));
         if (state.meas_record.size() < module->total_meas_slots) {

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -1,0 +1,117 @@
+"""Closed-form micro-probes for the exact sampling mode.
+
+Successors to the retired equalized-mode divergence probes: each pins, in
+closed form built on the first-principles oracle, a property the exact mode
+must have and that ahead-of-time sampling could not deliver -- zero fires
+from a gate-determined source, destination-collapse correlations with an
+entangled partner, and the sqrt(1 - p) no-fire coherence that separates
+``damping="exact"`` from ``damping="neglect"``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import utils_noncomp_oracle as oracle
+from conftest import binomial_tolerance
+
+from clifft import noncomp
+
+Level = noncomp.Level
+SHOTS = 20_000
+
+
+def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
+    m = [[0.0] * 5 for _ in range(5)]
+    for (to, frm), p in entries.items():
+        m[to][frm] = p
+    return m
+
+
+def _faithful_classifier() -> noncomp.Classifier:
+    """g/leak_g read 0; e/leak_e read 1; lost reads a fair coin."""
+    m = [[0.0] * 5 for _ in range(2)]
+    m[0][Level.G] = m[1][Level.E] = 1.0
+    m[0][Level.LEAK_G] = m[1][Level.LEAK_E] = 1.0
+    m[0][Level.LOST] = m[1][Level.LOST] = 0.5
+    return noncomp.Classifier(["0", "1"], m)
+
+
+def _model(transitions: dict, damping: str = "exact") -> noncomp.Model:
+    return noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions=transitions,
+        classifier=_faithful_classifier(),
+        unknown_source_policy="exact",
+        lost_leaked_ops="drop",  # a fired branch's later gates drop, not reject
+        damping=damping,
+    )
+
+
+def test_gate_determined_source_fires_exactly_zero():
+    """H then H returns the qubit to |g> by algebra; a leak that fires only
+    from e must then never fire -- the fire draw conditions on the live
+    state, where <P_e> is exactly 0. The certain rate (p = 1) makes any
+    ahead-of-time source guess loud: a uniform draw would leak half the
+    shots."""
+    model = _model({"leak": _transition({(Level.LEAK_E, Level.E): 1.0})})
+    r = noncomp.sample("H 0\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0\n", model, shots=SHOTS, seed=11)
+    status = np.asarray(r.final_status)
+    assert (status == noncomp.QubitStatusKind.COMPUTATIONAL).all()
+    assert (np.asarray(r.measurements) == 0).all()  # H H |0> measures 0
+
+
+def test_bell_joint_correlation_has_tvd_zero():
+    """Source-dependent certain destinations on a Bell half: the collapse
+    that picks the source is the same collapse the partner's measurement
+    sees, so the classified record and the partner agree on every shot.
+    The exact joint is {00: 1/2, 11: 1/2}; any independent source draw
+    puts mass on 01/10."""
+    model = _model(
+        {"leak": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_E, Level.E): 1.0})}
+    )
+    r = noncomp.sample(
+        "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n", model, shots=SHOTS, seed=12
+    )
+    m = np.asarray(r.measurements)
+    assert (m[:, 0] == m[:, 1]).all()  # off-diagonal mass is exactly 0
+    assert abs(m[:, 0].mean() - 0.5) < binomial_tolerance(0.5, SHOTS)
+
+
+def test_damping_boundary_probe_separates_exact_from_neglect():
+    """|+> through one leak-from-e site, then an X-basis readout (H, M).
+
+    The no-fire branch's back-action is the whole difference between the
+    damping modes: exact applies the filter diag(1, sqrt(1 - p)), leaving
+    coherence sqrt(1 - p) and a nonzero X-basis flip rate; neglect keeps
+    |+> intact, so the no-fire branch reads 1 with probability exactly 0.
+    Both expectations are computed from the oracle's channel primitives,
+    and the closed forms are far enough apart that each sample can only
+    match its own mode."""
+    p = 0.84
+    transitions = {"leak": _transition({(Level.LEAK_E, Level.E): p})}
+    text = "H 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0\n"
+
+    plus = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
+    p_fire = p * oracle.prob_one(plus, 0, 1)  # fire weight: p * <P_e>
+
+    # Exact: damp, rotate, read. The fired branch is leaked and reads 1.
+    w0, damped = oracle.damp_no_fire(plus, 0, 0.0, p, 1)
+    p1_no_fire = oracle.prob_one(oracle.apply_1q(damped, "H", 0, 1), 0, 1)
+    expected_exact = p_fire * 1.0 + w0 * p1_no_fire
+
+    # Neglect: the no-fire branch keeps |+>, and H|+> = |0> reads 1 never.
+    expected_neglect = p_fire * 1.0
+
+    tol_exact = binomial_tolerance(expected_exact, SHOTS)
+    tol_neglect = binomial_tolerance(expected_neglect, SHOTS)
+    assert abs(expected_exact - expected_neglect) > 2 * (
+        tol_exact + tol_neglect
+    ), "probe lost its discriminating power; adjust p or SHOTS"
+
+    r_exact = noncomp.sample(text, _model(transitions, damping="exact"), shots=SHOTS, seed=13)
+    r_neglect = noncomp.sample(text, _model(transitions, damping="neglect"), shots=SHOTS, seed=14)
+    p1_exact = float(np.asarray(r_exact.measurements)[:, 0].mean())
+    p1_neglect = float(np.asarray(r_neglect.measurements)[:, 0].mean())
+
+    assert abs(p1_exact - expected_exact) < tol_exact
+    assert abs(p1_neglect - expected_neglect) < tol_neglect

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -73,6 +73,10 @@ def test_bell_joint_correlation_has_tvd_zero():
         "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n", model, shots=SHOTS, seed=12
     )
     m = np.asarray(r.measurements)
+    status = np.asarray(r.final_status)
+    # The certain fire really happened: an accidentally skipped transition
+    # would also show perfect agreement (a plain Bell pair does).
+    assert (status[:, 0] == noncomp.QubitStatusKind.LEAKED).all()
     assert (m[:, 0] == m[:, 1]).all()  # off-diagonal mass is exactly 0
     assert abs(m[:, 0].mean() - 0.5) < binomial_tolerance(0.5, SHOTS)
 

--- a/tests/python/test_noncomp_exact_tvd.py
+++ b/tests/python/test_noncomp_exact_tvd.py
@@ -155,9 +155,9 @@ def _shot_noise_band(probs: dict, shots: int, draws: int = 300) -> float:
     return 1.3 * float(np.max(tvds))
 
 
-def _status_kind_fractions(status_probs: dict[int, float]) -> tuple[float, float]:
-    leaked = status_probs.get(Level.LEAK_G, 0.0) + status_probs.get(Level.LEAK_E, 0.0)
-    lost = status_probs.get(Level.LOST, 0.0)
+def _status_kind_fractions(noncomp_probs: dict[int, float]) -> tuple[float, float]:
+    leaked = noncomp_probs.get(Level.LEAK_G, 0.0) + noncomp_probs.get(Level.LEAK_E, 0.0)
+    lost = noncomp_probs.get(Level.LOST, 0.0)
     return leaked, lost
 
 
@@ -184,7 +184,7 @@ def _run_and_compare(damping: str, seed: int) -> None:
     # Final-status marginals: leaked/lost fractions per qubit.
     status = np.asarray(r.final_status)
     for q in range(5):
-        want_leaked, want_lost = _status_kind_fractions(reference.status_probs[q])
+        want_leaked, want_lost = _status_kind_fractions(reference.noncomp_level_probs[q])
         got_leaked = float((status[:, q] == noncomp.QubitStatusKind.LEAKED).mean())
         got_lost = float((status[:, q] == noncomp.QubitStatusKind.LOST).mean())
         assert abs(got_leaked - want_leaked) < binomial_tolerance(max(want_leaked, 1e-4), SHOTS)

--- a/tests/python/test_noncomp_exact_tvd.py
+++ b/tests/python/test_noncomp_exact_tvd.py
@@ -1,0 +1,202 @@
+"""Distributional cross-check of the exact mode against the dense reference.
+
+The enumerator (``utils_noncomp_enumerator``) computes the exact joint
+distribution of the visible record from first principles; the tests here
+first self-check it against hand-derived closed forms, then compare
+clifft's exact-mode sampling to it on a distance-3 repetition-code round
+at cold-atom-magnitude rates, by total variation distance with a
+shot-noise band calibrated from the reference distribution itself.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import utils_noncomp_enumerator as en
+from conftest import binomial_tolerance
+
+from clifft import noncomp
+
+Level = noncomp.Level
+
+
+def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
+    m = [[0.0] * 5 for _ in range(5)]
+    for (to, frm), p in entries.items():
+        m[to][frm] = p
+    return m
+
+
+def _classifier_matrix() -> list[list[float]]:
+    """Faithful computational readout; leak_g reads 0, leak_e 1, lost a coin."""
+    m = [[0.0] * 5 for _ in range(2)]
+    m[0][Level.G] = m[1][Level.E] = 1.0
+    m[0][Level.LEAK_G] = m[1][Level.LEAK_E] = 1.0
+    m[0][Level.LOST] = m[1][Level.LOST] = 0.5
+    return m
+
+
+def _model(initial: list, transitions: dict, damping: str = "exact") -> noncomp.Model:
+    return noncomp.Model(
+        initial_state=initial,
+        transitions=transitions,
+        classifier=noncomp.Classifier(["0", "1"], _classifier_matrix()),
+        unknown_source_policy="exact",
+        lost_leaked_ops="drop",
+        damping=damping,
+    )
+
+
+# --- Enumerator self-checks against hand-derived closed forms -----------------
+
+
+def test_enumerator_lossless_bell_joint():
+    dist = en.enumerate_exact(
+        "H 0\nCX 0 1\nM 0\nM 1\n",
+        initial=[1, 0, 0, 0, 0],
+        transitions={},
+        classifier=_classifier_matrix(),
+    )
+    assert abs(dist.record_probs[(0, 0)] - 0.5) < 1e-12
+    assert abs(dist.record_probs[(1, 1)] - 0.5) < 1e-12
+    assert set(dist.record_probs) == {(0, 0), (1, 1)}
+    assert dist.dropped_mass < 1e-12
+
+
+def test_enumerator_plus_state_marginal_closed_form():
+    """|+> under leak-from-g (p = 0.4), leak reads 1: hand-derived forms.
+
+    Exact: fire p/2 reads 1; no-fire has weight (2 - p)/2 and the damped
+    state (sqrt(1-p)|g> + |e>)/norm reads 1 with probability 1/(2 - p),
+    so P(M=1) = p/2 + 1/2 = 0.7. Neglect: the no-fire branch keeps |+>
+    (reads 1 half the time), so P(M=1) = p/2 + (1 - p/2)/2 = 0.6.
+    """
+    p = 0.4
+    circuit = "H 0\nLEVEL_TRANSITION[leak] 0\nM 0\n"
+    transitions = {"leak": _transition({(Level.LEAK_E, Level.G): p})}
+
+    exact = en.enumerate_exact(
+        circuit,
+        initial=[1, 0, 0, 0, 0],
+        transitions=transitions,
+        classifier=_classifier_matrix(),
+        damping="exact",
+    )
+    p1 = sum(w for rec, w in exact.record_probs.items() if rec[0] == 1)
+    assert abs(p1 - 0.7) < 1e-12
+
+    neglect = en.enumerate_exact(
+        circuit,
+        initial=[1, 0, 0, 0, 0],
+        transitions=transitions,
+        classifier=_classifier_matrix(),
+        damping="neglect",
+    )
+    p1 = sum(w for rec, w in neglect.record_probs.items() if rec[0] == 1)
+    assert abs(p1 - 0.6) < 1e-12
+
+
+def test_enumerator_initial_leak_and_recapture():
+    """A leaked initial consults classically: seepage back to e is a
+    recapture, and the record then reads the re-prepared |1>."""
+    seep = 0.3
+    dist = en.enumerate_exact(
+        "LEVEL_TRANSITION[seep] 0\nM 0\n",
+        initial=[0, 0, 1, 0, 0],  # starts at leak_g
+        transitions={"seep": _transition({(Level.E, Level.LEAK_G): seep})},
+        classifier=_classifier_matrix(),
+    )
+    # Recaptured (p = 0.3): reads 1. Still leaked at leak_g: reads 0.
+    assert abs(dist.record_probs[(1,)] - seep) < 1e-12
+    assert abs(dist.record_probs[(0,)] - (1 - seep)) < 1e-12
+
+
+# --- Repetition-code round: TVD to the dense reference ------------------------
+
+# Cold-atom-magnitude rates, scaled x3 so a correlation-class error would
+# stand above the shot-noise band while staying in the published regime.
+SCALE = 3.0
+LEAK_2Q_E = 1.0e-3 * SCALE
+LEAK_2Q_G = 1.0e-4 * SCALE
+LEAK_1Q_E = 1.3e-3 * SCALE
+LOSS_P = 3.9e-3 * SCALE
+INITIAL = [1 - 0.015, 0.0, 0.015, 0.0, 0.0]
+
+REP_CODE_ROUND = f"""
+H 0 1 2
+CX 0 3
+LEVEL_TRANSITION[leak2q] 0 3
+CX 1 3
+LEVEL_TRANSITION[leak2q] 1 3
+CX 1 4
+LEVEL_TRANSITION[leak2q] 1 4
+CX 2 4
+LEVEL_TRANSITION[leak2q] 2 4
+LEVEL_TRANSITION[leak1q] 0 1 2
+LOSS({LOSS_P}) 0 1 2
+MR 3 4
+M 0 1 2
+"""
+
+TRANSITIONS = {
+    "leak2q": _transition({(Level.LEAK_E, Level.E): LEAK_2Q_E, (Level.LEAK_G, Level.G): LEAK_2Q_G}),
+    "leak1q": _transition({(Level.LEAK_E, Level.E): LEAK_1Q_E}),
+}
+
+SHOTS = 60_000
+
+
+def _shot_noise_band(probs: dict, shots: int, draws: int = 300) -> float:
+    """TVD band from multinomial resampling of the reference itself."""
+    keys = list(probs)
+    p = np.array([probs[k] for k in keys])
+    p = p / p.sum()
+    rng = np.random.default_rng(2026)
+    tvds = [0.5 * np.abs(rng.multinomial(shots, p) / shots - p).sum() for _ in range(draws)]
+    return 1.3 * float(np.max(tvds))
+
+
+def _status_kind_fractions(status_probs: dict[int, float]) -> tuple[float, float]:
+    leaked = status_probs.get(Level.LEAK_G, 0.0) + status_probs.get(Level.LEAK_E, 0.0)
+    lost = status_probs.get(Level.LOST, 0.0)
+    return leaked, lost
+
+
+def _run_and_compare(damping: str, seed: int) -> None:
+    reference = en.enumerate_exact(
+        REP_CODE_ROUND,
+        initial=INITIAL,
+        transitions=TRANSITIONS,
+        classifier=_classifier_matrix(),
+        damping=damping,
+    )
+    assert reference.dropped_mass < 1e-6
+
+    r = noncomp.sample(
+        REP_CODE_ROUND, _model(INITIAL, TRANSITIONS, damping=damping), shots=SHOTS, seed=seed
+    )
+    empirical = en.empirical_record_probs(np.asarray(r.measurements))
+
+    band = _shot_noise_band(reference.record_probs, SHOTS) + reference.dropped_mass
+    assert band < 0.05, "band too loose to be meaningful; raise SHOTS"
+    distance = en.tvd(reference.record_probs, empirical)
+    assert distance < band, f"TVD {distance:.4f} exceeds shot-noise band {band:.4f}"
+
+    # Final-status marginals: leaked/lost fractions per qubit.
+    status = np.asarray(r.final_status)
+    for q in range(5):
+        want_leaked, want_lost = _status_kind_fractions(reference.status_probs[q])
+        got_leaked = float((status[:, q] == noncomp.QubitStatusKind.LEAKED).mean())
+        got_lost = float((status[:, q] == noncomp.QubitStatusKind.LOST).mean())
+        assert abs(got_leaked - want_leaked) < binomial_tolerance(max(want_leaked, 1e-4), SHOTS)
+        assert abs(got_lost - want_lost) < binomial_tolerance(max(want_lost, 1e-4), SHOTS)
+
+
+def test_rep_code_round_tvd_reaches_shot_noise():
+    _run_and_compare("exact", seed=21)
+
+
+def test_rep_code_round_tvd_under_neglect_matches_its_own_reference():
+    """The neglect fallback must match the reference that omits the no-fire
+    filter -- pinning the driver's neglect semantics distributionally, not
+    just at micro-probes."""
+    _run_and_compare("neglect", seed=22)

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -150,3 +150,44 @@ def test_survivor_marginal_equals_partial_trace():
     expected_survivor = oracle.marginal_one_after_trace_out(bell, lost=0, survivor=1, n=2)
     assert abs(_p1(r, 1) - expected_survivor) < BAND  # survivor (M 1) == partial trace
     assert abs(_p1(r, 0) - 0.5) < BAND  # lost record (M 0) follows the [0.5, 0.5] classifier
+
+
+# --- Self-check: the exact-channel primitives ---------------------------------
+
+
+def test_channel_kraus_set_is_complete():
+    # Fire weights plus the no-fire weight must sum to 1 on any state:
+    # sum_s ptot_s * <P_s> + <K0' K0> = 1. Random states, random columns.
+    rng = np.random.default_rng(9)
+    for _ in range(20):
+        state = rng.normal(size=4) + 1j * rng.normal(size=4)
+        state = state / np.linalg.norm(state)
+        ptot_g, ptot_e = rng.uniform(0.0, 1.0, size=2)
+        for q in (0, 1):
+            pop_g, _ = oracle.collapse(state, q, 0, 2)
+            pop_e, _ = oracle.collapse(state, q, 1, 2)
+            w0, _ = oracle.damp_no_fire(state, q, ptot_g, ptot_e, 2)
+            total = ptot_g * pop_g + ptot_e * pop_e + w0
+            assert abs(total - 1.0) < 1e-12
+
+
+def test_damp_with_zero_rates_is_identity():
+    h = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
+    w, post = oracle.damp_no_fire(h, 0, 0.0, 0.0, 1)
+    assert abs(w - 1.0) < 1e-12
+    assert np.allclose(post, h)
+
+
+def test_collapse_reproduces_born_weights():
+    h = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
+    w0, post0 = oracle.collapse(h, 0, 0, 1)
+    w1, post1 = oracle.collapse(h, 0, 1, 1)
+    assert abs(w0 - 0.5) < 1e-12 and abs(w1 - 0.5) < 1e-12
+    assert abs(abs(post0[0]) - 1.0) < 1e-12  # renormalized |0>
+    assert abs(abs(post1[1]) - 1.0) < 1e-12  # renormalized |1>
+
+
+def test_set_collapsed_qubit_reprepares_destination():
+    _, at_e = oracle.collapse(oracle.apply_1q(oracle.zero_state(1), "X", 0, 1), 0, 1, 1)
+    moved = oracle.set_collapsed_qubit(at_e, 0, 1, 0, 1)
+    assert abs(abs(moved[0]) - 1.0) < 1e-12

--- a/tests/python/utils_noncomp_enumerator.py
+++ b/tests/python/utils_noncomp_enumerator.py
@@ -96,19 +96,32 @@ class _Branch:
 
 
 class ExactDistribution:
-    """The enumeration result: record joint, status marginals, dropped mass."""
+    """The enumeration result: record joint, noncomputational-level
+    marginals per qubit, and truncated mass.
+
+    Only noncomputational levels appear in ``noncomp_level_probs``: for a
+    computational qubit the classical ledger tracks the *category* (which
+    is all the branching semantics need), while the level itself is
+    quantum information living in the state -- so per-level computational
+    marginals are not representable here by design. The computational
+    mass per qubit is one minus the noncomputational sum.
+    """
 
     def __init__(self) -> None:
         self.record_probs: dict[tuple[int, ...], float] = {}
-        self.status_probs: list[dict[int, float]] = []
+        self.noncomp_level_probs: list[dict[int, float]] = []
         self.dropped_mass = 0.0
 
     def _absorb(self, branch: _Branch, num_qubits: int) -> None:
-        if not self.status_probs:
-            self.status_probs = [{} for _ in range(num_qubits)]
+        if not self.noncomp_level_probs:
+            self.noncomp_level_probs = [{} for _ in range(num_qubits)]
         self.record_probs[branch.record] = self.record_probs.get(branch.record, 0.0) + branch.weight
         for q, level in enumerate(branch.status):
-            self.status_probs[q][level] = self.status_probs[q].get(level, 0.0) + branch.weight
+            if level in _COMPUTATIONAL:
+                continue
+            self.noncomp_level_probs[q][level] = (
+                self.noncomp_level_probs[q].get(level, 0.0) + branch.weight
+            )
 
 
 def _hidden_collapse(branch: _Branch, q: int, n: int) -> list[tuple[float, np.ndarray, int]]:

--- a/tests/python/utils_noncomp_enumerator.py
+++ b/tests/python/utils_noncomp_enumerator.py
@@ -1,0 +1,338 @@
+"""Exact output-distribution enumerator for small noncomputational circuits.
+
+Test-only companion to ``utils_noncomp_oracle``: walks a small circuit over
+the default five-level set and returns the exact joint distribution of the
+visible measurement record, by branching a pure statevector over every
+classical event -- initial levels, transition fires, Born outcomes -- with
+explicit probability weights. Transition sites apply the physical per-site
+channel (source-conditioned collapse plus the sqrt(1 - p) no-fire filter),
+so the result is the dense reference the exact sampling mode must match to
+shot noise; ``damping="neglect"`` reproduces that mode's one documented
+omission by skipping the no-fire filter while keeping fire weights exact.
+
+Deliberately independent of clifft: its own line parser (a small subset),
+its own semantics written from the design notes -- operations touching a
+leaked or lost operand drop whole (measurements never drop; a classifier
+column supplies their record bit), R restores a leaked qubit and never a
+lost one, LOSS is a source-independent trace-out. Exponential in circuit
+size by construction; the branch cap guards against feeding it a scenario
+it was never meant to hold.
+
+Level ids match ``clifft.noncomp.Level``: g=0, e=1, leak_g=2, leak_e=3,
+lost=4.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+import utils_noncomp_oracle as oracle
+
+G, E, LEAK_G, LEAK_E, LOST = range(5)
+_COMPUTATIONAL = (G, E)
+
+_PRUNE_EPS = 1e-12
+_MAX_BRANCHES = 200_000
+
+
+@dataclass
+class _Op:
+    kind: str  # "gate" | "reset" | "measure" | "measure_reset" | "transition" | "loss"
+    targets: list[int]
+    gate: str = ""
+    tag: str = ""
+    prob: float = 0.0
+
+
+_GATE_1Q = {"H", "S", "X", "Y", "Z"}
+
+
+def parse_circuit(text: str) -> tuple[list[_Op], int]:
+    """Parse the supported subset; returns (ops, num_qubits)."""
+    ops: list[_Op] = []
+    max_q = -1
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, *args = line.split()
+        qubits = [int(a) for a in args]
+        max_q = max(max_q, *qubits) if qubits else max_q
+        if name in _GATE_1Q:
+            ops.extend(_Op("gate", [q], gate=name) for q in qubits)
+        elif name == "CX":
+            assert len(qubits) % 2 == 0
+            ops.extend(
+                _Op("gate", [qubits[i], qubits[i + 1]], gate="CX") for i in range(0, len(qubits), 2)
+            )
+        elif name == "R":
+            ops.extend(_Op("reset", [q]) for q in qubits)
+        elif name == "M":
+            ops.extend(_Op("measure", [q]) for q in qubits)
+        elif name == "MR":
+            ops.extend(_Op("measure_reset", [q]) for q in qubits)
+        elif name.startswith("LEVEL_TRANSITION["):
+            m = re.fullmatch(r"LEVEL_TRANSITION\[([^\]]+)\]", name)
+            assert m is not None, line
+            ops.extend(_Op("transition", [q], tag=m.group(1)) for q in qubits)
+        elif name.startswith("LOSS("):
+            m = re.fullmatch(r"LOSS\(([^)]+)\)", name)
+            assert m is not None, line
+            ops.extend(_Op("loss", [q], prob=float(m.group(1))) for q in qubits)
+        else:
+            raise ValueError(f"enumerator does not support: {line}")
+    return ops, max_q + 1
+
+
+@dataclass
+class _Branch:
+    weight: float
+    state: npt.NDArray[np.complex128]
+    status: tuple[int, ...]  # level id per qubit
+    record: tuple[int, ...]
+
+
+class ExactDistribution:
+    """The enumeration result: record joint, status marginals, dropped mass."""
+
+    def __init__(self) -> None:
+        self.record_probs: dict[tuple[int, ...], float] = {}
+        self.status_probs: list[dict[int, float]] = []
+        self.dropped_mass = 0.0
+
+    def _absorb(self, branch: _Branch, num_qubits: int) -> None:
+        if not self.status_probs:
+            self.status_probs = [{} for _ in range(num_qubits)]
+        self.record_probs[branch.record] = self.record_probs.get(branch.record, 0.0) + branch.weight
+        for q, level in enumerate(branch.status):
+            self.status_probs[q][level] = self.status_probs[q].get(level, 0.0) + branch.weight
+
+
+def _hidden_collapse(branch: _Branch, q: int, n: int) -> list[tuple[float, np.ndarray, int]]:
+    """Born-collapse qubit q without recording: [(weight, state, bit), ...]."""
+    out = []
+    for bit in (0, 1):
+        w, post = oracle.collapse(branch.state, q, bit, n)
+        if w > 0.0:
+            out.append((w, post, bit))
+    return out
+
+
+def _prep_zero(state: np.ndarray, q: int, bit_now: int, n: int) -> np.ndarray:
+    return oracle.set_collapsed_qubit(state, q, bit_now, 0, n)
+
+
+def enumerate_exact(
+    text: str,
+    *,
+    initial: list[float],
+    transitions: dict[str, list[list[float]]],
+    classifier: list[list[float]],
+    damping: str = "exact",
+) -> ExactDistribution:
+    """Exact record/status distribution for `text` under the given model.
+
+    `classifier` is P[symbol][level] with two symbols; computational
+    measurements are faithful Born readouts (identity columns required).
+    """
+    assert damping in ("exact", "neglect")
+    assert len(classifier) == 2
+    assert (
+        classifier[0][G] == 1.0 and classifier[1][E] == 1.0
+    ), "the enumerator models faithful computational readout only"
+    ops, n = parse_circuit(text)
+
+    # Initial branches: product over qubits of the level distribution.
+    # Computational e is an X-prep; noncomputational levels park the factor
+    # at |0> with the level recorded classically.
+    branches = [_Branch(1.0, oracle.zero_state(n), (G,) * n, ())]
+    for q in range(n):
+        seeded: list[_Branch] = []
+        for br in branches:
+            for level, p in enumerate(initial):
+                if p <= 0.0:
+                    continue
+                state = br.state
+                if level == E:
+                    state = oracle.apply_1q(state, "X", q, n)
+                status = list(br.status)
+                status[q] = level
+                seeded.append(_Branch(br.weight * p, state, tuple(status), ()))
+        branches = seeded
+
+    result = ExactDistribution()
+
+    def emit(br: _Branch) -> None:
+        result._absorb(br, n)
+
+    for op in ops:
+        nxt: list[_Branch] = []
+
+        for br in branches:
+            noncomp = [q for q in op.targets if br.status[q] not in _COMPUTATIONAL]
+
+            if op.kind == "gate":
+                if noncomp:
+                    nxt.append(br)  # the whole operation drops
+                    continue
+                if op.gate == "CX":
+                    state = oracle.apply_cx(br.state, op.targets[0], op.targets[1], n)
+                else:
+                    state = oracle.apply_1q(br.state, op.gate, op.targets[0], n)
+                nxt.append(_Branch(br.weight, state, br.status, br.record))
+                continue
+
+            q = op.targets[0]
+            level = br.status[q]
+
+            if op.kind == "reset":
+                if level == LOST:
+                    nxt.append(br)  # reset does not restore a lost qubit
+                    continue
+                for w, post, bit in _hidden_collapse(br, q, n):
+                    status = list(br.status)
+                    status[q] = G
+                    nxt.append(
+                        _Branch(
+                            br.weight * w,
+                            _prep_zero(post, q, bit, n),
+                            tuple(status),
+                            br.record,
+                        )
+                    )
+                continue
+
+            if op.kind in ("measure", "measure_reset"):
+                if level in _COMPUTATIONAL:
+                    for w, post, bit in _hidden_collapse(br, q, n):
+                        state = post
+                        if op.kind == "measure_reset":
+                            state = _prep_zero(post, q, bit, n)
+                        nxt.append(_Branch(br.weight * w, state, br.status, br.record + (bit,)))
+                else:
+                    for bit in (0, 1):
+                        p_bit = classifier[bit][level]
+                        if p_bit <= 0.0:
+                            continue
+                        status = list(br.status)
+                        if op.kind == "measure_reset" and level != LOST:
+                            status[q] = G  # reset restores the leaked qubit
+                        nxt.append(
+                            _Branch(
+                                br.weight * p_bit,
+                                br.state,
+                                tuple(status),
+                                br.record + (bit,),
+                            )
+                        )
+                continue
+
+            if op.kind == "loss":
+                if level == LOST:
+                    nxt.append(br)
+                    continue
+                p = op.prob
+                if p < 1.0:
+                    nxt.append(_Branch(br.weight * (1.0 - p), br.state, br.status, br.record))
+                if p > 0.0:
+                    status = list(br.status)
+                    status[q] = LOST
+                    if level in _COMPUTATIONAL:
+                        # Source-independent trace-out: hidden collapse, no filter.
+                        for w, post, _bit in _hidden_collapse(br, q, n):
+                            nxt.append(_Branch(br.weight * p * w, post, tuple(status), br.record))
+                    else:
+                        nxt.append(_Branch(br.weight * p, br.state, tuple(status), br.record))
+                continue
+
+            assert op.kind == "transition"
+            column = transitions[op.tag]
+
+            if level not in _COMPUTATIONAL:
+                # Classical consult: draw from the status level's column.
+                stay = 1.0 - sum(column[d][level] for d in range(5))
+                if stay > 0.0:
+                    nxt.append(_Branch(br.weight * stay, br.state, br.status, br.record))
+                for d in range(5):
+                    p = column[d][level]
+                    if p <= 0.0:
+                        continue
+                    status = list(br.status)
+                    status[q] = d
+                    if d in _COMPUTATIONAL:
+                        # Recapture: materialize the carrier at |d>.
+                        for w, post, bit in _hidden_collapse(br, q, n):
+                            state = oracle.set_collapsed_qubit(
+                                _prep_zero(post, q, bit, n), q, 0, d, n
+                            )
+                            nxt.append(_Branch(br.weight * p * w, state, tuple(status), br.record))
+                    else:
+                        nxt.append(_Branch(br.weight * p, br.state, tuple(status), br.record))
+                continue
+
+            # Quantum consult: the physical per-site channel.
+            ptot = [sum(column[d][s] for d in range(5)) for s in _COMPUTATIONAL]
+
+            # Fire branches: collapse onto the source, then land the destination.
+            pops = {}
+            for s in _COMPUTATIONAL:
+                w_s, collapsed = oracle.collapse(br.state, q, s, n)
+                pops[s] = w_s
+                if w_s <= 0.0:
+                    continue
+                for d in range(5):
+                    p = column[d][s]
+                    if p <= 0.0:
+                        continue
+                    status = list(br.status)
+                    if d in _COMPUTATIONAL:
+                        state = oracle.set_collapsed_qubit(collapsed, q, s, d, n)
+                    else:
+                        status[q] = d
+                        state = collapsed  # factored; parked at |s>
+                    nxt.append(_Branch(br.weight * w_s * p, state, tuple(status), br.record))
+
+            # No-fire branch.
+            if damping == "exact":
+                w0, post = oracle.damp_no_fire(br.state, q, ptot[G], ptot[E], n)
+                if w0 > 0.0:
+                    nxt.append(_Branch(br.weight * w0, post, br.status, br.record))
+            else:
+                w0 = 1.0 - ptot[G] * pops[G] - ptot[E] * pops[E]
+                if w0 > 0.0:
+                    nxt.append(_Branch(br.weight * w0, br.state, br.status, br.record))
+
+        # Prune and cap.
+        kept = []
+        for br in nxt:
+            if br.weight < _PRUNE_EPS:
+                result.dropped_mass += br.weight
+            else:
+                kept.append(br)
+        branches = kept
+        if len(branches) > _MAX_BRANCHES:
+            raise RuntimeError(f"branch explosion: {len(branches)} branches")
+
+    for br in branches:
+        emit(br)
+    return result
+
+
+def tvd(p: dict[tuple[int, ...], float], q: dict[tuple[int, ...], float]) -> float:
+    """Total variation distance between two record distributions."""
+    keys = set(p) | set(q)
+    return 0.5 * sum(abs(p.get(k, 0.0) - q.get(k, 0.0)) for k in keys)
+
+
+def empirical_record_probs(measurements: np.ndarray) -> dict[tuple[int, ...], float]:
+    """Empirical record joint from a (shots x slots) 0/1 array."""
+    m = np.asarray(measurements)
+    probs: dict[tuple[int, ...], float] = {}
+    inv = 1.0 / m.shape[0]
+    for row in m:
+        key = tuple(int(b) for b in row)
+        probs[key] = probs.get(key, 0.0) + inv
+    return probs

--- a/tests/python/utils_noncomp_oracle.py
+++ b/tests/python/utils_noncomp_oracle.py
@@ -1,17 +1,24 @@
 """Tiny dense reference for cross-checking noncomputational sampling.
 
-Test-only. A minimal density-matrix simulator over the computational subspace
-(<= 3 qubits), built from first principles -- statevector unitaries, Born-rule
-Z measurement, and partial trace -- and deliberately independent of clifft's
-sampler, rewriter, and SVM. Combined with explicit classical probabilities for
-initial levels, transitions, and the classifier, it yields expected output
-distributions to compare against ``clifft.noncomp.sample`` within shot noise.
+Test-only. A minimal quantum core over the computational subspace (<= 5
+qubits), built from first principles -- statevector unitaries, Born-rule
+Z measurement, partial trace, and the per-site exact transition channel
+(source-conditioned collapse plus the sqrt(1 - p) no-fire damping filter)
+-- and deliberately independent of clifft's sampler, rewriter, driver, and
+SVM. Combined with explicit classical probabilities for initial levels,
+transitions, and the classifier, it yields expected output distributions
+to compare against ``clifft.noncomp.sample`` within shot noise.
 
-Scope: the exact supported subset only -- small Clifford circuits, a Z-basis
-binary classifier, and state-independent loss handled as a true partial trace.
-This is not a general simulator and must not grow into one; the lossless
-self-check tests guard that its quantum core is correct before it is trusted to
-judge the noncomputational pipeline.
+The channel here is the *physical* Kraus map, applied uniformly to any
+computational qubit: it knows nothing of clifft's known/unknown status
+tracking, dormant/active instrument forms, traps, or continuations --
+every one of those implementation strategies must reproduce it.
+
+Scope: the exact supported subset only -- small Clifford circuits, a
+Z-basis binary classifier, loss as a true partial trace, and the exact
+per-site channel above. This is not a general simulator and must not grow
+into one; the lossless self-check tests guard that its quantum core is
+correct before it is trusted to judge the noncomputational pipeline.
 
 Qubit/bit convention: qubit 0 is the most significant factor in the Kronecker
 product, matching how the self-check compares against clifft's records.
@@ -97,3 +104,52 @@ def marginal_one_after_trace_out(
         raise ValueError("lost and survivor must be different qubits")
     rho = reduced_density(state, survivor, n)
     return float(np.real(rho[1, 1]))
+
+
+# --- Exact per-site transition channel ---------------------------------------
+#
+# The physical channel of one annotation target on a computational qubit,
+# as Kraus operators on that qubit's factor:
+#
+#   fire, source s, destination d:  K = sqrt(p[d][s]) |after_d><s|
+#   no fire:                        K0 = diag(sqrt(1 - ptot_g), sqrt(1 - ptot_e))
+#
+# where ptot_s is column s's total jump probability. A fire collapses the
+# qubit onto its source; a noncomputational destination then removes the
+# (now factored) qubit from the quantum register, a computational one
+# re-prepares it at |d>. The branch helpers below return (weight, state)
+# pairs with the state renormalized, so callers assemble the mixture with
+# explicit weights.
+
+
+def collapse(
+    state: npt.NDArray[np.complex128], q: int, bit: int, n: int
+) -> tuple[float, npt.NDArray[np.complex128]]:
+    """Project qubit q onto |bit> and renormalize: (Born weight, post state)."""
+    proj = _embed(_P1 if bit else _P0, q, n)
+    post = proj @ state
+    weight = float(np.real(post.conj() @ post))
+    if weight <= 0.0:
+        return 0.0, post
+    return weight, post / np.sqrt(weight)
+
+
+def damp_no_fire(
+    state: npt.NDArray[np.complex128], q: int, ptot_g: float, ptot_e: float, n: int
+) -> tuple[float, npt.NDArray[np.complex128]]:
+    """Apply the no-fire filter K0 on qubit q: (branch weight, post state)."""
+    k0 = np.array([[np.sqrt(1.0 - ptot_g), 0.0], [0.0, np.sqrt(1.0 - ptot_e)]], dtype=complex)
+    post = _embed(k0, q, n) @ state
+    weight = float(np.real(post.conj() @ post))
+    if weight <= 0.0:
+        return 0.0, post
+    return weight, post / np.sqrt(weight)
+
+
+def set_collapsed_qubit(
+    state: npt.NDArray[np.complex128], q: int, source: int, dest: int, n: int
+) -> npt.NDArray[np.complex128]:
+    """Re-prepare a just-collapsed (factored) qubit from |source> to |dest>."""
+    if source == dest:
+        return state
+    return _embed(GATES_1Q["X"], q, n) @ state

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -534,3 +534,22 @@ TEST_CASE("exact: a hand-built malformed LOSS rejects up front") {
                             ContainsSubstring("out of [0, 1]"));
     }
 }
+
+TEST_CASE("exact: a smaller starting module must not shrink the reused state") {
+    // A leaked initial compiles a from-the-top continuation with more
+    // hidden record slots (the MR restore) but a smaller peak rank than
+    // the main line, whose expand_damp site needs the array. A shot
+    // sequence interleaving both starting modules used to rebuild the
+    // state to the smaller module's rank while the tracker kept the
+    // maximum; the next main-line shot then overran its allocation --
+    // caught by the Debug kernel assert, an out-of-bounds write in
+    // Release.
+    ModelSpec spec;
+    spec.leak_from_e = 3e-3;  // source-dependent: the dormant site damp-expands
+    spec.leak_from_g = 3e-4;
+    spec.initial = {0.5, 0.0, 0.5, 0.0, 0.0};  // both starting modules occur
+    auto model = make_model(spec);
+    Circuit circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nMR 0\nM 0");
+    auto result = sample_noncomputational(circuit, model, 64, 5);
+    REQUIRE(result.shots == 64);
+}


### PR DESCRIPTION
> **Prototype note:** part of the `codex/noncomputational-structural-mvp` feature branch — scoped for lighter-weight review than main.

Step 7's validation half (`design/state-dependent-jumps.md` §5 items 1–4), tests only — no behavior change. The performance table and the default flip follow as the next PR.

## The reference

- **Oracle** (`utils_noncomp_oracle.py`): gains the physical per-site channel as Kraus primitives — `collapse` (source-conditioned Born projection), `damp_no_fire` (the `sqrt(1-p_s)` filter), `set_collapsed_qubit` (destination re-prep). The channel is applied uniformly to any computational qubit: the oracle knows nothing of clifft's known/unknown tracking, dormant/active instrument forms, traps, or continuations — **every implementation strategy must reproduce it**, which is the point of §5. Charter consciously raised from ≤3 to ≤5 qubits; new self-checks pin Kraus completeness on random states, zero-rate identity, and Born weights.
- **Enumerator** (`utils_noncomp_enumerator.py`, new): a first-principles exact-distribution builder — walks a small circuit branching a pure statevector over every classical event (initial levels, fires, Born outcomes) and returns the exact record joint + status marginals, with truncation mass tracked and a branch cap. Its own parser, its own semantics written from the design notes (drop-whole on leaked/lost operands, measurements never drop, R restores leaked and never lost, LOSS as source-independent trace-out). `damping="neglect"` skips the no-fire filter with fire weights kept exact. Self-checked against hand-derived closed forms (lossless Bell; the |+⟩ marginal **0.7 exact / 0.6 neglect**; classical seepage recapture).

## The campaign

- **Probe: gate-determined fires exactly 0** (§5.2) — `H H` returns the qubit to `g` by algebra; a *certain* leak-from-`e` then never fires (`⟨P_e⟩ = 0` on the live state), where any ahead-of-time source guess would leak half the shots. Asserts zero leaked statuses and all-zero records over 20k shots.
- **Probe: Bell joint TVD 0** (§5.2) — certain source-dependent destinations on a Bell half: classified record and partner agree on **every** shot; off-diagonal mass exactly 0.
- **Probe: the damping boundary** (§5.3) — |+⟩ through one no-fire leak-from-`e` site, read in the X basis: exact keeps coherence `sqrt(1-p)`, neglect keeps 1. Both modes must match their own oracle-computed closed form, and a power guard asserts the two forms are separated by more than twice both tolerance bands — the probe is the direct measurement of the fallback's one omission.
- **Rep-code TVD** (§5.4) — a d=3 repetition-code round (5 qubits, 5 record slots) at cold-atom-magnitude rates (leakage 1e-3-class, loss 3.9e-3, 1.5% leaked initials, ×3 scale so a correlation-class error would stand above noise), compared to the enumerator by TVD under a shot-noise band **calibrated by multinomial resampling of the reference itself** (max of 300 draws × 1.3 headroom), plus per-qubit leaked/lost marginals at 5σ. Run twice: `damping="exact"` against the exact reference, and `damping="neglect"` against *its own* reference — pinning the fallback's semantics distributionally, not just at micro-probes.

Runtime discipline per review guidance: the whole campaign adds ~9 s to the Python suite (60k-shot TVD runs included); no slow markers needed.

One incidental find while writing the probes: a fired branch's later gates hit the leaked qubit, so probe models need `lost_leaked_ops="drop"` — with the default reject policy the exact mode correctly *refuses* the circuit, which is itself the documented behavior.

**Verified**: Python **742** green (12 new tests; ~18 s total suite), pre-commit clean (ruff, ruff-format, mypy). C++ untouched.

Next: PR B — performance table (main-line overhead per instrument form, exact vs AOT per-shot-compile throughput, the squeeze-exclusion cost) + docs + default flip to `unknown_source_policy="exact"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



**Review round** (see latest commits): **[P1] was a real driver bug, and the campaign caught it** — the rep-code TVD run aborted on CI's Debug extension inside the `expand_damp` kernel ("exceeded AOT peak_rank allocation"). Root cause in the driver's cross-shot state reuse: a noncomputational-initial shot's from-the-top continuation can exceed the reused state on one axis while being *smaller* on the other (a leaked initial with `MR` carries more hidden record slots than the main line but a lower peak rank), and the rebuild sized the fresh state to the **triggering module** while the tracker kept the maxima — the next main-line shot then ran its damp-expansion against the smaller allocation. Debug asserts; **Release writes out of bounds**. Fix: rebuilds size to the running maxima. Minimal repro was `H 0 / LEVEL_TRANSITION / MR 0 / M 0` with mixed computational/leaked initials; the new C++ regression interleaves both starting modules and fails against the old driver (verified by stashing the fix). Why I missed it: I ran the Python suite only against a Release-built extension — CI builds it `SKBUILD_CMAKE_BUILD_TYPE: Debug`. Both are green now (Debug **742** in 49 s, Release **742**; C++ Debug/Release/clang-18 **1109** with the new case). **[P2]** applied — the Bell probe now asserts the consulted qubit is leaked on every shot, so it pins correlated collapse *through the transition*, not ordinary Bell correlation.


**Review round 2** (see latest commit): **[P3]** applied, one notch stronger than suggested — instead of documenting `status_probs`' computational entries as unreliable, the field is now `noncomp_level_probs` and holds noncomputational levels only, so the wrong reading is unrepresentable. The ledger's computational entries were meaningless by design (the category is all the branching needs; the level is quantum information in the state), and a future test wanting g/e marginals should derive them from the state. Python green on both extensions.