### PR TITLE
fix(noncomp): harden the driver and SVM growth paths

### DIFF
--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -521,7 +521,7 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
     const auto structure =
         make_stabilizer_amplitude_structure(program, inv_tableau, state.active_k);
     const auto state_px = MaskView{std::span<const uint64_t>(state.p_x)};
-    // validate_peak_rank() caps active_k below 63, so active bits fit in word 0
+    // validate_peak_rank() caps active_k below 60, so active bits fit in word 0
     // and this shift never reaches 64.
     const uint64_t active_z_mask =
         state.active_k == 0 ? 0 : (state.p_z[0] & ((uint64_t{1} << state.active_k) - uint64_t{1}));
@@ -533,7 +533,7 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
     auto current = mutable_basis_mask_view(current_storage);
 
     // Active bits live in [0, active_k). validate_peak_rank() caps active_k
-    // below 63, so the mask fits in one word and the shift never reaches 64.
+    // below 60, so the mask fits in one word and the shift never reaches 64.
     const uint64_t active_mask =
         state.active_k == 0 ? uint64_t{0} : (uint64_t{1} << state.active_k) - uint64_t{1};
 

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -73,17 +73,18 @@ class VirtualRegisterManager {
     uint32_t peak_k_ = 0;
 };
 
-/// Validate that the peak active rank fits the SVM's `1ULL << k` shift.
-/// k >= 63 produces undefined behavior in the bytecode interpreter, so
-/// lower() must reject before shipping the CompiledModule. Pulled out
+/// Validate that the peak active rank fits the SVM amplitude allocation.
+/// peak >= 60 overflows the byte size for 2^peak complex<double> amplitudes,
+/// so lower() must reject before shipping the CompiledModule. Pulled out
 /// of lower() so the guard can be unit-tested without spinning up a
 /// 65k-qubit Stim tableau -- and so the uint32_t input type is fixed
 /// at the boundary, preventing a regression where a uint16_t narrowing
 /// at the call site silently wraps a 65,536-axis peak to 0.
 inline void validate_peak_rank(uint32_t peak) {
-    if (peak >= 63) {
+    if (peak >= 60) {
         throw std::runtime_error("peak active rank (" + std::to_string(peak) +
-                                 ") >= 63: would cause undefined behavior in SVM 1ULL << k shifts");
+                                 ") >= 60: would overflow the SVM amplitude array byte size "
+                                 "(2^peak_rank * 16 must fit in size_t)");
     }
 }
 

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -629,11 +629,17 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
         // flags after it keeps every driver draw ahead of module lookup.
         ContinuationEntry* entry = &main_entry;
         CompiledModule* module = main_module;
-        std::vector<QubitStatus> final_status =
-            extend_classical_outcomes(annotated, events, model, driver_rng);
+        // An all-computational, no-jump walk consumes no randomness and
+        // moves no status: statuses leave Computational only via jumps or
+        // noncomputational initials, and classical consults happen only for
+        // noncomputational statuses.
+        std::vector<QubitStatus> final_status;
         if (any_noncomp_initial) {
+            final_status = extend_classical_outcomes(annotated, events, model, driver_rng);
             entry = &get_entry(events, false);
             module = get_module(*entry, flags_for(entry->rw), nullptr, 0);
+        } else {
+            final_status.assign(circuit.num_qubits, QubitStatus::Computational);
         }
 
         if (shot > 0) {
@@ -645,9 +651,9 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             state = make_state(state_rank, state_slots);
         }
         state.reseed(derive_seed(global_seed, shot, kExactSvmDomain));
-        if (state.meas_record.size() < module->total_meas_slots) {
-            state.meas_record.resize(module->total_meas_slots, 0);
-        }
+        assert(state.meas_record.size() >= module->total_meas_slots &&
+               "the rebuild block above guarantees meas_record capacity; "
+               "meas_record never shrinks");
         // A |1> initial level is an X at time zero: a Pauli, so a
         // per-shot frame preload rather than a distinct module.
         for (uint32_t q = 0; q < circuit.num_qubits; ++q) {
@@ -677,6 +683,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             // remains. The VM reports the collapsed source as its
             // computational axis index, which is the level index by
             // construction (G = 0, E = 1).
+            assert(trap.source <= 1 &&
+                   "the VM reports the collapsed source as a computational axis index");
             const Level source = static_cast<Level>(trap.source);
             Level dest = Level::Lost;
             if (channel.instrument != nullptr && trap.destination_pending) {

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -2286,7 +2286,7 @@ exec_exp_val(SchrodingerState& state, const ConstantPool& pool, uint32_t cp_exp_
     }
 
     // Step 3: Active-space evaluation.
-    // peak_rank < 63 invariant -> all active bits are in word[0].
+    // peak_rank < 60 invariant -> all active bits are in word[0].
     uint64_t x_active = 0;
     uint64_t z_active = 0;
     if (k > 0 && pm_x.num_words() > 0) {

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -18,9 +18,11 @@ namespace clifft {
 
 SchrodingerState::SchrodingerState(StateConfig cfg) : peak_rank_(cfg.peak_rank), rng_(0) {
     uint32_t peak_rank = cfg.peak_rank;
-    if (peak_rank >= 63) {
+    if (peak_rank >= 60) {
         throw std::invalid_argument(
-            "peak_rank >= 63 would cause undefined behavior in 1ULL << peak_rank");
+            "peak_rank >= 60 would overflow the amplitude array's byte size (2^peak_rank * 16 "
+            "must fit in size_t); peak_rank " +
+            std::to_string(peak_rank) + " is too large");
     }
     if (cfg.seed.has_value()) {
         rng_.seed(*cfg.seed);
@@ -46,55 +48,77 @@ SchrodingerState::SchrodingerState(StateConfig cfg) : peak_rank_(cfg.peak_rank),
     v_[0] = {1.0, 0.0};
 }
 
-void SchrodingerState::allocate_array(uint32_t peak_rank) {
-    peak_rank_ = peak_rank;
-    v_ = nullptr;
-    v_is_mmap_ = false;
-    array_size_ = 1ULL << peak_rank;
-    size_t bytes = array_size_ * sizeof(std::complex<double>);
+// Allocate a new amplitude array for `peak_rank` without touching any member.
+// Returns the raw pointer, the actual allocated byte count, and whether the
+// allocation used mmap (true) or aligned_alloc (false). The mmap path arrives
+// zero-filled from the kernel; the aligned_alloc path must be zeroed by the
+// caller. Throws std::bad_alloc on OOM; throws nothing else. Members are
+// committed only by the two callers (allocate_array and grow_for_continuation).
+struct AllocResult {
+    std::complex<double>* ptr;
+    size_t alloc_bytes;
+    bool is_mmap;
+};
+
+static AllocResult alloc_amplitude_array(uint32_t peak_rank) {
+    const uint64_t array_size = 1ULL << peak_rank;
+    const size_t bytes = array_size * sizeof(std::complex<double>);
     // Round up to page boundary for mmap/aligned_alloc compatibility.
-    size_t aligned_bytes = (bytes + 4095) & ~4095ULL;
-    v_alloc_bytes_ = aligned_bytes;
+    const size_t aligned_bytes = (bytes + 4095) & ~4095ULL;
+
+    AllocResult result{nullptr, aligned_bytes, false};
 
 #if defined(__linux__)
     // Try MAP_HUGETLB for 2MB huge pages (works without THP kernel support).
     // Only worthwhile for allocations >= 2MB.
     static constexpr size_t kHugePageSize = 2 * 1024 * 1024;
     if (aligned_bytes >= kHugePageSize) {
-        size_t huge_aligned = (aligned_bytes + kHugePageSize - 1) & ~(kHugePageSize - 1);
+        const size_t huge_aligned = (aligned_bytes + kHugePageSize - 1) & ~(kHugePageSize - 1);
         void* p = mmap(nullptr, huge_aligned, PROT_READ | PROT_WRITE,
                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
         if (p != MAP_FAILED) {
-            v_ = static_cast<std::complex<double>*>(p);
-            v_alloc_bytes_ = huge_aligned;
-            v_is_mmap_ = true;
+            result.ptr = static_cast<std::complex<double>*>(p);
+            result.alloc_bytes = huge_aligned;
+            result.is_mmap = true;
         }
     }
 
-    if (!v_) {
+    if (!result.ptr) {
         // Align to huge page boundary so madvise(MADV_HUGEPAGE) works on any
         // architecture (ARM64 may use 16KB or 64KB base pages).
-        size_t alloc_bytes = (aligned_bytes >= kHugePageSize)
-                                 ? ((aligned_bytes + kHugePageSize - 1) & ~(kHugePageSize - 1))
-                                 : aligned_bytes;
-        size_t alloc_align = (aligned_bytes >= kHugePageSize) ? kHugePageSize : 4096;
-        v_ = static_cast<std::complex<double>*>(aligned_alloc_portable(alloc_align, alloc_bytes));
-        if (!v_) {
+        const size_t alloc_bytes =
+            (aligned_bytes >= kHugePageSize)
+                ? ((aligned_bytes + kHugePageSize - 1) & ~(kHugePageSize - 1))
+                : aligned_bytes;
+        const size_t alloc_align = (aligned_bytes >= kHugePageSize) ? kHugePageSize : 4096;
+        result.ptr =
+            static_cast<std::complex<double>*>(aligned_alloc_portable(alloc_align, alloc_bytes));
+        if (!result.ptr) {
             throw std::bad_alloc();
         }
         if (aligned_bytes >= kHugePageSize) {
-            madvise(v_, alloc_bytes, MADV_HUGEPAGE);
+            madvise(result.ptr, alloc_bytes, MADV_HUGEPAGE);
         }
-        v_alloc_bytes_ = alloc_bytes;
+        result.alloc_bytes = alloc_bytes;
     }
 #else
-    if (!v_) {
-        v_ = static_cast<std::complex<double>*>(aligned_alloc_portable(4096, aligned_bytes));
-        if (!v_) {
-            throw std::bad_alloc();
-        }
+    result.ptr = static_cast<std::complex<double>*>(aligned_alloc_portable(4096, aligned_bytes));
+    if (!result.ptr) {
+        throw std::bad_alloc();
     }
 #endif
+
+    return result;
+}
+
+void SchrodingerState::allocate_array(uint32_t peak_rank) {
+    const AllocResult alloc = alloc_amplitude_array(peak_rank);
+
+    peak_rank_ = peak_rank;
+    v_ = alloc.ptr;
+    v_is_mmap_ = alloc.is_mmap;
+    array_size_ = 1ULL << peak_rank;
+    v_alloc_bytes_ = alloc.alloc_bytes;
 
     // mmap(MAP_ANONYMOUS) guarantees zero-filled pages from the kernel.
     // Only aligned_alloc needs explicit zeroing. Parallelizing the fill
@@ -128,21 +152,56 @@ void SchrodingerState::free_array() noexcept {
 void SchrodingerState::grow_for_continuation(uint32_t peak_rank) {
     assert(pending_trap.has_value() &&
            "the amplitude array may grow only at the trap boundary, under a pending trap");
-    if (peak_rank >= 63) {
+    if (peak_rank >= 60) {
         throw std::invalid_argument(
-            "peak_rank >= 63 would cause undefined behavior in 1ULL << peak_rank");
+            "peak_rank >= 60 would overflow the amplitude array's byte size (2^peak_rank * 16 "
+            "must fit in size_t); peak_rank " +
+            std::to_string(peak_rank) + " is too large");
     }
     if ((1ULL << peak_rank) <= array_size_) {
         return;
     }
 
+    // Snapshot the live prefix size before any mutation so the memcpy below
+    // copies exactly the active amplitudes from the old buffer.
+    const uint64_t live = v_size();
+
+    // Allocate the new buffer into locals; on OOM alloc_amplitude_array throws
+    // before any member is touched, leaving the state completely valid.
+    const AllocResult alloc = alloc_amplitude_array(peak_rank);
+
+    // Zero the non-mmap allocation (mmap pages arrive zero-filled from the
+    // kernel). The full array_size entries must be zeroed, not only the live
+    // prefix, because the continuation will write into the upper half.
+    if (!alloc.is_mmap) {
+        const uint64_t new_array_size = 1ULL << peak_rank;
+        int64_t n = static_cast<int64_t>(new_array_size);
+        if (peak_rank >= kMinRankForThreads) {
+#pragma omp parallel for schedule(static)
+            for (int64_t i = 0; i < n; ++i) {
+                alloc.ptr[i] = {0.0, 0.0};
+            }
+        } else {
+            for (int64_t i = 0; i < n; ++i) {
+                alloc.ptr[i] = {0.0, 0.0};
+            }
+        }
+    }
+
+    // Copy the live prefix from the old buffer into the new one.
+    std::memcpy(alloc.ptr, v_, live * sizeof(std::complex<double>));
+
+    // Free the old buffer.
     std::complex<double>* old_v = v_;
     const size_t old_bytes = v_alloc_bytes_;
     const bool old_mmap = v_is_mmap_;
-    const uint64_t live = v_size();
 
-    allocate_array(peak_rank);
-    std::memcpy(v_, old_v, live * sizeof(std::complex<double>));
+    // Commit all members only after the new allocation and copy have succeeded.
+    v_ = alloc.ptr;
+    v_alloc_bytes_ = alloc.alloc_bytes;
+    v_is_mmap_ = alloc.is_mmap;
+    array_size_ = 1ULL << peak_rank;
+    peak_rank_ = peak_rank;
 
 #if defined(__linux__)
     if (old_mmap) {
@@ -152,6 +211,7 @@ void SchrodingerState::grow_for_continuation(uint32_t peak_rank) {
     }
 #else
     (void)old_bytes;
+    (void)old_mmap;
     aligned_free_portable(old_v);
 #endif
 }

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -225,14 +225,15 @@ static bool all_frame_opcodes(const std::vector<Instruction>& bytecode) {
 // validate_peak_rank guard
 // =============================================================================
 
-TEST_CASE("validate_peak_rank accepts ranks below 63") {
+TEST_CASE("validate_peak_rank accepts ranks below 60") {
     REQUIRE_NOTHROW(validate_peak_rank(0));
     REQUIRE_NOTHROW(validate_peak_rank(1));
     REQUIRE_NOTHROW(validate_peak_rank(31));
-    REQUIRE_NOTHROW(validate_peak_rank(62));
+    REQUIRE_NOTHROW(validate_peak_rank(59));
 }
 
-TEST_CASE("validate_peak_rank rejects ranks at or above 63") {
+TEST_CASE("validate_peak_rank rejects ranks at or above 60") {
+    REQUIRE_THROWS_AS(validate_peak_rank(60), std::runtime_error);
     REQUIRE_THROWS_AS(validate_peak_rank(63), std::runtime_error);
     REQUIRE_THROWS_AS(validate_peak_rank(64), std::runtime_error);
     REQUIRE_THROWS_AS(validate_peak_rank(100), std::runtime_error);
@@ -240,7 +241,7 @@ TEST_CASE("validate_peak_rank rejects ranks at or above 63") {
 
 TEST_CASE("validate_peak_rank rejects 65536 without uint16 wrap") {
     // Regression: an earlier version narrowed the input to uint16_t
-    // before checking >= 63, which silently wrapped a 65,536-axis peak
+    // before checking >= 60, which silently wrapped a 65,536-axis peak
     // (the program activates every axis at the VM ceiling) to 0 and
     // slipped past the guard. Pass the value through as uint32_t and
     // assert the helper rejects.

--- a/tests/test_svm.cc
+++ b/tests/test_svm.cc
@@ -8,11 +8,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
 #include <complex>
+#include <stdexcept>
 #include <vector>
 
 using namespace clifft;
+using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
 using Catch::Matchers::WithinRel;
 using clifft::test::check_complex;
@@ -84,6 +87,15 @@ TEST_CASE("SchrodingerState config initializes optional buffers and seed") {
     CHECK(a.obs_record.size() == 3);
     CHECK(a.exp_vals.size() == 4);
     CHECK(a.random_double() == b.random_double());
+}
+
+TEST_CASE("SchrodingerState rejects peak_rank >= 60") {
+    // 2^60 * 16 bytes == 2^64 bytes, which wraps to 0 in size_t on a 64-bit
+    // platform. The guard fires before any allocation attempt.
+    REQUIRE_THROWS_AS(SchrodingerState(StateConfig{.peak_rank = 60}), std::invalid_argument);
+    REQUIRE_THROWS_WITH(SchrodingerState(StateConfig{.peak_rank = 60}),
+                        ContainsSubstring("peak_rank >= 60 would overflow the amplitude array's "
+                                          "byte size"));
 }
 
 // =============================================================================


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Five independent hardenings of the exact driver and the SVM growth path, from the pre-merge review:

- **Exception-safe growth**: `grow_for_continuation` previously called `allocate_array`, which nulls `v_` and updates the size members *before* the allocation that can throw — an OOM during a 2^k doubling leaked the old (potentially multi-GB) buffer and poisoned the state. The raw mmap-hugepage/aligned_alloc logic now lives in a member-free helper; both callers commit members only after success, and `grow` copies the live prefix before committing and freeing. Refactor-only on the success path (page rounding, hugepage threshold, madvise, NUMA first-touch zero-fill all preserved).
- **No-event fast path**: the per-shot status walk is a provable no-op for all-computational, no-jump shots (statuses only move via jumps or noncomputational initials; classical consults only happen for noncomputational statuses; no RNG is consumed). It is now guarded, taking the dominant shot path from O(nodes) with per-node allocations to O(qubits). Draw-stream identity verified externally: fixed-seed SHA-256 fingerprints of measurements/final_status/heralds/detectors/observables across 7 path-covering configs × 2 seeds are byte-identical to the base tip.
- **Dead resize → assert**: the shot-loop `meas_record` resize was unreachable (the rebuild block above guarantees capacity) and read as a third growth path inside the shot loop; the assert keeps the allocate-once story auditable.
- **`trap.source` contract assert** before the `Level` cast (the VM reports the collapsed source as a computational axis index; CI runs Debug, so this is live there).
- **Real `peak_rank` bound**: `2^peak_rank * sizeof(complex<double>)` wraps `size_t` at `peak_rank == 60`, so 60–62 passed the old `>= 63` shift-UB guard and would zero-fill out of bounds behind a zero-byte allocation. Both guards tightened to `>= 60` with the constraint named in the message, plus a constructor-path test (the guard fires before any allocation).

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1045 cases (+1: the new guard test)
- Python: 888 pass on both the Release and Debug wheels
- Draw-stream fingerprints identical to base across plain/in-line-fire/trap-mix/loss/noncomp-initial+herald/chain/recapture configs at two seeds each
- `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
