### PR TITLE
test(noncomp): consolidate shared fixtures

### DIFF
--- a/tests/instrument_test_helpers.h
+++ b/tests/instrument_test_helpers.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "clifft/backend/backend.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/svm/svm.h"
+
+#include <cstdint>
+#include <string_view>
+
+namespace clifft {
+namespace test {
+
+// Source-dependent fixture used to follow one instrument through tracing and
+// lowering. The unassigned fire mass is the noncomputational trap remainder.
+inline InstrumentTraceOptions source_dependent_jump_options(bool neglect_damping = false) {
+    InstrumentTraceOptions options;
+    InstrumentProbabilities probabilities;
+    probabilities.p_fire[0] = 0.1;
+    probabilities.p_computational_dest[0][0] = 0.02;
+    probabilities.p_computational_dest[0][1] = 0.03;
+    probabilities.p_fire[1] = 0.4;
+    options.transitions.emplace("jump", probabilities);
+    options.neglect_instrument_damping = neglect_damping;
+    return options;
+}
+
+inline CompiledModule compile_instruments_raw(std::string_view text,
+                                              const InstrumentTraceOptions& options) {
+    return lower(trace(parse(text), &options));
+}
+
+inline CompiledModule compile_instruments_full(std::string_view text,
+                                               const InstrumentTraceOptions& options) {
+    auto hir = trace(parse(text), &options);
+    auto hir_passes = default_hir_pass_manager();
+    hir_passes.run(hir);
+    auto module = lower(hir);
+    auto bytecode_passes = default_bytecode_pass_manager();
+    bytecode_passes.run(module);
+    return module;
+}
+
+inline SchrodingerState make_shot_state(const CompiledModule& module, uint64_t seed) {
+    return SchrodingerState(StateConfig{.peak_rank = module.peak_rank,
+                                        .num_measurements = module.total_meas_slots,
+                                        .num_qubits = module.num_qubits,
+                                        .num_detectors = module.num_detectors,
+                                        .num_observables = module.num_observables,
+                                        .num_exp_vals = module.num_exp_vals,
+                                        .seed = seed});
+}
+
+}  // namespace test
+}  // namespace clifft

--- a/tests/noncomp_test_helpers.h
+++ b/tests/noncomp_test_helpers.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "clifft/noncomp/level.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace clifft {
+namespace test {
+
+// Raw input shape used by model construction tests. It remains dynamic so
+// validation tests can deliberately form malformed matrices.
+using RawProbabilityMatrix = std::vector<std::vector<double>>;
+
+constexpr size_t level_index(Level level) {
+    return static_cast<size_t>(level);
+}
+
+inline RawProbabilityMatrix zero_transition_matrix() {
+    return RawProbabilityMatrix(kNumLevels, std::vector<double>(kNumLevels, 0.0));
+}
+
+// A source-independent certain transition from either computational level.
+inline RawProbabilityMatrix certain_transition_from_computational(Level destination) {
+    auto matrix = zero_transition_matrix();
+    matrix[level_index(destination)][level_index(Level::G)] = 1.0;
+    matrix[level_index(destination)][level_index(Level::E)] = 1.0;
+    return matrix;
+}
+
+inline std::vector<double> pure_initial_state(Level level) {
+    std::vector<double> probabilities(kNumLevels, 0.0);
+    probabilities[level_index(level)] = 1.0;
+    return probabilities;
+}
+
+// Classifier with one selected column replaced. Computational readout is
+// faithful, and unselected noncomputational levels report symbol 0.
+inline RawProbabilityMatrix classifier_matrix_with_column(Level level,
+                                                          std::vector<double> probabilities) {
+    RawProbabilityMatrix matrix(probabilities.size(), std::vector<double>(kNumLevels, 0.0));
+    for (size_t index = 0; index < kNumLevels; ++index) {
+        matrix[0][index] = 1.0;
+    }
+    matrix[0][level_index(Level::E)] = 0.0;
+    matrix[1][level_index(Level::E)] = 1.0;
+    for (size_t symbol = 0; symbol < probabilities.size(); ++symbol) {
+        matrix[symbol][level_index(level)] = probabilities[symbol];
+    }
+    return matrix;
+}
+
+}  // namespace test
+}  // namespace clifft

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,32 @@
 """Shared test fixtures and utilities for Clifft Python tests."""
 
+from collections.abc import Mapping, Sequence
+
 import numpy as np
 import numpy.typing as npt
+
+
+def noncomp_transition_matrix(
+    entries: Mapping[tuple[int, int], float],
+) -> list[list[float]]:
+    """Build a five-level T[to][from] matrix from its nonzero entries."""
+    matrix = [[0.0] * 5 for _ in range(5)]
+    for (destination, source), probability in entries.items():
+        matrix[destination][source] = probability
+    return matrix
+
+
+def noncomp_classifier_matrix_with_column(
+    level: int, probabilities: Sequence[float]
+) -> list[list[float]]:
+    """Build a faithful computational classifier with one replaced column."""
+    matrix = [[0.0] * 5 for _ in probabilities]
+    for current_level in range(5):
+        matrix[0][current_level] = 1.0
+    matrix[0][1], matrix[1][1] = 0.0, 1.0
+    for symbol, probability in enumerate(probabilities):
+        matrix[symbol][level] = probability
+    return matrix
 
 
 def assert_statevectors_equiv(

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from conftest import noncomp_classifier_matrix_with_column, noncomp_transition_matrix
 
 from clifft import noncomp
 
@@ -26,23 +27,12 @@ def _zeros(rows: int, cols: int) -> list[list[float]]:
 
 def transition_to(level: int) -> list[list[float]]:
     """T[to][from]: g and e both jump to `level` (source-independent)."""
-    m = _zeros(5, 5)
-    m[level][noncomp.Level.G] = 1.0
-    m[level][noncomp.Level.E] = 1.0
-    return m
+    return noncomp_transition_matrix({(level, noncomp.Level.G): 1.0, (level, noncomp.Level.E): 1.0})
 
 
 def classifier_for(level: int, col: list[float]) -> noncomp.Classifier:
-    """Binary classifier; `level`'s column is `col`, computational levels read
-    out faithfully (no readout confusion), other columns are symbol 0."""
-    m = _zeros(2, 5)
-    for lvl in range(5):
-        m[0][lvl] = 1.0
-    m[0][noncomp.Level.E] = 0.0
-    m[1][noncomp.Level.E] = 1.0
-    m[0][level] = col[0]
-    m[1][level] = col[1]
-    return noncomp.Classifier(m)
+    """Classifier whose selected column is `col`; computational readout is faithful."""
+    return noncomp.Classifier(noncomp_classifier_matrix_with_column(level, col))
 
 
 def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
@@ -279,21 +269,12 @@ def test_classifier_stores_matrix():
     assert len(c.matrix[0]) == 5
 
 
-def _ternary_classifier(level: int, col: list[float]) -> noncomp.Classifier:
-    """Three-symbol classifier; `level`'s column is `col`, others read symbol 0."""
-    m = _zeros(3, 5)
-    for lvl in range(5):
-        m[0][lvl] = 1.0
-    m[0][level], m[1][level], m[2][level] = col
-    return noncomp.Classifier(m)
-
-
 def test_ternary_herald_rides_the_sidecar():
     """A lost qubit's measurement heralds; the visible record stays binary."""
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
-        classifier=_ternary_classifier(LOST, [0.0, 0.0, 1.0]),
+        classifier=classifier_for(LOST, [0.0, 0.0, 1.0]),
     )
     r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=4000, seed=21)
     assert r.heralds.shape == (4000, 2)
@@ -319,7 +300,7 @@ def test_herald_deterministic_in_seed():
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
-        classifier=_ternary_classifier(LOST, [0.2, 0.1, 0.7]),
+        classifier=classifier_for(LOST, [0.2, 0.1, 0.7]),
     )
     a = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
     b = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
@@ -339,7 +320,7 @@ def test_ternary_herald_feeds_detector_and_observable():
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
-        classifier=_ternary_classifier(LOST, [0.2, 0.1, 0.7]),
+        classifier=classifier_for(LOST, [0.2, 0.1, 0.7]),
     )
     circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n"
     r = noncomp.sample(circuit, model, shots=4000, seed=24)

--- a/tests/python/test_noncomp_exact_probes.py
+++ b/tests/python/test_noncomp_exact_probes.py
@@ -11,19 +11,12 @@ from __future__ import annotations
 
 import numpy as np
 import utils_noncomp_oracle as oracle
-from conftest import binomial_tolerance
+from conftest import binomial_tolerance, noncomp_transition_matrix
 
 from clifft import noncomp
 
 Level = noncomp.Level
 SHOTS = 20_000
-
-
-def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
-    m = [[0.0] * 5 for _ in range(5)]
-    for (to, frm), p in entries.items():
-        m[to][frm] = p
-    return m
 
 
 def _faithful_classifier() -> noncomp.Classifier:
@@ -50,7 +43,7 @@ def test_gate_determined_source_fires_exactly_zero():
     state, where <P_e> is exactly 0. The certain rate (p = 1) makes any
     ahead-of-time source guess loud: a uniform draw would leak half the
     shots."""
-    model = _model({"leak": _transition({(Level.LEAK_E, Level.E): 1.0})})
+    model = _model({"leak": noncomp_transition_matrix({(Level.LEAK_E, Level.E): 1.0})})
     r = noncomp.sample("H 0\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0\n", model, shots=SHOTS, seed=11)
     status = np.asarray(r.final_status)
     assert (status == noncomp.QubitStatus.COMPUTATIONAL).all()
@@ -64,7 +57,11 @@ def test_bell_joint_correlation_has_tvd_zero():
     The exact joint is {00: 1/2, 11: 1/2}; any independent source draw
     puts mass on 01/10."""
     model = _model(
-        {"leak": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_E, Level.E): 1.0})}
+        {
+            "leak": noncomp_transition_matrix(
+                {(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_E, Level.E): 1.0}
+            )
+        }
     )
     r = noncomp.sample(
         "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n", model, shots=SHOTS, seed=12
@@ -89,7 +86,7 @@ def test_damping_boundary_probe_separates_exact_from_neglect():
     and the closed forms are far enough apart that each sample can only
     match its own mode."""
     p = 0.84
-    transitions = {"leak": _transition({(Level.LEAK_E, Level.E): p})}
+    transitions = {"leak": noncomp_transition_matrix({(Level.LEAK_E, Level.E): p})}
     text = "H 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0\n"
 
     plus = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
@@ -128,7 +125,9 @@ def test_damping_null_source_independent_rates_make_neglect_exact():
     so the H .. H sandwich returns |0> deterministically in both modes."""
     shots = 4000
     p = 0.3
-    transitions = {"leak": _transition({(Level.LEAK_G, Level.G): p, (Level.LEAK_G, Level.E): p})}
+    transitions = {
+        "leak": noncomp_transition_matrix({(Level.LEAK_G, Level.G): p, (Level.LEAK_G, Level.E): p})
+    }
     # g reads 0, e reads 1, every noncomputational level reads 1: a leak
     # reads 1, and the survivor check expects 0 (H .. H returns g).
     classifier = noncomp.Classifier([[1, 0, 0, 0, 0], [0, 1, 1, 1, 1]])
@@ -184,7 +183,7 @@ def test_entangled_two_site_chain_matches_hand_derived_distribution():
       111 -> 0.005  (no-fire1, no-fire2, q0 collapses to |1>; two dampings)
     Every other pattern has probability exactly 0.
     """
-    model = _model({"leak": _transition({(Level.LEAK_G, Level.E): 0.9})})
+    model = _model({"leak": noncomp_transition_matrix({(Level.LEAK_G, Level.E): 0.9})})
     circuit = (
         "H 0\nCX 0 1\nCX 0 2\n"
         "LEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
@@ -251,7 +250,7 @@ def test_neglect_bell_correlation_probe():
     the cold-atom rates used there.
     """
     PROBE_SHOTS = 512
-    transitions = {"leak": _transition({(Level.LEAK_E, Level.E): 1.0})}
+    transitions = {"leak": noncomp_transition_matrix({(Level.LEAK_E, Level.E): 1.0})}
     model = _model(transitions, damping="neglect")
     text = "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n"
 

--- a/tests/python/test_noncomp_exact_tvd.py
+++ b/tests/python/test_noncomp_exact_tvd.py
@@ -12,18 +12,11 @@ from __future__ import annotations
 
 import numpy as np
 import utils_noncomp_enumerator as en
-from conftest import binomial_tolerance
+from conftest import binomial_tolerance, noncomp_transition_matrix
 
 from clifft import noncomp
 
 Level = noncomp.Level
-
-
-def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
-    m = [[0.0] * 5 for _ in range(5)]
-    for (to, frm), p in entries.items():
-        m[to][frm] = p
-    return m
 
 
 def _classifier_matrix() -> list[list[float]]:
@@ -70,7 +63,7 @@ def test_enumerator_plus_state_marginal_closed_form():
     """
     p = 0.4
     circuit = "H 0\nLEVEL_TRANSITION[leak] 0\nM 0\n"
-    transitions = {"leak": _transition({(Level.LEAK_E, Level.G): p})}
+    transitions = {"leak": noncomp_transition_matrix({(Level.LEAK_E, Level.G): p})}
 
     exact = en.enumerate_exact(
         circuit,
@@ -100,7 +93,7 @@ def test_enumerator_initial_leak_and_recapture():
     dist = en.enumerate_exact(
         "LEVEL_TRANSITION[seep] 0\nM 0\n",
         initial=[0, 0, 1, 0, 0],  # starts at leak_g
-        transitions={"seep": _transition({(Level.E, Level.LEAK_G): seep})},
+        transitions={"seep": noncomp_transition_matrix({(Level.E, Level.LEAK_G): seep})},
         classifier=_classifier_matrix(),
     )
     # Recaptured (p = 0.3): reads 1. Still leaked at leak_g: reads 0.
@@ -136,8 +129,10 @@ M 0 1 2
 """
 
 TRANSITIONS = {
-    "leak2q": _transition({(Level.LEAK_E, Level.E): LEAK_2Q_E, (Level.LEAK_G, Level.G): LEAK_2Q_G}),
-    "leak1q": _transition({(Level.LEAK_E, Level.E): LEAK_1Q_E}),
+    "leak2q": noncomp_transition_matrix(
+        {(Level.LEAK_E, Level.E): LEAK_2Q_E, (Level.LEAK_G, Level.G): LEAK_2Q_G}
+    ),
+    "leak1q": noncomp_transition_matrix({(Level.LEAK_E, Level.E): LEAK_1Q_E}),
 }
 
 SHOTS = 60_000

--- a/tests/python/test_noncomp_examples.py
+++ b/tests/python/test_noncomp_examples.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from conftest import noncomp_classifier_matrix_with_column, noncomp_transition_matrix
 
 from clifft import noncomp
 
@@ -22,18 +23,7 @@ BAND = 0.04
 
 
 def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
-    m = [[0.0] * 5 for _ in range(2)]  # P[symbol][level]
-    for lvl in range(5):
-        m[0][lvl] = 1.0
-    m[0][level], m[1][level] = col[0], col[1]
-    return noncomp.Classifier(m)
-
-
-def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
-    m = [[0.0] * 5 for _ in range(5)]  # T[to][from]
-    for (to, frm), p in entries.items():
-        m[to][frm] = p
-    return m
+    return noncomp.Classifier(noncomp_classifier_matrix_with_column(level, col))
 
 
 # --- Supported categories ----------------------------------------------------
@@ -66,7 +56,9 @@ def test_example_after_gate_leakage_with_classifier():
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={
-            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
+            "S": noncomp_transition_matrix(
+                {(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0}
+            )
         },
         classifier=_classifier(Level.LEAK_G, [0.0, 1.0]),
     )
@@ -80,7 +72,7 @@ def test_example_relaxation_to_ground_on_known_qubit():
     # relaxed 0, not the stale |1>, and the qubit stays computational.
     model = noncomp.Model(
         initial_state=[0.0, 1.0, 0.0, 0.0, 0.0],
-        transitions={"S": _transition({(Level.G, Level.E): 1.0})},
+        transitions={"S": noncomp_transition_matrix({(Level.G, Level.E): 1.0})},
     )
     r = noncomp.sample("S 0\nM 0\n", model, shots=64, seed=6)
     assert (np.asarray(r.measurements)[:, 0] == 0).all()
@@ -96,7 +88,9 @@ def test_reject_parity_measurement_under_capable_model():
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={
-            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
+            "S": noncomp_transition_matrix(
+                {(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0}
+            )
         },
         classifier=noncomp.Classifier([[1.0] * 5, [0.0] * 5]),
     )

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -21,6 +21,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 import utils_noncomp_oracle as oracle
+from conftest import noncomp_classifier_matrix_with_column, noncomp_transition_matrix
 
 import clifft
 from clifft import noncomp
@@ -30,22 +31,8 @@ BAND = 0.04  # ~7 sigma at 8000 shots for p near 0.5
 SHOTS = 8000
 
 
-def _transition(entries: dict[tuple[int, int], float]) -> list[list[float]]:
-    """5x5 T[to][from]; a column's deficit below 1 is the no-jump (stay) weight."""
-    m = [[0.0] * 5 for _ in range(5)]
-    for (to, frm), p in entries.items():
-        m[to][frm] = p
-    return m
-
-
 def _classifier(level: int, col: list[float]) -> noncomp.Classifier:
-    m = [[0.0] * 5 for _ in range(2)]  # P[symbol][level], two symbols
-    for lvl in range(5):
-        m[0][lvl] = 1.0
-    # Computational levels read out faithfully (no readout confusion).
-    m[0][noncomp.Level.E], m[1][noncomp.Level.E] = 0.0, 1.0
-    m[0][level], m[1][level] = col[0], col[1]
-    return noncomp.Classifier(m)
+    return noncomp.Classifier(noncomp_classifier_matrix_with_column(level, col))
 
 
 def _p1(result: noncomp.NonComputationalSample, slot: int) -> float:
@@ -101,7 +88,7 @@ def test_transition_probability_on_known_source():
     # On known g, S jumps to leak_g with prob 0.4 (deficit 0.6 stays g).
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
-        transitions={"S": _transition({(Level.LEAK_G, Level.G): 0.4})},
+        transitions={"S": noncomp_transition_matrix({(Level.LEAK_G, Level.G): 0.4})},
     )
     r = noncomp.sample("S 0\n", model, shots=SHOTS, seed=3)
     leaked = np.isin(
@@ -116,7 +103,9 @@ def test_classifier_replacement_distribution(col, expected):
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={
-            "S": _transition({(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0})
+            "S": noncomp_transition_matrix(
+                {(Level.LEAK_G, Level.G): 1.0, (Level.LEAK_G, Level.E): 1.0}
+            )
         },
         classifier=_classifier(Level.LEAK_G, col),
     )
@@ -130,7 +119,9 @@ def test_partial_relaxation_matches_analytic_mixture():
     p = 0.3
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
-        transitions={"S": _transition({(Level.G, Level.G): p, (Level.G, Level.E): p})},
+        transitions={
+            "S": noncomp_transition_matrix({(Level.G, Level.G): p, (Level.G, Level.E): p})
+        },
     )
     r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=6)
     h = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
@@ -143,7 +134,9 @@ def test_survivor_marginal_equals_partial_trace():
     # reference partial trace (0.5), and the lost record follows the classifier.
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
-        transitions={"S": _transition({(Level.LOST, Level.G): 1.0, (Level.LOST, Level.E): 1.0})},
+        transitions={
+            "S": noncomp_transition_matrix({(Level.LOST, Level.G): 1.0, (Level.LOST, Level.E): 1.0})
+        },
         classifier=_classifier(Level.LOST, [0.5, 0.5]),
     )
     r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=SHOTS, seed=5)
@@ -215,7 +208,7 @@ def test_two_site_exact_damping_composition_matches_enumerator():
     import utils_noncomp_enumerator as en
 
     p = 0.5
-    transitions = {"leak": _transition({(Level.LEAK_E, Level.E): p})}
+    transitions = {"leak": noncomp_transition_matrix({(Level.LEAK_E, Level.E): p})}
     circuit_text = "H 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0\n"
     classifier_matrix = [[1.0, 0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0]]
 

--- a/tests/test_backend_instruments.cc
+++ b/tests/test_backend_instruments.cc
@@ -4,10 +4,9 @@
 // prefix-identity contract that trap re-entry depends on.
 
 #include "clifft/backend/backend.h"
-#include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
-#include "clifft/optimizer/pass_factory.h"
-#include "clifft/svm/svm.h"
+
+#include "instrument_test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
@@ -20,41 +19,13 @@
 using namespace clifft;
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
+using clifft::test::compile_instruments_full;
+using clifft::test::compile_instruments_raw;
+using clifft::test::source_dependent_jump_options;
 
 namespace {
 
 constexpr double kTol = 1e-15;
-
-InstrumentTraceOptions demo_options(bool neglect = false) {
-    InstrumentTraceOptions options;
-    InstrumentProbabilities spec;
-    spec.p_fire[0] = 0.1;
-    spec.p_computational_dest[0][0] = 0.02;
-    spec.p_computational_dest[0][1] = 0.03;
-    spec.p_fire[1] = 0.4;
-    options.transitions.emplace("jump", spec);
-    options.neglect_instrument_damping = neglect;
-    return options;
-}
-
-// trace + lower, no optimization passes: fully deterministic opcode
-// sequences for the classification checks.
-CompiledModule compile_raw(const char* text, const InstrumentTraceOptions& options) {
-    auto hir = trace(parse(text), &options);
-    return lower(hir);
-}
-
-// The full default pipeline (HIR passes, lower, bytecode passes): what a
-// real compilation runs, for the prefix-identity and offset-validity checks.
-CompiledModule compile_full(const char* text, const InstrumentTraceOptions& options) {
-    auto hir = trace(parse(text), &options);
-    auto hir_passes = default_hir_pass_manager();
-    hir_passes.run(hir);
-    auto module = lower(hir);
-    auto bytecode_passes = default_bytecode_pass_manager();
-    bytecode_passes.run(module);
-    return module;
-}
 
 bool is_instrument_opcode(Opcode op) {
     return op == Opcode::OP_INSTRUMENT_ACTIVE || op == Opcode::OP_INSTRUMENT_DORMANT_STATIC ||
@@ -82,7 +53,8 @@ size_t sole_instrument_index(const CompiledModule& module) {
 // =============================================================================
 
 TEST_CASE("lowering: a fresh-qubit site is dormant-static with its spec in the pool") {
-    auto module = compile_raw("LEVEL_TRANSITION[jump] 0", demo_options());
+    auto module =
+        compile_instruments_raw("LEVEL_TRANSITION[jump] 0", source_dependent_jump_options());
 
     const size_t at = sole_instrument_index(module);
     const Instruction& instr = module.bytecode[at];
@@ -116,7 +88,8 @@ TEST_CASE("lowering: a fresh-qubit site is dormant-static with its spec in the p
 }
 
 TEST_CASE("lowering: a Pauli before the site lands in FLAG_SIGN") {
-    auto module = compile_raw("X 0\nLEVEL_TRANSITION[jump] 0", demo_options());
+    auto module =
+        compile_instruments_raw("X 0\nLEVEL_TRANSITION[jump] 0", source_dependent_jump_options());
     const Instruction& instr = module.bytecode[sole_instrument_index(module)];
     REQUIRE(instr.opcode == Opcode::OP_INSTRUMENT_DORMANT_STATIC);
     REQUIRE((instr.flags & Instruction::FLAG_SIGN) != 0);
@@ -125,7 +98,8 @@ TEST_CASE("lowering: a Pauli before the site lands in FLAG_SIGN") {
 TEST_CASE("lowering: an active qubit gets the fused active form on its axis") {
     // H 0; T 0 activates qubit 0 (the T's route expands it); the site's
     // rewound X-projector maps through the route's virtual H back to Z.
-    auto module = compile_raw("H 0\nT 0\nLEVEL_TRANSITION[jump] 0", demo_options());
+    auto module = compile_instruments_raw("H 0\nT 0\nLEVEL_TRANSITION[jump] 0",
+                                          source_dependent_jump_options());
 
     const size_t at = sole_instrument_index(module);
     const Instruction& instr = module.bytecode[at];
@@ -139,7 +113,8 @@ TEST_CASE("lowering: an active qubit gets the fused active form on its axis") {
 TEST_CASE("lowering: an active X-basis site gets an absorbed array Hadamard") {
     // The trailing H makes the rewound projector plain Z, which the
     // route's accumulated virtual H maps to X on the active axis.
-    auto module = compile_raw("H 0\nT 0\nH 0\nLEVEL_TRANSITION[jump] 0", demo_options());
+    auto module = compile_instruments_raw("H 0\nT 0\nH 0\nLEVEL_TRANSITION[jump] 0",
+                                          source_dependent_jump_options());
 
     const size_t at = sole_instrument_index(module);
     REQUIRE(module.bytecode[at].opcode == Opcode::OP_INSTRUMENT_ACTIVE);
@@ -148,7 +123,8 @@ TEST_CASE("lowering: an active X-basis site gets an absorbed array Hadamard") {
 }
 
 TEST_CASE("lowering: source-dependent rates under exact damping expand at the site") {
-    auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0", demo_options());
+    auto module =
+        compile_instruments_raw("H 0\nLEVEL_TRANSITION[jump] 0", source_dependent_jump_options());
 
     const size_t at = sole_instrument_index(module);
     REQUIRE(module.bytecode[at].opcode == Opcode::OP_INSTRUMENT_EXPAND);
@@ -171,14 +147,15 @@ TEST_CASE("lowering: equal per-source rates skip the expansion even under exact 
     spec.p_computational_dest[1][1] = 0.03;
     options.transitions.emplace("jump", spec);
 
-    auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0", options);
+    auto module = compile_instruments_raw("H 0\nLEVEL_TRANSITION[jump] 0", options);
     const size_t at = sole_instrument_index(module);
     REQUIRE(module.bytecode[at].opcode == Opcode::OP_INSTRUMENT_DORMANT_NEGLECT);
     REQUIRE(module.peak_rank == 0);
 }
 
 TEST_CASE("lowering: dormant-random under neglect keeps k and skips the expansion") {
-    auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0", demo_options(/*neglect=*/true));
+    auto module = compile_instruments_raw("H 0\nLEVEL_TRANSITION[jump] 0",
+                                          source_dependent_jump_options(/*neglect_damping=*/true));
 
     const size_t at = sole_instrument_index(module);
     REQUIRE(module.bytecode[at].opcode == Opcode::OP_INSTRUMENT_DORMANT_NEGLECT);
@@ -192,7 +169,8 @@ TEST_CASE("lowering: dormant-random under neglect keeps k and skips the expansio
 TEST_CASE("lowering: an entangled site still localizes to one instrument") {
     // The rewound projector of the CNOT target is a two-qubit Pauli; the
     // localization emits reduction ops and one instrument on the pivot.
-    auto module = compile_raw("H 0\nCX 0 1\nT 0\nLEVEL_TRANSITION[jump] 1", demo_options());
+    auto module = compile_instruments_raw("H 0\nCX 0 1\nT 0\nLEVEL_TRANSITION[jump] 1",
+                                          source_dependent_jump_options());
     const size_t at = sole_instrument_index(module);
     const auto& site =
         module.constant_pool.instrument_sites[module.bytecode[at].instrument.cp_site_idx];
@@ -211,10 +189,10 @@ TEST_CASE("lowering: offsets stay valid through the default bytecode passes") {
     // Noise before the site coalesces into a block under the default
     // passes, shifting instruction indices; the rebuilt table must still
     // point at the instrument.
-    auto module = compile_full(
+    auto module = compile_instruments_full(
         "X_ERROR(0.01) 0\nX_ERROR(0.01) 1\nX_ERROR(0.01) 2\n"
         "LEVEL_TRANSITION[jump] 0\nM 0",
-        demo_options());
+        source_dependent_jump_options());
 
     REQUIRE(module.instrument_offsets.size() == 1);
     const uint32_t offset = module.instrument_offsets[0];
@@ -227,10 +205,10 @@ TEST_CASE("fences: noise blocks never coalesce across an instrument") {
     // by construction; exercise the pass that matters most (noise-block
     // coalescing drove the atomized-fence cost in the spike): noise on
     // both sides of a site stays on both sides, in separate runs.
-    auto module = compile_full(
+    auto module = compile_instruments_full(
         "X_ERROR(0.01) 0\nX_ERROR(0.01) 1\nLEVEL_TRANSITION[jump] 2\n"
         "X_ERROR(0.01) 0\nX_ERROR(0.01) 1\nM 0",
-        demo_options());
+        source_dependent_jump_options());
 
     const size_t at = sole_instrument_index(module);
     bool noise_before = false;
@@ -249,14 +227,16 @@ TEST_CASE("fences: noise blocks never coalesce across an instrument") {
 }
 
 TEST_CASE("exact record and basis probabilities reject instrument programs") {
-    auto module = compile_raw("LEVEL_TRANSITION[jump] 0\nM 0", demo_options());
+    auto module =
+        compile_instruments_raw("LEVEL_TRANSITION[jump] 0\nM 0", source_dependent_jump_options());
     const std::vector<uint8_t> record{0};
     REQUIRE_THROWS_WITH(record_probabilities(module, record, 1),
                         ContainsSubstring("record_probabilities()"));
 
     // basis_probabilities takes measurement-free unitary programs, so its
     // rejection path needs its own instrument program to exercise.
-    auto unitary = compile_raw("LEVEL_TRANSITION[jump] 0", demo_options());
+    auto unitary =
+        compile_instruments_raw("LEVEL_TRANSITION[jump] 0", source_dependent_jump_options());
     const std::vector<uint64_t> masks{0};
     REQUIRE_THROWS_WITH(basis_probabilities(unitary, masks, 1, 1),
                         ContainsSubstring("basis_probabilities()"));
@@ -268,12 +248,12 @@ TEST_CASE("fences: prefix compilation is bit-identical across different suffixes
     // identically no matter what follows the fence, through the full
     // default pipeline. The suffixes differ in ways the peephole would
     // exploit across the fence if it could (a fusable T pair).
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     const char* with_fusion_bait = "H 0\nT 0\nLEVEL_TRANSITION[jump] 0\nT 0\nM 0";
     const char* with_other_suffix = "H 0\nT 0\nLEVEL_TRANSITION[jump] 0\nT_DAG 0\nH 0\nM 0\nM 1";
 
-    auto a = compile_full(with_fusion_bait, options);
-    auto b = compile_full(with_other_suffix, options);
+    auto a = compile_instruments_full(with_fusion_bait, options);
+    auto b = compile_instruments_full(with_other_suffix, options);
 
     REQUIRE(a.instrument_offsets.size() == 1);
     REQUIRE(b.instrument_offsets.size() == 1);

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -13,6 +13,8 @@
 #include "clifft/noncomp/seed.h"
 #include "clifft/util/xoshiro.h"
 
+#include "noncomp_test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -25,12 +27,14 @@
 
 using namespace clifft;
 using Catch::Matchers::ContainsSubstring;
+using clifft::test::certain_transition_from_computational;
+using clifft::test::classifier_matrix_with_column;
+using clifft::test::level_index;
+using clifft::test::pure_initial_state;
+using clifft::test::RawProbabilityMatrix;
+using clifft::test::zero_transition_matrix;
 
 namespace {
-
-constexpr uint8_t kLeakG = 2;
-constexpr uint8_t kLeak = 3;
-constexpr uint8_t kLost = 4;
 
 struct ModelSpec {
     double leak_from_g = 0.0;
@@ -41,22 +45,21 @@ struct ModelSpec {
     DampingPolicy damping = DampingPolicy::Exact;
 };
 
-NonComputationalModel make_model(const ModelSpec& spec) {
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeak][0] = spec.leak_from_g;
-    leak[kLeak][1] = spec.leak_from_e;
-    leak[1][kLeak] = spec.seep_to_e;
-    std::map<std::string, std::vector<std::vector<double>>> transitions{{"leak", leak}};
+NonComputationalModel make_driver_model(const ModelSpec& spec) {
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakE)][level_index(Level::G)] = spec.leak_from_g;
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = spec.leak_from_e;
+    leak[level_index(Level::E)][level_index(Level::LeakE)] = spec.seep_to_e;
+    std::map<std::string, RawProbabilityMatrix> transitions{{"leak", leak}};
     if (spec.flip_g_to_e > 0.0) {
         // A purely computational g -> e transition: its fires resolve
         // in-line inside the VM and never trap.
-        std::vector<std::vector<double>> flip(5, std::vector<double>(5, 0.0));
-        flip[1][0] = spec.flip_g_to_e;
+        auto flip = zero_transition_matrix();
+        flip[level_index(Level::E)][level_index(Level::G)] = spec.flip_g_to_e;
         transitions.emplace("flip", std::move(flip));
     }
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const auto classifier = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
 
     NonComputationalPolicy policy;
     policy.damping = spec.damping;
@@ -79,15 +82,12 @@ double mean_of(const std::vector<uint8_t>& bits, uint32_t stride, uint32_t index
 // e reads 1); the noncomputational columns read the parked-carrier
 // convention (leak_g/lost read 0, leak_e reads 1).
 NonComputationalModel make_lose_model() {
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;  // g -> lost, certainly
-    lose[kLost][1] = 1.0;  // e -> lost, certainly
+    auto lose = certain_transition_from_computational(Level::Lost);
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const auto classifier = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
 
     NonComputationalPolicy policy;
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+    return NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"lose", lose}},
                                             std::make_optional(classifier), policy);
 }
 
@@ -97,7 +97,7 @@ TEST_CASE("exact: an untrapped run reproduces plain sampling behavior") {
     // No annotations at all: the exact path is one shared module executed
     // per shot. A Bell pair's measurements must be perfectly correlated.
     ModelSpec spec;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("H 0\nCX 0 1\nM 0\nM 1");
 
     auto result = sample_noncomputational(circuit, model, 200, 7);
@@ -114,13 +114,13 @@ TEST_CASE("exact: an untrapped run reproduces plain sampling behavior") {
     }
 }
 
-TEST_CASE("exact: a certain leak traps, classifies, and reports the status") {
+TEST_CASE("exact: a certain leak reports the trapped classified status") {
     // From |1> (X prep), the site fires every shot; the leaked qubit's
     // measurement classifies (leaked column reads 1) and the sidecar
     // carries the leaked status. Qubit 1 is untouched.
     ModelSpec spec;
     spec.leak_from_e = 1.0;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("X 0\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
 
     auto result = sample_noncomputational(circuit, model, 25, 3);
@@ -137,7 +137,7 @@ TEST_CASE("exact: a known |1> initial preloads the frame without a distinct modu
     // frame preload alone.
     ModelSpec spec;
     spec.initial = {0.0, 1.0, 0.0, 0.0, 0.0};
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 25, 11);
@@ -152,7 +152,7 @@ TEST_CASE("exact: a noncomputational initial compiles its own continuation") {
     // the lost column, and the final status stays Lost.
     ModelSpec spec;
     spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 10, 5);
@@ -170,7 +170,7 @@ TEST_CASE("exact: seepage after a trap recaptures through a classical consult") 
     ModelSpec spec;
     spec.leak_from_e = 1.0;
     spec.seep_to_e = 1.0;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("X 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 20, 13);
@@ -187,7 +187,7 @@ TEST_CASE("exact: an in-line computational fire is never reported as a known lev
     // measurement mixture verifies that the fire really happens.
     ModelSpec spec;
     spec.flip_g_to_e = 0.5;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("LEVEL_TRANSITION[flip] 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 200, 17);
@@ -209,7 +209,7 @@ TEST_CASE("exact: a later trap composes with an earlier in-line fire") {
     ModelSpec spec;
     spec.flip_g_to_e = 0.5;
     spec.leak_from_e = 1.0;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("LEVEL_TRANSITION[flip] 0\nLEVEL_TRANSITION[leak] 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 200, 19);
@@ -238,7 +238,7 @@ TEST_CASE("exact: a source-independent rate matches its closed form") {
     ModelSpec spec;
     spec.leak_from_g = 0.3;
     spec.leak_from_e = 0.3;
-    auto result = sample_noncomputational(circuit, make_model(spec), shots, 17);
+    auto result = sample_noncomputational(circuit, make_driver_model(spec), shots, 17);
 
     const double mean = mean_of(result.measurements, 1, 0);
     // Binomial std at p = 0.3 over 4000 shots is ~0.007; allow 5 sigma.
@@ -249,7 +249,7 @@ TEST_CASE("exact: same seed reproduces identical runs") {
     ModelSpec spec;
     spec.leak_from_e = 0.5;
     spec.initial = {0.5, 0.5, 0.0, 0.0, 0.0};
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("H 1\nCX 1 0\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
 
     auto a = sample_noncomputational(circuit, model, 100, 23);
@@ -285,7 +285,7 @@ TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
     // sites push the peak to 3, over a cap of 2.
     ModelSpec spec;
     spec.leak_from_e = 0.2;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse(
         "H 0\nH 1\nH 2\n"
         "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
@@ -305,17 +305,16 @@ TEST_CASE("exact: a trap-form fire keeps the fire-side correlation") {
     // M 0 *is* the reported source, and the partner's M 1 must equal it
     // on every shot, because the continuation's trace-out is forced to
     // that same source. Independent redraw would mismatch half the time.
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeakG][0] = 1.0;  // from g: leak_g, certainly
-    leak[kLeak][1] = 1.0;   // from e: leak_e, certainly
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakG)][level_index(Level::G)] = 1.0;  // from g: leak_g, certainly
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = 1.0;  // from e: leak_e, certainly
 
-    const std::vector<std::vector<double>> classifier = {
-        {1.0, 0.0, 1.0, 0.0, 1.0},   // leak_g reads 0
-        {0.0, 1.0, 0.0, 1.0, 0.0}};  // leak_e reads 1
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},   // leak_g reads 0
+                                             {0.0, 1.0, 0.0, 1.0, 0.0}};  // leak_e reads 1
 
     NonComputationalPolicy policy;
     policy.damping = DampingPolicy::Neglect;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(classifier), policy);
 
     auto circuit = parse("H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1");
@@ -344,7 +343,7 @@ TEST_CASE("exact: a trap may insert a classical consult between pre-drawn ones")
     ModelSpec spec;
     spec.leak_from_e = 1.0;
     spec.initial = {0.0, 0.0, 0.0, 1.0, 0.0};  // all mass on the leaked level
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse(
         "R 0\nX 0\n"
         "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\n"
@@ -366,16 +365,15 @@ TEST_CASE("exact: a chain of two forced traps keeps both correlations") {
     // contains the first's forced instruction (exercising the
     // sampling/forced mask in the debug prefix comparison). Both
     // partner correlations must survive.
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeakG][0] = 1.0;
-    leak[kLeak][1] = 1.0;
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakG)][level_index(Level::G)] = 1.0;
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = 1.0;
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.damping = DampingPolicy::Neglect;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(classifier), policy);
 
     auto circuit = parse(
@@ -398,16 +396,15 @@ TEST_CASE("exact: a neglect fire onto a computational destination stays correlat
     // materialization collapses the partner to the source while the
     // trapped qubit re-preps at the destination, so the two measurements
     // must anti-correlate on every shot.
-    std::vector<std::vector<double>> swap_ge(5, std::vector<double>(5, 0.0));
-    swap_ge[1][0] = 1.0;  // g -> e, certainly
-    swap_ge[0][1] = 1.0;  // e -> g, certainly
+    auto swap_ge = zero_transition_matrix();
+    swap_ge[level_index(Level::E)][level_index(Level::G)] = 1.0;  // g -> e, certainly
+    swap_ge[level_index(Level::G)][level_index(Level::E)] = 1.0;  // e -> g, certainly
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.damping = DampingPolicy::Neglect;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"swap", swap_ge}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"swap", swap_ge}},
                                                   std::make_optional(classifier), policy);
 
     auto circuit = parse("H 0\nCX 0 1\nLEVEL_TRANSITION[swap] 0\nM 0\nM 1");
@@ -435,14 +432,14 @@ TEST_CASE("exact: herald flags drawn in one continuation are reused by the next"
     // time. The two-trap chain makes slot 0's flag be drawn while
     // compiling continuation one and reused by continuation two, where
     // the measurement actually executes.
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeak][1] = 1.0;  // certain leak from e
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = 1.0;  // certain leak from e
 
-    const std::vector<std::vector<double>> classifier = {
+    const RawProbabilityMatrix classifier = {
         {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.5, 0.0}, {0.0, 0.0, 0.0, 0.5, 0.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(classifier), policy);
 
     auto circuit = parse("X 0\nX 1\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nM 0\nM 1");
@@ -471,7 +468,7 @@ TEST_CASE("exact: spectator noise between two traps fires exactly once") {
     // deterministic record.
     ModelSpec spec;
     spec.leak_from_e = 1.0;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse(
         "X 0\nX 1\n"
         "LEVEL_TRANSITION[leak] 0\nX_ERROR(1) 2\nLEVEL_TRANSITION[leak] 1\nX_ERROR(1) 2\n"
@@ -492,7 +489,7 @@ TEST_CASE("exact: a detector and observable span the trap boundary") {
     // the observable carries the classified bit.
     ModelSpec spec;
     spec.leak_from_e = 1.0;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse(
         "X 0\nM 0\nLEVEL_TRANSITION[leak] 0\nM 0\n"
         "DETECTOR rec[-1] rec[-2]\nOBSERVABLE_INCLUDE(0) rec[-1]");
@@ -515,7 +512,7 @@ TEST_CASE("exact: a hand-written multi-target annotation traps on one target") {
     // target's instrument live.
     ModelSpec spec;
     spec.leak_from_e = 1.0;  // fires from e only
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("X 0\nLEVEL_TRANSITION[leak] 0 1\nM 0\nM 1");
 
     auto result = sample_noncomputational(circuit, model, 20, 67);
@@ -531,7 +528,7 @@ TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
     ModelSpec spec;
     spec.leak_from_e = 0.3;  // source-dependent: the damp is non-scalar
     spec.damping = DampingPolicy::Neglect;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0");
 
     // max_rank 0 admits the neglect compile (no expansion) and would
@@ -542,7 +539,7 @@ TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
     ModelSpec exact_spec = spec;
     exact_spec.damping = DampingPolicy::Exact;
     REQUIRE_THROWS_WITH(
-        sample_noncomputational(circuit, make_model(exact_spec), 50, 37, /*max_rank=*/0),
+        sample_noncomputational(circuit, make_driver_model(exact_spec), 50, 37, /*max_rank=*/0),
         ContainsSubstring("exceeds max_rank 0"));
 }
 
@@ -550,14 +547,14 @@ TEST_CASE("exact: ternary heralds ride the cache key") {
     // A three-symbol classifier whose leaked column always heralds: every
     // trapped shot's classified slot reports a herald, and the record bit
     // stays roughly fair across shots.
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeak][1] = 1.0;
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = 1.0;
 
-    const std::vector<std::vector<double>> classifier = {
+    const RawProbabilityMatrix classifier = {
         {1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({0.0, 1.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::E), {{"leak", leak}},
                                                   std::make_optional(classifier), policy);
 
     auto circuit = parse("LEVEL_TRANSITION[leak] 0\nM 0");
@@ -580,7 +577,7 @@ TEST_CASE("exact: a hand-built malformed LOSS rejects up front") {
     // validates before the first compile instead. The parser guarantees
     // LOSS(p) for parsed circuits; these are programmatically built.
     ModelSpec spec;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     Circuit circuit = parse("H 0\nM 0");
     SECTION("missing the probability argument") {
         circuit.nodes.insert(circuit.nodes.begin() + 1,
@@ -603,7 +600,7 @@ TEST_CASE("exact: hand-built annotation targets reject up front") {
         ModelSpec spec;
         circuit.nodes.insert(circuit.nodes.begin(),
                              AstNode{GateType::LOSS, {Target::qubit(1000000)}, {0.1}, 0});
-        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_model(spec), 1, 1),
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_driver_model(spec), 1, 1),
                             ContainsSubstring("target qubit 1000000 is out of range"));
     }
 
@@ -612,7 +609,7 @@ TEST_CASE("exact: hand-built annotation targets reject up front") {
         spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};
         circuit.nodes.insert(circuit.nodes.begin(),
                              AstNode{GateType::LOSS, {Target::qubit(1000000)}, {0.1}, 0});
-        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_model(spec), 1, 1),
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_driver_model(spec), 1, 1),
                             ContainsSubstring("target qubit 1000000 is out of range"));
     }
 
@@ -620,7 +617,7 @@ TEST_CASE("exact: hand-built annotation targets reject up front") {
         ModelSpec spec;
         circuit.nodes.insert(circuit.nodes.begin(),
                              AstNode{GateType::LOSS, {Target::rec(0)}, {0.1}, 0});
-        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_model(spec), 1, 1),
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_driver_model(spec), 1, 1),
                             ContainsSubstring("requires plain qubit targets"));
     }
 }
@@ -638,21 +635,20 @@ TEST_CASE("exact: a smaller starting module must not shrink the reused state") {
     spec.leak_from_e = 3e-3;  // source-dependent: the dormant site damp-expands
     spec.leak_from_g = 3e-4;
     spec.initial = {0.5, 0.0, 0.5, 0.0, 0.0};  // both starting modules occur
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     Circuit circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nMR 0\nM 0");
     auto result = sample_noncomputational(circuit, model, 64, 5);
     REQUIRE(result.shots == 64);
 }
 
-TEST_CASE("exact: a zero-fire LOSS(0) before a firing LOSS does not shift site ids") {
+TEST_CASE("exact: a zero-fire LOSS before a firing LOSS does not shift site ids") {
     // LOSS(0) can never fire from a computational qubit; trace() skips it.
     // The rewriter must skip it too, so LOSS(1) gets site id 0 and the
     // driver maps the trap correctly.
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("LOSS(0) 0\nLOSS(1) 0\nM 0");
 
@@ -668,14 +664,14 @@ TEST_CASE("exact: a seepage-only transition before a firing site does not shift 
     // from leak_e to e only) cannot fire on a computational qubit; trace()
     // skips it. The rewriter must skip it too so the firing LOSS(1) that
     // follows gets site id 0 and the driver maps the trap correctly.
-    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
-    seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
+    auto seep = zero_transition_matrix();
+    seep[level_index(Level::E)][level_index(Level::LeakE)] =
+        1.0;  // leak_e -> e, prob 1; computational columns zero
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"seep", seep}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"seep", seep}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0");
 
@@ -692,15 +688,15 @@ TEST_CASE("exact: a seepage-only transition on q0 does not corrupt q1's site id"
     // In Release, a stale site id would read the wrong trap record and
     // silently produce wrong results; in Debug, the site-table lookup
     // overruns or mismatches.
-    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
-    seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
+    auto seep = zero_transition_matrix();
+    seep[level_index(Level::E)][level_index(Level::LeakE)] =
+        1.0;  // leak_e -> e, prob 1; computational columns zero
 
     // q0: stays computational (no loss); q1: lost reads 1.
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"seep", seep}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"seep", seep}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[seep] 0\nLOSS(1) 1\nM 0\nM 1");
 
@@ -718,11 +714,11 @@ TEST_CASE("exact: a seepage-only transition still seeps a noncomputational qubit
     // must still execute its classical consult for a noncomputational qubit.
     // Here leak_e is the starting level; the seep fires (classical consult
     // with destination e) and the qubit recaptures to |1>, so M reads 1.
-    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
-    seep[1][kLeak] = 1.0;  // leak_e -> e, prob 1; computational columns zero
+    auto seep = zero_transition_matrix();
+    seep[level_index(Level::E)][level_index(Level::LeakE)] =
+        1.0;  // leak_e -> e, prob 1; computational columns zero
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     // All initial mass on leak_e (index 3).
@@ -787,12 +783,9 @@ TEST_CASE("exact: a correlated-chain head with a leaked operand does not orphan 
     // X0 lands there as a frame flip nothing reads. The conditioning must
     // be identical: E(1) fires, the ELSE never does. The leak column reads
     // 1, so q0's record is the classifier bit, not the carrier.
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeakG][0] = 1.0;
-    leak[kLeakG][1] = 1.0;
-    const std::vector<std::vector<double>> cl = {{1.0, 0.0, 0.0, 0.0, 1.0},
-                                                 {0.0, 1.0, 1.0, 1.0, 0.0}};
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto leak = certain_transition_from_computational(Level::LeakG);
+    const RawProbabilityMatrix cl = {{1.0, 0.0, 0.0, 0.0, 1.0}, {0.0, 1.0, 1.0, 1.0, 0.0}};
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(cl), NonComputationalPolicy{});
     auto circuit = parse(
         "LEVEL_TRANSITION[leak] 0\n"
@@ -810,12 +803,9 @@ TEST_CASE("exact: a correlated-chain head with a leaked operand does not orphan 
 }
 
 TEST_CASE("exact: a fired head with a leaked operand prevents the ELSE from firing") {
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeakG][0] = 1.0;
-    leak[kLeakG][1] = 1.0;
-    const std::vector<std::vector<double>> cl = {{1.0, 0.0, 0.0, 0.0, 1.0},
-                                                 {0.0, 1.0, 1.0, 1.0, 0.0}};
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto leak = certain_transition_from_computational(Level::LeakG);
+    const RawProbabilityMatrix cl = {{1.0, 0.0, 0.0, 0.0, 1.0}, {0.0, 1.0, 1.0, 1.0, 0.0}};
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(cl), NonComputationalPolicy{});
     auto circuit = parse(
         "LEVEL_TRANSITION[leak] 0\n"
@@ -847,11 +837,11 @@ TEST_CASE("exact: a mixed-operand chain member keeps the healthy qubit's Pauli")
     }
 }
 
-TEST_CASE("exact: E(1) X0 X1 with no loss applies X to both qubits") {
+TEST_CASE("exact: a certain correlated X0 X1 error applies X to both qubits") {
     // Baseline: all computational, E(1) fires with certainty applying X0 X1.
     // Both qubits start at |0> so both measure 1 after X.
     ModelSpec spec;  // all computational, no loss
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("E(1) X0 X1\nM 0\nM 1\n");
     auto result = sample_noncomputational(circuit, model, 5, 99);
     for (uint32_t shot = 0; shot < 5; ++shot) {
@@ -870,18 +860,16 @@ namespace {
 // leak columns deterministic symbol 0.
 NonComputationalModel make_classify_lost_model(std::vector<double> lost_col,
                                                bool with_hook = false) {
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    auto lose = certain_transition_from_computational(Level::Lost);
+    std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("lose", lose);
 
     // g=0, e=1, leak_g=0, leak_e=0, lost=lost_col
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 1.0, lost_col[0]},
-                                                         {0.0, 1.0, 0.0, 0.0, lost_col[1]}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 1.0, lost_col[0]},
+                                             {0.0, 1.0, 0.0, 0.0, lost_col[1]}};
     (void)with_hook;
     NonComputationalPolicy policy;
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
+    return NonComputationalModel::from_spec(pure_initial_state(Level::G), transitions,
                                             std::make_optional(classifier), policy);
 }
 
@@ -924,16 +912,14 @@ TEST_CASE("exact: ternary herald column on MX sets sidecar flag and patches reco
     // Three-symbol classifier for the lost level: {0, 0, 1} always heralds.
     // The herald flag must be 1 on every shot; the record carries an
     // unbiased bit (matches the existing M-herald test in make_lose_model).
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
+    auto lose = certain_transition_from_computational(Level::Lost);
 
     // lost column = {0, 0, 1}: always heralds. g/e/leak columns symbol 0.
-    const std::vector<std::vector<double>> classifier = {
+    const RawProbabilityMatrix classifier = {
         {1.0, 0.0, 1.0, 1.0, 0.0}, {0.0, 1.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 1.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"lose", lose}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX 0");
     auto result = sample_noncomputational(circuit, model, 40, 107);
@@ -947,7 +933,7 @@ TEST_CASE("exact: computational X-basis behavior is untouched by MX classify cha
     // RX prepares |+>; MX measures in the X basis and records 0 deterministically.
     // No noncomputational model capability: the classifier path must never fire.
     ModelSpec spec;  // all computational
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("RX 0\nMX 0");
     auto result = sample_noncomputational(circuit, model, 20, 109);
     for (uint32_t shot = 0; shot < 20; ++shot) {
@@ -956,18 +942,17 @@ TEST_CASE("exact: computational X-basis behavior is untouched by MX classify cha
     }
 }
 
-TEST_CASE("exact: memory-X smoke: two qubits, low-rate leak hook, MX measures both") {
+TEST_CASE("exact: memory-X smoke measures two qubits after a low-rate leak hook") {
     // The motivating use case: a stim-style memory-X circuit that ends in MX
     // on data qubits runs cleanly under a leakage model.
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLost][0] = 0.01;  // low-rate loss from g
-    leak[kLost][1] = 0.01;
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::Lost)][level_index(Level::G)] = 0.01;  // low-rate loss from g
+    leak[level_index(Level::Lost)][level_index(Level::E)] = 0.01;
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 1.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 0.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 1.0, 1.0}, {0.0, 1.0, 0.0, 0.0, 0.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("RX 0 1\nLEVEL_TRANSITION[leak] 0 1\nMX 0 1");
     // Equal-rate loss keeps stabilizer cost under exact damping: max_rank 0.
@@ -1008,7 +993,7 @@ TEST_CASE("exact: computational-only model permits MPP") {
     // A model with no capability (initial all-g, no leak/loss transitions)
     // leaves MPP supported.
     ModelSpec spec;  // all computational
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("H 0\nCX 0 1\nMPP Z0*Z1");
     auto result = sample_noncomputational(circuit, model, 10, 1);
     REQUIRE(result.shots == 10);
@@ -1022,11 +1007,9 @@ TEST_CASE("exact: capable model with measurement requires classifier") {
     // A model with a LEVEL_TRANSITION annotation that can fire into a
     // noncomputational level, paired with a measurement, must throw when
     // no classifier is present.
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
+    auto lose = certain_transition_from_computational(Level::Lost);
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"lose", lose}},
                                                   std::nullopt, policy);
     // The annotation makes the circuit capable.
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nM 0");
@@ -1036,11 +1019,9 @@ TEST_CASE("exact: capable model with measurement requires classifier") {
 
 TEST_CASE("exact: capable model without measurement does not require classifier") {
     // A capable model without a classifier is fine if the circuit has no measurements.
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
+    auto lose = certain_transition_from_computational(Level::Lost);
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"lose", lose}},
                                                   std::nullopt, policy);
     // Circuit has no measurement nodes.
     auto circuit = parse("H 0\nLEVEL_TRANSITION[lose] 0");
@@ -1052,7 +1033,7 @@ TEST_CASE("exact: computational-only model with MX does not require classifier")
     // A non-capable model (no loss/leak transitions, all-g initial) plus
     // MX requires no classifier.
     ModelSpec spec;  // all computational, no loss
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("RX 0\nMX 0");
     auto result = sample_noncomputational(circuit, model, 10, 1);
     REQUIRE(result.shots == 10);
@@ -1067,11 +1048,9 @@ TEST_CASE("exact: coarse capability boundary requires a classifier for any measu
     // never touches a vacated carrier in any reachable shot. The capability
     // boundary is coarse: capable model plus any measurement requires a
     // classifier.
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;  // q0 loses certainly from g
-    lose[kLost][1] = 1.0;
+    auto lose = certain_transition_from_computational(Level::Lost);
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"lose", lose}},
                                                   std::nullopt, policy);
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nM 1");
     REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
@@ -1081,11 +1060,9 @@ TEST_CASE("exact: coarse capability boundary requires a classifier for any measu
 TEST_CASE("exact: the model contract is validated even for zero shots") {
     // Validation is shot-count independent: a zero-shot call still checks
     // the circuit/model contract, and a valid pair returns empty results.
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
-    auto no_classifier = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
-                                                          std::nullopt, NonComputationalPolicy{});
+    auto lose = certain_transition_from_computational(Level::Lost);
+    auto no_classifier = NonComputationalModel::from_spec(
+        pure_initial_state(Level::G), {{"S", lose}}, std::nullopt, NonComputationalPolicy{});
     REQUIRE_THROWS_WITH(sample_noncomputational(parse("S 0\nM 0"), no_classifier, 0, 1),
                         ContainsSubstring("classifier is required"));
 
@@ -1104,17 +1081,16 @@ namespace {
 // Certain e->leak_e leak and certain leak_e->e seep; g initial.
 // Circuit must prep |e> (e.g. X 0) before the first annotation fires.
 NonComputationalModel make_leak_seep_model() {
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeak][1] = 1.0;  // e -> leak_e, certainly
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = 1.0;  // e -> leak_e, certainly
 
-    std::vector<std::vector<double>> seep(5, std::vector<double>(5, 0.0));
-    seep[1][kLeak] = 1.0;  // leak_e -> e, certainly
+    auto seep = zero_transition_matrix();
+    seep[level_index(Level::E)][level_index(Level::LeakE)] = 1.0;  // leak_e -> e, certainly
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0},
+    return NonComputationalModel::from_spec(pure_initial_state(Level::G),
                                             {{"leak", leak}, {"seep", seep}},
                                             std::make_optional(classifier), policy);
 }
@@ -1144,15 +1120,12 @@ TEST_CASE("exact: multi-target annotation jumps both targets in one shot") {
     // lose channel is source-independent (g->lost p=1, e->lost p=1), so both
     // qubits lose in every shot. Both records read 0 (identity classifier's
     // lost column), both statuses are Lost.
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;  // g -> lost, certainly
-    lose[kLost][1] = 1.0;  // e -> lost, certainly
+    auto lose = certain_transition_from_computational(Level::Lost);
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"lose", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"lose", lose}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("LEVEL_TRANSITION[lose] 0 1\nM 0\nM 1");
 
@@ -1169,14 +1142,14 @@ TEST_CASE("exact: multi-target annotation jumps both targets in one shot") {
 // LOSS on already-leaked and already-lost qubits
 // =========================================================================
 
-TEST_CASE("exact: LOSS(1) on a pure leak_g initial vacates the carrier") {
+TEST_CASE("exact: certain LOSS on a pure leak_g initial vacates the carrier") {
     // Initial mass entirely on leak_g (index 2): the qubit is already
     // noncomputational. LOSS(1) on a leaked qubit still vacates it (the
     // channel fires from any non-lost level). Every shot: status Lost,
     // record 0 (identity classifier's lost column reads 0).
     ModelSpec spec;
     spec.initial = {0.0, 0.0, 1.0, 0.0, 0.0};  // pure leak_g
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("LOSS(1) 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 20, 141);
@@ -1186,12 +1159,12 @@ TEST_CASE("exact: LOSS(1) on a pure leak_g initial vacates the carrier") {
     }
 }
 
-TEST_CASE("exact: LOSS(1) on a pure lost initial is a no-op") {
+TEST_CASE("exact: certain LOSS on a pure lost initial is a no-op") {
     // Initial mass entirely on lost (index 4): LOSS is a no-op on an
     // already-lost qubit. Status Lost, record 0 on every shot.
     ModelSpec spec;
     spec.initial = {0.0, 0.0, 0.0, 0.0, 1.0};  // pure lost
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("LOSS(1) 0\nM 0");
 
     auto result = sample_noncomputational(circuit, model, 20, 143);
@@ -1210,10 +1183,10 @@ TEST_CASE("exact: LOSS on a lost qubit spends no draw -- a later consult sees th
     // shift; instead the two runs must agree shot by shot on records and
     // statuses alike.
     const uint64_t seed = 147;
-    std::vector<std::vector<double>> recover(5, std::vector<double>(5, 0.0));
-    recover[1][kLost] = 0.5;  // lost -> e, probability one half
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    auto recover = zero_transition_matrix();
+    recover[level_index(Level::E)][level_index(Level::Lost)] =
+        0.5;  // lost -> e, probability one half
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
     auto model =
         NonComputationalModel::from_spec({0.0, 0.0, 0.0, 0.0, 1.0}, {{"recover", recover}},
                                          std::make_optional(classifier), NonComputationalPolicy{});
@@ -1243,8 +1216,7 @@ TEST_CASE("exact: a non-restoring lost MRX spends no hidden draw -- M and MRX re
     // carrier, whose hidden MX would spend an SVM draw and shift every
     // later outcome on qubit 1's stream.
     const uint64_t seed = 61;
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
     auto model = NonComputationalModel::from_spec(
         {1.0, 0.0, 0.0, 0.0, 0.0}, {}, std::make_optional(classifier), NonComputationalPolicy{});
 
@@ -1281,16 +1253,13 @@ TEST_CASE("exact: classified record drives a CX feedback gate") {
     // Note: a feedback-onto-leaked observability test would be a vacuous
     // pass -- a dropped virtual correction on a vacated carrier is
     // unobservable by design (the carrier is gone).
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
+    auto lose = certain_transition_from_computational(Level::Lost);
 
     // g=0, e=1, leak_g=0, leak_e=1, lost=1
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 0.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 1.0, 1.0}};
 
     NonComputationalPolicy policy;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"S", lose}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("S 0\nM 0\nCX rec[-1] 1\nM 1");
 
@@ -1313,16 +1282,13 @@ TEST_CASE("exact: a reset truly re-prepares a restored-lost qubit") {
     // |+> state would read 0 or 1 at random). A true re-prepare resets
     // to |0>, so M 0 must read 0 and the final status must be Computational
     // on every shot.
-    std::vector<std::vector<double>> lose(5, std::vector<double>(5, 0.0));
-    lose[kLost][0] = 1.0;
-    lose[kLost][1] = 1.0;
+    auto lose = certain_transition_from_computational(Level::Lost);
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
+    const RawProbabilityMatrix classifier = {{1.0, 0.0, 1.0, 0.0, 1.0}, {0.0, 1.0, 0.0, 1.0, 0.0}};
 
     NonComputationalPolicy policy;
     policy.reset_restores_lost = true;
-    auto model = NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"S", lose}},
+    auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"S", lose}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("H 0\nS 0\nR 0\nM 0");
 
@@ -1343,7 +1309,7 @@ TEST_CASE("exact: max_rank succeeds exactly at the required rank") {
     // same circuit must succeed with max_rank = 3 (the actual required rank).
     ModelSpec spec;
     spec.leak_from_e = 0.2;
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse(
         "H 0\nH 1\nH 2\n"
         "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
@@ -1367,7 +1333,7 @@ TEST_CASE("exact: different seeds produce different records") {
     ModelSpec spec;
     spec.leak_from_e = 0.35;
     spec.initial = {0.5, 0.5, 0.0, 0.0, 0.0};
-    auto model = make_model(spec);
+    auto model = make_driver_model(spec);
     auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nM 0");
 
     auto a = sample_noncomputational(circuit, model, 64, 97);
@@ -1383,8 +1349,8 @@ TEST_CASE("exact: max_rank is not checked against the unreachable all-computatio
     // The lost column reads symbol 1 with certainty: a raw readout of the
     // dropped-everything |0> carriers would give 0, so all-1 records verify
     // that the classifier wrote them.
-    const std::vector<std::vector<double>> classifier_matrix = {{1.0, 0.0, 1.0, 0.0, 0.0},
-                                                                {0.0, 1.0, 0.0, 1.0, 1.0}};
+    const RawProbabilityMatrix classifier_matrix = {{1.0, 0.0, 1.0, 0.0, 0.0},
+                                                    {0.0, 1.0, 0.0, 1.0, 1.0}};
     // Lost model: all qubits start lost.
     const NonComputationalModel lost_model = NonComputationalModel::from_spec(
         {0.0, 0.0, 0.0, 0.0, 1.0}, {}, std::make_optional(classifier_matrix),
@@ -1422,109 +1388,26 @@ TEST_CASE("exact: max_rank is not checked against the unreachable all-computatio
 
 namespace {
 
-// Helpers for the classifier/herald/confusion test group below.
-// Make an all-zero 5x5 matrix.
-std::vector<std::vector<double>> zeros5() {
-    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
-}
-
-// Source-independent: g and e both jump to leak_g with certainty.
-std::vector<std::vector<double>> certain_leak() {
-    auto m = zeros5();
-    m[kLeakG][0] = 1.0;
-    m[kLeakG][1] = 1.0;
-    return m;
-}
-
-// Source-independent: g and e both jump to lost with certainty.
-std::vector<std::vector<double>> certain_loss() {
-    auto m = zeros5();
-    m[kLost][0] = 1.0;
-    m[kLost][1] = 1.0;
-    return m;
-}
-
-// Source-independent: g and e both jump to the computational g level.
-std::vector<std::vector<double>> certain_jump_to_g() {
-    auto m = zeros5();
-    m[0][0] = 1.0;
-    m[0][1] = 1.0;
-    return m;
-}
-
-// Source-independent: g and e both jump to the computational e level.
-std::vector<std::vector<double>> certain_jump_to_e() {
-    auto m = zeros5();
-    m[1][0] = 1.0;
-    m[1][1] = 1.0;
-    return m;
-}
-
-// Two-symbol classifier whose column for `level` is `col`; computational
-// levels read out faithfully (no readout confusion) and other
-// noncomputational levels read a deterministic symbol 0.
-std::vector<std::vector<double>> classifier_with(uint8_t level, std::vector<double> col) {
-    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
-        m[0][l] = 1.0;  // symbol "0"
-    }
-    // Computational levels read out faithfully (identity columns) so the
-    // classifier adds no readout confusion here.
-    m[0][1] = 0.0;
-    m[1][1] = 1.0;
-    m[0][level] = col[0];
-    m[1][level] = col[1];
-    return m;
-}
-
-// The common case: classify the leak_g column.
-std::vector<std::vector<double>> leakg_classifier(std::vector<double> leakg) {
-    return classifier_with(kLeakG, std::move(leakg));
-}
-
 // Build a NonComputationalModel directly from raw vectors.
 NonComputationalModel make_direct_model(
-    std::vector<double> initial_state,
-    std::map<std::string, std::vector<std::vector<double>>> transitions,
-    std::optional<std::vector<std::vector<double>>> classifier = std::nullopt,
+    std::vector<double> initial_state, std::map<std::string, RawProbabilityMatrix> transitions,
+    std::optional<RawProbabilityMatrix> classifier = std::nullopt,
     NonComputationalPolicy policy = {}) {
     return NonComputationalModel::from_spec(std::move(initial_state), transitions,
                                             std::move(classifier), policy);
 }
 
-std::vector<double> all_g() {
-    return {1.0, 0.0, 0.0, 0.0, 0.0};
-}
-std::vector<double> all_e() {
-    return {0.0, 1.0, 0.0, 0.0, 0.0};
-}
-
-// Three-symbol classifier whose column for `level` is `col`; computational
-// levels read out faithfully and other levels default to symbol 0.
-std::vector<std::vector<double>> ternary_classifier_with(uint8_t level, std::vector<double> col) {
-    std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
-        m[0][l] = 1.0;
-    }
-    m[0][1] = 0.0;
-    m[1][1] = 1.0;
-    m[0][level] = col[0];
-    m[1][level] = col[1];
-    m[2][level] = col[2];
-    return m;
-}
-
 // Classifier with confused computational columns; noncomputational levels
 // deterministically read symbol 0.
-std::vector<std::vector<double>> comp_confusion(double p01, double p10) {
-    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
+RawProbabilityMatrix comp_confusion(double p01, double p10) {
+    RawProbabilityMatrix m(2, std::vector<double>(kNumLevels, 0.0));
+    for (size_t l = 0; l < kNumLevels; ++l) {
         m[0][l] = 1.0;
     }
-    m[0][0] = 1.0 - p01;
-    m[1][0] = p01;
-    m[0][1] = p10;
-    m[1][1] = 1.0 - p10;
+    m[0][level_index(Level::G)] = 1.0 - p01;
+    m[1][level_index(Level::G)] = p01;
+    m[0][level_index(Level::E)] = p10;
+    m[1][level_index(Level::E)] = 1.0 - p10;
     return m;
 }
 
@@ -1532,10 +1415,11 @@ std::vector<std::vector<double>> comp_confusion(double p01, double p10) {
 
 TEST_CASE("exact: a partial classifier bit matches its frequency") {
     Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
     NonComputationalModel model =
-        make_direct_model(all_g(), std::move(transitions), leakg_classifier({0.5, 0.5}));
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions),
+                          classifier_matrix_with_column(Level::LeakG, {0.5, 0.5}));
 
     NonComputationalSample s = sample_noncomputational(c, model, 2000, 3);
     size_t ones = 0;
@@ -1546,15 +1430,16 @@ TEST_CASE("exact: a partial classifier bit matches its frequency") {
     REQUIRE(ones < 1150);
 }
 
-TEST_CASE("exact: the herald symbol fills the sidecar, not the record") {
+TEST_CASE("exact: the herald symbol fills the sidecar rather than the record") {
     // Qubit 1 leaks and its column always heralds; qubit 0 stays
     // computational. The heralded slot's visible record bit is a uniform
     // draw, so the record layout is unchanged and both values occur.
     Circuit c = parse("H 1\nS 1\nM 1\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
-    auto cl = ternary_classifier_with(kLeakG, {0.0, 0.0, 1.0});
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions), std::move(cl));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
+    auto cl = classifier_matrix_with_column(Level::LeakG, {0.0, 0.0, 1.0});
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 256;
     NonComputationalSample r = sample_noncomputational(c, model, kShots, 5);
@@ -1571,10 +1456,11 @@ TEST_CASE("exact: the herald symbol fills the sidecar, not the record") {
 
 TEST_CASE("exact: a partial herald column matches its frequency") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
-    auto cl = ternary_classifier_with(kLeakG, {0.3, 0.0, 0.7});
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions), std::move(cl));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
+    auto cl = classifier_matrix_with_column(Level::LeakG, {0.3, 0.0, 0.7});
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 1000;
     NonComputationalSample r = sample_noncomputational(c, model, kShots, 6);
@@ -1592,10 +1478,11 @@ TEST_CASE("exact: the record bit is uniform given a herald and fixed otherwise")
     // heralded slots kept the not-heralded flip probability (0), their bits
     // would all read 0.
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
-    auto cl = ternary_classifier_with(kLeakG, {0.5, 0.0, 0.5});
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions), std::move(cl));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
+    auto cl = classifier_matrix_with_column(Level::LeakG, {0.5, 0.0, 0.5});
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 2000;
     NonComputationalSample r = sample_noncomputational(c, model, kShots, 13);
@@ -1618,10 +1505,11 @@ TEST_CASE("exact: the record bit is uniform given a herald and fixed otherwise")
 
 TEST_CASE("exact: a two-symbol classifier leaves the herald sidecar zero") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
-    auto cl = leakg_classifier({0.5, 0.5});
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions), std::move(cl));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
+    auto cl = classifier_matrix_with_column(Level::LeakG, {0.5, 0.5});
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions), std::move(cl));
 
     constexpr uint32_t kShots = 64;
     NonComputationalSample r = sample_noncomputational(c, model, kShots, 7);
@@ -1635,7 +1523,7 @@ TEST_CASE("exact: a circuit with EXP_VAL probes rejects") {
     Circuit c;
     c.num_qubits = 1;
     c.num_exp_vals = 1;  // EXP_VAL output is not carried by the noncomp sidecar
-    NonComputationalModel model = make_direct_model(all_g(), {});
+    NonComputationalModel model = make_direct_model(pure_initial_state(Level::G), {});
     REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 4, 1), ContainsSubstring("EXP_VAL"));
 }
 
@@ -1644,10 +1532,11 @@ TEST_CASE("exact: a measure-and-reset on a leaked qubit injects and restores") {
     // |0>; the following M then deterministically reads 0 -- proving the reset
     // actually ran in the SVM, not just in the trajectory bookkeeping.
     Circuit c = parse("H 0\nS 0\nMR 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
     NonComputationalModel model =
-        make_direct_model(all_g(), std::move(transitions), leakg_classifier({0.0, 1.0}));
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions),
+                          classifier_matrix_with_column(Level::LeakG, {0.0, 1.0}));
 
     NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
     REQUIRE(s.num_measurements == 2);
@@ -1661,12 +1550,13 @@ TEST_CASE("exact: a lost-qubit measurement feeds the detector the classifier bit
     // A lost qubit (vacated site) is still measured; the classifier supplies
     // the record bit just as for a leaked qubit, so the detector reads it.
     Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_loss());
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::Lost));
 
     // Force the lost column -> symbol 1 -> record bit 1.
     NonComputationalModel model =
-        make_direct_model(all_g(), std::move(transitions), classifier_with(kLost, {0.0, 1.0}));
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions),
+                          classifier_matrix_with_column(Level::Lost, {0.0, 1.0}));
     NonComputationalSample s = sample_noncomputational(c, model, 200, 9);
     REQUIRE(s.num_detectors == 1);
     REQUIRE(s.detectors.size() == 200);
@@ -1677,13 +1567,14 @@ TEST_CASE("exact: a lost-qubit measurement feeds the detector the classifier bit
 
 TEST_CASE("exact: a leaked measurement feeds the observable the classifier bit") {
     Circuit c = parse("H 0\nS 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_leak());
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
 
     // Force leak_g -> symbol 1 -> record bit 1; the observable must see it,
     // not the residual |0>.
     NonComputationalModel model =
-        make_direct_model(all_g(), std::move(transitions), leakg_classifier({0.0, 1.0}));
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions),
+                          classifier_matrix_with_column(Level::LeakG, {0.0, 1.0}));
     NonComputationalSample s = sample_noncomputational(c, model, 200, 11);
     REQUIRE(s.num_observables == 1);
     REQUIRE(s.observables.size() == 200);
@@ -1698,9 +1589,10 @@ TEST_CASE("exact: a jump to the ground level forces the measurement to 0") {
     // fire resolves entirely inside the VM; the sidecar reports the bare
     // computational kind, never a level claim.
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_jump_to_g());
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::G));
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions));
     NonComputationalSample s = sample_noncomputational(c, model, 200, 1);
     for (uint8_t bit : s.measurements) {
         REQUIRE(bit == 0);
@@ -1712,9 +1604,10 @@ TEST_CASE("exact: a jump to the ground level forces the measurement to 0") {
 
 TEST_CASE("exact: a jump to the excited level forces the measurement to 1") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_jump_to_e());
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::E));
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions));
 
     NonComputationalSample s = sample_noncomputational(c, model, 200, 1);
     for (uint8_t bit : s.measurements) {
@@ -1729,12 +1622,13 @@ TEST_CASE("exact: a partial jump to ground matches the analytic mixture") {
     // With probability p the S transition collapses the H-prepared |+> to g;
     // otherwise the carrier stays coherent. P(M = 1) = (1 - p) / 2 = 0.35.
     Circuit c = parse("H 0\nS 0\nM 0\n");
-    auto m = zeros5();
-    m[0][0] = 0.3;
-    m[0][1] = 0.3;
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    auto m = zero_transition_matrix();
+    m[level_index(Level::G)][level_index(Level::G)] = 0.3;
+    m[level_index(Level::G)][level_index(Level::E)] = 0.3;
+    std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("S", std::move(m));
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions));
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions));
 
     NonComputationalSample s = sample_noncomputational(c, model, 4000, 3);
     size_t ones = 0;
@@ -1750,11 +1644,12 @@ TEST_CASE("exact: a measurement records the pre-relaxation bit") {
     // after the base op: the first M reads the original |1>, the relaxation
     // then materializes g, and the second M reads the relaxed 0.
     Circuit c = parse("M 0\nM 0\n");
-    auto m = zeros5();
-    m[0][1] = 1.0;  // e relaxes to g with certainty; g stays
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    auto m = zero_transition_matrix();
+    m[level_index(Level::G)][level_index(Level::E)] = 1.0;
+    std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("M", std::move(m));
-    NonComputationalModel model = make_direct_model(all_e(), std::move(transitions));
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::E), std::move(transitions));
 
     NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
     REQUIRE(s.num_measurements == 2);
@@ -1770,13 +1665,14 @@ TEST_CASE("exact: recapturing a lost qubit clears the stale residual") {
     // attached recapture jump materializes g; the third M must read the
     // recaptured 0.
     Circuit c = parse("M 0\nM 0\nM 0\n");
-    auto m = zeros5();
-    m[kLost][1] = 1.0;  // e is lost with certainty
-    m[0][kLost] = 1.0;  // a lost qubit is recaptured at g with certainty
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    auto m = zero_transition_matrix();
+    m[level_index(Level::Lost)][level_index(Level::E)] = 1.0;
+    m[level_index(Level::G)][level_index(Level::Lost)] = 1.0;
+    std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("M", std::move(m));
     NonComputationalModel model =
-        make_direct_model(all_e(), std::move(transitions), classifier_with(kLost, {1.0, 0.0}));
+        make_direct_model(pure_initial_state(Level::E), std::move(transitions),
+                          classifier_matrix_with_column(Level::Lost, {1.0, 0.0}));
 
     NonComputationalSample s = sample_noncomputational(c, model, 64, 7);
     REQUIRE(s.num_measurements == 3);
@@ -1793,11 +1689,12 @@ TEST_CASE("exact: a multi-round circuit runs through loss") {
     // reads the classifier's lost bit -- dropping ops on a vacated site is
     // the (only) op policy.
     Circuit c = parse("H 0\nS 0\nCX 0 1\nMR 1\nCX 0 1\nMR 1\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", certain_loss());
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::Lost));
 
     NonComputationalModel model =
-        make_direct_model(all_g(), std::move(transitions), classifier_with(kLost, {0.0, 1.0}));
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions),
+                          classifier_matrix_with_column(Level::Lost, {0.0, 1.0}));
     NonComputationalSample r = sample_noncomputational(c, model, 16, 3);
     REQUIRE(r.num_measurements == 3);
     for (uint32_t shot = 0; shot < 16; ++shot) {
@@ -1813,7 +1710,8 @@ TEST_CASE("exact: computational confusion misreports into the detector") {
     // shot even though the qubit is |0> -- the flip is in-circuit, not
     // postprocessing.
     Circuit c = parse("M 0\nDETECTOR rec[-1]\n");
-    NonComputationalModel model = make_direct_model(all_g(), {}, comp_confusion(1.0, 0.0));
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), {}, comp_confusion(1.0, 0.0));
 
     NonComputationalSample s = sample_noncomputational(c, model, 64, 3);
     for (uint32_t shot = 0; shot < s.shots; ++shot) {
@@ -1825,7 +1723,8 @@ TEST_CASE("exact: computational confusion misreports into the detector") {
 TEST_CASE("exact: asymmetric confusion matches its rates") {
     // True bit is 1 (X-prepared); it is misread as 0 with probability 0.2.
     Circuit c = parse("X 0\nM 0\n");
-    NonComputationalModel model = make_direct_model(all_g(), {}, comp_confusion(0.0, 0.2));
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), {}, comp_confusion(0.0, 0.2));
 
     constexpr uint32_t kShots = 4000;
     NonComputationalSample s = sample_noncomputational(c, model, kShots, 9);
@@ -1842,18 +1741,12 @@ TEST_CASE("exact: hand-written LOSS and LEVEL_TRANSITION run end to end") {
     // lost bit. Qubit 1 leaks via a local named LEVEL_TRANSITION; its measurement
     // takes the leak_g bit.
     Circuit c = parse("H 0\nH 1\nLOSS(1) 0\nLEVEL_TRANSITION[leak] 1\nM 0\nM 1\n");
-    auto leak = zeros5();
-    leak[kLeakG][0] = 1.0;
-    leak[kLeakG][1] = 1.0;
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
+    auto leak = certain_transition_from_computational(Level::LeakG);
+    std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("leak", std::move(leak));
-    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    m[0][0] = 1.0;
-    m[1][1] = 1.0;
-    m[1][kLeakG] = 1.0;  // leaked reads 1
-    m[0][kLost] = 1.0;   // lost reads 0
-    m[0][3] = 1.0;
-    NonComputationalModel model = make_direct_model(all_g(), std::move(transitions), std::move(m));
+    auto m = classifier_matrix_with_column(Level::LeakG, {0.0, 1.0});
+    NonComputationalModel model =
+        make_direct_model(pure_initial_state(Level::G), std::move(transitions), std::move(m));
 
     NonComputationalSample s = sample_noncomputational(c, model, 64, 5);
     for (uint32_t shot = 0; shot < s.shots; ++shot) {

--- a/tests/test_execute_instruments.cc
+++ b/tests/test_execute_instruments.cc
@@ -8,10 +8,10 @@
 // validation belongs to the exact-mode validation campaign.
 
 #include "clifft/backend/backend.h"
-#include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
-#include "clifft/optimizer/pass_factory.h"
 #include "clifft/svm/svm.h"
+
+#include "instrument_test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
@@ -24,6 +24,9 @@
 
 using namespace clifft;
 using Catch::Matchers::ContainsSubstring;
+using clifft::test::compile_instruments_full;
+using clifft::test::compile_instruments_raw;
+using clifft::test::make_shot_state;
 
 namespace {
 
@@ -36,31 +39,6 @@ InstrumentProbabilities to_level(double p_g, double p_e, int dest) {
     spec.p_computational_dest[0][dest] = p_g;
     spec.p_computational_dest[1][dest] = p_e;
     return spec;
-}
-
-CompiledModule compile_raw(const char* text, const InstrumentTraceOptions& options) {
-    auto hir = trace(parse(text), &options);
-    return lower(hir);
-}
-
-// The full default pipeline, for tests that must survive real HIR and
-// bytecode optimization (virtual-S absorption in particular).
-CompiledModule compile_full(const char* text, const InstrumentTraceOptions& options) {
-    auto hir = trace(parse(text), &options);
-    auto hir_passes = default_hir_pass_manager();
-    hir_passes.run(hir);
-    auto module = lower(hir);
-    auto bytecode_passes = default_bytecode_pass_manager();
-    bytecode_passes.run(module);
-    return module;
-}
-
-SchrodingerState make_shot_state(const CompiledModule& module, uint64_t seed) {
-    return SchrodingerState(StateConfig{.peak_rank = module.peak_rank,
-                                        .num_measurements = module.total_meas_slots,
-                                        .num_qubits = module.num_qubits,
-                                        .num_exp_vals = module.num_exp_vals,
-                                        .seed = seed});
 }
 
 // Execute one shot with a fixed seed and return the measurement record.
@@ -90,8 +68,8 @@ TEST_CASE("execute: a certain relaxation fires in-line and flips the record") {
     InstrumentTraceOptions options;
     options.transitions.emplace("relax", to_level(/*p_g=*/0.0, /*p_e=*/1.0, /*dest=*/0));
 
-    auto relaxed = compile_raw("X 0\nLEVEL_TRANSITION[relax] 0\nM 0", options);
-    auto untouched = compile_raw("LEVEL_TRANSITION[relax] 0\nM 0", options);
+    auto relaxed = compile_instruments_raw("X 0\nLEVEL_TRANSITION[relax] 0\nM 0", options);
+    auto untouched = compile_instruments_raw("LEVEL_TRANSITION[relax] 0\nM 0", options);
 
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(relaxed, seed) == std::vector<uint8_t>{0});
@@ -103,7 +81,7 @@ TEST_CASE("execute: a certain excitation from a definite g fires to e") {
     InstrumentTraceOptions options;
     options.transitions.emplace("excite", to_level(/*p_g=*/1.0, /*p_e=*/0.0, /*dest=*/1));
 
-    auto module = compile_raw("LEVEL_TRANSITION[excite] 0\nM 0", options);
+    auto module = compile_instruments_raw("LEVEL_TRANSITION[excite] 0\nM 0", options);
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(module, seed) == std::vector<uint8_t>{1});
     }
@@ -117,7 +95,7 @@ TEST_CASE("execute: an active-axis certain reset collapses the carrier to g") {
     InstrumentTraceOptions options;
     options.transitions.emplace("reset_g", to_level(/*p_g=*/1.0, /*p_e=*/1.0, /*dest=*/0));
 
-    auto module = compile_raw("H 0\nT 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
+    auto module = compile_instruments_raw("H 0\nT 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
     REQUIRE(module.peak_rank == 1);
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(module, seed) == std::vector<uint8_t>{0});
@@ -133,7 +111,7 @@ TEST_CASE("execute: a dormant-random source-dependent site expands and measures 
     InstrumentTraceOptions options;
     options.transitions.emplace("reset_g", to_level(/*p_g=*/0.0, /*p_e=*/1.0, /*dest=*/0));
 
-    auto module = compile_raw("H 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
+    auto module = compile_instruments_raw("H 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
     REQUIRE(module.peak_rank == 1);  // the site's own expansion
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(module, seed) == std::vector<uint8_t>{0});
@@ -148,7 +126,7 @@ TEST_CASE("execute: the no-fire path of a weak site leaves a definite carrier al
     InstrumentTraceOptions options;
     options.transitions.emplace("relax", to_level(0.0, 0.05, /*dest=*/0));
 
-    auto module = compile_raw("X 0\nLEVEL_TRANSITION[relax] 0\nM 0", options);
+    auto module = compile_instruments_raw("X 0\nLEVEL_TRANSITION[relax] 0\nM 0", options);
     int ones = 0;
     for (uint64_t seed = 1; seed <= 50; ++seed) {
         auto first = run_shot(module, seed);
@@ -160,7 +138,7 @@ TEST_CASE("execute: the no-fire path of a weak site leaves a definite carrier al
 
 TEST_CASE("execute: a leaked/lost fire halts with the trap recorded") {
     InstrumentTraceOptions options;  // LOSS needs no spec
-    auto module = compile_raw("H 1\nLOSS(1.0) 0\nM 0", options);
+    auto module = compile_instruments_raw("H 1\nLOSS(1.0) 0\nM 0", options);
 
     auto state = make_shot_state(module, /*seed=*/7);
     execute(module, state);
@@ -193,7 +171,7 @@ TEST_CASE("execute: the no-fire back-action matches its closed form through the 
     const char* expand_form = "H 0\nLEVEL_TRANSITION[damp] 0\nH 0\nEXP_VAL Z0\nM 0";
 
     for (const char* text : {active_form, expand_form}) {
-        auto module = compile_raw(text, options);
+        auto module = compile_instruments_raw(text, options);
         int completed = 0;
         int trapped = 0;
         for (uint64_t seed = 1; seed <= 40; ++seed) {
@@ -220,7 +198,8 @@ TEST_CASE("execute: an absorbed virtual S conjugates the destination flip") {
     InstrumentTraceOptions options;
     options.transitions.emplace("reset_g", to_level(1.0, 1.0, /*dest=*/0));
 
-    auto module = compile_full("X 0\nH 0\nT 0\nT 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
+    auto module =
+        compile_instruments_full("X 0\nH 0\nT 0\nT 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(module, seed) == std::vector<uint8_t>{0});
     }
@@ -236,7 +215,7 @@ TEST_CASE("execute: sequential sites compose and a drained source never fires") 
     options.transitions.emplace("reset_e", to_level(1.0, 1.0, /*dest=*/1));
     options.transitions.emplace("g_pump", to_level(1.0, 0.0, /*dest=*/1));
 
-    auto module = compile_raw(
+    auto module = compile_instruments_raw(
         "H 0\nT 0\nLEVEL_TRANSITION[reset_e] 0\nLEVEL_TRANSITION[g_pump] 0\nM 0", options);
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         REQUIRE(run_shot(module, seed) == std::vector<uint8_t>{1});
@@ -251,7 +230,8 @@ TEST_CASE("execute: a localization sign threads through the active fire path") {
     InstrumentTraceOptions options;
     options.transitions.emplace("reset_g", to_level(1.0, 1.0, /*dest=*/0));
 
-    auto module = compile_raw("X 0\nH 0\nT 0\nH 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
+    auto module =
+        compile_instruments_raw("X 0\nH 0\nT 0\nH 0\nLEVEL_TRANSITION[reset_g] 0\nM 0", options);
     bool saw_signed_instrument = false;
     for (const auto& instr : module.bytecode) {
         if (instr.opcode == Opcode::OP_INSTRUMENT_ACTIVE &&
@@ -272,7 +252,8 @@ TEST_CASE("execute: an entangled site's multi-axis destination flip lands correc
     InstrumentTraceOptions options;
     options.transitions.emplace("reset_g", to_level(1.0, 1.0, /*dest=*/0));
 
-    auto module = compile_raw("H 0\nH 1\nCZ 0 1\nLEVEL_TRANSITION[reset_g] 1\nM 1", options);
+    auto module =
+        compile_instruments_raw("H 0\nH 1\nCZ 0 1\nLEVEL_TRANSITION[reset_g] 1\nM 1", options);
     const auto& site = module.constant_pool.instrument_sites.at(0);
     auto flip =
         module.constant_pool.instrument_destination_flip_masks.at(site.destination_flip_mask);
@@ -292,7 +273,7 @@ TEST_CASE("execute: a neglect-mode dormant-random site is silent until it fires"
     // Fire probability is 0.3 per shot; k stays 0 either way. Fired
     // shots trap (all destinations are leaked/lost here); silent shots
     // measure the untouched |+> fairly.
-    auto module = compile_raw("H 0\nLEVEL_TRANSITION[leak] 0\nM 0", options);
+    auto module = compile_instruments_raw("H 0\nLEVEL_TRANSITION[leak] 0\nM 0", options);
     REQUIRE(module.peak_rank == 0);
 
     int traps = 0;

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -16,6 +16,7 @@
 #include "clifft/optimizer/peephole.h"
 #include "clifft/optimizer/statevector_squeeze_pass.h"
 
+#include "instrument_test_helpers.h"
 #include "test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -27,23 +28,11 @@
 using namespace clifft;
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
+using clifft::test::source_dependent_jump_options;
 
 namespace {
 
 constexpr double kTol = 1e-15;
-
-// A source-dependent transition: from g, 0.02 -> g, 0.03 -> e, 0.05 to a
-// noncomputational level (the trap remainder); from e, 0.4 entirely trap.
-InstrumentTraceOptions demo_options() {
-    InstrumentTraceOptions options;
-    InstrumentProbabilities probabilities;
-    probabilities.p_fire[0] = 0.1;
-    probabilities.p_computational_dest[0][0] = 0.02;
-    probabilities.p_computational_dest[0][1] = 0.03;
-    probabilities.p_fire[1] = 0.4;
-    options.transitions.emplace("jump", probabilities);
-    return options;
-}
 
 HirModule hir_with_instruments(const char* text, const InstrumentTraceOptions& options) {
     return trace(parse(text), &options);
@@ -79,7 +68,7 @@ TEST_CASE("trace: annotations still reject without instrument options") {
 }
 
 TEST_CASE("trace: LEVEL_TRANSITION materializes an INSTRUMENT with its spec") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     auto hir = hir_with_instruments("H 1\nLEVEL_TRANSITION[jump] 0", options);
 
     REQUIRE(hir.ops.size() == 1);
@@ -106,7 +95,7 @@ TEST_CASE("trace: LEVEL_TRANSITION materializes an INSTRUMENT with its spec") {
 }
 
 TEST_CASE("trace: the instrument mask is the rewound source projector") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
 
     // X before the site: Z -> -Z, so the mask picks up a sign.
     auto flipped = hir_with_instruments("X 0\nLEVEL_TRANSITION[jump] 0", options);
@@ -179,7 +168,7 @@ TEST_CASE("trace: non-finite compressed instrument probabilities reject") {
 }
 
 TEST_CASE("trace: the damping policy is recorded once on the HIR module") {
-    auto options = demo_options();
+    auto options = source_dependent_jump_options();
     options.neglect_instrument_damping = true;
     auto hir = hir_with_instruments("LEVEL_TRANSITION[jump] 0\nLOSS(0.1) 1", options);
     REQUIRE(hir.instrument_sites.size() == 2);
@@ -217,7 +206,7 @@ TEST_CASE("instrument_trace_options: resolves model transitions and policy") {
 // =============================================================================
 
 TEST_CASE("fences: can_swap refuses to move anything across an instrument") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     // The T and the instrument act on different qubits: their masks
     // commute, so only the positional clause can block the swap.
     auto hir = hir_with_instruments("T 0\nLEVEL_TRANSITION[jump] 1", options);
@@ -227,7 +216,7 @@ TEST_CASE("fences: can_swap refuses to move anything across an instrument") {
 }
 
 TEST_CASE("fences: the peephole does not fuse a T pair across an instrument") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     auto fenced = hir_with_instruments("T 0\nLEVEL_TRANSITION[jump] 1\nT 0", options);
     REQUIRE(fenced.ops.size() == 3);
 
@@ -242,7 +231,7 @@ TEST_CASE("fences: the peephole does not fuse a T pair across an instrument") {
 }
 
 TEST_CASE("fences: the squeeze pass does not bubble a measurement across an instrument") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     // Without the barrier, M 0 commutes with a site on qubit 1 and would
     // compact leftward past it.
     auto hir = hir_with_instruments("LEVEL_TRANSITION[jump] 1\nM 0", options);
@@ -256,7 +245,7 @@ TEST_CASE("fences: the squeeze pass does not bubble a measurement across an inst
 }
 
 TEST_CASE("fences: an absorbed virtual S conjugates the instrument mask like a measurement") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     // T 0; T 0 fuses to a virtual S along Z(0). The H makes the site's
     // rewound projector X(0), which anti-commutes with the S axis, so the
     // absorption must rotate it to Y(0) -- the same conjugation measures
@@ -284,12 +273,12 @@ TEST_CASE("fences: an absorbed virtual S conjugates the instrument mask like a m
 }
 
 TEST_CASE("fences: an absorbed virtual S conjugates the side-table destination flip too") {
-    const auto options = demo_options();
+    const auto options = source_dependent_jump_options();
     // With the T pair after the H, the virtual S runs along X(0): now the
     // site's own mask (X-like) commutes and stays put, while the destination flip
     // (rewound X = Z(0)) anti-commutes and must rotate to Y(0). A sweep
-    // that only conjugates op-attached masks misses it -- the side-table
-    // twin of the C2 destination-flip bug.
+    // that only conjugates op-attached masks misses the side-table
+    // destination flip.
     auto hir = hir_with_instruments("H 0\nT 0\nT 0\nLEVEL_TRANSITION[jump] 0", options);
     REQUIRE(hir.ops.size() == 3);
 

--- a/tests/test_noncomp_classifier.cc
+++ b/tests/test_noncomp_classifier.cc
@@ -1,6 +1,7 @@
 #include "clifft/noncomp/classifier.h"
 #include "clifft/noncomp/level.h"
 
+#include "noncomp_test_helpers.h"
 #include "test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -16,35 +17,25 @@ using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
 using clifft::Level;
 using clifft::MeasurementClassifier;
+using clifft::test::classifier_matrix_with_column;
 using clifft::test::opaque_infinity;
 using clifft::test::opaque_nan;
-
-namespace {
-
-// Identity readout on g/e; leak_g/lost read "0", leak_e reads "1".
-// Every column sums to 1, as construction requires.
-std::vector<std::vector<double>> default_matrix() {
-    return {
-        {1, 0, 1, 0, 1},  // P("0" | level) over [g, e, leak_g, leak_e, lost]
-        {0, 1, 0, 1, 0},  // P("1" | level)
-    };
-}
-
-}  // namespace
+using clifft::test::RawProbabilityMatrix;
 
 // =========================================================================
 // Construction validation
 // =========================================================================
 
 TEST_CASE("MeasurementClassifier: accepts a stochastic two-symbol matrix") {
-    auto classifier = MeasurementClassifier::from_matrix(default_matrix());
+    auto classifier =
+        MeasurementClassifier::from_matrix(classifier_matrix_with_column(Level::LeakE, {0.0, 1.0}));
     REQUIRE(classifier.num_symbols() == 2);
     REQUIRE_FALSE(classifier.has_herald());
 }
 
 TEST_CASE("MeasurementClassifier: accepts a three-symbol matrix with a noncomp herald") {
     // The herald symbol may carry mass only on noncomputational columns.
-    std::vector<std::vector<double>> m = {
+    RawProbabilityMatrix m = {
         {1, 0, 0.5, 0, 0},
         {0, 1, 0.2, 1, 0},
         {0, 0, 0.3, 0, 1},  // herald: leak_g sometimes, lost always
@@ -57,23 +48,23 @@ TEST_CASE("MeasurementClassifier: accepts a three-symbol matrix with a noncomp h
 }
 
 TEST_CASE("MeasurementClassifier: rejects symbol counts other than two or three") {
-    std::vector<std::vector<double>> one = {{1, 1, 1, 1, 1}};
+    RawProbabilityMatrix one = {{1, 1, 1, 1, 1}};
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(one),
                         ContainsSubstring("two record symbols") && ContainsSubstring("got 1"));
-    std::vector<std::vector<double>> four = {
+    RawProbabilityMatrix four = {
         {1, 1, 1, 1, 1}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}};
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(four), ContainsSubstring("got 4"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects wrong row count") {
-    std::vector<std::vector<double>> m = {
+    RawProbabilityMatrix m = {
         {1, 1, 1, 1, 1},
     };
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m), ContainsSubstring("got 1"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects wrong column count") {
-    std::vector<std::vector<double>> m = {
+    RawProbabilityMatrix m = {
         {1, 0, 1, 0},  // only 4 columns
         {0, 1, 0, 1},
     };
@@ -82,33 +73,33 @@ TEST_CASE("MeasurementClassifier: rejects wrong column count") {
 }
 
 TEST_CASE("MeasurementClassifier: rejects negative entry") {
-    std::vector<std::vector<double>> m = default_matrix();
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][0] = -0.1;
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
                         ContainsSubstring("entry") && ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects entry above 1") {
-    std::vector<std::vector<double>> m = default_matrix();
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][0] = 1.5;
     REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix(m), std::invalid_argument);
 }
 
 TEST_CASE("MeasurementClassifier: rejects NaN entry") {
-    std::vector<std::vector<double>> m = default_matrix();
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][0] = opaque_nan();
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
                         ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("MeasurementClassifier: rejects infinity entry") {
-    std::vector<std::vector<double>> m = default_matrix();
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][0] = opaque_infinity();
     REQUIRE_THROWS_AS(MeasurementClassifier::from_matrix(m), std::invalid_argument);
 }
 
-TEST_CASE("MeasurementClassifier: rejects a substochastic (reject) column") {
-    std::vector<std::vector<double>> m = default_matrix();
+TEST_CASE("MeasurementClassifier: rejects a substochastic reject column") {
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][2] = 0.5;  // leak_g column now sums to 0.5
     m[1][2] = 0.0;
     REQUIRE_THROWS_WITH(
@@ -117,25 +108,25 @@ TEST_CASE("MeasurementClassifier: rejects a substochastic (reject) column") {
 }
 
 TEST_CASE("MeasurementClassifier: rejects a column sum above 1") {
-    std::vector<std::vector<double>> m = default_matrix();
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][0] = 0.6;
     m[1][0] = 0.6;  // g column sums to 1.2
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m), ContainsSubstring("must sum to 1"));
 }
 
-TEST_CASE("MeasurementClassifier: column sum tolerance: accepts inside, rejects outside") {
+TEST_CASE("MeasurementClassifier: column sum tolerance accepts inside and rejects outside") {
     // kProbTolerance = 1e-12. A sum of 1 + 1e-13 is clearly inside the band
     // and must be accepted; a sum of 1 + 1e-11 is clearly outside and must
     // be rejected. Both individual entries are in [0, 1] so the per-entry
     // check cannot fire.
     SECTION("clearly accepted: sum = 1 + 1e-13") {
-        std::vector<std::vector<double>> m = default_matrix();
+        RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
         m[0][0] = 0.5 + 1e-13;  // entry in [0,1]; the sum exceeds 1 by 1e-13, inside the tolerance
         m[1][0] = 0.5;
         REQUIRE_NOTHROW(MeasurementClassifier::from_matrix(m));
     }
     SECTION("clearly rejected: sum = 1 + 1e-11") {
-        std::vector<std::vector<double>> m = default_matrix();
+        RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
         m[0][0] = 0.5 + 1e-11;  // entry in [0,1]; the sum exceeds 1 by 1e-11, outside the tolerance
         m[1][0] = 0.5;
         REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
@@ -144,7 +135,7 @@ TEST_CASE("MeasurementClassifier: column sum tolerance: accepts inside, rejects 
 }
 
 TEST_CASE("MeasurementClassifier: rejects herald mass on a computational column") {
-    std::vector<std::vector<double>> m = {
+    RawProbabilityMatrix m = {
         {1, 0, 1, 0, 1}, {0, 0.8, 0, 1, 0}, {0, 0.2, 0, 0, 0},  // e column puts 0.2 on the herald
     };
     REQUIRE_THROWS_WITH(MeasurementClassifier::from_matrix(m),
@@ -155,8 +146,8 @@ TEST_CASE("MeasurementClassifier: rejects herald mass on a computational column"
 // Accessors
 // =========================================================================
 
-TEST_CASE("MeasurementClassifier: prob returns the entry under (symbol, level) convention") {
-    std::vector<std::vector<double>> m = default_matrix();
+TEST_CASE("MeasurementClassifier: prob follows the symbol-level convention") {
+    RawProbabilityMatrix m = classifier_matrix_with_column(Level::LeakE, {0.0, 1.0});
     m[0][2] = 0.25;  // P("0" | leak_g) = 0.25
     m[1][2] = 0.75;  // P("1" | leak_g) = 0.75
     auto classifier = MeasurementClassifier::from_matrix(m);
@@ -169,6 +160,7 @@ TEST_CASE("MeasurementClassifier: prob returns the entry under (symbol, level) c
 }
 
 TEST_CASE("MeasurementClassifier: out-of-range symbol probability throws") {
-    auto classifier = MeasurementClassifier::from_matrix(default_matrix());
+    auto classifier =
+        MeasurementClassifier::from_matrix(classifier_matrix_with_column(Level::LeakE, {0.0, 1.0}));
     REQUIRE_THROWS_AS(classifier.prob(99, Level::G), std::invalid_argument);
 }

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -12,6 +12,8 @@
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/rewriter.h"
 
+#include "noncomp_test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -21,27 +23,26 @@
 
 using namespace clifft;
 using Catch::Matchers::ContainsSubstring;
+using clifft::test::classifier_matrix_with_column;
+using clifft::test::level_index;
+using clifft::test::pure_initial_state;
+using clifft::test::zero_transition_matrix;
 
 namespace {
-
-// Matrix index of the leak_e level the demo model leaks to.
-constexpr uint8_t kLeak = 3;
 
 // A model with one named leak transition (e leaks at 0.4, g at 0.1),
 // seepage back from the leaked level (0.2 to e), and a faithful
 // two-symbol classifier whose leaked column reads 1.
 NonComputationalModel demo_model() {
-    std::vector<std::vector<double>> leak(5, std::vector<double>(5, 0.0));
-    leak[kLeak][0] = 0.1;
-    leak[kLeak][1] = 0.4;
-    leak[1][kLeak] = 0.2;  // seepage: leaked -> e
+    auto leak = zero_transition_matrix();
+    leak[level_index(Level::LeakE)][level_index(Level::G)] = 0.1;
+    leak[level_index(Level::LeakE)][level_index(Level::E)] = 0.4;
+    leak[level_index(Level::E)][level_index(Level::LeakE)] = 0.2;
 
-    const std::vector<std::vector<double>> classifier = {{1.0, 0.0, 1.0, 0.0, 1.0},
-                                                         {0.0, 1.0, 0.0, 1.0, 0.0}};
-
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, {{"leak", leak}},
-                                            std::make_optional(classifier),
-                                            NonComputationalPolicy{});
+    return NonComputationalModel::from_spec(
+        pure_initial_state(Level::G), {{"leak", leak}},
+        std::make_optional(classifier_matrix_with_column(Level::LeakE, {0.0, 1.0})),
+        NonComputationalPolicy{});
 }
 
 std::vector<QubitStatus> computational_initials(uint32_t n) {

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -5,6 +5,7 @@
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/policy.h"
 
+#include "noncomp_test_helpers.h"
 #include "test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -27,23 +28,12 @@ using clifft::kAllLevels;
 using clifft::Level;
 using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
+using clifft::test::classifier_matrix_with_column;
 using clifft::test::opaque_nan;
+using clifft::test::RawProbabilityMatrix;
+using clifft::test::zero_transition_matrix;
 
 namespace {
-
-// All-zero transition matrix: every source has no-jump weight 1, i.e.
-// nothing happens. The honest no-op default.
-std::vector<std::vector<double>> zero_matrix() {
-    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
-}
-
-// Identity readout on g/e; leak_g/lost read "0", leak_e reads "1".
-std::vector<std::vector<double>> identity_classifier() {
-    return {
-        {1, 0, 1, 0, 1},
-        {0, 1, 0, 1, 0},
-    };
-}
 
 // A valid probability vector over the 5 levels.
 std::vector<double> default_initial_state() {
@@ -65,9 +55,10 @@ double sum(const std::vector<double>& v) {
 // =========================================================================
 
 TEST_CASE("NonComputationalModel: accepts a fully specified model") {
-    auto model = NonComputationalModel::from_spec(default_initial_state(), {{"H", zero_matrix()}},
-                                                  std::make_optional(identity_classifier()),
-                                                  NonComputationalPolicy{});
+    auto model = NonComputationalModel::from_spec(
+        default_initial_state(), {{"H", zero_transition_matrix()}},
+        std::make_optional(classifier_matrix_with_column(Level::LeakE, {0.0, 1.0})),
+        NonComputationalPolicy{});
     REQUIRE(model.transitions().size() == 1);
     REQUIRE(model.classifier() != nullptr);
 }
@@ -102,8 +93,9 @@ TEST_CASE("NonComputationalModel: normalizes the stored initial state") {
 }
 
 TEST_CASE("NonComputationalModel: alias key is stored verbatim and hooks the canonical gate") {
-    auto model = NonComputationalModel::from_spec(
-        default_initial_state(), {{"CNOT", zero_matrix()}}, std::nullopt, NonComputationalPolicy{});
+    auto model = NonComputationalModel::from_spec(default_initial_state(),
+                                                  {{"CNOT", zero_transition_matrix()}},
+                                                  std::nullopt, NonComputationalPolicy{});
     // Stored under the original key; the hook resolves the canonical gate.
     REQUIRE(model.transitions().count("CNOT") == 1);
     REQUIRE(model.transition_hooks().at(GateType::CX) == "CNOT");
@@ -122,7 +114,7 @@ TEST_CASE("NonComputationalModel: rejects initial state with wrong length") {
         ContainsSubstring("initial_state has 2 entries") && ContainsSubstring("expected 5"));
 }
 
-TEST_CASE("NonComputationalModel: rejects initial state entry out of [0, 1]") {
+TEST_CASE("NonComputationalModel: rejects initial state entry outside the unit interval") {
     REQUIRE_THROWS_WITH(
         NonComputationalModel::from_spec({1.5, -0.5, 0.0, 0.0, 0.0}, {}, std::nullopt,
                                          NonComputationalPolicy{}),
@@ -146,31 +138,32 @@ TEST_CASE("NonComputationalModel: rejects initial state that does not sum to 1")
 // Construction: transition validation
 // =========================================================================
 
-TEST_CASE("NonComputationalModel: a non-gate transition key is a named transition, not a hook") {
-    auto model =
-        NonComputationalModel::from_spec(default_initial_state(), {{"my_leak", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{});
+TEST_CASE("NonComputationalModel: a non-gate transition key is named rather than hooked") {
+    auto model = NonComputationalModel::from_spec(default_initial_state(),
+                                                  {{"my_leak", zero_transition_matrix()}},
+                                                  std::nullopt, NonComputationalPolicy{});
     REQUIRE(model.transition_named("my_leak") != nullptr);
     REQUIRE(model.transition_hooks().empty());
 }
 
 TEST_CASE(
     "NonComputationalModel: rejects a transition key a LEVEL_TRANSITION tag cannot reference") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"bad]key", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("bad]key") &&
-            ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"bad]key", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("bad]key") &&
+                            ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: a non-hookable gate-named key is a named-only transition") {
     // Keys naming non-hookable instructions (noise channels, annotations,
     // LOSS itself) register no hook, but stay referenceable from a
     // LEVEL_TRANSITION[key] annotation like any other name.
-    auto model = NonComputationalModel::from_spec(
-        default_initial_state(),
-        {{"DEPOLARIZE1", zero_matrix()}, {"TICK", zero_matrix()}, {"LOSS", zero_matrix()}},
-        std::nullopt, NonComputationalPolicy{});
+    auto model = NonComputationalModel::from_spec(default_initial_state(),
+                                                  {{"DEPOLARIZE1", zero_transition_matrix()},
+                                                   {"TICK", zero_transition_matrix()},
+                                                   {"LOSS", zero_transition_matrix()}},
+                                                  std::nullopt, NonComputationalPolicy{});
     REQUIRE(model.transition_named("DEPOLARIZE1") != nullptr);
     REQUIRE(model.transition_named("TICK") != nullptr);
     REQUIRE(model.transition_named("LOSS") != nullptr);
@@ -178,15 +171,15 @@ TEST_CASE("NonComputationalModel: a non-hookable gate-named key is a named-only 
 }
 
 TEST_CASE("NonComputationalModel: rejects two keys resolving to the same gate") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(),
-                                         {{"CX", zero_matrix()}, {"CNOT", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("both resolve to gate 'CX'"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(
+                            default_initial_state(),
+                            {{"CX", zero_transition_matrix()}, {"CNOT", zero_transition_matrix()}},
+                            std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("both resolve to gate 'CX'"));
 }
 
-TEST_CASE("NonComputationalModel: a malformed transition matrix rejects, naming the component") {
-    auto bad = zero_matrix();
+TEST_CASE("NonComputationalModel: a malformed transition matrix names its component") {
+    auto bad = zero_transition_matrix();
     bad[0][0] = 1.5;
     REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(), {{"H", bad}},
                                                          std::nullopt, NonComputationalPolicy{}),
@@ -206,8 +199,9 @@ TEST_CASE("NonComputationalModel: initial_probability returns per-level values")
 }
 
 TEST_CASE("NonComputationalModel: transition hooks resolve known gates and miss absent ones") {
-    auto model = NonComputationalModel::from_spec(default_initial_state(), {{"H", zero_matrix()}},
-                                                  std::nullopt, NonComputationalPolicy{});
+    auto model =
+        NonComputationalModel::from_spec(default_initial_state(), {{"H", zero_transition_matrix()}},
+                                         std::nullopt, NonComputationalPolicy{});
     REQUIRE(model.transition_hooks().at(GateType::H) == "H");
     REQUIRE(model.transition_named("H") != nullptr);
     REQUIRE(model.transition_hooks().count(GateType::CX) == 0);
@@ -227,74 +221,80 @@ TEST_CASE("NonComputationalModel: policy accessor reflects the constructed polic
 // Construction: dead-hook key rejection
 // =========================================================================
 
-TEST_CASE("NonComputationalModel: rejects MXX as a hook key (rewritten at parse time)") {
+TEST_CASE("NonComputationalModel: rejects parser-rewritten MXX as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"MXX", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
+        NonComputationalModel::from_spec(default_initial_state(),
+                                         {{"MXX", zero_transition_matrix()}}, std::nullopt,
+                                         NonComputationalPolicy{}),
         ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects MYY as a hook key (rewritten at parse time)") {
+TEST_CASE("NonComputationalModel: rejects parser-rewritten MYY as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"MYY", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
+        NonComputationalModel::from_spec(default_initial_state(),
+                                         {{"MYY", zero_transition_matrix()}}, std::nullopt,
+                                         NonComputationalPolicy{}),
         ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects MZZ as a hook key (rewritten at parse time)") {
+TEST_CASE("NonComputationalModel: rejects parser-rewritten MZZ as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"MZZ", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
+        NonComputationalModel::from_spec(default_initial_state(),
+                                         {{"MZZ", zero_transition_matrix()}}, std::nullopt,
+                                         NonComputationalPolicy{}),
         ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects CH as a hook key (rewritten at parse time)") {
+TEST_CASE("NonComputationalModel: rejects parser-rewritten CH as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"CH", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
+        NonComputationalModel::from_spec(default_initial_state(),
+                                         {{"CH", zero_transition_matrix()}}, std::nullopt,
+                                         NonComputationalPolicy{}),
         ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects CCX as a hook key (rewritten at parse time)") {
+TEST_CASE("NonComputationalModel: rejects parser-rewritten CCX as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"CCX", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
+        NonComputationalModel::from_spec(default_initial_state(),
+                                         {{"CCX", zero_transition_matrix()}}, std::nullopt,
+                                         NonComputationalPolicy{}),
         ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects CCZ as a hook key (rewritten at parse time)") {
+TEST_CASE("NonComputationalModel: rejects parser-rewritten CCZ as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"CCZ", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
+        NonComputationalModel::from_spec(default_initial_state(),
+                                         {{"CCZ", zero_transition_matrix()}}, std::nullopt,
+                                         NonComputationalPolicy{}),
         ContainsSubstring("rewritten at parse time and never appears as a circuit node"));
 }
 
-TEST_CASE("NonComputationalModel: rejects I as a hook key (identity no-op)") {
+TEST_CASE("NonComputationalModel: rejects identity I as a hook key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"I", zero_matrix()}},
+        NonComputationalModel::from_spec(default_initial_state(), {{"I", zero_transition_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
         ContainsSubstring("identity no-ops emit no circuit nodes"));
 }
 
-TEST_CASE("NonComputationalModel: rejects II as a hook key (identity no-op)") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"II", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("identity no-ops emit no circuit nodes"));
+TEST_CASE("NonComputationalModel: rejects identity II as a hook key") {
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"II", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("identity no-ops emit no circuit nodes"));
 }
 
-TEST_CASE("NonComputationalModel: rejects I_ERROR as a hook key (identity no-op)") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"I_ERROR", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("identity no-ops emit no circuit nodes"));
+TEST_CASE("NonComputationalModel: rejects identity I_ERROR as a hook key") {
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"I_ERROR", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("identity no-ops emit no circuit nodes"));
 }
 
-TEST_CASE("NonComputationalModel: rejects II_ERROR as a hook key (identity no-op)") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"II_ERROR", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("identity no-ops emit no circuit nodes"));
+TEST_CASE("NonComputationalModel: rejects identity II_ERROR as a hook key") {
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"II_ERROR", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("identity no-ops emit no circuit nodes"));
 }
 
 // =========================================================================
@@ -303,67 +303,69 @@ TEST_CASE("NonComputationalModel: rejects II_ERROR as a hook key (identity no-op
 
 TEST_CASE("NonComputationalModel: rejects empty transition key") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"", zero_matrix()}},
+        NonComputationalModel::from_spec(default_initial_state(), {{"", zero_transition_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
         ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: rejects keys with leading whitespace") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{" padded", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{" padded", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: rejects keys with trailing whitespace") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"padded ", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"padded ", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: rejects keys that are only whitespace") {
     REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{" ", zero_matrix()}},
+        NonComputationalModel::from_spec(default_initial_state(), {{" ", zero_transition_matrix()}},
                                          std::nullopt, NonComputationalPolicy{}),
         ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: rejects keys containing a closing bracket") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"a]b", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"a]b", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: rejects keys containing a hash") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"a#b", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"a#b", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: rejects keys containing a newline") {
-    REQUIRE_THROWS_WITH(
-        NonComputationalModel::from_spec(default_initial_state(), {{"a\nb", zero_matrix()}},
-                                         std::nullopt, NonComputationalPolicy{}),
-        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
+    REQUIRE_THROWS_WITH(NonComputationalModel::from_spec(default_initial_state(),
+                                                         {{"a\nb", zero_transition_matrix()}},
+                                                         std::nullopt, NonComputationalPolicy{}),
+                        ContainsSubstring("cannot be written as a LEVEL_TRANSITION tag"));
 }
 
 TEST_CASE("NonComputationalModel: accepts keys with internal spaces") {
-    REQUIRE_NOTHROW(NonComputationalModel::from_spec(
-        default_initial_state(), {{"a b", zero_matrix()}}, std::nullopt, NonComputationalPolicy{}));
+    REQUIRE_NOTHROW(NonComputationalModel::from_spec(default_initial_state(),
+                                                     {{"a b", zero_transition_matrix()}},
+                                                     std::nullopt, NonComputationalPolicy{}));
 }
 
 TEST_CASE("NonComputationalModel: accepts keys with an opening bracket") {
-    REQUIRE_NOTHROW(NonComputationalModel::from_spec(
-        default_initial_state(), {{"a[b", zero_matrix()}}, std::nullopt, NonComputationalPolicy{}));
+    REQUIRE_NOTHROW(NonComputationalModel::from_spec(default_initial_state(),
+                                                     {{"a[b", zero_transition_matrix()}},
+                                                     std::nullopt, NonComputationalPolicy{}));
 }
 
 TEST_CASE("NonComputationalModel: accepts keys with hyphens and digits") {
     REQUIRE_NOTHROW(NonComputationalModel::from_spec(default_initial_state(),
-                                                     {{"T1-decay", zero_matrix()}}, std::nullopt,
-                                                     NonComputationalPolicy{}));
+                                                     {{"T1-decay", zero_transition_matrix()}},
+                                                     std::nullopt, NonComputationalPolicy{}));
 }
 
 TEST_CASE("NonComputationalModel: accepted weird keys survive LEVEL_TRANSITION tag round-trip") {
@@ -371,9 +373,9 @@ TEST_CASE("NonComputationalModel: accepted weird keys survive LEVEL_TRANSITION t
     const std::vector<std::string> weird_keys = {"a b", "a[b", "T1-decay"};
     for (const auto& key : weird_keys) {
         INFO("key: '" + key + "'");
-        auto model =
-            NonComputationalModel::from_spec(default_initial_state(), {{key, zero_matrix()}},
-                                             std::nullopt, NonComputationalPolicy{});
+        auto model = NonComputationalModel::from_spec(default_initial_state(),
+                                                      {{key, zero_transition_matrix()}},
+                                                      std::nullopt, NonComputationalPolicy{});
         std::string circuit_text = "LEVEL_TRANSITION[" + key + "] 0\n";
         auto circuit = clifft::parse(circuit_text);
         REQUIRE(circuit.nodes.size() == 1);
@@ -467,9 +469,9 @@ TEST_CASE("model: every registered gate hook names a gate the parser can produce
         // constructor rejects the key (rejection tests cover those cases).
         std::optional<NonComputationalModel> maybe_model;
         try {
-            maybe_model =
-                NonComputationalModel::from_spec(default_initial_state(), {{name, zero_matrix()}},
-                                                 std::nullopt, NonComputationalPolicy{});
+            maybe_model = NonComputationalModel::from_spec(default_initial_state(),
+                                                           {{name, zero_transition_matrix()}},
+                                                           std::nullopt, NonComputationalPolicy{});
         } catch (const std::invalid_argument&) {
             continue;
         }

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -22,6 +22,8 @@
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_factory.h"
 
+#include "noncomp_test_helpers.h"
+
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
@@ -41,6 +43,7 @@ using clifft::default_hir_pass_manager;
 using clifft::ExactShotEvents;
 using clifft::GateType;
 using clifft::HirModule;
+using clifft::kNumLevels;
 using clifft::Level;
 using clifft::MeasurementClassifier;
 using clifft::NonComputationalModel;
@@ -50,62 +53,33 @@ using clifft::QubitStatus;
 using clifft::rewrite_continuation;
 using clifft::trace;
 using clifft::TransitionInstrument;
+using clifft::test::certain_transition_from_computational;
+using clifft::test::classifier_matrix_with_column;
+using clifft::test::level_index;
+using clifft::test::pure_initial_state;
+using clifft::test::RawProbabilityMatrix;
+using clifft::test::zero_transition_matrix;
 
 namespace {
 
-// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
-constexpr uint8_t kG = 0;
-constexpr uint8_t kLeakG = 2;
-constexpr uint8_t kLost = 4;
-
-std::vector<std::vector<double>> zeros5() {
-    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
-}
-
-// Source-independent: always jumps to lost.
-std::vector<std::vector<double>> always_lost() {
-    auto m = zeros5();
-    m[kLost][0] = 1.0;
-    m[kLost][1] = 1.0;
-    return m;
-}
-
-NonComputationalModel make_model(
-    std::map<std::string, std::vector<std::vector<double>>> transitions,
-    NonComputationalPolicy policy = {}) {
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions, std::nullopt,
+NonComputationalModel make_rewriter_model(std::map<std::string, RawProbabilityMatrix> transitions,
+                                          NonComputationalPolicy policy = {}) {
+    return NonComputationalModel::from_spec(pure_initial_state(Level::G), transitions, std::nullopt,
                                             policy);
 }
 
-// Classifier whose column for `level` is `col` (two or three symbols by
-// col's length); computational levels read out faithfully and other levels
-// default to a deterministic symbol 0.
-std::vector<std::vector<double>> classifier_with(uint8_t level, std::vector<double> col) {
-    std::vector<std::vector<double>> m(col.size(), std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
-        m[0][l] = 1.0;
-    }
-    m[0][1] = 0.0;
-    m[1][1] = 1.0;
-    for (size_t s = 0; s < col.size(); ++s) {
-        m[s][level] = col[s];
-    }
-    return m;
-}
-
-NonComputationalModel make_model_with_classifier(
-    std::map<std::string, std::vector<std::vector<double>>> transitions,
-    std::vector<std::vector<double>> classifier, NonComputationalPolicy policy = {}) {
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
+NonComputationalModel make_rewriter_model_with_classifier(
+    std::map<std::string, RawProbabilityMatrix> transitions, RawProbabilityMatrix classifier,
+    NonComputationalPolicy policy = {}) {
+    return NonComputationalModel::from_spec(pure_initial_state(Level::G), transitions,
                                             std::make_optional(std::move(classifier)), policy);
 }
 
-// Per-qubit initial statuses from level indices.
-std::vector<QubitStatus> initials(const std::vector<uint8_t>& levels) {
+std::vector<QubitStatus> initials(const std::vector<Level>& levels) {
     std::vector<QubitStatus> out;
     out.reserve(levels.size());
-    for (uint8_t l : levels) {
-        out.push_back(clifft::status_for(clifft::kAllLevels[l]));
+    for (Level level : levels) {
+        out.push_back(clifft::status_for(level));
     }
     return out;
 }
@@ -122,7 +96,7 @@ size_t count_gate(const Circuit& c, GateType gate) {
 
 // Expand hooks and rewrite under the given initial statuses and events.
 ContinuationRewrite rewritten(const Circuit& c, const NonComputationalModel& model,
-                              const std::vector<uint8_t>& initial_levels,
+                              const std::vector<Level>& initial_levels,
                               ExactShotEvents events = {}) {
     Circuit annotated = annotate(c, model);
     events.initial_status = initials(initial_levels);
@@ -137,13 +111,13 @@ ContinuationRewrite rewritten(const Circuit& c, const NonComputationalModel& mod
 
 TEST_CASE("rewrite: a coherent qubit's recorded jump to lost gets a trace-out R") {
     Circuit c = parse("H 0\nLEVEL_TRANSITION[lk] 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("lk", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     ExactShotEvents events;
     events.jumps.push_back({{/*op_index=*/1, /*qubit=*/0}, /*destination_level=*/Level::Lost});
-    ContinuationRewrite rw = rewritten(c, model, {kG}, events);
+    ContinuationRewrite rw = rewritten(c, model, {Level::G}, events);
     // H and the site kept; one trace-out R follows the site.
     REQUIRE(rw.circuit.nodes.size() == 3);
     REQUIRE(rw.circuit.nodes[1].gate == GateType::LEVEL_TRANSITION);
@@ -151,31 +125,31 @@ TEST_CASE("rewrite: a coherent qubit's recorded jump to lost gets a trace-out R"
     REQUIRE(rw.circuit.nodes[2].targets[0].value() == 0);
 }
 
-TEST_CASE("rewrite: a recorded jump to the |0> level inserts an R, no X") {
+TEST_CASE("rewrite: a recorded jump to the zero level inserts R without X") {
     Circuit c = parse("H 0\nLEVEL_TRANSITION[lk] 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("lk", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     ExactShotEvents events;
     events.jumps.push_back({{1, 0}, /*destination_level=*/Level::G});
-    ContinuationRewrite rw = rewritten(c, model, {kG}, events);
+    ContinuationRewrite rw = rewritten(c, model, {Level::G}, events);
     REQUIRE(count_gate(rw.circuit, GateType::R) == 1);  // materialize at |0>
     REQUIRE(count_gate(rw.circuit, GateType::X) == 0);
 }
 
 TEST_CASE("rewrite: an inserted trace-out R survives compilation as one hidden measurement") {
     Circuit c = parse("H 0\nLEVEL_TRANSITION[lk] 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("lk", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     ExactShotEvents events;
     events.jumps.push_back({{1, 0}, Level::Lost});
-    ContinuationRewrite rw = rewritten(c, model, {kG}, events);
+    ContinuationRewrite rw = rewritten(c, model, {Level::G}, events);
 
     // Baseline: the same rewrite with no jump recorded (the site runs live).
-    ContinuationRewrite base = rewritten(c, model, {kG});
+    ContinuationRewrite base = rewritten(c, model, {Level::G});
     clifft::InstrumentTraceOptions options = clifft::instrument_trace_options(model);
     HirModule base_hir = trace(base.circuit, &options);
     HirModule hir = trace(rw.circuit, &options);
@@ -188,14 +162,14 @@ TEST_CASE("rewrite: an inserted trace-out R survives compilation as one hidden m
 TEST_CASE("rewrite: an inserted R does not shift visible measurements or detectors") {
     Circuit c =
         parse("M 0\nDETECTOR rec[-1]\nH 1\nLEVEL_TRANSITION[lk] 1\nM 0\nDETECTOR rec[-1]\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("lk", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     ExactShotEvents events;
     events.jumps.push_back({{3, 1}, Level::Lost});
-    ContinuationRewrite rw = rewritten(c, model, {kG, kG}, events);
-    ContinuationRewrite base = rewritten(c, model, {kG, kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::G, Level::G}, events);
+    ContinuationRewrite base = rewritten(c, model, {Level::G, Level::G});
 
     clifft::InstrumentTraceOptions options = clifft::instrument_trace_options(model);
     HirModule base_hir = trace(base.circuit, &options);
@@ -214,8 +188,8 @@ TEST_CASE("rewrite: an inserted R does not shift visible measurements or detecto
 
 TEST_CASE("rewrite: a two-qubit gate on a lost operand drops whole") {
     Circuit c = parse("CZ 0 1\nM 1\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost, Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::CZ) == 0);  // identity on the survivor
     REQUIRE(count_gate(rw.circuit, GateType::M) == 1);   // record slot preserved
 }
@@ -224,51 +198,51 @@ TEST_CASE("rewrite: a dropped gate leaves the surviving operand's status untouch
     // The CZ drops whole (lost operand); qubit 1 stays computational
     // through to the end of the walk.
     Circuit c = parse("CZ 0 1\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost, Level::G});
     REQUIRE(rw.final_status[1] == clifft::QubitStatus::Computational);
 }
 
 TEST_CASE("rewrite: a single-qubit gate on a leaked qubit drops") {
     Circuit c = parse("X 0\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::LeakG});
     REQUIRE(count_gate(rw.circuit, GateType::X) == 0);
 }
 
 TEST_CASE("rewrite: a single-qubit gate on a lost qubit drops") {
     Circuit c = parse("X 0\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::X) == 0);
 }
 
 TEST_CASE("rewrite: classical feedback onto a lost qubit drops") {
     Circuit c = parse("H 1\nM 1\nCX rec[-1] 0\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost, Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::CX) == 0);
 }
 
 TEST_CASE("rewrite: a two-qubit noise channel on a lost operand drops") {
     Circuit c = parse("DEPOLARIZE2(0.1) 0 1\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost, Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::DEPOLARIZE2) == 0);
 }
 
 TEST_CASE("rewrite: a non-restoring lost reset drops; reset_restores_lost keeps it") {
     Circuit c = parse("R 0\n");
 
-    NonComputationalModel dropped = make_model({});
-    ContinuationRewrite rw_drop = rewritten(c, dropped, {kLost});
+    NonComputationalModel dropped = make_rewriter_model({});
+    ContinuationRewrite rw_drop = rewritten(c, dropped, {Level::Lost});
     REQUIRE(count_gate(rw_drop.circuit, GateType::R) == 0);
     REQUIRE(rw_drop.final_status[0] == clifft::QubitStatus::Lost);  // not restored
 
     NonComputationalPolicy restore;
     restore.reset_restores_lost = true;
-    NonComputationalModel reload = make_model({}, restore);
-    ContinuationRewrite rw_keep = rewritten(c, reload, {kLost});
+    NonComputationalModel reload = make_rewriter_model({}, restore);
+    ContinuationRewrite rw_keep = rewritten(c, reload, {Level::Lost});
     REQUIRE(count_gate(rw_keep.circuit, GateType::R) == 1);
     REQUIRE(rw_keep.final_status[0] == clifft::QubitStatus::Computational);
 }
@@ -277,9 +251,9 @@ TEST_CASE("rewrite: an X-basis measurement of a noncomputational qubit classifie
     // On a vacated carrier the readout basis is incidental: MX classifies
     // exactly like M, substituting a MPAD+READOUT_NOISE for the original MX.
     Circuit c = parse("MX 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {0.5, 0.5}));
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {0.5, 0.5}));
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::MX) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
@@ -295,10 +269,10 @@ TEST_CASE("rewrite: an X-basis measurement of a noncomputational qubit classifie
 
 TEST_CASE("rewrite: a lost-qubit measurement becomes a classifier record write") {
     Circuit c = parse("M 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {0.5, 0.5}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {0.5, 0.5}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::M) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
@@ -314,12 +288,12 @@ TEST_CASE("rewrite: a lost-qubit measurement becomes a classifier record write")
     REQUIRE(noise.args[0] == 0.5);
 }
 
-TEST_CASE("rewrite: a deterministic classifier column pads the literal bit, no draw") {
+TEST_CASE("rewrite: a deterministic classifier column pads the literal bit without a draw") {
     Circuit c = parse("M 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {0.0, 1.0}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {0.0, 1.0}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     for (const AstNode& node : rw.circuit.nodes) {
@@ -333,10 +307,10 @@ TEST_CASE("rewrite: a deterministic classifier column pads the literal bit, no d
 
 TEST_CASE("rewrite: an inverted noncomputational classifier flips a deterministic bit") {
     Circuit c = parse("M !0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {1.0, 0.0}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     for (const AstNode& node : rw.circuit.nodes) {
@@ -350,10 +324,10 @@ TEST_CASE("rewrite: an inverted noncomputational classifier flips a deterministi
 
 TEST_CASE("rewrite: an inverted noncomputational classifier complements stochastic flips") {
     Circuit c = parse("M !0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {0.7, 0.3}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {0.7, 0.3}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(rw.classified_measurements.size() == 1);
     const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
@@ -361,14 +335,14 @@ TEST_CASE("rewrite: an inverted noncomputational classifier complements stochast
     REQUIRE(noise.args[0] == Catch::Approx(0.7));
 }
 
-TEST_CASE("rewrite: the record write flips its own slot, not an earlier one") {
+TEST_CASE("rewrite: the record write flips its own slot rather than an earlier one") {
     // Slot 0 is a computational measurement on qubit 1; the lost qubit's
     // measurement is slot 1 and its READOUT_NOISE must target slot 1.
     Circuit c = parse("M 1\nM 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {0.5, 0.5}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {0.5, 0.5}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost, Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::M) == 1);  // the computational one
     REQUIRE(rw.classified_measurements.size() == 1);
     REQUIRE(rw.classified_measurements[0].slot == 1);
@@ -381,10 +355,10 @@ TEST_CASE("rewrite: a ternary column emits the not-heralded conditional flip") {
     // 0.1 / (1 - 0.6) = 0.25. A ternary slot always gets a READOUT_NOISE so
     // the driver's herald patching has a node to re-point at one half.
     Circuit c = parse("M 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLeakG, {0.3, 0.1, 0.6}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::LeakG, {0.3, 0.1, 0.6}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::LeakG});
     REQUIRE(rw.classified_measurements.size() == 1);
     const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
@@ -394,10 +368,10 @@ TEST_CASE("rewrite: a ternary column emits the not-heralded conditional flip") {
 TEST_CASE("rewrite: an inverted ternary column complements the not-heralded flip") {
     // Non-heralded P(bit=1) is 0.1 / (1 - 0.6) = 0.25 before inversion.
     Circuit c = parse("M !0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLeakG, {0.3, 0.1, 0.6}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::LeakG, {0.3, 0.1, 0.6}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::LeakG});
     REQUIRE(rw.classified_measurements.size() == 1);
     const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
@@ -408,10 +382,10 @@ TEST_CASE("rewrite: an always-herald ternary column still emits a patchable node
     // {0, 0, 1} has no not-heralded conditional; one half stands in, and the
     // herald patching overwrites it on every (always-heralding) draw.
     Circuit c = parse("M 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLeakG, {0.0, 0.0, 1.0}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::LeakG, {0.0, 0.0, 1.0}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::LeakG});
     REQUIRE(rw.classified_measurements.size() == 1);
     REQUIRE(rw.classified_measurements[0].noise_node.has_value());
     const AstNode& noise = rw.circuit.nodes[*rw.classified_measurements[0].noise_node];
@@ -420,15 +394,16 @@ TEST_CASE("rewrite: an always-herald ternary column still emits a patchable node
 
 TEST_CASE("rewrite: a noncomputational measurement without a classifier rejects") {
     Circuit c = parse("M 0\n");
-    NonComputationalModel model = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(c, model, {kLost}), ContainsSubstring("requires a classifier"));
+    NonComputationalModel model = make_rewriter_model({});
+    REQUIRE_THROWS_WITH(rewritten(c, model, {Level::Lost}),
+                        ContainsSubstring("requires a classifier"));
 }
 
 TEST_CASE("rewrite: a parity measurement on a lost qubit rejects") {
     // MPP has no faithful single-bit substitution on a noncomputational
     // operand, so it rejects. MX and MY classify (tested separately).
-    NonComputationalModel model = make_model({});
-    REQUIRE_THROWS_WITH(rewritten(parse("MPP X0\n"), model, {kLost}),
+    NonComputationalModel model = make_rewriter_model({});
+    REQUIRE_THROWS_WITH(rewritten(parse("MPP X0\n"), model, {Level::Lost}),
                         ContainsSubstring("MPP") && ContainsSubstring("Lost"));
 }
 
@@ -439,9 +414,9 @@ TEST_CASE("rewrite: reset_restores_lost restores a measure-and-reset's lost qubi
     Circuit c = parse("MR 0\n");
     NonComputationalPolicy restore;
     restore.reset_restores_lost = true;
-    NonComputationalModel reload =
-        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}), restore);
-    ContinuationRewrite rw = rewritten(c, reload, {kLost});
+    NonComputationalModel reload = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {1.0, 0.0}), restore);
+    ContinuationRewrite rw = rewritten(c, reload, {Level::Lost});
     // The MR splits into the classifier record write plus its kept reset.
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
@@ -452,10 +427,10 @@ TEST_CASE("rewrite: reset_restores_lost restores a measure-and-reset's lost qubi
 
 TEST_CASE("rewrite: a measure-and-reset on a leaked qubit records and resets") {
     Circuit c = parse("MR 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLeakG, {0.5, 0.5}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::LeakG, {0.5, 0.5}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLeakG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::LeakG});
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
@@ -465,10 +440,10 @@ TEST_CASE("rewrite: a measure-and-reset on a leaked qubit records and resets") {
 
 TEST_CASE("rewrite: a measure-and-reset on a non-restoring lost qubit records without its reset") {
     Circuit c = parse("MR 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {1.0, 0.0}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::MR) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);  // record slot preserved
     // The stepper leaves the qubit Lost, so the reset half is dropped: the
@@ -482,10 +457,10 @@ TEST_CASE("rewrite: a non-restoring lost MRX drops its X-basis reset half") {
     // An emitted RX would spend a hidden SVM draw on the vacated carrier;
     // with the status still Lost it must not be emitted.
     Circuit c = parse("MRX 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {1.0, 0.0}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {1.0, 0.0}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kLost});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost});
     REQUIRE(count_gate(rw.circuit, GateType::MRX) == 0);
     REQUIRE(count_gate(rw.circuit, GateType::MPAD) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::RX) == 0);
@@ -502,15 +477,15 @@ namespace {
 // Classifier with confused computational columns: a true 0 is misread as 1
 // with probability p01, a true 1 as 0 with probability p10; noncomputational
 // levels deterministically read symbol 0.
-std::vector<std::vector<double>> confused_classifier(double p01, double p10) {
-    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
+RawProbabilityMatrix confused_classifier(double p01, double p10) {
+    RawProbabilityMatrix m(2, std::vector<double>(kNumLevels, 0.0));
+    for (size_t l = 0; l < kNumLevels; ++l) {
         m[0][l] = 1.0;
     }
-    m[0][0] = 1.0 - p01;
-    m[1][0] = p01;
-    m[0][1] = p10;
-    m[1][1] = 1.0 - p10;
+    m[0][level_index(Level::G)] = 1.0 - p01;
+    m[1][level_index(Level::G)] = p01;
+    m[0][level_index(Level::E)] = p10;
+    m[1][level_index(Level::E)] = 1.0 - p10;
     return m;
 }
 
@@ -518,9 +493,10 @@ std::vector<std::vector<double>> confused_classifier(double p01, double p10) {
 
 TEST_CASE("rewrite: computational readout confusion appends an asymmetric flip") {
     Circuit c = parse("H 0\nM 0\n");
-    NonComputationalModel model = make_model_with_classifier({}, confused_classifier(0.1, 0.2));
+    NonComputationalModel model =
+        make_rewriter_model_with_classifier({}, confused_classifier(0.1, 0.2));
 
-    ContinuationRewrite rw = rewritten(c, model, {kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::M) == 1);  // measurement kept
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
     const AstNode& noise = rw.circuit.nodes.back();
@@ -535,10 +511,10 @@ TEST_CASE("rewrite: computational readout confusion appends an asymmetric flip")
 
 TEST_CASE("rewrite: identity computational columns add no readout confusion") {
     Circuit c = parse("H 0\nM 0\n");
-    NonComputationalModel model =
-        make_model_with_classifier({}, classifier_with(kLost, {0.5, 0.5}));
+    NonComputationalModel model = make_rewriter_model_with_classifier(
+        {}, classifier_matrix_with_column(Level::Lost, {0.5, 0.5}));
 
-    ContinuationRewrite rw = rewritten(c, model, {kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 0);
 }
 
@@ -546,9 +522,10 @@ TEST_CASE("rewrite: an inverted measurement swaps the confusion probabilities") 
     // Confusion physically precedes the reporting convention, and
     // invert-after-flip(p01, p10) equals flip(p10, p01)-after-invert.
     Circuit c = parse("H 0\nM !0\n");
-    NonComputationalModel model = make_model_with_classifier({}, confused_classifier(0.1, 0.2));
+    NonComputationalModel model =
+        make_rewriter_model_with_classifier({}, confused_classifier(0.1, 0.2));
 
-    ContinuationRewrite rw = rewritten(c, model, {kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::G});
     const AstNode& noise = rw.circuit.nodes.back();
     REQUIRE(noise.gate == GateType::READOUT_NOISE);
     REQUIRE(noise.args[0] == 0.2);
@@ -557,9 +534,10 @@ TEST_CASE("rewrite: an inverted measurement swaps the confusion probabilities") 
 
 TEST_CASE("rewrite: confusion applies to MR but not X-basis measurements") {
     Circuit c = parse("MR 0\nMX 0\n");
-    NonComputationalModel model = make_model_with_classifier({}, confused_classifier(0.1, 0.2));
+    NonComputationalModel model =
+        make_rewriter_model_with_classifier({}, confused_classifier(0.1, 0.2));
 
-    ContinuationRewrite rw = rewritten(c, model, {kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::READOUT_NOISE) == 1);
     for (const AstNode& node : rw.circuit.nodes) {
         if (node.gate == GateType::READOUT_NOISE) {
@@ -569,29 +547,29 @@ TEST_CASE("rewrite: confusion applies to MR but not X-basis measurements") {
 }
 
 TEST_CASE("rewrite: a substochastic computational column rejects") {
-    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
+    RawProbabilityMatrix m(2, std::vector<double>(kNumLevels, 0.0));
+    for (size_t l = 0; l < kNumLevels; ++l) {
         m[0][l] = 1.0;
     }
-    m[0][0] = 0.6;  // g column sums to 0.8: reject mass on a computational level
-    m[1][0] = 0.2;
-    m[0][1] = 0.0;
-    m[1][1] = 1.0;
+    m[0][level_index(Level::G)] = 0.6;  // g column sums to 0.8: reject mass
+    m[1][level_index(Level::G)] = 0.2;
+    m[0][level_index(Level::E)] = 0.0;
+    m[1][level_index(Level::E)] = 1.0;
     REQUIRE_THROWS_WITH(
-        make_model_with_classifier({}, std::move(m)),
+        make_rewriter_model_with_classifier({}, std::move(m)),
         ContainsSubstring("reject columns are not supported") && ContainsSubstring("'g'"));
 }
 
 TEST_CASE("rewrite: a computational column with herald mass rejects") {
-    std::vector<std::vector<double>> m(3, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
+    RawProbabilityMatrix m(3, std::vector<double>(kNumLevels, 0.0));
+    for (size_t l = 0; l < kNumLevels; ++l) {
         m[0][l] = 1.0;
     }
-    m[0][0] = 0.9;  // g column puts 0.1 on the herald symbol
-    m[2][0] = 0.1;
-    m[0][1] = 0.0;
-    m[1][1] = 1.0;
-    REQUIRE_THROWS_WITH(make_model_with_classifier({}, std::move(m)),
+    m[0][level_index(Level::G)] = 0.9;  // g column puts 0.1 on the herald symbol
+    m[2][level_index(Level::G)] = 0.1;
+    m[0][level_index(Level::E)] = 0.0;
+    m[1][level_index(Level::E)] = 1.0;
+    REQUIRE_THROWS_WITH(make_rewriter_model_with_classifier({}, std::move(m)),
                         ContainsSubstring("record symbols 0 and 1") && ContainsSubstring("'g'"));
 }
 
@@ -601,9 +579,9 @@ TEST_CASE("rewrite: a computational column with herald mass rejects") {
 
 TEST_CASE("annotate: gate hooks expand to per-operand LEVEL_TRANSITION annotations") {
     Circuit c = parse("H 0\nCZ 0 1\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("CZ", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("CZ", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     Circuit ann = annotate(c, model);
     // H, CZ, LEVEL_TRANSITION(0), LEVEL_TRANSITION(1), M.
@@ -618,9 +596,9 @@ TEST_CASE("annotate: gate hooks expand to per-operand LEVEL_TRANSITION annotatio
 
 TEST_CASE("annotate: feedback operands get no annotation") {
     Circuit c = parse("M 0\nCX rec[-1] 1\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("CX", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("CX", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     Circuit ann = annotate(c, model);
     REQUIRE(ann.nodes.size() == c.nodes.size());  // virtual correction: no consult point
@@ -628,9 +606,10 @@ TEST_CASE("annotate: feedback operands get no annotation") {
 
 TEST_CASE("annotate: an unhooked model leaves the circuit unchanged") {
     Circuit c = parse("H 0\nM 0\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("my_leak", always_lost());  // named, no hook
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("my_leak",
+                        certain_transition_from_computational(Level::Lost));  // named, no hook
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     Circuit ann = annotate(c, model);
     REQUIRE(ann.nodes.size() == c.nodes.size());
@@ -646,13 +625,13 @@ TEST_CASE("rewrite: a zero-fire annotation is omitted from the node stream and s
     // rewriter must skip the zero-fire node and its site_targets entry; the
     // site table must hold exactly one entry pointing at the firing
     // annotation's (op_index, qubit), matching trace()'s elision.
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("zero", zeros5());
-    transitions.emplace("fire", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("zero", zero_transition_matrix());
+    transitions.emplace("fire", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
     Circuit c = parse("LEVEL_TRANSITION[zero] 0\nLEVEL_TRANSITION[fire] 0\n");
-    ContinuationRewrite rw = rewritten(c, model, {kG});
+    ContinuationRewrite rw = rewritten(c, model, {Level::G});
 
     // The zero-fire node must not appear in the rewritten stream.
     for (const AstNode& node : rw.circuit.nodes) {
@@ -670,10 +649,10 @@ TEST_CASE("rewrite: a malformed LOSS annotation rejects instead of reading past 
     // rewrite_continuation is callable without the driver's up-front
     // validation, so its own LOSS reads must validate the argument shape
     // rather than index into it.
-    NonComputationalModel model = make_model({});
+    NonComputationalModel model = make_rewriter_model({});
     Circuit c = parse("LOSS(0.5) 0\nM 0\n");
     ExactShotEvents events;
-    events.initial_status = initials({kG});
+    events.initial_status = initials({Level::G});
 
     SECTION("no arguments") {
         c.nodes[0].args.clear();
@@ -701,15 +680,15 @@ TEST_CASE("rewrite: a correlated chain whose head operand is lost survives the r
     // Both the CORRELATED_ERROR head and its ELSE_CORRELATED_ERROR member
     // must appear in the rewritten stream when q0 enters lost.
     Circuit c = parse("E(1) X0 X1\nELSE_CORRELATED_ERROR(1) X1\n");
-    NonComputationalModel model = make_model({});
-    ContinuationRewrite rw = rewritten(c, model, {kLost, kG});
+    NonComputationalModel model = make_rewriter_model({});
+    ContinuationRewrite rw = rewritten(c, model, {Level::Lost, Level::G});
     REQUIRE(count_gate(rw.circuit, GateType::CORRELATED_ERROR) == 1);
     REQUIRE(count_gate(rw.circuit, GateType::ELSE_CORRELATED_ERROR) == 1);
 }
 
 TEST_CASE("rewrite_continuation: unknown transition tag throws") {
     Circuit c = parse("LEVEL_TRANSITION[nosuch] 0\n");
-    NonComputationalModel model = make_model({});
+    NonComputationalModel model = make_rewriter_model({});
     ExactShotEvents events;
     events.initial_status = {QubitStatus::Computational};
     Circuit annotated = annotate(c, model);

--- a/tests/test_noncomp_transition_instrument.cc
+++ b/tests/test_noncomp_transition_instrument.cc
@@ -1,6 +1,7 @@
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/transition_instrument.h"
 
+#include "noncomp_test_helpers.h"
 #include "test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -17,32 +18,25 @@ using clifft::Level;
 using clifft::TransitionInstrument;
 using clifft::test::opaque_infinity;
 using clifft::test::opaque_nan;
-
-namespace {
-
-// 5x5 zero matrix over the five levels.
-std::vector<std::vector<double>> zero5() {
-    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
-}
-
-}  // namespace
+using clifft::test::RawProbabilityMatrix;
+using clifft::test::zero_transition_matrix;
 
 // =========================================================================
 // Shape validation
 // =========================================================================
 
 TEST_CASE("TransitionInstrument: accepts a zero matrix") {
-    REQUIRE_NOTHROW(TransitionInstrument::from_matrix(zero5()));
+    REQUIRE_NOTHROW(TransitionInstrument::from_matrix(zero_transition_matrix()));
 }
 
 TEST_CASE("TransitionInstrument: rejects wrong row count") {
-    std::vector<std::vector<double>> bad(4, std::vector<double>(5, 0.0));
+    RawProbabilityMatrix bad(4, std::vector<double>(5, 0.0));
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(bad),
                         ContainsSubstring("4 rows") && ContainsSubstring("expected 5"));
 }
 
 TEST_CASE("TransitionInstrument: rejects jagged row width") {
-    std::vector<std::vector<double>> bad = zero5();
+    RawProbabilityMatrix bad = zero_transition_matrix();
     bad[2].pop_back();  // row 2 now has 4 columns
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(bad),
                         ContainsSubstring("row 2") && ContainsSubstring("4 columns"));
@@ -53,20 +47,20 @@ TEST_CASE("TransitionInstrument: rejects jagged row width") {
 // =========================================================================
 
 TEST_CASE("TransitionInstrument: rejects negative entry") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     m[1][0] = -0.1;
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(m),
                         ContainsSubstring("entry") && ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("TransitionInstrument: rejects entry above 1") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     m[1][0] = 1.5;
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(m), ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("TransitionInstrument: rejects column sum above 1") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     m[2][0] = 0.6;
     m[3][0] = 0.6;  // column 0 sums to 1.2
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(m),
@@ -74,27 +68,27 @@ TEST_CASE("TransitionInstrument: rejects column sum above 1") {
 }
 
 TEST_CASE("TransitionInstrument: rejects NaN entry") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     m[1][0] = opaque_nan();
     REQUIRE_THROWS_WITH(TransitionInstrument::from_matrix(m),
                         ContainsSubstring("not finite") || ContainsSubstring("out of [0, 1]"));
 }
 
 TEST_CASE("TransitionInstrument: rejects positive infinity entry") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     m[1][0] = opaque_infinity();
     REQUIRE_THROWS_AS(TransitionInstrument::from_matrix(m), std::invalid_argument);
 }
 
 TEST_CASE("TransitionInstrument: entry validation has no tolerance slack") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     // Just barely above 1: with no tolerance on entries, this must reject.
     m[1][0] = std::nextafter(1.0, 2.0);
     REQUIRE_THROWS_AS(TransitionInstrument::from_matrix(m), std::invalid_argument);
 }
 
 TEST_CASE("TransitionInstrument: column sum within tolerance above 1 is clamped") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     // Two entries whose sum is the next representable double above 1.0
     // (1.0 + 2^-52, ~2.22e-16). Each entry passes the strict [0, 1]
     // entry check, the sum is strictly > 1.0 yet well within
@@ -118,7 +112,7 @@ TEST_CASE("TransitionInstrument: column sum within tolerance above 1 is clamped"
 // =========================================================================
 
 TEST_CASE("TransitionInstrument: column_sum matches the matrix") {
-    std::vector<std::vector<double>> m = zero5();
+    RawProbabilityMatrix m = zero_transition_matrix();
     // From g: 30% jump to leak_g, 10% jump to lost -> column sum 0.4.
     m[2][0] = 0.3;
     m[4][0] = 0.1;
@@ -132,8 +126,8 @@ TEST_CASE("TransitionInstrument: column_sum matches the matrix") {
     REQUIRE_THAT(instr.column_sum(Level::LeakG), WithinAbs(0.0, 1e-12));
 }
 
-TEST_CASE("TransitionInstrument: prob returns the entry under T[to, from] convention") {
-    std::vector<std::vector<double>> m = zero5();
+TEST_CASE("TransitionInstrument: prob follows the destination-source convention") {
+    RawProbabilityMatrix m = zero_transition_matrix();
     m[3][1] = 0.25;  // P(leak_e | from e) = 0.25
     auto instr = TransitionInstrument::from_matrix(m);
 

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -33,6 +33,8 @@
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_factory.h"
 
+#include "noncomp_test_helpers.h"
+
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -50,6 +52,7 @@ using clifft::Circuit;
 using clifft::default_hir_pass_manager;
 using clifft::GateType;
 using clifft::HirModule;
+using clifft::Level;
 using clifft::MeasurementClassifier;
 using clifft::NonComputationalModel;
 using clifft::NonComputationalPolicy;
@@ -60,45 +63,18 @@ using clifft::sample_noncomputational;
 using clifft::Target;
 using clifft::trace;
 using clifft::TransitionInstrument;
+using clifft::test::certain_transition_from_computational;
+using clifft::test::classifier_matrix_with_column;
+using clifft::test::pure_initial_state;
+using clifft::test::RawProbabilityMatrix;
 
 namespace {
 
-// Default-set ids: g=0, e=1, leak_g=2, leak_e=3, lost=4.
-constexpr uint8_t kLost = 4;
-
-std::vector<std::vector<double>> zeros5() {
-    return std::vector<std::vector<double>>(5, std::vector<double>(5, 0.0));
-}
-
-// Source-independent: g and e both jump to lost with certainty.
-std::vector<std::vector<double>> always_lost() {
-    auto m = zeros5();
-    m[kLost][0] = 1.0;
-    m[kLost][1] = 1.0;
-    return m;
-}
-
-// Two-symbol classifier whose lost column is `col`; computational levels
-// read out faithfully and leaked levels deterministically read symbol 0.
-std::vector<std::vector<double>> lost_classifier(std::vector<double> col) {
-    std::vector<std::vector<double>> m(2, std::vector<double>(5, 0.0));
-    for (size_t l = 0; l < 5; ++l) {
-        m[0][l] = 1.0;
-    }
-    // Computational levels read out faithfully (identity columns) so the
-    // classifier adds no readout confusion here.
-    m[0][1] = 0.0;
-    m[1][1] = 1.0;
-    m[0][kLost] = col[0];
-    m[1][kLost] = col[1];
-    return m;
-}
-
-NonComputationalModel make_model(
-    std::map<std::string, std::vector<std::vector<double>>> transitions,
-    std::optional<std::vector<std::vector<double>>> classifier = std::nullopt) {
+NonComputationalModel make_validation_model(
+    std::map<std::string, RawProbabilityMatrix> transitions,
+    std::optional<RawProbabilityMatrix> classifier = std::nullopt) {
     // Both halves start in g (|0>); no leading X-prep is needed.
-    return NonComputationalModel::from_spec({1.0, 0.0, 0.0, 0.0, 0.0}, transitions,
+    return NonComputationalModel::from_spec(pure_initial_state(Level::G), transitions,
                                             std::move(classifier), NonComputationalPolicy{});
 }
 
@@ -116,7 +92,7 @@ size_t count_gate(const Circuit& c, GateType gate) {
 
 TEST_CASE("validation: a lossless Bell pair measures as perfectly Z-correlated halves") {
     Circuit c = parse("H 0\nCX 0 1\nM 0\nM 1\n");
-    NonComputationalModel model = make_model({});  // no loss
+    NonComputationalModel model = make_validation_model({});  // no loss
 
     const uint32_t shots = 1024;
     NonComputationalSample s = sample_noncomputational(c, model, shots, 1);
@@ -141,9 +117,10 @@ TEST_CASE("validation: a lost Bell-pair qubit's classifier record is independent
     // consequence of the M0 -> MPAD(classifier_bit) substitution, not of the
     // hidden R (see the file header and the structural test below).
     Circuit c = parse("H 0\nCX 0 1\nS 0\nM 0\nM 1\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions), lost_classifier({0.5, 0.5}));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_validation_model(
+        std::move(transitions), classifier_matrix_with_column(Level::Lost, {0.5, 0.5}));
 
     const uint32_t shots = 4096;
     NonComputationalSample s = sample_noncomputational(c, model, shots, 7);
@@ -181,9 +158,10 @@ TEST_CASE(
     // the survivor is still an independent 50/50 -- the classifier governs the
     // vacated site's bit, not the surviving qubit.
     Circuit c = parse("H 0\nCX 0 1\nS 0\nM 0\nM 1\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", always_lost());
-    NonComputationalModel model = make_model(std::move(transitions), lost_classifier({1.0, 0.0}));
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::Lost));
+    NonComputationalModel model = make_validation_model(
+        std::move(transitions), classifier_matrix_with_column(Level::Lost, {1.0, 0.0}));
 
     const uint32_t shots = 2048;
     NonComputationalSample s = sample_noncomputational(c, model, shots, 5);
@@ -203,14 +181,15 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
     // hidden Z-basis unraveling for the coherent (entangled) carrier that jumps
     // to lost. Statistics cannot see this; gate counts and the lowered HIR can.
     Circuit c = parse("H 0\nCX 0 1\nS 0\nM 0\nM 1\n");
-    std::map<std::string, std::vector<std::vector<double>>> transitions;
-    transitions.emplace("S", always_lost());
+    std::map<std::string, RawProbabilityMatrix> transitions;
+    transitions.emplace("S", certain_transition_from_computational(Level::Lost));
     // The lost qubit's later M needs a classifier column for its record bit.
-    NonComputationalModel model = make_model(std::move(transitions), lost_classifier({1.0, 0.0}));
+    NonComputationalModel model = make_validation_model(
+        std::move(transitions), classifier_matrix_with_column(Level::Lost, {1.0, 0.0}));
 
     Circuit annotated = annotate(c, model);
     // The recorded jump is what the driver stores when the site traps: the
-    // deterministic always_lost fire on qubit 0 at the expanded annotation.
+    // deterministic loss on qubit 0 at the expanded annotation.
     clifft::ExactShotEvents events;
     events.initial_status.assign(2, clifft::QubitStatus::Computational);
     events.jumps.push_back(
@@ -241,7 +220,7 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
 TEST_CASE("validation: a hand-built multi-target measurement node is rejected up front") {
     // All tests use shots=0: validation runs before the zero-shot return, so
     // the driver checks node shapes without needing any state or randomness.
-    NonComputationalModel model = make_model({});  // lossless; no classifier needed
+    NonComputationalModel model = make_validation_model({});  // lossless; no classifier needed
 
     SECTION("multi-target M node is rejected") {
         // A hand-built node with two qubit targets bypasses the parser's

--- a/tests/test_noncomp_value_types.cc
+++ b/tests/test_noncomp_value_types.cc
@@ -58,7 +58,7 @@ TEST_CASE("QubitStatus: category predicates partition the statuses") {
     REQUIRE_FALSE(is_leaked(QubitStatus::Lost));
 }
 
-TEST_CASE("QubitStatus: noncomp_level names the definite level, throws on computational") {
+TEST_CASE("QubitStatus: noncomp_level names definite levels and throws on computational") {
     REQUIRE(noncomp_level(QubitStatus::LeakG) == Level::LeakG);
     REQUIRE(noncomp_level(QubitStatus::LeakE) == Level::LeakE);
     REQUIRE(noncomp_level(QubitStatus::Lost) == Level::Lost);

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -10,9 +10,10 @@
 // the prefix-identity contract that makes cross-module re-entry sound.
 
 #include "clifft/backend/backend.h"
-#include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/svm/svm.h"
+
+#include "instrument_test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
@@ -26,6 +27,8 @@
 
 using namespace clifft;
 using Catch::Matchers::ContainsSubstring;
+using clifft::test::compile_instruments_raw;
+using clifft::test::make_shot_state;
 
 namespace {
 
@@ -36,21 +39,6 @@ InstrumentProbabilities leak(double p_g, double p_e) {
     spec.p_fire[0] = p_g;
     spec.p_fire[1] = p_e;
     return spec;
-}
-
-CompiledModule compile_raw(const char* text, const InstrumentTraceOptions& options) {
-    auto hir = trace(parse(text), &options);
-    return lower(hir);
-}
-
-SchrodingerState make_shot_state(const CompiledModule& module, uint64_t seed) {
-    return SchrodingerState(StateConfig{.peak_rank = module.peak_rank,
-                                        .num_measurements = module.total_meas_slots,
-                                        .num_qubits = module.num_qubits,
-                                        .num_detectors = module.num_detectors,
-                                        .num_observables = module.num_observables,
-                                        .num_exp_vals = module.num_exp_vals,
-                                        .seed = seed});
 }
 
 // Resume a trapped state past its trap site in `continuation`.
@@ -67,7 +55,7 @@ TEST_CASE("trap+resume: a spectator loss resumes in the same module and complete
     // is its own valid continuation. H;T ... T_DAG;H on qubit 0 composes
     // to the identity: the record is deterministically 0, trap or no trap.
     InstrumentTraceOptions options;
-    auto module = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nM 0", options);
+    auto module = compile_instruments_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nM 0", options);
 
     for (uint64_t seed = 1; seed <= 20; ++seed) {
         auto state = make_shot_state(module, seed);
@@ -97,7 +85,7 @@ TEST_CASE("trap+resume: a trap-form fire reports its destination as pending") {
     }());
     options.neglect_instrument_damping = true;
 
-    auto module = compile_raw("H 0\nLEVEL_TRANSITION[jump] 0\nM 0", options);
+    auto module = compile_instruments_raw("H 0\nLEVEL_TRANSITION[jump] 0\nM 0", options);
     auto state = make_shot_state(module, /*seed=*/6);
     execute(module, state);
 
@@ -108,7 +96,7 @@ TEST_CASE("trap+resume: a trap-form fire reports its destination as pending") {
 
 TEST_CASE("trap+resume: resume refuses a state with no pending trap") {
     InstrumentTraceOptions options;
-    auto module = compile_raw("LOSS(1.0) 0\nM 0", options);
+    auto module = compile_instruments_raw("LOSS(1.0) 0\nM 0", options);
     auto state = make_shot_state(module, /*seed=*/8);
     REQUIRE_THROWS_WITH(resume(module, state, 1), ContainsSubstring("no pending trap"));
 }
@@ -119,7 +107,7 @@ TEST_CASE("trap+resume: resume rejects an offset that does not follow the trappe
     // valid entry. Rejected attempts leave the trap pending, so the
     // correct offset still works afterward.
     InstrumentTraceOptions options;
-    auto module = compile_raw("LOSS(1.0) 0\nX 0\nM 0", options);
+    auto module = compile_instruments_raw("LOSS(1.0) 0\nX 0\nM 0", options);
     auto state = make_shot_state(module, /*seed=*/12);
     execute(module, state);
     REQUIRE(state.pending_trap.has_value());
@@ -140,8 +128,9 @@ TEST_CASE("trap+resume: the continuation's suffix governs the outcome") {
     // into each must produce that module's suffix behavior: the original
     // undoes the H (measures 0), the continuation adds an X (measures 1).
     InstrumentTraceOptions options;
-    auto original = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nM 0", options);
-    auto continuation = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nX 0\nM 0", options);
+    auto original = compile_instruments_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nM 0", options);
+    auto continuation =
+        compile_instruments_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nX 0\nM 0", options);
 
     const uint32_t offset = original.instrument_offsets.at(0);
     REQUIRE(continuation.instrument_offsets.at(0) == offset);
@@ -166,7 +155,7 @@ TEST_CASE("trap+resume: an active-site trap hands over a collapsed carrier") {
     // zero and the surviving half matches the reported source.
     InstrumentTraceOptions options;
     options.transitions.emplace("leak", leak(1.0, 1.0));
-    auto module = compile_raw("H 0\nT 0\nLEVEL_TRANSITION[leak] 0\nM 0", options);
+    auto module = compile_instruments_raw("H 0\nT 0\nLEVEL_TRANSITION[leak] 0\nM 0", options);
 
     bool saw_g = false;
     bool saw_e = false;
@@ -194,8 +183,9 @@ TEST_CASE("trap+resume: the record buffer grows for a continuation with more hid
     // whose lowering adds a hidden measurement slot beyond what the
     // original module allocated. Visible slots stay layout-stable.
     InstrumentTraceOptions options;
-    auto original = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nM 0", options);
-    auto continuation = compile_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nR 1\nM 0", options);
+    auto original = compile_instruments_raw("H 0\nT 0\nLOSS(1.0) 1\nM 0", options);
+    auto continuation =
+        compile_instruments_raw("H 0\nT 0\nLOSS(1.0) 1\nT_DAG 0\nH 0\nR 1\nM 0", options);
     REQUIRE(continuation.total_meas_slots > original.total_meas_slots);
 
     auto state = make_shot_state(original, /*seed=*/5);
@@ -212,8 +202,9 @@ TEST_CASE("trap+resume: the amplitude array grows for a higher-rank continuation
     // The original needs k = 0; the continuation's suffix activates two
     // qubits (k = 2), exceeding the state's original allocation.
     InstrumentTraceOptions options;
-    auto original = compile_raw("LOSS(1.0) 2\nM 0", options);
-    auto continuation = compile_raw("LOSS(1.0) 2\nH 0\nT 0\nH 1\nT 1\nCX 0 1\nM 0\nM 1", options);
+    auto original = compile_instruments_raw("LOSS(1.0) 2\nM 0", options);
+    auto continuation =
+        compile_instruments_raw("LOSS(1.0) 2\nH 0\nT 0\nH 1\nT 1\nCX 0 1\nM 0\nM 1", options);
     REQUIRE(original.peak_rank == 0);
     REQUIRE(continuation.peak_rank == 2);
     REQUIRE(continuation.num_measurements == original.num_measurements + 1);
@@ -231,7 +222,7 @@ TEST_CASE("trap+resume: the amplitude array grows for a higher-rank continuation
     REQUIRE(state.meas_record.size() == continuation.total_meas_slots);
 }
 
-TEST_CASE("trap+resume: suffix noise fires after re-anchoring, prefix noise does not refire") {
+TEST_CASE("trap+resume: suffix noise fires after re-anchoring while prefix noise stays spent") {
     // Both errors are certain (p = 1). The prefix error flips qubit 0
     // before the trap; the suffix error flips it again after resume. A
     // broken cursor either refires the prefix site (record 0) or skips
@@ -240,7 +231,7 @@ TEST_CASE("trap+resume: suffix noise fires after re-anchoring, prefix noise does
     // deterministic record is 0, and a single miss or double-fire yields
     // 1 instead.
     InstrumentTraceOptions options;
-    auto module = compile_raw("X_ERROR(1) 0\nLOSS(1.0) 1\nX_ERROR(1) 0\nM 0", options);
+    auto module = compile_instruments_raw("X_ERROR(1) 0\nLOSS(1.0) 1\nX_ERROR(1) 0\nM 0", options);
 
     for (uint64_t seed = 1; seed <= 10; ++seed) {
         auto state = make_shot_state(module, seed);
@@ -258,7 +249,7 @@ TEST_CASE("trap+resume: suffix noise fires after re-anchoring, prefix noise does
 
 TEST_CASE("trap+resume: a chain of traps resumes one site at a time") {
     InstrumentTraceOptions options;
-    auto module = compile_raw("LOSS(1.0) 1\nX 0\nLOSS(1.0) 2\nX 0\nM 0", options);
+    auto module = compile_instruments_raw("LOSS(1.0) 1\nX 0\nLOSS(1.0) 2\nX 0\nM 0", options);
 
     auto state = make_shot_state(module, /*seed=*/11);
     execute(module, state);
@@ -276,7 +267,7 @@ TEST_CASE("trap+resume: a chain of traps resumes one site at a time") {
 
 TEST_CASE("trap+resume: reset clears a pending trap and its partial records") {
     InstrumentTraceOptions options;
-    auto module = compile_raw("X 0\nM 0\nLOSS(1.0) 1\nM 0", options);
+    auto module = compile_instruments_raw("X 0\nM 0\nLOSS(1.0) 1\nM 0", options);
 
     auto state = make_shot_state(module, /*seed=*/2);
     execute(module, state);
@@ -290,15 +281,15 @@ TEST_CASE("trap+resume: reset clears a pending trap and its partial records") {
 
 TEST_CASE("trap+resume: plain sampling rejects a shot that traps") {
     InstrumentTraceOptions options;
-    auto module = compile_raw("LOSS(1.0) 0\nM 0", options);
+    auto module = compile_instruments_raw("LOSS(1.0) 0\nM 0", options);
     REQUIRE_THROWS_WITH(sample(module, /*shots=*/4, /*seed=*/9),
                         ContainsSubstring("exact-mode driver"));
 }
 
 TEST_CASE("trap+resume: resume validates the handoff") {
     InstrumentTraceOptions options;
-    auto module = compile_raw("LOSS(1.0) 0\nM 0", options);
-    auto other_qubits = compile_raw("LOSS(1.0) 0\nM 0\nM 1", options);
+    auto module = compile_instruments_raw("LOSS(1.0) 0\nM 0", options);
+    auto other_qubits = compile_instruments_raw("LOSS(1.0) 0\nM 0\nM 1", options);
 
     auto state = make_shot_state(module, /*seed=*/4);
     execute(module, state);


### PR DESCRIPTION
## Summary

- centralize C++ noncomputational matrix fixtures around named `Level` values
- share the instrument compile pipeline and fully sized shot-state fixture
- align Python transition and classifier fixtures, including faithful excited-state readout
- remove stale fixture vocabulary and normalize touched Catch2 names

## Verification

- `cmake --build build -j 4`
- `ctest --test-dir build --output-on-failure -E '^Bench:'` (1,098 passed)
- `uv run pytest tests/python/ -v` (924 passed)
- `uv run pre-commit run --all-files`

The six `Bench:` CTest cases were intentionally skipped.
