### PR TITLE
fix(backend): equal-rate sites keep stabilizer cost under exact damping

### DIFF
--- a/docs/opcodes.json
+++ b/docs/opcodes.json
@@ -194,8 +194,8 @@
     },
     "OP_INSTRUMENT_DORMANT_NEGLECT": {
       "category": "Instrument",
-      "summary": "State-dependent jump site on a dormant-random qubit under damping=\"neglect\": Bernoulli fire, no back-action.",
-      "detail": "Fires with the state-independent probability (p_g + p_e) / 2 and applies no no-fire back-action (neglect's defining approximation). Every fire traps: an in-line collapse would re-anchor the Pauli frame conditionally, which compiled downstream code cannot account for.",
+      "summary": "State-dependent trap-form jump site on a dormant-random qubit: Bernoulli fire, no expansion.",
+      "detail": "Fires with the state-independent probability (p_g + p_e) / 2 and applies no no-fire back-action in the VM: neglect omits it, while equal rates make it a scalar that normalization removes. Every fire traps because an in-line collapse would re-anchor the Pauli frame conditionally, which compiled downstream code cannot account for.",
       "operands": "axis_1, instrument.cp_site_idx"
     },
     "OP_APPLY_PAULI": {

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -977,16 +977,21 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                     opcode = Opcode::OP_INSTRUMENT_ACTIVE;
                 } else if (result.basis == LocalizedBasis::Z_BASIS) {
                     opcode = Opcode::OP_INSTRUMENT_DORMANT_STATIC;
-                } else if (site.neglect_damping) {
-                    // Dormant-random under neglect: no expansion and no
-                    // no-fire back-action. Every fire traps: an in-line
-                    // collapse would re-anchor the frame conditionally,
-                    // which compiled downstream code cannot account for
-                    // (a measurement's anchor is unconditional, so its
+                } else if (site.neglect_damping || site.p_total[0] == site.p_total[1]) {
+                    // Dormant-random without expansion: no no-fire
+                    // back-action, and every fire traps (an in-line collapse
+                    // would re-anchor the frame conditionally, which
+                    // compiled downstream code cannot account for -- a
+                    // measurement's anchor is unconditional, so its
                     // compile-time virtual H is sound; a fire's is not).
+                    // Equal per-source rates take this path even under
+                    // exact damping because it is exact there: the skipped
+                    // no-fire back-action is proportional to identity, and
+                    // the deferred trace-out collapse is the Born posterior.
                     opcode = Opcode::OP_INSTRUMENT_DORMANT_NEGLECT;
                 } else {
-                    // Dormant-random under exact damping: activate the
+                    // Dormant-random with source-dependent rates under
+                    // exact damping: activate the
                     // qubit as route_to_active_z does, with the expansion
                     // fused into the instrument (+1 to k at this site).
                     auto next_axis = static_cast<uint16_t>(ctx.reg_manager.active_k());

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -978,22 +978,22 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                 } else if (result.basis == LocalizedBasis::Z_BASIS) {
                     opcode = Opcode::OP_INSTRUMENT_DORMANT_STATIC;
                 } else if (site.neglect_damping || site.p_total[0] == site.p_total[1]) {
-                    // Dormant-random without expansion: no no-fire
-                    // back-action, and every fire traps (an in-line collapse
-                    // would re-anchor the frame conditionally, which
-                    // compiled downstream code cannot account for -- a
-                    // measurement's anchor is unconditional, so its
-                    // compile-time virtual H is sound; a fire's is not).
-                    // Equal per-source rates take this path even under
-                    // exact damping because it is exact there: the skipped
-                    // no-fire back-action is proportional to identity, and
-                    // the deferred trace-out collapse is the Born posterior.
+                    // No expansion: the qubit stays out of the amplitude
+                    // array, a no-fire leaves the state untouched, and every
+                    // fire traps to the driver (an in-line collapse would
+                    // change the frame on some shots but not others, and the
+                    // downstream code was compiled for one fixed frame).
+                    // Neglect chooses this form directly. Equal per-source
+                    // rates also get it, under either damping, because it is
+                    // exact for them: damping both levels by the same factor
+                    // only rescales the state, which normalization undoes,
+                    // and the trapped fire is resolved exactly by the driver.
                     opcode = Opcode::OP_INSTRUMENT_DORMANT_NEGLECT;
                 } else {
-                    // Dormant-random with source-dependent rates under
-                    // exact damping: activate the
-                    // qubit as route_to_active_z does, with the expansion
-                    // fused into the instrument (+1 to k at this site).
+                    // Source-dependent rates under exact damping: expand the
+                    // qubit into the array (as route_to_active_z would), with
+                    // the expansion fused into the instrument -- +1 to k at
+                    // this site.
                     auto next_axis = static_cast<uint16_t>(ctx.reg_manager.active_k());
                     if (result.pivot != next_axis) {
                         emit_swap(ctx, result.pivot, next_axis);

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -85,7 +85,8 @@ enum class Opcode : uint8_t {
     OP_INSTRUMENT_ACTIVE,           // Fused damp+eval on an active axis (any axis)
     OP_INSTRUMENT_DORMANT_STATIC,   // Frame-deterministic source: Bernoulli fire
     OP_INSTRUMENT_EXPAND,           // Fused expand+damp (k -> k+1), damping="exact"
-    OP_INSTRUMENT_DORMANT_NEGLECT,  // Dormant-random, damping="neglect": every fire traps
+    OP_INSTRUMENT_DORMANT_NEGLECT,  // Dormant-random trap form (neglect, or equal rates): every
+                                    // fire traps
 
     // Classical / Errors
     OP_APPLY_PAULI,    // XORs a full N-bit mask from ConstantPool into P

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -702,7 +702,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             any_noncomp_initial |= !is_computational(events.initial_status.back());
         }
 
-        // Forced-outcome buffer for neglect-form trace-outs, one entry
+        // Forced-outcome buffer for trap-form trace-outs, one entry
         // per hidden slot the chain forces; reset() clears the state's
         // span each shot.
         std::vector<uint8_t> forced_buffer;
@@ -788,7 +788,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             const AstNode& node = annotated.nodes[op_index];
             const AnnotationChannel channel = resolve_annotation(node, model, op_index);
 
-            // Destination: at a neglect-form site nothing was drawn, so
+            // Destination: at a trap-form site nothing was drawn, so
             // the driver draws over the full column (computational
             // destinations included); elsewhere the class is already
             // leaked/lost and only the level within the trap remainder
@@ -811,7 +811,7 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             events.jumps.push_back({op_index, qubit, dest});
             extend_classical_outcomes(annotated, events, model, driver_rng);
 
-            // A neglect-form trap hands its carrier over uncollapsed; the
+            // A trap-form fire hands its carrier over uncollapsed; the
             // continuation's trace-out is forced to the reported source,
             // read from forced_record at the slot trace() assigned to the
             // rewrite's named reset node. The forced value is per-shot

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -318,7 +318,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
                 // site collapsed the carrier before trapping); for a
                 // computational destination it re-prepares the carrier at
                 // the destination level, with an X appended for |1>. A
-                // forced neglect trace-out points at the same reset.
+                // forced trap-form trace-out points at the same reset.
                 const size_t r_node = out.nodes.size();
                 out.nodes.push_back(single_qubit_op(GateType::R, qubit));
                 if (jump->second == Level::E) {

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -119,7 +119,7 @@ struct ContinuationRewrite {
 // before or at the last jump must be covered by the walk (no-fire for
 // targets not in `jumps`); classical_outcomes must list, in circuit
 // order, exactly the classical-source consults after the last jump.
-// `force_last_traceout` marks the last jump as a neglect-form trap whose
+// `force_last_traceout` marks the last jump as a trap-form fire whose
 // carrier arrives uncollapsed. Throws std::invalid_argument on policy
 // rejects and on events that do not describe this circuit.
 ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -216,7 +216,7 @@ class SchrodingerState {
     // --- Resumable trap state ---
     //
     // Set when an instrument fire cannot be resolved in-line: any form
-    // firing to a leaked/lost destination, or any fire at a neglect-mode
+    // firing to a leaked/lost destination, or any trap-form fire on a
     // dormant-random site (whose collapse belongs to the continuation).
     // execute() halts at the site with the state intact (the carrier
     // already collapsed onto the drawn source where the form allows it)

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -226,7 +226,7 @@ class SchrodingerState {
         uint32_t site_id = 0;  // CompiledInstrumentSite::site_id
         uint8_t source = 0;    // Drawn physical source level (0 = |0>)
 
-        // True at a neglect-form site: no destination has been drawn at
+        // True at a trap-form site: no destination has been drawn at
         // all, so the host draws from the site's full column --
         // computational destinations included -- and the continuation
         // performs the collapse. False elsewhere: the destination class
@@ -262,7 +262,7 @@ class SchrodingerState {
 
 /// Execute a compiled program for one shot, populating state with results.
 /// If an instrument fire cannot be resolved in-line (a leaked/lost
-/// destination on any form, or any fire at a neglect-form site),
+/// destination on any form, or any fire at a trap-form site),
 /// execution halts at the site with state.pending_trap set; continue via
 /// resume().
 void execute(const CompiledModule& program, SchrodingerState& state);

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1974,7 +1974,7 @@ static inline void exec_readout_noise(SchrodingerState& state, const ConstantPoo
 // Physical source/destination indices (0 = |0> level) map to localized
 // levels through FLAG_SIGN here; the kernels handle p_x[v] themselves. A
 // fire that cannot resolve in-line -- a leaked/lost destination on any
-// form, or any fire at a neglect-form site -- is a resumable trap: the
+// form, or any fire at a trap-form site -- is a resumable trap: the
 // dispatch halts with state.pending_trap set.
 
 // Destination of a fire from physical source s: a computational level d
@@ -2014,7 +2014,7 @@ static inline void apply_instrument_fixup(SchrodingerState& state, const Constan
 }
 
 // Returns false when the shot halts at a resumable trap: a fire to a
-// leaked/lost destination on any form, or any fire at a neglect-form
+// leaked/lost destination on any form, or any fire at a trap-form
 // site. The carrier is collapsed onto the drawn source *before* trapping
 // wherever the form allows it, so the continuation's trace-out measures
 // an already-definite carrier and the unraveling stays correlated with

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -2045,8 +2045,9 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
 
     if (instr.opcode == Opcode::OP_INSTRUMENT_DORMANT_NEGLECT) {
         // A dormant-random qubit's fire probability is exactly
-        // (p_g + p_e) / 2. No fire means no action at all -- neglect's
-        // defining approximation is omitting the no-fire back-action.
+        // (p_g + p_e) / 2. No fire means no action at all: neglect omits
+        // the no-fire back-action, while equal rates make it a scalar that
+        // normalization removes.
         // Every fire traps: an in-line collapse would re-anchor the frame
         // conditionally, which compiled downstream code cannot account
         // for. The carrier hands over uncollapsed with the drawn source

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -375,6 +375,37 @@ def test_policy_knob_strings_validate():
         noncomp.Model(initial_state=ALL_G, damping="bogus")
 
 
+def test_loss_only_exact_mode_stays_at_stabilizer_cost():
+    """Equal per-source rates (LOSS always qualifies) take the trap-form
+    lowering under damping="exact", so a loss-only model compiles at the
+    neglect rank -- max_rank=0 passes -- while the physics stays exact:
+    survivors keep full interference and the loss rate is right."""
+    circuit = "H 0\nLOSS(0.3) 0\nH 0\nM 0"
+    cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
+    model = noncomp.Model(classifier=cls)  # damping="exact" default
+    r = noncomp.sample(circuit, model, shots=4000, seed=17, max_rank=0)
+    meas = r.measurements[:, 0]
+    lost = r.final_status[:, 0] == noncomp.QubitStatus.LOST
+    # Survivors: the H .. H sandwich returns |0> deterministically; a lost
+    # qubit reads the classifier's lost column (1).
+    assert (meas[~lost] == 0).all()
+    assert (meas[lost] == 1).all()
+    assert lost.any() and (~lost).any()
+    assert abs(lost.mean() - 0.3) < 4 * (0.3 * 0.7 / 4000) ** 0.5
+
+
+def test_loss_on_many_coherent_qubits_compiles_flat():
+    """Per-qubit LOSS sites do not accumulate rank under damping="exact"."""
+    circuit = (
+        "".join(f"H {i}\n" for i in range(5))
+        + "".join(f"LOSS(0.01) {i}\n" for i in range(5))
+        + "".join(f"H {i}\nM {i}\n" for i in range(5))
+    )
+    cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
+    r = noncomp.sample(circuit, noncomp.Model(classifier=cls), shots=8, seed=3, max_rank=0)
+    assert r.num_measurements == 5
+
+
 def test_max_rank_rejects_over_budget_exact_but_neglect_fits():
     # A source-dependent leak (only out of e) on a coherent dormant qubit is
     # genuinely non-Clifford: damping="exact" expands it into the amplitude

--- a/tests/test_backend_instruments.cc
+++ b/tests/test_backend_instruments.cc
@@ -146,7 +146,7 @@ TEST_CASE("lowering: an active X-basis site gets an absorbed array Hadamard") {
     REQUIRE(module.bytecode[at - 1].opcode == Opcode::OP_ARRAY_H);
 }
 
-TEST_CASE("lowering: dormant-random under exact damping expands at the site") {
+TEST_CASE("lowering: source-dependent rates under exact damping expand at the site") {
     auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0", demo_options());
 
     const size_t at = sole_instrument_index(module);
@@ -154,6 +154,29 @@ TEST_CASE("lowering: dormant-random under exact damping expands at the site") {
     REQUIRE(at > 0);
     REQUIRE(module.bytecode[at - 1].opcode == Opcode::OP_FRAME_H);
     REQUIRE(module.peak_rank == 1);  // +1 to k at the site
+}
+
+TEST_CASE("lowering: equal per-source rates skip the expansion even under exact damping") {
+    // The trap-form lowering is exact when the two computational columns
+    // agree (the skipped no-fire back-action is proportional to identity),
+    // so exact damping takes it and k stays flat.
+    InstrumentTraceOptions options;
+    InstrumentSpec spec;
+    spec.p_total[0] = 0.1;
+    spec.p_dest[0][0] = 0.02;
+    spec.p_dest[0][1] = 0.03;
+    spec.p_total[1] = 0.1;
+    spec.p_dest[1][0] = 0.02;
+    spec.p_dest[1][1] = 0.03;
+    options.transitions.emplace("jump", spec);
+
+    auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0", options);
+    const size_t at = sole_instrument_index(module);
+    REQUIRE(module.bytecode[at].opcode == Opcode::OP_INSTRUMENT_DORMANT_NEGLECT);
+    REQUIRE(module.peak_rank == 0);
+    // The equal-rate path, not the policy: this is an exact-damping site.
+    REQUIRE_FALSE(module.constant_pool.instrument_sites[module.bytecode[at].instrument.cp_site_idx]
+                      .neglect_damping);
 }
 
 TEST_CASE("lowering: dormant-random under neglect keeps k and skips the expansion") {

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -296,7 +296,7 @@ TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
         ContainsSubstring("exceeds max_rank 2") && ContainsSubstring("circuit line"));
 }
 
-TEST_CASE("exact: a neglect-form trap keeps the fire-side correlation") {
+TEST_CASE("exact: a trap-form fire keeps the fire-side correlation") {
     // The decisive pin for the forced trace-out. Qubit 0 is Bell-entangled
     // with qubit 1 and dormant-random at the site; under neglect the fire
     // traps with the carrier uncollapsed. The channel is certain but

--- a/tests/test_execute_instruments.cc
+++ b/tests/test_execute_instruments.cc
@@ -124,11 +124,14 @@ TEST_CASE("execute: an active-axis certain reset collapses the carrier to g") {
     }
 }
 
-TEST_CASE("execute: a dormant-random certain reset expands, collapses, and measures g") {
-    // H leaves the qubit dormant-random; under exact damping the site
-    // expands (k -> k+1), fires with certainty, and collapses to g.
+TEST_CASE("execute: a dormant-random source-dependent site expands and measures g") {
+    // H leaves the qubit dormant-random; the source-dependent rates make
+    // the site expand (k -> k+1). Both branches land in g -- a fire (only
+    // from e) by its destination, a no-fire by the r_e = 0 filter -- so
+    // the measurement is deterministically 0 while the fused expand+damp
+    // path executes with a nontrivial damp.
     InstrumentTraceOptions options;
-    options.transitions.emplace("reset_g", to_level(1.0, 1.0, /*dest=*/0));
+    options.transitions.emplace("reset_g", to_level(/*p_g=*/0.0, /*p_e=*/1.0, /*dest=*/0));
 
     auto module = compile_raw("H 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
     REQUIRE(module.peak_rank == 1);  // the site's own expansion

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -85,7 +85,7 @@ TEST_CASE("trap+resume: a spectator loss resumes in the same module and complete
     }
 }
 
-TEST_CASE("trap+resume: a neglect-form trap reports its destination as pending") {
+TEST_CASE("trap+resume: a trap-form fire reports its destination as pending") {
     InstrumentTraceOptions options;
     options.transitions.emplace("jump", [] {
         InstrumentSpec spec;


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Fixes the final review's B1: under the default `damping="exact"`, a source-independent dormant-random site — every `LOSS`, by construction — expanded its qubit into the amplitude array, making loss-only models exponential in qubit count (measured: 5 qubits × `LOSS(0.01)` needed peak rank 5 under exact vs 0 under neglect) for an answer available at stabilizer cost.

The expansion bought nothing: the trap-form lowering is **bit-exact** when the two computational columns agree. The skipped no-fire back-action `diag(r, r)` is proportional to identity, the dormant-random populations are exactly ½/½ so the fire rate is exact, the trap's source draw is the Born posterior, and the forced trace-out collapse is the exact Kraus collapse — the same battle-tested mechanism the neglect path always used. The docs already promised this cost model ("a site whose rates differ between `g` and `e` needs its qubit in the active array"; `LOSS` "always qualifies"); the backend was the outlier, and after this one-condition change every doc sentence is true as written.

The classification becomes: trap-form when `neglect_damping` **or** `p_total[0] == p_total[1]`; source-dependent exact sites expand exactly as before (the pre-existing lowering test's fixture is source-dependent and is retitled to say so).

## Tests (all red with the fix reverted)

- **Opcode-level pin**: an equal-rate site under exact damping lowers to `OP_INSTRUMENT_DORMANT_NEGLECT` with `peak_rank == 0` and `neglect_damping == false` on the site record — proving it took the equal-rate path, not the policy path.
- **Physics at rank 0**: `H; LOSS(0.3); H; M` under exact at `max_rank=0` — survivors read 0 deterministically (interference fully preserved through the trap-form site), lost qubits read the classifier's lost column, and the loss rate lands within 4σ of 0.3.
- **No per-qubit accumulation**: five coherent qubits with per-qubit `LOSS` run at `max_rank=0`.

## Validation

- Full C++ suites (Debug + Release, `~[bench]`) and full Python suites on both size-verified wheels
- The sharp probes and oracle cross-checks pass unchanged (the source-dependent exact path is untouched; the damping-null probe now exercises identical lowerings by construction)
- **Fingerprint harness byte-identical** — draw streams change only for exact-mode circuits with an equal-rate site on a coherent qubit, and no harness config has one; the changed path's correctness is carried by the new pins and the closed-form suites
- One stale execute-level fixture pinned the old lowering (an equal-rate certain site expecting expansion + `peak_rank == 1`); retuned to a source-dependent site that still exercises the fused expand+damp path with a deterministic outcome (fire lands in `g` by destination, no-fire by the annihilating filter)
- `pre-commit run --all-files` clean

## Review round

- The classification comment is rewritten in plain words (reviewer: bachase) — what the no-expansion form does, why fires trap instead of collapsing in-line, and why equal rates may take it, without the jargon.
- The neglect-only naming debt is swept: comments and test names that described `OP_INSTRUMENT_DORMANT_NEGLECT`'s mechanism as "neglect-form" now say **trap-form** (named for what it does), and the opcode's declaration comment names both selectors (neglect, or equal rates). The opcode identifier itself is unchanged — renaming it is wider churn than a pre-merge round should carry; happy to do it as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

