### PR TITLE
feat(noncomp)!: classify single-qubit X/Y readout on vacated carriers

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -455,10 +455,10 @@ and qubit; no silent approximation.
 | Single-qubit Pauli noise | apply         | drop                                    | drop                                              |
 | Correlated-error chain (`E`/`ELSE_CORRELATED_ERROR`) | apply | apply | apply |
 | Two-qubit gate           | apply         | drop                                    | drop                                              |
-| MPP / multi-target meas  | apply         | reject                                  | reject                                            |
+| MPP / multi-target meas  | apply         | reject (up-front gate A)                | reject (up-front gate A)                         |
 | Visible Z-basis meas `M`              | apply; visible outcome from the SVM | classifier; reject probability per `leak_*` column | classifier; reject probability per `lost` column |
 | Visible Z-basis meas-and-reset `MR`   | apply; visible outcome from the SVM, reset re-prepares the site | classifier; restores if `reset_restores_lost` would allow it (leaked always restores) | classifier; restores if `reset_restores_lost`, else the site stays lost |
-| Visible X/Y-basis meas (`MX`/`MY`)    | apply | reject | reject |
+| Visible X/Y-basis meas (`MX`/`MY`)    | apply | classifier; same cell as `M` — readout basis is incidental on a vacated carrier | classifier; same cell as `M` |
 | Visible X/Y-basis meas-and-reset (`MRX`/`MRY`) | apply | classifier; restores (leaked always restores) | classifier; restores if `reset_restores_lost`, else the site stays lost |
 | Reset `R`/`RX`/`RY`      | apply         | restore to `Computational` | drop unless `policy.reset_restores_lost` is set; then restore to `Computational` |
 | Detector / Observable    | unchanged     | unchanged                               | unchanged                                         |
@@ -467,13 +467,20 @@ Notes:
 
 - An operation with no representable effect on a leaked or lost operand
   is dropped whole (identity on the surviving operands). This is the
-  only behavior, not a policy the caller selects. The exception is a
-  non-reset X/Y-basis measurement (`MX`/`MY`) or a multi-target/parity
-  measurement (`MPP`): it rejects, because the classifier defines a
-  single Z-basis-like record bit that is not a faithful X/Y or parity
-  outcome. A measure-and-reset (`MR`/`MRX`/`MRY`) is kept instead — its
-  record is the classifier bit and its reset re-prepares the site, so
-  the readout basis is incidental on a vacated carrier.
+  only behavior, not a policy the caller selects. Single-qubit
+  measurements (`M`, `MX`, `MY`) classify: on a vacated carrier the
+  readout basis is incidental, so the classifier's single record bit is
+  equally valid for Z-, X-, or Y-basis forms. A measure-and-reset
+  (`MR`/`MRX`/`MRY`) is kept the same way, with the reset additionally
+  re-preparing the site. The exception is a multi-qubit parity
+  measurement (`MPP`): it spans more than one qubit and has no faithful
+  single-bit substitution, so it is rejected before sampling begins
+  when the model is capable (gate A). The supported workaround is an
+  explicit ancilla circuit — the ancilla ladder gates drop on the
+  vacated operand, yielding the survivors' parity. A model that can
+  leak or lose qubits also requires a classifier when the circuit
+  measures (gate B); both checks are capability boundaries, not
+  per-qubit reachability analyses.
 - A correlated-error chain is never dropped, whatever its operands'
   statuses: each member must keep its slot in the else-conditioning
   (dropping the head would orphan the later members; dropping a middle
@@ -566,15 +573,17 @@ turn it off. Concretely:
 - non-restoring lost-qubit measure-and-reset: kept — the visible record
   slot must survive, the classifier supplies the bit, and the site
   simply stays lost;
-- a non-reset X/Y-basis or multi-target measurement (`MX`/`MY`/`MPP`)
-  rejects: dropping a measurement would shift the record, and no
-  single-bit substitution is a faithful X/Y or parity outcome.
+- single-qubit measurement (`M`, `MX`, `MY`) on a Leaked or Lost
+  operand: classifies — the readout basis is incidental on a vacated
+  carrier; all three forms map to the same classifier record bit;
+- multi-qubit parity measurement (`MPP`) with any Leaked or Lost
+  operand: rejected up front (gate A) before sampling begins, because
+  no single-bit substitution faithfully represents a parity outcome;
+  the supported workaround is an explicit ancilla expansion.
 
-A "does this model ever drive a dead qubit" contract check — distinct
-from these per-op representability limits — is a static validator's job
-(a future `noncomp.validate_static`), not a sampling policy: as a
-sampling-time reject it would fire seed-dependently, since whether a
-qubit is vacated before a given op is a per-shot draw.
+Capability contract checks (gate A — parity under capable model; gate
+B — no classifier when capable and measuring) run up front, before the
+first shot, as a capability boundary rather than per-qubit reachability.
 
 A dropped operation has no physical effect, so a surviving operand's
 status keeps its entry value (it is not demoted). Transition

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -442,6 +442,96 @@ bool equal_modulo_forced_swap(const Instruction& fresh, const Instruction& execu
     return std::memcmp(&swapped, &executed, sizeof(Instruction)) == 0;
 }
 
+// Up-front capability contract for the annotated circuit and model.
+//
+// This is a capability boundary, not a reachability analysis: a model that
+// can leak or lose qubits triggers both gate checks regardless of whether
+// any vacated qubit actually reaches a measurement in a given circuit. The
+// deliberate bluntness is a feature — it catches mismatches early and keeps
+// the contract independent of per-shot randomness.
+//
+// Gate A: parity measurements (MPP — MXX/MYY/MZZ desugar to MPP at parse
+// time) span multiple qubits and have no faithful single-bit classifier
+// substitution, so they are rejected up front when the model is capable.
+//
+// Gate B: a model that can leak or lose qubits requires a classifier when
+// the circuit has any measurements, because the classifier is the only
+// defined mapping from a noncomputational level to a record bit.
+void validate_model_contract(const Circuit& annotated, const NonComputationalModel& model) {
+    // Determine whether the model can ever produce a noncomputational qubit.
+    bool noncomp_capable = false;
+    for (const Level l : kAllLevels) {
+        if (category(l) != LevelCategory::Computational && model.initial_probability(l) > 0.0) {
+            noncomp_capable = true;
+            break;
+        }
+    }
+    if (!noncomp_capable) {
+        for (uint32_t i = 0; i < static_cast<uint32_t>(annotated.nodes.size()); ++i) {
+            const AstNode& node = annotated.nodes[i];
+            if (node.gate == GateType::LOSS && !node.args.empty() && node.args[0] > 0.0) {
+                noncomp_capable = true;
+                break;
+            }
+            if (node.gate == GateType::LEVEL_TRANSITION) {
+                const TransitionInstrument* instr = model.transition_named(node.tag);
+                if (instr == nullptr) {
+                    // Unresolvable tags were rejected by the annotation
+                    // validation loop that runs before this helper; the
+                    // null check is defensive for direct callers.
+                    continue;
+                }
+                for (const Level src : kAllLevels) {
+                    if (category(src) != LevelCategory::Computational) {
+                        continue;
+                    }
+                    for (const Level dst : kAllLevels) {
+                        if (category(dst) != LevelCategory::Computational &&
+                            instr->prob(dst, src) > 0.0) {
+                            noncomp_capable = true;
+                            break;
+                        }
+                    }
+                    if (noncomp_capable) {
+                        break;
+                    }
+                }
+            }
+            if (noncomp_capable) {
+                break;
+            }
+        }
+    }
+
+    if (!noncomp_capable) {
+        return;
+    }
+
+    // Gate A: parity measurements are not supported under a capable model.
+    for (uint32_t i = 0; i < static_cast<uint32_t>(annotated.nodes.size()); ++i) {
+        const AstNode& node = annotated.nodes[i];
+        // MPP has MULTI arity; MXX/MYY/MZZ desugar to MPP at parse time.
+        if (node.gate == GateType::MPP) {
+            throw std::invalid_argument(
+                "sample_noncomputational: parity measurement 'MPP' at op " + std::to_string(i) +
+                " is not supported under a model that can leak or lose qubits;"
+                " expand the parity readout into an explicit ancilla circuit");
+        }
+    }
+
+    // Gate B: a classifier is required when the circuit has any measurements.
+    if (model.classifier() == nullptr) {
+        for (const AstNode& node : annotated.nodes) {
+            if (is_measurement(node.gate)) {
+                throw std::invalid_argument(
+                    "sample_noncomputational: this model can leak or lose qubits and the circuit"
+                    " measures; a classifier is required to define what a measurement of a leaked"
+                    " or lost qubit reads");
+            }
+        }
+    }
+}
+
 }  // namespace
 
 NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
@@ -475,6 +565,12 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             resolve_annotation(node, model, op_index);
         }
     }
+
+    // Capability contract: check gate A (parity measurements unsupported
+    // with a capable model) and gate B (classifier required when the model
+    // is capable and the circuit measures). Runs after annotation resolution
+    // so LEVEL_TRANSITION tags are already validated.
+    validate_model_contract(annotated, model);
 
     const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
 

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -442,21 +442,12 @@ bool equal_modulo_forced_swap(const Instruction& fresh, const Instruction& execu
     return std::memcmp(&swapped, &executed, sizeof(Instruction)) == 0;
 }
 
-// Up-front capability contract for the annotated circuit and model.
+// Validate that the circuit is compatible with the model's leak/loss
+// semantics. When the model can produce noncomputational qubits at all
+// (no per-qubit tracking), the current restrictions are:
 //
-// This is a capability boundary, not a reachability analysis: a model that
-// can leak or lose qubits triggers both gate checks regardless of whether
-// any vacated qubit actually reaches a measurement in a given circuit. The
-// deliberate bluntness is a feature — it catches mismatches early and keeps
-// the contract independent of per-shot randomness.
-//
-// Gate A: parity measurements (MPP — MXX/MYY/MZZ desugar to MPP at parse
-// time) span multiple qubits and have no faithful single-bit classifier
-// substitution, so they are rejected up front when the model is capable.
-//
-// Gate B: a model that can leak or lose qubits requires a classifier when
-// the circuit has any measurements, because the classifier is the only
-// defined mapping from a noncomputational level to a record bit.
+// - parity measurements (MPP) are not supported; the circuit is rejected.
+// - a classifier is required if the circuit has any measurements.
 void validate_model_contract(const Circuit& annotated, const NonComputationalModel& model) {
     // Determine whether the model can ever produce a noncomputational qubit.
     bool noncomp_capable = false;
@@ -544,10 +535,6 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     result.num_measurements = circuit.num_measurements;
     result.num_detectors = circuit.num_detectors;
     result.num_observables = circuit.num_observables;
-    if (shots == 0) {
-        return result;
-    }
-
     const MeasurementClassifier* classifier = model.classifier();
     const bool ternary = classifier != nullptr && classifier->has_herald();
 
@@ -571,6 +558,12 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     // is capable and the circuit measures). Runs after annotation resolution
     // so LEVEL_TRANSITION tags are already validated.
     validate_model_contract(annotated, model);
+
+    // Validation is shot-count independent: a zero-shot call checks the
+    // circuit/model contract and returns empty results.
+    if (shots == 0) {
+        return result;
+    }
 
     const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
 

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -143,10 +143,9 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
 
     if (!drop_op) {
         if (classified_level.has_value()) {
-            // The policy pre-scan admits only single-qubit Z-basis
-            // measurement forms here (M and the measure-and-resets);
-            // X/Y-basis and multi-target measurements on a
-            // noncomputational operand reject above.
+            // The policy pre-scan admits single-qubit measurement forms
+            // M, MX, MY, and the measure-and-resets; multi-qubit parity
+            // measurements (MPP) on a noncomputational operand reject above.
             const uint32_t qubit = qubit_operands(node).front().qubit;
             const MeasurementClassifier& classifier = classifier_for(model, gate, op_index, qubit);
             const bool ternary = classifier.has_herald();

--- a/src/clifft/noncomp/status_step.cc
+++ b/src/clifft/noncomp/status_step.cc
@@ -41,22 +41,26 @@ OperandAction operand_action(GateType gate, QubitStatus status,
     // recorded outcome is supplied by the model's classifier downstream, so
     // the operation is kept: the record slot survives, and the site either
     // restores (leaked always; lost when the policy opts in) or simply stays
-    // lost. This admits the X/Y-basis forms (MRX/MRY) too: on a vacated
-    // carrier the classifier readout is basis-agnostic and the reset -- not
-    // the readout -- is the operation's effect. A non-reset X/Y measurement
-    // has no such reset and no faithful record bit, and rejects.
+    // lost. This admits the X/Y-basis forms (MRX/MRY): on a vacated carrier
+    // the classifier readout is basis-agnostic — the reset, not the readout,
+    // is the operation's effect.
     if (is_measure_reset(gate)) {
         return OperandAction::Apply;
     }
     // A plain measurement keeps its visible record slot so the record and its
     // rec[-k] references do not shift; on a leaked/lost qubit the outcome is
-    // supplied by the model's classifier downstream. That substitution is a
-    // single record bit, faithful only for a Z-basis M. An X/Y-basis (MX/MY)
-    // or multi-qubit-parity (MPP) measurement has no faithful single-bit form
-    // on a noncomputational operand, so it is not representable and rejects.
-    // This is a representability limit, not a policy choice.
+    // supplied by the model's classifier downstream. The classifier substitutes
+    // a single record bit — the readout basis is incidental on a vacated
+    // carrier, so Z-basis M, X-basis MX, and Y-basis MY are all equivalent
+    // from the model's perspective and all classify. A multi-qubit parity
+    // measurement (MPP, MXX, MYY, MZZ) spans more than one qubit and has no
+    // faithful single-bit substitution on a noncomputational operand; it
+    // rejects. MXX/MYY/MZZ desugar to MPP at parse time, so only MPP can
+    // appear here.
     if (is_measurement(gate)) {
-        return gate == GateType::M ? OperandAction::Apply : OperandAction::Reject;
+        return (gate == GateType::M || gate == GateType::MX || gate == GateType::MY)
+                   ? OperandAction::Apply
+                   : OperandAction::Reject;
     }
     // A reset restores a leaked qubit always, a lost qubit only by policy. A
     // non-restoring lost-qubit reset acts on a vacated site, so it drops.

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -132,12 +132,15 @@ class Model:
 
     An operation with no representable effect on a leaked or lost operand --
     e.g. a two-qubit gate onto a vacated site -- is dropped, acting as the
-    identity on the surviving operands. Measurements keep their record slot
-    (the classifier supplies the bit); a non-reset X/Y-basis measurement
-    (``MX``/``MY``) or a multi-qubit-parity measurement (``MPP``) of a leaked
-    or lost qubit has no faithful single-bit form and raises. A
-    measure-and-reset (``MR``/``MRX``/``MRY``) is kept instead -- its reset
-    re-prepares the site and the classifier supplies its record bit.
+    identity on the surviving operands. Single-qubit measurements (``M``,
+    ``MX``, ``MY``) keep their record slot; on a vacated carrier the readout
+    basis is incidental and the classifier supplies the bit. A
+    measure-and-reset (``MR``/``MRX``/``MRY``) is kept the same way, with
+    the reset additionally re-preparing the site. Parity measurements
+    (``MPP``) are not supported when the model can leak or lose qubits — they
+    have no faithful single-bit classifier substitution — and raise before
+    sampling begins. A model that can leak or lose qubits also requires a
+    classifier when the circuit measures.
 
     Construction validates shapes, probabilities, gate keys, policy values,
     and level table consistency in C++, raising ``ValueError`` on any
@@ -256,14 +259,19 @@ def sample(
     """Sample ``circuit`` under ``model`` for ``shots`` shots.
 
     ``circuit`` is a parsed ``clifft.Circuit`` or a Stim-format string. Returns a
-    :class:`NonComputationalSample`. Raises ``ValueError`` when the trajectory
-    policy rejects an operation, when a leaked/lost measurement needs a
-    classifier the model lacks, or when a classifier column is unsupported.
+    :class:`NonComputationalSample`. Single-qubit measurements (``M``, ``MX``,
+    ``MY``) of a leaked or lost qubit read the classifier; the readout basis is
+    incidental on a vacated carrier. A model that can leak or lose qubits
+    requires a classifier when the circuit measures, and parity measurements
+    (``MPP``) are not supported with such models — both are rejected before
+    sampling begins. Raises ``ValueError`` when one of these contracts is
+    violated, when a classifier column is unsupported, or when an operation
+    has no representable effect on a noncomputational operand.
 
-    ``max_rank`` caps the compiled peak rank under
-    exact-mode compilation: it fails with the offending
-    circuit line named, before any state allocation, instead of attempting
-    a ``2**k`` allocation. Unlimited when ``None``.
+    ``max_rank`` caps the compiled peak rank under exact-mode compilation;
+    the cap is enforced at each continuation compile, failing with the
+    offending circuit line named instead of attempting a ``2**k``
+    allocation. Unlimited when ``None``.
     """
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -422,16 +422,19 @@ def test_a_multi_round_circuit_runs_through_loss():
     assert np.all(r.final_status[:, 0] == LOST_KIND)
 
 
-def test_xy_basis_measurement_of_a_lost_qubit_raises():
-    """An X/Y-basis or parity measurement of a leaked or lost qubit has no
-    faithful single-bit form, so it raises -- a representability limit, not a
-    policy the caller can turn off."""
+def test_mx_measurement_of_a_lost_qubit_classifies():
+    """An X-basis measurement of a lost qubit reads the classifier bit.
+
+    On a vacated carrier the readout basis is incidental; MX classifies
+    identically to M.  The lost column [0.0, 1.0] is deterministic 1."""
     circuit = "S 0\nMX 0\n"
     transitions = {"S": transition_to(LOST)}
     classifier = classifier_for(LOST, [0.0, 1.0])
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
-    with pytest.raises(ValueError, match="representable"):
-        noncomp.sample(circuit, model, shots=4, seed=2)
+    r = noncomp.sample(circuit, model, shots=8, seed=2)
+    assert r.num_measurements == 1
+    assert (r.measurements[:, 0] == 1).all()
+    assert (r.final_status[:, 0] == LOST_KIND).all()
 
 
 def test_zero_fire_loss_before_firing_loss_samples_cleanly():
@@ -543,9 +546,12 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_restoring_reset():
     overwritten by the restoring reset, so the restored qubit reads a clean
     |0>. Had the qubit never been lost, the same X would flip a live qubit
     and the record would read 1, so a passing 0 proves the loss happened."""
+    # A classifier is required when the model is capable and the circuit
+    # measures; the identity columns carry no readout confusion here.
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
+        classifier=classifier_for(LOST, [1.0, 0.0]),
         reset_restores_lost=True,
     )
     result = noncomp.sample("S 0\nE(1) X0\nR 0\nM 0", model, shots=16, seed=11)
@@ -570,3 +576,72 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_recapture():
     assert np.all(result.measurements[:, 0] == 0)  # classified while leaked
     assert np.all(result.measurements[:, 1] == 1)  # recaptured to e
     assert (result.final_status[:, 0] == COMPUTATIONAL).all()
+
+
+# --- MX / MY classify on vacated carriers ------------------------------------
+
+
+def test_mx_classified_deterministic():
+    """MX on a certainly-lost qubit reads the classifier's lost column.
+
+    The lost column [0.0, 1.0] is deterministic 1."""
+    circuit = "S 0\nMX 0\n"
+    transitions = {"S": transition_to(LOST)}
+    classifier = classifier_for(LOST, [0.0, 1.0])
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
+    r = noncomp.sample(circuit, model, shots=8, seed=201)
+    assert r.num_measurements == 1
+    assert (r.measurements[:, 0] == 1).all()
+    assert (r.final_status[:, 0] == LOST_KIND).all()
+
+
+def test_mx_inverted_complements_classifier_bit():
+    """MX !0 on a certainly-lost qubit produces the complement of the classifier bit."""
+    circuit = "S 0\nMX !0\n"
+    transitions = {"S": transition_to(LOST)}
+    classifier = classifier_for(LOST, [0.0, 1.0])  # lost column: always 1 without inversion
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
+    r = noncomp.sample(circuit, model, shots=8, seed=203)
+    assert (r.measurements[:, 0] == 0).all()  # inverted: 1 -> 0
+
+
+# --- Gate B error (classifier required) --------------------------------------
+
+
+def test_gate_b_capable_model_with_measurement_no_classifier_raises():
+    """A model that can lose qubits requires a classifier when the circuit measures."""
+    transitions = {"S": transition_to(LOST)}
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions)
+    # The circuit uses the "S" hook so the annotated circuit has a
+    # LEVEL_TRANSITION node that fires into the noncomp category.
+    with pytest.raises(ValueError, match="classifier is required"):
+        noncomp.sample("H 0\nS 0\nM 0\n", model, shots=4, seed=4)
+
+
+# --- Gate A error (MPP unsupported under capable model) ----------------------
+
+
+def test_gate_a_mpp_under_capable_model_raises():
+    """MPP is not supported when the model can leak or lose qubits."""
+    transitions = {"S": transition_to(LOST)}
+    classifier = classifier_for(LOST, [0.5, 0.5])
+    model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
+    with pytest.raises(ValueError, match="not supported"):
+        noncomp.sample("S 0\nMPP Z0*Z1\n", model, shots=4, seed=5)
+
+
+# --- Memory-X smoke -----------------------------------------------------------
+
+
+def test_memory_x_smoke():
+    """A stim-style memory-X circuit ending in MX on two data qubits samples cleanly."""
+    # Low-rate loss; data qubits measured in X basis at the end.
+    loss_col = [0.0, 1.0]  # lost reads 1
+    classifier = classifier_for(LOST, loss_col)
+    model = noncomp.Model(initial_state=ALL_G, transitions={}, classifier=classifier)
+    # Trivial memory-X: two X-basis initialisations, final MX measurement.
+    r = noncomp.sample("RX 0 1\nMX 0 1\n", model, shots=16, seed=207)
+    assert r.num_measurements == 2
+    assert r.measurements.shape == (16, 2)
+    # All computational (no loss here); X-basis reset then MX reads 0.
+    assert (r.measurements == 0).all()

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -645,3 +645,11 @@ def test_memory_x_smoke():
     assert r.measurements.shape == (16, 2)
     # All computational (no loss here); X-basis reset then MX reads 0.
     assert (r.measurements == 0).all()
+
+
+def test_contract_validated_for_zero_shots():
+    """Validation is shot-count independent: shots=0 still rejects a
+    leak-capable model that measures without a classifier."""
+    model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
+    with pytest.raises(ValueError, match="classifier is required"):
+        noncomp.sample("S 0\nM 0", model, shots=0, seed=1)

--- a/tests/python/test_noncomp_examples.py
+++ b/tests/python/test_noncomp_examples.py
@@ -92,15 +92,15 @@ def test_example_relaxation_to_ground_on_known_qubit():
 # --- Intentionally unsupported -----------------------------------------------
 
 
-def test_reject_xy_measurement_on_noncomputational_qubit():
-    # Once qubit 0 is leaked, its downstream gates drop, but an X/Y-basis (or
-    # parity) measurement of it has no faithful single-bit form and is refused
-    # -- a representability limit, not a policy the caller can turn off.
+def test_reject_parity_measurement_under_capable_model():
+    # A parity measurement (MPP) is not supported when the model can leak
+    # or lose qubits, rejected before sampling begins.
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={
             "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
         },
+        classifier=noncomp.Classifier(["0", "1"], [[1.0] * 5, [0.0] * 5]),
     )
-    with pytest.raises(ValueError, match="not representable"):
-        noncomp.sample("H 0\nS 0\nMX 0\n", model, shots=8, seed=5)
+    with pytest.raises(ValueError, match="not supported"):
+        noncomp.sample("H 0\nS 0\nMPP Z0*Z1\n", model, shots=8, seed=5)

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -1005,3 +1005,20 @@ TEST_CASE(
     REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
                         ContainsSubstring("classifier is required"));
 }
+
+TEST_CASE("exact: the model contract is validated even for zero shots") {
+    // Validation is shot-count independent: a zero-shot call still checks
+    // the circuit/model contract, and a valid pair returns empty results.
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+    auto no_classifier = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
+                                                          std::nullopt, NonComputationalPolicy{});
+    REQUIRE_THROWS_WITH(sample_noncomputational(parse("S 0\nM 0"), no_classifier, 0, 1),
+                        ContainsSubstring("classifier is required"));
+
+    auto valid = make_lose_model();
+    auto result = sample_noncomputational(parse("S 0\nM 0"), valid, 0, 1);
+    REQUIRE(result.shots == 0);
+    REQUIRE(result.measurements.empty());
+}

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -792,3 +792,216 @@ TEST_CASE("exact: E(1) X0 X1 with no loss applies X to both qubits") {
         REQUIRE(result.measurements[shot * 2 + 1] == 1);  // X1 applied
     }
 }
+
+// =========================================================================
+// MX / MY classify on vacated carriers
+// =========================================================================
+
+namespace {
+
+// Classifier whose lost column is col (binary), g=0, e=1 faithful,
+// leak columns deterministic symbol 0.
+NonComputationalModel make_classify_lost_model(std::vector<double> lost_col,
+                                               bool with_hook = false) {
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    transitions.emplace("lose", lose);
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    // g=0, e=1, leak_g=0, leak_e=0, lost=lost_col
+    classifier.matrix = {{1.0, 0.0, 1.0, 1.0, lost_col[0]}, {0.0, 1.0, 0.0, 0.0, lost_col[1]}};
+    (void)with_hook;
+    NonComputationalPolicy policy;
+    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions, classifier,
+                                            policy);
+}
+
+}  // namespace
+
+TEST_CASE("exact: MX on a certainly-lost qubit reads the classifier bit") {
+    // lose column [0, 1]: the lost qubit reads 1 every shot; final status Lost.
+    auto model = make_classify_lost_model({0.0, 1.0});
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX 0");
+    auto result = sample_noncomputational(circuit, model, 20, 101);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: MY on a certainly-lost qubit reads the classifier bit") {
+    // Identical semantics to MX: the readout basis is incidental on a vacated carrier.
+    auto model = make_classify_lost_model({0.0, 1.0});
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMY 0");
+    auto result = sample_noncomputational(circuit, model, 20, 103);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: inverted MX !0 on a lost qubit complements the classifier bit") {
+    // lose column [0, 1]: classifier says 1; inversion flips to 0 every shot.
+    auto model = make_classify_lost_model({0.0, 1.0});
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX !0");
+    auto result = sample_noncomputational(circuit, model, 20, 105);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);  // inverted: 1 -> 0
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: ternary herald column on MX sets sidecar flag and patches record") {
+    // Three-symbol classifier for the lost level: {0, 0, 1} always heralds.
+    // The herald flag must be 1 on every shot; the record carries an
+    // unbiased bit (matches the existing M-herald test in make_lose_model).
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 3;
+    // lost column = {0, 0, 1}: always heralds. g/e/leak columns symbol 0.
+    classifier.matrix = {
+        {1.0, 0.0, 1.0, 1.0, 0.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 1.0}};
+
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+                                                  classifier, policy);
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX 0");
+    auto result = sample_noncomputational(circuit, model, 40, 107);
+    for (uint32_t shot = 0; shot < 40; ++shot) {
+        REQUIRE(result.heralds[shot] == 1);
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: computational X-basis behavior is untouched by MX classify change") {
+    // RX prepares |+>; MX measures in the X basis and records 0 deterministically.
+    // No noncomputational model capability: the classifier path must never fire.
+    ModelSpec spec;  // all computational
+    auto model = make_model(spec);
+    auto circuit = parse("RX 0\nMX 0");
+    auto result = sample_noncomputational(circuit, model, 20, 109);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);
+        REQUIRE(result.final_status[shot] == QubitStatus::Computational);
+    }
+}
+
+TEST_CASE("exact: memory-X smoke: two qubits, low-rate leak hook, MX measures both") {
+    // The motivating use case: a stim-style memory-X circuit that ends in MX
+    // on data qubits runs cleanly under a leakage model.
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLost][0] = 0.01;  // low-rate loss from g
+    leak[kLost][1] = 0.01;
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 1.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+                                                  classifier, policy);
+    auto circuit = parse("RX 0 1\nLEVEL_TRANSITION[leak] 0 1\nMX 0 1");
+    auto result = sample_noncomputational(circuit, model, 50, 111);
+    REQUIRE(result.shots == 50);
+    REQUIRE(result.num_measurements == 2);
+    // Shape check: result exists with the right dimensions.
+    REQUIRE(result.measurements.size() == 100u);
+    REQUIRE(result.final_status.size() == 100u);
+}
+
+// =========================================================================
+// Up-front capability contract (gate A and gate B)
+// =========================================================================
+
+TEST_CASE("exact: gate A: capable model + MPP rejects before sampling") {
+    // A capable model (non-zero loss) plus an MPP measurement must throw
+    // before any shots are drawn, with a message naming 'MPP', 'not supported',
+    // and 'ancilla'.
+    auto model = make_classify_lost_model({0.5, 0.5});
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMPP X0*X1");
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
+                        ContainsSubstring("MPP") && ContainsSubstring("not supported") &&
+                            ContainsSubstring("ancilla"));
+}
+
+TEST_CASE("exact: gate A: non-capable model + MPP samples fine") {
+    // A model with no capability (initial all-g, no leak/loss transitions)
+    // does not trigger gate A, so MPP is accepted.
+    ModelSpec spec;  // all computational
+    auto model = make_model(spec);
+    auto circuit = parse("H 0\nCX 0 1\nMPP Z0*Z1");
+    auto result = sample_noncomputational(circuit, model, 10, 1);
+    REQUIRE(result.shots == 10);
+    // ZZ stabilizer on Bell state: all 0.
+    for (uint32_t shot = 0; shot < 10; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);
+    }
+}
+
+TEST_CASE("exact: gate B: capable model + measurement + no classifier throws") {
+    // A model with a LEVEL_TRANSITION annotation that can fire into a
+    // noncomputational level, paired with a measurement, must throw when
+    // no classifier is present.
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+                                                  std::nullopt, policy);
+    // The annotation makes the circuit capable.
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nM 0");
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
+                        ContainsSubstring("classifier is required"));
+}
+
+TEST_CASE("exact: gate B: capable model + measurement-free circuit + no classifier samples") {
+    // A capable model without a classifier is fine if the circuit has no measurements.
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+                                                  std::nullopt, policy);
+    // Circuit has no measurement nodes.
+    auto circuit = parse("H 0\nLEVEL_TRANSITION[lose] 0");
+    auto result = sample_noncomputational(circuit, model, 10, 1);
+    REQUIRE(result.shots == 10);
+}
+
+TEST_CASE("exact: gate B: non-capable model + MX + no classifier samples") {
+    // A non-capable model (no loss/leak transitions, all-g initial) plus
+    // MX requires no classifier: gate B does not fire.
+    ModelSpec spec;  // all computational, no loss
+    auto model = make_model(spec);
+    auto circuit = parse("RX 0\nMX 0");
+    auto result = sample_noncomputational(circuit, model, 10, 1);
+    REQUIRE(result.shots == 10);
+    for (uint32_t shot = 0; shot < 10; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);
+    }
+}
+
+TEST_CASE(
+    "exact: bluntness pin -- model leaks only q0 via annotation, circuit measures only q1, "
+    "no classifier throws") {
+    // The contract is a capability boundary, not per-qubit reachability.
+    // The annotation on q0 makes the model capable; q1 is measured but
+    // never touches a vacated carrier in any reachable shot. Gate B still
+    // fires because the capability boundary is coarse: capable model +
+    // any measurement = classifier required.
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;  // q0 loses certainly from g
+    lose[kLost][1] = 1.0;
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+                                                  std::nullopt, policy);
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0\nM 1");
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
+                        ContainsSubstring("classifier is required"));
+}

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -186,8 +186,10 @@ TEST_CASE("sample_noncomputational: a measurement on a leaked qubit without a cl
     transitions.emplace("S", always_leaked());
     NonComputationalModel model = make_model(all_g(), std::move(transitions));  // no classifier
 
+    // The up-front gate B check fires before any shot: capable model +
+    // measurement without a classifier.
     REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 16, 1),
-                        ContainsSubstring("requires a classifier"));
+                        ContainsSubstring("classifier is required"));
 }
 
 TEST_CASE("sample_noncomputational: a four-symbol classifier rejects at construction") {

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -273,14 +273,20 @@ TEST_CASE("rewrite: a non-restoring lost reset drops; reset_restores_lost keeps 
     REQUIRE(rw_keep.final_status[0] == clifft::QubitStatus::Computational);
 }
 
-TEST_CASE("rewrite: an X/Y-basis measurement of a noncomputational qubit rejects") {
-    // No faithful single-bit form on a leaked/lost operand: a
-    // representability limit, not a policy choice, so it rejects even though
-    // drop is the only op policy.
+TEST_CASE("rewrite: an X-basis measurement of a noncomputational qubit classifies") {
+    // On a vacated carrier the readout basis is incidental: MX classifies
+    // exactly like M, substituting a MPAD+READOUT_NOISE for the original MX.
     Circuit c = parse("MX 0\n");
-    NonComputationalModel model = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(c, model, {kLeakG}),
-                        ContainsSubstring("MX") && ContainsSubstring("representable"));
+    NonComputationalModel model =
+        make_model_with_classifier({}, classifier_with(kLost, {0.5, 0.5}));
+    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    REQUIRE(count_gate(rw.circuit, GateType::MX) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
+    REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
+    REQUIRE(rw.circuit.num_measurements == 1);
+    REQUIRE(rw.classified_measurements.size() == 1);
+    REQUIRE(rw.classified_measurements[0].slot == 0);
+    REQUIRE(rw.classified_measurements[0].level == Level::Lost);
 }
 
 // =========================================================================
@@ -418,10 +424,10 @@ TEST_CASE("rewrite: a noncomputational measurement without a classifier rejects"
     REQUIRE_THROWS_WITH(rewritten(c, model, {kLost}), ContainsSubstring("requires a classifier"));
 }
 
-TEST_CASE("rewrite: an X/Y-basis or multi-qubit measurement on a lost qubit rejects") {
+TEST_CASE("rewrite: a parity measurement on a lost qubit rejects") {
+    // MPP has no faithful single-bit substitution on a noncomputational
+    // operand, so it rejects. MX and MY classify (tested separately).
     NonComputationalModel model = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(parse("MX 0\n"), model, {kLost}),
-                        ContainsSubstring("MX") && ContainsSubstring("Lost"));
     REQUIRE_THROWS_WITH(rewritten(parse("MPP X0\n"), model, {kLost}),
                         ContainsSubstring("MPP") && ContainsSubstring("Lost"));
 }


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

Supersedes #190 (closed unmerged). Review of that PR established that a static reachability scan cannot be both cheap and complete — and that the reject class it policed was the real problem.

## Summary

- **Non-reset `MX`/`MY` on a vacated (leaked/lost) qubit now classify, exactly like `M`**: record bit from the classifier column, with ternary herald columns and record-target inversion (`MX !0`) via the shared classified-measurement mechanics; status unchanged. The justification is the design's own basis-agnosticity argument, previously applied only to `MRX`/`MRY`: a vacated carrier has no basis for the readout to disagree with. Z-basis computational readout-confusion stays `M`/`MR`-only; computational-qubit `MX` behavior is untouched (pinned).
- This unblocks the motivating category: stim-style memory-X circuits (`RX`/`MX` data readout) now run under leakage models end to end (smoke-tested), where previously they failed on whichever shot first realized a leak.
- **The unsupported remainder becomes two explicit, deliberately coarse contracts** checked up front in the driver (no reachability analysis, no per-qubit tracking):
  - a leak/loss-**capable** model (noncomputational initial mass, any `LOSS(p>0)`, or any transition entry from a computational source into a noncomputational level) that **measures anything** requires a classifier;
  - `MPP` is **not supported** under capable models — the error names the op and points at the supported route: expand the parity readout into an explicit ancilla circuit, whose ladder gates drop on vacated operands and yield the survivors' parity (also the documented future semantics if built-in support is ever wanted).
  - Bluntness is the contract and is pinned by test: a model that leaks only unmeasured qubits still requires a classifier. The lazy rewriter checks remain as defense-in-depth for direct callers.
- With classification plus these gates, **no seed-dependent reject remains reachable through the public API** — the footgun that motivated the reachability scan is gone without the scan.
- Docs: §5.2 table row + notes rewritten (classify rule, `MPP` capability boundary, classifier contract); `sample()`/`Model` docstrings updated, including the honest `max_rank` wording (enforced per continuation compile).

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1060 cases (+12: MX/MY/inverted/herald/computational-untouched/memory-X pins, both gates positive and negative, bluntness pin)
- Python: 893 pass on both wheels (+5)
- Red/green: with only the `operand_action` change reverted, the new MX/MY tests fail with the old "not representable" rejection; restored, all green
- Draw-stream fingerprints byte-identical to the base tip across all baseline configs (none use `MX`/`MY`/`MPP`)
- `pre-commit run --all-files` clean

## Review round

- The contract helper's comment is condensed to the two current restrictions, per review wording.
- `shots=0` previously returned before validation ran, so it accepted pairs that `shots=1` rejects (reviewer's reproducer). The zero-shot early return now sits after the up-front validation — validation is shot-count independent, and `shots=0` doubles as a dry-run contract check returning empty results. Pinned at both layers (the reproducer shape in Python; C++ also pins the valid-pair empty return). Suites: C++ 1061×2, Python 894×2, streams identical, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)