### PR TITLE
refactor(noncomp): clarify instrument representation

### DIFF
--- a/docs/opcodes.json
+++ b/docs/opcodes.json
@@ -177,13 +177,13 @@
     "OP_INSTRUMENT_ACTIVE": {
       "category": "Instrument",
       "summary": "State-dependent jump site on an active axis: fused damp + evaluate, then the fire branch.",
-      "detail": "One array pass accumulates the pre-damp source populations while applying the no-fire damping filter diag(r_g, r_e); the fire branch is drawn from the populations. A computational-destination fire collapses in place (no compaction, any axis) and applies the site's virtualized Pauli fixup; a leaked/lost destination is a resumable trap. The ConstantPool instrument site carries the fire-branch probabilities.",
+      "detail": "One array pass accumulates the pre-damp source populations while applying the no-fire damping filter diag(r_g, r_e); the fire branch is drawn from the populations. A computational-destination fire collapses in place (no compaction, any axis) and applies the site's virtualized Pauli destination flip; a leaked/lost destination is a resumable trap. The ConstantPool instrument site carries the fire-branch probabilities.",
       "operands": "axis_1, instrument.cp_site_idx, instrument.r_g, instrument.r_e"
     },
     "OP_INSTRUMENT_DORMANT_STATIC": {
       "category": "Instrument",
       "summary": "State-dependent jump site on a frame-deterministic dormant qubit.",
-      "detail": "The source level is read from the Pauli frame bit, so the fire draw is a plain Bernoulli at that source's rate and the no-fire damp is a scalar that normalizes away. Computational fires resolve through the frame fixup; leaked/lost fires trap.",
+      "detail": "The source level is read from the Pauli frame bit, so the fire draw is a plain Bernoulli at that source's rate and the no-fire damp is a scalar that normalizes away. Computational fires resolve through the frame destination flip; leaked/lost fires trap.",
       "operands": "axis_1, instrument.cp_site_idx"
     },
     "OP_INSTRUMENT_EXPAND": {
@@ -349,7 +349,7 @@
     "INSTRUMENT": {
       "category": "Instrument",
       "summary": "State-dependent jump site: a transition instrument on one qubit, positioned where it fires.",
-      "detail": "Carries the rewound source projector Z_q as its Pauli mask (conjugated through the tableau exactly like a measurement mask) and references an InstrumentSite side-table entry with the per-source fire probabilities, computational-destination splits, and damp coefficients. Instruments are optimization fences: no pass moves any operation across one, which is what makes trap re-entry's prefix-identity contract hold.",
+      "detail": "Carries the rewound source observable Z_q as its Pauli mask (conjugated through the tableau exactly like a measurement mask) and references an InstrumentSite side-table entry with the per-source fire probabilities and computational-destination splits. The noncomputational destination probability is their remainder; no-fire damp coefficients are derived during lowering. Instruments are optimization fences: no pass moves any operation across one, which is what makes trap re-entry's prefix-identity contract hold.",
       "display": [
         "INSTRUMENT"
       ]

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -106,16 +106,11 @@ p_N(s)
   + T[\mathrm{lost}][s].
 $$
 
-Clifft keeps this split at a live computational site: the simulator resolves
-the source and any `g`/`e` destination inline, while a noncomputational
-destination transfers control to the trajectory driver, which selects the
-specific level from the original matrix. Once a source is already
-noncomputational, its matrix column is consulted entirely by the classical
-driver. The transition matrix supplies these scalar weights; the source
-projectors and a possible `g`/`e` destination flip are quantum operations on
-the live state. The no-fire probability is $1-p_{\mathrm{fire}}(s)$. In
-particular, a diagonal entry $T[s][s]$ is still a fire event that lands back on
-its source; it is not part of the no-fire branch.
+The no-jump probability from $s$ is $1-p_{\mathrm{fire}}(s)$. A diagonal
+entry $T[s][s]$ is still a jump event that lands back on its source; it is not
+part of the no-jump branch. The matrix entries are branch weights. A jump from
+a computational source acts on the live quantum state, while a jump from a
+noncomputational source can be sampled from its already definite level.
 
 A measurement classifier $P[\mathrm{symbol}][\mathrm{level}]$ defines the
 recorded result for each level. It has two binary record symbols and may have
@@ -190,6 +185,15 @@ Ordinary Clifft compiles a circuit once and reuses the program for many shots.
 The compiler absorbs deterministic Clifford evolution into an offline frame,
 localizes the remaining Pauli operations, and emits bytecode for the factored
 Schrodinger virtual machine.
+
+For a transition on a computational site, the compiled program carries the
+total jump probability for each computational source and the separate weights
+for `g` and `e` destinations. Their remainder is the combined weight for
+`leak_g`, `leak_e`, and `lost`. The virtual machine handles a computational
+destination directly. For a noncomputational destination, it returns control
+to the trajectory driver, which chooses the specific level from the original
+five-level matrix. Transitions whose source is already noncomputational are
+handled while constructing the trajectory-specific continuation.
 
 A noncomputational jump can change which later gates are skipped, which measurements use the classifier, and whether a site returns to the computational state. Those choices depend on the live state and differ between shots, so one model-independent program cannot describe every trajectory. `noncomp.sample` therefore interleaves execution with compilation of trajectory-specific continuations. A continuation is the circuit rewritten and compiled for the noncomputational events observed so far and the resulting status ledger. Its prefix matches the program already executed, while its remaining operations reflect the updated trajectory.
 

--- a/docs/theory/noncomputational.md
+++ b/docs/theory/noncomputational.md
@@ -85,6 +85,38 @@ they project onto their source level. The unused probability in a column is the
 no-jump probability. For computational sources, these probabilities define the
 jump and no-jump Kraus branches described below.
 
+For a computational source $s \in \{g,e\}$, define its total fire
+probability and its computational-destination probabilities by
+
+$$
+p_{\mathrm{fire}}(s) = \sum_{\ell} T[\ell][s],
+\qquad
+p_{\mathrm{comp}}(s \mathbin{\to} d) = T[d][s],
+\quad d \in \{g,e\}.
+$$
+
+The unconditional probability of firing into the noncomputational subspace is
+the remainder
+
+$$
+p_N(s)
+= p_{\mathrm{fire}}(s) - T[g][s] - T[e][s]
+= T[\mathrm{leak\_g}][s]
+  + T[\mathrm{leak\_e}][s]
+  + T[\mathrm{lost}][s].
+$$
+
+Clifft keeps this split at a live computational site: the simulator resolves
+the source and any `g`/`e` destination inline, while a noncomputational
+destination transfers control to the trajectory driver, which selects the
+specific level from the original matrix. Once a source is already
+noncomputational, its matrix column is consulted entirely by the classical
+driver. The transition matrix supplies these scalar weights; the source
+projectors and a possible `g`/`e` destination flip are quantum operations on
+the live state. The no-fire probability is $1-p_{\mathrm{fire}}(s)$. In
+particular, a diagonal entry $T[s][s]$ is still a fire event that lands back on
+its source; it is not part of the no-fire branch.
+
 A measurement classifier $P[\mathrm{symbol}][\mathrm{level}]$ defines the
 recorded result for each level. It has two binary record symbols and may have
 a third herald symbol, typically for loss. For example, the `leak_g` column

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -688,7 +688,8 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
     ctx.constant_pool.pauli_masks = PauliMaskArena(n, num_apply_paulis);
     ctx.constant_pool.exp_val_masks = PauliMaskArena(n, num_exp_val_masks);
     ctx.constant_pool.noise_channel_masks = PauliMaskArena(n, num_noise_channels);
-    ctx.constant_pool.instrument_fixup_masks = PauliMaskArena(n, hir.instrument_sites.size());
+    ctx.constant_pool.instrument_destination_flip_masks =
+        PauliMaskArena(n, hir.instrument_sites.size());
     size_t next_cp_pauli = 0;
     size_t next_cp_exp_val = 0;
     size_t next_cp_noise = 0;
@@ -977,7 +978,8 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                     opcode = Opcode::OP_INSTRUMENT_ACTIVE;
                 } else if (result.basis == LocalizedBasis::Z_BASIS) {
                     opcode = Opcode::OP_INSTRUMENT_DORMANT_STATIC;
-                } else if (site.neglect_damping || site.p_total[0] == site.p_total[1]) {
+                } else if (hir.neglect_instrument_damping ||
+                           site.probabilities.p_fire[0] == site.probabilities.p_fire[1]) {
                     // No expansion: the qubit stays out of the amplitude
                     // array, a no-fire leaves the state untouched, and every
                     // fire traps to the driver (an in-line collapse would
@@ -1004,37 +1006,33 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
                     opcode = Opcode::OP_INSTRUMENT_EXPAND;
                 }
 
-                // Destination fixup: the site's rewound X observable,
+                // Destination flip: the site's rewound X observable,
                 // virtualized through the frame as it stands after the
                 // localization and basis emissions, so XORing it into the
                 // runtime Pauli frame is correct at the instrument
                 // instruction's position.
                 {
-                    auto hir_fixup = hir.pauli_masks.at(site.fixup_mask);
-                    auto fixup_v =
-                        map_to_virtual(ctx, hir_fixup.x(), hir_fixup.z(), hir_fixup.sign(), n);
-                    auto slot = ctx.constant_pool.instrument_fixup_masks.mut_at(
+                    auto hir_flip = hir.pauli_masks.at(site.destination_flip_mask);
+                    auto flip_v =
+                        map_to_virtual(ctx, hir_flip.x(), hir_flip.z(), hir_flip.sign(), n);
+                    auto slot = ctx.constant_pool.instrument_destination_flip_masks.mut_at(
                         static_cast<PauliMaskHandle>(hir_site_idx));
-                    stim_to_mask_view(fixup_v.xs, n, slot.x());
-                    stim_to_mask_view(fixup_v.zs, n, slot.z());
-                    slot.set_sign(fixup_v.sign);
+                    stim_to_mask_view(flip_v.xs, n, slot.x());
+                    stim_to_mask_view(flip_v.zs, n, slot.z());
+                    slot.set_sign(flip_v.sign);
                 }
 
                 CompiledInstrumentSite compiled;
                 compiled.site_id = hir_site_idx;
-                for (int s = 0; s < 2; ++s) {
-                    compiled.p_total[s] = site.p_total[s];
-                    compiled.p_dest[s][0] = site.p_dest[s][0];
-                    compiled.p_dest[s][1] = site.p_dest[s][1];
-                }
-                compiled.fixup_mask = static_cast<PauliMaskHandle>(hir_site_idx);
-                compiled.neglect_damping = site.neglect_damping;
+                compiled.probabilities = site.probabilities;
+                compiled.destination_flip_mask = static_cast<PauliMaskHandle>(hir_site_idx);
                 const auto cp_idx =
                     static_cast<uint32_t>(ctx.constant_pool.instrument_sites.size());
                 ctx.constant_pool.instrument_sites.push_back(compiled);
 
-                ctx.emit(make_instrument(opcode, result.pivot, cp_idx, result.sign, site.damp[0],
-                                         site.damp[1]));
+                const double r_g = std::sqrt(1.0 - site.probabilities.p_fire[0]);
+                const double r_e = std::sqrt(1.0 - site.probabilities.p_fire[1]);
+                ctx.emit(make_instrument(opcode, result.pivot, cp_idx, result.sign, r_g, r_e));
 
                 if (opcode == Opcode::OP_INSTRUMENT_EXPAND) {
                     ctx.reg_manager.activate();

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -172,7 +172,7 @@ struct alignas(32) Instruction {
         } exp_val;
 
         // Variant H: Instrument site (OP_INSTRUMENT_*). r_g/r_e are the
-        // no-fire damp coefficients sqrt(1 - p_total[s]), physical order
+        // no-fire damp coefficients sqrt(1 - p_fire[s]), physical order
         // (the localization sign rides in FLAG_SIGN); unused by the
         // dormant variants.
         struct {
@@ -280,24 +280,20 @@ struct FusedU4Node {
     Entry entries[16];  // Indexed by 4-bit incoming frame state
 };
 
-// Compiled instrument site: the fire-branch data the dispatcher reads only
-// when a fire is drawn (the hot no-fire path reads just the instruction
-// payload). Probabilities are physical (source/destination index 0 is the
-// |0> level); the localization sign lives on the instruction. site_id is
-// the HirModule::instrument_sites index and keys the compiled module's
-// instrument_offsets table and the trap protocol.
+// Compiled instrument site: probabilities are physical
+// (source/destination index 0 is the |0> level); the localization sign lives
+// on the instruction. site_id is the HirModule::instrument_sites index and
+// keys the compiled module's instrument_offsets table and trap protocol.
 struct CompiledInstrumentSite {
     uint32_t site_id = 0;
-    double p_total[2] = {0.0, 0.0};
-    double p_dest[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
 
     // Virtualized X_q at the site (handle into
-    // ConstantPool::instrument_fixup_masks): the destination fixup for an
-    // in-line computational fire whose destination differs from its
-    // source, XORed into the Pauli frame.
-    PauliMaskHandle fixup_mask{};
+    // ConstantPool::instrument_destination_flip_masks): the destination
+    // flip for an in-line computational fire whose destination differs
+    // from its source, XORed into the Pauli frame.
+    PauliMaskHandle destination_flip_mask{};
 
-    bool neglect_damping = false;
+    InstrumentProbabilities probabilities;
 };
 
 struct ConstantPool {
@@ -330,9 +326,9 @@ struct ConstantPool {
     std::vector<ReadoutNoiseEntry> readout_noise;
 
     // Instrument sites for OP_INSTRUMENT_*, and the arena holding their
-    // virtualized destination-fixup masks.
+    // virtualized destination-flip masks.
     std::vector<CompiledInstrumentSite> instrument_sites;
-    PauliMaskArena instrument_fixup_masks;
+    PauliMaskArena instrument_destination_flip_masks;
 
     // Target lists for detector parity checks
     std::vector<std::vector<uint32_t>> detector_targets;
@@ -366,8 +362,8 @@ inline void assert_arena_widths_match(uint32_t num_qubits, const ConstantPool& p
            "exp_val_masks arena width does not match num_qubits");
     assert(pool.noise_channel_masks.num_words() == expected &&
            "noise_channel_masks arena width does not match num_qubits");
-    assert(pool.instrument_fixup_masks.num_words() == expected &&
-           "instrument_fixup_masks arena width does not match num_qubits");
+    assert(pool.instrument_destination_flip_masks.num_words() == expected &&
+           "instrument_destination_flip_masks arena width does not match num_qubits");
 }
 
 // =============================================================================

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -2,8 +2,8 @@
 
 #include "stim.h"
 
-#include <bit>
 #include <cmath>
+#include <cstring>
 #include <initializer_list>
 #include <limits>
 #include <numbers>
@@ -412,9 +412,13 @@ void validate_instrument_probabilities(const InstrumentProbabilities& probabilit
     static_assert(std::numeric_limits<double>::is_iec559,
                   "instrument probabilities require IEEE 754 doubles");
     constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    // Keep this at least as loose as the model layer's kProbTolerance.
+    // TransitionInstrument clamps column sums within that tolerance to 1.
     constexpr double kTolerance = 1e-12;
     auto finite = [](double value) {
-        return (std::bit_cast<uint64_t>(value) & kExpMask) != kExpMask;
+        uint64_t bits;
+        std::memcpy(&bits, &value, sizeof(bits));
+        return (bits & kExpMask) != kExpMask;
     };
 
     for (uint8_t source = 0; source < 2; ++source) {

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -2,8 +2,10 @@
 
 #include "stim.h"
 
+#include <bit>
 #include <cmath>
 #include <initializer_list>
+#include <limits>
 #include <numbers>
 #include <random>
 #include <stdexcept>
@@ -371,7 +373,7 @@ size_t count_pauli_masks(const Circuit& circuit) {
             case GateType::LEVEL_TRANSITION:
             case GateType::LOSS:
                 // Two masks per materialized instrument site: the rewound
-                // source projector on the op, and the rewound X fixup in
+                // source projector on the op, and the rewound X destination flip in
                 // the side-table. Counted unconditionally: without
                 // instrument options these gates reject before claiming,
                 // and an over-sized arena is harmless.
@@ -399,6 +401,49 @@ size_t count_pauli_masks(const Circuit& circuit) {
     return count;
 }
 
+// InstrumentTraceOptions is a C++ trace boundary in its own right, even
+// though the noncomputational model normally constructs it from already
+// validated matrices. Validate raw specs here so a malformed compressed
+// payload cannot produce a negative square root or an invalid destination
+// draw downstream. Release builds use -ffast-math, so inspect IEEE 754 bits
+// instead of relying on std::isfinite().
+void validate_instrument_probabilities(const InstrumentProbabilities& probabilities,
+                                       const std::string& site) {
+    static_assert(std::numeric_limits<double>::is_iec559,
+                  "instrument probabilities require IEEE 754 doubles");
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    constexpr double kTolerance = 1e-12;
+    auto finite = [](double value) {
+        return (std::bit_cast<uint64_t>(value) & kExpMask) != kExpMask;
+    };
+
+    for (uint8_t source = 0; source < 2; ++source) {
+        const double p_fire = probabilities.p_fire[source];
+        if (!finite(p_fire) || p_fire < 0.0 || p_fire > 1.0) {
+            throw std::invalid_argument("trace: " + site + " has invalid p_fire[" +
+                                        std::to_string(source) + "] = " + std::to_string(p_fire));
+        }
+
+        double p_computational = 0.0;
+        for (uint8_t destination = 0; destination < 2; ++destination) {
+            const double p = probabilities.p_computational_dest[source][destination];
+            if (!finite(p) || p < 0.0 || p > 1.0) {
+                throw std::invalid_argument(
+                    "trace: " + site + " has invalid p_computational_dest[" +
+                    std::to_string(source) + "][" + std::to_string(destination) +
+                    "] = " + std::to_string(p));
+            }
+            p_computational += p;
+        }
+        if (p_computational > p_fire + kTolerance) {
+            throw std::invalid_argument("trace: " + site +
+                                        " has computational destination probability " +
+                                        std::to_string(p_computational) + " above p_fire[" +
+                                        std::to_string(source) + "] = " + std::to_string(p_fire));
+        }
+    }
+}
+
 }  // namespace
 
 HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instruments) {
@@ -415,6 +460,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
     hir.num_detectors = circuit.num_detectors;
     hir.num_observables = circuit.num_observables;
     hir.num_exp_vals = circuit.num_exp_vals;
+    hir.neglect_instrument_damping =
+        instruments != nullptr && instruments->neglect_instrument_damping;
 
     std::mt19937_64 rng(0);
     stim::TableauSimulator<kStimWidth> sim(std::move(rng), circuit.num_qubits);
@@ -773,7 +820,7 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     const uint32_t qubit = target.value();
                     InstrumentSite site;
                     site.qubit = qubit;
-                    site.neglect_damping = instruments->neglect_damping;
+                    std::string site_description;
                     if (node.gate == GateType::LOSS) {
                         // Uniform loss: source-independent rate, destination
                         // entirely the trap remainder. A missing argument is
@@ -784,8 +831,9 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                                 " requires exactly one argument (the loss probability)");
                         }
                         const double p = node.args[0];
-                        site.p_total[0] = p;
-                        site.p_total[1] = p;
+                        site.probabilities.p_fire[0] = p;
+                        site.probabilities.p_fire[1] = p;
+                        site_description = "LOSS at line " + std::to_string(node.source_line);
                     } else {
                         const auto it = instruments->transitions.find(node.tag);
                         if (it == instruments->transitions.end()) {
@@ -795,27 +843,26 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                                 " does not name a transition in the instrument options");
                         }
                         const InstrumentSpec& spec = it->second;
-                        for (int s = 0; s < 2; ++s) {
-                            site.p_total[s] = spec.p_total[s];
-                            site.p_dest[s][0] = spec.p_dest[s][0];
-                            site.p_dest[s][1] = spec.p_dest[s][1];
-                        }
+                        site.probabilities = spec;
+                        site_description = "LEVEL_TRANSITION[" + node.tag + "] at line " +
+                                           std::to_string(node.source_line);
                     }
+                    validate_instrument_probabilities(site.probabilities, site_description);
                     // A site that can never fire is the identity channel.
-                    if (site.p_total[0] == 0.0 && site.p_total[1] == 0.0) {
+                    if (site.probabilities.p_fire[0] == 0.0 &&
+                        site.probabilities.p_fire[1] == 0.0) {
                         continue;
                     }
-                    site.damp[0] = std::sqrt(1.0 - site.p_total[0]);
-                    site.damp[1] = std::sqrt(1.0 - site.p_total[1]);
 
-                    // Destination fixup: the rewound X observable, stored
+                    // Destination flip: the rewound X observable, stored
                     // in the arena so downstream mask conjugation can
                     // reach it through the side-table handle.
-                    site.fixup_mask = hir.claim_side_mask([&](MutablePauliMaskView slot) {
-                        bool sign;
-                        extract_rewound_x_into(sim, qubit, slot.x(), slot.z(), sign);
-                        slot.set_sign(sign);
-                    });
+                    site.destination_flip_mask =
+                        hir.claim_side_mask([&](MutablePauliMaskView slot) {
+                            bool sign;
+                            extract_rewound_x_into(sim, qubit, slot.x(), slot.z(), sign);
+                            slot.set_sign(sign);
+                        });
 
                     const InstrumentSiteIdx site_idx{
                         static_cast<uint32_t>(hir.instrument_sites.size())};

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -1,11 +1,11 @@
 #include "clifft/frontend/frontend.h"
 
+#include "clifft/util/numeric.h"
+
 #include "stim.h"
 
 #include <cmath>
-#include <cstring>
 #include <initializer_list>
-#include <limits>
 #include <numbers>
 #include <random>
 #include <stdexcept>
@@ -409,21 +409,13 @@ size_t count_pauli_masks(const Circuit& circuit) {
 // instead of relying on std::isfinite().
 void validate_instrument_probabilities(const InstrumentProbabilities& probabilities,
                                        const std::string& site) {
-    static_assert(std::numeric_limits<double>::is_iec559,
-                  "instrument probabilities require IEEE 754 doubles");
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
     // Keep this at least as loose as the model layer's kProbTolerance.
     // TransitionInstrument clamps column sums within that tolerance to 1.
     constexpr double kTolerance = 1e-12;
-    auto finite = [](double value) {
-        uint64_t bits;
-        std::memcpy(&bits, &value, sizeof(bits));
-        return (bits & kExpMask) != kExpMask;
-    };
 
     for (uint8_t source = 0; source < 2; ++source) {
         const double p_fire = probabilities.p_fire[source];
-        if (!finite(p_fire) || p_fire < 0.0 || p_fire > 1.0) {
+        if (!is_finite_robust(p_fire) || p_fire < 0.0 || p_fire > 1.0) {
             throw std::invalid_argument("trace: " + site + " has invalid p_fire[" +
                                         std::to_string(source) + "] = " + std::to_string(p_fire));
         }
@@ -431,7 +423,7 @@ void validate_instrument_probabilities(const InstrumentProbabilities& probabilit
         double p_computational = 0.0;
         for (uint8_t destination = 0; destination < 2; ++destination) {
             const double p = probabilities.p_computational_dest[source][destination];
-            if (!finite(p) || p < 0.0 || p > 1.0) {
+            if (!is_finite_robust(p) || p < 0.0 || p > 1.0) {
                 throw std::invalid_argument(
                     "trace: " + site + " has invalid p_computational_dest[" +
                     std::to_string(source) + "][" + std::to_string(destination) +
@@ -846,8 +838,7 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                                 std::to_string(node.source_line) +
                                 " does not name a transition in the instrument options");
                         }
-                        const InstrumentSpec& spec = it->second;
-                        site.probabilities = spec;
+                        site.probabilities = it->second;
                         site_description = "LEVEL_TRANSITION[" + node.tag + "] at line " +
                                            std::to_string(node.source_line);
                     }

--- a/src/clifft/frontend/frontend.h
+++ b/src/clifft/frontend/frontend.h
@@ -25,20 +25,13 @@
 
 namespace clifft {
 
-// Per-transition probabilities for materializing LEVEL_TRANSITION
-// annotations into INSTRUMENT ops. InstrumentProbabilities documents the
-// exact five-level-matrix compression. The alias names this payload's role at
-// the trace boundary while keeping InstrumentSpec and InstrumentSite on one
-// shared representation. The front-end remains model-free: the
-// noncomputational layer resolves matrices into these plain numbers through
-// instrument_trace_options().
-using InstrumentSpec = InstrumentProbabilities;
-
 // Opt-in instrument materialization for trace(). `transitions` maps a
 // LEVEL_TRANSITION tag to its spec; LOSS needs no entry (its probability
 // is inline and its destination is entirely the trap remainder).
 struct InstrumentTraceOptions {
-    std::map<std::string, InstrumentSpec, std::less<>> transitions;
+    // The front-end remains model-free: the noncomputational layer compresses
+    // each five-level matrix into InstrumentProbabilities before tracing.
+    std::map<std::string, InstrumentProbabilities, std::less<>> transitions;
 
     // damping="neglect": dormant-random sites skip the expansion and the
     // no-fire back-action. trace() copies this module-wide setting once to

--- a/src/clifft/frontend/frontend.h
+++ b/src/clifft/frontend/frontend.h
@@ -26,16 +26,13 @@
 namespace clifft {
 
 // Per-transition probabilities for materializing LEVEL_TRANSITION
-// annotations into INSTRUMENT ops, in the InstrumentSite convention
-// (source/destination index 0 is the |0> level, 1 the |1> level; the
-// per-source trap remainder is p_total[s] - p_dest[s][0] - p_dest[s][1]).
-// The front-end knows nothing of level tables or transition matrices:
-// the noncomputational layer resolves a model into these plain numbers
-// (instrument_trace_options() in noncomp/instrument_options.h).
-struct InstrumentSpec {
-    double p_total[2] = {0.0, 0.0};
-    double p_dest[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
-};
+// annotations into INSTRUMENT ops. InstrumentProbabilities documents the
+// exact five-level-matrix compression. The alias names this payload's role at
+// the trace boundary while keeping InstrumentSpec and InstrumentSite on one
+// shared representation. The front-end remains model-free: the
+// noncomputational layer resolves matrices into these plain numbers through
+// instrument_trace_options().
+using InstrumentSpec = InstrumentProbabilities;
 
 // Opt-in instrument materialization for trace(). `transitions` maps a
 // LEVEL_TRANSITION tag to its spec; LOSS needs no entry (its probability
@@ -44,8 +41,9 @@ struct InstrumentTraceOptions {
     std::map<std::string, InstrumentSpec, std::less<>> transitions;
 
     // damping="neglect": dormant-random sites skip the expansion and the
-    // no-fire back-action. Copied onto every materialized site.
-    bool neglect_damping = false;
+    // no-fire back-action. trace() copies this module-wide setting once to
+    // HirModule::neglect_instrument_damping.
+    bool neglect_instrument_damping = false;
 
     // When set, trace() reports the hidden measurement slot it assigns to
     // the reset at this node index (in the circuit being traced) through

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -18,6 +18,7 @@
 
 #include "stim.h"
 
+#include <algorithm>
 #include <cassert>
 #include <complex>
 #include <cstddef>
@@ -103,41 +104,69 @@ inline constexpr PauliMaskHandle kNoMask = static_cast<PauliMaskHandle>(~uint32_
 // Instrument Sites
 // =============================================================================
 //
-// An InstrumentSite is one state-dependent jump site on one qubit: a
-// transition from the noncomputational trajectory model (leakage, loss,
-// relaxation) whose firing probability depends on the qubit's
-// computational level. It carries the per-source fire probabilities,
-// split into computational-destination jumps (resolved in-line by the VM)
-// and the leaked/lost remainder (a resumable trap). The op's Pauli mask is
-// the source projector Z_q rewound through the trace tableau, exactly like
-// a measurement mask. Source index 0 is the |0> (g) level, 1 is |1> (e).
+// A five-level transition matrix T[to][from] is compressed before it reaches
+// the HIR because only the computational source levels remain quantum. For
+// each source s in {G, E}, InstrumentProbabilities stores
+//
+//   p_fire[s]                  = sum_to T[to][s]
+//   p_computational_dest[s][d] = T[d][s], d in {G, E}
+//
+// and therefore
+//
+//   p_noncomputational_dest[s]
+//       = p_fire[s]
+//         - p_computational_dest[s][G]
+//         - p_computational_dest[s][E].
+//
+// The last quantity aggregates destinations LeakG, LeakE, and Lost. A fire
+// into that remainder traps to the exact-mode driver, which consults the
+// original matrix to choose the specific noncomputational destination.
+// Columns whose source is already noncomputational are handled classically
+// by the driver and never enter this HIR representation. The no-fire
+// probability is 1 - p_fire[s]; a diagonal matrix entry is still a fire
+// that lands back on its source, not the no-fire branch.
+//
+// The probabilities are scalar weights, not quantum operators. An
+// INSTRUMENT op's own Pauli mask is the source observable Z_q rewound through
+// the trace tableau; its +/- eigenspaces supply the G/E source projectors.
+// InstrumentSite::destination_flip_mask is the separately rewound X_q,
+// applied when an in-line computational destination differs from the
+// collapsed source. Source/destination index 0 is G = |0>, 1 is E = |1>.
+
+struct InstrumentProbabilities {
+    // Total fire probability for each computational source.
+    double p_fire[2] = {0.0, 0.0};
+
+    // Unconditional fire probability from source s to computational
+    // destination d. Dividing by p_fire[s] gives the destination
+    // probability conditioned on a fire from s.
+    double p_computational_dest[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
+
+    [[nodiscard]] double p_noncomputational_dest(uint8_t source) const {
+        assert(source < 2 && "instrument source must be G or E");
+        const double remainder =
+            p_fire[source] - p_computational_dest[source][0] - p_computational_dest[source][1];
+        // Model validation permits derived column sums to drift within its
+        // probability tolerance. Do not expose a tiny negative trap weight.
+        return std::max(0.0, remainder);
+    }
+};
+
+// One state-dependent jump site on one qubit. The probability payload is
+// the quantum-source compression above; qubit and destination_flip_mask
+// supply the site-specific carrier operation.
 
 struct InstrumentSite {
     uint32_t qubit = 0;  // Physical qubit, for suffix rewrites + diagnostics
 
     // The rewound X observable of the qubit at the site (same tableau
-    // conjugation as the op's Z-projector mask): the destination fixup a
+    // conjugation as the op's Z-projector mask): the destination flip a
     // computational fire applies when its destination differs from its
     // source. Handle into HirModule::pauli_masks. Passes that conjugate
     // the op's mask must conjugate this slot identically.
-    PauliMaskHandle fixup_mask = kNoMask;
+    PauliMaskHandle destination_flip_mask = kNoMask;
 
-    // Total fire probability per computational source s.
-    double p_total[2] = {0.0, 0.0};
-
-    // p_dest[s][d]: probability that a fire from source s lands on
-    // computational level d. The trap (Leaked/Lost) remainder per source
-    // is p_total[s] - p_dest[s][0] - p_dest[s][1].
-    double p_dest[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
-
-    // No-fire damp coefficients sqrt(1 - p_total[s]).
-    double damp[2] = {1.0, 1.0};
-
-    // Under damping="neglect", a dormant-random site skips the expansion
-    // and applies no no-fire back-action (see DampingPolicy in
-    // noncomp/policy.h). Baked in at materialization from the model
-    // policy.
-    bool neglect_damping = false;
+    InstrumentProbabilities probabilities;
 };
 
 // Operation types in the HIR
@@ -415,6 +444,12 @@ struct HirModule {
     uint32_t num_observables = 0;
     uint32_t num_exp_vals = 0;
 
+    // Under damping="neglect", dormant-random instrument sites skip the
+    // expansion and apply no no-fire back-action. The noncomputational
+    // policy is module-wide, so trace() records it once rather than on every
+    // InstrumentSite.
+    bool neglect_instrument_damping = false;
+
     std::complex<double> global_weight = {1.0, 0.0};
 
     /// Parallel to ops: source_map[i] lists the source line(s) that
@@ -527,7 +562,7 @@ struct HirModule {
     }
 
     /// Claim a pauli_masks slot referenced from a side-table entry rather
-    /// than an op (e.g. an instrument's destination fixup), filled via the
+    /// than an op (e.g. an instrument's destination flip), filled via the
     /// callable like the append_* builders.
     template <typename Fill>
     PauliMaskHandle claim_side_mask(Fill&& fill) {

--- a/src/clifft/noncomp/instrument_options.cc
+++ b/src/clifft/noncomp/instrument_options.cc
@@ -9,7 +9,7 @@ InstrumentTraceOptions instrument_trace_options(const NonComputationalModel& mod
     options.neglect_instrument_damping = model.policy().damping == DampingPolicy::Neglect;
 
     for (const auto& [name, instrument] : model.transitions()) {
-        InstrumentSpec spec;
+        InstrumentProbabilities probabilities;
         // Compress only the columns whose source remains quantum. p_fire
         // retains each full five-level column sum, while
         // p_computational_dest retains its G/E destination entries. Their
@@ -17,13 +17,13 @@ InstrumentTraceOptions instrument_trace_options(const NonComputationalModel& mod
         // Columns sourced at a noncomputational level stay in the model and
         // are consulted classically by the exact-mode driver.
         for (int s = 0; s < 2; ++s) {
-            spec.p_fire[s] = instrument.column_sum(computational[s]);
+            probabilities.p_fire[s] = instrument.column_sum(computational[s]);
             for (int d = 0; d < 2; ++d) {
-                spec.p_computational_dest[s][d] =
+                probabilities.p_computational_dest[s][d] =
                     instrument.prob(computational[d], computational[s]);
             }
         }
-        options.transitions.emplace(name, spec);
+        options.transitions.emplace(name, probabilities);
     }
     return options;
 }

--- a/src/clifft/noncomp/instrument_options.cc
+++ b/src/clifft/noncomp/instrument_options.cc
@@ -6,14 +6,21 @@ InstrumentTraceOptions instrument_trace_options(const NonComputationalModel& mod
     constexpr Level computational[2] = {Level::G, Level::E};
 
     InstrumentTraceOptions options;
-    options.neglect_damping = model.policy().damping == DampingPolicy::Neglect;
+    options.neglect_instrument_damping = model.policy().damping == DampingPolicy::Neglect;
 
     for (const auto& [name, instrument] : model.transitions()) {
         InstrumentSpec spec;
+        // Compress only the columns whose source remains quantum. p_fire
+        // retains each full five-level column sum, while
+        // p_computational_dest retains its G/E destination entries. Their
+        // difference is the aggregate LeakG/LeakE/Lost trap probability.
+        // Columns sourced at a noncomputational level stay in the model and
+        // are consulted classically by the exact-mode driver.
         for (int s = 0; s < 2; ++s) {
-            spec.p_total[s] = instrument.column_sum(computational[s]);
+            spec.p_fire[s] = instrument.column_sum(computational[s]);
             for (int d = 0; d < 2; ++d) {
-                spec.p_dest[s][d] = instrument.prob(computational[d], computational[s]);
+                spec.p_computational_dest[s][d] =
+                    instrument.prob(computational[d], computational[s]);
             }
         }
         options.transitions.emplace(name, spec);

--- a/src/clifft/noncomp/instrument_options.h
+++ b/src/clifft/noncomp/instrument_options.h
@@ -1,11 +1,11 @@
 #pragma once
 
 // Bridge from a NonComputationalModel to the front-end's instrument
-// materialization: resolve every named transition into the plain
-// per-computational-source probabilities trace() consumes, and bake in
-// the model's damping policy. The front-end stays model-free -- level
-// tables, transition matrices, and policy enums never cross this
-// boundary, only InstrumentSpec numbers.
+// materialization: compress each named five-level transition matrix into
+// InstrumentSpec's two quantum-source columns, and carry the model-wide
+// damping setting. The front-end stays model-free -- level tables,
+// transition matrices, and policy enums never cross this boundary, only
+// InstrumentSpec numbers.
 
 #include "clifft/frontend/frontend.h"
 #include "clifft/noncomp/model.h"

--- a/src/clifft/noncomp/instrument_options.h
+++ b/src/clifft/noncomp/instrument_options.h
@@ -2,10 +2,9 @@
 
 // Bridge from a NonComputationalModel to the front-end's instrument
 // materialization: compress each named five-level transition matrix into
-// InstrumentSpec's two quantum-source columns, and carry the model-wide
-// damping setting. The front-end stays model-free -- level tables,
-// transition matrices, and policy enums never cross this boundary, only
-// InstrumentSpec numbers.
+// the two quantum-source columns in InstrumentProbabilities, and carry the
+// model-wide damping setting. The front-end stays model-free -- level tables,
+// transition matrices, and policy enums never cross this boundary.
 
 #include "clifft/frontend/frontend.h"
 #include "clifft/noncomp/model.h"

--- a/src/clifft/noncomp/numeric.h
+++ b/src/clifft/noncomp/numeric.h
@@ -2,30 +2,14 @@
 
 // Shared numeric helpers for noncomputational model validation.
 
-#include <cstdint>
-#include <cstring>
-#include <limits>
+#include "clifft/util/numeric.h"
 
 namespace clifft {
-
-// The IEEE 754 bit tricks below assume that layout. Make it explicit.
-static_assert(std::numeric_limits<double>::is_iec559, "clifft::noncomp requires IEEE 754 doubles");
 
 // Tolerance for derived-quantity bounds (column sums, the
 // initial-state sum, source-independence equality). Raw user-supplied
 // matrix entries are checked strictly against [0, 1]; only quantities
 // derived from them tolerate this much floating drift.
 inline constexpr double kProbTolerance = 1e-12;
-
-// Release builds use -ffast-math, which implies -ffinite-math-only.
-// That folds away std::isfinite() and lets `v >= 0.0 && v <= 1.0`
-// pass NaN through. Inspect the IEEE 754 bit pattern instead: a
-// non-finite double has all exponent bits set.
-inline bool is_finite_robust(double v) {
-    uint64_t bits;
-    std::memcpy(&bits, &v, sizeof(bits));
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
-    return (bits & kExpMask) != kExpMask;
-}
 
 }  // namespace clifft

--- a/src/clifft/optimizer/drop_non_unitary_pass.cc
+++ b/src/clifft/optimizer/drop_non_unitary_pass.cc
@@ -40,6 +40,7 @@ void DropNonUnitaryPass::run(HirModule& hir) {
     hir.num_detectors = 0;
     hir.num_observables = 0;
     hir.num_exp_vals = 0;
+    hir.neglect_instrument_damping = false;
     hir.source_map.clear();
 }
 

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -215,12 +215,12 @@ void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, MaskView x_v, 
                 bool sign_i = m.sign();
                 conjugate_pauli_by_S(x_v, z_v, sign_v, m.x(), m.z(), sign_i, is_dagger);
                 m.set_sign(sign_i);
-                // The site's destination fixup rides in the arena behind a
+                // The site's destination flip rides in the arena behind a
                 // side-table handle; it must track the same frame change
                 // as the op's own mask.
                 const auto& site =
                     hir.instrument_sites[static_cast<uint32_t>(op.instrument_site_idx())];
-                auto f = hir.pauli_masks.mut_at(site.fixup_mask);
+                auto f = hir.pauli_masks.mut_at(site.destination_flip_mask);
                 bool sign_f = f.sign();
                 conjugate_pauli_by_S(x_v, z_v, sign_v, f.x(), f.z(), sign_f, is_dagger);
                 f.set_sign(sign_f);

--- a/src/clifft/svm/svm_instrument_kernels.h
+++ b/src/clifft/svm/svm_instrument_kernels.h
@@ -25,7 +25,7 @@
 // None of these kernels rolls the PRNG: instrument_fire_branch() turns one
 // caller-supplied uniform variate into the branch decision, so every
 // function here is deterministic and directly oracle-testable. The
-// destination fixup for a jump whose destination differs from its source
+// destination flip for a jump whose destination differs from its source
 // is a Pauli and is likewise the caller's, through the existing frame
 // machinery.
 //

--- a/src/clifft/svm/svm_kernels.inl
+++ b/src/clifft/svm/svm_kernels.inl
@@ -1978,16 +1978,18 @@ static inline void exec_readout_noise(SchrodingerState& state, const ConstantPoo
 // dispatch halts with state.pending_trap set.
 
 // Destination of a fire from physical source s: a computational level d
-// in {0, 1} with probability p_dest[s][d] / p_total[s] -- d != s is a
+// in {0, 1} with probability p_computational_dest[s][d] / p_fire[s] -- d != s is a
 // |0> <-> |1> jump, d == s a jump onto the source's own level (pure
-// collapse, no fixup) -- else -1 for the leaked/lost trap remainder.
+// collapse, no destination flip) -- else -1 for the leaked/lost trap remainder.
 static inline int draw_instrument_destination(SchrodingerState& state,
                                               const CompiledInstrumentSite& site, uint8_t source) {
-    const double u = state.random_double() * site.p_total[source];
-    if (u < site.p_dest[source][0]) {
+    const auto& probabilities = site.probabilities;
+    const double u = state.random_double() * probabilities.p_fire[source];
+    if (u < probabilities.p_computational_dest[source][0]) {
         return 0;
     }
-    if (u < site.p_dest[source][0] + site.p_dest[source][1]) {
+    if (u < probabilities.p_computational_dest[source][0] +
+                probabilities.p_computational_dest[source][1]) {
         return 1;
     }
     return -1;
@@ -2004,12 +2006,13 @@ static inline bool instrument_trap(SchrodingerState& state, const CompiledInstru
     return false;
 }
 
-// Destination fixup for an in-line computational fire whose destination
+// Destination flip for an in-line computational fire whose destination
 // differs from its source (a |0> <-> |1> jump): XOR the site's
 // virtualized X_q into the frame.
-static inline void apply_instrument_fixup(SchrodingerState& state, const ConstantPool& pool,
-                                          const CompiledInstrumentSite& site) {
-    auto mask = pool.instrument_fixup_masks.at(site.fixup_mask);
+static inline void apply_instrument_destination_flip(SchrodingerState& state,
+                                                     const ConstantPool& pool,
+                                                     const CompiledInstrumentSite& site) {
+    auto mask = pool.instrument_destination_flip_masks.at(site.destination_flip_mask);
     apply_pauli_to_frame(state, mask.x(), mask.z(), mask.sign());
 }
 
@@ -2028,7 +2031,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
     if (instr.opcode == Opcode::OP_INSTRUMENT_DORMANT_STATIC) {
         const auto source = static_cast<uint8_t>(static_cast<uint8_t>(bit_get(state.p_x, v)) ^
                                                  static_cast<uint8_t>(sign));
-        if (state.random_double() >= site.p_total[source]) {
+        if (state.random_double() >= site.probabilities.p_fire[source]) {
             return true;  // no fire; the definite-source damp is a scalar
         }
         const int dest = draw_instrument_destination(state, site, source);
@@ -2038,7 +2041,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
             return instrument_trap(state, site, source, /*destination_pending=*/false);
         }
         if (dest != source) {
-            apply_instrument_fixup(state, pool, site);
+            apply_instrument_destination_flip(state, pool, site);
         }
         return true;
     }
@@ -2055,12 +2058,12 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         // collapse as a trace-out forced to that source, keeping the
         // fire-side correlations exact (see DampingPolicy in
         // noncomp/policy.h).
-        const double mass = site.p_total[0] + site.p_total[1];
+        const double mass = site.probabilities.p_fire[0] + site.probabilities.p_fire[1];
         if (state.random_double() * 2.0 >= mass) {
             return true;
         }
         const double w = state.random_double() * mass;
-        return instrument_trap(state, site, w < site.p_total[0] ? 0 : 1,
+        return instrument_trap(state, site, w < site.probabilities.p_fire[0] ? 0 : 1,
                                /*destination_pending=*/true);
     }
 
@@ -2080,8 +2083,8 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         // Populations of a dormant-random qubit are exactly half-half, so
         // the branch is drawn before anything is materialized.
         const InstrumentBranch branch =
-            instrument_fire_branch(InstrumentPopulations{1.0, 1.0}, site.p_total[0],
-                                   site.p_total[1], state.random_double());
+            instrument_fire_branch(InstrumentPopulations{1.0, 1.0}, site.probabilities.p_fire[0],
+                                   site.probabilities.p_fire[1], state.random_double());
         if (!branch.fired) {
             if (fused) {
                 exec_instrument_expand_damp(state, v, c_g, c_e);
@@ -2090,7 +2093,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
                 // No-fire with a certain-fire source: the posterior
                 // excludes it. Materialize, then collapse onto the
                 // surviving level.
-                const uint8_t survivor = site.p_total[0] >= 1.0 ? 1 : 0;
+                const uint8_t survivor = site.probabilities.p_fire[0] >= 1.0 ? 1 : 0;
                 exec_instrument_expand_damp(state, v, 1.0, 1.0);
                 const InstrumentPopulations pops = exec_instrument_damp_eval(state, v, 1.0, 1.0);
                 exec_instrument_collapse_active(state, v, static_cast<uint8_t>(survivor ^ sign),
@@ -2112,7 +2115,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
                                    /*destination_pending=*/false);
         }
         if (dest != branch.source) {
-            apply_instrument_fixup(state, pool, site);
+            apply_instrument_destination_flip(state, pool, site);
         }
         return true;
     }
@@ -2124,14 +2127,14 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         std::swap(pops.pop_g, pops.pop_e);
     }
     const double total = pops.pop_g + pops.pop_e;
-    const InstrumentBranch branch =
-        instrument_fire_branch(pops, site.p_total[0], site.p_total[1], state.random_double());
+    const InstrumentBranch branch = instrument_fire_branch(
+        pops, site.probabilities.p_fire[0], site.probabilities.p_fire[1], state.random_double());
     if (!branch.fired) {
         if (fused) {
             state.scale_magnitude(
                 std::sqrt(total / (r_g * r_g * pops.pop_g + r_e * r_e * pops.pop_e)));
         } else {
-            const uint8_t survivor = site.p_total[0] >= 1.0 ? 1 : 0;
+            const uint8_t survivor = site.probabilities.p_fire[0] >= 1.0 ? 1 : 0;
             exec_instrument_collapse_active(state, v, static_cast<uint8_t>(survivor ^ sign), total);
         }
         return true;
@@ -2142,7 +2145,7 @@ static inline bool exec_instrument(SchrodingerState& state, const ConstantPool& 
         return instrument_trap(state, site, branch.source, /*destination_pending=*/false);
     }
     if (dest != branch.source) {
-        apply_instrument_fixup(state, pool, site);
+        apply_instrument_destination_flip(state, pool, site);
     }
     return true;
 }

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// Numeric checks that must remain valid under Release -ffast-math.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+namespace clifft {
+
+// The IEEE 754 bit trick below assumes that layout. Make it explicit.
+static_assert(std::numeric_limits<double>::is_iec559,
+              "Clifft probability validation requires IEEE 754 doubles");
+
+// -ffast-math implies -ffinite-math-only, which can fold away
+// std::isfinite() and NaN-aware comparisons. Inspect the exponent bits
+// instead: a non-finite double has all exponent bits set.
+inline bool is_finite_robust(double value) {
+    uint64_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
+}
+
+}  // namespace clifft

--- a/tests/test_backend_instruments.cc
+++ b/tests/test_backend_instruments.cc
@@ -27,7 +27,7 @@ constexpr double kTol = 1e-15;
 
 InstrumentTraceOptions demo_options(bool neglect = false) {
     InstrumentTraceOptions options;
-    InstrumentSpec spec;
+    InstrumentProbabilities spec;
     spec.p_fire[0] = 0.1;
     spec.p_computational_dest[0][0] = 0.02;
     spec.p_computational_dest[0][1] = 0.03;
@@ -162,7 +162,7 @@ TEST_CASE("lowering: equal per-source rates skip the expansion even under exact 
     // agree (the skipped no-fire back-action is proportional to identity),
     // so exact damping takes it and k stays flat.
     InstrumentTraceOptions options;
-    InstrumentSpec spec;
+    InstrumentProbabilities spec;
     spec.p_fire[0] = 0.1;
     spec.p_computational_dest[0][0] = 0.02;
     spec.p_computational_dest[0][1] = 0.03;

--- a/tests/test_backend_instruments.cc
+++ b/tests/test_backend_instruments.cc
@@ -1,6 +1,6 @@
 // Backend lowering tests for INSTRUMENT ops: opcode selection by the
 // localized-basis classification, the site -> bytecode offset table, the
-// destination fixup mask, peak_rank accounting, and the fixed
+// destination flip mask, peak_rank accounting, and the fixed
 // prefix-identity contract that trap re-entry depends on.
 
 #include "clifft/backend/backend.h"
@@ -28,12 +28,12 @@ constexpr double kTol = 1e-15;
 InstrumentTraceOptions demo_options(bool neglect = false) {
     InstrumentTraceOptions options;
     InstrumentSpec spec;
-    spec.p_total[0] = 0.1;
-    spec.p_dest[0][0] = 0.02;
-    spec.p_dest[0][1] = 0.03;
-    spec.p_total[1] = 0.4;
+    spec.p_fire[0] = 0.1;
+    spec.p_computational_dest[0][0] = 0.02;
+    spec.p_computational_dest[0][1] = 0.03;
+    spec.p_fire[1] = 0.4;
     options.transitions.emplace("jump", spec);
-    options.neglect_damping = neglect;
+    options.neglect_instrument_damping = neglect;
     return options;
 }
 
@@ -96,19 +96,20 @@ TEST_CASE("lowering: a fresh-qubit site is dormant-static with its spec in the p
     REQUIRE(module.constant_pool.instrument_sites.size() == 1);
     const CompiledInstrumentSite& site =
         module.constant_pool.instrument_sites[instr.instrument.cp_site_idx];
+    const InstrumentProbabilities& probabilities = site.probabilities;
     REQUIRE(site.site_id == 0);
-    REQUIRE_THAT(site.p_total[0], WithinAbs(0.1, kTol));
-    REQUIRE_THAT(site.p_total[1], WithinAbs(0.4, kTol));
-    REQUIRE_THAT(site.p_dest[0][0], WithinAbs(0.02, kTol));
-    REQUIRE_THAT(site.p_dest[0][1], WithinAbs(0.03, kTol));
-    REQUIRE_THAT(site.p_total[1] - site.p_dest[1][0] - site.p_dest[1][1], WithinAbs(0.4, kTol));
-    REQUIRE(!site.neglect_damping);
+    REQUIRE_THAT(probabilities.p_fire[0], WithinAbs(0.1, kTol));
+    REQUIRE_THAT(probabilities.p_fire[1], WithinAbs(0.4, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[0][0], WithinAbs(0.02, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[0][1], WithinAbs(0.03, kTol));
+    REQUIRE_THAT(probabilities.p_noncomputational_dest(1), WithinAbs(0.4, kTol));
 
-    // Identity frame: the destination fixup is exactly X on qubit 0.
-    auto fixup = module.constant_pool.instrument_fixup_masks.at(site.fixup_mask);
-    REQUIRE(fixup.x().bit_get(0));
-    REQUIRE(fixup.x().popcount() == 1);
-    REQUIRE(fixup.z().popcount() == 0);
+    // Identity frame: the destination flip is exactly X on qubit 0.
+    auto flip =
+        module.constant_pool.instrument_destination_flip_masks.at(site.destination_flip_mask);
+    REQUIRE(flip.x().bit_get(0));
+    REQUIRE(flip.x().popcount() == 1);
+    REQUIRE(flip.z().popcount() == 0);
 
     REQUIRE(module.instrument_offsets.size() == 1);
     REQUIRE(module.instrument_offsets[0] == at);
@@ -162,21 +163,18 @@ TEST_CASE("lowering: equal per-source rates skip the expansion even under exact 
     // so exact damping takes it and k stays flat.
     InstrumentTraceOptions options;
     InstrumentSpec spec;
-    spec.p_total[0] = 0.1;
-    spec.p_dest[0][0] = 0.02;
-    spec.p_dest[0][1] = 0.03;
-    spec.p_total[1] = 0.1;
-    spec.p_dest[1][0] = 0.02;
-    spec.p_dest[1][1] = 0.03;
+    spec.p_fire[0] = 0.1;
+    spec.p_computational_dest[0][0] = 0.02;
+    spec.p_computational_dest[0][1] = 0.03;
+    spec.p_fire[1] = 0.1;
+    spec.p_computational_dest[1][0] = 0.02;
+    spec.p_computational_dest[1][1] = 0.03;
     options.transitions.emplace("jump", spec);
 
     auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0", options);
     const size_t at = sole_instrument_index(module);
     REQUIRE(module.bytecode[at].opcode == Opcode::OP_INSTRUMENT_DORMANT_NEGLECT);
     REQUIRE(module.peak_rank == 0);
-    // The equal-rate path, not the policy: this is an exact-damping site.
-    REQUIRE_FALSE(module.constant_pool.instrument_sites[module.bytecode[at].instrument.cp_site_idx]
-                      .neglect_damping);
 }
 
 TEST_CASE("lowering: dormant-random under neglect keeps k and skips the expansion") {
@@ -189,8 +187,6 @@ TEST_CASE("lowering: dormant-random under neglect keeps k and skips the expansio
         REQUIRE(instr.opcode != Opcode::OP_EXPAND);
         REQUIRE(instr.opcode != Opcode::OP_FRAME_H);
     }
-    REQUIRE(module.constant_pool.instrument_sites[module.bytecode[at].instrument.cp_site_idx]
-                .neglect_damping);
 }
 
 TEST_CASE("lowering: an entangled site still localizes to one instrument") {
@@ -200,10 +196,11 @@ TEST_CASE("lowering: an entangled site still localizes to one instrument") {
     const size_t at = sole_instrument_index(module);
     const auto& site =
         module.constant_pool.instrument_sites[module.bytecode[at].instrument.cp_site_idx];
-    // The fixup is the virtualized X of the annotated qubit; entanglement
+    // The destination flip is the virtualized X of the annotated qubit; entanglement
     // makes it a genuine mask, not necessarily single-qubit.
-    auto fixup = module.constant_pool.instrument_fixup_masks.at(site.fixup_mask);
-    REQUIRE(fixup.x().popcount() + fixup.z().popcount() > 0);
+    auto flip =
+        module.constant_pool.instrument_destination_flip_masks.at(site.destination_flip_mask);
+    REQUIRE(flip.x().popcount() + flip.z().popcount() > 0);
 }
 
 // =============================================================================

--- a/tests/test_execute_instruments.cc
+++ b/tests/test_execute_instruments.cc
@@ -29,8 +29,8 @@ namespace {
 
 // A transition spec with total rate p_g/p_e from each source and every
 // fire landing on computational level `dest`.
-InstrumentSpec to_level(double p_g, double p_e, int dest) {
-    InstrumentSpec spec;
+InstrumentProbabilities to_level(double p_g, double p_e, int dest) {
+    InstrumentProbabilities spec;
     spec.p_fire[0] = p_g;
     spec.p_fire[1] = p_e;
     spec.p_computational_dest[0][dest] = p_g;
@@ -185,7 +185,7 @@ TEST_CASE("execute: the no-fire back-action matches its closed form through the 
     const double want = 2.0 * r / (1.0 + r * r);
 
     InstrumentTraceOptions options;
-    InstrumentSpec damp;  // fires only from g, entirely to leaked/lost
+    InstrumentProbabilities damp;  // fires only from g, entirely to leaked/lost
     damp.p_fire[0] = p;
     options.transitions.emplace("damp", damp);
 
@@ -285,7 +285,8 @@ TEST_CASE("execute: an entangled site's multi-axis destination flip lands correc
 
 TEST_CASE("execute: a neglect-mode dormant-random site is silent until it fires") {
     InstrumentTraceOptions options;
-    options.transitions.emplace("leak", InstrumentSpec{{0.3, 0.3}, {{0.0, 0.0}, {0.0, 0.0}}});
+    options.transitions.emplace("leak",
+                                InstrumentProbabilities{{0.3, 0.3}, {{0.0, 0.0}, {0.0, 0.0}}});
     options.neglect_instrument_damping = true;
 
     // Fire probability is 0.3 per shot; k stays 0 either way. Fired

--- a/tests/test_execute_instruments.cc
+++ b/tests/test_execute_instruments.cc
@@ -31,10 +31,10 @@ namespace {
 // fire landing on computational level `dest`.
 InstrumentSpec to_level(double p_g, double p_e, int dest) {
     InstrumentSpec spec;
-    spec.p_total[0] = p_g;
-    spec.p_total[1] = p_e;
-    spec.p_dest[0][dest] = p_g;
-    spec.p_dest[1][dest] = p_e;
+    spec.p_fire[0] = p_g;
+    spec.p_fire[1] = p_e;
+    spec.p_computational_dest[0][dest] = p_g;
+    spec.p_computational_dest[1][dest] = p_e;
     return spec;
 }
 
@@ -84,7 +84,7 @@ std::optional<double> run_shot_exp_val(const CompiledModule& module, uint64_t se
 }  // namespace
 
 TEST_CASE("execute: a certain relaxation fires in-line and flips the record") {
-    // From |1>, a p = 1 transition to g fires every shot; the fixup turns
+    // From |1>, a p = 1 transition to g fires every shot; the destination flip turns
     // the subsequent measurement into 0. The same site on |0> has rate 0
     // from g and never fires.
     InstrumentTraceOptions options;
@@ -186,7 +186,7 @@ TEST_CASE("execute: the no-fire back-action matches its closed form through the 
 
     InstrumentTraceOptions options;
     InstrumentSpec damp;  // fires only from g, entirely to leaked/lost
-    damp.p_total[0] = p;
+    damp.p_fire[0] = p;
     options.transitions.emplace("damp", damp);
 
     const char* active_form = "H 0\nT 0\nLEVEL_TRANSITION[damp] 0\nT_DAG 0\nH 0\nEXP_VAL Z0\nM 0";
@@ -211,11 +211,11 @@ TEST_CASE("execute: the no-fire back-action matches its closed form through the 
     }
 }
 
-TEST_CASE("execute: an absorbed virtual S conjugates the fixup the fire path applies") {
+TEST_CASE("execute: an absorbed virtual S conjugates the destination flip") {
     // Through the full default pipeline, the T pair fuses into a virtual
     // S along X(0) -- which leaves the site's own X-like mask alone but
-    // must rotate its Z-like fixup mask. A fixup left stale (the C2 bug
-    // class) sends the source-e shots' destination flip to the wrong
+    // must rotate its Z-like destination-flip mask. A stale mask sends the
+    // source-e shots' destination flip to the wrong
     // Pauli, and the certain reset stops reading 0.
     InstrumentTraceOptions options;
     options.transitions.emplace("reset_g", to_level(1.0, 1.0, /*dest=*/0));
@@ -265,8 +265,8 @@ TEST_CASE("execute: a localization sign threads through the active fire path") {
     }
 }
 
-TEST_CASE("execute: an entangled site's multi-axis fixup lands on the right qubit") {
-    // After H;H;CZ the fixup (the site qubit's rewound X) has support on
+TEST_CASE("execute: an entangled site's multi-axis destination flip lands correctly") {
+    // After H;H;CZ the destination flip (the site qubit's rewound X) has support on
     // both qubits. A certain reset on qubit 1 must read 0 on its record
     // for every seed, whichever source the populations select.
     InstrumentTraceOptions options;
@@ -274,8 +274,9 @@ TEST_CASE("execute: an entangled site's multi-axis fixup lands on the right qubi
 
     auto module = compile_raw("H 0\nH 1\nCZ 0 1\nLEVEL_TRANSITION[reset_g] 1\nM 1", options);
     const auto& site = module.constant_pool.instrument_sites.at(0);
-    auto fixup = module.constant_pool.instrument_fixup_masks.at(site.fixup_mask);
-    REQUIRE(fixup.x().popcount() + fixup.z().popcount() >= 2);  // genuinely multi-axis
+    auto flip =
+        module.constant_pool.instrument_destination_flip_masks.at(site.destination_flip_mask);
+    REQUIRE(flip.x().popcount() + flip.z().popcount() >= 2);  // genuinely multi-axis
 
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(module, seed) == std::vector<uint8_t>{0});
@@ -285,7 +286,7 @@ TEST_CASE("execute: an entangled site's multi-axis fixup lands on the right qubi
 TEST_CASE("execute: a neglect-mode dormant-random site is silent until it fires") {
     InstrumentTraceOptions options;
     options.transitions.emplace("leak", InstrumentSpec{{0.3, 0.3}, {{0.0, 0.0}, {0.0, 0.0}}});
-    options.neglect_damping = true;
+    options.neglect_instrument_damping = true;
 
     // Fire probability is 0.3 per shot; k stays 0 either way. Fired
     // shots trap (all destinations are leaked/lost here); silent shots

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -20,7 +20,6 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <cmath>
 #include <string>
 
 using namespace clifft;
@@ -36,10 +35,10 @@ constexpr double kTol = 1e-15;
 InstrumentTraceOptions demo_options() {
     InstrumentTraceOptions options;
     InstrumentSpec spec;
-    spec.p_total[0] = 0.1;
-    spec.p_dest[0][0] = 0.02;
-    spec.p_dest[0][1] = 0.03;
-    spec.p_total[1] = 0.4;
+    spec.p_fire[0] = 0.1;
+    spec.p_computational_dest[0][0] = 0.02;
+    spec.p_computational_dest[0][1] = 0.03;
+    spec.p_fire[1] = 0.4;
     options.transitions.emplace("jump", spec);
     return options;
 }
@@ -87,18 +86,17 @@ TEST_CASE("trace: LEVEL_TRANSITION materializes an INSTRUMENT with its spec") {
 
     REQUIRE(hir.instrument_sites.size() == 1);
     const InstrumentSite& site = hir.instrument_sites[0];
+    const InstrumentProbabilities& probabilities = site.probabilities;
     REQUIRE(site.qubit == 0);
-    REQUIRE(site.neglect_damping == false);
-    REQUIRE_THAT(site.p_total[0], WithinAbs(0.1, kTol));
-    REQUIRE_THAT(site.p_total[1], WithinAbs(0.4, kTol));
-    REQUIRE_THAT(site.p_dest[0][0], WithinAbs(0.02, kTol));
-    REQUIRE_THAT(site.p_dest[0][1], WithinAbs(0.03, kTol));
-    REQUIRE_THAT(site.p_dest[1][0], WithinAbs(0.0, kTol));
-    REQUIRE_THAT(site.p_dest[1][1], WithinAbs(0.0, kTol));
-    REQUIRE_THAT(site.p_total[0] - site.p_dest[0][0] - site.p_dest[0][1], WithinAbs(0.05, kTol));
-    REQUIRE_THAT(site.p_total[1] - site.p_dest[1][0] - site.p_dest[1][1], WithinAbs(0.4, kTol));
-    REQUIRE_THAT(site.damp[0], WithinAbs(std::sqrt(0.9), kTol));
-    REQUIRE_THAT(site.damp[1], WithinAbs(std::sqrt(0.6), kTol));
+    REQUIRE_FALSE(hir.neglect_instrument_damping);
+    REQUIRE_THAT(probabilities.p_fire[0], WithinAbs(0.1, kTol));
+    REQUIRE_THAT(probabilities.p_fire[1], WithinAbs(0.4, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[0][0], WithinAbs(0.02, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[0][1], WithinAbs(0.03, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[1][0], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[1][1], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(probabilities.p_noncomputational_dest(0), WithinAbs(0.05, kTol));
+    REQUIRE_THAT(probabilities.p_noncomputational_dest(1), WithinAbs(0.4, kTol));
 
     // Identity tableau at the site: the mask is plain Z on qubit 0.
     REQUIRE(hir.ops[0].instrument_site_idx() == InstrumentSiteIdx{0});
@@ -127,14 +125,12 @@ TEST_CASE("trace: LOSS materializes a source-independent all-trap site per targe
     REQUIRE(hir.instrument_sites.size() == 2);
     for (int i = 0; i < 2; ++i) {
         const InstrumentSite& site = hir.instrument_sites[static_cast<size_t>(i)];
+        const InstrumentProbabilities& probabilities = site.probabilities;
         REQUIRE(site.qubit == static_cast<uint32_t>(i));
-        REQUIRE_THAT(site.p_total[0], WithinAbs(0.25, kTol));
-        REQUIRE_THAT(site.p_total[1], WithinAbs(0.25, kTol));
-        REQUIRE_THAT(site.p_total[0] - site.p_dest[0][0] - site.p_dest[0][1],
-                     WithinAbs(0.25, kTol));
-        REQUIRE_THAT(site.p_total[1] - site.p_dest[1][0] - site.p_dest[1][1],
-                     WithinAbs(0.25, kTol));
-        REQUIRE_THAT(site.damp[0], WithinAbs(std::sqrt(0.75), kTol));
+        REQUIRE_THAT(probabilities.p_fire[0], WithinAbs(0.25, kTol));
+        REQUIRE_THAT(probabilities.p_fire[1], WithinAbs(0.25, kTol));
+        REQUIRE_THAT(probabilities.p_noncomputational_dest(0), WithinAbs(0.25, kTol));
+        REQUIRE_THAT(probabilities.p_noncomputational_dest(1), WithinAbs(0.25, kTol));
         REQUIRE(mask_is(hir, hir.ops[static_cast<size_t>(i)], static_cast<uint32_t>(i), false, true,
                         false));
     }
@@ -157,13 +153,24 @@ TEST_CASE("trace: an unresolved tag names itself in the error") {
         ContainsSubstring("LEVEL_TRANSITION[ghost]") && ContainsSubstring("instrument options"));
 }
 
-TEST_CASE("trace: the damping policy is copied onto every site") {
+TEST_CASE("trace: malformed compressed instrument probabilities reject") {
+    InstrumentTraceOptions options;
+    InstrumentSpec invalid;
+    invalid.p_fire[0] = 0.1;
+    invalid.p_computational_dest[0][0] = 0.2;
+    options.transitions.emplace("invalid", invalid);
+
+    REQUIRE_THROWS_WITH(
+        hir_with_instruments("LEVEL_TRANSITION[invalid] 0", options),
+        ContainsSubstring("LEVEL_TRANSITION[invalid]") && ContainsSubstring("above p_fire"));
+}
+
+TEST_CASE("trace: the damping policy is recorded once on the HIR module") {
     auto options = demo_options();
-    options.neglect_damping = true;
+    options.neglect_instrument_damping = true;
     auto hir = hir_with_instruments("LEVEL_TRANSITION[jump] 0\nLOSS(0.1) 1", options);
     REQUIRE(hir.instrument_sites.size() == 2);
-    REQUIRE(hir.instrument_sites[0].neglect_damping);
-    REQUIRE(hir.instrument_sites[1].neglect_damping);
+    REQUIRE(hir.neglect_instrument_damping);
 }
 
 // =============================================================================
@@ -182,13 +189,14 @@ TEST_CASE("instrument_trace_options: resolves model transitions and policy") {
                                                         {{"relax", matrix}}, std::nullopt, policy);
 
     const InstrumentTraceOptions options = instrument_trace_options(model);
-    REQUIRE(options.neglect_damping);
+    REQUIRE(options.neglect_instrument_damping);
     REQUIRE(options.transitions.size() == 1);
     const InstrumentSpec& spec = options.transitions.at("relax");
-    REQUIRE_THAT(spec.p_total[0], WithinAbs(0.0, kTol));
-    REQUIRE_THAT(spec.p_total[1], WithinAbs(0.4, kTol));
-    REQUIRE_THAT(spec.p_dest[1][0], WithinAbs(0.1, kTol));
-    REQUIRE_THAT(spec.p_dest[1][1], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(spec.p_fire[0], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(spec.p_fire[1], WithinAbs(0.4, kTol));
+    REQUIRE_THAT(spec.p_computational_dest[1][0], WithinAbs(0.1, kTol));
+    REQUIRE_THAT(spec.p_computational_dest[1][1], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(spec.p_noncomputational_dest(1), WithinAbs(0.3, kTol));
 }
 
 // =============================================================================
@@ -239,7 +247,7 @@ TEST_CASE("fences: an absorbed virtual S conjugates the instrument mask like a m
     // T 0; T 0 fuses to a virtual S along Z(0). The H makes the site's
     // rewound projector X(0), which anti-commutes with the S axis, so the
     // absorption must rotate it to Y(0) -- the same conjugation measures
-    // and probes receive. The site's fixup (rewound X = Z(0) here)
+    // and probes receive. The site's destination flip (rewound X = Z(0) here)
     // commutes with the S axis and must stay put.
     auto hir = hir_with_instruments("T 0\nT 0\nH 0\nLEVEL_TRANSITION[jump] 0", options);
     REQUIRE(hir.ops.size() == 3);
@@ -257,18 +265,18 @@ TEST_CASE("fences: an absorbed virtual S conjugates the instrument mask like a m
     REQUIRE(destab.bit_get(0));
     REQUIRE(stab.bit_get(0));
 
-    auto fixup = hir.pauli_masks.at(hir.instrument_sites[0].fixup_mask);
-    REQUIRE(!fixup.x().bit_get(0));
-    REQUIRE(fixup.z().bit_get(0));
+    auto flip = hir.pauli_masks.at(hir.instrument_sites[0].destination_flip_mask);
+    REQUIRE(!flip.x().bit_get(0));
+    REQUIRE(flip.z().bit_get(0));
 }
 
-TEST_CASE("fences: an absorbed virtual S conjugates the side-table fixup mask too") {
+TEST_CASE("fences: an absorbed virtual S conjugates the side-table destination flip too") {
     const auto options = demo_options();
     // With the T pair after the H, the virtual S runs along X(0): now the
-    // site's own mask (X-like) commutes and stays put, while the fixup
+    // site's own mask (X-like) commutes and stays put, while the destination flip
     // (rewound X = Z(0)) anti-commutes and must rotate to Y(0). A sweep
     // that only conjugates op-attached masks misses it -- the side-table
-    // twin of the C2 fixup bug.
+    // twin of the C2 destination-flip bug.
     auto hir = hir_with_instruments("H 0\nT 0\nT 0\nLEVEL_TRANSITION[jump] 0", options);
     REQUIRE(hir.ops.size() == 3);
 
@@ -281,10 +289,10 @@ TEST_CASE("fences: an absorbed virtual S conjugates the side-table fixup mask to
     // Op mask: still X-like.
     REQUIRE(hir.destab_mask(hir.ops[0]).bit_get(0));
     REQUIRE(!hir.stab_mask(hir.ops[0]).bit_get(0));
-    // Fixup: rotated to Y-like.
-    auto fixup = hir.pauli_masks.at(hir.instrument_sites[0].fixup_mask);
-    REQUIRE(fixup.x().bit_get(0));
-    REQUIRE(fixup.z().bit_get(0));
+    // Destination flip: rotated to Y-like.
+    auto flip = hir.pauli_masks.at(hir.instrument_sites[0].destination_flip_mask);
+    REQUIRE(flip.x().bit_get(0));
+    REQUIRE(flip.z().bit_get(0));
 }
 
 TEST_CASE("trace: a hand-built LOSS without its argument rejects") {

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -36,12 +36,12 @@ constexpr double kTol = 1e-15;
 // noncomputational level (the trap remainder); from e, 0.4 entirely trap.
 InstrumentTraceOptions demo_options() {
     InstrumentTraceOptions options;
-    InstrumentSpec spec;
-    spec.p_fire[0] = 0.1;
-    spec.p_computational_dest[0][0] = 0.02;
-    spec.p_computational_dest[0][1] = 0.03;
-    spec.p_fire[1] = 0.4;
-    options.transitions.emplace("jump", spec);
+    InstrumentProbabilities probabilities;
+    probabilities.p_fire[0] = 0.1;
+    probabilities.p_computational_dest[0][0] = 0.02;
+    probabilities.p_computational_dest[0][1] = 0.03;
+    probabilities.p_fire[1] = 0.4;
+    options.transitions.emplace("jump", probabilities);
     return options;
 }
 
@@ -140,7 +140,7 @@ TEST_CASE("trace: LOSS materializes a source-independent all-trap site per targe
 
 TEST_CASE("trace: a zero-rate site is elided") {
     InstrumentTraceOptions options;
-    options.transitions.emplace("nothing", InstrumentSpec{});
+    options.transitions.emplace("nothing", InstrumentProbabilities{});
 
     auto hir = hir_with_instruments("LOSS(0) 0\nLEVEL_TRANSITION[nothing] 0", options);
     REQUIRE(hir.ops.empty());
@@ -157,7 +157,7 @@ TEST_CASE("trace: an unresolved tag names itself in the error") {
 
 TEST_CASE("trace: malformed compressed instrument probabilities reject") {
     InstrumentTraceOptions options;
-    InstrumentSpec invalid;
+    InstrumentProbabilities invalid;
     invalid.p_fire[0] = 0.1;
     invalid.p_computational_dest[0][0] = 0.2;
     options.transitions.emplace("invalid", invalid);
@@ -169,7 +169,7 @@ TEST_CASE("trace: malformed compressed instrument probabilities reject") {
 
 TEST_CASE("trace: non-finite compressed instrument probabilities reject") {
     InstrumentTraceOptions options;
-    InstrumentSpec invalid;
+    InstrumentProbabilities invalid;
     invalid.p_fire[0] = clifft::test::opaque_nan();
     options.transitions.emplace("invalid", invalid);
 
@@ -204,12 +204,12 @@ TEST_CASE("instrument_trace_options: resolves model transitions and policy") {
     const InstrumentTraceOptions options = instrument_trace_options(model);
     REQUIRE(options.neglect_instrument_damping);
     REQUIRE(options.transitions.size() == 1);
-    const InstrumentSpec& spec = options.transitions.at("relax");
-    REQUIRE_THAT(spec.p_fire[0], WithinAbs(0.0, kTol));
-    REQUIRE_THAT(spec.p_fire[1], WithinAbs(0.4, kTol));
-    REQUIRE_THAT(spec.p_computational_dest[1][0], WithinAbs(0.1, kTol));
-    REQUIRE_THAT(spec.p_computational_dest[1][1], WithinAbs(0.0, kTol));
-    REQUIRE_THAT(spec.p_noncomputational_dest(1), WithinAbs(0.3, kTol));
+    const InstrumentProbabilities& probabilities = options.transitions.at("relax");
+    REQUIRE_THAT(probabilities.p_fire[0], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(probabilities.p_fire[1], WithinAbs(0.4, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[1][0], WithinAbs(0.1, kTol));
+    REQUIRE_THAT(probabilities.p_computational_dest[1][1], WithinAbs(0.0, kTol));
+    REQUIRE_THAT(probabilities.p_noncomputational_dest(1), WithinAbs(0.3, kTol));
 }
 
 // =============================================================================

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -16,6 +16,8 @@
 #include "clifft/optimizer/peephole.h"
 #include "clifft/optimizer/statevector_squeeze_pass.h"
 
+#include "test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -163,6 +165,17 @@ TEST_CASE("trace: malformed compressed instrument probabilities reject") {
     REQUIRE_THROWS_WITH(
         hir_with_instruments("LEVEL_TRANSITION[invalid] 0", options),
         ContainsSubstring("LEVEL_TRANSITION[invalid]") && ContainsSubstring("above p_fire"));
+}
+
+TEST_CASE("trace: non-finite compressed instrument probabilities reject") {
+    InstrumentTraceOptions options;
+    InstrumentSpec invalid;
+    invalid.p_fire[0] = clifft::test::opaque_nan();
+    options.transitions.emplace("invalid", invalid);
+
+    REQUIRE_THROWS_WITH(
+        hir_with_instruments("LEVEL_TRANSITION[invalid] 0", options),
+        ContainsSubstring("LEVEL_TRANSITION[invalid]") && ContainsSubstring("invalid p_fire"));
 }
 
 TEST_CASE("trace: the damping policy is recorded once on the HIR module") {

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -33,8 +33,8 @@ namespace {
 // rates (p_g, p_e).
 InstrumentSpec leak(double p_g, double p_e) {
     InstrumentSpec spec;
-    spec.p_total[0] = p_g;
-    spec.p_total[1] = p_e;
+    spec.p_fire[0] = p_g;
+    spec.p_fire[1] = p_e;
     return spec;
 }
 
@@ -89,13 +89,13 @@ TEST_CASE("trap+resume: a trap-form fire reports its destination as pending") {
     InstrumentTraceOptions options;
     options.transitions.emplace("jump", [] {
         InstrumentSpec spec;
-        spec.p_total[0] = 1.0;
-        spec.p_total[1] = 1.0;
-        spec.p_dest[0][1] = 0.5;  // half the column is computational:
-        spec.p_dest[1][0] = 0.5;  // the host must draw over all of it
+        spec.p_fire[0] = 1.0;
+        spec.p_fire[1] = 1.0;
+        spec.p_computational_dest[0][1] = 0.5;  // half the column is computational:
+        spec.p_computational_dest[1][0] = 0.5;  // the host must draw over all of it
         return spec;
     }());
-    options.neglect_damping = true;
+    options.neglect_instrument_damping = true;
 
     auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0\nM 0", options);
     auto state = make_shot_state(module, /*seed=*/6);

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -31,8 +31,8 @@ namespace {
 
 // A transition whose entire fire mass is leaked/lost, with per-source
 // rates (p_g, p_e).
-InstrumentSpec leak(double p_g, double p_e) {
-    InstrumentSpec spec;
+InstrumentProbabilities leak(double p_g, double p_e) {
+    InstrumentProbabilities spec;
     spec.p_fire[0] = p_g;
     spec.p_fire[1] = p_e;
     return spec;
@@ -88,7 +88,7 @@ TEST_CASE("trap+resume: a spectator loss resumes in the same module and complete
 TEST_CASE("trap+resume: a trap-form fire reports its destination as pending") {
     InstrumentTraceOptions options;
     options.transitions.emplace("jump", [] {
-        InstrumentSpec spec;
+        InstrumentProbabilities spec;
         spec.p_fire[0] = 1.0;
         spec.p_fire[1] = 1.0;
         spec.p_computational_dest[0][1] = 0.5;  // half the column is computational:


### PR DESCRIPTION
## Summary

- introduce one shared InstrumentProbabilities representation and document how the five-level transition matrix is compressed at the quantum trace boundary
- distinguish the HIR op source-observable mask from the side-table destination-flip mask throughout frontend, backend, optimizer, VM, docs, and tests
- store the neglect-damping policy once per HIR module, derive damping coefficients during lowering, and arrange per-site fields without avoidable alignment padding
- validate programmatically supplied compressed probability payloads before lowering

## Validation

- uv run pre-commit run --all-files
- cmake --build build -j 2
- 65 focused C++ frontend, lowering, execution, and trap/resume correctness tests
- uv run pytest tests/python/test_noncomp.py tests/python/test_noncomp_examples.py tests/python/test_noncomp_exact_probes.py -q (80 passed)

Benchmark-style CTest registrations were intentionally skipped because this is a structural representation refactor.