### PR TITLE
chore(circuit): document READOUT_NOISE and prune a dead parser check

### DIFF
--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -146,10 +146,15 @@ Two-qubit Cliffords are also absorbed at compile time.
 | `PAULI_CHANNEL_3(...)` | General three-qubit Pauli channel (63 params) |
 | `CORRELATED_ERROR(p)` / `E(p)` | Correlated Pauli product error |
 | `ELSE_CORRELATED_ERROR(p)` | Else-branch in a correlated-error chain |
+| `READOUT_NOISE(p01[, p10])` | Classical bit-flip on a measurement record (`rec[-k]` targets) |
 
-Noisy measurements (e.g., `M(0.01) 0`) are decomposed by the parser into a
-clean measurement followed by an internal `READOUT_NOISE` instruction that
-models classical bit-flip errors on the measurement result.
+`READOUT_NOISE` flips already-recorded bits rather than acting on a qubit,
+so its targets are measurement-record references. With one argument the
+flip is symmetric; with two, a recorded 0 flips with probability `p01` and
+a recorded 1 with probability `p10`. Record targets do not take the `!`
+inversion marker — swap the two probabilities instead. Noisy measurements
+(e.g., `M(0.01) 0`) are parser shorthand for a clean measurement followed
+by `READOUT_NOISE(0.01) rec[-1]`.
 
 `DEPOLARIZE3(p) a b c` applies one of the 63 non-identity Pauli products on
 `a,b,c` with probability `p/63` each, and identity with probability `1-p`.

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -121,8 +121,9 @@ enum class GateType : uint16_t {
     CORRELATED_ERROR,       // E(p): correlated Pauli product error
     ELSE_CORRELATED_ERROR,  // Else-branch in a correlated error chain
 
-    // Synthetic gates (emitted by parser, not in input syntax)
-    READOUT_NOISE,  // Classical bit-flip on measurement result
+    // Record-bit noise: emitted by the parser for noisy measurements like
+    // M(p), and also writable directly in circuit text
+    READOUT_NOISE,  // Classical bit-flip on a recorded result
 
     // QEC annotations
     DETECTOR,            // Detector declaration

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -692,8 +692,10 @@ class Parser {
             if (!is_rec_token && gate == GateType::READOUT_NOISE) {
                 throw ParseError("READOUT_NOISE targets must be rec references", line_num);
             }
-            if ((gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) &&
-                (is_rec_token || token[0] == '!')) {
+            // '!' marks measurement-record inversion, which has no meaning
+            // on a transition or loss site. (Record targets on these gates
+            // are rejected by the rec-token check above.)
+            if ((gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) && token[0] == '!') {
                 throw ParseError(
                     std::string(clifft::gate_name(gate)) + " targets must be plain qubit indices",
                     line_num);

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1963,4 +1963,5 @@ TEST_CASE("LOSS parses its probability and rejects bad forms") {
     CHECK_THROWS_AS(parse("LOSS 0\n"), ParseError);       // missing probability
     CHECK_THROWS_AS(parse("LOSS(1.5) 0\n"), ParseError);  // out of range
     CHECK_THROWS_AS(parse("LOSS(0.1, 0.2) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LOSS(0.1) !0\n"), ParseError);  // inverted target
 }


### PR DESCRIPTION
> **Prototype note:** this targets the `codex/noncomputational-structural-mvp` feature branch — prototype code under less-strict review.

## Summary

Cleanup from the final branch review (the parser region around `parse_standard_gate`'s target loop):

- **Prune the dead half of the LEVEL_TRANSITION/LOSS target check.** The generic rec-token check earlier in the loop rejects record targets on these gates first (verified: `LEVEL_TRANSITION[t] rec[-1]` throws the generic message), so the `is_rec_token` half of the condition could never fire. It now tests only the `!` inversion marker, with a comment stating the semantic reason (inversion is a measurement-record concept with no meaning on a transition or loss site). The existing `LEVEL_TRANSITION[t] !0` rejection test still covers it, and `LOSS(0.1) !0` gains the missing twin.
- **Document READOUT_NOISE as directly writable.** Both text forms parse deliberately — `READOUT_NOISE(p) rec[-k]` and the two-argument asymmetric `READOUT_NOISE(p01, p10)` added with the local-annotation work — but `gate_data.h` still said "not in input syntax" and the gates reference mentioned it only as an internal detail of `M(p)` shorthand. The gates page now has a proper entry (record targets, one-argument symmetric flip, `p01`/`p10` convention verified against the frontend lowering, the no-inversion rule), and the enum comment states the real contract. The text forms were already covered by parser tests.

The general inverted-target question (`H !0` parses; stim rejects it) is filed separately as #212 — it is pre-existing main behavior, best fixed after this branch merges, at which point it subsumes the special-case check touched here.

Verified: 1094/1094 via ctest in Debug and Release, 924 Python on both size-verified wheels, doc codeblocks pass, `mkdocs build --strict` clean, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
