### PR TITLE
feat(python)!: report full-fidelity qubit statuses and trim the model API

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -190,21 +190,19 @@ model = clifft.NonComputationalModel(
     },
 
     # Level -> visible-symbol classifier applied at measurement.
-    # Shape: (len(symbols), len(levels)). Entry matrix[s, l] is
-    # P(symbol=s | level=l).
+    # Two rows (record symbols 0 and 1), or three when the third row
+    # is the herald symbol; columns run over the levels. Entry
+    # matrix[s, l] is P(symbol=s | level=l).
     #
-    # The matrix is COLUMN-SUBSTOCHASTIC: each column sum lies in
-    # [0, 1] and the deficit `1 - sum(column)` is implicit
-    # P(reject | level). A classifier call that samples "reject"
-    # raises with the offending qubit and level. Default identity +
-    # reject is just:
-    #     [[1, 0, 0, 0, 0],   # P("0" | level) over [g, e, leak_g, leak_e, lost]
-    #      [0, 1, 0, 0, 0]]   # P("1" | level)
-    # which has column sums [1, 1, 0, 0, 0] — leaked/lost reject
-    # with probability 1.
+    # The matrix is COLUMN-STOCHASTIC: every column sums to 1 within
+    # tolerance. Substochastic "reject" columns are not supported and
+    # fail at construction, and a computational column places no mass
+    # on the herald row. The faithful identity readout is:
+    #     [[1, 0, 1, 0, 1],   # P("0" | level) over [g, e, leak_g, leak_e, lost]
+    #      [0, 1, 0, 1, 0]]   # P("1" | level)
     classifier=clifft.MeasurementClassifier(
-        matrix=[[1, 0, 0, 0, 0],
-                [0, 1, 0, 0, 0]],
+        matrix=[[1, 0, 1, 0, 1],
+                [0, 1, 0, 1, 0]],
     ),
 
     # Policy for downstream operations on noncomputational qubits.
@@ -265,20 +263,18 @@ public:
     // ... accessors for per-source branches, no-jump weight per source, etc.
 };
 
-// Distinct from TransitionInstrument: rectangular column-substochastic
-// map from levels to reported user-facing symbols. Column sums lie in
-// [0, 1]; the deficit per level is implicit P(reject | level). No
-// no-jump branch, no concept of source-independence on Computational
-// levels.
+// Distinct from TransitionInstrument: a rectangular column-stochastic
+// map from levels to record symbols -- two rows, or three when the
+// third row is the herald symbol. Every column sums to 1 within
+// tolerance; substochastic (reject) columns fail at construction, and
+// a computational column places no mass on the herald row. No no-jump
+// branch, no concept of source-independence on Computational levels.
 class MeasurementClassifier {
 public:
     static MeasurementClassifier from_matrix(
-        std::vector<std::string> symbols,
-        std::vector<std::vector<double>> matrix);  // shape (symbols, levels)
+        size_t num_symbols,
+        std::vector<std::vector<double>> matrix);  // shape (num_symbols, levels)
 
-    // P(reject | level) = 1 - sum_s matrix[s, level], computed at
-    // construction and used by the sampler.
-    double reject_probability(uint8_t level_id) const;
     // ... accessors
 };
 
@@ -337,11 +333,12 @@ representable in the MVP.
    of scope.)
 4. **Transition matrix column sums in [0, 1].** Implied no-jump weight
    per source is `1 - sum(col)`.
-5. **Classifier matrix is column-substochastic.** If a
-   `MeasurementClassifier` is provided, its matrix has shape
-   `(len(symbols), len(levels))`, every entry is in `[0, 1]`, and
-   every column sum lies in `[0, 1]`. The deficit per column is
-   `P(reject | level)`.
+5. **Classifier matrix is column-stochastic.** If a
+   `MeasurementClassifier` is provided, its matrix has two or three
+   rows (the third is the herald symbol), every entry is in `[0, 1]`,
+   and every column sums to 1 within tolerance; a computational column
+   places no mass on the herald row. Substochastic (reject) columns
+   fail at construction.
 6. **Policy values are well-formed** (enum values, not free strings on
    the C++ side; Python sugar translates).
 7. **Transition keys are tag-safe names**: nonempty, with no `]` or

--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -170,6 +170,7 @@ model = clifft.NonComputationalModel(
 
     # Independent per-qubit initial level distribution.
     # Indices into levels[]; sums to 1 per qubit (validated in C++).
+    # Optional; defaults to [1.0, 0.0, 0.0, 0.0, 0.0] (all qubits in g).
     initial_state=[0.0065, 0.96, 0.0065, 0.027, 0.0],
 
     # Per-gate transition instruments. Matrix shorthand uses T[to, from]
@@ -202,7 +203,6 @@ model = clifft.NonComputationalModel(
     # which has column sums [1, 1, 0, 0, 0] — leaked/lost reject
     # with probability 1.
     classifier=clifft.MeasurementClassifier(
-        symbols=["0", "1"],
         matrix=[[1, 0, 0, 0, 0],
                 [0, 1, 0, 0, 0]],
     ),

--- a/examples/leakage_and_loss.ipynb
+++ b/examples/leakage_and_loss.ipynb
@@ -93,7 +93,7 @@
     "    m[0][Level.LEAK_G], m[1][Level.LEAK_G] = 1 - leak_confusion, leak_confusion\n",
     "    m[1][Level.LEAK_E], m[0][Level.LEAK_E] = 1 - leak_confusion, leak_confusion\n",
     "    m[2][Level.LOST] = 1.0\n",
-    "    return noncomp.Classifier([\"0\", \"1\", \"2\"], m)\n",
+    "    return noncomp.Classifier(m)\n",
     "\n",
     "\n",
     "print(\"clifft\", clifft.version())"
@@ -149,7 +149,7 @@
     ")\n",
     "print(\"expected:                                      \", [0.95, 0.03, 0.02])\n",
     "print(\"ternary readout counts (0/1/2):\", [int((r.symbols()[:, 0] == v).sum()) for v in (0, 1, 2)])\n",
-    "assert abs((status == noncomp.QubitStatusKind.LOST).mean() - 0.02) < 0.005"
+    "assert abs((status == noncomp.QubitStatus.LOST).mean() - 0.02) < 0.005"
    ]
   },
   {
@@ -290,7 +290,9 @@
     ")\n",
     "r = noncomp.sample(\"H 0\\nS 0\\nM 0\\n\", exact, shots=SHOTS, seed=5)\n",
     "print(f\"P(M=1) = {r.measurements[:, 0].mean():.4f}   (analytic: {0.5 + p / 2})\")\n",
-    "leaked = (r.final_status[:, 0] == noncomp.QubitStatusKind.LEAKED).mean()\n",
+    "leaked = np.isin(\n",
+    "    r.final_status[:, 0], (noncomp.QubitStatus.LEAK_G, noncomp.QubitStatus.LEAK_E)\n",
+    ").mean()\n",
     "print(f\"P(leaked) = {leaked:.4f}   (analytic: {p / 2})\")\n",
     "assert abs(r.measurements[:, 0].mean() - (0.5 + p / 2)) < 0.01"
    ]

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -108,24 +108,12 @@ void register_noncomp(nb::module_& m) {
                 nb::gil_scoped_release release;
                 r = clifft::sample_noncomputational(circuit, model, shots, seed, max_rank);
             }
-            // Map each qubit's final status onto the sidecar's stable code
-            // {0 computational, 1 leaked, 2 lost}, shared with Python's
-            // QubitStatusKind enum. Exhaustive on purpose: a new status
-            // must decide its code here.
+            // Pass the raw status bytes through: QubitStatus is uint8_t with values
+            // Computational=0, LeakG=1, LeakE=2, Lost=3, matching Python's QubitStatus
+            // enum exactly. No coarsening: leaked substates are individually preserved.
             std::vector<uint8_t> status(r.final_status.size());
             for (size_t i = 0; i < r.final_status.size(); ++i) {
-                switch (r.final_status[i]) {
-                    case clifft::QubitStatus::Computational:
-                        status[i] = 0;
-                        break;
-                    case clifft::QubitStatus::LeakG:
-                    case clifft::QubitStatus::LeakE:
-                        status[i] = 1;
-                        break;
-                    case clifft::QubitStatus::Lost:
-                        status[i] = 2;
-                        break;
-                }
+                status[i] = static_cast<uint8_t>(r.final_status[i]);
             }
             auto meas = vec_to_numpy(std::move(r.measurements), {shots, r.num_measurements});
             auto det = vec_to_numpy(std::move(r.detectors), {shots, r.num_detectors});

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -9,15 +9,14 @@ sampler:
     model = noncomp.Model(
         initial_state=[1, 0, 0, 0, 0],                  # P(level) over the 5-level set
         transitions={"S": T},                           # gate -> T[to][from]
-        classifier=noncomp.Classifier(["0", "1"], P),   # optional; P[symbol][level]
-        reset_restores_lost=False,
+        classifier=noncomp.Classifier(P),               # optional; P[symbol][level]
     )
     r = noncomp.sample("H 0\\nCX 0 1\\nS 0\\nM 0\\nM 1\\n", model, shots=1000, seed=7)
     r.measurements   # np.uint8 [shots, num_measurements]
-    r.final_status   # np.uint8 [shots, num_qubits], values in QubitStatusKind
+    r.final_status   # np.uint8 [shots, num_qubits], values in QubitStatus
 
-This API supports exactly the built-in five-level set, named by ``Level`` and
-``LEVELS`` (g, e, leak_g, leak_e, lost); matrix rows and columns are indexed by
+This API supports exactly the built-in five-level set, named by ``Level``
+(g, e, leak_g, leak_e, lost); matrix rows and columns are indexed by
 ``Level``. A classifier has two or three symbols with stochastic columns: the
 first two symbols are the record bit, an optional third symbol heralds the
 measurement (reported per slot in ``heralds``; the visible record stays binary
@@ -38,24 +37,34 @@ from clifft import _clifft_core
 from clifft._clifft_core import Circuit
 
 __all__ = [
-    "LEVELS",
     "Classifier",
     "Level",
     "Model",
     "NonComputationalSample",
-    "QubitStatusKind",
+    "QubitStatus",
     "sample",
 ]
 
 Matrix = Sequence[Sequence[float]]
 
 
-class QubitStatusKind(IntEnum):
-    """A qubit's final status in the per-shot sidecar."""
+class QubitStatus(IntEnum):
+    """Per-qubit outcome in ``final_status``, one value per shot.
+
+    These are per-qubit *status* codes, not matrix indices. ``Level`` names
+    matrix rows and columns (indices 0--4); ``QubitStatus`` names per-qubit
+    outcomes (indices 0--3). The two enums share member names (``LEAK_G``,
+    ``LEAK_E``, ``LOST``) with *different* integer values -- never substitute
+    one for the other.
+
+    ``LEAK_G`` and ``LEAK_E`` are individually distinguishable in
+    ``final_status``, unlike the coarse leaked/lost grouping some tools use.
+    """
 
     COMPUTATIONAL = 0
-    LEAKED = 1
-    LOST = 2
+    LEAK_G = 1
+    LEAK_E = 2
+    LOST = 3
 
 
 class Level(IntEnum):
@@ -68,23 +77,20 @@ class Level(IntEnum):
     LOST = 4
 
 
-LEVELS = ("g", "e", "leak_g", "leak_e", "lost")
-
-
 def _as_matrix(matrix: Matrix) -> list[list[float]]:
     """Normalize a nested sequence or 2-D array to list-of-lists of float."""
     return [[float(x) for x in row] for row in matrix]
 
 
 class Classifier:
-    """A measurement classifier: symbol labels and ``P[symbol][level]``.
+    """A measurement classifier: ``P[symbol][level]`` stochastic matrix.
 
-    Two or three symbols; each level's column must sum to one (substochastic
-    reject columns are not supported). The first two symbols map directly to
-    the measurement record bit. An optional third symbol heralds the
-    measurement -- typically the loss outcome -- reported per record slot in
-    :attr:`NonComputationalSample.heralds` while the visible record keeps a
-    uniformly drawn bit, so the record layout is unchanged.
+    The row count (two or three) determines the symbol alphabet; C++ validates
+    it. The first two rows map to the measurement record bit (0 or 1). An
+    optional third row heralds the measurement -- typically the loss outcome --
+    reported per record slot in :attr:`NonComputationalSample.heralds` while
+    the visible record keeps a uniformly drawn bit, so the record layout is
+    unchanged.
 
     The computational columns define readout confusion for Z-basis
     measurements of computational qubits: the true outcome is misreported
@@ -94,13 +100,9 @@ class Classifier:
     place probability beyond the two record symbols.
     """
 
-    __slots__ = ("symbols", "matrix")
+    __slots__ = ("matrix",)
 
-    def __init__(self, symbols: Sequence[str], matrix: Matrix) -> None:
-        self.symbols = [str(s) for s in symbols]
-        if len(self.symbols) != len(set(self.symbols)):
-            duplicates = sorted({s for s in self.symbols if self.symbols.count(s) > 1})
-            raise ValueError(f"noncomp classifier: duplicate symbol label(s): {duplicates}")
+    def __init__(self, matrix: Matrix) -> None:
         self.matrix = _as_matrix(matrix)
 
 
@@ -109,6 +111,8 @@ class Model:
 
     Args:
         initial_state: probability per level, ``P(level)``, summing to one.
+            Defaults to ``[1.0, 0.0, 0.0, 0.0, 0.0]`` (all qubits start in
+            the ground state).
         transitions: maps a name to its ``T[to][from]`` matrix. A key that
             names a gate (e.g. ``"CZ"``) is a *hook*: it expands to a
             ``LEVEL_TRANSITION[key]`` annotation after every occurrence of that
@@ -148,20 +152,28 @@ class Model:
     problem.
     """
 
-    __slots__ = ("_handle",)
+    __slots__ = (
+        "_handle",
+        "_transition_keys",
+        "_classifier_rows",
+        "_reset_restores_lost",
+        "_damping",
+    )
 
     def __init__(
         self,
-        initial_state: Sequence[float],
+        initial_state: Sequence[float] | None = None,
         transitions: Mapping[str, Matrix] | None = None,
         classifier: Classifier | None = None,
         reset_restores_lost: bool = False,
         damping: str = "exact",
     ) -> None:
+        if initial_state is None:
+            initial_state = [1.0, 0.0, 0.0, 0.0, 0.0]
         transition_matrices = {
             str(gate): _as_matrix(matrix) for gate, matrix in (transitions or {}).items()
         }
-        num_symbols = None if classifier is None else len(classifier.symbols)
+        num_symbols = None if classifier is None else len(classifier.matrix)
         matrix = None if classifier is None else classifier.matrix
         self._handle = _clifft_core._build_noncomp_model(
             [float(p) for p in initial_state],
@@ -171,6 +183,18 @@ class Model:
             bool(reset_restores_lost),
             str(damping),
         )
+        self._transition_keys: list[str] = sorted(transition_matrices.keys())
+        self._classifier_rows: int | None = num_symbols
+        self._reset_restores_lost: bool = bool(reset_restores_lost)
+        self._damping: str = str(damping)
+
+    def __repr__(self) -> str:
+        parts = [f"transitions={self._transition_keys!r}"]
+        if self._classifier_rows is not None:
+            parts.append(f"classifier={self._classifier_rows}-symbol")
+        parts.append(f"reset_restores_lost={self._reset_restores_lost!r}")
+        parts.append(f"damping={self._damping!r}")
+        return f"Model({', '.join(parts)})"
 
 
 class NonComputationalSample:
@@ -178,13 +202,12 @@ class NonComputationalSample:
 
     Attributes:
         measurements, detectors, observables: uint8 arrays, shape (shots, width).
-        final_status: uint8 array (shots, num_qubits) of :class:`QubitStatusKind`.
-            Leaked/lost statuses are per-shot truth. Computational qubits
-            report as a single category: transitions with computational
-            destinations resolve entirely inside the simulator, so no
-            final level is claimed.
-            Coarse: it reports computational/leaked/lost, not the specific leaked
-            or lost level.
+        final_status: uint8 array (shots, num_qubits) of :class:`QubitStatus`.
+            Reports the definite noncomputational level per shot: ``LEAK_G``
+            and ``LEAK_E`` are individually distinguishable. Computational
+            qubits report as :attr:`QubitStatus.COMPUTATIONAL`: transitions
+            with computational destinations resolve entirely inside the
+            simulator, so no final level is claimed.
         heralds: uint8 array (shots, num_measurements); 1 where the classifier
             sampled the herald (third) symbol for that slot, else 0.
         shots, num_qubits, num_measurements, num_detectors, num_observables: ints.

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -16,9 +16,8 @@ from clifft import noncomp
 LEAK_G, LEAK_E, LOST = noncomp.Level.LEAK_G, noncomp.Level.LEAK_E, noncomp.Level.LOST
 ALL_G = [1.0, 0.0, 0.0, 0.0, 0.0]
 ALL_E = [0.0, 1.0, 0.0, 0.0, 0.0]
-COMPUTATIONAL = noncomp.QubitStatusKind.COMPUTATIONAL
-LEAKED = noncomp.QubitStatusKind.LEAKED
-LOST_KIND = noncomp.QubitStatusKind.LOST
+COMPUTATIONAL = noncomp.QubitStatus.COMPUTATIONAL
+LOST_KIND = noncomp.QubitStatus.LOST
 
 
 def _zeros(rows: int, cols: int) -> list[list[float]]:
@@ -43,7 +42,7 @@ def classifier_for(level: int, col: list[float]) -> noncomp.Classifier:
     m[1][noncomp.Level.E] = 1.0
     m[0][level] = col[0]
     m[1][level] = col[1]
-    return noncomp.Classifier(["0", "1"], m)
+    return noncomp.Classifier(m)
 
 
 def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
@@ -56,7 +55,6 @@ def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
 
 
 def test_level_names_and_indices():
-    assert noncomp.LEVELS == ("g", "e", "leak_g", "leak_e", "lost")
     assert (int(noncomp.Level.G), int(noncomp.Level.LEAK_G), int(noncomp.Level.LOST)) == (0, 2, 4)
 
 
@@ -150,7 +148,7 @@ def test_known_source_dependent_transition_accepted():
     t[LEAK_E][1] = 1.0
     model = noncomp.Model(initial_state=ALL_G, transitions={"S": t})
     r = noncomp.sample("S 0\n", model, shots=8, seed=5)
-    assert (r.final_status == LEAKED).all()
+    assert (r.final_status == noncomp.QubitStatus.LEAK_G).all()
 
 
 def test_reset_reload_policy_changes_lost_site():
@@ -249,17 +247,18 @@ def test_four_symbol_classifier_rejects_at_construction():
         mat[0][lvl] = 1.0
     mat[0][LEAK_G], mat[1][LEAK_G], mat[2][LEAK_G], mat[3][LEAK_G] = 0.4, 0.3, 0.2, 0.1
     with pytest.raises(ValueError, match="two record symbols"):
-        leak_model(noncomp.Classifier(["0", "1", "2", "3"], mat))
+        leak_model(noncomp.Classifier(mat))
 
 
-def test_duplicate_classifier_symbols_reject_in_python():
+def test_classifier_stores_matrix():
     mat = _zeros(2, 5)
     for lvl in range(5):
         mat[0][lvl] = 1.0
     mat[0][noncomp.Level.E] = 0.0
     mat[1][noncomp.Level.E] = 1.0
-    with pytest.raises(ValueError, match="duplicate symbol"):
-        noncomp.Classifier(["0", "0"], mat)
+    c = noncomp.Classifier(mat)
+    assert len(c.matrix) == 2
+    assert len(c.matrix[0]) == 5
 
 
 def _ternary_classifier(level: int, col: list[float]) -> noncomp.Classifier:
@@ -268,7 +267,7 @@ def _ternary_classifier(level: int, col: list[float]) -> noncomp.Classifier:
     for lvl in range(5):
         m[0][lvl] = 1.0
     m[0][level], m[1][level], m[2][level] = col
-    return noncomp.Classifier(["0", "1", "2"], m)
+    return noncomp.Classifier(m)
 
 
 def test_ternary_herald_rides_the_sidecar():
@@ -444,9 +443,7 @@ def test_zero_fire_loss_before_firing_loss_samples_cleanly():
     trace() elided it, causing a site-id mismatch that aborted in Debug or
     segfaulted in Release.
     """
-    classifier = noncomp.Classifier(
-        ["0", "1"], [[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]]
-    )
+    classifier = noncomp.Classifier([[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]])
     model = noncomp.Model(initial_state=ALL_G, classifier=classifier)
     r = noncomp.sample("LOSS(0) 0\nLOSS(0.5) 0\nM 0\n", model, shots=64, seed=90)
     assert r.shots == 64
@@ -469,9 +466,7 @@ def test_seepage_only_before_firing_site_samples_cleanly():
     seep = _zeros(5, 5)
     seep[LEAK_E][LEAK_E] = 1.0  # leak_e -> leak_e, only noncomp columns
 
-    classifier = noncomp.Classifier(
-        ["0", "1"], [[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]]
-    )
+    classifier = noncomp.Classifier([[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]])
     model = noncomp.Model(initial_state=ALL_G, transitions={"seep": seep}, classifier=classifier)
     r = noncomp.sample("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0\n", model, shots=32, seed=91)
     assert r.shots == 32
@@ -490,9 +485,7 @@ def test_computational_readout_confusion_misreports_the_record():
     m[1][noncomp.Level.E] = 0.8
     for lvl in (LEAK_G, LEAK_E, LOST):
         m[0][lvl] = 1.0
-    model = noncomp.Model(
-        initial_state=ALL_G, transitions={}, classifier=noncomp.Classifier(["0", "1"], m)
-    )
+    model = noncomp.Model(initial_state=ALL_G, transitions={}, classifier=noncomp.Classifier(m))
 
     zero = noncomp.sample("M 0", model, shots=4000, seed=11)
     ones = int(zero.measurements[:, 0].sum())
@@ -685,3 +678,65 @@ def test_sample_type_hints_resolve_at_runtime():
 
     hints = get_type_hints(noncomp.sample)
     assert "circuit" in hints
+
+
+# --- Item 1: QubitStatus enum (fine-grained status) --------------------------
+
+
+def test_qubit_status_values():
+    """QubitStatus integer values differ from Level values for the shared names."""
+    assert int(noncomp.QubitStatus.COMPUTATIONAL) == 0
+    assert int(noncomp.QubitStatus.LEAK_G) == 1
+    assert int(noncomp.QubitStatus.LEAK_E) == 2
+    assert int(noncomp.QubitStatus.LOST) == 3
+
+
+def test_qubit_status_not_level_collision_guard():
+    """QubitStatus.LOST != Level.LOST and QubitStatus.LEAK_G != Level.LEAK_G.
+
+    The two enums share member names with different integer values; mixing
+    them in a comparison would silently produce wrong results.
+    """
+    assert int(noncomp.QubitStatus.LOST) != int(noncomp.Level.LOST)
+    assert int(noncomp.QubitStatus.LEAK_G) != int(noncomp.Level.LEAK_G)
+
+
+def test_fine_grained_leak_e_status():
+    """A certain leak into leak_e yields final_status == QubitStatus.LEAK_E."""
+    t = _zeros(5, 5)
+    t[noncomp.Level.LEAK_E][noncomp.Level.G] = 1.0
+    t[noncomp.Level.LEAK_E][noncomp.Level.E] = 1.0
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": t},
+        classifier=classifier_for(noncomp.Level.LEAK_E, [0.0, 1.0]),
+    )
+    r = noncomp.sample("S 0\n", model, shots=8, seed=77)
+    assert (r.final_status == noncomp.QubitStatus.LEAK_E).all()
+
+
+# --- Item 3: Model() with no initial_state defaults to ground state ----------
+
+
+def test_model_default_initial_state_constructs():
+    model = noncomp.Model()
+    assert isinstance(model, noncomp.Model)
+
+
+def test_model_default_initial_state_reads_zero():
+    r = noncomp.sample("M 0", noncomp.Model(), shots=4, seed=1)
+    assert np.all(r.measurements == 0)
+
+
+# --- Item 5: Model.__repr__ --------------------------------------------------
+
+
+def test_model_repr_contains_keys_and_damping():
+    model = noncomp.Model(
+        transitions={"S": transition_to(LEAK_G), "seep": transition_to(LEAK_E)},
+        damping="neglect",
+    )
+    r = repr(model)
+    assert "S" in r
+    assert "seep" in r
+    assert "neglect" in r

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -33,7 +33,7 @@ def _faithful_classifier() -> noncomp.Classifier:
     m[0][Level.G] = m[1][Level.E] = 1.0
     m[0][Level.LEAK_G] = m[1][Level.LEAK_E] = 1.0
     m[0][Level.LOST] = m[1][Level.LOST] = 0.5
-    return noncomp.Classifier(["0", "1"], m)
+    return noncomp.Classifier(m)
 
 
 def _model(transitions: dict, damping: str = "exact") -> noncomp.Model:
@@ -54,7 +54,7 @@ def test_gate_determined_source_fires_exactly_zero():
     model = _model({"leak": _transition({(Level.LEAK_E, Level.E): 1.0})})
     r = noncomp.sample("H 0\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0\n", model, shots=SHOTS, seed=11)
     status = np.asarray(r.final_status)
-    assert (status == noncomp.QubitStatusKind.COMPUTATIONAL).all()
+    assert (status == noncomp.QubitStatus.COMPUTATIONAL).all()
     assert (np.asarray(r.measurements) == 0).all()  # H H |0> measures 0
 
 
@@ -74,7 +74,7 @@ def test_bell_joint_correlation_has_tvd_zero():
     status = np.asarray(r.final_status)
     # The certain fire really happened: an accidentally skipped transition
     # would also show perfect agreement (a plain Bell pair does).
-    assert (status[:, 0] == noncomp.QubitStatusKind.LEAKED).all()
+    assert np.isin(status[:, 0], (noncomp.QubitStatus.LEAK_G, noncomp.QubitStatus.LEAK_E)).all()
     assert (m[:, 0] == m[:, 1]).all()  # off-diagonal mass is exactly 0
     assert abs(m[:, 0].mean() - 0.5) < binomial_tolerance(0.5, SHOTS)
 

--- a/tests/python/test_noncomp_exact_tvd.py
+++ b/tests/python/test_noncomp_exact_tvd.py
@@ -39,7 +39,7 @@ def _model(initial: list, transitions: dict, damping: str = "exact") -> noncomp.
     return noncomp.Model(
         initial_state=initial,
         transitions=transitions,
-        classifier=noncomp.Classifier(["0", "1"], _classifier_matrix()),
+        classifier=noncomp.Classifier(_classifier_matrix()),
         damping=damping,
     )
 
@@ -183,8 +183,10 @@ def _run_and_compare(damping: str, seed: int) -> None:
     status = np.asarray(r.final_status)
     for q in range(5):
         want_leaked, want_lost = _status_kind_fractions(reference.noncomp_level_probs[q])
-        got_leaked = float((status[:, q] == noncomp.QubitStatusKind.LEAKED).mean())
-        got_lost = float((status[:, q] == noncomp.QubitStatusKind.LOST).mean())
+        got_leaked = float(
+            np.isin(status[:, q], (noncomp.QubitStatus.LEAK_G, noncomp.QubitStatus.LEAK_E)).mean()
+        )
+        got_lost = float((status[:, q] == noncomp.QubitStatus.LOST).mean())
         assert abs(got_leaked - want_leaked) < binomial_tolerance(max(want_leaked, 1e-4), SHOTS)
         assert abs(got_lost - want_lost) < binomial_tolerance(max(want_lost, 1e-4), SHOTS)
 

--- a/tests/python/test_noncomp_examples.py
+++ b/tests/python/test_noncomp_examples.py
@@ -16,9 +16,8 @@ import pytest
 from clifft import noncomp
 
 Level = noncomp.Level
-COMPUTATIONAL = noncomp.QubitStatusKind.COMPUTATIONAL
-LEAKED = noncomp.QubitStatusKind.LEAKED
-LOST = noncomp.QubitStatusKind.LOST
+COMPUTATIONAL = noncomp.QubitStatus.COMPUTATIONAL
+LOST = noncomp.QubitStatus.LOST
 SHOTS = 8000
 BAND = 0.04
 
@@ -28,7 +27,7 @@ def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
     for lvl in range(5):
         m[0][lvl] = 1.0
     m[0][level], m[1][level] = col[0], col[1]
-    return noncomp.Classifier(["0", "1"], m)
+    return noncomp.Classifier(m)
 
 
 def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
@@ -50,7 +49,7 @@ def test_example_initial_leaked_population():
     )
     r = noncomp.sample("M 0\n", model, shots=SHOTS, seed=1)
     assert abs(np.asarray(r.measurements)[:, 0].mean() - 0.3) < BAND
-    assert abs((np.asarray(r.final_status) == LEAKED).mean() - 0.3) < BAND
+    assert abs((np.asarray(r.final_status) == noncomp.QubitStatus.LEAK_G).mean() - 0.3) < BAND
 
 
 def test_example_initial_lost_population():
@@ -74,7 +73,7 @@ def test_example_after_gate_leakage_with_classifier():
     )
     r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=3)
     assert (np.asarray(r.measurements)[:, 0] == 1).all()
-    assert (np.asarray(r.final_status) == LEAKED).all()
+    assert (np.asarray(r.final_status) == noncomp.QubitStatus.LEAK_G).all()
 
 
 def test_example_relaxation_to_ground_on_known_qubit():
@@ -100,7 +99,7 @@ def test_reject_parity_measurement_under_capable_model():
         transitions={
             "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
         },
-        classifier=noncomp.Classifier(["0", "1"], [[1.0] * 5, [0.0] * 5]),
+        classifier=noncomp.Classifier([[1.0] * 5, [0.0] * 5]),
     )
     with pytest.raises(ValueError, match="not supported"):
         noncomp.sample("H 0\nS 0\nMPP Z0*Z1\n", model, shots=8, seed=5)

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -45,7 +45,7 @@ def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
     # Computational levels read out faithfully (no readout confusion).
     m[0][noncomp.Level.E], m[1][noncomp.Level.E] = 0.0, 1.0
     m[0][level], m[1][level] = col[0], col[1]
-    return noncomp.Classifier(["0", "1"], m)
+    return noncomp.Classifier(m)
 
 
 def _p1(result: noncomp.NonComputationalSample, slot: int) -> float:
@@ -104,7 +104,9 @@ def test_transition_probability_on_known_source():
         transitions={"S": _transition({(Level.LEAK_G, Level.G): 0.4})},
     )
     r = noncomp.sample("S 0\n", model, shots=SHOTS, seed=3)
-    leaked = (np.asarray(r.final_status) == noncomp.QubitStatusKind.LEAKED).mean()
+    leaked = np.isin(
+        np.asarray(r.final_status), (noncomp.QubitStatus.LEAK_G, noncomp.QubitStatus.LEAK_E)
+    ).mean()
     assert abs(leaked - 0.4) < BAND
 
 

--- a/tools/bench/test_bench_noncomp.py
+++ b/tools/bench/test_bench_noncomp.py
@@ -64,7 +64,7 @@ def ternary_classifier() -> noncomp.Classifier:
     m[1][noncomp.Level.E] = 1.0
     m[1][noncomp.Level.LEAK_E] = 1.0
     m[2][noncomp.Level.LOST] = 1.0
-    return noncomp.Classifier(["0", "1", "2"], m)
+    return noncomp.Classifier(m)
 
 
 def noncomp_model(p: float) -> noncomp.Model:


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review. Breaking Python API changes; nothing has shipped externally.

## Summary

The approved Python-shape round from the pre-merge review:

- **Full-fidelity `QubitStatus` replaces the coarse `QubitStatusKind`**: `final_status` now reports `COMPUTATIONAL`/`LEAK_G`/`LEAK_E`/`LOST` straight from the per-shot ledger — the binding's coarsening switch is deleted (a plain cast; the C++ and Python enumerators match by construction, confirmed against `level.h`). This resolves both review findings at once: the leak level is no longer collapsed, and the docstring plus a collision-guard test make the `Level`-vs-`QubitStatus` distinction explicit (same member names, deliberately different values — one indexes matrices, the other reports outcomes). Every consumer updated: aggregate "leaked" checks became `np.isin(status, (LEAK_G, LEAK_E))` where the fixture genuinely spans both, and fine-grained members where it doesn't (each site enumerated in review).
- **`Classifier(matrix)`** — the label list was ceremony consumed by nothing (semantics are positional; the row count implies the optional herald). Constructor, tests, bench, and the notebook's call sites updated.
- **`Model(initial_state=None)`** defaults to the ground state — `noncomp.Model()` is now a valid trivial model, pinned by test.
- **`LEVELS` deleted** (redundant with `Level`).
- **`Model.__repr__`** added: `Model(transitions=['S', 'seep'], classifier=2-symbol, reset_restores_lost=False, damping='exact')` — debugging visibility without widening the public attribute surface.
- Design note §3.1 sketch kept true (classifier signature, initial_state default).

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1061 cases (unchanged; C++ never consumed the coarsening)
- Python: 909 pass on both wheels (+6: status values, collision guard, fine-grained leak_e, default-model ×2, repr)
- **Draw streams byte-identical** to the base tip under a draws-only fingerprint (measurements/heralds/detectors/observables) — the status *encoding* changes by design, the randomness does not
- Spot-checked: `QubitStatus.LOST == 3` vs `Level.LOST == 4`; certain leak-to-leak_e reports `LEAK_E`; matrix-only classifier samples; `Model()` samples ground state
- `pre-commit run --all-files` clean (mypy included)

## Review round

- P2 (valid): the design note's live classifier sections still described the retired contract (symbol-label construction, column-substochastic matrices with implicit reject probability — stale from two separate refactors). The §3 Python and C++ API sketches and the §6 validation contract now state the current semantics: matrix-only construction, two or three rows with the third as the herald symbol, every column summing to 1, reject columns failing at construction; the misleading "identity + reject" example became the faithful identity readout. The §7 test plan is untouched by design — it opens with an explicit banner declaring it the original plan kept as a record, so its retired-API mentions (including `reject_probability`) are covered framing rather than live claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)