### PR TITLE
fix: honor inversion for noncomp classifier records

### DIFF
--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -150,13 +150,15 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
             const uint32_t qubit = qubit_operands(node).front().qubit;
             const MeasurementClassifier& classifier = classifier_for(model, gate, op_index, qubit);
             const bool ternary = classifier.has_herald();
+            const bool inverted = node.targets.front().is_inverted();
 
-            // The record bit's flip probability on top of MPAD 0:
-            // P(symbol 1 | level) for a two-symbol column; for a ternary
-            // column, the bit's not-heralded conditional -- the herald
-            // pass re-points heralded slots at one half. An always-herald
-            // column has no not-heralded conditional; one half stands in
-            // (every draw heralds, so the pass always overwrites it).
+            // MPAD starts the visible record at 0, then READOUT_NOISE flips it
+            // with probability `flip`. Binary classifiers use P(symbol 1 |
+            // level). Ternary classifiers use P(symbol 1 | level, no herald),
+            // because heralded slots are later patched to an unbiased bit.
+            // Target inversion complements only this visible bit; the herald
+            // flag still means the classifier's third symbol. If every draw
+            // heralds, the placeholder flip is irrelevant and 0.5 is used.
             double flip;
             if (ternary) {
                 const double p_herald =
@@ -166,6 +168,9 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
                 flip = std::min(1.0, std::max(0.0, flip));
             } else {
                 flip = classifier.prob(1, *classified_level);
+            }
+            if (inverted) {
+                flip = 1.0 - flip;
             }
 
             size_t noise_node = SIZE_MAX;

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -191,6 +191,19 @@ def test_classifier_bit_feeds_observable():
     assert (r.observables == 1).all()
 
 
+def test_inverted_classifier_bit_feeds_records_detectors_and_observables():
+    model = leak_model(classifier_for(LEAK_G, [1.0, 0.0]))
+    r = noncomp.sample(
+        "H 0\nS 0\nM !0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n",
+        model,
+        shots=64,
+        seed=101,
+    )
+    assert (r.measurements[:, 0] == 1).all()
+    assert (r.detectors[:, 0] == 1).all()
+    assert (r.observables[:, 0] == 1).all()
+
+
 def test_lost_measurement_classifier_bit():
     model = noncomp.Model(
         initial_state=ALL_G,
@@ -207,6 +220,14 @@ def test_measure_reset_on_leaked_preserves_slot_and_resets():
     assert r.num_measurements == 2
     assert (r.measurements[:, 0] == 1).all()  # MR slot: classifier bit
     assert (r.measurements[:, 1] == 0).all()  # reset, then M reads 0
+
+
+def test_inverted_measure_reset_classifier_preserves_slot_and_resets():
+    model = leak_model(classifier_for(LEAK_G, [1.0, 0.0]))
+    r = noncomp.sample("H 0\nS 0\nMR !0\nM 0\n", model, shots=64, seed=102)
+    assert r.num_measurements == 2
+    assert (r.measurements[:, 0] == 1).all()
+    assert (r.measurements[:, 1] == 0).all()
 
 
 def test_missing_classifier_on_leaked_measurement_raises():

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -325,6 +325,36 @@ TEST_CASE("rewrite: a deterministic classifier column pads the literal bit, no d
     REQUIRE(rw.classified_measurements[0].noise_node == SIZE_MAX);
 }
 
+TEST_CASE("rewrite: an inverted noncomputational classifier flips a deterministic bit") {
+    Circuit c = parse("M !0\n");
+    NonComputationalModel model =
+        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
+
+    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
+    for (const AstNode& node : rw.circuit.nodes) {
+        if (node.gate == GateType::MPAD) {
+            REQUIRE(node.targets[0].value() == 1);
+        }
+    }
+    REQUIRE(rw.classified_measurements.size() == 1);
+    REQUIRE(rw.classified_measurements[0].noise_node == SIZE_MAX);
+}
+
+TEST_CASE("rewrite: an inverted noncomputational classifier complements stochastic flips") {
+    Circuit c = parse("M !0\n");
+    NonComputationalModel model =
+        make_model_with_classifier({}, classifier_with(kLost, {0.7, 0.3}));
+
+    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    REQUIRE(rw.classified_measurements.size() == 1);
+    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(noise.gate == GateType::READOUT_NOISE);
+    REQUIRE(noise.targets[0].value() == 0);
+    REQUIRE(noise.args[0] == Catch::Approx(0.7));
+}
+
 TEST_CASE("rewrite: the record write flips its own slot, not an earlier one") {
     // Slot 0 is a computational measurement on qubit 1; the lost qubit's
     // measurement is slot 1 and its READOUT_NOISE must target slot 1.
@@ -353,6 +383,19 @@ TEST_CASE("rewrite: a ternary column emits the not-heralded conditional flip") {
     const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
     REQUIRE(noise.args[0] == Catch::Approx(0.25));
+}
+
+TEST_CASE("rewrite: an inverted ternary column complements the not-heralded flip") {
+    // Non-heralded P(bit=1) is 0.1 / (1 - 0.6) = 0.25 before inversion.
+    Circuit c = parse("M !0\n");
+    NonComputationalModel model =
+        make_model_with_classifier({}, classifier_with(kLeakG, {0.3, 0.1, 0.6}));
+
+    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    REQUIRE(rw.classified_measurements.size() == 1);
+    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(noise.gate == GateType::READOUT_NOISE);
+    REQUIRE(noise.args[0] == Catch::Approx(0.75));
 }
 
 TEST_CASE("rewrite: an always-herald ternary column still emits a patchable node") {


### PR DESCRIPTION
## Summary
- apply Stim measurement target inversion to noncomputational classifier record bits
- keep ternary herald sidecar semantics separate from visible-bit inversion
- add C++ rewrite regressions and Python API coverage for M !q and MR !q

## Tests
- uv run pytest tests/python/test_noncomp.py -q
- cmake --build build
- ctest --test-dir build --output-on-failure -R 'noncomp|exact|validation|rewrite|continuation|herald|lost|leak'
- uv run pytest tests/python/test_noncomp_exact_probes.py tests/python/test_noncomp_exact_tvd.py -q
- uv run pre-commit run --all-files