### PR TITLE
bench: tighten the noncomp benchmark ladder

### DIFF
--- a/tools/bench/README.md
+++ b/tools/bench/README.md
@@ -21,6 +21,7 @@ uv run pytest tools/bench/ --benchmark-sort=name --benchmark-columns=Mean,StdDev
 | `test_bench_qec.py` | d=3 surface code (`tests/fixtures/target_qec.stim`) | Compile and sample latency vs Stim |
 | `test_bench_deep_clifford.py` | 50-qubit, 5000 random Cliffords | Pure Clifford compile/sample throughput |
 | `test_bench_qv.py` | 20-qubit Quantum Volume (`fixtures/qv20_seed42.stim`) | Large statevector (peak rank 20) per-shot throughput |
+| `test_bench_noncomp.py` | d=17, r=5 repetition-code memory with a hooked leak/loss layer | Noncomputational pipeline overhead and trap/continuation cost vs plain sampling |
 
 ## Fixtures
 

--- a/tools/bench/test_bench_noncomp.py
+++ b/tools/bench/test_bench_noncomp.py
@@ -1,17 +1,12 @@
 """pytest-benchmark cases for the noncomputational (leakage/loss) path.
 
-A ladder per repetition-code memory circuit (d data qubits, r rounds,
+A ladder on one repetition-code memory circuit (d data qubits, r rounds,
 n = 2d-1 qubits; a hooked S layer on the data each round): plain sampling,
-the noncomputational pipeline with a lossless model (isolating the shared
-main line's overhead over plain sampling), and a representative
-low-probability leakage-plus-loss model (drop on leaked/lost operands,
-ternary herald classifier).
-
-A final cross-simulator rung runs the same circuit and noise model on the
-cirq-superstaq leakage simulator. That package is not a committed dependency
-(its simulator lives on an unmerged upstream branch), so the rung skips
-unless it is importable in the local environment; everything else runs
-everywhere.
+the noncomputational pipeline with a lossless model (isolating the
+pipeline's per-shot overhead over plain sampling -- the per-call
+rewrite-and-compile cost amortizes out at this batch size), and a
+representative low-probability leakage-plus-loss model (drop on
+leaked/lost operands, ternary herald classifier).
 """
 
 from __future__ import annotations
@@ -24,11 +19,17 @@ import clifft
 from clifft import noncomp
 
 CONFIGS = [
-    pytest.param(3, 3, 200, id="d3-r3"),
-    pytest.param(17, 5, 100, id="d17-r5"),
+    pytest.param(17, 5, id="d17-r5"),
 ]
 
 LEAK_P = 0.01
+
+# The plain and lossless rungs cost microseconds per shot, so a larger
+# batch keeps their tracked means well above timer and runner noise. The
+# leak rung traps and compiles continuations, which puts 100 shots in the
+# tens of milliseconds already.
+FAST_SHOTS = 2000
+LEAK_SHOTS = 100
 
 
 def rep_code_text(d: int, r: int) -> str:
@@ -73,60 +74,27 @@ def noncomp_model(p: float) -> noncomp.Model:
     )
 
 
-@pytest.mark.parametrize("d,r,shots", CONFIGS)
-def test_bench_noncomp_plain(benchmark: Any, d: int, r: int, shots: int) -> None:
+@pytest.mark.parametrize("d,r", CONFIGS)
+def test_bench_noncomp_plain(benchmark: Any, d: int, r: int) -> None:
     program = clifft.compile(rep_code_text(d, r))
     clifft.sample(program, 2, 1)  # warm
-    benchmark.extra_info["shots"] = shots
-    benchmark(clifft.sample, program, shots, 1)
+    benchmark.extra_info["shots"] = FAST_SHOTS
+    benchmark(clifft.sample, program, FAST_SHOTS, 1)
 
 
-@pytest.mark.parametrize("d,r,shots", CONFIGS)
-def test_bench_noncomp_lossless(benchmark: Any, d: int, r: int, shots: int) -> None:
+@pytest.mark.parametrize("d,r", CONFIGS)
+def test_bench_noncomp_lossless(benchmark: Any, d: int, r: int) -> None:
     circuit = clifft.parse(rep_code_text(d, r))
     model = noncomp_model(0.0)
     noncomp.sample(circuit, model, shots=2, seed=1)  # warm
-    benchmark.extra_info["shots"] = shots
-    benchmark(noncomp.sample, circuit, model, shots=shots, seed=1)
+    benchmark.extra_info["shots"] = FAST_SHOTS
+    benchmark(noncomp.sample, circuit, model, shots=FAST_SHOTS, seed=1)
 
 
-@pytest.mark.parametrize("d,r,shots", CONFIGS)
-def test_bench_noncomp_leak(benchmark: Any, d: int, r: int, shots: int) -> None:
+@pytest.mark.parametrize("d,r", CONFIGS)
+def test_bench_noncomp_leak(benchmark: Any, d: int, r: int) -> None:
     circuit = clifft.parse(rep_code_text(d, r))
     model = noncomp_model(LEAK_P)
     noncomp.sample(circuit, model, shots=2, seed=1)  # warm
-    benchmark.extra_info["shots"] = shots
-    benchmark(noncomp.sample, circuit, model, shots=shots, seed=1)
-
-
-@pytest.mark.parametrize("d,r,shots", CONFIGS)
-def test_bench_noncomp_sqale_comparison(benchmark: Any, d: int, r: int, shots: int) -> None:
-    cirq = pytest.importorskip("cirq")
-    leakage_sim = pytest.importorskip("cirq_superstaq.sim.leakage_sim")
-    sqale_model = pytest.importorskip("cirq_superstaq.sim.sqale_leakage_model")
-
-    qs = cirq.LineQubit.range(2 * d - 1)
-    data, anc = qs[:d], qs[d:]
-    ops: list = [cirq.H.on_each(*data)]
-    for k in range(r):
-        for i in range(d - 1):
-            ops.append(cirq.CX(data[i], anc[i]))
-            ops.append(cirq.CX(data[i + 1], anc[i]))
-        ops.append(cirq.S.on_each(*data))
-        ops.append(cirq.measure(*anc, key=f"m{k}"))
-        ops.extend(cirq.reset(a) for a in anc)
-    ops.append(cirq.measure(*data, key="final"))
-    model = sqale_model.SqaleLeakageModel(
-        rz_transition_matrix=leak_loss_matrix(LEAK_P), classifier_errors=(0, 0)
-    )
-    noisy = cirq.Circuit(ops).with_noise(model)
-
-    sq_shots = min(shots, 20)  # their per-shot stabilizer runs are slow at scale
-    benchmark.extra_info["shots"] = sq_shots
-    benchmark.pedantic(
-        leakage_sim.sample_circuit,
-        args=(noisy,),
-        kwargs={"repetitions": sq_shots, "max_workers": 0, "progressbar": False},
-        rounds=2,
-        iterations=1,
-    )
+    benchmark.extra_info["shots"] = LEAK_SHOTS
+    benchmark(noncomp.sample, circuit, model, shots=LEAK_SHOTS, seed=1)


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Bench-suite cleanup from the final manual review:

- **Drop the cross-simulator rung.** Its dependency lives on an unmerged upstream branch, so the case has never executed anywhere (permanent `importorskip`) and rots silently against that API. The historical comparison it supported is recorded; the harness stays in git history.
- **Drop the `d3-r3` configuration** — smoke-speed and duplicating what `d17-r5` covers.
- **Raise the plain and lossless rungs to 2000 shots** so their daily-chart means sit well above runner noise (~3 ms per call instead of 15–420 µs). Measured consequence worth knowing: at this batch size the per-call rewrite-and-compile cost amortizes out and lossless lands at parity with plain (2.99 ms vs 3.00 ms), so the lossless rung now isolates the pipeline's **per-shot** overhead — the regression mode that matters at production shot counts. A per-shot creep or an accidental per-shot compile pushes the ratio off 1.0 unmissably. The leak rung stays at 100 shots (~39 ms, dominated by trap + continuation compilation — the noncomp-specific machinery).
- **Add the missing README table row** for `test_bench_noncomp.py` (never added when #146 introduced the file).

Verified: the three rungs pass locally (means above), full `tools/bench/` collection intact (17 cases), pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
