### PR TITLE
fix(noncomp): reject multi-target measurement nodes; close final-review test and doc gaps

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -242,10 +242,14 @@ are in [Noncomputational States](../theory/noncomputational.md).
 Ordinary Clifft separates `compile()` from `sample()` because a compiled
 program is model-independent. Here it is not: the executable depends on
 the model and on each shot's jump outcomes. `noncomp.sample` takes the
-circuit and model together and compiles internally, caching one module
-per distinct event history within the call. For typical low-rate models
-nearly every shot realizes the no-event history, so the cache stays
-small. A model whose leaked or lost qubits keep making stochastic
-transitions can realize a distinct history per shot, and compile time and
-memory then grow linearly with the shot count. Pass a parsed
-`clifft.Circuit` instead of text to share parsing across calls.
+circuit and model together and compiles internally, caching one
+continuation per distinct event history and, for ternary classifiers, one
+module per herald-flag assignment observed for that history. Typical
+low-rate models reuse the no-event continuation on most shots, so the
+cache usually stays small. In the worst case, stochastic transitions can
+produce a distinct event history per shot; many ternary-classified
+measurements can similarly produce a distinct herald assignment per
+shot. Only observed combinations are cached, so for a fixed circuit
+compile time and memory can grow linearly, but not exponentially, with
+the shot count. Pass a parsed `clifft.Circuit` instead of text to share
+parsing across calls.

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -243,5 +243,9 @@ Ordinary Clifft separates `compile()` from `sample()` because a compiled
 program is model-independent. Here it is not: the executable depends on
 the model and on each shot's jump outcomes. `noncomp.sample` takes the
 circuit and model together and compiles internally, caching one module
-per distinct event history within the call. Pass a parsed
+per distinct event history within the call. For typical low-rate models
+nearly every shot realizes the no-event history, so the cache stays
+small. A model whose leaked or lost qubits keep making stochastic
+transitions can realize a distinct history per shot, and compile time and
+memory then grow linearly with the shot count. Pass a parsed
 `clifft.Circuit` instead of text to share parsing across calls.

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -519,16 +519,30 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
 
     const Circuit annotated = annotate(circuit, model);
 
-    // Validate every annotation up front -- tag resolution, LOSS shape --
-    // so a malformed node fails here, deterministically, rather than on
-    // whichever shot first traps or consults it classically: a live site
-    // rides through the rewrite verbatim, and trace() must never be the
-    // first to look at its arguments.
+    // Validate annotations and measurement node shapes up front so a malformed
+    // node fails here, deterministically, rather than on whichever shot first
+    // traps or consults it classically: a live site rides through the rewrite
+    // verbatim, and trace() must never be the first to look at its arguments.
     for (uint32_t op_index = 0; op_index < static_cast<uint32_t>(annotated.nodes.size());
          ++op_index) {
         const AstNode& node = annotated.nodes[op_index];
         if (node.gate == GateType::LEVEL_TRANSITION || node.gate == GateType::LOSS) {
             resolve_annotation(node, model, op_index);
+        }
+        // The parser normalizes single-arity measurements to one node per target.
+        // The rewrite counts one record slot per measurement node and classifies
+        // at most one operand per node, so a hand-built multi-target node would
+        // silently corrupt the record layout. MPP is exempt because it is
+        // multi-target by design and produces one record bit. MPAD is covered
+        // because each node pads one literal.
+        if (is_measurement(node.gate) && node.gate != GateType::MPP && node.targets.size() != 1) {
+            throw std::invalid_argument(
+                "sample_noncomputational: measurement '" + std::string(gate_name(node.gate)) +
+                "' at op " + std::to_string(op_index) + " carries " +
+                std::to_string(node.targets.size()) + " targets; the parser" +
+                " emits one measurement node per target and the rewrite's" +
+                " record accounting relies on that shape; split the node" +
+                " into single-target measurements");
         }
     }
 

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -328,6 +328,45 @@ def test_herald_deterministic_in_seed():
     assert abs(a.heralds[:, 0].mean() - 0.7) < 0.15
 
 
+def test_ternary_herald_feeds_detector_and_observable():
+    """Heralded slots keep a binary record drawn uniformly; anything consuming
+    the record (detectors, observables) must see that same patched bit, and
+    the herald rides only in the sidecar."""
+    # The S hook loses with certainty; every shot is classified.
+    # Classifier for LOST: P(0)=0.2, P(1)=0.1, P(herald)=0.7.
+    # Heralded shots draw a uniform binary bit for the record.
+    # Non-heralded shots draw binary from the conditional: P(1|not herald)=0.1/0.3=1/3.
+    model = noncomp.Model(
+        initial_state=ALL_G,
+        transitions={"S": transition_to(LOST)},
+        classifier=_ternary_classifier(LOST, [0.2, 0.1, 0.7]),
+    )
+    circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n"
+    r = noncomp.sample(circuit, model, shots=4000, seed=24)
+
+    # Detector and observable both read the classifier-substituted measurement bit.
+    assert np.array_equal(r.detectors[:, 0], r.measurements[:, 0])
+    assert np.array_equal(r.observables[:, 0], r.measurements[:, 0])
+
+    heralded = r.heralds[:, 0].astype(bool)
+
+    # Herald fraction.
+    assert abs(heralded.mean() - 0.7) < 0.04
+
+    # Among heralded shots, the binary record is uniform.
+    meas = r.measurements[:, 0]
+    assert abs(float(meas[heralded].mean()) - 0.5) < 0.05
+
+    # Among non-heralded shots, the record is drawn from the binary conditional.
+    assert abs(float(meas[~heralded].mean()) - 1 / 3) < 0.07
+
+    # symbols() reports 2 exactly where the herald is set; elsewhere it matches
+    # the binary measurement bit.
+    sym = r.symbols()
+    assert np.array_equal(sym[:, 0] == 2, heralded)
+    assert np.array_equal(sym[~heralded, 0], meas[~heralded])
+
+
 # --- 4. Record layout invariants -------------------------------------------
 
 

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -161,6 +161,76 @@ def test_damping_null_source_independent_rates_make_neglect_exact():
     assert abs(means["exact"] - means["neglect"]) < 8 * sigma
 
 
+def test_entangled_two_site_chain_matches_hand_derived_distribution():
+    """GHZ across three qubits with two sequential leak sites; exact joint distribution.
+
+    State after H 0 / CX 0 1 / CX 0 2: (|000> + |111>) / sqrt(2).
+    LEVEL_TRANSITION[leak] on q1 fires only from e with p=0.9, so
+    P(fire1) = 0.5 * 0.9 = 0.45.  A fire at q1 collapses the GHZ to |111>,
+    sending q1 to LEAK_G (reads 0 via the faithful classifier) and leaving
+    q2 at definite e.  The q2 site then fires with probability 0.9.
+
+    On no-fire at q1 (total weight 0.55), the exact no-fire filter multiplies
+    the |111> e-amplitude of q1 by sqrt(1 - 0.9) = sqrt(0.1), giving the
+    unnormalized residual (|000> + sqrt(0.1)|111>) / sqrt(2).  After this,
+    q2's e-population is (0.1/2) / 0.55 = 1/11, and the q2 site fires with
+    probability 0.9/11.
+
+    The full outcome table for (M0, M1, M2):
+      100 -> 0.405  (fire1, fire2: both transitions trapped and chained)
+      101 -> 0.045  (fire1, no-fire2)
+      110 -> 0.045  (no-fire1, fire2: q2's e-branch collapses q0 to 1)
+      000 -> 0.5    (no-fire1, no-fire2, q0 collapses to |0>)
+      111 -> 0.005  (no-fire1, no-fire2, q0 collapses to |1>; two dampings)
+    Every other pattern has probability exactly 0.
+    """
+    model = _model({"leak": _transition({(Level.LEAK_G, Level.E): 0.9})})
+    circuit = (
+        "H 0\nCX 0 1\nCX 0 2\n"
+        "LEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
+        "M 0\nM 1\nM 2\n"
+    )
+    r = noncomp.sample(circuit, model, shots=SHOTS, seed=16)
+    m = np.asarray(r.measurements)
+
+    expected = {
+        (1, 0, 0): 0.405,
+        (1, 0, 1): 0.045,
+        (1, 1, 0): 0.045,
+        (0, 0, 0): 0.500,
+        (1, 1, 1): 0.005,
+    }
+
+    for pattern, p in expected.items():
+        mask = (m[:, 0] == pattern[0]) & (m[:, 1] == pattern[1]) & (m[:, 2] == pattern[2])
+        freq = float(mask.mean())
+        assert abs(freq - p) < binomial_tolerance(
+            p, SHOTS
+        ), f"pattern {pattern}: got {freq:.4f}, expected {p:.3f}"
+
+    # Patterns that never occur must have zero count.
+    for pat in [(0, 0, 1), (0, 1, 0), (0, 1, 1)]:
+        mask = (m[:, 0] == pat[0]) & (m[:, 1] == pat[1]) & (m[:, 2] == pat[2])
+        assert int(mask.sum()) == 0, f"pattern {pat} must be impossible but appeared"
+
+    # Final-status checks.
+    status = np.asarray(r.final_status)
+    # q0 is never given a LEVEL_TRANSITION; it stays computational on every shot.
+    assert (status[:, 0] == noncomp.QubitStatus.COMPUTATIONAL).all()
+    # q1 transitions to LEAK_G on exactly the shots where the q1 site fired.
+    leak_q1 = (status[:, 1] == noncomp.QubitStatus.LEAK_G).mean()
+    assert abs(leak_q1 - 0.45) < binomial_tolerance(0.45, SHOTS)
+    # q2 transitions to LEAK_G on fire1-fire2 shots (0.405) and
+    # no-fire1-fire2 shots (0.045), totalling 0.45 as well.
+    leak_q2 = (status[:, 2] == noncomp.QubitStatus.LEAK_G).mean()
+    assert abs(leak_q2 - 0.45) < binomial_tolerance(0.45, SHOTS)
+    # The two-trap chain branch: both q1 and q2 leaked on 40.5 % of shots.
+    both_leaked = (
+        (status[:, 1] == noncomp.QubitStatus.LEAK_G) & (status[:, 2] == noncomp.QubitStatus.LEAK_G)
+    ).mean()
+    assert abs(float(both_leaked) - 0.405) < binomial_tolerance(0.405, SHOTS)
+
+
 def test_neglect_bell_correlation_probe():
     """Neglect-mode forced trace-out keeps the source-determined partner correlation.
 

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -35,13 +35,17 @@
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdint>
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+using Catch::Matchers::ContainsSubstring;
 using clifft::annotate;
+using clifft::AstNode;
 using clifft::Circuit;
 using clifft::default_hir_pass_manager;
 using clifft::GateType;
@@ -53,6 +57,7 @@ using clifft::NonComputationalSample;
 using clifft::parse;
 using clifft::rewrite_continuation;
 using clifft::sample_noncomputational;
+using clifft::Target;
 using clifft::trace;
 using clifft::TransitionInstrument;
 
@@ -231,4 +236,55 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
     default_hir_pass_manager().run(hir);
     REQUIRE(hir.num_hidden_measurements == base.num_hidden_measurements + 1);
     REQUIRE(hir.num_measurements == base.num_measurements);
+}
+
+TEST_CASE("validation: a hand-built multi-target measurement node is rejected up front") {
+    // All tests use shots=0: validation runs before the zero-shot return, so
+    // the driver checks node shapes without needing any state or randomness.
+    NonComputationalModel model = make_model({});  // lossless; no classifier needed
+
+    SECTION("multi-target M node is rejected") {
+        // A hand-built node with two qubit targets bypasses the parser's
+        // one-node-per-target normalization. The driver must catch this up
+        // front, before any rewrite or compilation.
+        Circuit c;
+        c.num_qubits = 2;
+        c.num_measurements = 2;
+        AstNode node;
+        node.gate = GateType::M;
+        node.targets = {Target::qubit(0), Target::qubit(1)};
+        node.source_line = 0;
+        c.nodes.push_back(node);
+
+        REQUIRE_THROWS_AS(sample_noncomputational(c, model, 0, 1), std::invalid_argument);
+        REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 0, 1),
+                            ContainsSubstring("one measurement node per target"));
+    }
+
+    SECTION("multi-target MPAD node is rejected") {
+        // MPAD pads one literal per node; a node with two literal targets would
+        // corrupt the record layout in the same way as a multi-target M node.
+        Circuit c;
+        c.num_qubits = 0;
+        c.num_measurements = 2;
+        AstNode node;
+        node.gate = GateType::MPAD;
+        node.targets = {Target::qubit(0), Target::qubit(1)};  // values 0 and 1
+        node.source_line = 0;
+        c.nodes.push_back(node);
+
+        REQUIRE_THROWS_AS(sample_noncomputational(c, model, 0, 1), std::invalid_argument);
+        REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 0, 1),
+                            ContainsSubstring("one measurement node per target"));
+    }
+
+    SECTION("parsed M instruction produces single-target nodes and does not throw") {
+        // The parser normalizes "M 0 1" into two separate single-target nodes.
+        // A model with all mass on g and no transitions cannot leak or lose, so
+        // no classifier is required, and the shape validation succeeds.
+        Circuit c = parse("M 0 1\n");
+        REQUIRE(c.nodes.size() == 2);
+
+        REQUIRE_NOTHROW(sample_noncomputational(c, model, 0, 1));
+    }
 }


### PR DESCRIPTION
Pre-merge hardening on the noncomp feature branch, closing the actionable items from the final merge-readiness review.

## Validation hardening

The parser normalizes single-arity measurements to one AST node per target, and the exact-mode rewrite relies on that shape: it counts one record slot per measurement node and classifies at most one operand per node. A hand-built C++ `Circuit` violating the normal form would silently corrupt the record layout. The driver's up-front validation loop now rejects any measurement node other than `MPP` (multi-target by design, one record bit) that carries more than one target — deterministically, before any state is allocated. Unreachable through the Python API (the parser guarantees the normal form); this turns a silent corruption into a clear error for C++ embedders.

## Tests

- **`test_entangled_two_site_chain_matches_hand_derived_distribution`** (exact probes): GHZ across three qubits with two sequential source-dependent leak sites at p = 0.9. Checks the full 5-outcome joint record distribution, the exact impossibility of the other three patterns, and the final-status marginals against a hand-derived closed form. The 40.5% branch is exactly the shots whose two fires trapped and chained two continuations — the multi-jump entangled-chain coverage the final review identified as the top test gap. The closed form was cross-checked against the sampler at 200k shots during the review.
- **`test_ternary_herald_feeds_detector_and_observable`**: a ternary-classified lost measurement feeding a `DETECTOR` and an `OBSERVABLE_INCLUDE`. Verifies both consumers read the same patched record bit per shot (heralded slots included), the herald fraction and conditional record statistics, and that `symbols()` folds the herald back coherently.
- **`validation: a hand-built multi-target measurement node is rejected up front`** (C++): the new rejection for hand-built `M` and `MPAD` nodes, plus a positive control that parsed `M 0 1` normalizes to two nodes and passes.

## Docs

The "Why there is no compile step" section of the leakage guide now states the continuation-cache scaling property: low-rate models keep the cache small, while a model whose leaked/lost qubits keep making stochastic transitions can realize a distinct event history per shot, making compile time and memory linear in shots.

## Verification

- Debug and Release C++ suites: 1094/1094 (new TEST_CASE discovered cleanly).
- Full Python suite on a Debug extension: 923 passed (+2 new).
- `pre-commit run --all-files` clean.
