### PR TITLE
docs: add leakage/loss guide and theory pages

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -207,10 +207,11 @@ why this matters and what it costs.
   qubit re-prepares the site or is dropped. A reset always restores a
   *leaked* qubit; a measure-and-reset keeps its record either way, with
   its reset half following the same rule.
-- **`damping`** (default `"exact"`): at a coherent site whose rates differ
-  between `g` and `e`, the exact no-fire back-action costs one unit of
-  active rank. `"neglect"` keeps the rank and omits the back-action — an
-  error of order $\lvert p_g - p_e \rvert$ per site, and exactly zero for
+- **`damping`** (default `"exact"`): a site whose rates differ between
+  `g` and `e` needs its qubit in the active array for the exact no-fire
+  back-action; a coherent qubit still outside it is expanded at the site.
+  `"neglect"` skips the expansion and the back-action — an error of order
+  $\lvert p_g - p_e \rvert$ per site, and exactly zero for
   source-independent rates (`LOSS` always qualifies).
 - **`seed`**: same contract as ordinary sampling — a fixed seed is fully
   reproducible, `None` uses hardware entropy.
@@ -226,9 +227,12 @@ why this matters and what it costs.
   ancilla's ladder gates then drop per the rules above.
 - **A classifier is required** whenever a capable model meets a measuring
   circuit; the error names the missing piece before sampling begins.
-- Each coherent state-dependent site adds one unit of peak rank under
-  `damping="exact"`; the [performance model](performance.md) applies
-  unchanged with that addition.
+- Under `damping="exact"`, a state-dependent site on a coherent qubit
+  outside the active array expands that qubit into it — one unit of peak
+  rank at that site. An already-active qubit adds nothing, and later
+  sites on a qubit that stays active do not stack, so the worst case is
+  one unit per *qubit* held coherent across its sites, not one per site.
+  The [performance model](performance.md) otherwise applies unchanged.
 
 ## Why there is no compile step
 

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -53,10 +53,12 @@ assert (r.heralds[:, 0] == (status == noncomp.QubitStatus.LOST)).all()
 ```
 
 `measurements`, `detectors`, and `observables` are laid out exactly as in
-ordinary sampling — a measurement of a leaked or lost qubit still occupies
-its record slot, with the classifier supplying the bit. `symbols()` folds
-the herald back in as a third value per slot (0, 1, or 2), for comparing
-against tools that report loss in-band.
+ordinary sampling: a measurement of a leaked or lost qubit still occupies
+its record slot, with the classifier supplying the bit. When the
+classifier samples its herald symbol, `heralds` marks the slot and the
+binary `measurements` entry holds a uniformly drawn placeholder;
+`symbols()` folds the herald back in as a third value per slot (0, 1,
+or 2), for comparing against tools that report loss in-band.
 
 Omitting `initial_state` starts every qubit in `g`. A model that can leak
 or lose qubits requires a classifier if the circuit measures.
@@ -110,9 +112,9 @@ assert r.measurements.shape == (1000, 2)
 
 ## What happens on a leaked or lost qubit
 
-Gates addressing a leaked or lost qubit drop: the interaction physically
-cannot happen, and the operation acts as the identity on the surviving
-operands. Measurements keep their record slot and read the classifier
+Gates addressing a leaked or lost qubit are dropped, acting as the
+identity on the surviving operands. Measurements keep their record slot
+and read the classifier
 (`M`, `MX`, and `MY` alike: the readout basis is incidental once the
 qubit has left the computational subspace).
 

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -3,8 +3,8 @@
 !!! warning "Experimental"
     `clifft.noncomp` is experimental and may change between minor releases.
 
-Real devices leak (a carrier is excited out of the qubit subspace) and lose
-atoms (the carrier leaves the trap). Ordinary Pauli noise cannot represent
+Real devices leak (an atom is excited out of the qubit encoding) and lose
+atoms (the atom leaves the trap). Ordinary Pauli noise cannot represent
 either. `clifft.noncomp` samples circuits under a five-level leakage/loss
 model: transition matrices describe when qubits jump between levels, and a
 classifier describes what a measurement of a leaked or lost qubit records.
@@ -110,14 +110,14 @@ assert r.measurements.shape == (1000, 2)
 
 ## What happens on a leaked or lost qubit
 
-Gates addressing a leaked or lost qubit drop — the interaction physically
+Gates addressing a leaked or lost qubit drop: the interaction physically
 cannot happen, and the operation acts as the identity on the surviving
 operands. Measurements keep their record slot and read the classifier
 (`M`, `MX`, and `MY` alike: the readout basis is incidental once the
-carrier has left the qubit subspace).
+qubit has left the computational subspace).
 
 Losing one half of an entangled pair leaves the partner in the reduced
-state — for a Bell pair, maximally mixed:
+state; for a Bell pair, maximally mixed:
 
 ```python
 import numpy as np
@@ -143,9 +143,8 @@ assert (r.final_status[:, 0] == noncomp.QubitStatus.LOST).all()
 assert (r.final_status[:, 1] == noncomp.QubitStatus.COMPUTATIONAL).all()
 ```
 
-Because classification happens before detectors are evaluated, leakage
-surfaces as detector events — the property error-correction workflows
-need:
+Classification happens before detectors are evaluated, so leakage
+surfaces as detector events:
 
 ```python
 import numpy as np
@@ -195,11 +194,11 @@ r = noncomp.sample("H 0\nS 0\nM 0", model, shots=20_000, seed=5)
 assert abs(r.measurements[:, 0].mean() - (0.5 + p / 2)) < 0.01
 ```
 
-Runtime resolution also preserves correlations that ahead-of-time
-sampling cannot: when the jump's destination depends on the source level,
-the leaked qubit's classified readout stays correlated with its entangled
-partner. See [Noncomputational States](../theory/noncomputational.md) for
-why this matters and what it costs.
+Resolving draws against the live state also preserves correlations that
+ahead-of-time sampling cannot produce: when the jump's destination depends
+on the source level, the leaked qubit's classified readout stays
+correlated with its entangled partner. The semantics and the rank cost
+are in [Noncomputational States](../theory/noncomputational.md).
 
 ## Policy knobs
 
@@ -210,7 +209,7 @@ why this matters and what it costs.
 - **`damping`** (default `"exact"`): a site whose rates differ between
   `g` and `e` needs its qubit in the active array for the exact no-fire
   back-action; a coherent qubit still outside it is expanded at the site.
-  `"neglect"` skips the expansion and the back-action — an error of order
+  `"neglect"` skips the expansion and the back-action: an error of order
   $\lvert p_g - p_e \rvert$ per site, and exactly zero for
   source-independent rates (`LOSS` always qualifies).
 - **`seed`**: same contract as ordinary sampling — a fixed seed is fully
@@ -228,20 +227,17 @@ why this matters and what it costs.
 - **A classifier is required** whenever a capable model meets a measuring
   circuit; the error names the missing piece before sampling begins.
 - Under `damping="exact"`, a state-dependent site on a coherent qubit
-  outside the active array expands that qubit into it — one unit of peak
-  rank at that site. An already-active qubit adds nothing, and later
+  outside the active array expands that qubit into it, adding one unit of
+  peak rank at that site. An already-active qubit adds nothing, and later
   sites on a qubit that stays active do not stack, so the worst case is
   one unit per *qubit* held coherent across its sites, not one per site.
   The [performance model](performance.md) otherwise applies unchanged.
 
 ## Why there is no compile step
 
-Ordinary Clifft separates `compile()` from `sample()` because the compiled
-program is a model-independent artifact. Under a leakage/loss model there
-is no such artifact: the executable depends on the model (which rewrites
-measurements and gates) and on each shot's jump outcomes (which rewrite
-the remainder of the shot). `noncomp.sample` therefore takes the circuit
-and model together and compiles internally, caching within the call — one
-module per distinct event history, reused across the shots that share it.
-A parsed `clifft.Circuit` can be passed instead of text to share parsing
-across calls.
+Ordinary Clifft separates `compile()` from `sample()` because a compiled
+program is model-independent. Here it is not: the executable depends on
+the model and on each shot's jump outcomes. `noncomp.sample` takes the
+circuit and model together and compiles internally, caching one module
+per distinct event history within the call. Pass a parsed
+`clifft.Circuit` instead of text to share parsing across calls.

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -1,0 +1,243 @@
+# Leakage and Loss
+
+!!! warning "Experimental"
+    `clifft.noncomp` is experimental and may change between minor releases.
+
+Real devices leak (a carrier is excited out of the qubit subspace) and lose
+atoms (the carrier leaves the trap). Ordinary Pauli noise cannot represent
+either. `clifft.noncomp` samples circuits under a five-level leakage/loss
+model: transition matrices describe when qubits jump between levels, and a
+classifier describes what a measurement of a leaked or lost qubit records.
+
+This page is the API walkthrough. The model and its simulation semantics
+are described in [Noncomputational States](../theory/noncomputational.md).
+
+## A model and its outputs
+
+A `noncomp.Model` bundles an initial level distribution, per-gate
+transition matrices, a classifier, and policy knobs. `noncomp.sample`
+returns the usual records plus two sidecars: each qubit's final status and
+a per-measurement herald.
+
+```python
+import numpy as np
+
+from clifft import noncomp
+
+Level = noncomp.Level
+
+# Classifier P[symbol][level]: g and leak_g read 0, e and leak_e read 1,
+# lost heralds (third symbol).
+classifier = noncomp.Classifier(
+    [
+        [1, 0, 1, 0, 0],  # P(record 0 | level)
+        [0, 1, 0, 1, 0],  # P(record 1 | level)
+        [0, 0, 0, 0, 1],  # P(herald   | level)
+    ]
+)
+
+model = noncomp.Model(
+    initial_state=[0.95, 0.00, 0.02, 0.01, 0.02],  # P(g, e, leak_g, leak_e, lost)
+    classifier=classifier,
+)
+
+r = noncomp.sample("M 0", model, shots=20_000, seed=1)
+
+# final_status: (shots, num_qubits) of QubitStatus values.
+status = r.final_status[:, 0]
+lost = (status == noncomp.QubitStatus.LOST).mean()
+assert abs(lost - 0.02) < 0.005
+
+# heralds: (shots, num_measurements); 1 where the classifier heralded.
+assert (r.heralds[:, 0] == (status == noncomp.QubitStatus.LOST)).all()
+```
+
+`measurements`, `detectors`, and `observables` are laid out exactly as in
+ordinary sampling — a measurement of a leaked or lost qubit still occupies
+its record slot, with the classifier supplying the bit. `symbols()` folds
+the herald back in as a third value per slot (0, 1, or 2), for comparing
+against tools that report loss in-band.
+
+Omitting `initial_state` starts every qubit in `g`. A model that can leak
+or lose qubits requires a classifier if the circuit measures.
+
+## Transitions: hooks and inline annotations
+
+A transition matrix `T[to][from]` gives the probability of jumping between
+levels when it fires; a column's deficit below 1 is "no jump". There are
+three ways to attach one to a circuit:
+
+- **Gate hooks.** A `transitions` key that names a gate (`"CZ"`, `"S"`, …)
+  fires after every occurrence of that gate.
+- **Inline references.** `LEVEL_TRANSITION[name] 0` fires the named matrix
+  on qubit 0 at that circuit position. Any key can be referenced this way,
+  gate-named or not.
+- **Inline loss.** `LOSS(p) 0` loses qubit 0 with probability `p` from any
+  occupied level.
+
+```python
+from clifft import noncomp
+
+Level = noncomp.Level
+
+
+def T(entries):
+    """Build a 5x5 transition matrix T[to][from] from {(to, from): p}."""
+    m = [[0.0] * 5 for _ in range(5)]
+    for (to, frm), p in entries.items():
+        m[to][frm] = p
+    return m
+
+
+classifier = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
+leak = T({(Level.LEAK_E, Level.G): 0.01, (Level.LEAK_E, Level.E): 0.01})
+
+model = noncomp.Model(
+    transitions={"CZ": leak},  # hook: fires after every CZ
+    classifier=classifier,
+)
+
+circuit = """
+    H 0
+    CZ 0 1
+    LOSS(0.005) 1
+    LEVEL_TRANSITION[CZ] 0
+    M 0 1
+"""
+r = noncomp.sample(circuit, model, shots=1000, seed=7)
+assert r.measurements.shape == (1000, 2)
+```
+
+## What happens on a leaked or lost qubit
+
+Gates addressing a leaked or lost qubit drop — the interaction physically
+cannot happen, and the operation acts as the identity on the surviving
+operands. Measurements keep their record slot and read the classifier
+(`M`, `MX`, and `MY` alike: the readout basis is incidental once the
+carrier has left the qubit subspace).
+
+Losing one half of an entangled pair leaves the partner in the reduced
+state — for a Bell pair, maximally mixed:
+
+```python
+import numpy as np
+
+from clifft import noncomp
+
+Level = noncomp.Level
+
+lose_all = [[0.0] * 5 for _ in range(5)]
+lose_all[Level.LOST][Level.G] = 1.0
+lose_all[Level.LOST][Level.E] = 1.0
+
+model = noncomp.Model(
+    transitions={"S": lose_all},  # the hooked S loses its qubit with certainty
+    classifier=noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]]),
+)
+
+r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1", model, shots=20_000, seed=2)
+
+survivor = r.measurements[:, 1]
+assert abs(survivor.mean() - 0.5) < 0.01  # partial trace: maximally mixed
+assert (r.final_status[:, 0] == noncomp.QubitStatus.LOST).all()
+assert (r.final_status[:, 1] == noncomp.QubitStatus.COMPUTATIONAL).all()
+```
+
+Because classification happens before detectors are evaluated, leakage
+surfaces as detector events — the property error-correction workflows
+need:
+
+```python
+import numpy as np
+
+from clifft import noncomp
+
+Level = noncomp.Level
+
+leak_up = [[0.0] * 5 for _ in range(5)]
+leak_up[Level.LEAK_E][Level.G] = 1.0
+leak_up[Level.LEAK_E][Level.E] = 1.0
+
+model = noncomp.Model(
+    transitions={"S": leak_up},
+    classifier=noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]]),  # leak_e reads 1
+)
+
+# A reference measurement, then the leaked one; the detector XORs them.
+circuit = "M 1\nH 0\nS 0\nM 0\nDETECTOR rec[-1] rec[-2]"
+r = noncomp.sample(circuit, model, shots=1000, seed=4)
+assert (r.detectors[:, 0] == 1).all()  # the leaked qubit always reads 1
+```
+
+## State-dependent rates resolve at runtime
+
+If a transition's rate differs between `g` and `e`, the jump probability on
+a superposition depends on the amplitudes at that point in the shot. The
+draw happens at sample time against the live state, so the statistics are
+exact — on $\lvert + \rangle$ with leak probability $p$ out of `g` only
+(and the leaked level reading 1), the marginal is $\tfrac12 + \tfrac{p}{2}$:
+
+```python
+from clifft import noncomp
+
+Level = noncomp.Level
+
+p = 0.4
+leak_from_g = [[0.0] * 5 for _ in range(5)]
+leak_from_g[Level.LEAK_E][Level.G] = p
+
+model = noncomp.Model(
+    transitions={"S": leak_from_g},
+    classifier=noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]]),
+)
+
+r = noncomp.sample("H 0\nS 0\nM 0", model, shots=20_000, seed=5)
+assert abs(r.measurements[:, 0].mean() - (0.5 + p / 2)) < 0.01
+```
+
+Runtime resolution also preserves correlations that ahead-of-time
+sampling cannot: when the jump's destination depends on the source level,
+the leaked qubit's classified readout stays correlated with its entangled
+partner. See [Noncomputational States](../theory/noncomputational.md) for
+why this matters and what it costs.
+
+## Policy knobs
+
+- **`reset_restores_lost`** (default `False`): whether a reset on a lost
+  qubit re-prepares the site or is dropped. A reset always restores a
+  *leaked* qubit; a measure-and-reset keeps its record either way, with
+  its reset half following the same rule.
+- **`damping`** (default `"exact"`): at a coherent site whose rates differ
+  between `g` and `e`, the exact no-fire back-action costs one unit of
+  active rank. `"neglect"` keeps the rank and omits the back-action — an
+  error of order $\lvert p_g - p_e \rvert$ per site, and exactly zero for
+  source-independent rates (`LOSS` always qualifies).
+- **`seed`**: same contract as ordinary sampling — a fixed seed is fully
+  reproducible, `None` uses hardware entropy.
+- **`max_rank`**: caps the compiled peak rank before any state allocation.
+  The cap applies to each compiled module, including branches a given shot
+  never takes, so it is conservative.
+
+## Limits
+
+- **`MPP` is not supported** under a model that can leak or lose qubits —
+  a parity of levels outside the qubit subspace has no faithful single-bit
+  record. Expand the parity readout into an explicit ancilla circuit; the
+  ancilla's ladder gates then drop per the rules above.
+- **A classifier is required** whenever a capable model meets a measuring
+  circuit; the error names the missing piece before sampling begins.
+- Each coherent state-dependent site adds one unit of peak rank under
+  `damping="exact"`; the [performance model](performance.md) applies
+  unchanged with that addition.
+
+## Why there is no compile step
+
+Ordinary Clifft separates `compile()` from `sample()` because the compiled
+program is a model-independent artifact. Under a leakage/loss model there
+is no such artifact: the executable depends on the model (which rewrites
+measurements and gates) and on each shot's jump outcomes (which rewrite
+the remainder of the shot). `noncomp.sample` therefore takes the circuit
+and model together and compiles internally, caching within the call — one
+module per distinct event history, reused across the shots that share it.
+A parsed `clifft.Circuit` can be passed instead of text to share parsing
+across calls.

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -168,6 +168,17 @@ multiply modulo Pauli phase, so `E(1) X0 Z0` is equivalent to a Y error and
 firing. Clifft lowers each contiguous chain to one noise site with absolute
 channel probabilities.
 
+### Leakage and Loss Annotations (experimental)
+
+| Instruction | Notes |
+|-------------|-------|
+| `LOSS(p)` | Loses each target with probability `p`, from any occupied level |
+| `LEVEL_TRANSITION[name]` | Fires the model's named transition matrix on each target |
+
+Both are recognized only by the leakage/loss sampler — `clifft.compile()`
+rejects them and points to `clifft.noncomp.sample`. See the
+[Leakage and Loss guide](../guide/leakage-and-loss.md).
+
 ## Identity Gates
 
 | Gate | Notes |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -24,6 +24,23 @@
 
 ::: clifft.sample_k_survivors
 
+## Leakage and Loss (experimental)
+
+Sampling under a five-level leakage/loss model. See the
+[Leakage and Loss guide](../guide/leakage-and-loss.md).
+
+::: clifft.noncomp.sample
+
+::: clifft.noncomp.Model
+
+::: clifft.noncomp.Classifier
+
+::: clifft.noncomp.NonComputationalSample
+
+::: clifft.noncomp.Level
+
+::: clifft.noncomp.QubitStatus
+
 ## Strong Simulation
 
 ::: clifft.basis_probabilities

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -102,10 +102,14 @@ state-dependent rates, including the correlations ahead-of-time sampling
 cannot produce — when the jump's destination depends on the source level,
 the leaked qubit's readout stays correlated with its entangled partner.
 
-The one approximation on this path is opt-in. At a coherent site with
-source-dependent rates, the exact no-fire back-action costs one unit of
-active rank; `damping="neglect"` keeps the rank and omits the back-action,
-a survivorship tilt of order $\lvert p_g - p_e \rvert$ per site and exactly
+The one approximation on this path is opt-in. The exact no-fire
+back-action acts on the qubit's amplitudes, so a source-dependent site on
+a coherent qubit that is still *dormant* — held in the Clifford frame,
+outside the active array — expands that qubit into the array, one unit of
+active dimension at that site. A qubit already active costs nothing more,
+and later sites on a qubit that stays active do not stack.
+`damping="neglect"` skips the expansion and the back-action, a
+survivorship tilt of order $\lvert p_g - p_e \rvert$ per site and exactly
 zero at source-independent rates. The default is exact.
 
 ## Validation

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -48,10 +48,11 @@ qubit occupies. A computational qubit carries no level claim; whether it is
 $\lvert 0 \rangle$, $\lvert 1 \rangle$, or a superposition is tracked by
 the simulator, not the ledger.
 
-Classical tracking is exact here because noncomputational populations carry
-no coherences with the computational subspace (a leaked atom does not
-interfere with qubit amplitudes); recording their occupation per trajectory
-discards nothing.
+Classical tracking is exact for this trajectory model because jumps are
+treated as incoherent: a noncomputational population carries no coherence
+with the computational subspace. Under that assumption, recording
+occupation per trajectory discards nothing; coherent leakage is outside
+the model's scope.
 
 ## The vacated carrier
 
@@ -66,8 +67,8 @@ With the carrier vacated:
 
 - **Gates drop.** An operation with no representable effect on a leaked or
   lost operand (a single- or two-qubit gate, a noise channel, classical
-  feedback onto the site) physically cannot happen, and is excised whole,
-  acting as the identity on the surviving operands.
+  feedback onto the site) is excised whole, acting as the identity on the
+  surviving operands.
 - **Measurements classify.** A measurement of a noncomputational level is
   not a Born measurement of a qubit; the classifier defines its record
   symbol. The record slot is preserved, so `rec[-k]` references, detectors,

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -7,7 +7,7 @@
 Pauli noise moves a qubit around inside its two-dimensional subspace. Real
 devices also leave that subspace: an atom is excited to a level outside the
 qubit encoding (*leakage*), or leaves the trap entirely (*loss*). No Pauli
-channel can represent either — the state is no longer a qubit state at all.
+channel can represent either: the state is no longer a qubit state at all.
 
 Clifft models both with a five-level structure per qubit, a per-gate jump
 process between levels, and a classifier that defines what a measurement of
@@ -31,10 +31,10 @@ Two ingredients drive the dynamics:
 
 - **Transition matrices.** A $5 \times 5$ matrix $T[\text{to}][\text{from}]$
   attached to a circuit position gives the probability of jumping between
-  levels when that position executes. Every entry is a discrete jump event —
-  including diagonal entries, which project onto the source level — and a
-  column's deficit below 1 is the no-jump probability. `LOSS(p)` is the
-  special case of a uniform jump to `lost` from every occupied level.
+  levels when that position executes. Every entry is a discrete jump event
+  (diagonal entries project onto the source level), and a column's deficit
+  below 1 is the no-jump probability. `LOSS(p)` is the special case of a
+  uniform jump to `lost` from every occupied level.
 - **A classifier.** A stochastic matrix $P[\text{symbol}][\text{level}]$
   mapping the level at readout to a recorded symbol: two record symbols,
   plus an optional third that heralds the measurement (typically loss).
@@ -43,30 +43,30 @@ Two ingredients drive the dynamics:
 
 Each sampled shot is one trajectory. Along a trajectory the sampler keeps a
 classical *status* per qubit: computational, `leak_g`, `leak_e`, or `lost`.
-A noncomputational status is definite — the trajectory knows exactly which
-level the qubit occupies — while a computational qubit carries no level
-claim at all: whether it is $\lvert 0 \rangle$, $\lvert 1 \rangle$, or a
-superposition is the simulator's business, not the ledger's.
+A noncomputational status is definite: the trajectory knows which level the
+qubit occupies. A computational qubit carries no level claim; whether it is
+$\lvert 0 \rangle$, $\lvert 1 \rangle$, or a superposition is tracked by
+the simulator, not the ledger.
 
-This split is what keeps the model exact. Populations of noncomputational
-levels carry no coherences with the computational subspace (a trapped atom
-in a leaked level does not interfere with qubit amplitudes), so tracking
-their occupation classically per trajectory discards nothing.
+Classical tracking is exact here because noncomputational populations carry
+no coherences with the computational subspace (a leaked atom does not
+interfere with qubit amplitudes); recording their occupation per trajectory
+discards nothing.
 
 ## The vacated carrier
 
-When a qubit jumps out of the computational subspace, the amplitudes it
-held cannot simply be deleted — for an entangled qubit they define the
-partner's reduced state. The jump therefore traces the qubit out: a hidden
-collapse resolves its computational amplitude, the partner keeps the
-correct partial-trace statistics, and the simulated cell — the *carrier* —
-is left parked while the status ledger records the occupied level.
+When a qubit jumps out of the computational subspace, its amplitudes still
+matter: for an entangled qubit they define the partner's reduced state.
+The jump therefore traces the qubit out: a hidden collapse resolves its
+computational amplitude, the partner keeps the correct partial-trace
+statistics, and the simulated cell (the *carrier*) is left parked while
+the status ledger records the occupied level.
 
-Everything downstream follows from the carrier being vacated:
+With the carrier vacated:
 
 - **Gates drop.** An operation with no representable effect on a leaked or
-  lost operand — a single- or two-qubit gate, a noise channel, classical
-  feedback onto the site — physically cannot happen, and is excised whole,
+  lost operand (a single- or two-qubit gate, a noise channel, classical
+  feedback onto the site) physically cannot happen, and is excised whole,
   acting as the identity on the surviving operands.
 - **Measurements classify.** A measurement of a noncomputational level is
   not a Born measurement of a qubit; the classifier defines its record
@@ -84,7 +84,7 @@ Leakage becomes visible to error correction through the classifier:
 leaked and lost levels are classified into the measurement record before
 detectors are evaluated, so they surface as detector events.
 
-## Runtime resolution and exactness
+## State-dependent rates
 
 Whether a jump fires can depend on the state. If a transition leaks out of
 `g` and `e` at different rates, the fire probability on a superposition is
@@ -99,13 +99,13 @@ live state*: the fire decision is drawn from the simulator's own
 amplitudes, and when a jump lands, the remainder of the shot is rewritten
 under the recorded event and execution resumes. Sampling is exact for
 state-dependent rates, including the correlations ahead-of-time sampling
-cannot produce — when the jump's destination depends on the source level,
+cannot produce: when the jump's destination depends on the source level,
 the leaked qubit's readout stays correlated with its entangled partner.
 
 The one approximation on this path is opt-in. The exact no-fire
 back-action acts on the qubit's amplitudes, so a source-dependent site on
-a coherent qubit that is still *dormant* — held in the Clifford frame,
-outside the active array — expands that qubit into the array, one unit of
+a coherent qubit that is still *dormant* (held in the Clifford frame,
+outside the active array) expands that qubit into the array, one unit of
 active dimension at that site. A qubit already active costs nothing more,
 and later sites on a qubit that stays active do not stack.
 `damping="neglect"` skips the expansion and the back-action, a
@@ -114,20 +114,21 @@ zero at source-independent rates. The default is exact.
 
 ## Validation
 
-The implementation is checked at four levels, each anchoring the next:
+The implementation is checked at four levels:
 
 1. **Closed forms.** Micro-circuits with hand-derived outcomes: partial
    trace of a Bell pair under loss, marginals under state-dependent leak
    rates, classifier confusion arithmetic.
-2. **Sharp probes.** Fixed-seed tests that pin behavior distributions
-   cannot: the Bell-pair correlation that distinguishes runtime resolution
-   from ahead-of-time draws, and the damping boundary/null pair that
-   separates `exact` from `neglect` exactly where the $\lvert p_g - p_e
-   \rvert$ bound says they must differ and agree.
+2. **Sharp probes.** Fixed-seed tests for behavior that sampled
+   distributions alone cannot check: the Bell-pair correlation that
+   distinguishes live-state draws from ahead-of-time draws, and the
+   damping boundary/null pair that separates `exact` from `neglect`
+   exactly where the $\lvert p_g - p_e \rvert$ bound says they must
+   differ and agree.
 3. **A brute-force enumerator.** A dense density-matrix reference computes
    full record distributions for small circuits; sampled frequencies are
    checked against it. The enumerator shares the channel definitions with
    the sampler, so it is one independent implementation of the *dynamics*,
-   not of the model — the closed forms above anchor the model itself.
+   not of the model; the closed forms above anchor the model itself.
 4. **Statistical distance at scale.** Total-variation-distance checks on
    repetition-code rounds at realistic rates, bounded by shot noise.

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -1,0 +1,129 @@
+# Noncomputational States
+
+!!! warning "Experimental"
+    The leakage/loss API is experimental and may change between minor
+    releases.
+
+Pauli noise moves a qubit around inside its two-dimensional subspace. Real
+devices also leave that subspace: an atom is excited to a level outside the
+qubit encoding (*leakage*), or leaves the trap entirely (*loss*). No Pauli
+channel can represent either — the state is no longer a qubit state at all.
+
+Clifft models both with a five-level structure per qubit, a per-gate jump
+process between levels, and a classifier that defines what a measurement of
+a non-qubit level records. This page describes the model and its
+simulation semantics; the [Leakage and Loss guide](../guide/leakage-and-loss.md)
+shows the API.
+
+## The five-level model
+
+Every qubit carries the same fixed level set:
+
+| index | name | category | meaning |
+|---|---|---|---|
+| 0 | `g` | computational | the qubit $\lvert 0 \rangle$ |
+| 1 | `e` | computational | the qubit $\lvert 1 \rangle$ |
+| 2 | `leak_g` | leaked | carrier present, outside the qubit subspace |
+| 3 | `leak_e` | leaked | a second leaked level |
+| 4 | `lost` | lost | carrier gone |
+
+Two ingredients drive the dynamics:
+
+- **Transition matrices.** A $5 \times 5$ matrix $T[\text{to}][\text{from}]$
+  attached to a circuit position gives the probability of jumping between
+  levels when that position executes. Every entry is a discrete jump event —
+  including diagonal entries, which project onto the source level — and a
+  column's deficit below 1 is the no-jump probability. `LOSS(p)` is the
+  special case of a uniform jump to `lost` from every occupied level.
+- **A classifier.** A stochastic matrix $P[\text{symbol}][\text{level}]$
+  mapping the level at readout to a recorded symbol: two record symbols,
+  plus an optional third that heralds the measurement (typically loss).
+
+## Statuses: classical occupation, per trajectory
+
+Each sampled shot is one trajectory. Along a trajectory the sampler keeps a
+classical *status* per qubit: computational, `leak_g`, `leak_e`, or `lost`.
+A noncomputational status is definite — the trajectory knows exactly which
+level the qubit occupies — while a computational qubit carries no level
+claim at all: whether it is $\lvert 0 \rangle$, $\lvert 1 \rangle$, or a
+superposition is the simulator's business, not the ledger's.
+
+This split is what keeps the model exact. Populations of noncomputational
+levels carry no coherences with the computational subspace (a trapped atom
+in a leaked level does not interfere with qubit amplitudes), so tracking
+their occupation classically per trajectory discards nothing.
+
+## The vacated carrier
+
+When a qubit jumps out of the computational subspace, the amplitudes it
+held cannot simply be deleted — for an entangled qubit they define the
+partner's reduced state. The jump therefore traces the qubit out: a hidden
+collapse resolves its computational amplitude, the partner keeps the
+correct partial-trace statistics, and the simulated cell — the *carrier* —
+is left parked while the status ledger records the occupied level.
+
+Everything downstream follows from the carrier being vacated:
+
+- **Gates drop.** An operation with no representable effect on a leaked or
+  lost operand — a single- or two-qubit gate, a noise channel, classical
+  feedback onto the site — physically cannot happen, and is excised whole,
+  acting as the identity on the surviving operands.
+- **Measurements classify.** A measurement of a noncomputational level is
+  not a Born measurement of a qubit; the classifier defines its record
+  symbol. The record slot is preserved, so `rec[-k]` references, detectors,
+  and observables are laid out exactly as in the noiseless circuit. The
+  readout basis is incidental on a vacated carrier: `M`, `MX`, and `MY`
+  all classify identically. A multi-qubit parity measurement (`MPP`) has no
+  faithful single-bit substitution and is rejected up front.
+- **Restoration begins with a reset.** A qubit returns to the computational
+  subspace only through an operation that re-prepares the carrier: a reset
+  (a leaked qubit always; a lost qubit only when the model opts in) or a
+  transition whose destination is a computational level.
+
+Leakage becomes visible to error correction through the classifier:
+leaked and lost levels are classified into the measurement record before
+detectors are evaluated, so they surface as detector events.
+
+## Runtime resolution and exactness
+
+Whether a jump fires can depend on the state. If a transition leaks out of
+`g` and `e` at different rates, the fire probability on a superposition is
+not a number known ahead of time — it depends on the amplitudes at that
+point in that trajectory, and the no-fire branch back-acts on the state
+(the general-measurement update from Kraus operators
+$\smash{\sqrt{1-p_g}}\,\lvert g\rangle\langle g\rvert +
+\smash{\sqrt{1-p_e}}\,\lvert e\rangle\langle e\rvert$).
+
+Clifft resolves each potential jump *at its circuit position against the
+live state*: the fire decision is drawn from the simulator's own
+amplitudes, and when a jump lands, the remainder of the shot is rewritten
+under the recorded event and execution resumes. Sampling is exact for
+state-dependent rates, including the correlations ahead-of-time sampling
+cannot produce — when the jump's destination depends on the source level,
+the leaked qubit's readout stays correlated with its entangled partner.
+
+The one approximation on this path is opt-in. At a coherent site with
+source-dependent rates, the exact no-fire back-action costs one unit of
+active rank; `damping="neglect"` keeps the rank and omits the back-action,
+a survivorship tilt of order $\lvert p_g - p_e \rvert$ per site and exactly
+zero at source-independent rates. The default is exact.
+
+## Validation
+
+The implementation is checked at four levels, each anchoring the next:
+
+1. **Closed forms.** Micro-circuits with hand-derived outcomes: partial
+   trace of a Bell pair under loss, marginals under state-dependent leak
+   rates, classifier confusion arithmetic.
+2. **Sharp probes.** Fixed-seed tests that pin behavior distributions
+   cannot: the Bell-pair correlation that distinguishes runtime resolution
+   from ahead-of-time draws, and the damping boundary/null pair that
+   separates `exact` from `neglect` exactly where the $\lvert p_g - p_e
+   \rvert$ bound says they must differ and agree.
+3. **A brute-force enumerator.** A dense density-matrix reference computes
+   full record distributions for small circuits; sampled frequencies are
+   checked against it. The enumerator shares the channel definitions with
+   the sampler, so it is one independent implementation of the *dynamics*,
+   not of the model — the closed forms above anchor the model itself.
+4. **Statistical distance at scale.** Total-variation-distance checks on
+   repetition-code rounds at realistic rates, bounded by shot noise.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
   - User Guide:
     - Compiling Circuits: guide/compilation.md
     - Simulation: guide/simulation.md
+    - Leakage and Loss: guide/leakage-and-loss.md
     - Performance: guide/performance.md
     - "Tutorial: Strong Simulation": guide/strong-simulation.md
     - "Tutorial: Surface Code": guide/surface-code.md
@@ -105,6 +106,7 @@ nav:
     - Overview: theory/overview.md
     - Architecture: theory/architecture.md
     - Basis-State Probabilities: theory/basis_probabilities.md
+    - Noncomputational States: theory/noncomputational.md
   - Reference:
     - Supported Gates: reference/gates.md
     - Instruction Reference: reference/instructions.md

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -140,8 +140,9 @@ class Model:
     An operation with no representable effect on a leaked or lost operand --
     e.g. a two-qubit gate onto a vacated site -- is dropped, acting as the
     identity on the surviving operands. Single-qubit measurements (``M``,
-    ``MX``, ``MY``) keep their record slot; on a vacated carrier the readout
-    basis is incidental and the classifier supplies the bit. A
+    ``MX``, ``MY``) keep their record slot; once the qubit has left the
+    computational subspace the readout basis is incidental and the
+    classifier supplies the bit. A
     measure-and-reset (``MR``/``MRX``/``MRY``) keeps its record the same
     way; its reset half re-prepares the site only when the reset restores
     it (a leaked qubit always; a lost qubit only with
@@ -287,12 +288,12 @@ def sample(
     ``circuit`` is a parsed ``clifft.Circuit`` or a Stim-format string. Returns a
     :class:`NonComputationalSample`. Single-qubit measurements (``M``, ``MX``,
     ``MY``) of a leaked or lost qubit read the classifier; the readout basis is
-    incidental on a vacated carrier. A model that can leak or lose qubits
-    requires a classifier when the circuit measures, and parity measurements
-    (``MPP``) are not supported with such models — both are rejected before
-    sampling begins. Raises ``ValueError`` when one of these contracts is
-    violated, when a classifier column is unsupported, or when an operation
-    has no representable effect on a noncomputational operand.
+    incidental once the qubit has left the computational subspace. A model that
+    can leak or lose qubits requires a classifier when the circuit measures,
+    and parity measurements (``MPP``) are not supported with such models — both
+    are rejected before sampling begins. Raises ``ValueError`` when one of
+    these contracts is violated, when an annotation is malformed, or when
+    ``max_rank`` is exceeded.
 
     ``max_rank`` caps the compiled peak rank under exact-mode compilation;
     the cap is enforced at each continuation compile, failing with the

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -1,5 +1,7 @@
 """Noncomputational (leakage/loss) sampling.
 
+This module is experimental: the API may change between minor releases.
+
 Drives a structural leakage/loss trajectory model on top of the ordinary Clifft
 sampler:
 


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

First of the two documentation/cleanup PRs (the second deletes the design docs and the examples notebook once this durable home exists, and sweeps code comments).

- **`docs/guide/leakage-and-loss.md`** (User Guide, beside Simulation): the API walkthrough — model construction and the three outputs, gate hooks vs. inline `LOSS(p)`/`LEVEL_TRANSITION[name]` annotations, what happens on a vacated qubit (with runnable Bell-pair partial-trace and leakage-as-detector-event examples), runtime resolution of state-dependent rates, the policy knobs, the supported limits (`MPP`, classifier requirement, `max_rank` conservatism), and why sampling takes the circuit and model together instead of a separate compile step.
- **`docs/theory/noncomputational.md`** (Theory, beside Basis-State Probabilities): the model itself — the five-level structure, per-trajectory statuses and why classical occupation tracking is exact, the vacated-carrier semantics (drop / classify / restore-via-reset), runtime resolution and the `damping` approximation with its `|p_g − p_e|` bound, and the four-level validation ladder with an honest note on what the enumerator does and does not independently check.
- **Python API reference**: a "Leakage and Loss (experimental)" section with the six `clifft.noncomp` entries.
- **Experimental marker**: banner on both pages and a line in the module docstring.

Every Python code block on both pages executes in CI via `pytest --codeblocks` — the examples are self-testing, which is the role the notebook's asserts used to play.

## Validation

- `pytest --codeblocks docs/ README.md`: 30 passed (the two new pages contribute 5 executing blocks, all with assertions)
- `mkdocs build --strict`: clean — nav entries, internal links, and all `::: clifft.noncomp.*` mkdocstrings entries resolve and render
- Python noncomp suite green after the docstring edit; `pre-commit run --all-files` clean

## Review round

- Precision round (external review, all six points addressed): heralded slots' binary `measurements` placeholder stated in the guide; jump incoherence framed as the trajectory model's assumption; "physically cannot happen" replaced with plain drop semantics; `sample()`'s raises-clause fixed (drops don't raise — it now names contract violations, malformed annotations, and `max_rank`); "carrier" removed from the API docstrings the reference renders; `LOSS(p)`/`LEVEL_TRANSITION[name]` added to the Supported Gates reference with the `compile()` redirect noted.

- Prose round (external style review, mostly accepted): em dashes cut to at-or-below the site's own density, editorializing tails removed, the no-compile-step section shortened, "Runtime resolution" heading renamed to its subject, carrier vocabulary confined to the theory page that defines it. Kept deliberately: bold bullet lead-ins (the site's own idiom in simulation.md) and the "not a Born measurement" contrast (it is the semantic point, not rhetoric).

- Rank-cost wording corrected on both pages (external P2, valid): exact damping expands a coherent qubit *still outside the active array* into it — an already-active qubit costs nothing more, and later sites on a qubit that stays active do not stack. The worst case is one unit per qubit, not one per site; the `max_rank` guidance in Limits now says so, matching the module docstring's dormant-site framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



