### PR TITLE
fix(noncomp): drop the reset half of a non-restoring lost measure-and-reset

### DIFF
--- a/design/noncomputational-mvp.md
+++ b/design/noncomputational-mvp.md
@@ -468,8 +468,9 @@ Notes:
   measurements (`M`, `MX`, `MY`) classify: on a vacated carrier the
   readout basis is incidental, so the classifier's single record bit is
   equally valid for Z-, X-, or Y-basis forms. A measure-and-reset
-  (`MR`/`MRX`/`MRY`) is kept the same way, with the reset additionally
-  re-preparing the site. The exception is a multi-qubit parity
+  (`MR`/`MRX`/`MRY`) keeps its record the same way; its reset half
+  re-prepares the site only when the reset restores it (a leaked qubit
+  always; a lost qubit only by policy). The exception is a multi-qubit parity
   measurement (`MPP`): it spans more than one qubit and has no faithful
   single-bit substitution, so it is rejected before sampling begins
   when the model is capable (gate A). The supported workaround is an

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -147,11 +147,8 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
                 out.nodes.push_back(readout_noise_op(slot, flip));
                 noise_node = out.nodes.size() - 1;
             }
-            // The reset half is emitted only when the status stepper restored
-            // the qubit (leaked always; lost only when the policy opts in).
-            // A non-restoring lost qubit keeps its vacated carrier: emitting
-            // the reset would be dead work on a carrier nothing reads, and
-            // the X/Y-basis forms would spend a hidden SVM draw on it.
+            // The reset half runs only when the stepper restored the site;
+            // a non-restoring lost qubit keeps its vacated carrier.
             if (is_measure_reset(gate) && is_computational(status[qubit])) {
                 out.nodes.push_back(single_qubit_op(reset_for(gate), qubit));
             }

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -147,7 +147,12 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
                 out.nodes.push_back(readout_noise_op(slot, flip));
                 noise_node = out.nodes.size() - 1;
             }
-            if (is_measure_reset(gate)) {
+            // The reset half is emitted only when the status stepper restored
+            // the qubit (leaked always; lost only when the policy opts in).
+            // A non-restoring lost qubit keeps its vacated carrier: emitting
+            // the reset would be dead work on a carrier nothing reads, and
+            // the X/Y-basis forms would spend a hidden SVM draw on it.
+            if (is_measure_reset(gate) && is_computational(status[qubit])) {
                 out.nodes.push_back(single_qubit_op(reset_for(gate), qubit));
             }
             classified.push_back({slot, *classified_level, noise_node});

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -23,7 +23,9 @@
 //      detector/observable evaluation. A stochastic classifier column adds a
 //      READOUT_NOISE on that slot so the bit is drawn at sample time inside
 //      the VM; a deterministic column pads the literal bit with no draw. A
-//      measure-and-reset additionally keeps its reset as a separate node.
+//      measure-and-reset keeps its reset as a separate node only when the
+//      stepper restores the site (a leaked qubit always; a lost qubit only
+//      by policy) -- a non-restoring lost qubit keeps its vacated carrier.
 //      Each such replacement is reported in classified_measurements (in
 //      slot order) so callers can post-process per-slot classifier behavior
 //      -- e.g. the driver's herald patching for three-symbol classifiers,

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -140,8 +140,10 @@ class Model:
     identity on the surviving operands. Single-qubit measurements (``M``,
     ``MX``, ``MY``) keep their record slot; on a vacated carrier the readout
     basis is incidental and the classifier supplies the bit. A
-    measure-and-reset (``MR``/``MRX``/``MRY``) is kept the same way, with
-    the reset additionally re-preparing the site. Parity measurements
+    measure-and-reset (``MR``/``MRX``/``MRY``) keeps its record the same
+    way; its reset half re-prepares the site only when the reset restores
+    it (a leaked qubit always; a lost qubit only with
+    ``reset_restores_lost``). Parity measurements
     (``MPP``) are not supported when the model can leak or lose qubits — they
     have no faithful single-bit classifier substitution — and raise before
     sampling begins. A model that can leak or lose qubits also requires a

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -1149,6 +1149,36 @@ TEST_CASE("exact: LOSS on a lost qubit spends no draw -- a later consult sees th
     REQUIRE(saw_one);
 }
 
+TEST_CASE("exact: a non-restoring lost MRX spends no hidden draw -- M and MRX read identically") {
+    // Both circuits lose qubit 0 with certainty and classify its record
+    // slot from the same lost column, so they compile to the same module
+    // -- unless MRX's X-basis reset half were emitted on the vacated
+    // carrier, whose hidden MX would spend an SVM draw and shift every
+    // later outcome on qubit 1's stream.
+    const uint64_t seed = 61;
+    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
+    auto model = NonComputationalModel::from_spec(
+        {1.0, 0.0, 0.0, 0.0, 0.0}, {}, std::make_optional(classifier), NonComputationalPolicy{});
+
+    auto r_m = sample_noncomputational(parse("LOSS(1) 0\nM 0\nH 1\nM 1"), model, 128, seed);
+    auto r_mrx = sample_noncomputational(parse("LOSS(1) 0\nMRX 0\nH 1\nM 1"), model, 128, seed);
+    REQUIRE(r_m.measurements == r_mrx.measurements);
+    REQUIRE(r_m.final_status == r_mrx.final_status);
+
+    bool saw_zero = false;
+    bool saw_one = false;
+    for (uint32_t shot = 0; shot < 128; ++shot) {
+        // Slot 0 is the classifier's lost column: 1 with certainty.
+        REQUIRE(r_m.measurements[shot * 2] == 1);
+        // Vacuity guard: qubit 1's H-then-measure really draws -- both
+        // outcomes occur across the shots.
+        (r_m.measurements[shot * 2 + 1] == 0 ? saw_zero : saw_one) = true;
+    }
+    REQUIRE(saw_zero);
+    REQUIRE(saw_one);
+}
+
 // =========================================================================
 // Gap 5: Classified record drives feedback
 // =========================================================================

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -463,7 +463,7 @@ TEST_CASE("rewrite: a measure-and-reset on a leaked qubit records and resets") {
     REQUIRE(rw.final_status[0] == clifft::QubitStatus::Computational);
 }
 
-TEST_CASE("rewrite: a measure-and-reset on a non-restoring lost qubit is kept") {
+TEST_CASE("rewrite: a measure-and-reset on a non-restoring lost qubit records without its reset") {
     Circuit c = parse("MR 0\n");
     NonComputationalModel model =
         make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
@@ -471,8 +471,26 @@ TEST_CASE("rewrite: a measure-and-reset on a non-restoring lost qubit is kept") 
     ContinuationRewrite rw = rewritten(c, model, {kLost});
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);  // record slot preserved
+    // The stepper leaves the qubit Lost, so the reset half is dropped: the
+    // carrier stays vacated and nothing re-prepares it.
+    REQUIRE(count_gate(rw.circuit, GateType::R) == 0);
     REQUIRE(rw.circuit.num_measurements == 1);
     REQUIRE(rw.final_status[0] == clifft::QubitStatus::Lost);  // not restored
+}
+
+TEST_CASE("rewrite: a non-restoring lost MRX drops its X-basis reset half") {
+    // An emitted RX would spend a hidden SVM draw on the vacated carrier;
+    // with the status still Lost it must not be emitted.
+    Circuit c = parse("MRX 0\n");
+    NonComputationalModel model =
+        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
+
+    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    REQUIRE(count_gate(rw.circuit, GateType::MRX) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
+    REQUIRE(count_gate(rw.circuit, GateType::RX) == 0);
+    REQUIRE(count_gate(rw.circuit, GateType::R) == 0);
+    REQUIRE(rw.final_status[0] == clifft::QubitStatus::Lost);
 }
 
 // =========================================================================


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Second of the two external-review PRs (follows #196; the stream-changing fix, isolated so its evidence stands alone).

The rewriter's classified path emitted a measure-and-reset's reset half unconditionally — contradicting the status stepper's own stated rule that a non-restoring lost-qubit reset acts on a vacated site and drops. The emitted reset was unobservable dead work on `MR` (the carrier is never read while lost), but the X/Y-basis forms (`MRX`/`MRY`) lower through a hidden X/Y measurement that **spends an SVM draw** on the vacated carrier, shifting every later outcome on the shot's stream for a semantically inert node.

The fix reads the verdict off the stepped status itself — the reset is emitted iff the stepper restored the qubit (leaked always; lost only under `reset_restores_lost`) — so emission and status can no longer disagree. This is the same single-sourcing shape as #196's shared status walk.

## Tests

- Rewrite-level: the non-restoring lost `MR` records without a reset node (`R == 0`), and the `MRX` form emits no `RX`; the restoring counterpart (existing test) still pins `R == 1`.
- End to end: `M` and `MRX` on a certainly-lost qubit at the same seed read **identically shot by shot** (records and statuses) — with the old emission, `MRX`'s hidden draw shifts qubit 1's downstream `H`-measure stream. Classified slot pinned to the lost column (all 1s), vacuity guard on the downstream measurement.
- Red/green: with the fix reverted, all three pins fail.

## Validation

- C++ Debug and Release: full suites (`~[bench]`) pass
- Python: full suite passes on both wheels (Release wheel verified by binary size after the uv-cache flush; see #196 discussion of the cache footgun)
- Draw-stream fingerprint harness byte-identical (no harness config exercises a non-restoring lost measure-and-reset; the new e2e pin carries the evidence for the changed path)
- `pre-commit run --all-files` clean

## Review round

- The emission-site comment is cut to the invariant (it read like a defense of the fix — reviewer: bachase).
- Every remaining description of the measure-and-reset now states the conditional reset half (rewriter header, Python module docstring, design note): the record is always kept; the reset re-prepares the site only when it restores it — a leaked qubit always, a lost qubit only by policy. (External-review P3.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

