### PR TITLE
fix(noncomp): align the rewrite's site table with trace()'s zero-fire elision

### DIFF
--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -519,6 +519,14 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             CompiledModule module = lower(hir);
             exact_bytecode_pass_manager().run(module);
             check_max_rank(module, max_rank);
+            if (module.instrument_offsets.size() != entry.rw.site_targets.size()) {
+                throw std::logic_error(
+                    "sample_noncomputational: compiled module has " +
+                    std::to_string(module.instrument_offsets.size()) +
+                    " instrument site(s) but the rewrite's site table has " +
+                    std::to_string(entry.rw.site_targets.size()) +
+                    "; the rewriter and trace() must elide zero-fire sites identically");
+            }
             if (entry.rw.forced_traceout_slot != SIZE_MAX) {
                 swap_traceout_to_forced(module, entry.rw.forced_traceout_slot);
             }

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -335,7 +335,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
                 // column_sum(G) != 0 or column_sum(E) != 0. These predicates
                 // are exact 0.0 comparisons, matching frontend.cc.
                 if (gate == GateType::LOSS) {
-                    if (node.args[0] == 0.0) {
+                    if (loss_probability(node.args, op_index, "rewrite_continuation") == 0.0) {
                         continue;
                     }
                 } else {

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -326,7 +326,27 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
                     continue;
                 }
 
-                // Quantum source: the annotation stays a runtime instrument.
+                // Quantum source: if the channel can never fire from any
+                // computational level, the site is the identity on this qubit
+                // and trace() will elide it. The site table and trace()'s
+                // materialization must elide identically, so skip both the
+                // node emission and the site_targets entry.
+                // LOSS(p): fires iff p != 0. LEVEL_TRANSITION[tag]: fires iff
+                // column_sum(G) != 0 or column_sum(E) != 0. These predicates
+                // are exact 0.0 comparisons, matching frontend.cc.
+                if (gate == GateType::LOSS) {
+                    if (node.args[0] == 0.0) {
+                        continue;
+                    }
+                } else {
+                    const TransitionInstrument* instr = model.transition_named(node.tag);
+                    if (instr != nullptr && instr->column_sum(Level::G) == 0.0 &&
+                        instr->column_sum(Level::E) == 0.0) {
+                        continue;
+                    }
+                }
+
+                // The annotation stays a runtime instrument.
                 // Split multi-target nodes so a sibling target with a
                 // classical status is not re-materialized.
                 result.site_targets.emplace_back(op_index, qubit);

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -434,6 +434,48 @@ def test_xy_basis_measurement_of_a_lost_qubit_raises():
         noncomp.sample(circuit, model, shots=4, seed=2)
 
 
+def test_zero_fire_loss_before_firing_loss_samples_cleanly():
+    """LOSS(0) before LOSS(0.5) must not shift site ids or abort.
+
+    Before the fix, LOSS(0) was incorrectly kept in the site table while
+    trace() elided it, causing a site-id mismatch that aborted in Debug or
+    segfaulted in Release.
+    """
+    classifier = noncomp.Classifier(
+        ["0", "1"], [[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]]
+    )
+    model = noncomp.Model(initial_state=ALL_G, classifier=classifier)
+    r = noncomp.sample("LOSS(0) 0\nLOSS(0.5) 0\nM 0\n", model, shots=64, seed=90)
+    assert r.shots == 64
+    # Every shot ends Lost or Computational (no assertion failures).
+    assert r.final_status.shape == (64, 1)
+    # Lost shots read 1 (classifier's lost column), computational shots read 0.
+    for i in range(64):
+        if r.final_status[i, 0] == LOST_KIND:
+            assert r.measurements[i, 0] == 1
+        else:
+            assert r.final_status[i, 0] == COMPUTATIONAL
+
+
+def test_seepage_only_before_firing_site_samples_cleanly():
+    """A seepage-only LEVEL_TRANSITION before a firing site must not shift site ids.
+
+    A transition with column_sum(G)=column_sum(E)=0 is elided by trace() but
+    was previously kept in the site table, producing a site-id mismatch.
+    """
+    seep = _zeros(5, 5)
+    seep[LEAK_E][LEAK_E] = 1.0  # leak_e -> leak_e, only noncomp columns
+
+    classifier = noncomp.Classifier(
+        ["0", "1"], [[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]]
+    )
+    model = noncomp.Model(initial_state=ALL_G, transitions={"seep": seep}, classifier=classifier)
+    r = noncomp.sample("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0\n", model, shots=32, seed=91)
+    assert r.shots == 32
+    assert (r.final_status == LOST_KIND).all()
+    assert (r.measurements[:, 0] == 1).all()
+
+
 def test_computational_readout_confusion_misreports_the_record():
     """The classifier's computational columns act as asymmetric readout
     confusion on Z measurements: the qubit collapses to its true state but

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -603,3 +603,100 @@ TEST_CASE("exact: a smaller starting module must not shrink the reused state") {
     auto result = sample_noncomputational(circuit, model, 64, 5);
     REQUIRE(result.shots == 64);
 }
+
+TEST_CASE("exact: a zero-fire LOSS(0) before a firing LOSS does not shift site ids") {
+    // LOSS(0) can never fire from a computational qubit; trace() skips it.
+    // The rewriter must skip it too, so LOSS(1) gets site id 0 and the
+    // driver maps the trap correctly.
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+
+    NonComputationalPolicy policy;
+    auto model =
+        NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {}, classifier, policy);
+    auto circuit = parse("LOSS(0) 0\nLOSS(1) 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 20, 71);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);  // lost: classifier's lost column reads 1
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: a seepage-only transition before a firing site does not shift site ids") {
+    // A LEVEL_TRANSITION whose computational columns are both zero (seepage
+    // from leak_e to e only) cannot fire on a computational qubit; trace()
+    // skips it. The rewriter must skip it too so the firing LOSS(1) that
+    // follows gets site id 0 and the driver maps the trap correctly.
+    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
+    seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"seep", seep}},
+                                                  classifier, policy);
+    auto circuit = parse("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 20, 73);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);  // lost: classifier's lost column reads 1
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: a seepage-only transition on q0 does not corrupt q1's site id") {
+    // Cross-qubit arrangement: the seepage-only LEVEL_TRANSITION on q0 must
+    // not occupy a site slot, so the firing LOSS(1) on q1 keeps site id 0.
+    // In Release, a stale site id would read the wrong trap record and
+    // silently produce wrong results; in Debug, the site-table lookup
+    // overruns or mismatches.
+    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
+    seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    // q0: stays computational (no loss); q1: lost reads 1.
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"seep", seep}},
+                                                  classifier, policy);
+    auto circuit = parse("LEVEL_TRANSITION[seep] 0\nLOSS(1) 1\nM 0\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 20, 79);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == 0);      // q0: computational, M reads 0
+        REQUIRE(result.measurements[shot * 2 + 1] == 1);  // q1: lost, classifier reads 1
+        REQUIRE(result.final_status[shot * 2] == QubitStatus::Computational);
+        REQUIRE(result.final_status[shot * 2 + 1] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: a seepage-only transition still seeps a noncomputational qubit") {
+    // A zero-fire annotation is skipped for a computational pre-status, but
+    // must still execute its classical consult for a noncomputational qubit.
+    // Here leak_e is the starting level; the seep fires (classical consult
+    // with destination e) and the qubit recaptures to |1>, so M reads 1.
+    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
+    seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    // All initial mass on leak_e (index 3).
+    auto model = NonComputationalModel::from_spec({0.0, 0.0, 0.0, 1.0, 0.0}, {{"seep", seep}},
+                                                  classifier, policy);
+    auto circuit = parse("LEVEL_TRANSITION[seep] 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 20, 83);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);  // recaptured to |e>=|1>, M reads 1
+        REQUIRE(result.final_status[shot] == QubitStatus::Computational);
+    }
+}

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -611,3 +611,33 @@ TEST_CASE("annotate: an unhooked model leaves the circuit unchanged") {
     Circuit ann = annotate(c, model);
     REQUIRE(ann.nodes.size() == c.nodes.size());
 }
+
+// =========================================================================
+// Zero-fire site elision: site_targets / trace() alignment
+// =========================================================================
+
+TEST_CASE("rewrite: a zero-fire annotation is omitted from the node stream and site table") {
+    // One LEVEL_TRANSITION[zero] (column_sum(G) = column_sum(E) = 0) before
+    // one LEVEL_TRANSITION[fire] (fires certainly from any level). The
+    // rewriter must skip the zero-fire node and its site_targets entry; the
+    // site table must hold exactly one entry pointing at the firing
+    // annotation's (op_index, qubit), matching trace()'s elision.
+    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    transitions.emplace("zero", zeros5());
+    transitions.emplace("fire", always_lost());
+    NonComputationalModel model = make_model(std::move(transitions));
+
+    Circuit c = parse("LEVEL_TRANSITION[zero] 0\nLEVEL_TRANSITION[fire] 0\n");
+    ContinuationRewrite rw = rewritten(c, model, {kG});
+
+    // The zero-fire node must not appear in the rewritten stream.
+    for (const AstNode& node : rw.circuit.nodes) {
+        if (node.gate == GateType::LEVEL_TRANSITION) {
+            REQUIRE(node.tag == "fire");
+        }
+    }
+
+    // Exactly one site entry; it names qubit 0.
+    REQUIRE(rw.site_targets.size() == 1);
+    REQUIRE(rw.site_targets[0].second == 0);
+}

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -641,3 +641,30 @@ TEST_CASE("rewrite: a zero-fire annotation is omitted from the node stream and s
     REQUIRE(rw.site_targets.size() == 1);
     REQUIRE(rw.site_targets[0].second == 0);
 }
+
+TEST_CASE("rewrite: a malformed LOSS annotation rejects instead of reading past its args") {
+    // rewrite_continuation is callable without the driver's up-front
+    // validation, so its own LOSS reads must validate the argument shape
+    // rather than index into it.
+    NonComputationalModel model = make_model({});
+    Circuit c = parse("LOSS(0.5) 0\nM 0\n");
+    ExactShotEvents events;
+    events.initial_status = initials({kG});
+
+    SECTION("no arguments") {
+        c.nodes[0].args.clear();
+        Circuit annotated = annotate(c, model);
+        REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
+                            ContainsSubstring("rewrite_continuation") &&
+                                ContainsSubstring("LOSS") &&
+                                ContainsSubstring("exactly one argument"));
+    }
+
+    SECTION("two arguments with a zero first must not silently elide") {
+        c.nodes[0].args = {0.0, 0.3};
+        Circuit annotated = annotate(c, model);
+        REQUIRE_THROWS_WITH(
+            rewrite_continuation(annotated, events, false, model),
+            ContainsSubstring("rewrite_continuation") && ContainsSubstring("exactly one argument"));
+    }
+}


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

- `rewrite_continuation` now skips zero-fire computational-source annotations — `LOSS(0)`, and `LEVEL_TRANSITION`s whose computational columns are both empty (pure seepage/recapture channels) — from **both** the emitted node stream and `site_targets`, mirroring `trace()`'s materialization predicate exactly (the `p_total[0] == 0 && p_total[1] == 0` elision).
- The driver cross-checks every compiled module's instrument-site count against the rewrite's site table and throws `std::logic_error` naming both counts on mismatch, so any future drift between the two elisions fails loudly instead of resolving traps at the wrong site.
- The classical-consult path is untouched: a seepage-only channel still seeps a leaked qubit (pinned by a new test).

Before this fix: `LOSS(0) 0 / LOSS(0.5) 0 / M 0` aborted on the Debug prefix-identity assert and **segfaulted the Release wheel**; a seepage-only transition before a firing site raised "destination draw over an empty column"; cross-qubit arrangements silently corrupted records in Release. A zeroed rate is exactly what a parameter sweep produces at its endpoint.

## Validation

- C++ Debug and Release: 1038 cases each (`~[bench]`), all pass — 5 new (4 driver regressions incl. the cross-qubit arrangement + 1 rewriter alignment pin)
- Python: 884 pass on both the Release and Debug wheels — 2 new regressions
- Red/green: with the rewriter fix reverted, the new driver cross-check catches the misalignment in 7 tests (the 5 new plus 2 pre-existing circuits that carry benign zero-fire annotations)
- The original crash repros re-run against this branch sample cleanly with the expected ~50/50 lost/kept split
- `pre-commit run --all-files` clean

## Review round

- P3: the LOSS zero-fire predicate read `node.args[0]` directly — undefined behavior for a hand-built `LOSS` with no arguments, and a wrong-shape `LOSS` with a zero first argument silently elided. The read now routes through `loss_probability(node.args, op_index, "rewrite_continuation")`, matching the driver's validation, with a rewriter test pinning both malformed shapes to deterministic rejections. Suites re-run green (C++ 1039×2, Python 884×2, pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)