### PR TITLE
docs(noncomp): clarify herald semantics and model scope

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -3,10 +3,15 @@
 !!! warning "Experimental"
     `clifft.noncomp` is experimental and may change between minor releases.
 
-Real devices leak (an atom is excited out of the qubit encoding) and lose
-atoms (the atom leaves the trap). Ordinary Pauli noise cannot represent
-either. `clifft.noncomp` samples circuits under a five-level leakage/loss
-model: transition matrices describe when qubits jump between levels, and a
+Real devices can leave the computational subspace (*leakage*) or lose the
+physical carrier from its site (*loss*). These faults can persist until the
+qubit relaxes, the carrier is recaptured, or the site is reset, so one event
+can affect a sequence of later operations and detector outcomes. The
+resulting correlations are not faithfully represented by independent Pauli
+faults.
+
+`clifft.noncomp` samples circuits under a five-level leakage/loss model:
+transition matrices describe when qubits jump between levels, and a
 classifier describes what a measurement of a leaked or lost qubit records.
 
 This page is the API walkthrough. The model and its simulation semantics
@@ -60,6 +65,12 @@ binary `measurements` entry holds a uniformly drawn placeholder;
 `symbols()` folds the herald back in as a third value per slot (0, 1,
 or 2), for comparing against tools that report loss in-band.
 
+`heralds[shot, slot]` means that the classifier emitted its third symbol at
+that measurement slot. It does not identify when or where the underlying
+transition occurred, so it is not an exact spacetime erasure flag. The
+herald is side information for downstream analysis or adaptive decoding;
+it is not folded into the binary detector record.
+
 Omitting `initial_state` starts every qubit in `g`. A model that can leak
 or lose qubits requires a classifier if the circuit measures a qubit.
 
@@ -78,6 +89,9 @@ three ways to attach one to a circuit:
   gate-named or not.
 - **Inline loss.** `LOSS(p) 0` loses qubit 0 with probability `p` from any
   occupied level.
+
+A transition back to `g` or `e` can represent relaxation or recapture into
+the computational subspace; a reset represents active re-preparation.
 
 ```python
 from clifft import noncomp
@@ -147,8 +161,9 @@ assert (r.final_status[:, 0] == noncomp.QubitStatus.LOST).all()
 assert (r.final_status[:, 1] == noncomp.QubitStatus.COMPUTATIONAL).all()
 ```
 
-Classification happens before detectors are evaluated, so leakage
-surfaces as detector events:
+The classifier supplies the binary record bit before detectors and
+observables are evaluated, so a noncomputational readout can produce
+detector events:
 
 ```python
 import numpy as np
@@ -224,6 +239,15 @@ are in [Noncomputational States](../theory/noncomputational.md).
 
 ## Limits
 
+- **Partner-error channels and leakage transport are not modeled.** A two-qubit
+  operation touching a leaked or lost operand is dropped whole. The model
+  does not add partner depolarization conditioned on that status or move
+  leakage between qubits.
+- **Coherent leakage is outside the trajectory model.** Jumps into a
+  noncomputational level are treated as incoherent, definite occupations.
+- **The API produces trajectory samples.** It does not construct
+  conditional or adaptive detector error models or run an adaptive decoder;
+  records and heralds are available for downstream tooling.
 - **`MPP` is not supported** under a model that can leak or lose qubits —
   a parity of levels outside the qubit subspace has no faithful single-bit
   record. Expand the parity readout into an explicit ancilla circuit; the

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -5,9 +5,11 @@
     releases.
 
 Pauli noise moves a qubit around inside its two-dimensional subspace. Real
-devices also leave that subspace: an atom is excited to a level outside the
-qubit encoding (*leakage*), or leaves the trap entirely (*loss*). No Pauli
-channel can represent either: the state is no longer a qubit state at all.
+devices can instead leave that subspace (*leakage*) or lose the physical
+carrier from its site (*loss*). No Pauli channel can represent either: the
+state is no longer a qubit state at all. Because the condition can persist
+across later circuit positions, one event can correlate deviations across
+time rather than acting like an independent local fault.
 
 Clifft models both with a five-level structure per qubit, a per-gate jump
 process between levels, and a classifier that defines what a measurement of
@@ -76,14 +78,21 @@ With the carrier vacated:
   readout basis is incidental on a vacated carrier: `M`, `MX`, and `MY`
   all classify identically. A multi-qubit parity measurement (`MPP`) has no
   faithful single-bit substitution and is rejected up front.
-- **Restoration begins with a reset.** A qubit returns to the computational
-  subspace only through an operation that re-prepares the carrier: a reset
-  (a leaked qubit always; a lost qubit only when the model opts in) or a
-  transition whose destination is a computational level.
+- **Restoration is explicit.** A qubit returns to the computational subspace
+  only through an operation that restores the carrier: a reset (a leaked
+  qubit always; a lost qubit only when the model opts in) or a transition to
+  `g` or `e`, modeling relaxation or recapture.
 
-Leakage becomes visible to error correction through the classifier:
-leaked and lost levels are classified into the measurement record before
-detectors are evaluated, so they surface as detector events.
+The gate-drop rule is structural: it does not add partner depolarization
+conditioned on another operand's status or transport leakage between
+qubits.
+
+Classifier-substituted record bits are consumed by detectors and observables
+like ordinary measurements, so a noncomputational readout can produce
+detector events. An optional herald remains separate, per-measurement side
+information: it identifies the readout where the classifier emitted its
+third symbol, not the time or location of the underlying transition, and is
+not an exact spacetime erasure flag.
 
 ## State-dependent rates
 


### PR DESCRIPTION
## Summary

- strengthen the QEC motivation around persistent, time-correlated noncomputational faults
- distinguish measurement-time heralds from exact spacetime erasure flags
- name relaxation and recapture, and document the current partner-error, leakage-transport, coherent-leakage, and adaptive-DEM limits
- tighten detector wording so classified readouts can produce events while heralds remain side information

## Test plan

- [ ] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`) - not run; documentation-only change
- [ ] Python tests pass (`uv run pytest tests/python/ -v`) - not run; documentation-only change
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [x] Strict docs build passes (`uv run --group docs mkdocs build --strict`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project Apache-2.0 license.
- [x] This contribution was AI-assisted; I reviewed the generated documentation and included an `Assisted-by:` git trailer in the commit message.