### PR TITLE
fix(noncomp): compile the main line lazily and single-source the status walk

### DIFF
--- a/src/clifft/noncomp/classifier.cc
+++ b/src/clifft/noncomp/classifier.cc
@@ -10,19 +10,13 @@
 namespace clifft {
 
 MeasurementClassifier MeasurementClassifier::from_matrix(
-    size_t num_symbols, const std::vector<std::vector<double>>& matrix) {
-    if (num_symbols != 2 && num_symbols != 3) {
+    const std::vector<std::vector<double>>& matrix) {
+    const size_t s_n = matrix.size();
+    if (s_n != 2 && s_n != 3) {
         throw std::invalid_argument(
             "MeasurementClassifier::from_matrix: a classifier has two record symbols and an "
             "optional third herald symbol; got " +
-            std::to_string(num_symbols) + " symbols");
-    }
-
-    const size_t s_n = num_symbols;
-    if (matrix.size() != s_n) {
-        throw std::invalid_argument("MeasurementClassifier::from_matrix: matrix has " +
-                                    std::to_string(matrix.size()) + " rows; expected " +
-                                    std::to_string(s_n) + " (one per symbol)");
+            std::to_string(s_n) + " rows");
     }
 
     // Single pass: validate row width and entry bounds while copying
@@ -76,7 +70,7 @@ MeasurementClassifier MeasurementClassifier::from_matrix(
         }
     }
 
-    return MeasurementClassifier(num_symbols, std::move(flat));
+    return MeasurementClassifier(s_n, std::move(flat));
 }
 
 double MeasurementClassifier::prob(uint8_t symbol_idx, Level level) const {

--- a/src/clifft/noncomp/classifier.h
+++ b/src/clifft/noncomp/classifier.h
@@ -29,13 +29,12 @@ namespace clifft {
 class MeasurementClassifier {
   public:
     // Validates that:
-    //   - num_symbols is two or three;
-    //   - matrix has shape (num_symbols, kNumLevels);
+    //   - matrix.size() (the row count) is two or three;
+    //   - every row has kNumLevels columns;
     //   - every entry is finite and lies in [0, 1] (strict);
     //   - every column sums to 1 within tolerance;
     //   - the computational columns place no mass on the herald symbol.
-    static MeasurementClassifier from_matrix(size_t num_symbols,
-                                             const std::vector<std::vector<double>>& matrix);
+    static MeasurementClassifier from_matrix(const std::vector<std::vector<double>>& matrix);
 
     // The positional index of the herald symbol, when one is present.
     static constexpr uint8_t kHeraldSymbol = 2;

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -239,21 +239,10 @@ void extend_classical_outcomes(const Circuit& annotated, ExactShotEvents& events
             }
             continue;
         }
-        // Ordinary operations advance statuses exactly as the rewrite
-        // does; drops keep entry statuses, which the stepper handles via
-        // the shared policy scan semantics.
-        bool drop_op = false;
-        for (const QubitOperand& operand : qubit_operands(node)) {
-            if (operand_action(gate, status[operand.qubit], model.policy()) ==
-                OperandAction::Drop) {
-                drop_op = true;
-            }
-        }
-        for (const QubitOperand& operand : qubit_operands(node)) {
-            const QubitStatus pre = status[operand.qubit];
-            status[operand.qubit] =
-                drop_op ? pre : normal_post_op_status(pre, gate, operand.role, model.policy());
-        }
+        // Ordinary operations advance statuses through the shared walk --
+        // the same walk the rewriter uses, now via a single helper.
+        advance_ordinary_node(annotated.nodes[op_index], op_index, status, model.policy(),
+                              "sample_noncomputational");
     }
     events.classical_outcomes = std::move(ordered);
 }
@@ -604,8 +593,10 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             for (size_t i = 0; i < flags.size(); ++i) {
                 if (flags[i] != 0) {
                     const ClassifiedMeasurement& m = entry.rw.classified_measurements[i];
-                    assert(m.noise_node != SIZE_MAX);
-                    patched.nodes[m.noise_node].args[0] = 0.5;
+                    assert(m.noise_node.has_value() &&
+                           "classified measurement must have a READOUT_NOISE node to patch for "
+                           "herald");
+                    patched.nodes[*m.noise_node].args[0] = 0.5;
                 }
             }
             // When the rewrite names a forced trace-out node, ask trace()
@@ -684,10 +675,6 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     // The shared main line: the continuation of "nothing happened".
     ExactShotEvents no_events;
     no_events.initial_status.assign(circuit.num_qubits, QubitStatus::Computational);
-    ContinuationEntry& main_entry = get_entry(no_events, false);
-    CompiledModule* main_module = get_module(
-        main_entry, std::vector<uint8_t>(main_entry.rw.classified_measurements.size(), 0), nullptr,
-        0);
 
     // The state is reused across shots (growth from trap continuations
     // amortizes to the chain maximum); a starting module that outgrows it
@@ -696,17 +683,18 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     // to the running maxima, never to the triggering module: a starting
     // module can exceed on one axis (say, hidden record slots) while
     // being smaller on the other, and later shots reuse the state.
-    auto make_state = [&](uint32_t peak_rank, uint32_t total_meas_slots) {
-        return SchrodingerState(StateConfig{.peak_rank = peak_rank,
-                                            .num_measurements = total_meas_slots,
-                                            .num_qubits = main_module->num_qubits,
-                                            .num_detectors = main_module->num_detectors,
-                                            .num_observables = main_module->num_observables,
-                                            .seed = 0});
+    auto make_state = [&](const CompiledModule& m, uint32_t peak_rank, uint32_t total_meas_slots) {
+        return SchrodingerState(StateConfig{
+            .peak_rank = peak_rank,
+            .num_measurements = total_meas_slots,
+            .num_qubits = m.num_qubits,
+            .num_detectors = m.num_detectors,
+            .num_observables = m.num_observables,
+            .seed = 0});  // placeholder; reseed() supplies the per-shot seed before execution
     };
-    uint32_t state_rank = main_module->peak_rank;
-    uint32_t state_slots = main_module->total_meas_slots;
-    SchrodingerState state = make_state(state_rank, state_slots);
+    uint32_t state_rank = 0;
+    uint32_t state_slots = 0;
+    std::optional<SchrodingerState> state_storage;
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
         Xoshiro256PlusPlus driver_rng(derive_seed(global_seed, shot, kExactDriverDomain));
@@ -755,8 +743,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
         // consults over the whole circuit are pre-drawn for it. The
         // rewrite fetch consumes no randomness, so drawing the herald
         // flags after it keeps every driver draw ahead of module lookup.
-        ContinuationEntry* entry = &main_entry;
-        CompiledModule* module = main_module;
+        ContinuationEntry* entry = nullptr;
+        CompiledModule* module = nullptr;
         // An all-computational, no-jump walk consumes no randomness and
         // moves no status: statuses leave Computational only via jumps or
         // noncomputational initials, and classical consults happen only for
@@ -768,17 +756,24 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             module = get_module(*entry, flags_for(entry->rw), nullptr, 0);
             final_status = entry->rw.final_status;
         } else {
+            entry = &get_entry(no_events, false);
+            module = get_module(*entry, flags_for(entry->rw), nullptr, 0);
             final_status.assign(circuit.num_qubits, QubitStatus::Computational);
         }
 
-        if (shot > 0) {
-            state.reset();
+        if (!state_storage.has_value()) {
+            state_rank = module->peak_rank;
+            state_slots = module->total_meas_slots;
+            state_storage.emplace(make_state(*module, state_rank, state_slots));
+        } else {
+            state_storage->reset();
+            if (module->peak_rank > state_rank || module->total_meas_slots > state_slots) {
+                state_rank = std::max(state_rank, module->peak_rank);
+                state_slots = std::max(state_slots, module->total_meas_slots);
+                state_storage.emplace(make_state(*module, state_rank, state_slots));
+            }
         }
-        if (module->peak_rank > state_rank || module->total_meas_slots > state_slots) {
-            state_rank = std::max(state_rank, module->peak_rank);
-            state_slots = std::max(state_slots, module->total_meas_slots);
-            state = make_state(state_rank, state_slots);
-        }
+        SchrodingerState& state = *state_storage;
         state.reseed(derive_seed(global_seed, shot, kExactSvmDomain));
         assert(state.meas_record.size() >= module->total_meas_slots &&
                "the rebuild block above guarantees meas_record capacity; "
@@ -856,6 +851,11 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
 
             entry = &next_entry;
             module = next_module;
+            // grow_for_continuation sizes the state to this module inside resume();
+            // track it so a later starting-module rebuild never shrinks capacity
+            // the chain already reached.
+            state_rank = std::max(state_rank, module->peak_rank);
+            state_slots = std::max(state_slots, module->total_meas_slots);
             resume(*module, state, module->instrument_offsets[trap.site_id] + 1);
         }
 

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -130,7 +130,8 @@ NonComputationalModel::NonComputationalModel(
 NonComputationalModel NonComputationalModel::from_spec(
     std::vector<double> initial_state,
     const std::map<std::string, std::vector<std::vector<double>>>& transition_matrices,
-    std::optional<ClassifierSpec> classifier_spec, NonComputationalPolicy policy) {
+    std::optional<std::vector<std::vector<double>>> classifier_matrix,
+    NonComputationalPolicy policy) {
     std::map<std::string, TransitionInstrument> transitions;
     for (const auto& [gate, matrix] : transition_matrices) {
         try {
@@ -142,9 +143,8 @@ NonComputationalModel NonComputationalModel::from_spec(
     }
 
     std::optional<MeasurementClassifier> classifier;
-    if (classifier_spec.has_value()) {
-        classifier = MeasurementClassifier::from_matrix(classifier_spec->num_symbols,
-                                                        classifier_spec->matrix);
+    if (classifier_matrix.has_value()) {
+        classifier = MeasurementClassifier::from_matrix(*classifier_matrix);
     }
 
     return NonComputationalModel(std::move(initial_state), std::move(transitions),

--- a/src/clifft/noncomp/model.h
+++ b/src/clifft/noncomp/model.h
@@ -33,22 +33,12 @@
 
 namespace clifft {
 
-// Raw classifier spec: symbol count and the stochastic matrix
-// P[symbol][level]. Symbol labels belong to the Python-facing API; C++
-// only needs the positional record/herald convention. Bundled so the
-// model builder takes an optional classifier without a separate presence
-// flag.
-struct ClassifierSpec {
-    size_t num_symbols;
-    std::vector<std::vector<double>> matrix;
-};
-
 class NonComputationalModel {
   public:
     // The one construction path: build every TransitionInstrument and
     // the classifier from raw matrices, then assemble and validate.
     // `transition_matrices` maps a transition key to its T[to][from]
-    // matrix; `classifier_spec` is optional. Throws
+    // matrix; `classifier_matrix` is optional. Throws
     // std::invalid_argument, naming the offending component, when a
     // matrix is malformed, the initial state is not a probability
     // vector over the five levels, a transition key cannot be
@@ -58,7 +48,8 @@ class NonComputationalModel {
     static NonComputationalModel from_spec(
         std::vector<double> initial_state,
         const std::map<std::string, std::vector<std::vector<double>>>& transition_matrices,
-        std::optional<ClassifierSpec> classifier_spec, NonComputationalPolicy policy);
+        std::optional<std::vector<std::vector<double>>> classifier_matrix,
+        NonComputationalPolicy policy);
 
     // P(initial level). The stored distribution sums to exactly 1.
     double initial_probability(Level level) const {

--- a/src/clifft/noncomp/op_role.cc
+++ b/src/clifft/noncomp/op_role.cc
@@ -90,8 +90,9 @@ OrdinaryStep advance_ordinary_node(const AstNode& node, uint32_t op_index,
         }
     }
 
-    // Set when this (single-qubit Z-basis) measurement reads a leaked or
-    // lost qubit: the classifier, not the SVM, defines its record bit.
+    // Set when this single-qubit measurement (any basis -- the readout
+    // basis is incidental on a vacated carrier) reads a leaked or lost
+    // qubit: the classifier, not the SVM, defines its record bit.
     std::optional<Level> classified_level;
 
     for (const QubitOperand& operand : qubit_operands(node)) {

--- a/src/clifft/noncomp/op_role.cc
+++ b/src/clifft/noncomp/op_role.cc
@@ -2,9 +2,13 @@
 
 #include "clifft/circuit/gate_data.h"
 #include "clifft/circuit/target.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/status_step.h"
 
+#include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace clifft {
 
@@ -54,6 +58,54 @@ std::vector<QubitOperand> qubit_operands(const AstNode& node) {
         operands.push_back(QubitOperand{target.value(), role});
     }
     return operands;
+}
+
+OrdinaryStep advance_ordinary_node(const AstNode& node, uint32_t op_index,
+                                   std::vector<QubitStatus>& status,
+                                   const NonComputationalPolicy& policy, std::string_view caller) {
+    const GateType gate = node.gate;
+
+    // Policy pre-scan over entry statuses: any rejecting operand rejects
+    // the whole operation; otherwise any dropping operand drops it whole
+    // (identity on the surviving operands).
+    bool drop_op = false;
+    for (const QubitOperand& operand : qubit_operands(node)) {
+        const uint32_t qubit = operand.qubit;
+        if (qubit >= status.size()) {
+            throw std::invalid_argument(std::string(caller) + ": operand qubit " +
+                                        std::to_string(qubit) + " is out of range at op " +
+                                        std::to_string(op_index));
+        }
+        switch (operand_action(gate, status[qubit], policy)) {
+            case OperandAction::Reject:
+                throw std::invalid_argument(
+                    std::string(caller) + ": operation '" + std::string(gate_name(gate)) +
+                    "' on a " + status_name(status[qubit]) + " qubit " + std::to_string(qubit) +
+                    " at op " + std::to_string(op_index) + " is not representable; rejecting");
+            case OperandAction::Drop:
+                drop_op = true;
+                break;
+            case OperandAction::Apply:
+                break;
+        }
+    }
+
+    // Set when this (single-qubit Z-basis) measurement reads a leaked or
+    // lost qubit: the classifier, not the SVM, defines its record bit.
+    std::optional<Level> classified_level;
+
+    for (const QubitOperand& operand : qubit_operands(node)) {
+        const uint32_t qubit = operand.qubit;
+        const QubitStatus pre = status[qubit];
+
+        if (is_measurement(gate) && !is_computational(pre)) {
+            classified_level = noncomp_level(pre);
+        }
+
+        status[qubit] = drop_op ? pre : normal_post_op_status(pre, gate, operand.role, policy);
+    }
+
+    return OrdinaryStep{drop_op, classified_level};
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/op_role.h
+++ b/src/clifft/noncomp/op_role.h
@@ -15,6 +15,8 @@
 #include "clifft/noncomp/status_step.h"
 
 #include <cstdint>
+#include <optional>
+#include <string_view>
 #include <vector>
 
 namespace clifft {
@@ -29,5 +31,20 @@ struct QubitOperand {
 // control is classical feedback, so its qubit operands get the Feedback
 // role; otherwise operands are Physical.
 std::vector<QubitOperand> qubit_operands(const AstNode& node);
+
+// One ordinary (non-annotation) node of the shared status walk: range-check
+// operands, decide the whole-op policy verdict, and advance `status`.
+// A rejecting operand throws std::invalid_argument (`caller` names the
+// context); when any operand drops, the whole operation drops and every
+// operand holds its entry status. For a measurement whose operand enters
+// leaked or lost, reports that entry level -- the classifier consult the
+// rewriter turns into a record substitution.
+struct OrdinaryStep {
+    bool dropped = false;
+    std::optional<Level> measured_noncomp_level;
+};
+OrdinaryStep advance_ordinary_node(const AstNode& node, uint32_t op_index,
+                                   std::vector<QubitStatus>& status,
+                                   const NonComputationalPolicy& policy, std::string_view caller);
 
 }  // namespace clifft

--- a/src/clifft/noncomp/orchestrator.h
+++ b/src/clifft/noncomp/orchestrator.h
@@ -4,11 +4,11 @@
 //
 // sample_noncomputational(circuit, model, shots, seed) validates the
 // circuit, resolves the global seed, and hands the run to the exact-mode
-// driver (exact_driver.h) -- the one sampling path: the annotated circuit
-// compiles once as a shared main line, transition fires resolve at
-// runtime against the live state, and the driver returns the user-facing
-// records plus the noncomputational sidecar (final statuses and herald
-// flags).
+// driver (exact_driver.h) -- the one sampling path: the annotated
+// circuit's rewrites compile lazily, one memoized module per event delta
+// (the no-event main line included), transition fires resolve at runtime
+// against the live state, and the driver returns the user-facing records
+// plus the noncomputational sidecar (final statuses and herald flags).
 //
 // Randomness is deterministic in `seed`: per-shot driver and SVM streams
 // derive from domain-separated sub-seeds (seed.h). Stochastic classifier

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -102,44 +102,9 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
     const NonComputationalPolicy& policy = model.policy();
     const GateType gate = node.gate;
 
-    // Policy pre-scan over entry statuses: any rejecting operand rejects
-    // the whole operation; otherwise any dropping operand drops it whole
-    // (identity on the surviving operands).
-    bool drop_op = false;
-    for (const QubitOperand& operand : qubit_operands(node)) {
-        const uint32_t qubit = operand.qubit;
-        if (qubit >= status.size()) {
-            throw std::invalid_argument("rewrite: operand qubit " + std::to_string(qubit) +
-                                        " is out of range at op " + std::to_string(op_index));
-        }
-        switch (operand_action(gate, status[qubit], policy)) {
-            case OperandAction::Reject:
-                throw std::invalid_argument(
-                    "rewrite: operation '" + std::string(gate_name(gate)) + "' on a " +
-                    status_name(status[qubit]) + " qubit " + std::to_string(qubit) + " at op " +
-                    std::to_string(op_index) + " is not representable; rejecting");
-            case OperandAction::Drop:
-                drop_op = true;
-                break;
-            case OperandAction::Apply:
-                break;
-        }
-    }
-
-    // Set when this (single-qubit Z-basis) measurement reads a leaked or
-    // lost qubit: the classifier, not the SVM, defines its record bit.
-    std::optional<Level> classified_level;
-
-    for (const QubitOperand& operand : qubit_operands(node)) {
-        const uint32_t qubit = operand.qubit;
-        const QubitStatus pre = status[qubit];
-
-        if (is_measurement(gate) && !is_computational(pre)) {
-            classified_level = noncomp_level(pre);
-        }
-
-        status[qubit] = drop_op ? pre : normal_post_op_status(pre, gate, operand.role, policy);
-    }
+    const OrdinaryStep step = advance_ordinary_node(node, op_index, status, policy, "rewrite");
+    bool drop_op = step.dropped;
+    std::optional<Level> classified_level = step.measured_noncomp_level;
 
     if (!drop_op) {
         if (classified_level.has_value()) {
@@ -172,7 +137,7 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
                 flip = 1.0 - flip;
             }
 
-            size_t noise_node = SIZE_MAX;
+            std::optional<size_t> noise_node;
             if (!ternary && (flip == 0.0 || flip == 1.0)) {
                 // Deterministic column: the bit is the padding literal
                 // itself, no sample-time draw.
@@ -245,7 +210,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
 
     // Node index (into `out`) of the last jump's trace-out R, when one is
     // emitted; converted to a hidden record slot after the walk.
-    size_t traceout_node = SIZE_MAX;
+    std::optional<size_t> traceout_node;
 
     uint32_t slot = 0;  // visible measurement record index
 
@@ -318,8 +283,12 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
                     }
                 } else {
                     const TransitionInstrument* instr = model.transition_named(node.tag);
-                    if (instr != nullptr && instr->column_sum(Level::G) == 0.0 &&
-                        instr->column_sum(Level::E) == 0.0) {
+                    if (instr == nullptr) {
+                        throw std::invalid_argument(
+                            "rewrite_continuation: unknown transition tag '" + node.tag +
+                            "' at op " + std::to_string(op_index));
+                    }
+                    if (instr->column_sum(Level::G) == 0.0 && instr->column_sum(Level::E) == 0.0) {
                         continue;
                     }
                 }
@@ -375,9 +344,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
             "consults");
     }
 
-    if (traceout_node != SIZE_MAX) {
-        result.forced_traceout_node = traceout_node;
-    }
+    result.forced_traceout_node = traceout_node;
 
     result.final_status = std::move(status);
     return result;

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -9,10 +9,12 @@
 //      shared status stepper and keep, drop, or reject the operation. An
 //      operation with no representable effect on a leaked or lost operand is
 //      excised whole (identity on the surviving operands), whose statuses
-//      then keep their entry values. A non-reset X/Y-basis measurement
-//      (MX/MY) or a multi-qubit-parity measurement (MPP) of such an operand
-//      has no faithful single-bit form and is rejected -- a representability
-//      limit, not a policy choice. A measure-and-reset (MR/MRX/MRY) is kept.
+//      then keep their entry values. A single-qubit measurement (M, MX, MY)
+//      on a leaked or lost operand classifies exactly as a Z-basis measurement
+//      -- the readout basis is incidental on a vacated carrier. A multi-qubit
+//      parity measurement (MPP) rejects as it has no faithful single-bit form
+//      -- a representability limit, not a policy choice. A measure-and-reset
+//      (MR/MRX/MRY) is kept.
 //   2. Classifier record write: a measurement on a leaked or lost qubit is
 //      not a physical Born measurement -- the model's classifier defines its
 //      record bit. The measurement node is replaced by an MPAD writing the
@@ -71,9 +73,9 @@ struct ClassifiedMeasurement {
     Level level = Level::G;
 
     // Index into the rewritten circuit's nodes of the READOUT_NOISE node
-    // drawing this slot's bit, or SIZE_MAX when the column is deterministic
+    // drawing this slot's bit, or absent when the column is deterministic
     // and the bit is the MPAD literal itself.
-    size_t noise_node = SIZE_MAX;
+    std::optional<size_t> noise_node;
 };
 
 // =============================================================================

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -66,7 +66,6 @@ void register_noncomp(nb::module_& m) {
         "_build_noncomp_model",
         [](std::vector<double> initial_state,
            std::map<std::string, std::vector<std::vector<double>>> transitions,
-           std::optional<size_t> classifier_num_symbols,
            std::optional<std::vector<std::vector<double>>> classifier_matrix,
            bool reset_restores_lost, const std::string& damping) {
             clifft::NonComputationalPolicy policy;
@@ -80,21 +79,10 @@ void register_noncomp(nb::module_& m) {
                     "noncomp model: damping must be 'exact' or 'neglect', got '" + damping + "'");
             }
 
-            std::optional<clifft::ClassifierSpec> spec;
-            if (classifier_num_symbols.has_value() || classifier_matrix.has_value()) {
-                if (!classifier_num_symbols.has_value() || !classifier_matrix.has_value()) {
-                    throw std::invalid_argument(
-                        "noncomp model: a classifier needs both a symbol count and a matrix");
-                }
-                spec =
-                    clifft::ClassifierSpec{*classifier_num_symbols, std::move(*classifier_matrix)};
-            }
-
             return clifft::NonComputationalModel::from_spec(std::move(initial_state), transitions,
-                                                            std::move(spec), policy);
+                                                            std::move(classifier_matrix), policy);
         },
-        nb::arg("initial_state"), nb::arg("transitions"),
-        nb::arg("classifier_num_symbols") = nb::none(), nb::arg("classifier_matrix") = nb::none(),
+        nb::arg("initial_state"), nb::arg("transitions"), nb::arg("classifier_matrix") = nb::none(),
         nb::arg("reset_restores_lost") = false, nb::arg("damping") = "exact",
         "Build a default 5-level NonComputationalModel from raw matrices. See "
         "clifft.noncomp.Model.");

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -173,18 +173,16 @@ class Model:
         transition_matrices = {
             str(gate): _as_matrix(matrix) for gate, matrix in (transitions or {}).items()
         }
-        num_symbols = None if classifier is None else len(classifier.matrix)
         matrix = None if classifier is None else classifier.matrix
         self._handle = _clifft_core._build_noncomp_model(
             [float(p) for p in initial_state],
             transition_matrices,
-            num_symbols,
             matrix,
             bool(reset_restores_lost),
             str(damping),
         )
         self._transition_keys: list[str] = sorted(transition_matrices.keys())
-        self._classifier_rows: int | None = num_symbols
+        self._classifier_rows: int | None = None if classifier is None else len(classifier.matrix)
         self._reset_restores_lost: bool = bool(reset_restores_lost)
         self._damping: str = str(damping)
 
@@ -295,7 +293,10 @@ def sample(
     ``max_rank`` caps the compiled peak rank under exact-mode compilation;
     the cap is enforced at each continuation compile, failing with the
     offending circuit line named instead of attempting a ``2**k``
-    allocation. Unlimited when ``None``.
+    allocation. The cap applies to each compiled module, including branches
+    a given shot never takes (such as the no-fire suffix past a
+    certain-fire annotation), so it is conservative: a rejected circuit may
+    keep every reachable trajectory within the cap. Unlimited when ``None``.
     """
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -404,6 +404,29 @@ def test_max_rank_rejects_over_budget_exact_but_neglect_fits():
     assert r.num_measurements == 3
 
 
+def test_max_rank_ignores_the_unreachable_all_computational_module():
+    """A model whose initial state has zero computational mass never runs the
+    no-event module; its rank must not be able to reject the run."""
+    circuit = (
+        "H 0\n"
+        + "".join(f"CX 0 {i}\n" for i in range(1, 6))
+        + "".join(f"T {i}\nH {i}\n" for i in range(6))
+        + "".join(f"M {i}\n" for i in range(6))
+    )
+    cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
+    # Control: with computational initials the no-event module is real and
+    # its rank exceeds the cap -- this is what makes the test discriminating.
+    with pytest.raises(ValueError, match="max_rank"):
+        noncomp.sample(circuit, noncomp.Model(classifier=cls), shots=4, seed=3, max_rank=0)
+    lost = noncomp.Model(initial_state=[0, 0, 0, 0, 1], classifier=cls)
+    r = noncomp.sample(circuit, lost, shots=16, seed=3, max_rank=0)
+    assert (r.final_status == noncomp.QubitStatus.LOST).all()
+    # The lost column reads symbol 1 with certainty: a raw readout of the
+    # dropped-everything |0> carriers would give 0, so all-1 records pin
+    # that the classifier wrote them.
+    assert (r.measurements == 1).all()
+
+
 def test_a_multi_round_circuit_runs_through_loss():
     """A lost data qubit drops its syndrome CXs (identity on the ancilla).
 

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -118,6 +118,49 @@ def test_damping_boundary_probe_separates_exact_from_neglect():
     assert abs(p1_neglect - expected_neglect) < tol_neglect
 
 
+def test_damping_null_source_independent_rates_make_neglect_exact():
+    """Null counterpart of the boundary probe, which pins the direction the
+    modes separate at source-DEPENDENT rates: when a transition's
+    computational columns are EQUAL (fire 0.3 from g and from e, both to
+    leak_g), the no-fire back-action is proportional to identity, so
+    damping="exact" and damping="neglect" must agree in distribution.  For
+    a surviving (never-fired) qubit the interference is fully preserved,
+    so the H .. H sandwich returns |0> deterministically in both modes."""
+    shots = 4000
+    p = 0.3
+    transitions = {"leak": _transition({(Level.LEAK_G, Level.G): p, (Level.LEAK_G, Level.E): p})}
+    # g reads 0, e reads 1, every noncomputational level reads 1: a leak
+    # reads 1, and the survivor pin expects 0 (H .. H returns g).
+    classifier = noncomp.Classifier([[1, 0, 0, 0, 0], [0, 1, 1, 1, 1]])
+    text = "H 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0\n"
+
+    sigma = np.sqrt(p * (1.0 - p) / shots)
+    means = {}
+    for damping in ("exact", "neglect"):
+        model = noncomp.Model(
+            initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
+            transitions=transitions,
+            classifier=classifier,
+            damping=damping,
+        )
+        r = noncomp.sample(text, model, shots=shots, seed=11)
+        meas = np.asarray(r.measurements)[:, 0]
+        status = np.asarray(r.final_status)[:, 0]
+
+        # Sharp per-shot null: a fired shot leaked and reads 1; a survivor is
+        # computational with interference fully restored, reading 0.
+        assert ((meas == 1) == (status == noncomp.QubitStatus.LEAK_G)).all()
+        assert ((meas == 0) == (status == noncomp.QubitStatus.COMPUTATIONAL)).all()
+        # Both outcomes occur (vacuity guard).
+        assert (status == noncomp.QubitStatus.LEAK_G).any()
+        assert (status == noncomp.QubitStatus.COMPUTATIONAL).any()
+        # The leak rate is the source-independent p in both modes.
+        means[damping] = float(meas.mean())
+        assert abs(means[damping] - p) < 4 * sigma
+
+    assert abs(means["exact"] - means["neglect"]) < 8 * sigma
+
+
 def test_neglect_bell_correlation_probe():
     """Neglect-mode forced trace-out keeps the source-determined partner correlation.
 

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -54,13 +55,13 @@ NonComputationalModel make_model(const ModelSpec& spec) {
         transitions.emplace("flip", std::move(flip));
     }
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.damping = spec.damping;
-    return NonComputationalModel::from_spec(spec.initial, transitions, classifier, policy);
+    return NonComputationalModel::from_spec(spec.initial, transitions,
+                                            std::make_optional(classifier), policy);
 }
 
 double mean_of(const std::vector<uint8_t>& bits, uint32_t stride, uint32_t index) {
@@ -82,13 +83,12 @@ NonComputationalModel make_lose_model() {
     lose[kLost][0] = 1.0;  // g -> lost, certainly
     lose[kLost][1] = 1.0;  // e -> lost, certainly
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}}, classifier,
-                                            policy);
+    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+                                            std::make_optional(classifier), policy);
 }
 
 }  // namespace
@@ -309,15 +309,14 @@ TEST_CASE("exact: a neglect-form trap keeps the fire-side correlation") {
     leak[kLeakG][0] = 1.0;  // from g: leak_g, certainly
     leak[kLeak][1] = 1.0;   // from e: leak_e, certainly
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0},   // leak_g reads 0
-                         {0.0, 1.0, 0.0, 1.0, 0.0}};  // leak_e reads 1
+    const std::vector<std::vector<double>> classifier = {
+        {1.0, 0.0, 1.0, 0.0, 1.0},   // leak_g reads 0
+        {0.0, 1.0, 0.0, 1.0, 0.0}};  // leak_e reads 1
 
     NonComputationalPolicy policy;
     policy.damping = DampingPolicy::Neglect;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
 
     auto circuit = parse("H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
     auto result = sample_noncomputational(circuit, model, 100, 29);
@@ -371,14 +370,13 @@ TEST_CASE("exact: a chain of two forced traps keeps both correlations") {
     leak[kLeakG][0] = 1.0;
     leak[kLeak][1] = 1.0;
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.damping = DampingPolicy::Neglect;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
 
     auto circuit = parse(
         "H 0\nCX 0 1\nH 2\nCX 2 3\n"
@@ -404,14 +402,13 @@ TEST_CASE("exact: a neglect fire onto a computational destination stays correlat
     swap_ge[1][0] = 1.0;  // g -> e, certainly
     swap_ge[0][1] = 1.0;  // e -> g, certainly
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.damping = DampingPolicy::Neglect;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"swap", swap_ge}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
 
     auto circuit = parse("H 0\nCX 0 1\nLEVEL_TRANSITION[swap] 0\nM 0\nM 1");
     auto result = sample_noncomputational(circuit, model, 60, 47);
@@ -441,14 +438,12 @@ TEST_CASE("exact: herald flags drawn in one continuation are reused by the next"
     std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
     leak[kLeak][1] = 1.0;  // certain leak from e
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 3;
-    classifier.matrix = {
+    const std::vector<std::vector<double>> classifier = {
         {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.5, 0.0}, {0.0, 0.0, 0.0, 0.5, 0.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
 
     auto circuit = parse("X 0\nX 1\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nM 0\nM 1");
     auto result = sample_noncomputational(circuit, model, 200, 53);
@@ -558,14 +553,12 @@ TEST_CASE("exact: ternary heralds ride the cache key") {
     std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
     leak[kLeak][1] = 1.0;
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 3;
-    classifier.matrix = {
+    const std::vector<std::vector<double>> classifier = {
         {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({0.0, 1.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
 
     auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
     auto result = sample_noncomputational(circuit, model, 200, 31);
@@ -626,13 +619,12 @@ TEST_CASE("exact: a zero-fire LOSS(0) before a firing LOSS does not shift site i
     // LOSS(0) can never fire from a computational qubit; trace() skips it.
     // The rewriter must skip it too, so LOSS(1) gets site id 0 and the
     // driver maps the trap correctly.
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
-    auto model =
-        NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {}, classifier, policy);
+    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {},
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("LOSS(0) 0\nLOSS(1) 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 20, 71);
@@ -650,13 +642,12 @@ TEST_CASE("exact: a seepage-only transition before a firing site does not shift 
     std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
     seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"seep", seep}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 20, 73);
@@ -675,14 +666,13 @@ TEST_CASE("exact: a seepage-only transition on q0 does not corrupt q1's site id"
     std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
     seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
     // q0: stays computational (no loss); q1: lost reads 1.
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"seep", seep}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[seep] 0\nLOSS(1) 1\nM 0\nM 1");
 
     auto result = sample_noncomputational(circuit, model, 20, 79);
@@ -702,14 +692,13 @@ TEST_CASE("exact: a seepage-only transition still seeps a noncomputational qubit
     std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
     seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     // All initial mass on leak_e (index 3).
     auto model = NonComputationalModel::from_spec({0.0, 0.0, 0.0, 1.0, 0.0}, {{"seep", seep}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[seep] 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 20, 83);
@@ -809,14 +798,13 @@ NonComputationalModel make_classify_lost_model(std::vector<double> lost_col,
     std::map<std::string, std::vector<std::vector<double>>> transitions;
     transitions.emplace("lose", lose);
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
     // g=0, e=1, leak_g=0, leak_e=0, lost=lost_col
-    classifier.matrix = {{1.0, 0.0, 1.0, 1.0, lost_col[0]}, {0.0, 1.0, 0.0, 0.0, lost_col[1]}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 1.0, lost_col[0]},
+                                                         {0.0, 1.0, 0.0, 0.0, lost_col[1]}};
     (void)with_hook;
     NonComputationalPolicy policy;
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions, classifier,
-                                            policy);
+    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
+                                            std::make_optional(classifier), policy);
 }
 
 }  // namespace
@@ -862,15 +850,13 @@ TEST_CASE("exact: ternary herald column on MX sets sidecar flag and patches reco
     lose[kLost][0] = 1.0;
     lose[kLost][1] = 1.0;
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 3;
     // lost column = {0, 0, 1}: always heralds. g/e/leak columns symbol 0.
-    classifier.matrix = {
+    const std::vector<std::vector<double>> classifier = {
         {1.0, 0.0, 1.0, 1.0, 0.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 1.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX 0");
     auto result = sample_noncomputational(circuit, model, 40, 107);
     for (uint32_t shot = 0; shot < 40; ++shot) {
@@ -899,13 +885,12 @@ TEST_CASE("exact: memory-X smoke: two qubits, low-rate leak hook, MX measures bo
     leak[kLost][0] = 0.01;  // low-rate loss from g
     leak[kLost][1] = 0.01;
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 1.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 1.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 0.0, 0.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("RX 0 1\nLEVEL_TRANSITION[leak] 0 1\nMX 0 1");
     auto result = sample_noncomputational(circuit, model, 50, 111);
     REQUIRE(result.shots == 50);
@@ -1038,13 +1023,13 @@ NonComputationalModel make_leak_seep_model() {
     std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
     seep[1][kLeak] = 1.0;  // leak_e -> e, certainly
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0},
-                                            {{"leak", leak}, {"seep", seep}}, classifier, policy);
+                                            {{"leak", leak}, {"seep", seep}},
+                                            std::make_optional(classifier), policy);
 }
 
 }  // namespace
@@ -1076,13 +1061,12 @@ TEST_CASE("exact: multi-target annotation jumps both targets in one shot") {
     lose[kLost][0] = 1.0;  // g -> lost, certainly
     lose[kLost][1] = 1.0;  // e -> lost, certainly
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[lose] 0 1\nM 0\nM 1");
 
     auto result = sample_noncomputational(circuit, model, 20, 133);
@@ -1141,11 +1125,11 @@ TEST_CASE("exact: LOSS on a lost qubit spends no draw -- a later consult sees th
     const uint64_t seed = 147;
     std::vector<std::vector<double>> recover(5, std::vector<double>(5, 0.0));
     recover[1][kLost] = 0.5;  // lost -> e, probability one half
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
-    auto model = NonComputationalModel::from_spec({0.0, 0.0, 0.0, 0.0, 1.0}, {{"recover", recover}},
-                                                  classifier, NonComputationalPolicy{});
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    auto model =
+        NonComputationalModel::from_spec({0.0, 0.0, 0.0, 0.0, 1.0}, {{"recover", recover}},
+                                         std::make_optional(classifier), NonComputationalPolicy{});
 
     auto r_plain =
         sample_noncomputational(parse("LEVEL_TRANSITION[recover] 0\nM 0"), model, 128, seed);
@@ -1184,14 +1168,13 @@ TEST_CASE("exact: classified record drives a CX feedback gate") {
     lose[kLost][0] = 1.0;
     lose[kLost][1] = 1.0;
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
     // g=0, e=1, leak_g=0, leak_e=1, lost=1
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("S 0\nM 0\nCX rec[-1] 1\nM 1");
 
     auto result = sample_noncomputational(circuit, model, 25, 151);
@@ -1217,14 +1200,13 @@ TEST_CASE("exact: a reset truly re-prepares a restored-lost qubit") {
     lose[kLost][0] = 1.0;
     lose[kLost][1] = 1.0;
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.reset_restores_lost = true;
     auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
-                                                  classifier, policy);
+                                                  std::make_optional(classifier), policy);
     auto circuit = parse("H 0\nS 0\nR 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 30, 161);
@@ -1276,4 +1258,43 @@ TEST_CASE("exact: different seeds produce different records") {
     // 64 coin-flip measurements collide with probability 2^-64; this is
     // astronomically unlikely for any two distinct seeds.
     REQUIRE(a.measurements != b.measurements);
+}
+
+TEST_CASE("exact: max_rank is not checked against the unreachable all-computational module") {
+    // When every qubit starts lost, the no-event module is never used;
+    // its rank must not trigger a max_rank rejection.
+    // The lost column reads symbol 1 with certainty: a raw readout of the
+    // dropped-everything |0> carriers would give 0, so all-1 records pin
+    // that the classifier wrote them.
+    const std::vector<std::vector<double>> classifier_matrix = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                                {0.0, 1.0, 0.0, 1.0, 1.0}};
+    // Lost model: all qubits start lost.
+    const NonComputationalModel lost_model = NonComputationalModel::from_spec(
+        {0.0, 0.0, 0.0, 0.0, 1.0}, {}, std::make_optional(classifier_matrix),
+        NonComputationalPolicy{});
+    // Ground model: all qubits start in g -- the no-event module IS compiled.
+    const NonComputationalModel ground_model = NonComputationalModel::from_spec(
+        {1.0, 0.0, 0.0, 0.0, 0.0}, {}, std::make_optional(classifier_matrix),
+        NonComputationalPolicy{});
+
+    // Circuit with T gates -- non-trivial rank.
+    const std::string circuit_str =
+        "H 0\n"
+        "CX 0 1\nCX 0 2\nCX 0 3\nCX 0 4\nCX 0 5\n"
+        "T 0\nH 0\nT 1\nH 1\nT 2\nH 2\nT 3\nH 3\nT 4\nH 4\nT 5\nH 5\n"
+        "M 0\nM 1\nM 2\nM 3\nM 4\nM 5\n";
+    const Circuit circuit = parse(circuit_str);
+
+    // Ground model at max_rank=0 must throw (the no-event module exceeds it).
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, ground_model, 4, 1, 0),
+                        ContainsSubstring("max_rank"));
+
+    // Lost model at max_rank=0 must run (the no-event module is lazy).
+    const NonComputationalSample r = sample_noncomputational(circuit, lost_model, 16, 1, 0);
+    for (const uint8_t bit : r.measurements) {
+        REQUIRE(bit == 1);
+    }
+    for (size_t i = 0; i < r.final_status.size(); ++i) {
+        REQUIRE(r.final_status[i] == QubitStatus::Lost);
+    }
 }

--- a/tests/test_noncomp_classifier.cc
+++ b/tests/test_noncomp_classifier.cc
@@ -37,7 +37,7 @@ std::vector<std::vector<double>> default_matrix() {
 // =========================================================================
 
 TEST_CASE("MeasurementClassifier: accepts a stochastic two-symbol matrix") {
-    auto classifier = MeasurementClassifier::from_matrix(2, default_matrix());
+    auto classifier = MeasurementClassifier::from_matrix(default_matrix());
     REQUIRE(classifier.num_symbols() == 2);
     REQUIRE_FALSE(classifier.has_herald());
 }
@@ -49,7 +49,7 @@ TEST_CASE("MeasurementClassifier: accepts a three-symbol matrix with a noncomp h
         {0, 1, 0.2, 1, 0},
         {0, 0, 0.3, 0, 1},  // herald: leak_g sometimes, lost always
     };
-    auto classifier = MeasurementClassifier::from_matrix(3, m);
+    auto classifier = MeasurementClassifier::from_matrix(m);
     REQUIRE(classifier.num_symbols() == 3);
     REQUIRE(classifier.has_herald());
     REQUIRE_THAT(classifier.prob(MeasurementClassifier::kHeraldSymbol, Level::Lost),
@@ -58,19 +58,18 @@ TEST_CASE("MeasurementClassifier: accepts a three-symbol matrix with a noncomp h
 
 TEST_CASE("MeasurementClassifier: rejects symbol counts other than two or three") {
     std::vector<std::vector<double>> one = {{1, 1, 1, 1, 1}};
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(1, one),
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(one),
                         ContainsSubstring("two record symbols") && ContainsSubstring("got 1"));
     std::vector<std::vector<double>> four = {
         {1, 1, 1, 1, 1}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}};
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(4, four), ContainsSubstring("got 4"));
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(four), ContainsSubstring("got 4"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects wrong row count") {
     std::vector<std::vector<double>> m = {
         {1, 1, 1, 1, 1},
     };
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(2, m),
-                        ContainsSubstring("1 rows") && ContainsSubstring("expected 2"));
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m), ContainsSubstring("got 1"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects wrong column count") {
@@ -78,34 +77,34 @@ TEST_CASE("MeasurementClassifier: rejects wrong column count") {
         {1, 0, 1, 0},  // only 4 columns
         {0, 1, 0, 1},
     };
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(2, m),
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
                         ContainsSubstring("4 columns") && ContainsSubstring("expected 5"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects negative entry") {
     std::vector<std::vector<double>> m = default_matrix();
     m[0][0] = -0.1;
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(2, m),
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
                         ContainsSubstring("entry") && ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects entry above 1") {
     std::vector<std::vector<double>> m = default_matrix();
     m[0][0] = 1.5;
-    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix(2, m), std::invalid_argument);
+    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix(m), std::invalid_argument);
 }
 
 TEST_CASE("MeasurementClassifier: rejects NaN entry") {
     std::vector<std::vector<double>> m = default_matrix();
     m[0][0] = opaque_nan();
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(2, m),
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
                         ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects infinity entry") {
     std::vector<std::vector<double>> m = default_matrix();
     m[0][0] = opaque_infinity();
-    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix(2, m), std::invalid_argument);
+    REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix(m), std::invalid_argument);
 }
 
 TEST_CASE("MeasurementClassifier: rejects a substochastic (reject) column") {
@@ -113,7 +112,7 @@ TEST_CASE("MeasurementClassifier: rejects a substochastic (reject) column") {
     m[0][2] = 0.5;  // leak_g column now sums to 0.5
     m[1][2] = 0.0;
     REQUIRE_THROWS_WITH(
-        MeasurementClassifier::from_matrix(2, m),
+        MeasurementClassifier::from_matrix(m),
         ContainsSubstring("reject columns are not supported") && ContainsSubstring("leak_g"));
 }
 
@@ -121,8 +120,7 @@ TEST_CASE("MeasurementClassifier: rejects a column sum above 1") {
     std::vector<std::vector<double>> m = default_matrix();
     m[0][0] = 0.6;
     m[1][0] = 0.6;  // g column sums to 1.2
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(2, m),
-                        ContainsSubstring("must sum to 1"));
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m), ContainsSubstring("must sum to 1"));
 }
 
 TEST_CASE("MeasurementClassifier: accepts a column sum within tolerance of 1") {
@@ -136,14 +134,14 @@ TEST_CASE("MeasurementClassifier: accepts a column sum within tolerance of 1") {
     REQUIRE(a + b < 1.0 + 1e-12);
     m[0][0] = a;
     m[1][0] = b;
-    REQUIRE_NOTHROW(MeasurementClassifier::from_matrix(2, m));
+    REQUIRE_NOTHROW(MeasurementClassifier::from_matrix(m));
 }
 
 TEST_CASE("MeasurementClassifier: rejects herald mass on a computational column") {
     std::vector<std::vector<double>> m = {
         {1, 0, 1, 0, 1}, {0, 0.8, 0, 1, 0}, {0, 0.2, 0, 0, 0},  // e column puts 0.2 on the herald
     };
-    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(3, m),
+    REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
                         ContainsSubstring("record symbols 0 and 1") && ContainsSubstring("'e'"));
 }
 
@@ -155,7 +153,7 @@ TEST_CASE("MeasurementClassifier: prob returns the entry under (symbol, level) c
     std::vector<std::vector<double>> m = default_matrix();
     m[0][2] = 0.25;  // P("0" | leak_g) = 0.25
     m[1][2] = 0.75;  // P("1" | leak_g) = 0.75
-    auto classifier = MeasurementClassifier::from_matrix(2, m);
+    auto classifier = MeasurementClassifier::from_matrix(m);
 
     REQUIRE_THAT(classifier.prob(0, Level::G), WithinAbs(1.0, 1e-12));
     REQUIRE_THAT(classifier.prob(1, Level::E), WithinAbs(1.0, 1e-12));
@@ -165,6 +163,6 @@ TEST_CASE("MeasurementClassifier: prob returns the entry under (symbol, level) c
 }
 
 TEST_CASE("MeasurementClassifier: out-of-range symbol probability throws") {
-    auto classifier = MeasurementClassifier::from_matrix(2, default_matrix());
+    auto classifier = MeasurementClassifier::from_matrix(default_matrix());
     REQUIRE_THROWS_AS(classifier.prob(99, Level::G), std::invalid_argument);
 }

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -35,11 +36,11 @@ NonComputationalModel demo_model() {
     leak[kLeak][1] = 0.4;
     leak[1][kLeak] = 0.2;  // seepage: leaked -> e
 
-    ClassifierSpec classifier;
-    classifier.num_symbols = 2;
-    classifier.matrix = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
 
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}}, classifier,
+    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+                                            std::make_optional(classifier),
                                             NonComputationalPolicy{});
 }
 

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -18,7 +18,6 @@
 
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
-using clifft::ClassifierSpec;
 using clifft::GateType;
 using clifft::kAllLevels;
 using clifft::Level;
@@ -35,12 +34,11 @@ std::vector<std::vector<double>> zero_matrix() {
 }
 
 // Identity readout on g/e; leak_g/lost read "0", leak_e reads "1".
-ClassifierSpec identity_classifier() {
-    return ClassifierSpec{2,
-                          {
-                              {1, 0, 1, 0, 1},
-                              {0, 1, 0, 1, 0},
-                          }};
+std::vector<std::vector<double>> identity_classifier() {
+    return {
+        {1, 0, 1, 0, 1},
+        {0, 1, 0, 1, 0},
+    };
 }
 
 // A valid probability vector over the 5 levels.
@@ -64,7 +62,8 @@ double sum(const std::vector<double>& v) {
 
 TEST_CASE("NonComputationalModel: accepts a fully specified model") {
     auto model = NonComputationalModel::from_spec(default_initial_state(), {{"H", zero_matrix()}},
-                                                  identity_classifier(), NonComputationalPolicy{});
+                                                  std::make_optional(identity_classifier()),
+                                                  NonComputationalPolicy{});
     REQUIRE(model.transitions().size() == 1);
     REQUIRE(model.classifier() != nullptr);
 }

--- a/tests/test_noncomp_op_role.cc
+++ b/tests/test_noncomp_op_role.cc
@@ -2,20 +2,31 @@
 #include "clifft/circuit/gate_data.h"
 #include "clifft/circuit/parser.h"
 #include "clifft/circuit/target.h"
+#include "clifft/noncomp/level.h"
+#include "clifft/noncomp/model.h"
 #include "clifft/noncomp/op_role.h"
+#include "clifft/noncomp/policy.h"
 #include "clifft/noncomp/status_step.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <stdexcept>
 #include <vector>
 
+using Catch::Matchers::StartsWith;
+using clifft::advance_ordinary_node;
 using clifft::AstNode;
 using clifft::Circuit;
 using clifft::GateType;
+using clifft::Level;
+using clifft::NonComputationalPolicy;
 using clifft::OperandRole;
+using clifft::OrdinaryStep;
 using clifft::parse;
 using clifft::qubit_operands;
 using clifft::QubitOperand;
+using clifft::QubitStatus;
 using clifft::Target;
 
 namespace {
@@ -82,4 +93,37 @@ TEST_CASE("qubit_operands: non-qubit operations produce no operands") {
 TEST_CASE("qubit_operands: a record control with a qubit on a non-CX/CZ gate is rejected") {
     REQUIRE_THROWS_AS(qubit_operands(node(GateType::H, {Target::rec(0), Target::qubit(1)})),
                       std::invalid_argument);
+}
+
+TEST_CASE("advance_ordinary_node: two-qubit gate with one lost operand drops whole") {
+    // CX 0 1 where qubit 1 is lost: the op drops, both statuses hold.
+    Circuit c = parse("CX 0 1\n");
+    const AstNode& node = c.nodes[0];
+    std::vector<QubitStatus> status = {QubitStatus::Computational, QubitStatus::Lost};
+    NonComputationalPolicy policy;
+    OrdinaryStep step = advance_ordinary_node(node, 0, status, policy, "test");
+    REQUIRE(step.dropped);
+    REQUIRE(status[0] == QubitStatus::Computational);
+    REQUIRE(status[1] == QubitStatus::Lost);
+}
+
+TEST_CASE("advance_ordinary_node: M on a leaked qubit reports the level and keeps status") {
+    Circuit c = parse("M 0\n");
+    const AstNode& node = c.nodes[0];
+    std::vector<QubitStatus> status = {QubitStatus::LeakG};
+    NonComputationalPolicy policy;
+    OrdinaryStep step = advance_ordinary_node(node, 0, status, policy, "test");
+    REQUIRE_FALSE(step.dropped);
+    REQUIRE(step.measured_noncomp_level.has_value());
+    REQUIRE(*step.measured_noncomp_level == Level::LeakG);
+    REQUIRE(status[0] == QubitStatus::LeakG);  // measurement does not reset
+}
+
+TEST_CASE("advance_ordinary_node: MPP on a lost operand throws with caller prefix") {
+    Circuit c = parse("MPP X0*Z1\n");
+    const AstNode& node = c.nodes[0];
+    std::vector<QubitStatus> status = {QubitStatus::Computational, QubitStatus::Lost};
+    NonComputationalPolicy policy;
+    REQUIRE_THROWS_WITH(advance_ordinary_node(node, 0, status, policy, "myfunc"),
+                        StartsWith("myfunc:"));
 }

--- a/tests/test_noncomp_orchestrator.cc
+++ b/tests/test_noncomp_orchestrator.cc
@@ -17,7 +17,6 @@
 
 using Catch::Matchers::ContainsSubstring;
 using clifft::Circuit;
-using clifft::ClassifierSpec;
 using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
 using clifft::NonComputationalSample;
@@ -70,7 +69,7 @@ std::vector<std::vector<double>> always_to_e() {
 // Two-symbol classifier whose column for `level` is `col`; computational
 // levels read out faithfully (no readout confusion) and other
 // noncomputational levels read a deterministic symbol 0.
-ClassifierSpec classifier_with(uint8_t level, std::vector<double> col) {
+std::vector<std::vector<double>> classifier_with(uint8_t level, std::vector<double> col) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;  // symbol "0"
@@ -81,18 +80,19 @@ ClassifierSpec classifier_with(uint8_t level, std::vector<double> col) {
     m[1][1] = 1.0;
     m[0][level] = col[0];
     m[1][level] = col[1];
-    return ClassifierSpec{2, std::move(m)};
+    return m;
 }
 
 // The common case: classify the leak_g column.
-ClassifierSpec make_classifier(std::vector<double> leakg) {
+std::vector<std::vector<double>> make_classifier(std::vector<double> leakg) {
     return classifier_with(kLeakG, std::move(leakg));
 }
 
 NonComputationalModel make_model(
     std::vector<double> initial_state,
     std::map<std::string, std::vector<std::vector<double>>> transitions,
-    std::optional<ClassifierSpec> classifier = std::nullopt, NonComputationalPolicy policy = {}) {
+    std::optional<std::vector<std::vector<double>>> classifier = std::nullopt,
+    NonComputationalPolicy policy = {}) {
     return NonComputationalModel::from_spec(std::move(initial_state), transitions,
                                             std::move(classifier), policy);
 }
@@ -205,16 +205,15 @@ TEST_CASE("sample_noncomputational: a four-symbol classifier rejects at construc
     m[3][kLeakG] = 0.1;
     std::map<std::string, std::vector<std::vector<double>>> transitions;
     transitions.emplace("S", always_leaked());
-    REQUIRE_THROWS_WITH(
-        make_model(all_g(), std::move(transitions), ClassifierSpec{4, std::move(m)}),
-        ContainsSubstring("two record symbols") && ContainsSubstring("got 4"));
+    REQUIRE_THROWS_WITH(make_model(all_g(), std::move(transitions), std::move(m)),
+                        ContainsSubstring("two record symbols") && ContainsSubstring("got 4"));
 }
 
 namespace {
 
 // Three-symbol classifier whose column for `level` is `col`; computational
 // levels read out faithfully and other levels default to symbol 0.
-ClassifierSpec ternary_classifier_with(uint8_t level, std::vector<double> col) {
+std::vector<std::vector<double>> ternary_classifier_with(uint8_t level, std::vector<double> col) {
     std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
@@ -226,7 +225,7 @@ ClassifierSpec ternary_classifier_with(uint8_t level, std::vector<double> col) {
     m[0][level] = col[0];
     m[1][level] = col[1];
     m[2][level] = col[2];
-    return ClassifierSpec{3, std::move(m)};
+    return m;
 }
 
 }  // namespace
@@ -238,7 +237,7 @@ TEST_CASE("sample_noncomputational: the herald symbol fills the sidecar, not the
     Circuit c = parse("H 1\nS 1\nM 1\nM 0\n");
     std::map<std::string, std::vector<std::vector<double>>> transitions;
     transitions.emplace("S", always_leaked());
-    ClassifierSpec cl = ternary_classifier_with(kLeakG, {0.0, 0.0, 1.0});
+    auto cl = ternary_classifier_with(kLeakG, {0.0, 0.0, 1.0});
     NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 256;
@@ -258,7 +257,7 @@ TEST_CASE("sample_noncomputational: a partial herald column matches its frequenc
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, std::vector<std::vector<double>>> transitions;
     transitions.emplace("S", always_leaked());
-    ClassifierSpec cl = ternary_classifier_with(kLeakG, {0.3, 0.0, 0.7});
+    auto cl = ternary_classifier_with(kLeakG, {0.3, 0.0, 0.7});
     NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 1000;
@@ -279,7 +278,7 @@ TEST_CASE("sample_noncomputational: the record bit is uniform given a herald, pi
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, std::vector<std::vector<double>>> transitions;
     transitions.emplace("S", always_leaked());
-    ClassifierSpec cl = ternary_classifier_with(kLeakG, {0.5, 0.0, 0.5});
+    auto cl = ternary_classifier_with(kLeakG, {0.5, 0.0, 0.5});
     NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 2000;
@@ -305,7 +304,7 @@ TEST_CASE("sample_noncomputational: a two-symbol classifier leaves the herald si
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, std::vector<std::vector<double>>> transitions;
     transitions.emplace("S", always_leaked());
-    ClassifierSpec cl = make_classifier({0.5, 0.5});
+    auto cl = make_classifier({0.5, 0.5});
     NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 64;
@@ -523,7 +522,7 @@ namespace {
 
 // Classifier with confused computational columns; noncomputational levels
 // deterministically read symbol 0.
-ClassifierSpec comp_confusion(double p01, double p10) {
+std::vector<std::vector<double>> comp_confusion(double p01, double p10) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
@@ -532,7 +531,7 @@ ClassifierSpec comp_confusion(double p01, double p10) {
     m[1][0] = p01;
     m[0][1] = p10;
     m[1][1] = 1.0 - p10;
-    return ClassifierSpec{2, std::move(m)};
+    return m;
 }
 
 }  // namespace
@@ -582,8 +581,7 @@ TEST_CASE("sample_noncomputational: hand-written LOSS and LEVEL_TRANSITION run e
     m[1][kLeakG] = 1.0;  // leaked reads 1
     m[0][kLost] = 1.0;   // lost reads 0
     m[0][3] = 1.0;
-    NonComputationalModel model =
-        make_model(all_g(), std::move(transitions), ClassifierSpec{2, std::move(m)});
+    NonComputationalModel model = make_model(all_g(), std::move(transitions), std::move(m));
 
     NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
     for (uint32_t shot = 0; shot < s.shots; ++shot) {

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -28,6 +28,7 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,6 @@ using Catch::Matchers::ContainsSubstring;
 using clifft::annotate;
 using clifft::AstNode;
 using clifft::Circuit;
-using clifft::ClassifierSpec;
 using clifft::ContinuationRewrite;
 using clifft::default_hir_pass_manager;
 using clifft::ExactShotEvents;
@@ -80,7 +80,7 @@ NonComputationalModel make_model(
 // Classifier whose column for `level` is `col` (two or three symbols by
 // col's length); computational levels read out faithfully and other levels
 // default to a deterministic symbol 0.
-ClassifierSpec classifier_with(uint8_t level, std::vector<double> col) {
+std::vector<std::vector<double>> classifier_with(uint8_t level, std::vector<double> col) {
     std::vector<std::vector<double>> m(col.size(), std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
@@ -90,14 +90,14 @@ ClassifierSpec classifier_with(uint8_t level, std::vector<double> col) {
     for (size_t s = 0; s < col.size(); ++s) {
         m[s][level] = col[s];
     }
-    return ClassifierSpec{col.size(), std::move(m)};
+    return m;
 }
 
 NonComputationalModel make_model_with_classifier(
-    std::map<std::string, std::vector<std::vector<double>>> transitions, ClassifierSpec classifier,
-    NonComputationalPolicy policy = {}) {
+    std::map<std::string, std::vector<std::vector<double>>> transitions,
+    std::vector<std::vector<double>> classifier, NonComputationalPolicy policy = {}) {
     return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
-                                            std::move(classifier), policy);
+                                            std::make_optional(std::move(classifier)), policy);
 }
 
 // Per-qubit initial statuses from level indices.
@@ -307,7 +307,7 @@ TEST_CASE("rewrite: a lost-qubit measurement becomes a classifier record write")
     REQUIRE(rw.classified_measurements.size() == 1);
     REQUIRE(rw.classified_measurements[0].slot == 0);
     REQUIRE(rw.classified_measurements[0].level == Level::Lost);
-    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
     REQUIRE(noise.targets[0].is_rec());
     REQUIRE(noise.targets[0].value() == 0);
@@ -328,7 +328,7 @@ TEST_CASE("rewrite: a deterministic classifier column pads the literal bit, no d
         }
     }
     REQUIRE(rw.classified_measurements.size() == 1);
-    REQUIRE(rw.classified_measurements[0].noise_node == SIZE_MAX);
+    REQUIRE(rw.classified_measurements[0].noise_node == std::nullopt);
 }
 
 TEST_CASE("rewrite: an inverted noncomputational classifier flips a deterministic bit") {
@@ -345,7 +345,7 @@ TEST_CASE("rewrite: an inverted noncomputational classifier flips a deterministi
         }
     }
     REQUIRE(rw.classified_measurements.size() == 1);
-    REQUIRE(rw.classified_measurements[0].noise_node == SIZE_MAX);
+    REQUIRE(rw.classified_measurements[0].noise_node == std::nullopt);
 }
 
 TEST_CASE("rewrite: an inverted noncomputational classifier complements stochastic flips") {
@@ -355,7 +355,7 @@ TEST_CASE("rewrite: an inverted noncomputational classifier complements stochast
 
     ContinuationRewrite rw = rewritten(c, model, {kLost});
     REQUIRE(rw.classified_measurements.size() == 1);
-    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
     REQUIRE(noise.targets[0].value() == 0);
     REQUIRE(noise.args[0] == Catch::Approx(0.7));
@@ -372,7 +372,7 @@ TEST_CASE("rewrite: the record write flips its own slot, not an earlier one") {
     REQUIRE(count_gate(rw.circuit, GateType::M) == 1);  // the computational one
     REQUIRE(rw.classified_measurements.size() == 1);
     REQUIRE(rw.classified_measurements[0].slot == 1);
-    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.targets[0].value() == 1);
 }
 
@@ -386,7 +386,7 @@ TEST_CASE("rewrite: a ternary column emits the not-heralded conditional flip") {
 
     ContinuationRewrite rw = rewritten(c, model, {kLeakG});
     REQUIRE(rw.classified_measurements.size() == 1);
-    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
     REQUIRE(noise.args[0] == Catch::Approx(0.25));
 }
@@ -399,7 +399,7 @@ TEST_CASE("rewrite: an inverted ternary column complements the not-heralded flip
 
     ContinuationRewrite rw = rewritten(c, model, {kLeakG});
     REQUIRE(rw.classified_measurements.size() == 1);
-    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
     REQUIRE(noise.args[0] == Catch::Approx(0.75));
 }
@@ -413,8 +413,8 @@ TEST_CASE("rewrite: an always-herald ternary column still emits a patchable node
 
     ContinuationRewrite rw = rewritten(c, model, {kLeakG});
     REQUIRE(rw.classified_measurements.size() == 1);
-    REQUIRE(rw.classified_measurements[0].noise_node != SIZE_MAX);
-    const AstNode& noise = rw.circuit.nodes[rw.classified_measurements[0].noise_node];
+    REQUIRE(rw.classified_measurements[0].noise_node.has_value());
+    const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.args[0] == 0.5);
 }
 
@@ -484,7 +484,7 @@ namespace {
 // Classifier with confused computational columns: a true 0 is misread as 1
 // with probability p01, a true 1 as 0 with probability p10; noncomputational
 // levels deterministically read symbol 0.
-ClassifierSpec confused_classifier(double p01, double p10) {
+std::vector<std::vector<double>> confused_classifier(double p01, double p10) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
@@ -493,7 +493,7 @@ ClassifierSpec confused_classifier(double p01, double p10) {
     m[1][0] = p01;
     m[0][1] = p10;
     m[1][1] = 1.0 - p10;
-    return ClassifierSpec{2, std::move(m)};
+    return m;
 }
 
 }  // namespace
@@ -560,7 +560,7 @@ TEST_CASE("rewrite: a substochastic computational column rejects") {
     m[0][1] = 0.0;
     m[1][1] = 1.0;
     REQUIRE_THROWS_WITH(
-        make_model_with_classifier({}, ClassifierSpec{2, std::move(m)}),
+        make_model_with_classifier({}, std::move(m)),
         ContainsSubstring("reject columns are not supported") && ContainsSubstring("'g'"));
 }
 
@@ -573,7 +573,7 @@ TEST_CASE("rewrite: a computational column with herald mass rejects") {
     m[2][0] = 0.1;
     m[0][1] = 0.0;
     m[1][1] = 1.0;
-    REQUIRE_THROWS_WITH(make_model_with_classifier({}, ClassifierSpec{3, std::move(m)}),
+    REQUIRE_THROWS_WITH(make_model_with_classifier({}, std::move(m)),
                         ContainsSubstring("record symbols 0 and 1") && ContainsSubstring("'g'"));
 }
 
@@ -687,4 +687,14 @@ TEST_CASE("rewrite: a correlated chain whose head operand is lost survives the r
     ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
     REQUIRE(count_gate(rw.circuit, GateType::CORRELATED_ERROR) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::ELSE_CORRELATED_ERROR) == 1);
+}
+
+TEST_CASE("rewrite_continuation: unknown transition tag throws") {
+    Circuit c = parse("LEVEL_TRANSITION[nosuch] 0\n");
+    NonComputationalModel model = make_model({});
+    ExactShotEvents events;
+    events.initial_status = {QubitStatus::Computational};
+    Circuit annotated = annotate(c, model);
+    REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
+                        ContainsSubstring("unknown transition tag 'nosuch'"));
 }

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -43,7 +43,6 @@
 
 using clifft::annotate;
 using clifft::Circuit;
-using clifft::ClassifierSpec;
 using clifft::default_hir_pass_manager;
 using clifft::GateType;
 using clifft::HirModule;
@@ -76,7 +75,7 @@ std::vector<std::vector<double>> always_lost() {
 
 // Two-symbol classifier whose lost column is `col`; computational levels
 // read out faithfully and leaked levels deterministically read symbol 0.
-ClassifierSpec lost_classifier(std::vector<double> col) {
+std::vector<std::vector<double>> lost_classifier(std::vector<double> col) {
     std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
     for (size_t l = 0; l < 5; ++l) {
         m[0][l] = 1.0;
@@ -87,12 +86,12 @@ ClassifierSpec lost_classifier(std::vector<double> col) {
     m[1][1] = 1.0;
     m[0][kLost] = col[0];
     m[1][kLost] = col[1];
-    return ClassifierSpec{2, std::move(m)};
+    return m;
 }
 
 NonComputationalModel make_model(
     std::map<std::string, std::vector<std::vector<double>>> transitions,
-    std::optional<ClassifierSpec> classifier = std::nullopt) {
+    std::optional<std::vector<std::vector<double>>> classifier = std::nullopt) {
     // Both halves start in g (|0>); no leading X-prep is needed.
     return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
                                             std::move(classifier), NonComputationalPolicy{});


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

First of two PRs landing the confirmed findings from the external pre-merge reviews (the second, stream-changing fix — the measure-and-reset's reset half on a non-restoring lost qubit — follows separately). Everything here is draw-stream neutral, proven by fingerprint identity against the base tip.

- **Lazy main line (the confirmed false-reject).** The driver compiled and allocated the all-computational "nothing happened" module before any shot. With zero computational initial mass, every trajectory drops that path, yet `max_rank` was checked against it — runtime-reproduced as a false reject at `max_rank=0`. The main line now compiles through the same memoized path as every other continuation, on the first shot that needs it, and the state is sized from the first module actually executed. The sibling case (an unreachable no-fire suffix inside a module a shot *does* start) is inherent to the static per-module bound; the `max_rank` docstring now states that conservatism explicitly.
- **Capacity tracker follows the chain.** The trap loop records each continuation's rank/slot needs, so a later starting-module rebuild can no longer discard capacity a previous shot's chain already grew to (redundant reallocation, not a correctness issue).
- **One status walk.** The driver's classical-consult scan re-implemented the rewriter's pre-scan-and-step loop, minus the range check and reject arm — the same two-places-must-agree shape #189 removed for slot numbering. Both callers now use a single `advance_ordinary_node` helper that owns the verdict, the stepping, and the measured-level capture.
- **API/plumbing trims:** classifier symbol count derived from the matrix end-to-end (`ClassifierSpec` and the extra binding parameter deleted); `noise_node`/`traceout_node` sentinels → `std::optional`; unknown transition tags throw a named error in the zero-fire predicate instead of deferring to a worse one in `trace()`; stale `rewriter.h` claim fixed (MX/MY classify; only MPP rejects).

## Tests

- Lazy-main regression in both layers: a pure-lost model runs a rank-1 circuit under `max_rank=0` while the computational control rejects (the control is what makes it discriminating), and the classifier's lost column reads 1 — a raw readout of the dropped-everything carriers would give 0, so the all-1 records prove the classifier wrote them.
- Damping null at source-independent rates: with equal computational columns the no-fire back-action is proportional to identity, so `exact` and `neglect` must agree in distribution and survivors read 0 deterministically — the null counterpart of the existing boundary probe, and the sharpest cheap statement of the damping bound.
- Unit coverage for the shared walk helper (drop-whole holds statuses; measured-level capture; caller-prefixed reject) and the unknown-tag throw.

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass — 1074 cases (+5)
- Python: 915 pass on both wheels (+2)
- Draw-stream fingerprints byte-identical to the base tip (14 configs × seeds)
- `pre-commit run --all-files` clean

## Review round

- Two stale comments this PR's own change falsified, both reviewer-caught: the orchestrator header still described the annotated circuit as "compiles once as a shared main line" (now: rewrites compile lazily, one memoized module per event delta), and the shared walk's classified-level comment still said "Z-basis" (the classifier reads any single-qubit basis on a vacated carrier). Comment-only; full Debug suite re-run green (1074 cases), pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

