### PR TITLE
refactor(noncomp): thread the forced trace-out slot out of trace()

### DIFF
--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -729,8 +729,9 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                         // multi-target reset being supplied as the request (the
                         // rewriter only ever names single-target Rs).
                         if (instruments != nullptr &&
-                            node_index == instruments->forced_traceout_node) {
-                            assert(hir.forced_traceout_slot == SIZE_MAX &&
+                            instruments->forced_traceout_node.has_value() &&
+                            node_index == *instruments->forced_traceout_node) {
+                            assert(!hir.forced_traceout_slot.has_value() &&
                                    "forced_traceout_node named a multi-target reset");
                             hir.forced_traceout_slot = this_meas;
                         }

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -723,6 +723,17 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                                 slot.set_sign(sign);
                             });
                         meas_op.set_hidden(true);
+                        // Report the hidden slot to the caller when this node
+                        // is the one it requested. The slot is reported through
+                        // hir.forced_traceout_slot; the assert guards against a
+                        // multi-target reset being supplied as the request (the
+                        // rewriter only ever names single-target Rs).
+                        if (instruments != nullptr &&
+                            node_index == instruments->forced_traceout_node) {
+                            assert(hir.forced_traceout_slot == SIZE_MAX &&
+                                   "forced_traceout_node named a multi-target reset");
+                            hir.forced_traceout_slot = this_meas;
+                        }
                     } else {
                         this_meas = static_cast<uint32_t>(meas_idx);
                         hir.append_measure(meas_idx, [&](MutablePauliMaskView slot) {

--- a/src/clifft/frontend/frontend.h
+++ b/src/clifft/frontend/frontend.h
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace clifft {
@@ -46,13 +47,13 @@ struct InstrumentTraceOptions {
     // no-fire back-action. Copied onto every materialized site.
     bool neglect_damping = false;
 
-    // When set to a value other than SIZE_MAX, trace() reports the hidden
-    // measurement slot it assigns to the reset at this node index (in the
-    // circuit being traced) through HirModule::forced_traceout_slot. The
-    // caller is responsible for ensuring the named node is a single-target
-    // pure reset (R/RX/RY); trace() sets the output field when it processes
-    // that node's hidden-branch target. SIZE_MAX means no slot is requested.
-    size_t forced_traceout_node = SIZE_MAX;
+    // When set, trace() reports the hidden measurement slot it assigns to
+    // the reset at this node index (in the circuit being traced) through
+    // HirModule::forced_traceout_slot. The caller is responsible for
+    // ensuring the named node is a single-target pure reset (R/RX/RY);
+    // trace() sets the output field when it processes that node's
+    // hidden-branch target. nullopt means no slot is requested.
+    std::optional<size_t> forced_traceout_node;
 };
 
 // Trace a circuit through the Front-End, producing a HirModule.

--- a/src/clifft/frontend/frontend.h
+++ b/src/clifft/frontend/frontend.h
@@ -18,6 +18,7 @@
 #include "clifft/circuit/circuit.h"
 #include "clifft/frontend/hir.h"
 
+#include <cstddef>
 #include <map>
 #include <string>
 
@@ -44,6 +45,14 @@ struct InstrumentTraceOptions {
     // damping="neglect": dormant-random sites skip the expansion and the
     // no-fire back-action. Copied onto every materialized site.
     bool neglect_damping = false;
+
+    // When set to a value other than SIZE_MAX, trace() reports the hidden
+    // measurement slot it assigns to the reset at this node index (in the
+    // circuit being traced) through HirModule::forced_traceout_slot. The
+    // caller is responsible for ensuring the named node is a single-target
+    // pure reset (R/RX/RY); trace() sets the output field when it processes
+    // that node's hidden-branch target. SIZE_MAX means no slot is requested.
+    size_t forced_traceout_node = SIZE_MAX;
 };
 
 // Trace a circuit through the Front-End, producing a HirModule.

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -431,9 +431,9 @@ struct HirModule {
 
     // Hidden measurement slot trace() assigned to the requested node's
     // reset (set when InstrumentTraceOptions::forced_traceout_node names a
-    // node index whose hidden-branch target trace() processes; SIZE_MAX
+    // node index whose hidden-branch target trace() processes; nullopt
     // when no slot was requested or the node was not encountered).
-    size_t forced_traceout_slot = SIZE_MAX;
+    std::optional<size_t> forced_traceout_slot;
 
     /// True when the evolution is a fixed unitary: no measurements, noise,
     /// readout noise, or measurement-conditioned Paulis. Deterministic

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <stdexcept>
@@ -427,6 +428,12 @@ struct HirModule {
     std::vector<std::vector<uint32_t>> source_map;
 
     std::optional<stim::Tableau<kStimWidth>> final_tableau;
+
+    // Hidden measurement slot trace() assigned to the requested node's
+    // reset (set when InstrumentTraceOptions::forced_traceout_node names a
+    // node index whose hidden-branch target trace() processes; SIZE_MAX
+    // when no slot was requested or the node was not encountered).
+    size_t forced_traceout_slot = SIZE_MAX;
 
     /// True when the evolution is a fixed unitary: no measurements, noise,
     /// readout noise, or measurement-conditioned Paulis. Deterministic

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -306,7 +306,7 @@ struct ContinuationEntry {
     // Hidden measurement slot trace() assigned to the forced trace-out reset
     // named by rw.forced_traceout_node. Populated on first compile;
     // subsequent flag-variant compiles assert it is consistent.
-    size_t forced_traceout_slot = SIZE_MAX;
+    std::optional<size_t> forced_traceout_slot;
 };
 
 void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_rank) {
@@ -514,25 +514,25 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             // When the rewrite names a forced trace-out node, ask trace()
             // to report the hidden slot it assigns to that reset.
             HirModule hir = [&]() -> HirModule {
-                if (entry.rw.forced_traceout_node != SIZE_MAX) {
+                if (entry.rw.forced_traceout_node.has_value()) {
                     InstrumentTraceOptions opts = instrument_options;
                     opts.forced_traceout_node = entry.rw.forced_traceout_node;
                     return trace(patched, &opts);
                 }
                 return trace(patched, &instrument_options);
             }();
-            if (entry.rw.forced_traceout_node != SIZE_MAX) {
-                if (hir.forced_traceout_slot == SIZE_MAX) {
+            if (entry.rw.forced_traceout_node.has_value()) {
+                if (!hir.forced_traceout_slot.has_value()) {
                     throw std::logic_error(
                         "sample_noncomputational: trace() did not encounter the forced "
                         "trace-out reset at node " +
-                        std::to_string(entry.rw.forced_traceout_node) +
+                        std::to_string(*entry.rw.forced_traceout_node) +
                         "; the rewrite and trace() must walk the same stream");
                 }
                 // First compile: record the slot. Later flag-variant
                 // compiles: assert it is consistent (same circuit, same R
                 // node, same hidden numbering -- the slot cannot differ).
-                if (entry.forced_traceout_slot == SIZE_MAX) {
+                if (!entry.forced_traceout_slot.has_value()) {
                     entry.forced_traceout_slot = hir.forced_traceout_slot;
                 } else {
                     assert(entry.forced_traceout_slot == hir.forced_traceout_slot &&
@@ -558,8 +558,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                     std::to_string(entry.rw.site_targets.size()) +
                     "; the rewriter and trace() must elide zero-fire sites identically");
             }
-            if (entry.rw.forced_traceout_node != SIZE_MAX) {
-                swap_traceout_to_forced(module, entry.forced_traceout_slot);
+            if (entry.rw.forced_traceout_node.has_value()) {
+                swap_traceout_to_forced(module, *entry.forced_traceout_slot);
             }
 #ifndef NDEBUG
             // Re-entry contract: the continuation's prefix must be
@@ -744,9 +744,9 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             if (force) {
                 // get_module always populates forced_traceout_slot before
                 // returning when forced_traceout_node is set.
-                assert(next_entry.forced_traceout_slot != SIZE_MAX &&
+                assert(next_entry.forced_traceout_slot.has_value() &&
                        "forced trace-out slot not populated by get_module");
-                const size_t slot = next_entry.forced_traceout_slot;
+                const size_t slot = *next_entry.forced_traceout_slot;
                 if (forced_buffer.size() <= slot) {
                     forced_buffer.resize(slot + 1, 0);
                 }

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -303,6 +303,10 @@ std::string cache_key(const ExactShotEvents& events) {
 struct ContinuationEntry {
     ContinuationRewrite rw;
     std::map<std::vector<uint8_t>, CompiledModule> modules;
+    // Hidden measurement slot trace() assigned to the forced trace-out reset
+    // named by rw.forced_traceout_node. Populated on first compile;
+    // subsequent flag-variant compiles assert it is consistent.
+    size_t forced_traceout_slot = SIZE_MAX;
 };
 
 void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_rank) {
@@ -507,7 +511,34 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                     patched.nodes[m.noise_node].args[0] = 0.5;
                 }
             }
-            HirModule hir = trace(patched, &instrument_options);
+            // When the rewrite names a forced trace-out node, ask trace()
+            // to report the hidden slot it assigns to that reset.
+            HirModule hir = [&]() -> HirModule {
+                if (entry.rw.forced_traceout_node != SIZE_MAX) {
+                    InstrumentTraceOptions opts = instrument_options;
+                    opts.forced_traceout_node = entry.rw.forced_traceout_node;
+                    return trace(patched, &opts);
+                }
+                return trace(patched, &instrument_options);
+            }();
+            if (entry.rw.forced_traceout_node != SIZE_MAX) {
+                if (hir.forced_traceout_slot == SIZE_MAX) {
+                    throw std::logic_error(
+                        "sample_noncomputational: trace() did not encounter the forced "
+                        "trace-out reset at node " +
+                        std::to_string(entry.rw.forced_traceout_node) +
+                        "; the rewrite and trace() must walk the same stream");
+                }
+                // First compile: record the slot. Later flag-variant
+                // compiles: assert it is consistent (same circuit, same R
+                // node, same hidden numbering -- the slot cannot differ).
+                if (entry.forced_traceout_slot == SIZE_MAX) {
+                    entry.forced_traceout_slot = hir.forced_traceout_slot;
+                } else {
+                    assert(entry.forced_traceout_slot == hir.forced_traceout_slot &&
+                           "flag-variant compile yielded a different forced_traceout_slot");
+                }
+            }
 #ifndef NDEBUG
             const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
 #endif
@@ -527,8 +558,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                     std::to_string(entry.rw.site_targets.size()) +
                     "; the rewriter and trace() must elide zero-fire sites identically");
             }
-            if (entry.rw.forced_traceout_slot != SIZE_MAX) {
-                swap_traceout_to_forced(module, entry.rw.forced_traceout_slot);
+            if (entry.rw.forced_traceout_node != SIZE_MAX) {
+                swap_traceout_to_forced(module, entry.forced_traceout_slot);
             }
 #ifndef NDEBUG
             // Re-entry contract: the continuation's prefix must be
@@ -701,9 +732,9 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
 
             // A neglect-form trap hands its carrier over uncollapsed; the
             // continuation's trace-out is forced to the reported source,
-            // read from forced_record at the slot the rewrite names. The
-            // forced value is per-shot runtime state, so the module stays
-            // source-independent.
+            // read from forced_record at the slot trace() assigned to the
+            // rewrite's named reset node. The forced value is per-shot
+            // runtime state, so the module stays source-independent.
             const bool force = trap.destination_pending;
             const uint32_t prefix_end = module->instrument_offsets[trap.site_id] + 1;
             ContinuationEntry& next_entry = get_entry(events, force);
@@ -711,7 +742,11 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
                 get_module(next_entry, flags_for(next_entry.rw), module, prefix_end);
 
             if (force) {
-                const size_t slot = next_entry.rw.forced_traceout_slot;
+                // get_module always populates forced_traceout_slot before
+                // returning when forced_traceout_node is set.
+                assert(next_entry.forced_traceout_slot != SIZE_MAX &&
+                       "forced trace-out slot not populated by get_module");
+                const size_t slot = next_entry.forced_traceout_slot;
                 if (forced_buffer.size() <= slot) {
                     forced_buffer.resize(slot + 1, 0);
                 }

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -203,27 +203,6 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
     }
 }
 
-// The hidden measurement-record slot trace() assigns to the reset at
-// `reset_node` in the rewritten stream. This mirrors trace()'s hidden
-// numbering (frontend.cc: hidden_meas_idx starts at the visible-measurement
-// count and increments by one per pure-reset target, in circuit order).
-// The two counts must agree -- the driver forces exactly this slot -- so
-// the contract is stated in both places and cross-checked at runtime by
-// swap_traceout_to_forced, which fails loudly if the slot names anything
-// other than exactly one forced-capable measurement. Threading the slot out
-// of trace() directly (so it is assigned in one place) is a worthwhile
-// follow-up; it needs the HIR measure op to carry its source node.
-size_t forced_reset_hidden_slot(const Circuit& rewritten, size_t reset_node,
-                                uint32_t num_visible_measurements) {
-    uint32_t hidden_before = 0;
-    for (size_t i = 0; i < reset_node; ++i) {
-        if (is_reset(rewritten.nodes[i].gate)) {
-            hidden_before += static_cast<uint32_t>(rewritten.nodes[i].targets.size());
-        }
-    }
-    return static_cast<size_t>(num_visible_measurements) + hidden_before;
-}
-
 }  // namespace
 
 ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,
@@ -398,8 +377,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
     }
 
     if (traceout_node != SIZE_MAX) {
-        result.forced_traceout_slot =
-            forced_reset_hidden_slot(out, traceout_node, annotated.num_measurements);
+        result.forced_traceout_node = traceout_node;
     }
 
     result.final_status = std::move(status);

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -137,18 +137,20 @@ struct ExactShotEvents {
 // A compiled-continuation rewrite: the circuit, the classifier record
 // writes in its suffix, and -- when the *last* jump in the chain traps at
 // a site whose collapse could not happen in-line (a neglect-form site on
-// a coherent carrier) -- the hidden record slot of that jump's carrier
-// reset, which the driver forces to the trap's reported source.
+// a coherent carrier) -- the node index (in the rewritten stream) of the
+// last recorded jump's trace-out reset, which the driver hands to trace()
+// to obtain the hidden slot. Every jump emits a reset, so the forced form
+// always has one to point at.
 struct ContinuationRewrite {
     Circuit circuit;
     std::vector<ClassifiedMeasurement> classified_measurements;
 
-    // Hidden record slot of the reset that collapses the last jump's
-    // carrier -- the trace-out R of a noncomputational destination, or
-    // the materializing R of a computational one -- or SIZE_MAX when the
-    // caller did not request forcing. Every jump emits a reset, so the
-    // forced form always has one to point at.
-    size_t forced_traceout_slot = SIZE_MAX;
+    // Node index (in the rewritten stream) of the last recorded jump's
+    // trace-out reset, or SIZE_MAX when the caller did not request forcing.
+    // The driver hands this to trace() via
+    // InstrumentTraceOptions::forced_traceout_node; trace() reports the
+    // hidden slot it assigns through HirModule::forced_traceout_slot.
+    size_t forced_traceout_node = SIZE_MAX;
 
     // Annotation target of each kept (runtime-instrument) site, in
     // emission order -- which is trace()'s materialization order, so the

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -146,11 +146,11 @@ struct ContinuationRewrite {
     std::vector<ClassifiedMeasurement> classified_measurements;
 
     // Node index (in the rewritten stream) of the last recorded jump's
-    // trace-out reset, or SIZE_MAX when the caller did not request forcing.
+    // trace-out reset, or nullopt when the caller did not request forcing.
     // The driver hands this to trace() via
     // InstrumentTraceOptions::forced_traceout_node; trace() reports the
     // hidden slot it assigns through HirModule::forced_traceout_slot.
-    size_t forced_traceout_node = SIZE_MAX;
+    std::optional<size_t> forced_traceout_node;
 
     // Annotation target of each kept (runtime-instrument) site, in
     // emission order -- which is trace()'s materialization order, so the

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -327,10 +327,10 @@ TEST_CASE("trace: forced_traceout_node on the first reset yields slot == num_vis
     REQUIRE(hir.forced_traceout_slot == 2);
 }
 
-TEST_CASE("trace: forced_traceout_node unset leaves forced_traceout_slot at SIZE_MAX") {
+TEST_CASE("trace: forced_traceout_node unset leaves forced_traceout_slot empty") {
     // No forced_traceout_node set: the output slot stays at its default.
     InstrumentTraceOptions options;
-    // forced_traceout_node defaults to SIZE_MAX -- no request
+    // forced_traceout_node defaults to nullopt -- no request
     auto hir = trace(parse("M 0\nR 1\nM 2"), &options);
-    REQUIRE(hir.forced_traceout_slot == SIZE_MAX);
+    REQUIRE(!hir.forced_traceout_slot.has_value());
 }

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -295,3 +295,42 @@ TEST_CASE("trace: a hand-built LOSS without its argument rejects") {
     c.nodes.push_back(AstNode{GateType::LOSS, {Target::qubit(0)}, {}, 0});
     REQUIRE_THROWS_WITH(trace(c, &options), ContainsSubstring("exactly one argument"));
 }
+
+// =============================================================================
+// forced_traceout_node / forced_traceout_slot
+// =============================================================================
+
+TEST_CASE("trace: forced_traceout_node reports the hidden slot of the requested reset") {
+    // The SINGLE-arity parser emits one node per target, so "R 2 3" becomes
+    // two nodes. Parsed circuit: M 0 (n0), M 1 (n1), R 2 (n2), R 3 (n3),
+    // R 4 (n4), M 5 (n5). num_visible = 3; hidden_meas_idx starts at 3.
+    //   node 2 (R 2): hidden slot 3
+    //   node 3 (R 3): hidden slot 4  <- forced_traceout_node = 3
+    //   node 4 (R 4): hidden slot 5
+    // forced_traceout_slot = 4 (third hidden slot, index 1 in hidden slots)
+    InstrumentTraceOptions options;
+    options.forced_traceout_node = 3;  // R 3 (second of the two split resets)
+    auto hir = trace(parse("M 0\nM 1\nR 2 3\nR 4\nM 5"), &options);
+    REQUIRE(hir.forced_traceout_slot == 4);
+}
+
+TEST_CASE("trace: forced_traceout_node on the first reset yields slot == num_visible") {
+    // Circuit: R 0  M 1  M 2
+    //   node 0: R 0 -> hidden slot 2 (num_visible = 2)
+    //   node 1: M 1 -> visible slot 0
+    //   node 2: M 2 -> visible slot 1
+    // hidden before node 0 = 0
+    // forced_traceout_slot = 2 + 0 = 2
+    InstrumentTraceOptions options;
+    options.forced_traceout_node = 0;  // R 0, the first and only reset
+    auto hir = trace(parse("R 0\nM 1\nM 2"), &options);
+    REQUIRE(hir.forced_traceout_slot == 2);
+}
+
+TEST_CASE("trace: forced_traceout_node unset leaves forced_traceout_slot at SIZE_MAX") {
+    // No forced_traceout_node set: the output slot stays at its default.
+    InstrumentTraceOptions options;
+    // forced_traceout_node defaults to SIZE_MAX -- no request
+    auto hir = trace(parse("M 0\nR 1\nM 2"), &options);
+    REQUIRE(hir.forced_traceout_slot == SIZE_MAX);
+}

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -70,7 +70,7 @@ TEST_CASE("continuation: empty events reproduce the annotated circuit verbatim")
 
     auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/false, model);
     REQUIRE(gate_sequence(result.circuit) == gate_sequence(annotated));
-    REQUIRE(result.forced_traceout_node == SIZE_MAX);
+    REQUIRE(!result.forced_traceout_node.has_value());
     REQUIRE(result.classified_measurements.empty());
 }
 

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -70,7 +70,7 @@ TEST_CASE("continuation: empty events reproduce the annotated circuit verbatim")
 
     auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/false, model);
     REQUIRE(gate_sequence(result.circuit) == gate_sequence(annotated));
-    REQUIRE(result.forced_traceout_slot == SIZE_MAX);
+    REQUIRE(result.forced_traceout_node == SIZE_MAX);
     REQUIRE(result.classified_measurements.empty());
 }
 
@@ -132,10 +132,9 @@ TEST_CASE("continuation: classical-source consults consume pre-drawn outcomes") 
     REQUIRE(gate_sequence(result.circuit) == want);
 }
 
-TEST_CASE("continuation: the forced trace-out slot mirrors trace's hidden numbering") {
-    // Hidden slots are assigned per pure-reset target in circuit order,
-    // after the visible slots. With one visible measurement and one reset
-    // ahead of the trace-out, the trace-out owns hidden slot 2.
+TEST_CASE("continuation: the forced trace-out node names the trace-out R in the rewritten stream") {
+    // The rewrite emits: [R 1, H 0, LEVEL_TRANSITION 0, R 0 (trace-out), MPAD].
+    // The trace-out R lands at node index 3 in the rewritten stream.
     auto model = demo_model();
     auto circuit = parse("R 1\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0");
     auto annotated = annotate(circuit, model);
@@ -145,14 +144,12 @@ TEST_CASE("continuation: the forced trace-out slot mirrors trace's hidden number
     events.jumps.push_back({2, 0, Level::LeakE});
 
     auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/true, model);
-    REQUIRE(result.forced_traceout_slot == 2);  // 1 visible + 1 hidden before it
+    REQUIRE(result.forced_traceout_node == 3);  // index in the rewritten stream
 }
 
-TEST_CASE("continuation: the forced trace-out slot counts every prior reset") {
-    // The slot derivation accumulates one hidden slot per prior reset target,
-    // so it must sum across resets, not stop at the first. With one visible
-    // measurement and two resets ahead of the trace-out, the trace-out owns
-    // hidden slot 3 (1 visible + 2 hidden).
+TEST_CASE("continuation: the forced trace-out node is correct with multiple prior resets") {
+    // The rewrite emits: [R 1, R 2, H 0, LEVEL_TRANSITION 0, R 0 (trace-out), MPAD].
+    // The trace-out R lands at node index 4 in the rewritten stream.
     auto model = demo_model();
     auto circuit = parse("R 1\nR 2\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0");
     auto annotated = annotate(circuit, model);
@@ -162,7 +159,7 @@ TEST_CASE("continuation: the forced trace-out slot counts every prior reset") {
     events.jumps.push_back({3, 0, Level::LeakE});  // the annotation is node 3
 
     auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/true, model);
-    REQUIRE(result.forced_traceout_slot == 3);  // 1 visible + 2 hidden (R 1, R 2) before it
+    REQUIRE(result.forced_traceout_node == 4);  // index in the rewritten stream
 }
 
 TEST_CASE("continuation: events that do not describe the circuit reject") {
@@ -197,10 +194,11 @@ TEST_CASE("continuation: events that do not describe the circuit reject") {
     }
     SECTION("forcing the trace-out any jump emits") {
         // Every recorded jump emits a carrier reset, so the forced form
-        // always has one to point at.
+        // always has one to point at. Rewritten stream: [LEVEL_TRANSITION,
+        // R (trace-out), MPAD], so the trace-out R is at node index 1.
         ExactShotEvents events = base;
         events.jumps.push_back({0, 0, Level::LeakE});
         auto result = rewrite_continuation(annotated, events, true, model);
-        REQUIRE(result.forced_traceout_slot == 1);  // 1 visible slot before it
+        REQUIRE(result.forced_traceout_node == 1);  // index in the rewritten stream
     }
 }


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Closes #180 — the last two-places-must-agree numbering contract in the exact pipeline.

- `forced_reset_hidden_slot` (the rewriter's mirror of `trace()`'s hidden-slot numbering, counting reset targets in circuit order) is **deleted**. The rewrite now records only *which node* is the last jump's trace-out reset (`ContinuationRewrite::forced_traceout_node`).
- `InstrumentTraceOptions` gains the request field; `trace()` reports the assigned slot through `HirModule::forced_traceout_slot` at the single place hidden slots are born (the hidden-measurement branch of the lowering loop), with a once-only assert.
- The driver validates the report (a `logic_error` naming the node if `trace()` never encountered it — the rewrite and trace must walk the same stream), caches the slot per continuation entry (flag-variant compiles assert consistency), and feeds the unchanged `swap_traceout_to_forced` + forced-record plumbing. The swap stays: it is the opcode-flip mechanism, and its input is now ground truth rather than a parallel count.

New frontend unit pins for the reporting: mixed visible/hidden arrangements (including the parser's one-node-per-target split for multi-target resets — the arithmetic was verified against `trace()`'s behavior, which caught exactly the off-by-N this refactor exists to prevent), a first-reset case, and the unrequested sentinel. Continuation tests now pin the node index instead of re-deriving slot values.

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1048 cases (+3 frontend pins)
- Python: 888 pass on both the Release and Debug wheels
- Draw-stream fingerprints byte-identical to the base tip across 7 path-covering configs × 2 seeds (this refactor must compile byte-identical modules — verified)
- The neglect-mode forced-path behavior tests (Bell correlations, multi-reset arrangements) pass unchanged
- `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
