### PR TITLE
docs: add front-end integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ print(result.measurements[:5])
 
 For more details and examples, check out the [documentation](https://unitaryfoundation.github.io/clifft) or take Clifft for a spin in the web-based [interactive playground](https://unitaryfoundation.github.io/clifft/playground/).
 
+## Front-End Integrations
+
+Clifft's native API accepts Stim-compatible circuit text. If your workflow
+starts in another circuit framework, companion packages make the supported path
+discoverable:
+
+- **Qiskit**: [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit)
+  provides a Qiskit `BackendV2` provider for running supported
+  `QuantumCircuit` instances on Clifft.
+- **Cirq**: [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq)
+  converts parameter-resolved `cirq.Circuit` instances to Clifft text and
+  provides a Cirq-style sampler backed by Clifft.
+
+See the [front-end integrations guide](https://unitaryfoundation.github.io/clifft/getting-started/integrations/)
+for installation commands, minimal examples, and current limitations.
+
 ## Performance
 
 Clifft is designed for near-Clifford circuits where non-Clifford activity remains localized. In this regime, the dominant cost scales with the peak active dimension `k`, not directly with the total number of physical qubits.

--- a/docs/getting-started/integrations.md
+++ b/docs/getting-started/integrations.md
@@ -1,0 +1,96 @@
+<!--pytest-codeblocks:skipfile-->
+
+# Front-End Integrations
+
+Clifft's native input is Stim-compatible circuit text with Clifft extensions for
+non-Clifford operations. If your circuits are already written in another quantum
+software framework, companion packages can translate or route supported circuits
+to Clifft without hand-writing that text.
+
+These packages are maintained separately from the core `clifft` package and are
+released on their own schedule. Use their READMEs as the source of truth for the
+full supported operation set and current limitations.
+
+## Integration Options
+
+| Starting point | Package | What it provides |
+|---|---|---|
+| Stim-compatible text | [`clifft`](https://pypi.org/project/clifft/) | Direct parsing, compilation, sampling, state-vector access, detectors, observables, and QEC-oriented workflows. |
+| Qiskit `QuantumCircuit` | [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) | A Qiskit `BackendV2` provider that runs supported circuits on Clifft and returns Qiskit-style results. |
+| Cirq `cirq.Circuit` | [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) | A converter to Clifft circuit text plus a Cirq-style sampler facade backed by Clifft. |
+
+Use the native `clifft` API when you are already working with Stim-style circuit
+text, detector annotations, observables, post-selection, or importance sampling.
+Use an adapter when the circuit construction, decomposition, or surrounding
+workflow already lives in Qiskit or Cirq.
+
+## Qiskit
+
+Install the Qiskit adapter:
+
+```bash
+pip install clifft-qiskit
+```
+
+Then run a supported `QuantumCircuit` through the Clifft backend:
+
+```python
+from qiskit import QuantumCircuit
+from clifft_qiskit import ClifftProvider
+
+qc = QuantumCircuit(2, 2)
+qc.h(0)
+qc.cx(0, 1)
+qc.measure([0, 1], [0, 1])
+
+backend = ClifftProvider().get_backend("clifft")
+counts = backend.run(qc, shots=1000).result().get_counts()
+print(counts)
+```
+
+The adapter targets terminal-measurement sampling and counts. Unsupported
+semantics, such as mid-circuit measurement, feedforward, `reset`, and other
+non-unitary operations, are rejected explicitly.
+
+See the [`clifft-qiskit` repository](https://github.com/unitaryfoundation/clifft-qiskit)
+for the current supported basis, decomposition behavior, and package-specific
+limitations.
+
+## Cirq
+
+Install the Cirq adapter:
+
+```bash
+pip install clifft-cirq
+```
+
+Convert a parameter-resolved qubit circuit to Clifft text or sample it through
+the Cirq-style facade:
+
+```python
+import cirq
+import clifft_cirq
+
+q0, q1 = cirq.LineQubit.range(2)
+circuit = cirq.Circuit(
+    cirq.H(q0),
+    cirq.CNOT(q0, q1),
+    cirq.measure(q0, q1, key="m"),
+)
+
+converted = clifft_cirq.to_clifft_text(circuit)
+print(converted.clifft_text)
+
+sampler = clifft_cirq.ClifftSampler(seed=123)
+result = sampler.run(circuit, repetitions=1000)
+print(result)
+```
+
+The converter supports parameter-resolved qubit circuits and common one-, two-,
+and three-qubit gates that map to Clifft. It does not model Cirq device,
+timing, calibration, qudit, arbitrary classical-control, or noise-channel
+semantics.
+
+See the [`clifft-cirq` repository](https://github.com/unitaryfoundation/clifft-cirq)
+for the current supported operations, conversion metadata, and package-specific
+limitations.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -91,4 +91,5 @@ result = clifft.sample(program, shots=10000, seed=42)
 
 - [Compiling Circuits](../guide/compilation.md) — the compilation pipeline in detail
 - [Simulation](../guide/simulation.md) — sampling, state vectors, and detectors
+- [Front-End Integrations](integrations.md): using Clifft from Qiskit or Cirq
 - [Supported Gates](../reference/gates.md) — full gate reference

--- a/docs/guide/compilation.md
+++ b/docs/guide/compilation.md
@@ -2,6 +2,14 @@
 
 Clifft compiles Stim-format circuit text into an executable SVM program. For most users, `clifft.compile()` is the only compilation API needed. Lower-level APIs are available when you want to inspect intermediate representations, customize optimization passes, or build your own compilation flow.
 
+!!! tip "Using Qiskit or Cirq?"
+    The core compiler consumes Clifft's Stim-compatible text format. If your
+    circuits start in Qiskit or Cirq, use the companion
+    [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) or
+    [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) packages
+    to route supported circuits to Clifft. See
+    [Front-End Integrations](../getting-started/integrations.md).
+
 ## One-Step Compilation
 
 For most use cases, `clifft.compile()` parses the circuit, traces Clifford operations into the Heisenberg IR, applies the default HIR and bytecode optimization passes, and returns a simulatable program:

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,10 @@ print(result.measurements[:5])  # First 5 shots.
 
     Multi-level optimization passes reduce active state-vector work before execution.
 
+- **Qiskit and Cirq Integrations**
+
+    Run supported circuits from Qiskit or Cirq through companion packages without hand-writing Clifft circuit text.
+
 - **Active-Dimension Scaling**
 
     For circuits with bounded active dimension, memory and runtime scale with the localized active state rather than the full qubit count.
@@ -84,11 +88,13 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 
 [Try the Playground]({{ playground_url }}){ .md-button }
 
+[Use Qiskit or Cirq](getting-started/integrations.md){ .md-button }
+
 ## What's New in 0.5.0
 
 Clifft 0.5.0 broadens the circuits users can write directly and makes the project easier to try from both the playground and Python docs. The parser now accepts common controlled gates (`CCZ`, `CCX`, `CH`) through exact Clifford+T rewrites, the simulator supports three-qubit Pauli noise channels (`DEPOLARIZE3`), and phase-sensitive statevector behavior is better tested and documented.
 
-This release also includes several [unitaryHACK 2026](https://unitaryhack.dev/) contributions: @Samfresh-ai added starter circuits to the playground, @manasa-manoj-nbr added an auto-generated Python API reference, and @ashmitjsg completed the Qiskit backend bounty as the companion [unitaryfoundation/clifft-qiskit](https://github.com/unitaryfoundation/clifft-qiskit) package, so Qiskit users can run supported circuits on Clifft without hand-writing Stim.
+This release also includes several [unitaryHACK 2026](https://unitaryhack.dev/) contributions: @Samfresh-ai added starter circuits to the playground, @manasa-manoj-nbr added an auto-generated Python API reference, and @ashmitjsg completed the Qiskit backend bounty as the companion [unitaryfoundation/clifft-qiskit](https://github.com/unitaryfoundation/clifft-qiskit) package. Users starting from Qiskit or Cirq can now find both [clifft-qiskit](https://github.com/unitaryfoundation/clifft-qiskit) and [clifft-cirq](https://github.com/unitaryfoundation/clifft-cirq) from the [front-end integrations guide](getting-started/integrations.md).
 
 ## What's New in 0.4.0
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
   - Getting Started:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
+    - Front-End Integrations: getting-started/integrations.md
   - User Guide:
     - Compiling Circuits: guide/compilation.md
     - Simulation: guide/simulation.md


### PR DESCRIPTION
## Summary
- add a permanent Front-End Integrations docs page for native Clifft, clifft-qiskit, and clifft-cirq
- link the guide from the docs nav, home page, quickstart, compilation guide, and README
- update the 0.5.0 What's New entry to point Qiskit and Cirq users to the guide

## Tests
- uv run --group docs mkdocs build --strict
- uv run pytest --codeblocks docs/ README.md -v
- uv run pre-commit run --all-files