### PR TITLE
test(noncomp): close the review's semantic pinning gaps

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -824,6 +824,15 @@ qubits + classical statuses. Bounded to ~4 qubits and ~10 events;
 fast enough for parameter sweeps. No sqale-sim dependency in the
 MVP.
 
+Note on oracle independence: the enumerator (`utils_noncomp_enumerator`)
+imports the oracle's channel primitives (`utils_noncomp_oracle`) for its
+quantum-core steps, so the Python validation campaign constitutes one
+independent reference, not two.  A shared misconception of the physical
+channel would pass both; the oracle and enumerator self-checks, together
+with several hand-derived closed-form checks (Bell joint, |+> marginal,
+initial-leak recapture), anchor the campaign at concrete analytic points
+that do not rely on the oracle's own machinery.
+
 ## 8. Open question to settle before §6 step 7 (`rewriter`)
 
 One remaining sidecar-shape question, not load-bearing for the

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -740,3 +740,75 @@ def test_model_repr_contains_keys_and_damping():
     assert "S" in r
     assert "seep" in r
     assert "neglect" in r
+
+
+# --- Gap 7: ternary herald on a measure-reset ---------------------------------
+
+
+def test_ternary_herald_on_measure_reset():
+    """MR on a leaked qubit heralds the sidecar, resets the qubit, and the
+    next M reads 0.
+
+    Three-row classifier: always-herald column for leak_g ([[1,0,0,0,1],
+    [0,1,0,1,0],[0,0,1,0,0]]). "leak" = {g->leak_g p=1} hooked on S.
+    Circuit: S 0 / MR 0 / M 0.
+
+    Expect:
+    - heralds[:, 0] == 1 on every shot (MR slot heralded).
+    - r.measurements[:, 0] carries an unbiased bit (both 0 and 1 occur over
+      >= 256 shots): the heralded slot gets a uniformly drawn replacement.
+    - r.measurements[:, 1] == 0 on every shot: MR restored the leaked qubit
+      to |0>, so the second M reads 0.
+    - final_status[:, 0] == COMPUTATIONAL: the MR reset the qubit level.
+    """
+    HERALD_SHOTS = 256
+
+    # Three-row classifier: g/e faithful; leak_g always heralds (row 2);
+    # e/leak_e/lost columns are standard symbol-0 or symbol-1 per level.
+    clf_matrix = [
+        [1.0, 0.0, 0.0, 0.0, 1.0],  # symbol 0
+        [0.0, 1.0, 0.0, 1.0, 0.0],  # symbol 1
+        [0.0, 0.0, 1.0, 0.0, 0.0],  # symbol 2 (herald)
+    ]
+    transitions_leak = _zeros(5, 5)
+    transitions_leak[LEAK_G][noncomp.Level.G] = 1.0  # g -> leak_g, certainly
+    transitions_leak[LEAK_G][noncomp.Level.E] = 1.0  # e -> leak_g, certainly
+
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transitions_leak},
+        classifier=noncomp.Classifier(clf_matrix),
+    )
+    r = noncomp.sample("S 0\nMR 0\nM 0\n", model, shots=HERALD_SHOTS, seed=271)
+
+    assert r.num_measurements == 2
+
+    # MR slot heralds on every shot.
+    assert np.all(r.heralds[:, 0] == 1), "MR slot did not herald on every shot"
+
+    # The heralded MR record bit is a uniformly drawn replacement: both values occur.
+    mr_bits = r.measurements[:, 0]
+    assert mr_bits.any(), "MR slot never recorded 1 over 256 shots"
+    assert not mr_bits.all(), "MR slot always recorded 1 over 256 shots"
+
+    # The second M reads 0 on every shot: MR restored the leaked qubit.
+    assert np.all(r.measurements[:, 1] == 0), "post-MR measurement was not 0"
+
+    # Final status is COMPUTATIONAL: the MR reset cleared the leak level.
+    assert np.all(r.final_status[:, 0] == COMPUTATIONAL), "final status was not COMPUTATIONAL"
+
+
+# --- Gap 10: seed=None smoke --------------------------------------------------
+
+
+def test_seed_none_smoke():
+    """sample() with no seed runs and returns the correct shapes.
+
+    The entropy-default path (seed=None) is never exercised by the
+    determinism or different-seed pins.  A shape-only smoke test is
+    sufficient: correctness is covered by the seeded suite."""
+    r = noncomp.sample("H 0\nM 0", noncomp.Model(), shots=8)
+    assert r.shots == 8
+    assert r.num_measurements == 1
+    assert r.measurements.shape == (8, 1)
+    assert r.final_status.shape == (8, 1)

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -116,3 +116,38 @@ def test_damping_boundary_probe_separates_exact_from_neglect():
 
     assert abs(p1_exact - expected_exact) < tol_exact
     assert abs(p1_neglect - expected_neglect) < tol_neglect
+
+
+def test_neglect_bell_correlation_probe():
+    """Neglect-mode forced trace-out keeps the source-determined partner correlation.
+
+    Model: source-dependent "leak" (e->leak_e p=1, g stays), identity
+    classifier (leak_e reads 1, leak_g reads 0), damping="neglect".
+    Circuit: H 0 / CX 0 1 / LEVEL_TRANSITION[leak] 0 / M 0 / M 1.
+
+    Under neglect every fire traps with the carrier uncollapsed; the
+    continuation forces a trace-out onto the reported source, so m0 and m1
+    must agree on every shot.  Fired shots (q0 was on e): leak_e reads 1;
+    the partner collapses to 1.  Unfired shots (q0 was on g): q0 reads 0;
+    q1 measures from the post-trace |0>, also 0.  Both outcomes must occur
+    to guard vacuity.
+
+    This is the sharp neglect-mode pin at the Bell-correlation level; the
+    TVD test exercises neglect end-to-end against the enumerator reference
+    but cannot resolve the O(p^2) difference between exact and neglect at
+    the cold-atom rates used there.
+    """
+    PROBE_SHOTS = 512
+    transitions = {"leak": _transition({(Level.LEAK_E, Level.E): 1.0})}
+    model = _model(transitions, damping="neglect")
+    text = "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n"
+
+    r = noncomp.sample(text, model, shots=PROBE_SHOTS, seed=15)
+    m = np.asarray(r.measurements)
+
+    # Per-shot correlation: m0 and m1 must agree on every shot.
+    assert (m[:, 0] == m[:, 1]).all(), "neglect Bell correlation violated"
+
+    # Both outcomes occur (guard vacuity).
+    assert m[:, 0].any(), "no shot had m0 == 1; transition never fired"
+    assert not m[:, 0].all(), "every shot had m0 == 1; g->g stay branch missing"

--- a/tests/python/test_noncomp_exact_tvd.py
+++ b/tests/python/test_noncomp_exact_tvd.py
@@ -196,7 +196,14 @@ def test_rep_code_round_tvd_reaches_shot_noise():
 
 
 def test_rep_code_round_tvd_under_neglect_matches_its_own_reference():
-    """The neglect fallback must match the reference that omits the no-fire
-    filter -- pinning the driver's neglect semantics distributionally, not
-    just at micro-probes."""
+    """The neglect fallback must match the reference that omits the no-fire filter.
+
+    This exercises neglect end-to-end against the enumerator at
+    repetition-code rates; the sharp neglect-mode pins are
+    ``test_damping_boundary_probe_separates_exact_from_neglect`` (which
+    separates exact from neglect by a closed-form O(p) gap on a single
+    site) and ``test_neglect_bell_correlation_probe`` (which pins the
+    forced trace-out at the Bell-correlation level).  At the cold-atom
+    magnitudes used here, exact and neglect differ by O(p^2), well below
+    the shot-noise band, so this test cannot distinguish the two modes."""
     _run_and_compare("neglect", seed=22)

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -193,3 +193,49 @@ def test_set_collapsed_qubit_reprepares_destination():
     _, at_e = oracle.collapse(oracle.apply_1q(oracle.zero_state(1), "X", 0, 1), 0, 1, 1)
     moved = oracle.set_collapsed_qubit(at_e, 0, 1, 0, 1)
     assert abs(abs(moved[0]) - 1.0) < 1e-12
+
+
+# --- Gap 4: two-site exact-damping composition vs enumerator ------------------
+
+
+def test_two_site_exact_damping_composition_matches_enumerator():
+    """Two LEVEL_TRANSITION[leak] sites in a row with p=0.5 from e, exact damping.
+
+    Circuit: H 0 / LEVEL_TRANSITION[leak] 0 / LEVEL_TRANSITION[leak] 0 / H 0 / M 0.
+    The channel contains two consecutive source-dependent (e-only) sites; the
+    composition of two non-scalar damp filters is the first multi-site exact-
+    damping check at a rate where any TVD between exact and neglect would be
+    observable.  Compare sampled record/status frequencies against the
+    enumerator's exact distribution within the file's existing BAND tolerance.
+
+    This exercises the composed-continuation path from the exact side: each
+    site adds one branch at run time, and the no-fire filter at each site
+    accumulates multiplicatively.
+    """
+    import utils_noncomp_enumerator as en
+
+    p = 0.5
+    transitions = {"leak": _transition({(Level.LEAK_E, Level.E): p})}
+    circuit_text = "H 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0\n"
+    classifier_matrix = [[1.0, 0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0]]
+
+    reference = en.enumerate_exact(
+        circuit_text,
+        initial=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions=transitions,
+        classifier=classifier_matrix,
+        damping="exact",
+    )
+    assert reference.dropped_mass < 1e-12
+
+    model = noncomp.Model(
+        initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions=transitions,
+        classifier=_classifier(Level.LEAK_E, [0.0, 1.0]),
+        damping="exact",
+    )
+    r = noncomp.sample(circuit_text, model, shots=SHOTS, seed=31)
+
+    empirical = en.empirical_record_probs(np.asarray(r.measurements))
+    tvd = en.tvd(reference.record_probs, empirical)
+    assert tvd < BAND, f"TVD {tvd:.4f} exceeds tolerance {BAND}"

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -1022,3 +1022,239 @@ TEST_CASE("exact: the model contract is validated even for zero shots") {
     REQUIRE(result.shots == 0);
     REQUIRE(result.measurements.empty());
 }
+
+// =========================================================================
+// Gap 1: Same-qubit re-trap (composed-continuation path)
+// =========================================================================
+
+namespace {
+
+// Certain e->leak_e leak and certain leak_e->e seep; g initial.
+// Circuit must prep |e> (e.g. X 0) before the first annotation fires.
+NonComputationalModel make_leak_seep_model() {
+    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
+    leak[kLeak][1] = 1.0;  // e -> leak_e, certainly
+
+    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
+    seep[1][kLeak] = 1.0;  // leak_e -> e, certainly
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0},
+                                            {{"leak", leak}, {"seep", seep}}, classifier, policy);
+}
+
+}  // namespace
+
+TEST_CASE("exact: same-qubit re-trap: leak then recapture then leak again") {
+    // X 0 preps |e>. LEVEL_TRANSITION[leak] traps (e->leak_e, certainly).
+    // LEVEL_TRANSITION[seep] recaptures back to e (classical consult).
+    // The second LEVEL_TRANSITION[leak] traps again (e->leak_e).
+    // The composed-continuation path exercises trap->recapture-consult->trap on one qubit.
+    // Expect: every shot reads 1 (leak_e column) and final status LeakE.
+    auto model = make_leak_seep_model();
+    auto circuit = parse(
+        "X 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[seep] 0\n"
+        "LEVEL_TRANSITION[leak] 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 30, 131);
+    for (uint32_t shot = 0; shot < 30; ++shot) {
+        REQUIRE(result.measurements[shot] == 1);  // leak_e column reads 1
+        REQUIRE(result.final_status[shot] == QubitStatus::LeakE);
+    }
+}
+
+TEST_CASE("exact: multi-target annotation jumps both targets in one shot") {
+    // LEVEL_TRANSITION[lose] on both q0 and q1 in a single annotation; the
+    // lose channel is source-independent (g->lost p=1, e->lost p=1), so both
+    // qubits lose in every shot. Both records read 0 (identity classifier's
+    // lost column), both statuses are Lost.
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;  // g -> lost, certainly
+    lose[kLost][1] = 1.0;  // e -> lost, certainly
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+                                                  classifier, policy);
+    auto circuit = parse("LEVEL_TRANSITION[lose] 0 1\nM 0\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 20, 133);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot * 2] == 0);      // lost column reads 0
+        REQUIRE(result.measurements[shot * 2 + 1] == 0);  // lost column reads 0
+        REQUIRE(result.final_status[shot * 2] == QubitStatus::Lost);
+        REQUIRE(result.final_status[shot * 2 + 1] == QubitStatus::Lost);
+    }
+}
+
+// =========================================================================
+// Gap 2: LOSS on already-leaked and already-lost
+// =========================================================================
+
+TEST_CASE("exact: LOSS(1) on a pure leak_g initial vacates the carrier") {
+    // Initial mass entirely on leak_g (index 2): the qubit is already
+    // noncomputational. LOSS(1) on a leaked qubit still vacates it (the
+    // channel fires from any non-lost level). Every shot: status Lost,
+    // record 0 (identity classifier's lost column reads 0).
+    ModelSpec spec;
+    spec.initial = {0.0, 0.0, 1.0, 0.0, 0.0};  // pure leak_g
+    auto model = make_model(spec);
+    auto circuit = parse("LOSS(1) 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 20, 141);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);  // identity classifier, lost column reads 0
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: LOSS(1) on a pure lost initial is a no-op") {
+    // Initial mass entirely on lost (index 4): LOSS is a no-op on an
+    // already-lost qubit. Status Lost, record 0 on every shot.
+    ModelSpec spec;
+    spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};  // pure lost
+    auto model = make_model(spec);
+    auto circuit = parse("LOSS(1) 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 20, 143);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);  // identity classifier, lost column reads 0
+        REQUIRE(result.final_status[shot] == QubitStatus::Lost);
+    }
+}
+
+TEST_CASE("exact: LOSS on a lost qubit spends no draw -- records are identical") {
+    // A LOSS(1) on a pure-lost initial must produce the same records as a
+    // plain M 0 on the same initial at the same seed: the lost-qubit LOSS
+    // consult emits no node in the compiled module, so the draw streams are
+    // unchanged. This guards that the implementation really no-ops at lost
+    // rather than consuming any RNG draw.
+    const uint64_t seed = 147;
+    ModelSpec spec;
+    spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};  // pure lost
+    auto model = make_model(spec);
+
+    auto r_plain = sample_noncomputational(parse("M 0"), model, 30, seed);
+    auto r_loss = sample_noncomputational(parse("LOSS(1) 0\nM 0"), model, 30, seed);
+    REQUIRE(r_plain.measurements == r_loss.measurements);
+}
+
+// =========================================================================
+// Gap 5: Classified record drives feedback
+// =========================================================================
+
+TEST_CASE("exact: classified record drives a CX feedback gate") {
+    // "lose" is hooked on S: g and e both jump to lost with certainty.
+    // Classifier: classified symbol 0 always reads 0, classified symbol 1
+    // always reads 1; the lost column has weight on symbol 1, so rec[-1]
+    // after the S-annotated M 0 is 1 on every shot.
+    // CX rec[-1] 1 flips q1 conditioned on that classified record.
+    // Final M 1 must read 1 on every shot; q1 stays Computational.
+    //
+    // Note: a feedback-onto-leaked observability test would be a vacuous
+    // pass -- a dropped virtual correction on a vacated carrier is
+    // unobservable by design (the carrier is gone).
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    // g=0, e=1, leak_g=0, leak_e=1, lost=1
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+
+    NonComputationalPolicy policy;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
+                                                  classifier, policy);
+    auto circuit = parse("S 0\nM 0\nCX rec[-1] 1\nM 1");
+
+    auto result = sample_noncomputational(circuit, model, 25, 151);
+    for (uint32_t shot = 0; shot < 25; ++shot) {
+        REQUIRE(result.measurements[shot * 2 + 1] == 1);  // classified record drove the CX
+        REQUIRE(result.final_status[shot * 2 + 1] == QubitStatus::Computational);
+    }
+}
+
+// =========================================================================
+// Gap 6: Restored-lost qubit is actually re-prepared
+// =========================================================================
+
+TEST_CASE("exact: a reset truly re-prepares a restored-lost qubit") {
+    // "lose" is hooked on S (g and e both -> lost with certainty).
+    // reset_restores_lost=true means R 0 reloads the lost carrier.
+    // H 0 before S scrambles the pre-loss state: if R did NOT re-prepare
+    // the carrier the record would be random (the lost carrier's parked
+    // |+> state would read 0 or 1 at random). A true re-prepare resets
+    // to |0>, so M 0 must read 0 and the final status must be Computational
+    // on every shot.
+    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
+    lose[kLost][0] = 1.0;
+    lose[kLost][1] = 1.0;
+
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+
+    NonComputationalPolicy policy;
+    policy.reset_restores_lost = true;
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
+                                                  classifier, policy);
+    auto circuit = parse("H 0\nS 0\nR 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 30, 161);
+    for (uint32_t shot = 0; shot < 30; ++shot) {
+        REQUIRE(result.measurements[shot] == 0);  // re-prepared to |0>
+        REQUIRE(result.final_status[shot] == QubitStatus::Computational);
+    }
+}
+
+// =========================================================================
+// Gap 8: max_rank succeeds exactly at the cap
+// =========================================================================
+
+TEST_CASE("exact: max_rank succeeds exactly at the required rank") {
+    // Reuses the over-cap circuit from the rejection test: three H-prefixed
+    // source-dependent sites push peak rank to 3 (over a cap of 2). The
+    // same circuit must succeed with max_rank = 3 (the actual required rank).
+    ModelSpec spec;
+    spec.leak_from_e = 0.2;
+    auto model = make_model(spec);
+    auto circuit = parse(
+        "H 0\nH 1\nH 2\n"
+        "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
+        "M 0\nM 1\nM 2");
+
+    // max_rank = 3 is exactly the peak; must succeed.
+    auto result = sample_noncomputational(circuit, model, 5, 1, /*max_rank=*/3);
+    REQUIRE(result.shots == 5);
+    REQUIRE(result.num_measurements == 3);
+}
+
+// =========================================================================
+// Gap 9: C++ different-seed-differs
+// =========================================================================
+
+TEST_CASE("exact: different seeds produce different records") {
+    // A stochastic config (leak p=0.35 from e after H) sampled at two
+    // different seeds must differ: a constant-output implementation that
+    // ignores the seed would collide here with probability 2^(-measurements).
+    // This is the C++ companion to the Python same-seed/different-seed pins.
+    ModelSpec spec;
+    spec.leak_from_e = 0.35;
+    spec.initial = {0.5, 0.5, 0.0, 0.0, 0.0};
+    auto model = make_model(spec);
+    auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+
+    auto a = sample_noncomputational(circuit, model, 64, 97);
+    auto b = sample_noncomputational(circuit, model, 64, 98);
+    // 64 coin-flip measurements collide with probability 2^-64; this is
+    // astronomically unlikely for any two distinct seeds.
+    REQUIRE(a.measurements != b.measurements);
+}

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -1130,20 +1130,39 @@ TEST_CASE("exact: LOSS(1) on a pure lost initial is a no-op") {
     }
 }
 
-TEST_CASE("exact: LOSS on a lost qubit spends no draw -- records are identical") {
-    // A LOSS(1) on a pure-lost initial must produce the same records as a
-    // plain M 0 on the same initial at the same seed: the lost-qubit LOSS
-    // consult emits no node in the compiled module, so the draw streams are
-    // unchanged. This guards that the implementation really no-ops at lost
-    // rather than consuming any RNG draw.
+TEST_CASE("exact: LOSS on a lost qubit spends no draw -- a later consult sees the same stream") {
+    // A LOSS(1) on an already-lost qubit records its no-op without
+    // consuming any driver randomness. The discriminator is a stochastic
+    // consult AFTER it: the recover channel returns the lost qubit to e
+    // with probability one half, drawing from the driver stream. If the
+    // preceding LOSS spent a draw, every later recover outcome would
+    // shift; instead the two runs must agree shot by shot on records and
+    // statuses alike.
     const uint64_t seed = 147;
-    ModelSpec spec;
-    spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};  // pure lost
-    auto model = make_model(spec);
+    std::vector<std::vector<double>> recover(5, std::vector<double>(5, 0.0));
+    recover[1][kLost] = 0.5;  // lost -> e, probability one half
+    ClassifierSpec classifier;
+    classifier.num_symbols = 2;
+    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    auto model = NonComputationalModel::from_spec({0.0, 0.0, 0.0, 0.0, 1.0}, {{"recover", recover}},
+                                                  classifier, NonComputationalPolicy{});
 
-    auto r_plain = sample_noncomputational(parse("M 0"), model, 30, seed);
-    auto r_loss = sample_noncomputational(parse("LOSS(1) 0\nM 0"), model, 30, seed);
+    auto r_plain =
+        sample_noncomputational(parse("LEVEL_TRANSITION[recover] 0\nM 0"), model, 128, seed);
+    auto r_loss = sample_noncomputational(parse("LOSS(1) 0\nLEVEL_TRANSITION[recover] 0\nM 0"),
+                                          model, 128, seed);
     REQUIRE(r_plain.measurements == r_loss.measurements);
+    REQUIRE(r_plain.final_status == r_loss.final_status);
+
+    // Vacuity guard: the recover consult really is stochastic -- both
+    // outcomes occur across the shots.
+    bool saw_zero = false;
+    bool saw_one = false;
+    for (uint32_t shot = 0; shot < 128; ++shot) {
+        (r_plain.measurements[shot] == 0 ? saw_zero : saw_one) = true;
+    }
+    REQUIRE(saw_zero);
+    REQUIRE(saw_one);
 }
 
 // =========================================================================


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review. Tests and docs only; `src/` is untouched.

## Summary

Closes the pre-merge review's test-gap list. Every expected value was runtime-verified before being written down, and every pin carries a discriminating assertion (no vacuous passes):

- **Same-qubit re-trap** (leak → recapture-consult → leak again in one shot) — the composed-continuation path at the heart of the trap engine, previously exercised nowhere — plus both targets of one multi-target annotation jumping in a single shot.
- **`LOSS` on already-noncomputational carriers**: vacates a leaked qubit, no-ops on a lost one, and *spends no draw* there — pinned by same-seed record identity between circuits with and without the lost-qubit `LOSS`.
- **Python neglect Bell-correlation probe** — the sharp forced-trace-out pin existed only in C++; the primary API now carries it (per-shot `m0 == m1` with both outcomes occurring).
- **Two-site exact-damping composition** vs the enumerator at p=0.5 — the first multi-site damping check at a rate the TVD band could never resolve (all prior closed-form pins were single-site).
- **Classified record drives `CX rec[-1]`** end to end; **restored-lost qubit measures a clean |0⟩** after a randomizing `H` (proving the reset re-prepares the carrier, not just the ledger); **ternary herald on a measure-reset** slot; **`max_rank` succeeds exactly at the cap**; **C++ different-seed divergence**; **`seed=None` smoke**.
- **Honesty edits**: the neglect-mode TVD test's docstring now states that at cold-atom rates exact and neglect differ by O(p²) below its band and names the two sharp probes that do the real pinning; the design note records that the enumerator imports the oracle's channel primitives — one independent reference, not two, anchored by hand-derived closed forms.

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1069 cases (+9)
- Python: 913 pass on both wheels (+4)
- Zero expectation discrepancies — every reviewer-verified value held on first run, none retuned
- Draw-stream fingerprints byte-identical to the base tip (tests/docs only)
- `pre-commit run --all-files` clean

## Review round

- P2 (valid — and the spec's fault, not the implementation's): the lost-`LOSS` draw-neutrality pin had no downstream stochastic event, so a regression consuming a driver draw would have passed unseen — exactly the "passes with the mechanism removed" failure mode. The pin now places a probability-½ recover consult after the `LOSS`: its outcome rides the driver stream, so shot-by-shot record/status identity between the two runs holds only if the `LOSS` truly spends nothing, with a vacuity guard pinning that both consult outcomes occur. Suite re-run green (1069 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)