### PR TITLE
docs: Update noncomputational documentation

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -102,8 +102,12 @@ transition occurred, so it is not an exact spacetime erasure flag. The
 herald is side information for downstream analysis or adaptive decoding;
 it is not folded into the binary detector record.
 
-Omitting `initial_state` starts every site in `g`, which matches standard Clifft convention that all qubits start in $\lvert 0 \rangle$. A model that can leak or
-lose a site requires a classifier if the circuit measures it.
+Omitting `initial_state` starts every site in `g`, which matches the standard
+Clifft convention that all qubits start in $\lvert 0 \rangle$. A model capable
+of leakage or loss requires a classifier whenever the circuit contains any
+physical-qubit measurement, even if the measured site cannot itself become
+noncomputational. `MPAD` is exempt because it appends a classical literal
+rather than measuring a site.
 
 ## Transitions: hooks and inline annotations
 
@@ -124,11 +128,13 @@ three ways to attach one to a circuit:
   `p` from any occupied level.
 
 Before sampling, Clifft expands each gate hook into a
-`LEVEL_TRANSITION[name]` annotation for every site operand of the hooked gate.
-Use a hook when the same transition should follow every occurrence of a gate;
-use an inline reference for selected circuit positions or transitions with
-arbitrary names. `LOSS(p)` provides a self-contained inline loss probability
-without requiring a transition matrix in the model.
+`LEVEL_TRANSITION[name]` annotation for every physical site operand of the
+hooked gate. Record-controlled feedback operations are virtual and receive no
+transition annotations. Use a hook when the same transition should follow
+every occurrence of a gate; use an inline reference for selected circuit
+positions or transitions with arbitrary names. `LOSS(p)` provides a
+self-contained inline loss probability without requiring a transition matrix
+in the model.
 
 A transition back to `g` or `e` can represent relaxation or recapture into
 the computational subspace; a reset represents active re-preparation.
@@ -171,10 +177,14 @@ assert r.measurements.shape == (1000, 2)
 
 ## What happens on a leaked or lost site
 
-A gate, noise channel, or classical correction touching a leaked or lost site
-is skipped as a whole and acts as the identity on every operand. A
-single-qubit measurement keeps its record slot, but the classifier rather
-than the measurement basis determines its result (`M`, `MX`, and `MY` alike).
+A unitary gate, ordinary noise channel, or classical correction touching a
+leaked or lost site is skipped as a whole and has no effect on any operand.
+Correlated-error instructions (`E`/`CORRELATED_ERROR` and
+`ELSE_CORRELATED_ERROR`) are retained to preserve chain conditioning; their
+Paulis still act on computational operands but are inert on the
+noncomputational site. A single-qubit measurement keeps its record slot, but
+the classifier rather than the measurement basis determines its result (`M`,
+`MX`, and `MY` alike).
 
 Losing one half of an entangled pair leaves the partner in the reduced
 state; for a Bell pair, maximally mixed:
@@ -290,8 +300,9 @@ with its entangled partner. The semantics and the rank cost are in
   a parity of levels outside the qubit subspace has no faithful single-bit
   record. Expand the parity readout into an explicit ancilla circuit; the
   ancilla's ladder gates then drop per the rules above.
-- **A classifier is required** whenever a capable model meets a circuit that
-  measures a site; the error names the missing piece before sampling begins.
+- **A classifier is required** whenever a model capable of leakage or loss
+  meets a circuit containing any physical-qubit measurement. This is a
+  model-level capability check, not a per-site reachability analysis.
 - Under `damping="exact"`, a transition with source-dependent rates on a
   coherent dormant site promotes that site into the active state array,
   adding one unit of peak rank. An already-active site adds nothing, and later

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -10,9 +10,20 @@ can affect a sequence of later operations and detector outcomes. The
 resulting correlations are not faithfully represented by independent Pauli
 faults.
 
-`clifft.noncomp` samples circuits under a five-level leakage/loss model:
-transition matrices describe when qubits jump between levels, and a
-classifier describes what a measurement of a leaked or lost qubit records.
+`clifft.noncomp` layers a classical status ledger over Clifft's ordinary
+coherent simulation. A site with computational status remains in the quantum
+state and can be in a superposition or entangled with other sites. A leaked or
+lost site instead occupies one definite noncomputational level on each
+trajectory.
+
+Through `noncomp.Model`, the user defines the initial level distribution,
+stochastic transitions between levels, how measurements are classified, and
+policies such as whether reset restores a lost site. Because a jump can change
+which later operations are skipped, which measurements use the classifier,
+and whether a site is restored, one program compiled before sampling cannot
+describe every trajectory. `noncomp.sample` therefore rewrites and compiles
+trajectory-specific continuations when needed, caching and reusing them across
+shots.
 
 This page is the API walkthrough. The model and its simulation semantics
 are described in [Noncomputational States](../theory/noncomputational.md).
@@ -21,8 +32,20 @@ are described in [Noncomputational States](../theory/noncomputational.md).
 
 A `noncomp.Model` bundles an initial level distribution, per-gate
 transition matrices, a classifier, and policy knobs. `noncomp.sample`
-returns the usual records plus two sidecars: each qubit's final status and
-a per-measurement herald.
+returns the usual records plus two sidecars: each circuit site's final status
+and a per-measurement herald.
+
+`Level` names the five rows and columns used by the model inputs.
+`QubitStatus` describes the runtime status ledger: `g` and `e` both correspond
+to `COMPUTATIONAL`, because a computational site remains in the coherent
+quantum state, while `leak_g`, `leak_e`, and `lost` are tracked as distinct
+classical statuses. An initial weight on `g` or `e` initializes the site in
+the corresponding computational basis state; later evolution may put it in a
+superposition or entangle it with other sites.
+
+This minimal model has no transitions. It samples an initial mixture of
+computational, leaked, and lost levels and shows how the classifier, final
+status ledger, and herald output fit together.
 
 ```python
 import numpy as np
@@ -55,15 +78,23 @@ assert abs(lost - 0.02) < 0.005
 
 # heralds: (shots, num_measurements); 1 where the classifier heralded.
 assert (r.heralds[:, 0] == (status == noncomp.QubitStatus.LOST)).all()
+
+# symbols() reports the herald as value 2 instead of the placeholder bit.
+symbols = r.symbols()
+assert np.array_equal(symbols[:, 0] == 2, r.heralds[:, 0])
 ```
 
 `measurements`, `detectors`, and `observables` are laid out exactly as in
-ordinary sampling: a measurement of a leaked or lost qubit still occupies
-its record slot, with the classifier supplying the bit. When the
-classifier samples its herald symbol, `heralds` marks the slot and the
-binary `measurements` entry holds a uniformly drawn placeholder;
-`symbols()` folds the herald back in as a third value per slot (0, 1,
-or 2), for comparing against tools that report loss in-band.
+ordinary sampling: a measurement of a leaked or lost site still occupies its
+record slot, with the classifier supplying the bit. On a computational site,
+Clifft performs the requested quantum measurement; the `g` and `e` classifier
+columns can model computational-basis readout confusion for `M` and `MR`. On
+a noncomputational site, the classifier replaces the quantum measurement and
+applies to `M`, `MX`, and `MY` alike. When the classifier samples its herald
+symbol, `heralds` marks the slot and the binary `measurements` entry holds a
+uniformly drawn placeholder; `symbols()` folds the herald back in as a third
+value per slot (0, 1, or 2), for comparing against tools that report loss
+in-band.
 
 `heralds[shot, slot]` means that the classifier emitted its third symbol at
 that measurement slot. It does not identify when or where the underlying
@@ -71,24 +102,33 @@ transition occurred, so it is not an exact spacetime erasure flag. The
 herald is side information for downstream analysis or adaptive decoding;
 it is not folded into the binary detector record.
 
-Omitting `initial_state` starts every qubit in `g`. A model that can leak
-or lose qubits requires a classifier if the circuit measures a qubit.
+Omitting `initial_state` starts every site in `g`, which matches standard Clifft convention that all qubits start in $\lvert 0 \rangle$. A model that can leak or
+lose a site requires a classifier if the circuit measures it.
 
 ## Transitions: hooks and inline annotations
 
-A transition matrix `T[to][from]` gives the probability of jumping between
-levels when it fires; a column's deficit below 1 is "no jump". There are
+A transition matrix `T[to][from]` is evaluated at an attached circuit
+position. Each entry gives the probability of a jump from one level to
+another; a column's deficit below 1 is the no-jump probability. There are
 three ways to attach one to a circuit:
 
 - **Gate hooks.** A `transitions` key that names a gate (`"CZ"`, `"S"`, …)
-  fires after every occurrence of that gate. Keys naming instructions that
-  never produce a circuit node (`MXX`/`MYY`/`MZZ`, `CH`/`CCX`/`CCZ`,
-  identity no-ops) are rejected at model construction.
-- **Inline references.** `LEVEL_TRANSITION[name] 0` fires the named matrix
-  on qubit 0 at that circuit position. Any key can be referenced this way,
-  gate-named or not.
-- **Inline loss.** `LOSS(p) 0` loses qubit 0 with probability `p` from any
-  occupied level.
+  evaluates its matrix after every occurrence of that gate. Keys naming
+  instructions that never produce a circuit node (`MXX`/`MYY`/`MZZ`,
+  `CH`/`CCX`/`CCZ`, identity no-ops) are rejected at model construction.
+- **Inline references.** `LEVEL_TRANSITION[name] 0` evaluates the named matrix
+  from the `transitions` mapping on site 0 at that circuit position. Any
+  transition name can be referenced explicitly, whether or not it also names
+  a gate hook.
+- **Inline loss.** `LOSS(p) 0` loses the carrier at site 0 with probability
+  `p` from any occupied level.
+
+Before sampling, Clifft expands each gate hook into a
+`LEVEL_TRANSITION[name]` annotation for every site operand of the hooked gate.
+Use a hook when the same transition should follow every occurrence of a gate;
+use an inline reference for selected circuit positions or transitions with
+arbitrary names. `LOSS(p)` provides a self-contained inline loss probability
+without requiring a transition matrix in the model.
 
 A transition back to `g` or `e` can represent relaxation or recapture into
 the computational subspace; a reset represents active re-preparation.
@@ -111,7 +151,10 @@ classifier = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
 leak = T({(Level.LEAK_E, Level.G): 0.01, (Level.LEAK_E, Level.E): 0.01})
 
 model = noncomp.Model(
-    transitions={"CZ": leak},  # hook: fires after every CZ
+    transitions={
+        "CZ": leak,  # hook: evaluated on each site after every CZ
+        "manual_leak": leak,  # evaluated only where explicitly referenced
+    },
     classifier=classifier,
 )
 
@@ -119,20 +162,19 @@ circuit = """
     H 0
     CZ 0 1
     LOSS(0.005) 1
-    LEVEL_TRANSITION[CZ] 0
+    LEVEL_TRANSITION[manual_leak] 0
     M 0 1
 """
 r = noncomp.sample(circuit, model, shots=1000, seed=7)
 assert r.measurements.shape == (1000, 2)
 ```
 
-## What happens on a leaked or lost qubit
+## What happens on a leaked or lost site
 
-Gates addressing a leaked or lost qubit are dropped, acting as the
-identity on the surviving operands. Measurements keep their record slot
-and read the classifier
-(`M`, `MX`, and `MY` alike: the readout basis is incidental once the
-qubit has left the computational subspace).
+A gate, noise channel, or classical correction touching a leaked or lost site
+is skipped as a whole and acts as the identity on every operand. A
+single-qubit measurement keeps its record slot, but the classifier rather
+than the measurement basis determines its result (`M`, `MX`, and `MY` alike).
 
 Losing one half of an entangled pair leaves the partner in the reduced
 state; for a Bell pair, maximally mixed:
@@ -189,11 +231,12 @@ assert (r.detectors[:, 0] == 1).all()  # the leaked qubit always reads 1
 
 ## State-dependent rates resolve at runtime
 
-If a transition's rate differs between `g` and `e`, the jump probability on
-a superposition depends on the amplitudes at that point in the shot. The
-draw happens at sample time against the live state, so the statistics are
-exact — on $\lvert + \rangle$ with leak probability $p$ out of `g` only
-(and the leaked level reading 1), the marginal is $\tfrac12 + \tfrac{p}{2}$:
+If a transition's rate differs between `g` and `e`, the jump probability for
+a computational site in a superposition depends on the amplitudes at that
+point in the shot. The draw happens at sample time against the live state, so
+the statistics are exact — on $\lvert + \rangle$ with leak probability $p$
+out of `g` only (and the leaked level reading 1), the marginal is
+$\tfrac12 + \tfrac{p}{2}$:
 
 ```python
 from clifft import noncomp
@@ -215,22 +258,21 @@ assert abs(r.measurements[:, 0].mean() - (0.5 + p / 2)) < 0.01
 
 Resolving draws against the live state also preserves correlations that
 ahead-of-time sampling cannot produce: when the jump's destination depends
-on the source level, the leaked qubit's classified readout stays
-correlated with its entangled partner. The semantics and the rank cost
-are in [Noncomputational States](../theory/noncomputational.md).
+on the source level, the leaked site's classified readout stays correlated
+with its entangled partner. The semantics and the rank cost are in
+[Noncomputational States](../theory/noncomputational.md).
 
 ## Policy knobs
 
-- **`reset_restores_lost`** (default `False`): whether a reset on a lost
-  qubit re-prepares the site or is dropped. A reset always restores a
-  *leaked* qubit; a measure-and-reset keeps its record either way, with
+- **`reset_restores_lost`** (default `False`): whether a reset on a lost site
+  re-prepares it or is dropped. A reset always restores a *leaked* site; a
+  measure-and-reset keeps its record either way, with
   its reset half following the same rule.
-- **`damping`** (default `"exact"`): a site whose rates differ between
-  `g` and `e` needs its qubit in the active array for the exact no-fire
-  back-action; a coherent qubit still outside it is expanded at the site.
-  `"neglect"` skips the expansion and the back-action: an error of order
-  $\lvert p_g - p_e \rvert$ per site, and exactly zero for
-  source-independent rates (`LOSS` always qualifies).
+- **`damping`** (default `"exact"`): source-dependent total jump rates on a
+  coherent dormant site require no-jump back-action. Exact simulation promotes
+  such a site into the active state array. `"neglect"` omits that promotion
+  and the no-jump back-action: an error of order
+  $\lvert p_g - p_e \rvert$ per site. There is no error when $p_g = p_e$, so `LOSS(p)` is always exact.
 - **`seed`**: same contract as ordinary sampling — a fixed seed is fully
   reproducible, `None` uses hardware entropy.
 - **`max_rank`**: caps the compiled peak rank before any state allocation.
@@ -238,42 +280,44 @@ are in [Noncomputational States](../theory/noncomputational.md).
   never takes, so it is conservative.
 
 ## Limits
-
-- **Partner-error channels and leakage transport are not modeled.** A two-qubit
-  operation touching a leaked or lost operand is dropped whole. The model
+- **Partner-error channels and leakage transport are not modeled.** An
+  operation touching a leaked or lost site is dropped whole. The model
   does not add partner depolarization conditioned on that status or move
-  leakage between qubits.
+  leakage between sites.
 - **Coherent leakage is outside the trajectory model.** Jumps into a
   noncomputational level are treated as incoherent, definite occupations.
-- **The API produces trajectory samples.** It does not construct
-  conditional or adaptive detector error models or run an adaptive decoder;
-  records and heralds are available for downstream tooling.
 - **`MPP` is not supported** under a model that can leak or lose qubits —
   a parity of levels outside the qubit subspace has no faithful single-bit
   record. Expand the parity readout into an explicit ancilla circuit; the
   ancilla's ladder gates then drop per the rules above.
 - **A classifier is required** whenever a capable model meets a circuit that
-  measures a qubit; the error names the missing piece before sampling begins.
-- Under `damping="exact"`, a state-dependent site on a coherent qubit
-  outside the active array expands that qubit into it, adding one unit of
-  peak rank at that site. An already-active qubit adds nothing, and later
-  sites on a qubit that stays active do not stack, so the worst case is
-  one unit per *qubit* held coherent across its sites, not one per site.
+  measures a site; the error names the missing piece before sampling begins.
+- Under `damping="exact"`, a transition with source-dependent rates on a
+  coherent dormant site promotes that site into the active state array,
+  adding one unit of peak rank. An already-active site adds nothing, and later
+  transition positions on a site that stays active do not stack, so the worst
+  case is one unit per coherent *site*, not one per transition position.
   The [performance model](performance.md) otherwise applies unchanged.
+
+Note that many of these can be revisited in future versions.
 
 ## Why there is no compile step
 
 Ordinary Clifft separates `compile()` from `sample()` because a compiled
 program is model-independent. Here it is not: the executable depends on
-the model and on each shot's jump outcomes. `noncomp.sample` takes the
-circuit and model together and compiles internally, caching one
-continuation per distinct event history and, for ternary classifiers, one
-module per herald-flag assignment observed for that history. Typical
-low-rate models reuse the no-event continuation on most shots, so the
-cache usually stays small. In the worst case, stochastic transitions can
-produce a distinct event history per shot; many ternary-classified
-measurements can similarly produce a distinct herald assignment per
-shot. Only observed combinations are cached, so for a fixed circuit
-compile time and memory can grow linearly, but not exponentially, with
-the shot count. Pass a parsed `clifft.Circuit` instead of text to share
-parsing across calls.
+the model and on each shot's jump outcomes. When a jump changes downstream
+semantics, `noncomp.sample` switches to a trajectory-specific continuation: a
+version of the circuit rewritten and compiled for the event history observed
+so far. The shot then resumes after the event. `noncomp.sample` therefore takes
+the circuit and model together and compiles internally.
+
+Continuations are cached by event history and shared across shots. For ternary
+classifiers, the cache also holds one module per herald-flag assignment
+observed for that history. Typical low-rate models reuse the no-jump
+continuation on most shots, so the cache usually stays small. In the worst
+case, stochastic transitions can produce a distinct event history per shot;
+many ternary-classified measurements can similarly produce a distinct herald
+assignment per shot. Only observed combinations are cached, so for a fixed
+circuit compile time and memory can grow linearly, but not exponentially, with
+the shot count. The theory page explains
+[how continuations compose with Clifft](../theory/noncomputational.md#how-this-composes-with-clifft). Future versions may reconsider this caching strategy if it becomes a memory issue in practice.

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -129,8 +129,9 @@ three ways to attach one to a circuit:
 
 Before sampling, Clifft expands each gate hook into a
 `LEVEL_TRANSITION[name]` annotation for every physical site operand of the
-hooked gate. Record-controlled feedback operations are virtual and receive no
-transition annotations. Use a hook when the same transition should follow
+hooked gate. Classical feedback (`CX rec[-1] 0`) receives no annotation: a
+record-conditioned Pauli is a frame update, not a physical execution of the
+hooked gate. Use a hook when the same transition should follow
 every occurrence of a gate; use an inline reference for selected circuit
 positions or transitions with arbitrary names. `LOSS(p)` provides a
 self-contained inline loss probability without requiring a transition matrix

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -7,7 +7,7 @@
 Pauli noise acts within a qubit's two-dimensional computational subspace. Real
 hardware can instead drive the state out of that subspace through *leakage*, or
 lose the physical carrier from its site entirely through *loss*. Neither
-process is a Pauli channel. Afterward, the site no longer holds an ordinary
+process is a Pauli channel, so the site no longer holds an ordinary
 qubit state.
 
 Clifft models these processes with a hybrid quantum-classical trajectory
@@ -23,8 +23,7 @@ This page explains the model and how it composes with Clifft's
 
 ## The effective five-level site
 
-Each circuit wire denotes a fixed physical *site*. When that site is occupied
-within the computational subspace, it holds a qubit. For modeling leakage and
+Each circuit wire denotes a fixed physical *site*. For modeling leakage and
 loss, Clifft uses the effective per-site space
 
 $$
@@ -46,7 +45,7 @@ $$
 \}.
 $$
 
-The five level labels are the row and column indices of the model matrices:
+The table below lists these levels and their categories:
 
 | index | name | category | meaning |
 |---|---|---|---|
@@ -56,30 +55,32 @@ The five level labels are the row and column indices of the model matrices:
 | 3 | `leak_e` | leaked | a second leaked level |
 | 4 | `lost` | lost | carrier absent from the site |
 
-The labels `g` and `e` name basis levels against which transition rates are
-defined. A computational site need not occupy either one definitely: it may be
-in any superposition or entangled state within $\mathcal H_C$.
+Under the model's incoherent-jump assumption, there is no coherence between
+$\mathcal H_C$ and $\mathcal H_N$, or between different noncomputational
+levels. The labels `g` and `e` name the computational basis levels used as
+matrix indices. They do not imply that a computational site occupies a
+definite level: its state may be any superposition or entangled state in
+$\mathcal H_C$. The status ledger therefore records one computational status
+rather than separate `g` and `e` occupations. We intentionally do not use $\lvert 0 \rangle, \lvert 1 \rangle$ for these level labels to underscore this distinction between the status ledger and the quantum state for site with computational status.
 
-Each sampled shot is one trajectory. Its state has two parts. Sites with
-computational status remain in Clifft's ordinary factored quantum state. The
-sampler also keeps a classical status ledger per site. Its entries are
-computational, `leak_g`, `leak_e`, or `lost`. The computational status
-deliberately does not choose between `g` and `e`; that information remains
-quantum. Each noncomputational status names one definite level.
-
-This representation is exact under the model's incoherent-jump assumption.
-There is no coherence between $\mathcal H_C$ and $\mathcal H_N$, or between
-different noncomputational levels. Coherent leakage is outside the model's
-scope.
+This gives a hybrid state representation. Each trajectory has two components:
+Clifft's ordinary factored quantum state over the computational sites, and a
+classical status ledger over all sites. The ledger entries are computational,
+`leak_g`, `leak_e`, or `lost`. A computational entry leaves the corresponding
+site in the quantum state. A noncomputational entry names one definite level.
+The sections below describe the dynamics and interactions of these states.
 
 ## Model inputs
+
+The user defines a model that determines how sites jump between levels and how
+measurements are classified.
 
 A transition matrix $T[\mathrm{to}][\mathrm{from}]$ attaches stochastic jumps
 to circuit positions. An entry gives the probability of a jump from one source
 level to one destination level. Diagonal entries are still jump events because
 they project onto their source level. The unused probability in a column is the
-no-jump probability. `LOSS(p)` is the special case of a uniform jump to `lost`
-from every occupied level.
+no-jump probability. For computational sources, these probabilities define the
+jump and no-jump Kraus branches described below.
 
 A measurement classifier $P[\mathrm{symbol}][\mathrm{level}]$ defines the
 recorded result for each level. It has two binary record symbols and may have
@@ -111,31 +112,32 @@ K_{\mathrm{stay}}
 \sqrt{1-p_e}\,\lvert e\rangle\langle e\rvert.
 $$
 
-Unequal rates therefore change the surviving coherent state. A transition
-from one definite noncomputational level to another is purely classical, as
+Unequal rates therefore change the surviving coherent state.
+
+A transition
+from one noncomputational level to another is purely classical, as
 is the status update. A transition back to `g` or `e` restores the site to the
 computational state at that basis level.
 
 ## Operations after a jump
 
 Once a site has noncomputational status, later circuit operations follow the
-current structural policy.
+policy below.
 
 - A gate, noise channel, or classical correction touching the site is skipped
   whole and acts as the identity on every operand.
-- `M`, `MX`, `MY`, `MR`, `MRX`, and `MRY` keep their measurement slot and use
-  the classifier. The basis is incidental once the site is outside
-  $\mathcal H_C$. For a measure-reset form, the reset half follows the
-  restoration policy below. A multi-qubit parity measurement has no faithful
-  single-bit substitution and is rejected.
+- Measurements use the classifier to determine the measured result and store it in the same record slot reserved for that measurement. Once the site is outside $\mathcal H_C$, the classifier rather than the measurement basis determines the recorded result. For a measure-reset form, the reset half
+  follows the restoration policy below. The current policy rejects multi-qubit
+  parity measurements (`MPP`) because they have no faithful single-bit
+  substitution; a future policy could define other semantics.
 - A reset restores a leaked site. It restores a lost site only when the model
   enables `reset_restores_lost`. A transition to `g` or `e` can also model
   relaxation or recapture.
 
-Gate dropping is the current interaction design, not a general law of
-leakage. The model does not yet add partner depolarization conditioned on a
-noncomputational operand or transport leakage between sites. Future policies
-may define those interactions differently.
+This policy describes the current implementation. Future work may add additional configurable
+semantics, for example by adding partner depolarization
+conditioned on a noncomputational operand or transporting leakage between
+sites.
 
 The visible binary result occupies the same record slot as the original
 measurement. Later `rec` references, detectors, observables, and classical
@@ -151,68 +153,29 @@ The compiler absorbs deterministic Clifford evolution into an offline frame,
 localizes the remaining Pauli operations, and emits bytecode for the factored
 Schrodinger virtual machine.
 
-A noncomputational jump can change which later gates are skipped, which
-measurements use the classifier, and whether a site returns to the
-computational state. Those choices depend on the live state and differ between
-shots, so one model-independent program cannot describe every trajectory.
-`noncomp.sample` therefore interleaves execution with cached continuation
-compilation. The workflow is shown below.
+A noncomputational jump can change which later gates are skipped, which measurements use the classifier, and whether a site returns to the computational state. Those choices depend on the live state and differ between shots, so one model-independent program cannot describe every trajectory. `noncomp.sample` therefore interleaves execution with compilation of trajectory-specific continuations. A continuation is the circuit rewritten and compiled for the noncomputational events observed so far and the resulting status ledger. Its prefix matches the program already executed, while its remaining operations reflect the updated trajectory.
 
-```text
-Circuit + model
-      |
-      v
-Annotate transition positions
-      |
-      v
-Rewrite for the current event history
-      |
-      v
-Trace -> optimize -> lower -> cache continuation
-      |
-      v
-Execute against the live factored state
-      |
-      +-- event handled inline ------------------------> continue
-      |
-      `-- fire requiring a new continuation -> resumable trap
-                                                   |
-                                                   v
-                                      Record jump and update status
-                                                   |
-                                                   v
-                                      Rewrite, compile, cache, resume
-```
+Execution continues through events that can be handled inline. When a fire requires different downstream semantics, the driver traps, records the event, fetches or compiles the matching continuation, and resumes after the trapped site. Continuations are cached, so shots that reach the same event history can reuse the same compiled program.
 
 Each continuation still uses Clifft's normal compiler and SVM architecture.
 Clifford operations are absorbed ahead of time, Pauli products are localized
-before execution, and the VM acts only on local array axes and frame data. The
-event history determines which continuation is compiled; it does not move
-global circuit topology into the runtime.
+before execution, and the VM acts only on local array axes and frame data.
 
 ## Active-dimension cost
 
-Most transition positions do not increase the
+With the default exact damping policy, the simulation is exact for this hybrid
+quantum-classical model. Most transition positions do not increase the
 [active dimension](overview.md#the-factored-state-representation). A source
 already in the active state uses its existing array axis. A definite dormant
-source is resolved from the Clifford and Pauli frames. When $p_g=p_e$, the
-no-jump operator is a scalar, so a coherent dormant source can also remain
-outside the active array without approximation.
+source is determined entirely from the Clifford and Pauli frames.
 
-Only an exact, source-dependent transition on a coherent dormant site must
-expand that site into the active state. This adds one active dimension at the
-transition position. While the site remains active, later transitions on it
-add no further dimension.
+The exceptional case is a coherent dormant site with source-dependent total
+jump rates, $p_g \neq p_e$. The $K_{\mathrm{stay}}$ operator above is then not
+proportional to the identity, and is non-Clifford. Exact simulation must promote the site from dormant to active.
 
-`damping="neglect"` avoids that expansion by omitting the no-jump back-action.
-It is exact when $p_g=p_e$ and otherwise introduces a survivorship tilt of
-order $\lvert p_g-p_e\rvert$ per position. The default policy keeps the exact
-back-action.
-
-## Current scope
-
-This model deliberately covers incoherent leakage and loss trajectories. It
-does not currently represent coherent superpositions involving
-$\mathcal H_N$ or construct adaptive detector error models. The sampler
-returns measurement records, detectors, observables, per-site final statuses,
-and heralds for downstream analysis or decoding.
+If this occurs frequently, it can increase the peak active dimension $k$, the
+dominant scaling quantity for Clifft's runtime. Users can instead choose
+`damping="neglect"`, which omits the no-jump back-action. This is exact when
+$p_g=p_e$ (since it is proportional to the identity in this case), and otherwise introduces a survivorship tilt of order
+$\lvert p_g-p_e\rvert$ per position. Under this policy, these transition
+positions do not increase $k$.

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -61,7 +61,10 @@ levels. The labels `g` and `e` name the computational basis levels used as
 matrix indices. They do not imply that a computational site occupies a
 definite level: its state may be any superposition or entangled state in
 $\mathcal H_C$. The status ledger therefore records one computational status
-rather than separate `g` and `e` occupations. We intentionally do not use $\lvert 0 \rangle, \lvert 1 \rangle$ for these level labels to underscore this distinction between the status ledger and the quantum state for site with computational status.
+rather than separate `g` and `e` occupations. We intentionally do not use
+$\lvert 0 \rangle, \lvert 1 \rangle$ for these level labels to underscore the
+distinction between the status ledger and the quantum state for a site with
+computational status.
 
 This gives a hybrid state representation. Each trajectory has two components:
 Clifft's ordinary factored quantum state over the computational sites, and a
@@ -124,8 +127,11 @@ computational state at that basis level.
 Once a site has noncomputational status, later circuit operations follow the
 policy below.
 
-- A gate, noise channel, or classical correction touching the site is skipped
-  whole and acts as the identity on every operand.
+- A unitary gate, ordinary noise channel, or classical correction touching the
+  site is skipped as a whole and has no effect on any operand. Correlated-error
+  instructions (`E`/`CORRELATED_ERROR` and `ELSE_CORRELATED_ERROR`) are
+  retained to preserve chain conditioning; their Paulis still act on
+  computational operands but are inert on the noncomputational site.
 - Measurements use the classifier to determine the measured result and store it in the same record slot reserved for that measurement. Once the site is outside $\mathcal H_C$, the classifier rather than the measurement basis determines the recorded result. For a measure-reset form, the reset half
   follows the restoration policy below. The current policy rejects multi-qubit
   parity measurements (`MPP`) because they have no faithful single-bit

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -4,141 +4,215 @@
     The leakage/loss API is experimental and may change between minor
     releases.
 
-Pauli noise moves a qubit around inside its two-dimensional subspace. Real
-devices can instead leave that subspace (*leakage*) or lose the physical
-carrier from its site (*loss*). No Pauli channel can represent either: the
-state is no longer a qubit state at all. Because the condition can persist
-across later circuit positions, one event can correlate deviations across
-time rather than acting like an independent local fault.
+Pauli noise acts within a qubit's two-dimensional computational subspace. Real
+hardware can instead drive the state out of that subspace through *leakage*, or
+lose the physical carrier from its site entirely through *loss*. Neither
+process is a Pauli channel. Afterward, the site no longer holds an ordinary
+qubit state.
 
-Clifft models both with a five-level structure per qubit, a per-gate jump
-process between levels, and a classifier that defines what a measurement of
-a non-qubit level records. This page describes the model and its
-simulation semantics; the [Leakage and Loss guide](../guide/leakage-and-loss.md)
-shows the API.
+Clifft models these processes with a hybrid quantum-classical trajectory
+model. Within the computational subspace, the state keeps its full coherent
+dynamics and entanglement. A leaked or lost site instead has a definite,
+classically tracked occupation on each trajectory. Transitions between the two
+are stochastic quantum jumps, including their back-action on the computational
+state.
 
-## The five-level model
+This page explains the model and how it composes with Clifft's
+[factored-state simulation](overview.md). The
+[Leakage and Loss guide](../guide/leakage-and-loss.md) shows the Python API.
 
-Every qubit carries the same fixed level set:
+## The effective five-level site
+
+Each circuit wire denotes a fixed physical *site*. When that site is occupied
+within the computational subspace, it holds a qubit. For modeling leakage and
+loss, Clifft uses the effective per-site space
+
+$$
+\mathcal H_{\mathrm{site}}
+=
+\mathcal H_C \oplus \mathcal H_N,
+\qquad
+\mathcal H_C = \operatorname{span}\{\lvert g\rangle,\lvert e\rangle\}
+\cong \operatorname{span}\{\lvert 0\rangle,\lvert 1\rangle\},
+$$
+
+with
+
+$$
+\mathcal H_N = \operatorname{span}\{
+\lvert \mathrm{leak\_g}\rangle,
+\lvert \mathrm{leak\_e}\rangle,
+\lvert \mathrm{lost}\rangle
+\}.
+$$
+
+The five level labels are the row and column indices of the model matrices:
 
 | index | name | category | meaning |
 |---|---|---|---|
-| 0 | `g` | computational | the qubit $\lvert 0 \rangle$ |
-| 1 | `e` | computational | the qubit $\lvert 1 \rangle$ |
+| 0 | `g` | computational | $\lvert g\rangle$, identified with logical $\lvert 0\rangle$ |
+| 1 | `e` | computational | $\lvert e\rangle$, identified with logical $\lvert 1\rangle$ |
 | 2 | `leak_g` | leaked | carrier present, outside the qubit subspace |
 | 3 | `leak_e` | leaked | a second leaked level |
-| 4 | `lost` | lost | carrier gone |
+| 4 | `lost` | lost | carrier absent from the site |
 
-Two ingredients drive the dynamics:
+The labels `g` and `e` name basis levels against which transition rates are
+defined. A computational site need not occupy either one definitely: it may be
+in any superposition or entangled state within $\mathcal H_C$.
 
-- **Transition matrices.** A $5 \times 5$ matrix $T[\text{to}][\text{from}]$
-  attached to a circuit position gives the probability of jumping between
-  levels when that position executes. Every entry is a discrete jump event
-  (diagonal entries project onto the source level), and a column's deficit
-  below 1 is the no-jump probability. `LOSS(p)` is the special case of a
-  uniform jump to `lost` from every occupied level.
-- **A classifier.** A stochastic matrix $P[\text{symbol}][\text{level}]$
-  mapping the level at readout to a recorded symbol: two record symbols,
-  plus an optional third that heralds the measurement (typically loss).
+Each sampled shot is one trajectory. Its state has two parts. Sites with
+computational status remain in Clifft's ordinary factored quantum state. The
+sampler also keeps a classical status ledger per site. Its entries are
+computational, `leak_g`, `leak_e`, or `lost`. The computational status
+deliberately does not choose between `g` and `e`; that information remains
+quantum. Each noncomputational status names one definite level.
 
-## Statuses: classical occupation, per trajectory
+This representation is exact under the model's incoherent-jump assumption.
+There is no coherence between $\mathcal H_C$ and $\mathcal H_N$, or between
+different noncomputational levels. Coherent leakage is outside the model's
+scope.
 
-Each sampled shot is one trajectory. Along a trajectory the sampler keeps a
-classical *status* per qubit: computational, `leak_g`, `leak_e`, or `lost`.
-A noncomputational status is definite: the trajectory knows which level the
-qubit occupies. A computational qubit carries no level claim; whether it is
-$\lvert 0 \rangle$, $\lvert 1 \rangle$, or a superposition is tracked by
-the simulator, not the ledger.
+## Model inputs
 
-Classical tracking is exact for this trajectory model because jumps are
-treated as incoherent: a noncomputational population carries no coherence
-with the computational subspace. Under that assumption, recording
-occupation per trajectory discards nothing; coherent leakage is outside
-the model's scope.
+A transition matrix $T[\mathrm{to}][\mathrm{from}]$ attaches stochastic jumps
+to circuit positions. An entry gives the probability of a jump from one source
+level to one destination level. Diagonal entries are still jump events because
+they project onto their source level. The unused probability in a column is the
+no-jump probability. `LOSS(p)` is the special case of a uniform jump to `lost`
+from every occupied level.
 
-## The vacated carrier
+A measurement classifier $P[\mathrm{symbol}][\mathrm{level}]$ defines the
+recorded result for each level. It has two binary record symbols and may have
+a third herald symbol, typically for loss. For example, the `leak_g` column
+can assign independent probabilities to records 0 and 1.
 
-When a qubit jumps out of the computational subspace, its amplitudes still
-matter: for an entangled qubit they define the partner's reduced state.
-The jump therefore traces the qubit out: a hidden collapse resolves its
-computational amplitude, the partner keeps the correct partial-trace
-statistics, and the simulated cell (the *carrier*) is left parked while
-the status ledger records the occupied level.
+## Jump back-action
 
-With the carrier vacated:
+When a jump leaves $\mathcal H_C$, its Kraus branch selects a computational
+source level and a destination. The source is resolved against the live
+quantum state, not drawn ahead of execution. Clifft realizes this back-action
+as a hidden collapse and removes the site from the coherent state. The hidden
+collapse writes no visible measurement record.
 
-- **Gates drop.** An operation with no representable effect on a leaked or
-  lost operand (a single- or two-qubit gate, a noise channel, classical
-  feedback onto the site) is excised whole, acting as the identity on the
-  surviving operands.
-- **Measurements classify.** A measurement of a noncomputational level is
-  not a Born measurement of a qubit; the classifier defines its record
-  symbol. The record slot is preserved, so `rec[-k]` references, detectors,
-  and observables are laid out exactly as in the noiseless circuit. The
-  readout basis is incidental on a vacated carrier: `M`, `MX`, and `MY`
-  all classify identically. A multi-qubit parity measurement (`MPP`) has no
-  faithful single-bit substitution and is rejected up front.
-- **Restoration is explicit.** A qubit returns to the computational subspace
-  only through an operation that restores the carrier: a reset (a leaked
-  qubit always; a lost qubit only when the model opts in) or a transition to
-  `g` or `e`, modeling relaxation or recapture.
+For an entangled site, the same collapse updates its partners. Each trajectory
+keeps the partner state conditioned on the selected jump branch; averaging
+over trajectories recovers the correct reduced-state statistics. A Bell-pair
+partner, for example, is maximally mixed in the ensemble after
+source-independent loss of the other half.
 
-The gate-drop rule is structural: it does not add partner depolarization
-conditioned on another operand's status or transport leakage between
-qubits.
+When no jump occurs, the state is also updated. If the total jump rates from
+`g` and `e` are $p_g$ and $p_e$, the no-jump branch applies
 
-Classifier-substituted record bits are consumed by detectors and observables
-like ordinary measurements, so a noncomputational readout can produce
-detector events. An optional herald remains separate, per-measurement side
-information: it identifies the readout where the classifier emitted its
-third symbol, not the time or location of the underlying transition, and is
-not an exact spacetime erasure flag.
+$$
+K_{\mathrm{stay}}
+=
+\sqrt{1-p_g}\,\lvert g\rangle\langle g\rvert
++
+\sqrt{1-p_e}\,\lvert e\rangle\langle e\rvert.
+$$
 
-## State-dependent rates
+Unequal rates therefore change the surviving coherent state. A transition
+from one definite noncomputational level to another is purely classical, as
+is the status update. A transition back to `g` or `e` restores the site to the
+computational state at that basis level.
 
-Whether a jump fires can depend on the state. If a transition leaks out of
-`g` and `e` at different rates, the fire probability on a superposition is
-not a number known ahead of time — it depends on the amplitudes at that
-point in that trajectory, and the no-fire branch back-acts on the state
-(the general-measurement update from Kraus operators
-$\smash{\sqrt{1-p_g}}\,\lvert g\rangle\langle g\rvert +
-\smash{\sqrt{1-p_e}}\,\lvert e\rangle\langle e\rvert$).
+## Operations after a jump
 
-Clifft resolves each potential jump *at its circuit position against the
-live state*: the fire decision is drawn from the simulator's own
-amplitudes, and when a jump lands, the remainder of the shot is rewritten
-under the recorded event and execution resumes. Sampling is exact for
-state-dependent rates, including the correlations ahead-of-time sampling
-cannot produce: when the jump's destination depends on the source level,
-the leaked qubit's readout stays correlated with its entangled partner.
+Once a site has noncomputational status, later circuit operations follow the
+current structural policy.
 
-The one approximation on this path is opt-in. The exact no-fire
-back-action acts on the qubit's amplitudes, so a source-dependent site on
-a coherent qubit that is still *dormant* (held in the Clifford frame,
-outside the active array) expands that qubit into the array, one unit of
-active dimension at that site. A qubit already active costs nothing more,
-and later sites on a qubit that stays active do not stack.
-`damping="neglect"` skips the expansion and the back-action, a
-survivorship tilt of order $\lvert p_g - p_e \rvert$ per site and exactly
-zero at source-independent rates. The default is exact.
+- A gate, noise channel, or classical correction touching the site is skipped
+  whole and acts as the identity on every operand.
+- `M`, `MX`, `MY`, `MR`, `MRX`, and `MRY` keep their measurement slot and use
+  the classifier. The basis is incidental once the site is outside
+  $\mathcal H_C$. For a measure-reset form, the reset half follows the
+  restoration policy below. A multi-qubit parity measurement has no faithful
+  single-bit substitution and is rejected.
+- A reset restores a leaked site. It restores a lost site only when the model
+  enables `reset_restores_lost`. A transition to `g` or `e` can also model
+  relaxation or recapture.
 
-## Validation
+Gate dropping is the current interaction design, not a general law of
+leakage. The model does not yet add partner depolarization conditioned on a
+noncomputational operand or transport leakage between sites. Future policies
+may define those interactions differently.
 
-The implementation is checked at four levels:
+The visible binary result occupies the same record slot as the original
+measurement. Later `rec` references, detectors, observables, and classical
+feedback all consume that substituted bit. When the classifier emits its third
+symbol, a separate herald marks the slot and the binary record receives a
+uniformly drawn placeholder. The herald identifies the readout, not the time or
+location of the underlying jump, so it is not an exact spacetime erasure flag.
 
-1. **Closed forms.** Micro-circuits with hand-derived outcomes: partial
-   trace of a Bell pair under loss, marginals under state-dependent leak
-   rates, classifier confusion arithmetic.
-2. **Sharp probes.** Fixed-seed tests for behavior that sampled
-   distributions alone cannot check: the Bell-pair correlation that
-   distinguishes live-state draws from ahead-of-time draws, and the
-   damping boundary/null pair that separates `exact` from `neglect`
-   exactly where the $\lvert p_g - p_e \rvert$ bound says they must
-   differ and agree.
-3. **A brute-force enumerator.** A dense density-matrix reference computes
-   full record distributions for small circuits; sampled frequencies are
-   checked against it. The enumerator shares the channel definitions with
-   the sampler, so it is one independent implementation of the *dynamics*,
-   not of the model; the closed forms above anchor the model itself.
-4. **Statistical distance at scale.** Total-variation-distance checks on
-   repetition-code rounds at realistic rates, bounded by shot noise.
+## How this composes with Clifft
+
+Ordinary Clifft compiles a circuit once and reuses the program for many shots.
+The compiler absorbs deterministic Clifford evolution into an offline frame,
+localizes the remaining Pauli operations, and emits bytecode for the factored
+Schrodinger virtual machine.
+
+A noncomputational jump can change which later gates are skipped, which
+measurements use the classifier, and whether a site returns to the
+computational state. Those choices depend on the live state and differ between
+shots, so one model-independent program cannot describe every trajectory.
+`noncomp.sample` therefore interleaves execution with cached continuation
+compilation. The workflow is shown below.
+
+```text
+Circuit + model
+      |
+      v
+Annotate transition positions
+      |
+      v
+Rewrite for the current event history
+      |
+      v
+Trace -> optimize -> lower -> cache continuation
+      |
+      v
+Execute against the live factored state
+      |
+      +-- event handled inline ------------------------> continue
+      |
+      `-- fire requiring a new continuation -> resumable trap
+                                                   |
+                                                   v
+                                      Record jump and update status
+                                                   |
+                                                   v
+                                      Rewrite, compile, cache, resume
+```
+
+Each continuation still uses Clifft's normal compiler and SVM architecture.
+Clifford operations are absorbed ahead of time, Pauli products are localized
+before execution, and the VM acts only on local array axes and frame data. The
+event history determines which continuation is compiled; it does not move
+global circuit topology into the runtime.
+
+## Active-dimension cost
+
+Most transition positions do not increase the
+[active dimension](overview.md#the-factored-state-representation). A source
+already in the active state uses its existing array axis. A definite dormant
+source is resolved from the Clifford and Pauli frames. When $p_g=p_e$, the
+no-jump operator is a scalar, so a coherent dormant source can also remain
+outside the active array without approximation.
+
+Only an exact, source-dependent transition on a coherent dormant site must
+expand that site into the active state. This adds one active dimension at the
+transition position. While the site remains active, later transitions on it
+add no further dimension.
+
+`damping="neglect"` avoids that expansion by omitting the no-jump back-action.
+It is exact when $p_g=p_e$ and otherwise introduces a survivorship tilt of
+order $\lvert p_g-p_e\rvert$ per position. The default policy keeps the exact
+back-action.
+
+## Current scope
+
+This model deliberately covers incoherent leakage and loss trajectories. It
+does not currently represent coherent superpositions involving
+$\mathcal H_N$ or construct adaptive detector error models. The sampler
+returns measurement records, detectors, observables, per-site final statuses,
+and heralds for downstream analysis or decoding.


### PR DESCRIPTION
## Summary

Improve the documentation for clarity, consistency and tone. This was a manual pass over the AI Generated content.
## Test plan

<!-- How was this tested? Check all that apply. -->

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [ ] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
