### PR TITLE
fix(noncomp): allow MPAD without a classifier

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -61,7 +61,7 @@ binary `measurements` entry holds a uniformly drawn placeholder;
 or 2), for comparing against tools that report loss in-band.
 
 Omitting `initial_state` starts every qubit in `g`. A model that can leak
-or lose qubits requires a classifier if the circuit measures.
+or lose qubits requires a classifier if the circuit measures a qubit.
 
 ## Transitions: hooks and inline annotations
 
@@ -228,8 +228,8 @@ are in [Noncomputational States](../theory/noncomputational.md).
   a parity of levels outside the qubit subspace has no faithful single-bit
   record. Expand the parity readout into an explicit ancilla circuit; the
   ancilla's ladder gates then drop per the rules above.
-- **A classifier is required** whenever a capable model meets a measuring
-  circuit; the error names the missing piece before sampling begins.
+- **A classifier is required** whenever a capable model meets a circuit that
+  measures a qubit; the error names the missing piece before sampling begins.
 - Under `damping="exact"`, a state-dependent site on a coherent qubit
   outside the active array expands that qubit into it, adding one unit of
   peak rank at that site. An already-active qubit adds nothing, and later

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -489,10 +489,11 @@ void validate_model_contract(const Circuit& annotated, const NonComputationalMod
         }
     }
 
-    // Gate B: a classifier is required when the circuit has any measurements.
+    // Gate B: a classifier is required when the circuit measures a physical qubit.
+    // MPAD only appends a classical literal to the record, so it never consults one.
     if (model.classifier() == nullptr) {
         for (const AstNode& node : annotated.nodes) {
-            if (is_measurement(node.gate)) {
+            if (is_measurement(node.gate) && node.gate != GateType::MPAD) {
                 throw std::invalid_argument(
                     "sample_noncomputational: this model can leak or lose qubits and the circuit"
                     " measures; a classifier is required to define what a measurement of a leaked"

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -154,7 +154,7 @@ class Model:
     (``MPP``) are not supported when the model can leak or lose qubits — they
     have no faithful single-bit classifier substitution — and raise before
     sampling begins. A model that can leak or lose qubits also requires a
-    classifier when the circuit measures.
+    classifier when the circuit measures a qubit.
 
     Construction validates shapes, probabilities, gate keys, policy values,
     and level table consistency in C++, raising ``ValueError`` on any
@@ -293,9 +293,9 @@ def sample(
     :class:`NonComputationalSample`. Single-qubit measurements (``M``, ``MX``,
     ``MY``) of a leaked or lost qubit read the classifier; the readout basis is
     incidental once the qubit has left the computational subspace. A model that
-    can leak or lose qubits requires a classifier when the circuit measures,
-    and parity measurements (``MPP``) are not supported with such models — both
-    are rejected before sampling begins. Raises ``ValueError`` when one of
+    can leak or lose qubits requires a classifier when the circuit measures a
+    qubit, and parity measurements (``MPP``) are not supported with such models —
+    both are rejected before sampling begins. Raises ``ValueError`` when one of
     these contracts is violated, when an annotation is malformed, or when
     ``max_rank`` is exceeded.
 

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -710,6 +710,15 @@ def test_gate_b_capable_model_with_measurement_no_classifier_raises():
         noncomp.sample("H 0\nS 0\nM 0\n", model, shots=4, seed=4)
 
 
+def test_gate_b_mpad_does_not_require_classifier():
+    """MPAD writes classical literals and never reads a noncomputational carrier."""
+    model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
+    result = noncomp.sample("S 0\nMPAD 0 1\n", model, shots=4, seed=4)
+
+    assert (result.measurements == [0, 1]).all()
+    assert (result.final_status[:, 0] == LOST_KIND).all()
+
+
 # --- Gate A error (MPP unsupported under capable model) ----------------------
 
 


### PR DESCRIPTION
## Summary

- Treat `MPAD` as classical record padding during noncomputational capability validation.
- Allow leak- or loss-capable circuits with `MPAD` but no physical measurements to sample without an unused classifier.
- Add Python public-API regression coverage for deterministic padding and final noncomputational status.
- Clarify the guide and Python API docstrings that classifiers are required for qubit measurements.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build-cpp -E Bench --output-on-failure -j8`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
