### PR TITLE
fix(noncomp): reject transition keys that can never fire as hooks

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -70,7 +70,9 @@ levels when it fires; a column's deficit below 1 is "no jump". There are
 three ways to attach one to a circuit:
 
 - **Gate hooks.** A `transitions` key that names a gate (`"CZ"`, `"S"`, …)
-  fires after every occurrence of that gate.
+  fires after every occurrence of that gate. Keys naming instructions that
+  never produce a circuit node (`MXX`/`MYY`/`MZZ`, `CH`/`CCX`/`CCZ`,
+  identity no-ops) are rejected at model construction.
 - **Inline references.** `LEVEL_TRANSITION[name] 0` fires the named matrix
   on qubit 0 at that circuit position. Any key can be referenced this way,
   gate-named or not.

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -162,6 +162,9 @@ struct GateTraits {
     bool measure_reset = false;
     bool identity_noop = false;
     bool noise = false;
+    // Lowered by the parser into other node kinds, so the gate never
+    // appears as an AST node.
+    bool parser_desugared = false;
     std::string_view name;
 };
 
@@ -240,9 +243,9 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = S, .measurement = true, .measure_reset = true, .name = "MR"},
     {.arity = S, .measurement = true, .measure_reset = true, .name = "MRX"},
     {.arity = ML, .measurement = true, .name = "MPP"},
-    {.arity = P, .measurement = true, .name = "MXX"},
-    {.arity = P, .measurement = true, .name = "MYY"},
-    {.arity = P, .measurement = true, .name = "MZZ"},
+    {.arity = P, .measurement = true, .parser_desugared = true, .name = "MXX"},
+    {.arity = P, .measurement = true, .parser_desugared = true, .name = "MYY"},
+    {.arity = P, .measurement = true, .parser_desugared = true, .name = "MZZ"},
     // Resets
     {.arity = S, .reset = true, .name = "R"},
     {.arity = S, .reset = true, .name = "RX"},
@@ -311,10 +314,8 @@ inline constexpr bool is_measure_reset(GateType g) {
 inline constexpr bool is_identity_noop(GateType g) {
     return gate_traits(g).identity_noop;
 }
-// MXX/MYY/MZZ parse into MPP nodes with Pauli-tagged targets, so these
-// GateTypes never appear in a parsed circuit.
 inline constexpr bool is_parser_desugared(GateType g) {
-    return g == GateType::MXX || g == GateType::MYY || g == GateType::MZZ;
+    return gate_traits(g).parser_desugared;
 }
 inline constexpr bool is_noise_gate(GateType g) {
     return gate_traits(g).noise;

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -311,6 +311,11 @@ inline constexpr bool is_measure_reset(GateType g) {
 inline constexpr bool is_identity_noop(GateType g) {
     return gate_traits(g).identity_noop;
 }
+// MXX/MYY/MZZ parse into MPP nodes with Pauli-tagged targets, so these
+// GateTypes never appear in a parsed circuit.
+inline constexpr bool is_parser_desugared(GateType g) {
+    return g == GateType::MXX || g == GateType::MYY || g == GateType::MZZ;
+}
 inline constexpr bool is_noise_gate(GateType g) {
     return gate_traits(g).noise;
 }

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -153,7 +153,7 @@ enum class GateType : uint16_t {
 enum class GateArity : uint8_t {
     SINGLE,      // Single qubit (H, S, X, T, M, etc.)
     PAIR,        // Two qubits consumed in pairs (CX, CY, CZ)
-    TRIPLE,      // Three qubits consumed in triples (3-qubit noise channels and parse rewrites)
+    TRIPLE,      // Three qubits consumed in triples (3-qubit noise channels and gates)
     MULTI,       // Variable targets (MPP)
     ANNOTATION,  // No qubit targets (TICK)
 };

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -139,6 +139,12 @@ enum class GateType : uint16_t {
     // Simulation-only probes
     EXP_VAL,  // Non-destructive expectation value
 
+    // Parse-time rewrites: the parser lowers these immediately; no AST node
+    // ever carries these types.
+    CH,   // Controlled-Hadamard (rewritten at parse time)
+    CCX,  // Toffoli / controlled-controlled-X (rewritten at parse time)
+    CCZ,  // Controlled-controlled-Z (rewritten at parse time)
+
     // Sentinel for unknown/unsupported gates
     UNKNOWN,
 };
@@ -147,7 +153,7 @@ enum class GateType : uint16_t {
 enum class GateArity : uint8_t {
     SINGLE,      // Single qubit (H, S, X, T, M, etc.)
     PAIR,        // Two qubits consumed in pairs (CX, CY, CZ)
-    TRIPLE,      // Three qubits consumed in triples (3-qubit noise channels)
+    TRIPLE,      // Three qubits consumed in triples (3-qubit noise channels and parse rewrites)
     MULTI,       // Variable targets (MPP)
     ANNOTATION,  // No qubit targets (TICK)
 };
@@ -280,6 +286,10 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = S, .name = "LOSS"},
     // Simulation-only probes
     {.arity = ML, .name = "EXP_VAL"},
+    // Parse-time rewrites: no AST nodes carry these types
+    {.arity = P, .parser_desugared = true, .name = "CH"},
+    {.arity = T, .parser_desugared = true, .name = "CCX"},
+    {.arity = T, .parser_desugared = true, .name = "CCZ"},
     // Sentinel
     {.arity = S, .name = "UNKNOWN"},
 };

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -88,12 +88,6 @@ bool is_representable_tag(std::string_view tag) {
     return tag.find_first_of("]#\n") == std::string_view::npos;
 }
 
-// CH, CCX, and CCZ are handled by parser rewrites before gate lookup; they
-// are lowered to sequences of other gates and never appear as AST nodes.
-bool is_parse_only_instruction(std::string_view name) {
-    return name == "CH" || name == "CCX" || name == "CCZ";
-}
-
 namespace {
 
 bool parse_int(std::string_view s, int& out) {
@@ -279,25 +273,6 @@ class Parser {
             return;
         }
 
-        // Parser-only rewrite gates. They are lowered immediately so the
-        // AST never contains frontend/backend-visible CH, CCZ, or CCX nodes.
-        if (gate_name == "CH") {
-            if (!args.empty()) {
-                throw ParseError("CH takes no arguments", line_num);
-            }
-            previous_correlated_error_link_ = false;
-            parse_ch_rewrite(rest, line_num, circuit);
-            return;
-        }
-        if (gate_name == "CCZ" || gate_name == "CCX") {
-            if (!args.empty()) {
-                throw ParseError(std::string(gate_name) + " takes no arguments", line_num);
-            }
-            previous_correlated_error_link_ = false;
-            parse_three_qubit_rewrite(gate_name, rest, line_num, circuit);
-            return;
-        }
-
         // Look up gate type.
         GateType gate = find_gate(gate_name);
         if (gate == GateType::UNKNOWN) {
@@ -312,6 +287,23 @@ class Parser {
         }
         previous_correlated_error_link_ =
             gate == GateType::CORRELATED_ERROR || gate == GateType::ELSE_CORRELATED_ERROR;
+
+        // CH/CCX/CCZ are lowered immediately, so the AST never contains their
+        // nodes; MXX/MYY/MZZ lower inside the pair-arity path below.
+        if (gate == GateType::CH) {
+            if (!args.empty()) {
+                throw ParseError("CH takes no arguments", line_num);
+            }
+            parse_ch_rewrite(rest, line_num, circuit);
+            return;
+        }
+        if (gate == GateType::CCX || gate == GateType::CCZ) {
+            if (!args.empty()) {
+                throw ParseError(std::string(gate_name) + " takes no arguments", line_num);
+            }
+            parse_three_qubit_rewrite(gate_name, rest, line_num, circuit);
+            return;
+        }
 
         // Validate argument counts for multi-probability channels.
         if (gate == GateType::PAULI_CHANNEL_1 && args.size() != 3) {

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -71,6 +71,31 @@ std::string_view trim(std::string_view s) {
     return s;
 }
 
+}  // namespace
+
+// Tags are trimmed as they are parsed, and a '#' starts a comment that
+// is stripped before tag parsing. A key with leading/trailing whitespace
+// or a '#' could never be written as a LEVEL_TRANSITION[key] tag and
+// reach the model unchanged.
+bool is_representable_tag(std::string_view tag) {
+    if (tag.empty()) {
+        return false;
+    }
+    if (std::isspace(static_cast<unsigned char>(tag.front())) ||
+        std::isspace(static_cast<unsigned char>(tag.back()))) {
+        return false;
+    }
+    return tag.find_first_of("]#\n") == std::string_view::npos;
+}
+
+// CH, CCX, and CCZ are handled by parser rewrites before gate lookup; they
+// are lowered to sequences of other gates and never appear as AST nodes.
+bool is_parse_only_instruction(std::string_view name) {
+    return name == "CH" || name == "CCX" || name == "CCZ";
+}
+
+namespace {
+
 bool parse_int(std::string_view s, int& out) {
     auto result = std::from_chars(s.data(), s.data() + s.size(), out);
     return result.ec == std::errc{} && result.ptr == s.data() + s.size();

--- a/src/clifft/circuit/parser.h
+++ b/src/clifft/circuit/parser.h
@@ -45,6 +45,17 @@ class ParseError : public std::runtime_error {
     uint32_t line_;
 };
 
+// True iff `tag` can appear as a LEVEL_TRANSITION bracket tag and parse
+// back to exactly this string: nonempty, no leading or trailing
+// whitespace (tags are trimmed), and no ']' (closes the tag), '#'
+// (starts a comment), or newline (ends the line).
+bool is_representable_tag(std::string_view tag);
+
+// True iff `name` is an instruction the parser lowers into other gates
+// without emitting a node of its own (CH, CCX, CCZ), so it can never be
+// matched by a gate hook.
+bool is_parse_only_instruction(std::string_view name);
+
 // Parse a circuit from text.
 // Uses kMaxUnrolledOps as the safety limit on total AST nodes.
 [[nodiscard]] Circuit parse(std::string_view text);

--- a/src/clifft/circuit/parser.h
+++ b/src/clifft/circuit/parser.h
@@ -51,11 +51,6 @@ class ParseError : public std::runtime_error {
 // (starts a comment), or newline (ends the line).
 bool is_representable_tag(std::string_view tag);
 
-// True iff `name` is an instruction the parser lowers into other gates
-// without emitting a node of its own (CH, CCX, CCZ), so it can never be
-// matched by a gate hook.
-bool is_parse_only_instruction(std::string_view name);
-
 // Parse a circuit from text.
 // Uses kMaxUnrolledOps as the safety limit on total AST nodes.
 [[nodiscard]] Circuit parse(std::string_view text);

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -1,6 +1,7 @@
 #include "clifft/noncomp/model.h"
 
 #include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/parser.h"
 #include "clifft/noncomp/numeric.h"
 
 #include <cstddef>
@@ -20,7 +21,10 @@ namespace {
 // silently accepted. Excludes annotations, identity no-ops, the
 // classical measurement pad (MPAD), the expectation-value probe, and
 // noise channels (whose composition with a level transition is
-// deliberately left unmodeled).
+// deliberately left unmodeled). MXX, MYY, and MZZ are measurement gates
+// by trait but are rejected as hook keys before this predicate is
+// consulted, because they desugar to MPP at parse time and never appear
+// as AST nodes.
 bool supports_transition(GateType g) {
     if (is_clifford(g)) {
         return true;  // single- and two-qubit Clifford gates
@@ -29,7 +33,7 @@ bool supports_transition(GateType g) {
         return true;  // R, RX, RY
     }
     if (is_measurement(g) && g != GateType::MPAD) {
-        return true;  // M, MX, MY, MR, MRX, MRY, MPP, MXX, MYY, MZZ
+        return true;  // M, MX, MY, MR, MRX, MRY, MPP
     }
     switch (g) {
         // Non-Clifford unitaries: no trait flag distinguishes these, so
@@ -87,18 +91,24 @@ NonComputationalModel::NonComputationalModel(
     }
 
     // A transition key is referenced from circuits by LEVEL_TRANSITION[key]
-    // annotations, so it must survive the tag syntax; a key that names a
+    // annotations, so it must survive the tag grammar. A key that names a
     // hookable physical gate additionally registers a gate hook,
     // canonicalized to GateType so no two spellings of one gate shadow
     // each other.
     for (auto& [name, instrument] : transitions) {
-        if (name.empty()) {
-            throw std::invalid_argument("NonComputationalModel: transition keys must be nonempty");
-        }
-        if (name.find(']') != std::string::npos || name.find('\n') != std::string::npos) {
+        if (!is_representable_tag(name)) {
             throw std::invalid_argument(
                 "NonComputationalModel: transition key '" + name +
-                "' contains ']' or a newline and cannot be referenced by a LEVEL_TRANSITION tag");
+                "' cannot be written as a LEVEL_TRANSITION tag: a key must be nonempty, have no "
+                "leading or trailing whitespace, and contain no ']', '#', or newline");
+        }
+        if (is_parse_only_instruction(name)) {
+            throw std::invalid_argument(
+                "NonComputationalModel: transition key '" + name +
+                "' cannot key a gate hook: the parser decomposes " + name +
+                " into other gates, so no " + name +
+                " node exists for the hook to expand onto; place LEVEL_TRANSITION[...] annotations "
+                "explicitly");
         }
         // Only a key naming a hookable physical gate registers a hook. Any
         // other key -- an arbitrary name, or one naming a non-hookable
@@ -106,6 +116,20 @@ NonComputationalModel::NonComputationalModel(
         // transition: referenceable from LEVEL_TRANSITION[key], expanded onto
         // nothing.
         const GateType gate = parse_gate_name(name);
+        if (gate != GateType::UNKNOWN && is_parser_desugared(gate)) {
+            throw std::invalid_argument(
+                "NonComputationalModel: transition key '" + name + "' cannot key a gate hook: " +
+                name + " desugars to MPP at parse time, so no " + name +
+                " node exists for the hook to expand onto; place LEVEL_TRANSITION[...] annotations "
+                "explicitly");
+        }
+        if (gate != GateType::UNKNOWN && is_identity_noop(gate)) {
+            throw std::invalid_argument(
+                "NonComputationalModel: transition key '" + name +
+                "' cannot key a gate hook: identity no-ops emit no circuit nodes, so the hook "
+                "could never fire; place LEVEL_TRANSITION[...] annotations at the intended "
+                "positions");
+        }
         if (gate != GateType::UNKNOWN && supports_transition(gate)) {
             auto [it, inserted] = hooks_.emplace(gate, name);
             if (!inserted) {

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -21,10 +21,8 @@ namespace {
 // silently accepted. Excludes annotations, identity no-ops, the
 // classical measurement pad (MPAD), the expectation-value probe, and
 // noise channels (whose composition with a level transition is
-// deliberately left unmodeled). MXX, MYY, and MZZ are measurement gates
-// by trait but are rejected as hook keys before this predicate is
-// consulted, because they desugar to MPP at parse time and never appear
-// as AST nodes.
+// deliberately left unmodeled). Parser-desugared gates are rejected as
+// hook keys before this predicate is consulted.
 bool supports_transition(GateType g) {
     if (is_clifford(g)) {
         return true;  // single- and two-qubit Clifford gates
@@ -102,14 +100,6 @@ NonComputationalModel::NonComputationalModel(
                 "' cannot be written as a LEVEL_TRANSITION tag: a key must be nonempty, have no "
                 "leading or trailing whitespace, and contain no ']', '#', or newline");
         }
-        if (is_parse_only_instruction(name)) {
-            throw std::invalid_argument(
-                "NonComputationalModel: transition key '" + name +
-                "' cannot key a gate hook: the parser decomposes " + name +
-                " into other gates, so no " + name +
-                " node exists for the hook to expand onto; place LEVEL_TRANSITION[...] annotations "
-                "explicitly");
-        }
         // Only a key naming a hookable physical gate registers a hook. Any
         // other key -- an arbitrary name, or one naming a non-hookable
         // instruction such as LOSS or a noise channel -- is a named-only
@@ -118,10 +108,11 @@ NonComputationalModel::NonComputationalModel(
         const GateType gate = parse_gate_name(name);
         if (gate != GateType::UNKNOWN && is_parser_desugared(gate)) {
             throw std::invalid_argument(
-                "NonComputationalModel: transition key '" + name + "' cannot key a gate hook: " +
-                name + " desugars to MPP at parse time, so no " + name +
-                " node exists for the hook to expand onto; place LEVEL_TRANSITION[...] annotations "
-                "explicitly");
+                "NonComputationalModel: transition key '" + name +
+                "' cannot key a gate hook: " + name +
+                " is rewritten at parse time and never appears as a circuit node, so the hook "
+                "could "
+                "never fire; place LEVEL_TRANSITION[...] annotations explicitly");
         }
         if (gate != GateType::UNKNOWN && is_identity_noop(gate)) {
             throw std::invalid_argument(

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -282,6 +282,10 @@ NB_MODULE(_clifft_core, m) {
         .value("LOSS", clifft::GateType::LOSS)
         // Simulation-only probes
         .value("EXP_VAL", clifft::GateType::EXP_VAL)
+        // Parse-time rewrites: no AST nodes carry these types
+        .value("CH", clifft::GateType::CH)
+        .value("CCX", clifft::GateType::CCX)
+        .value("CCZ", clifft::GateType::CCZ)
         // Sentinel for unknown/unsupported gates
         .value("UNKNOWN", clifft::GateType::UNKNOWN);
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -118,11 +118,15 @@ class Model:
         transitions: maps a name to its ``T[to][from]`` matrix. A key that
             names a gate (e.g. ``"CZ"``) is a *hook*: it expands to a
             ``LEVEL_TRANSITION[key]`` annotation after every occurrence of that
-            gate. Any key -- gate-named or not -- can be referenced
-            directly from the circuit with ``LEVEL_TRANSITION[key] q``, and
-            ``LOSS(p) q`` applies a uniform loss inline. A transition
-            fires at its circuit position, with the source taken from the
-            qubit's state there.
+            gate. A key naming an instruction that never parses into a node
+            of its own is rejected, since its hook could never fire:
+            ``MXX``/``MYY``/``MZZ`` (desugared to ``MPP``),
+            ``CH``/``CCX``/``CCZ`` (decomposed by the parser), and identity
+            no-ops. Annotate those positions explicitly instead. Any key --
+            gate-named or not -- can be referenced directly from the circuit
+            with ``LEVEL_TRANSITION[key] q``, and ``LOSS(p) q`` applies a
+            uniform loss inline. A transition fires at its circuit position,
+            with the source taken from the qubit's state there.
         classifier: optional :class:`Classifier` supplying leaked/lost
             measurement outcomes and computational readout confusion.
         reset_restores_lost: if true, a reset on a lost qubit restores it to

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -116,7 +116,7 @@ def test_transition_wrong_shape_raises():
 
 def test_desugared_gate_transition_key_raises():
     t = transition_to(LEAK_G)
-    with pytest.raises(ValueError, match="desugars to MPP"):
+    with pytest.raises(ValueError, match="rewritten at parse time"):
         noncomp.Model(initial_state=ALL_G, transitions={"MXX": t})
 
 

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -114,6 +114,24 @@ def test_transition_wrong_shape_raises():
         noncomp.Model(initial_state=ALL_G, transitions={"S": _zeros(4, 4)})
 
 
+def test_desugared_gate_transition_key_raises():
+    t = transition_to(LEAK_G)
+    with pytest.raises(ValueError, match="desugars to MPP"):
+        noncomp.Model(initial_state=ALL_G, transitions={"MXX": t})
+
+
+def test_identity_noop_transition_key_raises():
+    t = transition_to(LEAK_G)
+    with pytest.raises(ValueError, match="identity no-ops"):
+        noncomp.Model(initial_state=ALL_G, transitions={"I": t})
+
+
+def test_whitespace_transition_key_raises():
+    t = transition_to(LEAK_G)
+    with pytest.raises(ValueError, match="LEVEL_TRANSITION tag"):
+        noncomp.Model(initial_state=ALL_G, transitions={" padded": t})
+
+
 # --- 2. End-to-end sampling ------------------------------------------------
 
 

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -329,14 +329,14 @@ TEST_CASE("NonComputationalModel: rejects keys that are only whitespace") {
         ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
-TEST_CASE("NonComputationalModel: rejects keys containing ']'") {
+TEST_CASE("NonComputationalModel: rejects keys containing a closing bracket") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"a]b", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
         ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
-TEST_CASE("NonComputationalModel: rejects keys containing '#'") {
+TEST_CASE("NonComputationalModel: rejects keys containing a hash") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"a#b", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
@@ -355,7 +355,7 @@ TEST_CASE("NonComputationalModel: accepts keys with internal spaces") {
         default_initial_state(), {{"a b", zero_matrix()}}, std::nullopt, NonComputationalPolicy{}));
 }
 
-TEST_CASE("NonComputationalModel: accepts keys with '[' (only ']' is banned)") {
+TEST_CASE("NonComputationalModel: accepts keys with an opening bracket") {
     REQUIRE_NOTHROW(NonComputationalModel::from_spec(
         default_initial_state(), {{"a[b", zero_matrix()}}, std::nullopt, NonComputationalPolicy{}));
 }

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -1,4 +1,6 @@
 #include "clifft/circuit/gate_data.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/noncomp/annotate.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/policy.h"
@@ -14,6 +16,8 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 using Catch::Matchers::ContainsSubstring;
@@ -155,7 +159,8 @@ TEST_CASE(
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"bad]key", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("bad]key") && ContainsSubstring("cannot be referenced"));
+        ContainsSubstring("bad]key") &&
+            ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: a non-hookable gate-named key is a named-only transition") {
@@ -216,4 +221,292 @@ TEST_CASE("NonComputationalModel: policy accessor reflects the constructed polic
     auto model =
         NonComputationalModel::from_spec(default_initial_state(), {}, std::nullopt, policy);
     REQUIRE(model.policy().reset_restores_lost == true);
+}
+
+// =========================================================================
+// Construction: dead-hook key rejection
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: rejects MXX as a hook key (desugars to MPP)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"MXX", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("desugars to MPP"));
+}
+
+TEST_CASE("NonComputationalModel: rejects MYY as a hook key (desugars to MPP)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"MYY", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("desugars to MPP"));
+}
+
+TEST_CASE("NonComputationalModel: rejects MZZ as a hook key (desugars to MPP)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"MZZ", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("desugars to MPP"));
+}
+
+TEST_CASE("NonComputationalModel: rejects CH as a hook key (parser-only rewrite)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"CH", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("parser decomposes"));
+}
+
+TEST_CASE("NonComputationalModel: rejects CCX as a hook key (parser-only rewrite)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"CCX", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("parser decomposes"));
+}
+
+TEST_CASE("NonComputationalModel: rejects CCZ as a hook key (parser-only rewrite)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"CCZ", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("parser decomposes"));
+}
+
+TEST_CASE("NonComputationalModel: rejects I as a hook key (identity no-op)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"I", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("identity no-ops emit no circuit nodes"));
+}
+
+TEST_CASE("NonComputationalModel: rejects II as a hook key (identity no-op)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"II", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("identity no-ops emit no circuit nodes"));
+}
+
+TEST_CASE("NonComputationalModel: rejects I_ERROR as a hook key (identity no-op)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"I_ERROR", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("identity no-ops emit no circuit nodes"));
+}
+
+TEST_CASE("NonComputationalModel: rejects II_ERROR as a hook key (identity no-op)") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"II_ERROR", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("identity no-ops emit no circuit nodes"));
+}
+
+// =========================================================================
+// Construction: tag grammar validation
+// =========================================================================
+
+TEST_CASE("NonComputationalModel: rejects empty transition key") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: rejects keys with leading whitespace") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{" padded", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: rejects keys with trailing whitespace") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"padded ", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: rejects keys that are only whitespace") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{" ", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: rejects keys containing ']'") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"a]b", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: rejects keys containing '#'") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"a#b", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: rejects keys containing a newline") {
+    REQUIRE_THROWS_WITH(
+        NonComputationalModel::from_spec(default_initial_state(), {{"a\nb", zero_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{}),
+        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+}
+
+TEST_CASE("NonComputationalModel: accepts keys with internal spaces") {
+    REQUIRE_NOTHROW(NonComputationalModel::from_spec(
+        default_initial_state(), {{"a b", zero_matrix()}}, std::nullopt, NonComputationalPolicy{}));
+}
+
+TEST_CASE("NonComputationalModel: accepts keys with '[' (only ']' is banned)") {
+    REQUIRE_NOTHROW(NonComputationalModel::from_spec(
+        default_initial_state(), {{"a[b", zero_matrix()}}, std::nullopt, NonComputationalPolicy{}));
+}
+
+TEST_CASE("NonComputationalModel: accepts keys with hyphens and digits") {
+    REQUIRE_NOTHROW(NonComputationalModel::from_spec(default_initial_state(),
+                                                     {{"T1-decay", zero_matrix()}}, std::nullopt,
+                                                     NonComputationalPolicy{}));
+}
+
+TEST_CASE("NonComputationalModel: accepted weird keys survive LEVEL_TRANSITION tag round-trip") {
+    // Each key must parse back unchanged from a LEVEL_TRANSITION[key] circuit line.
+    const std::vector<std::string> weird_keys = {"a b", "a[b", "T1-decay"};
+    for (const auto& key : weird_keys) {
+        INFO("key: '" + key + "'");
+        auto model =
+            NonComputationalModel::from_spec(default_initial_state(), {{key, zero_matrix()}},
+                                             std::nullopt, NonComputationalPolicy{});
+        std::string circuit_text = "LEVEL_TRANSITION[" + key + "] 0\n";
+        auto circuit = clifft::parse(circuit_text);
+        REQUIRE(circuit.nodes.size() == 1);
+        REQUIRE(circuit.nodes[0].tag == key);
+        REQUIRE(model.transition_named(key) != nullptr);
+    }
+}
+
+// =========================================================================
+// Hook-fires invariant: every registered hook names a gate the parser emits
+// =========================================================================
+
+TEST_CASE("model: every registered gate hook names a gate the parser can produce") {
+    // A gate hook can fire only if its gate type appears in a parsed
+    // circuit. For every key the model registers as a hook, parse a sample
+    // line for that gate and require both a node of that type and the
+    // expanded annotation after it. The table must cover exactly the
+    // hookable gates: a missing or stale entry fails below.
+    const std::unordered_map<std::string_view, std::string_view> kSampleLines = {
+        {"H", "H 0"},
+        {"S", "S 0"},
+        {"S_DAG", "S_DAG 0"},
+        {"X", "X 0"},
+        {"Y", "Y 0"},
+        {"Z", "Z 0"},
+        {"SQRT_X", "SQRT_X 0"},
+        {"SQRT_X_DAG", "SQRT_X_DAG 0"},
+        {"SQRT_Y", "SQRT_Y 0"},
+        {"SQRT_Y_DAG", "SQRT_Y_DAG 0"},
+        {"H_XY", "H_XY 0"},
+        {"H_YZ", "H_YZ 0"},
+        {"H_NXY", "H_NXY 0"},
+        {"H_NXZ", "H_NXZ 0"},
+        {"H_NYZ", "H_NYZ 0"},
+        {"C_XYZ", "C_XYZ 0"},
+        {"C_ZYX", "C_ZYX 0"},
+        {"C_NXYZ", "C_NXYZ 0"},
+        {"C_NZYX", "C_NZYX 0"},
+        {"C_XNYZ", "C_XNYZ 0"},
+        {"C_XYNZ", "C_XYNZ 0"},
+        {"C_ZNYX", "C_ZNYX 0"},
+        {"C_ZYNX", "C_ZYNX 0"},
+        {"T", "T 0"},
+        {"T_DAG", "T_DAG 0"},
+        {"R_X", "R_X(0.25) 0"},
+        {"R_Y", "R_Y(0.25) 0"},
+        {"R_Z", "R_Z(0.25) 0"},
+        {"U3", "U3(0.1,0.2,0.3) 0"},
+        {"R_XX", "R_XX(0.25) 0 1"},
+        {"R_YY", "R_YY(0.25) 0 1"},
+        {"R_ZZ", "R_ZZ(0.25) 0 1"},
+        {"R_PAULI", "R_PAULI(0.1) X0*Y1"},
+        {"CX", "CX 0 1"},
+        {"CY", "CY 0 1"},
+        {"CZ", "CZ 0 1"},
+        {"SWAP", "SWAP 0 1"},
+        {"ISWAP", "ISWAP 0 1"},
+        {"ISWAP_DAG", "ISWAP_DAG 0 1"},
+        {"SQRT_XX", "SQRT_XX 0 1"},
+        {"SQRT_XX_DAG", "SQRT_XX_DAG 0 1"},
+        {"SQRT_YY", "SQRT_YY 0 1"},
+        {"SQRT_YY_DAG", "SQRT_YY_DAG 0 1"},
+        {"SQRT_ZZ", "SQRT_ZZ 0 1"},
+        {"SQRT_ZZ_DAG", "SQRT_ZZ_DAG 0 1"},
+        {"CXSWAP", "CXSWAP 0 1"},
+        {"CZSWAP", "CZSWAP 0 1"},
+        {"SWAPCX", "SWAPCX 0 1"},
+        {"XCX", "XCX 0 1"},
+        {"XCY", "XCY 0 1"},
+        {"XCZ", "XCZ 0 1"},
+        {"YCX", "YCX 0 1"},
+        {"YCY", "YCY 0 1"},
+        {"YCZ", "YCZ 0 1"},
+        {"M", "M 0"},
+        {"MX", "MX 0"},
+        {"MY", "MY 0"},
+        {"MR", "MR 0"},
+        {"MRX", "MRX 0"},
+        {"MRY", "MRY 0"},
+        {"MPP", "MPP X0*X1"},
+        {"R", "R 0"},
+        {"RX", "RX 0"},
+        {"RY", "RY 0"},
+    };
+
+    size_t hooked_gates = 0;
+    for (size_t i = 0; i < static_cast<size_t>(clifft::GateType::UNKNOWN); ++i) {
+        const auto g = static_cast<clifft::GateType>(i);
+        const std::string name{clifft::gate_name(g)};
+        // Build a model with a single hook for this gate; skip if the model
+        // constructor rejects the key (rejection tests cover those cases).
+        std::optional<NonComputationalModel> maybe_model;
+        try {
+            maybe_model =
+                NonComputationalModel::from_spec(default_initial_state(), {{name, zero_matrix()}},
+                                                 std::nullopt, NonComputationalPolicy{});
+        } catch (const std::invalid_argument&) {
+            continue;
+        }
+        const auto& model = *maybe_model;
+        // Only check gates that registered as hooks.
+        if (model.transition_hooks().find(g) == model.transition_hooks().end()) {
+            continue;
+        }
+        hooked_gates++;
+        // The hook must have a sample parse line; missing entries mean a future
+        // author added a hookable gate without adding parse coverage here.
+        auto it = kSampleLines.find(clifft::gate_name(g));
+        INFO("No sample parse line for hookable gate " + name +
+             ": add an entry to kSampleLines so the hook-fires invariant is covered");
+        REQUIRE(it != kSampleLines.end());
+        // Parse the sample line; at least one node must have gate == g.
+        auto circuit = clifft::parse(std::string(it->second) + "\n");
+        bool found = false;
+        for (const auto& node : circuit.nodes) {
+            if (node.gate == g) {
+                found = true;
+                break;
+            }
+        }
+        REQUIRE(found);
+        // annotate() must insert a LEVEL_TRANSITION node after the gate.
+        auto annotated = clifft::annotate(circuit, model);
+        bool found_lt = false;
+        for (const auto& node : annotated.nodes) {
+            if (node.gate == clifft::GateType::LEVEL_TRANSITION && node.tag == name) {
+                found_lt = true;
+                break;
+            }
+        }
+        REQUIRE(found_lt);
+    }
+    // Both directions: zero hooked gates would make the loop vacuous, and
+    // an unvisited table entry names a gate that is no longer hookable.
+    REQUIRE(hooked_gates == kSampleLines.size());
 }

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -227,46 +227,46 @@ TEST_CASE("NonComputationalModel: policy accessor reflects the constructed polic
 // Construction: dead-hook key rejection
 // =========================================================================
 
-TEST_CASE("NonComputationalModel: rejects MXX as a hook key (desugars to MPP)") {
+TEST_CASE("NonComputationalModel: rejects MXX as a hook key (rewritten at parse time)") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"MXX", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("desugars to MPP"));
+        ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects MYY as a hook key (desugars to MPP)") {
+TEST_CASE("NonComputationalModel: rejects MYY as a hook key (rewritten at parse time)") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"MYY", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("desugars to MPP"));
+        ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects MZZ as a hook key (desugars to MPP)") {
+TEST_CASE("NonComputationalModel: rejects MZZ as a hook key (rewritten at parse time)") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"MZZ", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("desugars to MPP"));
+        ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects CH as a hook key (parser-only rewrite)") {
+TEST_CASE("NonComputationalModel: rejects CH as a hook key (rewritten at parse time)") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"CH", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("parser decomposes"));
+        ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects CCX as a hook key (parser-only rewrite)") {
+TEST_CASE("NonComputationalModel: rejects CCX as a hook key (rewritten at parse time)") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"CCX", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("parser decomposes"));
+        ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects CCZ as a hook key (parser-only rewrite)") {
+TEST_CASE("NonComputationalModel: rejects CCZ as a hook key (rewritten at parse time)") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec(default_initial_state(), {{"CCZ", zero_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("parser decomposes"));
+        ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
 TEST_CASE("NonComputationalModel: rejects I as a hook key (identity no-op)") {


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Fixes the blocker from the post-#201 external review: `transitions={"MXX": ...}` was accepted and registered a gate hook, but the parser desugars MXX/MYY/MZZ into MPP nodes before hook expansion matches `node.gate`, so the hook silently never fired — sampling returned a different model than the one specified. Reproduced at runtime before the fix (final statuses stay computational, records show pure parity physics).

The reproduction surfaced a second consequence: the same physics written as explicit annotations is *rejected* by the driver's parity-measurement gate ("MPP is not supported under a model that can leak or lose qubits"), so the dead hook was also silently bypassing that reject. Preserving gate identity through parsing would therefore mostly manufacture rejects — model construction now refuses these keys and points at explicit `LEVEL_TRANSITION[...]` annotations, the review's other suggested arm.

The rejection also covers the quieter members of the same trap family: `CH`/`CCX`/`CCZ` (parser-only names, decomposed at parse) and the identity no-ops `I`/`II`/`I_ERROR`/`II_ERROR` (parse but never emit AST nodes) were silently accepted as named-only transitions despite the documented "a key that names a gate is a hook" contract.

Also lands the review's simplification finding: key validation now shares the parser's tag grammar via `is_representable_tag()` (exported from `parser.h`, defined next to the tag-parsing code) instead of a partial denylist. Keys containing `#` (stripped as a comment before tag parsing) or edge whitespace (tags are trimmed) were accepted but could never be referenced.

## Tests (+22 C++, +3 Python)

- Rejection contract for all ten dead-hook names, each with its distinct message.
- Tag-grammar rejects (`#`, `]`, newline, edge/only whitespace, empty) and accepts (`a b`, `a[b`, `T1-decay`), plus a parse round-trip for the accepted keys.
- Hook-fires invariant: for every GateType the model registers as a hook, a sample line must parse to a node of that type and expand through `annotate()`, and the sample-line table must cover exactly the hookable set — so a future gate that is parse-rewritten the way MXX was fails this test loudly.

## Docs

`Model` docstring and the guide's gate-hooks bullet now state the rejection and the explicit-annotation alternative.

## CI note

The first push failed CI in ctest discovery, not in test logic: `catch_discover_tests` re-parses Catch2 test names, and a lone `]`, `[`, or `#` in a TEST_CASE name breaks its splitting, collapsing every later test into one semicolon-joined entry that fails immediately. The key-grammar test names now spell those characters in words (`cce68c4`). Verified via `ctest -E Bench` on both configs (1093/1093) — the same harness CI uses; a direct Catch2 run cannot see this failure mode.

## Review round

`is_parser_desugared` is now a `parser_desugared` gate trait declared at the MXX/MYY/MZZ table rows instead of an enum switch, matching the other trait predicates (`ecef4a0`).

Extended in `45f0e96`: CH/CCX/CCZ join the gate table with the same `parser_desugared` trait (they were parser-only strings), the parser dispatches their rewrites on the enum after gate lookup, `is_parse_only_instruction` is deleted, and the model's two rejection branches collapse into one with a single message ("rewritten at parse time and never appears as a circuit node"). The hook-fires invariant test covers them through its enum loop, and the Python `GateType` enum gains the three values (introspection tripwire green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)