### PR TITLE
fix(python): bind annotation gate types and polish noncomp error surfaces

### DIFF
--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -764,10 +764,10 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
             case GateType::LEVEL_TRANSITION:
             case GateType::LOSS: {
                 if (instruments == nullptr) {
-                    throw std::runtime_error(
+                    throw std::invalid_argument(
                         std::string(gate_name(node.gate)) +
                         " is a noncomputational annotation; run the circuit through "
-                        "sample_noncomputational instead of compiling it directly");
+                        "clifft.noncomp.sample instead of compiling it directly");
                 }
                 for (const auto& target : node.targets) {
                     const uint32_t qubit = target.value();

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -133,7 +133,12 @@ NonComputationalModel NonComputationalModel::from_spec(
     std::optional<ClassifierSpec> classifier_spec, NonComputationalPolicy policy) {
     std::map<std::string, TransitionInstrument> transitions;
     for (const auto& [gate, matrix] : transition_matrices) {
-        transitions.emplace(gate, TransitionInstrument::from_matrix(matrix));
+        try {
+            transitions.emplace(gate, TransitionInstrument::from_matrix(matrix));
+        } catch (const std::invalid_argument& e) {
+            throw std::invalid_argument("NonComputationalModel: transition '" + gate +
+                                        "': " + e.what());
+        }
     }
 
     std::optional<MeasurementClassifier> classifier;

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -198,6 +198,10 @@ NB_MODULE(_clifft_core, m) {
     // the test_introspection.py tripwire will catch it.
     m.def("_num_optypes", []() { return static_cast<int>(clifft::OpType::NUM_OP_TYPES); });
     m.def("_num_opcodes", []() { return static_cast<int>(clifft::Opcode::NUM_OPCODES); });
+    m.def("_num_gate_types", []() {
+        return static_cast<int>(sizeof(clifft::detail::kGateTraitsData) /
+                                sizeof(clifft::detail::kGateTraitsData[0]));
+    });
 
     nb::enum_<clifft::GateType>(m, "GateType", "Quantum gate types")
         // Single-qubit Cliffords
@@ -297,6 +301,12 @@ NB_MODULE(_clifft_core, m) {
         .value("DETECTOR", clifft::GateType::DETECTOR)
         .value("OBSERVABLE_INCLUDE", clifft::GateType::OBSERVABLE_INCLUDE)
         .value("TICK", clifft::GateType::TICK)
+        // Noncomputational trajectory annotations
+        .value("LEVEL_TRANSITION", clifft::GateType::LEVEL_TRANSITION)
+        .value("LOSS", clifft::GateType::LOSS)
+        // Simulation-only probes
+        .value("EXP_VAL", clifft::GateType::EXP_VAL)
+        // Sentinel for unknown/unsupported gates
         .value("UNKNOWN", clifft::GateType::UNKNOWN);
 
     nb::class_<clifft::Target>(m, "Target", "Encoded quantum target")
@@ -325,6 +335,7 @@ NB_MODULE(_clifft_core, m) {
     nb::class_<clifft::AstNode>(m, "AstNode", "A single circuit operation")
         .def_ro("gate", &clifft::AstNode::gate)
         .def_ro("targets", &clifft::AstNode::targets)
+        .def_ro("tag", &clifft::AstNode::tag)
         .def_prop_ro("arg",
                      [](const clifft::AstNode& n) { return n.args.empty() ? 0.0 : n.args[0]; })
         .def_ro("args", &clifft::AstNode::args)

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -29,12 +29,15 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import numpy as np
 import numpy.typing as npt
 
 from clifft import _clifft_core
+
+if TYPE_CHECKING:
+    from clifft._clifft_core import Circuit
 
 __all__ = [
     "LEVELS",
@@ -250,7 +253,7 @@ class NonComputationalSample:
 
 
 def sample(
-    circuit: object,
+    circuit: Circuit | str,
     model: Model,
     shots: int,
     seed: int | None = None,

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -29,15 +29,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
-from typing import TYPE_CHECKING, Iterator
+from typing import Iterator
 
 import numpy as np
 import numpy.typing as npt
 
 from clifft import _clifft_core
-
-if TYPE_CHECKING:
-    from clifft._clifft_core import Circuit
+from clifft._clifft_core import Circuit
 
 __all__ = [
     "LEVELS",

--- a/tests/python/test_introspection.py
+++ b/tests/python/test_introspection.py
@@ -300,3 +300,39 @@ class TestEnumBindingCompleteness:
         for inst in prog:
             d: dict[str, Any] = inst.as_dict()
             assert d["opcode"] != "UNKNOWN", f"opcode_to_str returned UNKNOWN for {inst}"
+
+    def test_all_gate_types_bound(self) -> None:
+        from clifft._clifft_core import _num_gate_types
+
+        py_count = len(clifft.GateType.__members__)
+        cpp_count: int = _num_gate_types()
+        assert py_count == cpp_count, (
+            f"GateType mismatch: Python has {py_count} members but C++ has {cpp_count}. "
+            "A new GateType was added in gate_data.h but not bound in bindings.cc."
+        )
+
+
+class TestAstNodeAnnotations:
+    """AstNode.tag and annotation GateType binding tests."""
+
+    def test_loss_gate_type_is_bound(self) -> None:
+        node = clifft.parse("LOSS(0.1) 0\nM 0").nodes[0]
+        assert node.gate == clifft.GateType.LOSS
+
+    def test_level_transition_gate_type_is_bound(self) -> None:
+        node = clifft.parse("LEVEL_TRANSITION[cz_leak] 0\nM 0").nodes[0]
+        assert node.gate == clifft.GateType.LEVEL_TRANSITION
+
+    def test_level_transition_tag_property(self) -> None:
+        node = clifft.parse("LEVEL_TRANSITION[cz_leak] 0\nM 0").nodes[0]
+        assert node.tag == "cz_leak"
+
+    def test_loss_tag_is_empty(self) -> None:
+        node = clifft.parse("LOSS(0.1) 0\nM 0").nodes[0]
+        assert node.tag == ""
+
+    def test_repr_works_for_annotation_nodes(self) -> None:
+        circuit = clifft.parse("LOSS(0.1) 0\nM 0")
+        assert repr(circuit.nodes[0]) == "LOSS 0"
+        circuit2 = clifft.parse("LEVEL_TRANSITION[cz_leak] 0\nM 0")
+        assert repr(circuit2.nodes[0]) == "LEVEL_TRANSITION 0"

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -676,3 +676,12 @@ def test_compile_annotated_circuit_raises_invalid_argument_with_noncomp_sample_h
 
     with pytest.raises(ValueError, match="noncomp.sample"):
         clifft.compile("LOSS(0.1) 0\nM 0")
+
+
+def test_sample_type_hints_resolve_at_runtime():
+    """The Circuit | str annotation must be introspectable: Circuit is a
+    real module-level name, not a TYPE_CHECKING-only import."""
+    from typing import get_type_hints
+
+    hints = get_type_hints(noncomp.sample)
+    assert "circuit" in hints

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -653,3 +653,26 @@ def test_contract_validated_for_zero_shots():
     model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
     with pytest.raises(ValueError, match="classifier is required"):
         noncomp.sample("S 0\nM 0", model, shots=0, seed=1)
+
+
+# --- 10. Error message quality -----------------------------------------------
+
+
+def test_malformed_transition_error_names_key():
+    """A bad transition matrix error must include the offending key in the message."""
+    bad = [[0.0] * 5 for _ in range(5)]
+    bad[0][0] = 1.5  # column sum exceeds 1
+
+    with pytest.raises(ValueError, match="'CZ'"):
+        noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LEAK_G), "CZ": bad})
+
+
+# --- 11. Plain-pipeline redirect points to clifft.noncomp.sample -------------
+
+
+def test_compile_annotated_circuit_raises_invalid_argument_with_noncomp_sample_hint():
+    """clifft.compile() on a LOSS-annotated circuit raises ValueError naming noncomp.sample."""
+    import clifft
+
+    with pytest.raises(ValueError, match="noncomp.sample"):
+        clifft.compile("LOSS(0.1) 0\nM 0")

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1843,7 +1843,7 @@ TEST_CASE("Standalone READOUT_NOISE lowers one- and two-argument forms") {
 
 TEST_CASE("Trace rejects noncomputational annotations with a pointer to the entry point") {
     REQUIRE_THROWS_WITH(trace(parse("LEVEL_TRANSITION[t] 0\n")),
-                        Catch::Matchers::ContainsSubstring("sample_noncomputational"));
+                        Catch::Matchers::ContainsSubstring("noncomp.sample"));
     REQUIRE_THROWS_WITH(trace(parse("LOSS(0.1) 0\n")),
-                        Catch::Matchers::ContainsSubstring("sample_noncomputational"));
+                        Catch::Matchers::ContainsSubstring("noncomp.sample"));
 }

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -184,10 +184,10 @@ TEST_CASE("NonComputationalModel: rejects two keys resolving to the same gate") 
 TEST_CASE("NonComputationalModel: a malformed transition matrix rejects, naming the component") {
     auto bad = zero_matrix();
     bad[0][0] = 1.5;
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"H", bad}}, std::nullopt,
-                                         NonComputationalPolicy{}),
-        ContainsSubstring("TransitionInstrument") && ContainsSubstring("out of [0, 1]"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(), {{"H", bad}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("TransitionInstrument") &&
+                            ContainsSubstring("out of [0, 1]") && ContainsSubstring("'H'"));
 }
 
 // =========================================================================


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

The mechanical Python-surface round from the pre-merge review — six independent fixes, each with its original runtime reproducer re-verified:

- **`GateType` bindings completed**: `LEVEL_TRANSITION`, `LOSS`, and `EXP_VAL` were missing, so `AstNode.gate` on a parsed annotated circuit raised `ValueError: 88 is not a valid GateType` while `repr` worked — a supported introspection pattern crashed. A **`_num_gate_types` tripwire** (backed by the gate-traits table, which is already `static_assert`ed against the enum) joins the existing OpType/Opcode tripwires in `test_introspection.py`, and is what caught `EXP_VAL` beyond the two known-missing values.
- **`AstNode.tag` exposed** — a `LEVEL_TRANSITION` node's transition name is now introspectable.
- **Transition-matrix errors name the offending key**: `Model(transitions={"S": ok, "CZ": bad})` now fails with `NonComputationalModel: transition 'CZ': …` instead of an anonymous column report. Pinned in C++ and Python.
- **Plain-compile redirect fixed**: compiling an annotated circuit directly now raises `ValueError` (`invalid_argument`, matching its siblings) pointing at `clifft.noncomp.sample` — the Python entry point — instead of the C++ symbol. Existing message pins updated.
- **`sample()` type hint**: `circuit: Circuit | str`, matching the docstring, mypy-clean.

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1061 cases (unchanged; the key-naming pin extends an existing test)
- Python: 902 pass on both wheels (+8: tripwire, five AstNode-annotation tests, key-naming, redirect)
- All five original reproducers spot-checked with the new behavior shown
- Draw-stream fingerprints byte-identical to the base tip (no sampling-path changes)
- `pre-commit run --all-files` clean (mypy included)

## Review round

- P2 (valid): `Circuit` was imported only under `TYPE_CHECKING`, so `get_type_hints(noncomp.sample)` raised `NameError` — exactly the introspection surface this PR polishes. Now a real module-level import (matching the package `__init__`'s own runtime import of `Circuit`); the hint resolves to `clifft._clifft_core.Circuit | str`, pinned by a regression test. Python 903×2, mypy/pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)