### PR TITLE
feat(noncomp): reject unsupported circuit/model pairs before sampling

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(clifft_core STATIC
     noncomp/status_step.cc
     noncomp/op_role.cc
     noncomp/rewriter.cc
+    noncomp/static_check.cc
     noncomp/exact_driver.cc
     noncomp/orchestrator.cc
 )

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -50,6 +50,7 @@
 #include "clifft/noncomp/op_role.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/seed.h"
+#include "clifft/noncomp/static_check.h"
 #include "clifft/noncomp/status_step.h"
 #include "clifft/noncomp/transition_instrument.h"
 #include "clifft/optimizer/hir_pass_manager.h"
@@ -475,6 +476,13 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             resolve_annotation(node, model, op_index);
         }
     }
+
+    // Static pre-scan: reject circuit/model pairs that can never sample
+    // successfully because some reachable qubit status meets an
+    // unrepresentable operation.  This turns seed-dependent mid-sampling
+    // failures (only the shot that first hits the bad status raises) into
+    // a deterministic up-front rejection.
+    validate_static(annotated, model);
 
     const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
 

--- a/src/clifft/noncomp/static_check.cc
+++ b/src/clifft/noncomp/static_check.cc
@@ -1,0 +1,267 @@
+// Static pre-sampling validation for circuit/model pairs.
+//
+// Runs an abstract interpretation over per-qubit sets of reachable
+// QubitStatus values (a uint8_t bitmask), calling the same policy
+// primitives the rewriter calls on concrete statuses.  A set bit at
+// position s means QubitStatus(s) is reachable for that qubit.  Members
+// are only ever added, never removed: transitions are stochastic, so any
+// reachable status stays reachable even if the transition fires.
+//
+// Node kinds and how the abstract walk handles each:
+//
+//   LEVEL_TRANSITION[tag]  Look up instrument->prob(dest, source) for each
+//                          source level of the target qubit's current status
+//                          members.  For Computational members, the sources
+//                          are G and E; for a noncomp member s, the source
+//                          is noncomp_level(s).  Every destination level
+//                          with prob > 0 adds status_for(dest) to the set.
+//                          No member is removed (the fire is probabilistic).
+//
+//   LOSS(p)                p > 0 adds QubitStatus::Lost to each target's
+//                          set.  p == 0 is a no-op (mirrors trace()'s
+//                          zero-fire elision).
+//
+//   All other nodes        For each qubit operand and each member status s:
+//                          * operand_action(gate, s, policy) == Reject  →
+//                            throw std::invalid_argument immediately.
+//                          * is_measurement(gate) and s is not
+//                            Computational  →  require model.classifier()
+//                            != nullptr, else throw.
+//                          * New member set is the image
+//                            { normal_post_op_status(s, gate, role, policy)
+//                              : s ∈ set, action != Reject }
+//                            when the action is Apply, and s itself when
+//                            the action is Drop.
+
+#include "clifft/noncomp/static_check.h"
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/target.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/status_step.h"
+#include "clifft/noncomp/transition_instrument.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace clifft {
+
+namespace {
+
+// A bitmask over QubitStatus enumerators.  Bit i is set when
+// QubitStatus(i) is in the reachable set.  The four enumerators are
+// Computational=0, LeakG=1, LeakE=2, Lost=3, so a uint8_t suffices.
+using StatusSet = uint8_t;
+
+inline StatusSet set_of(QubitStatus s) {
+    return static_cast<uint8_t>(1u << static_cast<uint8_t>(s));
+}
+
+inline void add_status(StatusSet& set, QubitStatus s) {
+    set |= set_of(s);
+}
+
+inline bool has_status(StatusSet set, QubitStatus s) {
+    return (set & set_of(s)) != 0;
+}
+
+// Initial status set for one qubit: Computational is always reachable.
+// Any noncomputational level with model.initial_probability > 0 also
+// contributes its corresponding QubitStatus.
+StatusSet initial_set(const NonComputationalModel& model) {
+    StatusSet s = set_of(QubitStatus::Computational);
+    for (const Level l : kAllLevels) {
+        if (model.initial_probability(l) > 0.0) {
+            add_status(s, status_for(l));
+        }
+    }
+    return s;
+}
+
+// Advance `set` through a LEVEL_TRANSITION node's transition matrix.
+// For each member status s in the current set, iterate the source
+// levels that correspond to s and add status_for(dest) for every dest
+// with instrument.prob(dest, source) > 0.  Members are never removed.
+void advance_transition(StatusSet& set, const TransitionInstrument& instrument) {
+    const StatusSet entry_set = set;  // snapshot: iterate the entry, extend the result
+    for (uint8_t si = 0; si < 4; ++si) {
+        const QubitStatus member = static_cast<QubitStatus>(si);
+        if (!has_status(entry_set, member)) {
+            continue;
+        }
+        // Determine the source levels that correspond to this status.
+        // Computational covers both G and E (the SVM holds which one at
+        // runtime); noncomputational statuses map to a single definite level.
+        if (is_computational(member)) {
+            for (const Level src : {Level::G, Level::E}) {
+                for (const Level dest : kAllLevels) {
+                    if (instrument.prob(dest, src) > 0.0) {
+                        add_status(set, status_for(dest));
+                    }
+                }
+            }
+        } else {
+            const Level src = noncomp_level(member);
+            for (const Level dest : kAllLevels) {
+                if (instrument.prob(dest, src) > 0.0) {
+                    add_status(set, status_for(dest));
+                }
+            }
+        }
+    }
+}
+
+// Advance `set` through an ordinary (non-annotation) node for one
+// qubit operand with the given role.  Each member status is processed
+// through operand_action and normal_post_op_status:
+//   Apply  →  post = normal_post_op_status(s, gate, role, policy)
+//   Drop   →  post = s (entry status preserved)
+//   Reject →  caller has already thrown; unreachable here
+StatusSet advance_ordinary(StatusSet set, GateType gate, OperandRole role,
+                           const NonComputationalPolicy& policy) {
+    StatusSet next = 0;
+    for (uint8_t si = 0; si < 4; ++si) {
+        const QubitStatus s = static_cast<QubitStatus>(si);
+        if (!has_status(set, s)) {
+            continue;
+        }
+        const OperandAction action = operand_action(gate, s, policy);
+        if (action == OperandAction::Reject) {
+            // Callers check for Reject before calling this function.
+            // This branch is unreachable.
+            continue;
+        }
+        if (action == OperandAction::Drop) {
+            add_status(next, s);
+        } else {
+            add_status(next, normal_post_op_status(s, gate, role, policy));
+        }
+    }
+    return next;
+}
+
+}  // namespace
+
+void validate_static(const Circuit& annotated, const NonComputationalModel& model) {
+    const NonComputationalPolicy& policy = model.policy();
+    const uint32_t nq = annotated.num_qubits;
+
+    // Initialize per-qubit reachable-status sets from the model's initial
+    // distribution.
+    std::vector<StatusSet> sets(nq, initial_set(model));
+
+    for (uint32_t op_index = 0; op_index < static_cast<uint32_t>(annotated.nodes.size());
+         ++op_index) {
+        const AstNode& node = annotated.nodes[op_index];
+        const GateType gate = node.gate;
+
+        // --- Annotation nodes ---
+        if (gate == GateType::LEVEL_TRANSITION) {
+            // Guard against a null instrument (malformed model reference);
+            // the driver's up-front resolve_annotation will also catch this,
+            // but a defensive null check here keeps this function safe even
+            // when called before that loop.
+            const TransitionInstrument* instrument = model.transition_named(node.tag);
+            if (instrument == nullptr) {
+                // Unresolved tag: skip; resolve_annotation will throw.
+                continue;
+            }
+            for (const Target& t : node.targets) {
+                if (t.is_rec()) {
+                    continue;
+                }
+                const uint32_t q = t.value();
+                if (q < nq) {
+                    advance_transition(sets[q], *instrument);
+                }
+            }
+            continue;
+        }
+
+        if (gate == GateType::LOSS) {
+            // A LOSS with args size != 1 or out-of-range probability is
+            // rejected by the driver's up-front resolve_annotation; skip
+            // gracefully here rather than re-validating.
+            if (node.args.size() != 1) {
+                continue;
+            }
+            const double p = node.args[0];
+            if (p > 0.0) {
+                for (const Target& t : node.targets) {
+                    if (t.is_rec()) {
+                        continue;
+                    }
+                    const uint32_t q = t.value();
+                    if (q < nq) {
+                        add_status(sets[q], QubitStatus::Lost);
+                    }
+                }
+            }
+            // p == 0 is a no-op: the channel can never fire, so Lost is
+            // not added to the reachable set (mirrors trace()'s zero-fire
+            // elision).
+            continue;
+        }
+
+        // --- Ordinary nodes ---
+        // First pass: any Reject or missing-classifier member throws.
+        // Second pass: advance each operand's set pointwise (Drop members
+        // keep their entry status, Apply members map through
+        // normal_post_op_status).  The concrete walk drops a node whole
+        // when any operand drops, but that coupling needs no modeling
+        // here: only resets change statuses, and resets are single-qubit,
+        // so the pointwise image is exact.
+        const std::vector<QubitOperand> operands = qubit_operands(node);
+        for (const QubitOperand& operand : operands) {
+            const uint32_t q = operand.qubit;
+            if (q >= nq) {
+                continue;
+            }
+            const StatusSet qset = sets[q];
+            for (uint8_t si = 0; si < 4; ++si) {
+                const QubitStatus s = static_cast<QubitStatus>(si);
+                if (!has_status(qset, s)) {
+                    continue;
+                }
+                switch (operand_action(gate, s, policy)) {
+                    case OperandAction::Reject:
+                        throw std::invalid_argument(
+                            "sample_noncomputational: operation '" + std::string(gate_name(gate)) +
+                            "' on qubit " + std::to_string(q) + " at op " +
+                            std::to_string(op_index) + " can meet a " + status_name(s) +
+                            " qubit under this model and is not representable"
+                            "; rejecting before sampling");
+                    case OperandAction::Drop:
+                        break;
+                    case OperandAction::Apply:
+                        break;
+                }
+                // Classifier check: a measurement on a noncomputational
+                // qubit requires a classifier.
+                if (is_measurement(gate) && !is_computational(s)) {
+                    if (model.classifier() == nullptr) {
+                        throw std::invalid_argument(
+                            "sample_noncomputational: measurement '" +
+                            std::string(gate_name(gate)) + "' on qubit " + std::to_string(q) +
+                            " at op " + std::to_string(op_index) + " can meet a " + status_name(s) +
+                            " qubit and requires a classifier, but the model has none"
+                            "; rejecting before sampling");
+                    }
+                }
+            }
+        }
+
+        for (const QubitOperand& operand : operands) {
+            const uint32_t q = operand.qubit;
+            if (q >= nq) {
+                continue;
+            }
+            sets[q] = advance_ordinary(sets[q], gate, operand.role, policy);
+        }
+    }
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/static_check.cc
+++ b/src/clifft/noncomp/static_check.cc
@@ -3,9 +3,11 @@
 // Runs an abstract interpretation over per-qubit sets of reachable
 // QubitStatus values (a uint8_t bitmask), calling the same policy
 // primitives the rewriter calls on concrete statuses.  A set bit at
-// position s means QubitStatus(s) is reachable for that qubit.  Members
-// are only ever added, never removed: transitions are stochastic, so any
-// reachable status stays reachable even if the transition fires.
+// position s means QubitStatus(s) is reachable for that qubit.  The
+// governing rule for stochastic channels: a member survives a channel
+// only when its no-event branch is reachable -- a source whose jump
+// away is certain is replaced by its destinations, exactly as the
+// concrete draw can never keep it.
 //
 // Node kinds and how the abstract walk handles each:
 //
@@ -14,12 +16,15 @@
 //                          members.  For Computational members, the sources
 //                          are G and E; for a noncomp member s, the source
 //                          is noncomp_level(s).  Every destination level
-//                          with prob > 0 adds status_for(dest) to the set.
-//                          No member is removed (the fire is probabilistic).
+//                          with prob > 0 adds status_for(dest); the member
+//                          itself survives only when some source column
+//                          leaves no-fire mass (column_sum < 1).
 //
 //   LOSS(p)                p > 0 adds QubitStatus::Lost to each target's
-//                          set.  p == 0 is a no-op (mirrors trace()'s
-//                          zero-fire elision).
+//                          set; computational and leaked members survive
+//                          only when p < 1 (an already-lost member is a
+//                          no-op).  p == 0 is a no-op entirely (mirrors
+//                          trace()'s zero-fire elision).
 //
 //   All other nodes        For each qubit operand and each member status s:
 //                          * operand_action(gate, s, policy) == Reject  →
@@ -68,11 +73,12 @@ inline bool has_status(StatusSet set, QubitStatus s) {
     return (set & set_of(s)) != 0;
 }
 
-// Initial status set for one qubit: Computational is always reachable.
-// Any noncomputational level with model.initial_probability > 0 also
-// contributes its corresponding QubitStatus.
+// Initial status set for one qubit: every level with initial mass
+// contributes its corresponding QubitStatus (status_for collapses g and
+// e onto Computational). A model whose initial state carries no
+// computational mass starts with no Computational member.
 StatusSet initial_set(const NonComputationalModel& model) {
-    StatusSet s = set_of(QubitStatus::Computational);
+    StatusSet s = 0;
     for (const Level l : kAllLevels) {
         if (model.initial_probability(l) > 0.0) {
             add_status(s, status_for(l));
@@ -82,14 +88,16 @@ StatusSet initial_set(const NonComputationalModel& model) {
 }
 
 // Advance `set` through a LEVEL_TRANSITION node's transition matrix.
-// For each member status s in the current set, iterate the source
-// levels that correspond to s and add status_for(dest) for every dest
-// with instrument.prob(dest, source) > 0.  Members are never removed.
+// Each member is replaced by the image of its source levels: every
+// destination with prob > 0 contributes status_for(dest), and the
+// member itself survives only when some source column leaves no-fire
+// mass (column_sum < 1 -- from_matrix clamps in-tolerance sums to
+// exactly 1, so the comparison is exact for certain columns).
 void advance_transition(StatusSet& set, const TransitionInstrument& instrument) {
-    const StatusSet entry_set = set;  // snapshot: iterate the entry, extend the result
+    StatusSet next = 0;
     for (uint8_t si = 0; si < 4; ++si) {
         const QubitStatus member = static_cast<QubitStatus>(si);
-        if (!has_status(entry_set, member)) {
+        if (!has_status(set, member)) {
             continue;
         }
         // Determine the source levels that correspond to this status.
@@ -99,19 +107,26 @@ void advance_transition(StatusSet& set, const TransitionInstrument& instrument) 
             for (const Level src : {Level::G, Level::E}) {
                 for (const Level dest : kAllLevels) {
                     if (instrument.prob(dest, src) > 0.0) {
-                        add_status(set, status_for(dest));
+                        add_status(next, status_for(dest));
                     }
+                }
+                if (instrument.column_sum(src) < 1.0) {
+                    add_status(next, QubitStatus::Computational);
                 }
             }
         } else {
             const Level src = noncomp_level(member);
             for (const Level dest : kAllLevels) {
                 if (instrument.prob(dest, src) > 0.0) {
-                    add_status(set, status_for(dest));
+                    add_status(next, status_for(dest));
                 }
+            }
+            if (instrument.column_sum(src) < 1.0) {
+                add_status(next, member);
             }
         }
     }
+    set = next;
 }
 
 // Advance `set` through an ordinary (non-annotation) node for one
@@ -195,9 +210,24 @@ void validate_static(const Circuit& annotated, const NonComputationalModel& mode
                         continue;
                     }
                     const uint32_t q = t.value();
-                    if (q < nq) {
-                        add_status(sets[q], QubitStatus::Lost);
+                    if (q >= nq) {
+                        continue;
                     }
+                    // Computational and leaked members can vacate; they
+                    // survive only when the no-fire branch is reachable
+                    // (p < 1). An already-lost member is a no-op.
+                    StatusSet next = 0;
+                    for (uint8_t si = 0; si < 4; ++si) {
+                        const QubitStatus s = static_cast<QubitStatus>(si);
+                        if (!has_status(sets[q], s)) {
+                            continue;
+                        }
+                        add_status(next, QubitStatus::Lost);
+                        if (s == QubitStatus::Lost || p < 1.0) {
+                            add_status(next, s);
+                        }
+                    }
+                    sets[q] = next;
                 }
             }
             // p == 0 is a no-op: the channel can never fire, so Lost is

--- a/src/clifft/noncomp/static_check.h
+++ b/src/clifft/noncomp/static_check.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// Static pre-sampling validation for circuit/model pairs.
+//
+// validate_static rejects a circuit/model combination before any shot is
+// drawn when sampling could ever encounter an unrepresentable operation: an
+// X/Y-basis or parity measurement that a reachable leaked or lost qubit
+// could reach, or a measurement that requires a classifier the model lacks.
+//
+// The check runs an abstract interpretation over per-qubit SETS of reachable
+// QubitStatus values (a uint8_t bitmask), walking the annotated circuit with
+// the same policy primitives the rewriter applies to concrete statuses.
+// Because the two share primitives, they can never disagree: any path this
+// scan allows, the rewriter can handle, and any path this scan forbids,
+// the rewriter would reject at runtime.
+
+#include "clifft/circuit/circuit.h"
+#include "clifft/noncomp/model.h"
+
+namespace clifft {
+
+// Reject circuit/model pairs whose sampling could ever hit an
+// unrepresentable operation, before any shot is drawn. Walks the
+// annotated circuit with a per-qubit set of reachable statuses and
+// applies the same per-status policy primitives the rewrite applies to
+// concrete statuses, so the two can never disagree.
+//
+// Throws std::invalid_argument when a rejectable path is reachable.
+// The annotated circuit must be the result of annotate(original, model).
+void validate_static(const Circuit& annotated, const NonComputationalModel& model);
+
+}  // namespace clifft

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -259,11 +259,15 @@ def sample(
     :class:`NonComputationalSample`. Raises ``ValueError`` when the trajectory
     policy rejects an operation, when a leaked/lost measurement needs a
     classifier the model lacks, or when a classifier column is unsupported.
+    Circuit/model contract violations — an X/Y-basis or parity measurement
+    that can meet a leaked or lost qubit under the model's reachable status
+    sets, or a measurement of a noncomputational qubit without a classifier —
+    are detected before sampling begins and raise ``ValueError``.
 
-    ``max_rank`` caps the compiled peak rank under
-    exact-mode compilation: it fails with the offending
-    circuit line named, before any state allocation, instead of attempting
-    a ``2**k`` allocation. Unlimited when ``None``.
+    ``max_rank`` caps the compiled peak rank under exact-mode compilation:
+    it is enforced per continuation compile and raises ``ValueError`` naming
+    the offending circuit line when the limit is exceeded.
+    Unlimited when ``None``.
     """
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(clifft_tests
     test_exact_driver.cc
     test_noncomp_orchestrator.cc
     test_noncomp_validation.cc
+    test_noncomp_static_check.cc
 )
 
 target_link_libraries(clifft_tests PRIVATE

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -609,3 +609,29 @@ def test_static_check_r_restores_leak_before_mx():
     result = noncomp.sample("S 0\nR 0\nMX 0", model, shots=8, seed=1)
     assert result.shots == 8
     assert result.measurements.shape == (8, 1)
+
+
+def test_static_check_certain_recapture_accepts_mx():
+    """A qubit starting on leak_e whose S hook recaptures to g with
+    certainty always meets MX computationally; the no-event branch of the
+    leak_e source is unreachable, so the reachability walk must retire it."""
+    m = _zeros(5, 5)
+    m[LEAK_E][noncomp.Level.G] = 0.1
+    m[LEAK_E][noncomp.Level.E] = 0.1
+    m[noncomp.Level.G][LEAK_E] = 1.0
+    model = noncomp.Model(initial_state=[0.0, 0.0, 0.0, 1.0, 0.0], transitions={"S": m})
+    result = noncomp.sample("S 0\nMX 0", model, shots=4, seed=1)
+    assert result.measurements.shape == (4, 1)
+    assert (result.final_status[:, 0] == COMPUTATIONAL).all()
+
+
+def test_static_check_re_leak_after_recapture_rejects():
+    """After the certain recapture, a second S can leak again from the
+    computational columns, so MX genuinely can meet a leaked qubit."""
+    m = _zeros(5, 5)
+    m[LEAK_E][noncomp.Level.G] = 0.1
+    m[LEAK_E][noncomp.Level.E] = 0.1
+    m[noncomp.Level.G][LEAK_E] = 1.0
+    model = noncomp.Model(initial_state=[0.0, 0.0, 0.0, 1.0, 0.0], transitions={"S": m})
+    with pytest.raises(ValueError, match="representable"):
+        noncomp.sample("S 0\nS 0\nMX 0", model, shots=1, seed=1)

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -570,3 +570,42 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_recapture():
     assert np.all(result.measurements[:, 0] == 0)  # classified while leaked
     assert np.all(result.measurements[:, 1] == 1)  # recaptured to e
     assert (result.final_status[:, 0] == COMPUTATIONAL).all()
+
+
+# =========================================================================
+# Static pre-sampling validation tests
+# =========================================================================
+
+
+def test_static_check_low_rate_mx_raises_deterministically():
+    """A low-rate leak to leak_e makes MX not representable.
+
+    Before the static check, this circuit sampled cleanly on most seeds
+    because the 0.01 rate rarely fired on the first shot.  The static
+    check rejects the pair deterministically before any shot is drawn.
+    """
+    m = _zeros(5, 5)
+    m[LEAK_E][noncomp.Level.G] = 0.01
+    m[LEAK_E][noncomp.Level.E] = 0.01
+    transitions = {"S": m}
+    classifier = classifier_for(LEAK_E, [0.0, 1.0])
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
+    with pytest.raises(ValueError, match="representable"):
+        noncomp.sample("S 0\nMX 0", model, shots=1, seed=1)
+
+
+def test_static_check_r_restores_leak_before_mx():
+    """R always restores a leaked qubit; MX after R meets only a computational qubit.
+
+    This is a false-positive guard: the static check must not reject a
+    circuit where the leak is provably gone before the unsupported gate.
+    """
+    m = _zeros(5, 5)
+    m[LEAK_E][noncomp.Level.G] = 0.01
+    m[LEAK_E][noncomp.Level.E] = 0.01
+    transitions = {"S": m}
+    classifier = classifier_for(LEAK_E, [0.0, 1.0])
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
+    result = noncomp.sample("S 0\nR 0\nMX 0", model, shots=8, seed=1)
+    assert result.shots == 8
+    assert result.measurements.shape == (8, 1)

--- a/tests/test_noncomp_static_check.cc
+++ b/tests/test_noncomp_static_check.cc
@@ -1,0 +1,182 @@
+// Tests for the static pre-sampling validation (validate_static), exercised
+// end-to-end through sample_noncomputational.
+//
+// Rejection cases: all must throw std::invalid_argument before any shot is
+// drawn (shots=1 with any seed; the static check fires before the first shot).
+// Precision cases: false-positive guards -- these must sample cleanly.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/noncomp/model.h"
+#include "clifft/noncomp/orchestrator.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace clifft;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+// Level indices matching the fixed five-level set.
+constexpr uint8_t kG = 0;
+constexpr uint8_t kE = 1;
+constexpr uint8_t kLeakG = 2;
+constexpr uint8_t kLeakE = 3;
+constexpr uint8_t kLost = 4;
+
+// 5x5 zero matrix.
+std::vector<std::vector<double>> zeros5() {
+    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
+}
+
+// Transition matrix where both g and e leak to leak_e at rate `p`.
+std::vector<std::vector<double>> leak_to_leak_e(double p) {
+    auto m = zeros5();
+    m[kLeakE][kG] = p;
+    m[kLeakE][kE] = p;
+    return m;
+}
+
+// Binary classifier: slot 0 reads symbol 0, all others read symbol 0;
+// computational columns read out faithfully; noncomp level `level` reads `col`.
+ClassifierSpec binary_classifier(uint8_t level, std::vector<double> col) {
+    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
+    for (int l = 0; l < 5; ++l) {
+        m[0][l] = 1.0;
+    }
+    m[0][kE] = 0.0;
+    m[1][kE] = 1.0;
+    m[0][level] = col[0];
+    m[1][level] = col[1];
+    return ClassifierSpec{2, std::move(m)};
+}
+
+NonComputationalModel model_with_leak_transition(const std::string& key, double rate,
+                                                 bool with_classifier = true) {
+    std::map<std::string, std::vector<std::vector<double>>> transitions{
+        {key, leak_to_leak_e(rate)}};
+    std::optional<ClassifierSpec> classifier;
+    if (with_classifier) {
+        classifier = binary_classifier(kLeakE, {0.0, 1.0});
+    }
+    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions, classifier,
+                                            NonComputationalPolicy{});
+}
+
+}  // namespace
+
+// =========================================================================
+// Rejection cases
+// =========================================================================
+
+TEST_CASE("static_check: MX after a low-rate leak always rejects") {
+    // A 0.01-rate leak to leak_e means leak_e is reachable; MX on a
+    // leak_e qubit is not representable.  Before this check, the circuit
+    // sampled cleanly on most seeds (the low rate rarely fires on shot 0).
+    auto model = model_with_leak_transition("S", 0.01);
+    auto circuit = parse("S 0\nMX 0");
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 1, 1),
+                        ContainsSubstring("MX") && ContainsSubstring("not representable") &&
+                            ContainsSubstring("before sampling"));
+}
+
+TEST_CASE("static_check: MPP parity measurement after a low-rate leak always rejects") {
+    // Same reachability: leak_e is reachable on qubit 0 after the S
+    // transition; MPP over qubit 0 is not representable.
+    auto model = model_with_leak_transition("S", 0.01);
+    auto circuit = parse("S 0\nMPP X0*X1");
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 1, 1),
+                        ContainsSubstring("MPP") && ContainsSubstring("not representable") &&
+                            ContainsSubstring("before sampling"));
+}
+
+TEST_CASE("static_check: measurement without a classifier always rejects") {
+    // A model with no classifier: any shot that finds qubit 0 leaked
+    // after S would need a classifier for the M record.  The static
+    // check catches this before drawing any shot.
+    auto model = model_with_leak_transition("S", 0.01, /*with_classifier=*/false);
+    auto circuit = parse("S 0\nM 0");
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 1, 1),
+                        ContainsSubstring("requires a classifier, but the model has none") &&
+                            ContainsSubstring("before sampling"));
+}
+
+// =========================================================================
+// Precision cases (false-positive guards)
+// =========================================================================
+
+TEST_CASE("static_check: R restores a leaked qubit before MX -- no false positive") {
+    // A leaked qubit is always restored by R (leaked always restores),
+    // so MX after R meets only a Computational qubit.  Sampling must run.
+    auto model = model_with_leak_transition("S", 0.01);
+    auto circuit = parse("S 0\nR 0\nMX 0");
+
+    auto result = sample_noncomputational(circuit, model, 8, 1);
+    REQUIRE(result.shots == 8);
+    REQUIRE(result.measurements.size() == 8);
+}
+
+TEST_CASE("static_check: reset_restores_lost controls whether Lost survives R") {
+    // LOSS(0.5) on qubit 0: Lost is reachable.  M requires a classifier
+    // (no classifier provided); behavior depends on reset_restores_lost.
+
+    // Classifier-less model, no reset_restores_lost: Lost survives R, so
+    // M can meet a Lost qubit without a classifier -- rejects.
+    {
+        NonComputationalPolicy policy;
+        policy.reset_restores_lost = false;
+        auto model =
+            NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {}, std::nullopt, policy);
+        auto circuit = parse("H 0\nLOSS(0.5) 0\nR 0\nM 0");
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 1, 1),
+                            ContainsSubstring("requires a classifier, but the model has none"));
+    }
+
+    // With reset_restores_lost=true: R restores Lost to Computational,
+    // so M meets only a Computational qubit -- no classifier needed, samples.
+    {
+        NonComputationalPolicy policy;
+        policy.reset_restores_lost = true;
+        auto model =
+            NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {}, std::nullopt, policy);
+        auto circuit = parse("H 0\nLOSS(0.5) 0\nR 0\nM 0");
+        auto result = sample_noncomputational(circuit, model, 8, 1);
+        REQUIRE(result.shots == 8);
+        REQUIRE(result.measurements.size() == 8);
+    }
+}
+
+TEST_CASE("static_check: a zero-fire transition never adds leak to the reachable set") {
+    // A seepage-only transition (both computational columns zero) cannot
+    // fire on a Computational qubit; leak_e is never reachable from the
+    // initial state.  MX after S must sample cleanly.
+    std::vector<std::vector<double>> seep = zeros5();
+    seep[kE][kLeakE] = 1.0;  // leak_e -> e; computational columns zero
+    std::map<std::string, std::vector<std::vector<double>>> transitions{{"S", seep}};
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
+                                                  std::nullopt, NonComputationalPolicy{});
+    auto circuit = parse("S 0\nMX 0");
+
+    auto result = sample_noncomputational(circuit, model, 8, 1);
+    REQUIRE(result.shots == 8);
+    REQUIRE(result.measurements.size() == 8);
+}
+
+TEST_CASE("static_check: a leak on qubit 0 does not affect qubit 1's reachable set") {
+    // The 0.01-rate leak transition on S annotates qubit 0 only; qubit 1
+    // is a spectator.  MX on qubit 1 must sample cleanly.
+    auto model = model_with_leak_transition("S", 0.01);
+    auto circuit = parse("S 0\nMX 1");
+
+    auto result = sample_noncomputational(circuit, model, 8, 1);
+    REQUIRE(result.shots == 8);
+    REQUIRE(result.measurements.size() == 8);
+}

--- a/tests/test_noncomp_static_check.cc
+++ b/tests/test_noncomp_static_check.cc
@@ -180,3 +180,40 @@ TEST_CASE("static_check: a leak on qubit 0 does not affect qubit 1's reachable s
     REQUIRE(result.shots == 8);
     REQUIRE(result.measurements.size() == 8);
 }
+
+TEST_CASE("static check: a certain recapture retires the noncomputational member") {
+    // The qubit starts entirely on leak_e; the S hook's leak_e column
+    // recaptures to g with certainty, so MX always meets a computational
+    // qubit. The no-event branch of the leak_e source is unreachable, so
+    // the member must not survive the transition in the abstract walk.
+    auto m = zeros5();
+    m[kLeakE][kG] = 0.1;
+    m[kLeakE][kE] = 0.1;
+    m[kG][kLeakE] = 1.0;
+    auto model = NonComputationalModel::from_spec({0.0, 0.0, 0.0, 1.0, 0.0}, {{"S", m}},
+                                                  std::nullopt, NonComputationalPolicy{});
+    auto circuit = parse("S 0\nMX 0");
+
+    auto result = sample_noncomputational(circuit, model, 4, 1);
+    REQUIRE(result.shots == 4);
+    for (uint32_t shot = 0; shot < 4; ++shot) {
+        REQUIRE(result.final_status[shot] == QubitStatus::Computational);
+    }
+}
+
+TEST_CASE("static check: a re-leak after the certain recapture still rejects") {
+    // Same model, but a second S: after the certain recapture the
+    // computational columns leak again (rate 0.1), so at MX the leaked
+    // status is genuinely reachable and the pair must reject.
+    auto m = zeros5();
+    m[kLeakE][kG] = 0.1;
+    m[kLeakE][kE] = 0.1;
+    m[kG][kLeakE] = 1.0;
+    auto model = NonComputationalModel::from_spec({0.0, 0.0, 0.0, 1.0, 0.0}, {{"S", m}},
+                                                  std::nullopt, NonComputationalPolicy{});
+    auto circuit = parse("S 0\nS 0\nMX 0");
+
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 1, 1),
+                        ContainsSubstring("MX") && ContainsSubstring("not representable") &&
+                            ContainsSubstring("before sampling"));
+}


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Unsupported circuit/model pairs previously failed **seed-dependently mid-sampling**: an `MX`/`MY`/`MPP` whose operand the model can leak or lose rejects only on whichever shot first realizes the noncomputational status, and a classified measurement without a classifier likewise — at low rates, `sample(shots=N)` succeeded or raised by seed and discarded all completed shots.

- New `validate_static(annotated, model)` (src/clifft/noncomp/static_check.{h,cc}), wired into the driver's existing up-front validation: an abstract interpretation over per-qubit **sets of reachable statuses**. The design rule that keeps it honest: for ordinary nodes it loops each set member through the *same* primitives the concrete walk uses (`qubit_operands`, `operand_action`, `normal_post_op_status`) — there is no third encoding of the policy to drift. Annotations grow the sets by their reachable destinations (a zero-fire channel grows nothing, mirroring trace()'s elision); resets restore exactly the members the policy restores.
- Any member that would reject at runtime now rejects **before shot 0**, with the op index, qubit, gate, and the reachable status named ("can meet a leak_e qubit under this model and is not representable; rejecting before sampling"). The rewriter's lazy checks stay untouched as the guard for direct `rewrite_continuation` callers.
- Precision is pinned as hard as rejection: `S; R; MX` with a certain leak is **accepted** (leaked always restores), `LOSS; R; M` without a classifier rejects or samples exactly by `reset_restores_lost`, zero-fire channels don't poison reachability, and spectator qubits are untouched.
- `sample()`'s docstring stops over-promising: `max_rank` is enforced per continuation compile (not "before any state allocation"); contract violations are what fail before sampling begins.

One deliberate behavior change: pairs that previously *sometimes* sampled on lucky seeds now always reject — a sampler whose success depends on the seed was the footgun this removes.

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1055 cases (+7: 3 rejection + 4 precision)
- Python: 890 pass on both wheels (+2)
- Red/green: with the driver wiring commented out, the 3 rejection cases and the no-restore sub-case fail (the low-rate `MX` circuit samples cleanly on seed 1 — the exact seed-dependence being removed); precision cases pass either way
- Existing reject-path pins (C++ and Python) pass unchanged — the new messages keep their matched phrases
- Draw-stream fingerprints byte-identical to the base tip across all accepted configs (the pre-scan draws nothing)
- `pre-commit run --all-files` clean

## Review round — no-event-branch retirement

P1 (valid): the walk seeded `Computational` unconditionally and never retired a member whose jump away is certain, falsely rejecting a pure-`leak_e` initial whose transition recaptures to `g` with probability 1 before an `MX`. Both legs fixed under one uniform rule — **a member survives a stochastic channel only when its no-event branch is reachable**: the initial set carries `Computational` only when the model gives g/e mass; a transition replaces each member by its destinations, retaining the source only when its column leaves no-fire mass (`column_sum < 1`, exact after construction's clamping); `LOSS(p)` retains computational/leaked members only when `p < 1`. The reviewer's reproducer now samples identically to base, and its over-removal dual (a second `S` re-leaks from the computational columns, so `MX` must still reject) is pinned at both layers. Suites: C++ 1057×2, Python 892×2, streams identical, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)