### PR TITLE
feat(noncomp)!: make dropping the only lost/leaked-op policy

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -264,11 +264,11 @@ model = clifft.NonComputationalModel(
                 [0, 1, 0, 0, 0]],
     ),
 
-    # Policy hooks for downstream operations on noncomputational
-    # qubits. See section 5 for the default table.
+    # Policy for downstream operations on noncomputational qubits.
+    # See section 5 for the per-op table (ops with no representable
+    # effect on a vacated site are dropped).
     policy=clifft.NonComputationalPolicy(
         reset_restores_lost=False,
-        # ... other knobs, default-reject for ambiguous cases.
     ),
 )
 ```
@@ -551,27 +551,33 @@ the op runs unchanged but the qubit's status transitions
 
 | Operation                | ComputationalUnknown | ComputationalKnown                  | Leaked                                  | Lost                                              |
 |--------------------------|-----------------------|--------------------------------------|------------------------------------------|---------------------------------------------------|
-| Single-qubit gate        | apply                 | apply, demote to Unknown            | reject (policy override allowed)        | drop                                              |
+| Single-qubit gate        | apply                 | apply, demote to Unknown            | drop                                    | drop                                              |
 | Single-qubit Pauli noise | apply                 | apply, demote to Unknown            | drop                                    | drop                                              |
-| Two-qubit gate           | apply                 | apply, demote to Unknown on both    | reject                                  | reject (policy override: drop)                    |
+| Two-qubit gate           | apply                 | apply, demote to Unknown on both    | drop                                    | drop                                              |
 | MPP / multi-target meas  | apply                 | apply, demote to Unknown on all     | reject                                  | reject                                            |
 | Visible Z-basis meas `M`              | apply, promote to `ComputationalKnown(outcome)` | apply, visible outcome = current `level_id` (status unchanged) | classifier; reject probability per `leak_*` column | classifier; reject probability per `lost` column |
-| Visible Z-basis meas-and-reset `MR`   | apply, **post-op `ComputationalKnown(g)`**; visible outcome reflects sampled value | apply, visible outcome = current `level_id`; **post-op `ComputationalKnown(g)`** | classifier; post-op `ComputationalKnown(g)` if `reset_restores_lost` applies, else status preserved | classifier; reject unless `policy.reset_restores_lost`, then post-op `ComputationalKnown(g)` |
-| Visible X/Y-basis meas (`MX`/`MY`)    | apply, stays `ComputationalUnknown`  | apply, demote to Unknown | classifier; as above | classifier; as above |
-| Visible X/Y-basis meas-and-reset (`MRX`/`MRY`) | apply, stays `ComputationalUnknown`; **post-op also `ComputationalUnknown`** | apply, demote to Unknown | classifier; post-op `ComputationalUnknown` if `reset_restores_lost` applies, else preserved | classifier; reject unless `policy.reset_restores_lost`, then post-op `ComputationalUnknown` |
-| Z-basis reset `R`        | apply, promote to Known (`g`) | apply, set `level_id = g` | restore to ComputationalKnown (`g`) | reject unless `policy.reset_restores_lost` is set; then restore to ComputationalKnown (`g`) |
-| X/Y-basis reset `RX`/`RY` | apply, stays Unknown | apply, demote to Unknown | restore to ComputationalUnknown      | reject unless `policy.reset_restores_lost` is set; then restore to ComputationalUnknown |
+| Visible Z-basis meas-and-reset `MR`   | apply, **post-op `ComputationalKnown(g)`**; visible outcome reflects sampled value | apply, visible outcome = current `level_id`; **post-op `ComputationalKnown(g)`** | classifier; post-op `ComputationalKnown(g)` if `reset_restores_lost` applies, else status preserved | classifier; post-op `ComputationalKnown(g)` if `reset_restores_lost`, else the site stays lost |
+| Visible X/Y-basis meas (`MX`/`MY`)    | apply, stays `ComputationalUnknown`  | apply, demote to Unknown | reject | reject |
+| Visible X/Y-basis meas-and-reset (`MRX`/`MRY`) | apply, stays `ComputationalUnknown`; **post-op also `ComputationalUnknown`** | apply, demote to Unknown | classifier; post-op `ComputationalUnknown` if `reset_restores_lost` applies, else preserved | classifier; post-op `ComputationalUnknown` if `reset_restores_lost`, else the site stays lost |
+| Z-basis reset `R`        | apply, promote to Known (`g`) | apply, set `level_id = g` | restore to ComputationalKnown (`g`) | drop unless `policy.reset_restores_lost` is set; then restore to ComputationalKnown (`g`) |
+| X/Y-basis reset `RX`/`RY` | apply, stays Unknown | apply, demote to Unknown | restore to ComputationalUnknown      | drop unless `policy.reset_restores_lost` is set; then restore to ComputationalUnknown |
 | Detector / Observable    | unchanged             | unchanged                            | unchanged                               | unchanged                                         |
 
 Notes:
 
-- "Policy override allowed" means the cell rejects by default but the
-  user may set a `NonComputationalPolicy` field to flip it to a
-  specific behavior. The MVP exposes overrides only where listed.
-- There is no separate `RL` op in MVP. Lost-qubit reset rejects by
-  default; the `policy.reset_restores_lost` flag turns it into a
-  reload that restores the qubit to a `ComputationalKnown` status.
-  See §8 for the rationale.
+- An operation with no representable effect on a leaked or lost operand
+  is dropped whole (identity on the surviving operands). This is the
+  only behavior, not a policy the caller selects. The exception is a
+  non-reset X/Y-basis measurement (`MX`/`MY`) or a multi-target/parity
+  measurement (`MPP`): it rejects, because the classifier defines a
+  single Z-basis-like record bit that is not a faithful X/Y or parity
+  outcome. A measure-and-reset (`MR`/`MRX`/`MRY`) is kept instead — its
+  record is the classifier bit and its reset re-prepares the site, so
+  the readout basis is incidental on a vacated carrier.
+- There is no separate `RL` op in MVP. Lost-qubit reset drops by default
+  (the vacated site is unaffected); the `policy.reset_restores_lost`
+  flag turns it into a reload that restores the qubit to a
+  `ComputationalKnown` status. See §8 for the rationale.
 - **Lost-qubit measurement is fully specified by the classifier
   matrix's `lost` column.** There is no separate `lost_measurement`
   policy knob: random-bit is `[0.5, 0.5]`, deterministic-0 is
@@ -671,24 +677,30 @@ measurement back-action on the computational state or force a
 branch-and-continue boundary, which is exactly the dynamic/JIT path
 deferred in §1.
 
-### 5.2.3 Opt-in drop policy for leaked/lost operands
+### 5.2.3 Operations with no representable effect on leaked/lost operands
 
-`policy.lost_leaked_ops` selects how the reject cells above behave.
-`Reject` (default) keeps the table exactly as written. `Drop` opts into
-excising each such operation whole — identity on the surviving operands
-— modeling the physical reading that an interaction with a vacated or
-leaked site does not happen:
+An operation whose physical effect on a leaked or lost operand is not
+representable is excised whole — identity on the surviving operands —
+modeling the reading that an interaction with a vacated or leaked site
+does not happen. This is the only behavior; there is no policy knob to
+turn it off. Concretely:
 
-- single-qubit gate on Leaked: drop (was reject);
+- single-qubit gate on a Leaked operand: drop;
 - two-qubit gate, multi-qubit noise channel, or classical feedback with
-  a Leaked or Lost operand: drop whole (was reject);
-- non-restoring lost-qubit reset: drop (was reject);
+  a Leaked or Lost operand: drop whole;
+- non-restoring lost-qubit reset: drop;
 - non-restoring lost-qubit measure-and-reset: kept — the visible record
   slot must survive, the classifier supplies the bit, and the site
-  simply stays lost (was reject);
-- X/Y-basis and multi-target measurements still reject: dropping a
-  measurement would shift the record, and no single-bit substitution is
-  faithful.
+  simply stays lost;
+- a non-reset X/Y-basis or multi-target measurement (`MX`/`MY`/`MPP`)
+  rejects: dropping a measurement would shift the record, and no
+  single-bit substitution is a faithful X/Y or parity outcome.
+
+A "does this model ever drive a dead qubit" contract check — distinct
+from these per-op representability limits — is a static validator's job
+(a future `noncomp.validate_static`), not a sampling policy: as a
+sampling-time reject it would fire seed-dependently, since whether a
+qubit is vacated before a given op is a per-shot draw.
 
 A dropped operation has no physical effect, so a surviving operand's
 status keeps its entry value (it is not demoted). Transition

--- a/design/state-dependent-jumps.md
+++ b/design/state-dependent-jumps.md
@@ -541,8 +541,11 @@ with unrelated roadmap work.
 Post-plan (pre-release): with the campaign green and the default flipped,
 the `reject` strict guard and the ahead-of-time trajectory pipeline behind
 it were removed as well — exact runtime resolution is the only sampling
-path, and the final policy surface is `damping` plus `lost_leaked_ops` and
-`reset_restores_lost`. The AOT pipeline's differential-oracle role passed
+path, and the final policy surface is `damping` plus `reset_restores_lost`.
+(The `lost_leaked_ops` reject/drop knob was later removed too: dropping an
+op with no representable effect on a vacated site is the only behavior, so
+it needs no policy — see noncomputational-mvp.md §5.2.3.) The AOT
+pipeline's differential-oracle role passed
 to the first-principles enumerator (`tests/python`), its per-shot-compile
 baseline is recorded in the step-7 results above, and the strict guard's
 contract check is a future validator's job. Every future feature targets

--- a/examples/leakage_and_loss.ipynb
+++ b/examples/leakage_and_loss.ipynb
@@ -343,10 +343,9 @@
    "source": [
     "## Downstream of a lost site\n",
     "\n",
-    "An operation on a leaked or lost operand with no representable effect is refused by default.\n",
-    "`lost_leaked_ops=\"drop\"` excises such operations whole (identity on the surviving operands);\n",
-    "measurements are never dropped, so the record layout survives. With this and\n",
-    "`reset_restores_lost` on, multi-round circuits run through loss events end to end."
+    "An operation on a leaked or lost operand with no representable effect is dropped whole\n",
+    "(identity on the surviving operands); measurements are never dropped, so the record layout\n",
+    "survives. With `reset_restores_lost` on, multi-round circuits run through loss events end to end."
    ]
   },
   {
@@ -366,7 +365,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "default policy refuses: rewrite: operation 'CX' on a Lost qubit 0 at op 2 is not representable; rejectin ...\n",
       "ternary records (ancilla, ancilla, data):\n",
       "[[0 0 2]\n",
       " [0 0 2]\n",
@@ -379,21 +377,14 @@
     "circuit = \"H 0\\nS 0\\nCX 0 1\\nMR 1\\nCX 0 1\\nMR 1\\nM 0\\n\"\n",
     "lose_data = {\"S\": T({(Level.LOST, Level.G): 1.0, (Level.LOST, Level.E): 1.0})}\n",
     "\n",
-    "strict = noncomp.Model(\n",
-    "    initial_state=[1, 0, 0, 0, 0], transitions=lose_data, classifier=ternary_classifier()\n",
-    ")\n",
-    "try:\n",
-    "    noncomp.sample(circuit, strict, shots=4, seed=8)\n",
-    "except ValueError as err:\n",
-    "    print(\"default policy refuses:\", str(err)[:80], \"...\")\n",
-    "\n",
-    "compat = noncomp.Model(\n",
+    "model = noncomp.Model(\n",
     "    initial_state=[1, 0, 0, 0, 0],\n",
     "    transitions=lose_data,\n",
     "    classifier=ternary_classifier(),\n",
-    "    lost_leaked_ops=\"drop\",\n",
     ")\n",
-    "r = noncomp.sample(circuit, compat, shots=8, seed=8)\n",
+    "# The lost data qubit's syndrome CXs have no representable effect, so they\n",
+    "# drop (identity on the ancilla); the record layout is untouched.\n",
+    "r = noncomp.sample(circuit, model, shots=8, seed=8)\n",
     "print(\"ternary records (ancilla, ancilla, data):\")\n",
     "print(r.symbols()[:4])  # both CXs dropped: ancilla stays 0; the lost data heralds"
    ]
@@ -462,7 +453,6 @@
     "        },\n",
     "        classifier=ternary_classifier(leak_confusion=0.028),\n",
     "        reset_restores_lost=True,  # a fresh atom is loaded at ancilla reset\n",
-    "        lost_leaked_ops=\"drop\",\n",
     "    )\n",
     "\n",
     "\n",
@@ -555,7 +545,7 @@
     "| initial-state preparation channel | `initial_state=[...]` |\n",
     "| ternary readout (0 / 1 / loss) | three-symbol `Classifier`; the record stays binary, loss arrives in `heralds`, `symbols()` reconstructs the ternary view |\n",
     "| equalize-and-collapse on superposed qubits | superseded: these draws resolve at runtime against the live state, no collapse approximation |\n",
-    "| gates skipped on leaked or lost atoms | `lost_leaked_ops=\"drop\"` (opt-in) |\n",
+    "| gates skipped on leaked or lost atoms | dropped whole (identity on the survivors) |\n",
     "| reset reloads a lost atom | `reset_restores_lost=True` |\n",
     "| over-rotations twirled onto the sampler | `clifft.twirl` (or simulate the rotation exactly) |\n",
     "| `cirq.Circuit` input | Stim-format text; `DETECTOR` / `OBSERVABLE_INCLUDE` evaluated in-circuit |\n",

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -149,14 +149,6 @@ NonComputationalModel::NonComputationalModel(
     }
 
     // Policy must hold recognized enum values.
-    switch (policy_.lost_leaked_ops) {
-        case LostLeakedOpsPolicy::Reject:
-        case LostLeakedOpsPolicy::Drop:
-            break;
-        default:
-            throw std::invalid_argument(
-                "NonComputationalModel: unrecognized lost_leaked_ops value");
-    }
     switch (policy_.damping) {
         case DampingPolicy::Exact:
         case DampingPolicy::Neglect:

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -6,17 +6,6 @@
 
 namespace clifft {
 
-// Policy for operations touching a leaked or lost operand that have no
-// representable effect there. Reject refuses them. Drop excises the whole
-// operation (identity on the surviving operands): the physical
-// interaction cannot happen at a vacated or leaked site. Measurements are
-// never dropped -- their visible record slot is preserved and the
-// classifier supplies the outcome.
-enum class LostLeakedOpsPolicy : uint8_t {
-    Reject = 0,
-    Drop = 1,
-};
-
 // Damping policy for exact-mode compilation at sites where the no-fire
 // back-action is genuinely non-Clifford (a source-dependent transition on
 // a dormant qubit with a random outcome). Exact expands the qubit into
@@ -37,12 +26,10 @@ enum class DampingPolicy : uint8_t {
 };
 
 struct NonComputationalPolicy {
-    // When true, lost-qubit reset (R/RX/RY) restores the qubit to a
-    // computational state. When false (default), lost-qubit reset
-    // rejects (or drops, under LostLeakedOpsPolicy::Drop).
+    // When true, a reset (R/RX/RY) on a lost qubit restores it to a
+    // computational state. When false (default), the reset acts on a
+    // vacated site and is dropped (identity on the surviving operands).
     bool reset_restores_lost = false;
-
-    LostLeakedOpsPolicy lost_leaked_ops = LostLeakedOpsPolicy::Reject;
 
     DampingPolicy damping = DampingPolicy::Exact;
 };

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -252,6 +252,27 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
     }
 }
 
+// The hidden measurement-record slot trace() assigns to the reset at
+// `reset_node` in the rewritten stream. This mirrors trace()'s hidden
+// numbering (frontend.cc: hidden_meas_idx starts at the visible-measurement
+// count and increments by one per pure-reset target, in circuit order).
+// The two counts must agree -- the driver forces exactly this slot -- so
+// the contract is stated in both places and cross-checked at runtime by
+// swap_traceout_to_forced, which fails loudly if the slot names anything
+// other than exactly one forced-capable measurement. Threading the slot out
+// of trace() directly (so it is assigned in one place) is a worthwhile
+// follow-up; it needs the HIR measure op to carry its source node.
+size_t forced_reset_hidden_slot(const Circuit& rewritten, size_t reset_node,
+                                uint32_t num_visible_measurements) {
+    uint32_t hidden_before = 0;
+    for (size_t i = 0; i < reset_node; ++i) {
+        if (is_reset(rewritten.nodes[i].gate)) {
+            hidden_before += static_cast<uint32_t>(rewritten.nodes[i].targets.size());
+        }
+    }
+    return static_cast<size_t>(num_visible_measurements) + hidden_before;
+}
+
 }  // namespace
 
 ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,
@@ -415,17 +436,8 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
     }
 
     if (traceout_node != SIZE_MAX) {
-        // The forced trace-out's hidden record slot. Hidden slots are
-        // assigned by trace() sequentially in circuit order, one per pure
-        // reset target, starting after the visible slots; mirror that count
-        // over the rewritten node stream.
-        uint32_t hidden_before = 0;
-        for (size_t i = 0; i < traceout_node; ++i) {
-            if (is_reset(out.nodes[i].gate)) {
-                hidden_before += static_cast<uint32_t>(out.nodes[i].targets.size());
-            }
-        }
-        result.forced_traceout_slot = annotated.num_measurements + hidden_before;
+        result.forced_traceout_slot =
+            forced_reset_hidden_slot(out, traceout_node, annotated.num_measurements);
     }
 
     result.final_status = std::move(status);

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -7,9 +7,11 @@
 //
 //   1. Per-op policy: replay each operation's per-qubit status through the
 //      shared status stepper and keep, drop, or reject the operation. An
-//      ambiguous operation on a leaked or lost operand rejects by default;
-//      under LostLeakedOpsPolicy::Drop it is excised whole (identity on the
-//      surviving operands), whose statuses then keep their entry values.
+//      operation with no representable effect on a leaked or lost operand is
+//      excised whole (identity on the surviving operands), whose statuses
+//      then keep their entry values. An X/Y-basis or multi-qubit-parity
+//      measurement of such an operand has no faithful single-bit form and is
+//      rejected -- a representability limit, not a policy choice.
 //   2. Classifier record write: a measurement on a leaked or lost qubit is
 //      not a physical Born measurement -- the model's classifier defines its
 //      record bit. The measurement node is replaced by an MPAD writing the

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -9,9 +9,10 @@
 //      shared status stepper and keep, drop, or reject the operation. An
 //      operation with no representable effect on a leaked or lost operand is
 //      excised whole (identity on the surviving operands), whose statuses
-//      then keep their entry values. An X/Y-basis or multi-qubit-parity
-//      measurement of such an operand has no faithful single-bit form and is
-//      rejected -- a representability limit, not a policy choice.
+//      then keep their entry values. A non-reset X/Y-basis measurement
+//      (MX/MY) or a multi-qubit-parity measurement (MPP) of such an operand
+//      has no faithful single-bit form and is rejected -- a representability
+//      limit, not a policy choice. A measure-and-reset (MR/MRX/MRY) is kept.
 //   2. Classifier record write: a measurement on a leaked or lost qubit is
 //      not a physical Born measurement -- the model's classifier defines its
 //      record bit. The measurement node is replaced by an MPAD writing the

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -84,7 +84,10 @@ OperandAction operand_action(GateType gate, QubitStatusKind kind,
     // recorded outcome is supplied by the model's classifier downstream, so
     // the operation is kept: the record slot survives, and the site either
     // restores (leaked always; lost when the policy opts in) or simply stays
-    // lost.
+    // lost. This admits the X/Y-basis forms (MRX/MRY) too: on a vacated
+    // carrier the classifier readout is basis-agnostic and the reset -- not
+    // the readout -- is the operation's effect. A non-reset X/Y measurement
+    // has no such reset and no faithful record bit, and rejects.
     if (is_measure_reset(gate)) {
         return OperandAction::Apply;
     }

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -75,7 +75,6 @@ OperandAction operand_action(GateType gate, QubitStatusKind kind,
     }
 
     const bool lost = kind == QubitStatusKind::Lost;
-    const bool drop = policy.lost_leaked_ops == LostLeakedOpsPolicy::Drop;
 
     // An identity no-op is harmless to keep on any qubit.
     if (is_identity_noop(gate)) {
@@ -83,55 +82,36 @@ OperandAction operand_action(GateType gate, QubitStatusKind kind,
     }
     // A measure-and-reset both records an outcome and restores the site. The
     // recorded outcome is supplied by the model's classifier downstream, so
-    // the operation is kept whenever the record slot must exist. A leaked
-    // qubit always restores; a lost qubit restores only when the policy opts
-    // in. A non-restoring lost site still keeps the operation under Drop --
-    // the record slot survives and the site simply stays lost -- and rejects
-    // otherwise.
+    // the operation is kept: the record slot survives, and the site either
+    // restores (leaked always; lost when the policy opts in) or simply stays
+    // lost.
     if (is_measure_reset(gate)) {
-        if (!lost || policy.reset_restores_lost) {
-            return OperandAction::Apply;
-        }
-        return drop ? OperandAction::Apply : OperandAction::Reject;
+        return OperandAction::Apply;
     }
     // A plain measurement keeps its visible record slot so the record and its
     // rec[-k] references do not shift; on a leaked/lost qubit the outcome is
     // supplied by the model's classifier downstream. That substitution is a
     // single record bit, faithful only for a Z-basis M. An X/Y-basis (MX/MY)
     // or multi-qubit-parity (MPP) measurement has no faithful single-bit form
-    // on a noncomputational operand, so it is not representable and rejects
-    // under either policy.
+    // on a noncomputational operand, so it is not representable and rejects.
+    // This is a representability limit, not a policy choice.
     if (is_measurement(gate)) {
         return gate == GateType::M ? OperandAction::Apply : OperandAction::Reject;
     }
     // A reset restores a leaked qubit always, a lost qubit only by policy. A
-    // non-restoring lost-qubit reset acts on a vacated site, so it drops
-    // under Drop and rejects otherwise.
+    // non-restoring lost-qubit reset acts on a vacated site, so it drops.
     if (is_reset(gate)) {
         if (!lost || policy.reset_restores_lost) {
             return OperandAction::Apply;
         }
-        return drop ? OperandAction::Drop : OperandAction::Reject;
+        return OperandAction::Drop;
     }
-    // A single-qubit Pauli noise channel drops on a leaked or lost qubit; a
-    // single-qubit unitary gate drops on a lost qubit (no carrier remains).
-    if (gate_arity(gate) == GateArity::SINGLE) {
-        if (is_noise_gate(gate)) {
-            return OperandAction::Drop;
-        }
-        if (lost) {
-            return OperandAction::Drop;
-        }
-        // A single-qubit gate on a leaked qubit: the pulse addresses a
-        // carrier outside the computational subspace, so it has no effect
-        // there and drops under Drop; it rejects by default.
-        return drop ? OperandAction::Drop : OperandAction::Reject;
-    }
-    // Anything else touching a leaked or lost operand -- a two-qubit gate, a
-    // two-qubit noise channel, or classical feedback onto a vacated site --
-    // is the interaction that physically cannot happen, so it drops whole
-    // (identity on the surviving operands) under Drop and rejects by default.
-    return drop ? OperandAction::Drop : OperandAction::Reject;
+    // Any other operation on a leaked or lost operand -- a single-qubit gate
+    // or noise channel, a two-qubit gate or noise channel, or classical
+    // feedback onto a vacated site -- addresses a carrier outside the
+    // computational subspace, so the interaction physically cannot happen and
+    // it drops whole (identity on the surviving operands).
+    return OperandAction::Drop;
 }
 
 QubitStatus normal_post_op_status(const QubitStatus& entry, GateType gate, OperandRole role,

--- a/src/clifft/svm/svm_instrument_kernels.cc
+++ b/src/clifft/svm/svm_instrument_kernels.cc
@@ -94,7 +94,7 @@ void exec_instrument_collapse_active(SchrodingerState& state, uint16_t v, uint8_
 void exec_instrument_expand_damp(SchrodingerState& state, uint16_t v, double r_g, double r_e) {
     assert(v == state.active_k && "instrument expand_damp must target the next dormant axis");
     assert(state.v_size() <= state.array_size() / 2 &&
-           "instrument expand_damp exceeded AOT peak_rank allocation");
+           "instrument expand_damp exceeded the compiled peak_rank allocation");
     assert(r_g > 0.0 && r_g <= 1.0 && r_e > 0.0 && r_e <= 1.0 &&
            "instrument expand_damp: coefficients must be in (0, 1]; a p = 1 site lowers as "
            "plain expansion plus per-branch collapse");

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -877,7 +877,8 @@ static inline void exec_array_s_dag(SchrodingerState& state, uint16_t v) {
 // gamma /= sqrt(2) to maintain normalization.
 static inline void exec_expand(SchrodingerState& state, uint16_t v) {
     assert(v == state.active_k && "EXPAND must target the next dormant axis");
-    assert(state.v_size() <= state.array_size() / 2 && "EXPAND exceeded AOT peak_rank allocation!");
+    assert(state.v_size() <= state.array_size() / 2 &&
+           "EXPAND exceeded the compiled peak_rank allocation!");
     (void)v;
     uint64_t half = 1ULL << state.active_k;
     auto* __restrict arr = state.v();

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -69,19 +69,9 @@ void register_noncomp(nb::module_& m) {
            std::map<std::string, std::vector<std::vector<double>>> transitions,
            std::optional<std::vector<std::string>> classifier_symbols,
            std::optional<std::vector<std::vector<double>>> classifier_matrix,
-           bool reset_restores_lost, const std::string& lost_leaked_ops,
-           const std::string& damping) {
+           bool reset_restores_lost, const std::string& damping) {
             clifft::NonComputationalPolicy policy;
             policy.reset_restores_lost = reset_restores_lost;
-            if (lost_leaked_ops == "reject") {
-                policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Reject;
-            } else if (lost_leaked_ops == "drop") {
-                policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-            } else {
-                throw std::invalid_argument(
-                    "noncomp model: lost_leaked_ops must be 'reject' or 'drop', got '" +
-                    lost_leaked_ops + "'");
-            }
             if (damping == "exact") {
                 policy.damping = clifft::DampingPolicy::Exact;
             } else if (damping == "neglect") {
@@ -107,8 +97,7 @@ void register_noncomp(nb::module_& m) {
         },
         nb::arg("initial_state"), nb::arg("transitions"),
         nb::arg("classifier_symbols") = nb::none(), nb::arg("classifier_matrix") = nb::none(),
-        nb::arg("reset_restores_lost") = false, nb::arg("lost_leaked_ops") = "reject",
-        nb::arg("damping") = "exact",
+        nb::arg("reset_restores_lost") = false, nb::arg("damping") = "exact",
         "Build a default 5-level NonComputationalModel from raw matrices. See "
         "clifft.noncomp.Model.");
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -115,13 +115,9 @@ class Model:
             qubit's state there.
         classifier: optional :class:`Classifier` supplying leaked/lost
             measurement outcomes and computational readout confusion.
-        reset_restores_lost: if true, a reset on a lost qubit restores it.
-        lost_leaked_ops: how an operation with no representable effect on a
-            leaked or lost operand is handled. ``"reject"`` (the default)
-            raises; ``"drop"`` opts into excising the whole operation,
-            acting as the identity on the surviving operands. Measurements
-            are never dropped; their record slot is kept and the classifier
-            supplies the outcome.
+        reset_restores_lost: if true, a reset on a lost qubit restores it to
+            a computational state; if false (default), the reset acts on the
+            vacated site and is dropped.
         damping: exact-mode handling of sites whose no-fire back-action is
             genuinely non-Clifford (a source-dependent transition on a
             coherent qubit outside the amplitude array). ``"exact"`` (the
@@ -130,6 +126,13 @@ class Model:
             omits the no-fire back-action, a survivorship tilt of order
             ``|p_g - p_e|`` with no effect on source-independent rates.
             Only meaningful at coherent dormant sites (see the design note).
+
+    An operation with no representable effect on a leaked or lost operand --
+    e.g. a two-qubit gate onto a vacated site -- is dropped, acting as the
+    identity on the surviving operands. Measurements keep their record slot
+    (the classifier supplies the bit); an X/Y-basis or multi-qubit-parity
+    measurement of a leaked or lost qubit has no faithful single-bit form and
+    raises.
 
     Construction validates shapes, probabilities, gate keys, policy values,
     and level table consistency in C++, raising ``ValueError`` on any
@@ -144,7 +147,6 @@ class Model:
         transitions: Mapping[str, Matrix] | None = None,
         classifier: Classifier | None = None,
         reset_restores_lost: bool = False,
-        lost_leaked_ops: str = "reject",
         damping: str = "exact",
     ) -> None:
         transition_matrices = {
@@ -158,7 +160,6 @@ class Model:
             symbols,
             matrix,
             bool(reset_restores_lost),
-            str(lost_leaked_ops),
             str(damping),
         )
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -130,9 +130,11 @@ class Model:
     An operation with no representable effect on a leaked or lost operand --
     e.g. a two-qubit gate onto a vacated site -- is dropped, acting as the
     identity on the surviving operands. Measurements keep their record slot
-    (the classifier supplies the bit); an X/Y-basis or multi-qubit-parity
-    measurement of a leaked or lost qubit has no faithful single-bit form and
-    raises.
+    (the classifier supplies the bit); a non-reset X/Y-basis measurement
+    (``MX``/``MY``) or a multi-qubit-parity measurement (``MPP``) of a leaked
+    or lost qubit has no faithful single-bit form and raises. A
+    measure-and-reset (``MR``/``MRX``/``MRY``) is kept instead -- its reset
+    re-prepares the site and the classifier supplies its record bit.
 
     Construction validates shapes, probabilities, gate keys, policy values,
     and level table consistency in C++, raising ``ValueError`` on any

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -153,10 +153,12 @@ def test_known_source_dependent_transition_accepted():
 
 
 def test_reset_reload_policy_changes_lost_site():
+    # A reset on a lost qubit drops by default (the site stays lost); with
+    # reset_restores_lost it reloads the qubit to a computational state.
     circuit = "H 0\nS 0\nR 0\n"
-    reject = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
-    with pytest.raises(ValueError, match="not representable"):
-        noncomp.sample(circuit, reject, shots=8, seed=7)
+    dropped = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
+    r = noncomp.sample(circuit, dropped, shots=8, seed=7)
+    assert (r.final_status == LOST_KIND).all()  # reset dropped; the site stays lost
 
     restore = noncomp.Model(
         initial_state=ALL_G, transitions={"S": transition_to(LOST)}, reset_restores_lost=True
@@ -321,39 +323,83 @@ def test_deterministic_in_seed():
     assert np.array_equal(a.final_status, b.final_status)
 
 
+def test_different_seeds_differ():
+    # The companion to the determinism pin: a different seed must actually
+    # change the draws, so a fixed-sequence regression cannot masquerade as
+    # "deterministic". 128 coin-flip measurements collide with probability
+    # 2**-128.
+    model = leak_model(classifier_for(LEAK_G, [0.5, 0.5]))
+    circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\n"
+    a = noncomp.sample(circuit, model, shots=128, seed=42)
+    b = noncomp.sample(circuit, model, shots=128, seed=43)
+    assert not np.array_equal(a.measurements, b.measurements)
+
+
 # --- 8. Policy knobs --------------------------------------------------------
 
 
 def test_policy_knob_strings_validate():
-    noncomp.Model(initial_state=ALL_G, lost_leaked_ops="drop", damping="neglect")
-    with pytest.raises(ValueError, match="lost_leaked_ops"):
-        noncomp.Model(initial_state=ALL_G, lost_leaked_ops="bogus")
+    noncomp.Model(initial_state=ALL_G, damping="neglect")
     with pytest.raises(ValueError, match="damping"):
         noncomp.Model(initial_state=ALL_G, damping="bogus")
 
 
-def test_drop_policy_runs_a_multi_round_circuit_through_loss():
-    """A lost data qubit drops its syndrome CXs (identity on the ancilla)."""
+def test_max_rank_rejects_over_budget_exact_but_neglect_fits():
+    # A source-dependent leak (only out of e) on a coherent dormant qubit is
+    # genuinely non-Clifford: damping="exact" expands it into the amplitude
+    # array, adding one to the compiled rank per site. Three H-prefixed sites
+    # push the peak to 3, over a cap of 2, so exact rejects (naming the
+    # offending line); damping="neglect" keeps the rank flat and fits.
+    leak_from_e = _zeros(5, 5)
+    leak_from_e[LEAK_E][noncomp.Level.E] = 0.2  # T[to][from]; nothing out of g
+    circuit = (
+        "H 0\nH 1\nH 2\n"
+        "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
+        "M 0\nM 1\nM 2\n"
+    )
+
+    def model(damping: str) -> noncomp.Model:
+        return noncomp.Model(
+            initial_state=ALL_G,
+            transitions={"leak": leak_from_e},
+            classifier=classifier_for(LEAK_E, [0.0, 1.0]),
+            damping=damping,
+        )
+
+    with pytest.raises(ValueError, match="max_rank"):
+        noncomp.sample(circuit, model("exact"), shots=4, seed=1, max_rank=2)
+
+    r = noncomp.sample(circuit, model("neglect"), shots=4, seed=1, max_rank=2)
+    assert r.num_measurements == 3
+
+
+def test_a_multi_round_circuit_runs_through_loss():
+    """A lost data qubit drops its syndrome CXs (identity on the ancilla).
+
+    Dropping an operation with no representable effect on a vacated site is
+    the only op policy -- there is no reject mode to opt out of.
+    """
     circuit = "H 0\nS 0\nCX 0 1\nMR 1\nCX 0 1\nMR 1\nM 0\n"
     transitions = {"S": transition_to(LOST)}
     classifier = classifier_for(LOST, [0.0, 1.0])
 
-    reject_model = noncomp.Model(
-        initial_state=ALL_G, transitions=transitions, classifier=classifier
-    )
-    with pytest.raises(ValueError, match="CX"):
-        noncomp.sample(circuit, reject_model, shots=4, seed=2)
-
-    model = noncomp.Model(
-        initial_state=ALL_G,
-        transitions=transitions,
-        classifier=classifier,
-        lost_leaked_ops="drop",
-    )
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
     r = noncomp.sample(circuit, model, shots=16, seed=2)
     assert r.num_measurements == 3
     assert np.array_equal(r.measurements, np.tile([0, 0, 1], (16, 1)))
     assert np.all(r.final_status[:, 0] == LOST_KIND)
+
+
+def test_xy_basis_measurement_of_a_lost_qubit_raises():
+    """An X/Y-basis or parity measurement of a leaked or lost qubit has no
+    faithful single-bit form, so it raises -- a representability limit, not a
+    policy the caller can turn off."""
+    circuit = "S 0\nMX 0\n"
+    transitions = {"S": transition_to(LOST)}
+    classifier = classifier_for(LOST, [0.0, 1.0])
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
+    with pytest.raises(ValueError, match="representable"):
+        noncomp.sample(circuit, model, shots=4, seed=2)
 
 
 def test_computational_readout_confusion_misreports_the_record():

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -41,7 +41,6 @@ def _model(transitions: dict, damping: str = "exact") -> noncomp.Model:
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions=transitions,
         classifier=_faithful_classifier(),
-        lost_leaked_ops="drop",  # a fired branch's later gates drop, not reject
         damping=damping,
     )
 

--- a/tests/python/test_noncomp_exact_tvd.py
+++ b/tests/python/test_noncomp_exact_tvd.py
@@ -40,7 +40,6 @@ def _model(initial: list, transitions: dict, damping: str = "exact") -> noncomp.
         initial_state=initial,
         transitions=transitions,
         classifier=noncomp.Classifier(["0", "1"], _classifier_matrix()),
-        lost_leaked_ops="drop",
         damping=damping,
     )
 

--- a/tests/python/test_noncomp_examples.py
+++ b/tests/python/test_noncomp_examples.py
@@ -92,8 +92,10 @@ def test_example_relaxation_to_ground_on_known_qubit():
 # --- Intentionally unsupported -----------------------------------------------
 
 
-def test_reject_two_qubit_gate_on_leaked_qubit():
-    # Once qubit 0 is leaked, a following entangling gate on it is ambiguous.
+def test_reject_xy_measurement_on_noncomputational_qubit():
+    # Once qubit 0 is leaked, its downstream gates drop, but an X/Y-basis (or
+    # parity) measurement of it has no faithful single-bit form and is refused
+    # -- a representability limit, not a policy the caller can turn off.
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={
@@ -101,4 +103,4 @@ def test_reject_two_qubit_gate_on_leaked_qubit():
         },
     )
     with pytest.raises(ValueError, match="not representable"):
-        noncomp.sample("H 0\nS 0\nCX 0 1\n", model, shots=8, seed=5)
+        noncomp.sample("H 0\nS 0\nMX 0\n", model, shots=8, seed=5)

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -10,6 +10,8 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/orchestrator.h"
+#include "clifft/noncomp/seed.h"
+#include "clifft/util/xoshiro.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
@@ -48,7 +50,6 @@ NonComputationalModel make_model(const ModelSpec& spec) {
     classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
     policy.damping = spec.damping;
     return NonComputationalModel::from_spec(levels, spec.initial, {{"leak", leak}}, classifier,
                                             policy);
@@ -188,6 +189,25 @@ TEST_CASE("exact: same seed reproduces identical runs") {
     }
 }
 
+TEST_CASE("exact: the driver and SVM seed streams are domain-separated") {
+    // The host draws (initial levels, trap destinations, classifier consults)
+    // and the in-VM Born draws run on independent streams; handing the same
+    // per-shot seed to both would correlate them. Guard the documented domain
+    // split at its source: for every shot, the same (global, shot) with
+    // different domains yields unrelated seeds, and the streams they start
+    // diverge on the very first draw.
+    for (uint64_t global : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
+        for (uint64_t shot = 0; shot < 16; ++shot) {
+            const uint64_t host = derive_seed(global, shot, kExactDriverDomain);
+            const uint64_t svm = derive_seed(global, shot, kExactSvmDomain);
+            REQUIRE(host != svm);
+            Xoshiro256PlusPlus host_rng(host);
+            Xoshiro256PlusPlus svm_rng(svm);
+            REQUIRE(host_rng.next_double() != svm_rng.next_double());
+        }
+    }
+}
+
 TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
     // Each dormant-random exact site adds one to k: three H-prefixed
     // sites push the peak to 3, over a cap of 2.
@@ -224,7 +244,6 @@ TEST_CASE("exact: a neglect-form trap keeps the fire-side correlation") {
                          {0.0, 1.0, 0.0, 1.0, 0.0}};  // leak_e reads 1
 
     NonComputationalPolicy policy;
-    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
     policy.damping = DampingPolicy::Neglect;
     auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
                                                   {{"leak", leak}}, classifier, policy);
@@ -287,7 +306,6 @@ TEST_CASE("exact: a chain of two forced traps keeps both correlations") {
     classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
     policy.damping = DampingPolicy::Neglect;
     auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
                                                   {{"leak", leak}}, classifier, policy);
@@ -322,7 +340,6 @@ TEST_CASE("exact: a neglect fire onto a computational destination stays correlat
     classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
     policy.damping = DampingPolicy::Neglect;
     auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
                                                   {{"swap", swap_ge}}, classifier, policy);
@@ -362,7 +379,6 @@ TEST_CASE("exact: herald flags drawn in one continuation are reused by the next"
         {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.5, 0.0}, {0.0, 0.0, 0.0, 0.5, 0.0}};
 
     NonComputationalPolicy policy;
-    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
     auto model = NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0},
                                                   {{"leak", leak}}, classifier, policy);
 
@@ -481,7 +497,6 @@ TEST_CASE("exact: ternary heralds ride the cache key") {
         {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    policy.lost_leaked_ops = LostLeakedOpsPolicy::Drop;
     auto model = NonComputationalModel::from_spec(levels, {0.0, 1.0, 0.0, 0.0, 0.0},
                                                   {{"leak", leak}}, classifier, policy);
 

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -29,7 +29,7 @@ constexpr uint8_t kLeak = 3;
 // A model with one named leak transition (e leaks at 0.4, g at 0.1),
 // seepage back from the leaked level (0.2 to e), and a faithful
 // two-symbol classifier whose leaked column reads 1.
-NonComputationalModel demo_model(LostLeakedOpsPolicy lost_leaked = LostLeakedOpsPolicy::Drop) {
+NonComputationalModel demo_model() {
     LevelSet levels = LevelSet::default_set();
     std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
     leak[kLeak][0] = 0.1;
@@ -40,10 +40,8 @@ NonComputationalModel demo_model(LostLeakedOpsPolicy lost_leaked = LostLeakedOps
     classifier.symbols = {"0", "1"};
     classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = lost_leaked;
     return NonComputationalModel::from_spec(levels, {1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                            classifier, policy);
+                                            classifier, NonComputationalPolicy{});
 }
 
 std::vector<QubitStatus> computational_initials(const NonComputationalModel& model, uint32_t n) {
@@ -165,6 +163,23 @@ TEST_CASE("continuation: the forced trace-out slot mirrors trace's hidden number
 
     auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/true, model);
     REQUIRE(result.forced_traceout_slot == 2);  // 1 visible + 1 hidden before it
+}
+
+TEST_CASE("continuation: the forced trace-out slot counts every prior reset") {
+    // The slot derivation accumulates one hidden slot per prior reset target,
+    // so it must sum across resets, not stop at the first. With one visible
+    // measurement and two resets ahead of the trace-out, the trace-out owns
+    // hidden slot 3 (1 visible + 2 hidden).
+    auto model = demo_model();
+    auto circuit = parse("R 1\nR 2\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+    auto annotated = annotate(circuit, model);
+
+    ExactShotEvents events;
+    events.initial_status = computational_initials(model, 3);
+    events.jumps.push_back({3, 0, kLeak});  // the annotation is node 3
+
+    auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/true, model);
+    REQUIRE(result.forced_traceout_slot == 3);  // 1 visible + 2 hidden (R 1, R 2) before it
 }
 
 TEST_CASE("continuation: events that do not describe the circuit reject") {

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -523,35 +523,25 @@ TEST_CASE("sample_noncomputational: recapturing a lost qubit clears the stale re
     }
 }
 
-TEST_CASE("sample_noncomputational: drop policy runs a multi-round circuit through loss") {
+TEST_CASE("sample_noncomputational: a multi-round circuit runs through loss") {
     // The data qubit is lost up front; both syndrome CXs drop (identity on
     // the ancilla, which keeps reading 0) and the final data measurement
-    // reads the classifier's lost bit. The default policy rejects the same
-    // circuit at the first CX.
+    // reads the classifier's lost bit -- dropping ops on a vacated site is
+    // the (only) op policy.
     Circuit c = parse("H 0\nS 0\nCX 0 1\nMR 1\nCX 0 1\nMR 1\nM 0\n");
     std::map<std::string, TransitionInstrument> transitions;
     transitions.emplace("S", always_lost(LevelSet::default_set()));
     MeasurementClassifier cl = classifier_with(LevelSet::default_set(), kLost, {0.0, 1.0});
 
-    NonComputationalPolicy drop_policy;
-    drop_policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    {
-        std::map<std::string, TransitionInstrument> t2;
-        t2.emplace("S", always_lost(LevelSet::default_set()));
-        NonComputationalModel model = make_model(all_g(), std::move(t2), cl, drop_policy);
-        NonComputationalSample r = sample_noncomputational(c, model, 16, 3);
-        REQUIRE(r.num_measurements == 3);
-        for (uint32_t shot = 0; shot < 16; ++shot) {
-            REQUIRE(r.measurements[shot * 3 + 0] == 0);  // ancilla round 1
-            REQUIRE(r.measurements[shot * 3 + 1] == 0);  // ancilla round 2
-            REQUIRE(r.measurements[shot * 3 + 2] == 1);  // lost data, classifier bit
-            REQUIRE(r.final_status[shot * 2 + 0].kind() == QubitStatusKind::Lost);
-        }
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), cl);
+    NonComputationalSample r = sample_noncomputational(c, model, 16, 3);
+    REQUIRE(r.num_measurements == 3);
+    for (uint32_t shot = 0; shot < 16; ++shot) {
+        REQUIRE(r.measurements[shot * 3 + 0] == 0);  // ancilla round 1
+        REQUIRE(r.measurements[shot * 3 + 1] == 0);  // ancilla round 2
+        REQUIRE(r.measurements[shot * 3 + 2] == 1);  // lost data, classifier bit
+        REQUIRE(r.final_status[shot * 2 + 0].kind() == QubitStatusKind::Lost);
     }
-
-    NonComputationalModel reject_model = make_model(all_g(), std::move(transitions), cl);
-    REQUIRE_THROWS_WITH(sample_noncomputational(c, reject_model, 1, 3),
-                        ContainsSubstring("CX") && ContainsSubstring("Lost"));
 }
 
 namespace {

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -213,49 +213,9 @@ TEST_CASE("rewrite: an inserted R does not shift visible measurements or detecto
 // Policy scan: keep / drop / reject
 // =========================================================================
 
-TEST_CASE("rewrite: a two-qubit gate on a lost qubit rejects by default") {
-    Circuit c = parse("CZ 0 1\n");
-    NonComputationalModel model = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(c, model, {kLost, kG}), ContainsSubstring("CZ") &&
-                                                              ContainsSubstring("Lost") &&
-                                                              ContainsSubstring("qubit 0"));
-}
-
-TEST_CASE("rewrite: a single-qubit gate on a leaked qubit rejects by default") {
-    Circuit c = parse("X 0\n");
-    NonComputationalModel model = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(c, model, {kLeakG}),
-                        ContainsSubstring("Leaked") && ContainsSubstring("qubit 0"));
-}
-
-TEST_CASE("rewrite: drop policy drops a single-qubit gate on a lost qubit") {
-    Circuit c = parse("X 0\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model({}, policy);
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
-    REQUIRE(count_gate(rw.circuit, GateType::X) == 0);
-}
-
-TEST_CASE("rewrite: a lost-qubit reset rejects by default and restores under policy") {
-    Circuit c = parse("R 0\n");
-    NonComputationalModel reject = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(c, reject, {kLost}),
-                        ContainsSubstring("Lost") && ContainsSubstring("qubit 0"));
-
-    NonComputationalPolicy restore;
-    restore.reset_restores_lost = true;
-    NonComputationalModel reload = make_model({}, restore);
-    ContinuationRewrite rw = rewritten(c, reload, {kLost});
-    REQUIRE(count_gate(rw.circuit, GateType::R) == 1);
-    REQUIRE(rw.final_status[0].kind() == clifft::QubitStatusKind::ComputationalKnown);
-}
-
-TEST_CASE("rewrite: drop policy excises a two-qubit gate on a lost operand whole") {
+TEST_CASE("rewrite: a two-qubit gate on a lost operand drops whole") {
     Circuit c = parse("CZ 0 1\nM 1\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model({}, policy);
+    NonComputationalModel model = make_model({});
     ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
     REQUIRE(count_gate(rw.circuit, GateType::CZ) == 0);  // identity on the survivor
     REQUIRE(count_gate(rw.circuit, GateType::M) == 1);   // record slot preserved
@@ -265,40 +225,64 @@ TEST_CASE("rewrite: a dropped gate leaves the surviving operand's status untouch
     // The CZ drops whole (lost operand), so qubit 1 keeps its
     // instruction-known g status through to the end of the walk.
     Circuit c = parse("CZ 0 1\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model({}, policy);
+    NonComputationalModel model = make_model({});
     ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
     REQUIRE(rw.final_status[1].kind() == clifft::QubitStatusKind::ComputationalKnown);
     REQUIRE(rw.final_status[1].level_id() == kG);
 }
 
-TEST_CASE("rewrite: drop policy drops classical feedback onto a lost qubit") {
+TEST_CASE("rewrite: a single-qubit gate on a leaked qubit drops") {
+    Circuit c = parse("X 0\n");
+    NonComputationalModel model = make_model({});
+    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    REQUIRE(count_gate(rw.circuit, GateType::X) == 0);
+}
+
+TEST_CASE("rewrite: a single-qubit gate on a lost qubit drops") {
+    Circuit c = parse("X 0\n");
+    NonComputationalModel model = make_model({});
+    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    REQUIRE(count_gate(rw.circuit, GateType::X) == 0);
+}
+
+TEST_CASE("rewrite: classical feedback onto a lost qubit drops") {
     Circuit c = parse("H 1\nM 1\nCX rec[-1] 0\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model({}, policy);
+    NonComputationalModel model = make_model({});
     ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
     REQUIRE(count_gate(rw.circuit, GateType::CX) == 0);
 }
 
-TEST_CASE("rewrite: drop policy drops a two-qubit noise channel on a lost operand") {
+TEST_CASE("rewrite: a two-qubit noise channel on a lost operand drops") {
     Circuit c = parse("DEPOLARIZE2(0.1) 0 1\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model({}, policy);
+    NonComputationalModel model = make_model({});
     ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
     REQUIRE(count_gate(rw.circuit, GateType::DEPOLARIZE2) == 0);
 }
 
-TEST_CASE("rewrite: drop policy drops a non-restoring lost reset") {
+TEST_CASE("rewrite: a non-restoring lost reset drops; reset_restores_lost keeps it") {
     Circuit c = parse("R 0\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
-    NonComputationalModel model = make_model({}, policy);
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
-    REQUIRE(count_gate(rw.circuit, GateType::R) == 0);
-    REQUIRE(rw.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
+
+    NonComputationalModel dropped = make_model({});
+    ContinuationRewrite rw_drop = rewritten(c, dropped, {kLost});
+    REQUIRE(count_gate(rw_drop.circuit, GateType::R) == 0);
+    REQUIRE(rw_drop.final_status[0].kind() == clifft::QubitStatusKind::Lost);  // not restored
+
+    NonComputationalPolicy restore;
+    restore.reset_restores_lost = true;
+    NonComputationalModel reload = make_model({}, restore);
+    ContinuationRewrite rw_keep = rewritten(c, reload, {kLost});
+    REQUIRE(count_gate(rw_keep.circuit, GateType::R) == 1);
+    REQUIRE(rw_keep.final_status[0].kind() == clifft::QubitStatusKind::ComputationalKnown);
+}
+
+TEST_CASE("rewrite: an X/Y-basis measurement of a noncomputational qubit rejects") {
+    // No faithful single-bit form on a leaked/lost operand: a
+    // representability limit, not a policy choice, so it rejects even though
+    // drop is the only op policy.
+    Circuit c = parse("MX 0\n");
+    NonComputationalModel model = make_model({});
+    REQUIRE_THROWS_WITH(rewritten(c, model, {kLeakG}),
+                        ContainsSubstring("MX") && ContainsSubstring("representable"));
 }
 
 // =========================================================================
@@ -401,12 +385,11 @@ TEST_CASE("rewrite: an X/Y-basis or multi-qubit measurement on a lost qubit reje
                         ContainsSubstring("MPP") && ContainsSubstring("Lost"));
 }
 
-TEST_CASE("rewrite: a measure-and-reset on a lost qubit rejects by default, kept under policy") {
+TEST_CASE("rewrite: reset_restores_lost restores a measure-and-reset's lost qubit") {
+    // MR on a lost qubit is kept: the classifier supplies the record bit and
+    // the reset runs. With reset_restores_lost the reset returns the qubit to
+    // a computational state.
     Circuit c = parse("MR 0\n");
-    NonComputationalModel reject = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(c, reject, {kLost}),
-                        ContainsSubstring("MR") && ContainsSubstring("Lost"));
-
     NonComputationalPolicy restore;
     restore.reset_restores_lost = true;
     NonComputationalModel reload =
@@ -417,6 +400,7 @@ TEST_CASE("rewrite: a measure-and-reset on a lost qubit rejects by default, kept
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::R) == 1);
     REQUIRE(rw.circuit.num_measurements == 1);  // visible record preserved
+    REQUIRE(rw.final_status[0].kind() == clifft::QubitStatusKind::ComputationalKnown);
 }
 
 TEST_CASE("rewrite: a measure-and-reset on a leaked qubit records and resets") {
@@ -432,12 +416,10 @@ TEST_CASE("rewrite: a measure-and-reset on a leaked qubit records and resets") {
     REQUIRE(rw.final_status[0].kind() == clifft::QubitStatusKind::ComputationalKnown);
 }
 
-TEST_CASE("rewrite: drop policy keeps a measure-and-reset on a non-restoring lost qubit") {
+TEST_CASE("rewrite: a measure-and-reset on a non-restoring lost qubit is kept") {
     Circuit c = parse("MR 0\n");
-    NonComputationalPolicy policy;
-    policy.lost_leaked_ops = clifft::LostLeakedOpsPolicy::Drop;
     NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}), policy);
+        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
 
     ContinuationRewrite rw = rewritten(c, model, {kLost});
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);

--- a/tools/bench/test_bench_noncomp.py
+++ b/tools/bench/test_bench_noncomp.py
@@ -72,7 +72,6 @@ def noncomp_model(p: float) -> noncomp.Model:
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={"S": leak_loss_matrix(p)} if p > 0 else {},
         classifier=ternary_classifier(),
-        lost_leaked_ops="drop",
     )
 
 


### PR DESCRIPTION
> **Prototype / less-strict review.** This targets the `codex/noncomputational-structural-mvp` feature branch, not `main`. The noncomputational leakage/loss model is unreleased and still stabilizing, so reviewing for direction and correctness over release polish is fine.

## What

Removes the `lost_leaked_ops` policy knob. Dropping an operation with no representable effect on a leaked or lost operand (identity on the survivors) is now the only behavior; the `reject` value and the whole `LostLeakedOpsPolicy` enum are gone from both the C++ and Python surfaces.

## Why

`reject` was the default, but leak/loss is a per-shot stochastic draw, so a `reject` *sampling* policy makes `sample()` throw **seed-dependently** — the same circuit + model can sample cleanly under one seed and raise deep into a run under another (the first shot whose loss lands before a two-qubit gate). Every worked example, test, and benchmark already set `lost_leaked_ops="drop"` to avoid this. Dropping is the physically correct behavior (a pulse on a vacated site does nothing), so nothing exact is lost. This finishes the cleanup the branch started when it removed the `reject` unknown-source policy for the same reason: a "does any op drive a dead qubit" contract check belongs in a static validator (a future `validate_static`), not a sampling mode.

`MX`/`MY`/`MPP` on a leaked or lost qubit still raises — no faithful single-bit form — but that is a representability limit, unconditional in `operand_action`, not a policy the caller can turn off. `reset_restores_lost` is untouched.

## Also
- **Forced-slot hardening:** the rewriter re-derives `trace()`'s hidden-slot numbering to name the forced trace-out. Extracted it into a documented helper that states the contract, and added a continuation test exercising a nonzero prior-reset count. The fuller fix (thread the slot out of `trace()` so it is assigned in one place) needs the HIR measure op to carry its source node — left as a follow-up.
- **Tests:** driver-vs-SVM seed-stream domain separation; a different-seed companion to the determinism pin; Python `max_rank` coverage (exact rejects over budget naming the line, neglect fits).
- Dropped stale "AOT" wording from two `peak_rank` assert messages.

## Test plan
- Debug `ctest -E Bench`: all 1075 C++ cases pass.
- Debug wheel `pytest tests/python/test_noncomp*.py`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
