### PR TITLE
docs: prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] - 2026-07-14
+
+Clifft 0.6.0 adds Stim-compatible correlated Pauli noise chains through
+`CORRELATED_ERROR` / `E` and `ELSE_CORRELATED_ERROR`. It also adds a dedicated
+[front-end integrations guide](https://unitaryfoundation.github.io/clifft/getting-started/integrations/)
+for using Clifft from Qiskit and Cirq through their separately maintained
+companion packages.
+
+### Documentation
+
+- add front-end integration guide (#182) by @bachase in [#182](https://github.com/unitaryfoundation/clifft/pull/182)
+
+### Features
+
+- add correlated Pauli noise channels (#158) by @bachase in [#158](https://github.com/unitaryfoundation/clifft/pull/158)
+
 ## [0.5.0] - 2026-06-15
 
 Clifft 0.5.0 broadens the circuits users can write directly and makes the project easier to try from both the playground and Python docs. The parser now accepts common controlled gates (`CCZ`, `CCX`, `CH`) through exact Clifford+T rewrites, the simulator supports three-qubit Pauli noise channels (`DEPOLARIZE3`), and phase-sensitive statevector behavior is better tested and documented.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,10 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 
 [Use Qiskit or Cirq](getting-started/integrations.md){ .md-button }
 
+## What's New in 0.6.0
+
+Clifft 0.6.0 adds Stim-compatible correlated Pauli noise chains through `CORRELATED_ERROR` / `E` and `ELSE_CORRELATED_ERROR`. A new [front-end integrations guide](getting-started/integrations.md) also shows how to run supported Qiskit and Cirq circuits with the separately maintained `clifft-qiskit` and `clifft-cirq` companion packages.
+
 ## What's New in 0.5.0
 
 Clifft 0.5.0 broadens the circuits users can write directly and makes the project easier to try from both the playground and Python docs. The parser now accepts common controlled gates (`CCZ`, `CCX`, `CH`) through exact Clifford+T rewrites, the simulator supports three-qubit Pauli noise channels (`DEPOLARIZE3`), and phase-sensitive statevector behavior is better tested and documented.

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,18 +94,4 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 
 Clifft 0.6.0 adds Stim-compatible correlated Pauli noise chains through `CORRELATED_ERROR` / `E` and `ELSE_CORRELATED_ERROR`. A new [front-end integrations guide](getting-started/integrations.md) also shows how to run supported Qiskit and Cirq circuits with the separately maintained `clifft-qiskit` and `clifft-cirq` companion packages.
 
-## What's New in 0.5.0
-
-Clifft 0.5.0 broadens the circuits users can write directly and makes the project easier to try from both the playground and Python docs. The parser now accepts common controlled gates (`CCZ`, `CCX`, `CH`) through exact Clifford+T rewrites, the simulator supports three-qubit Pauli noise channels (`DEPOLARIZE3`), and phase-sensitive statevector behavior is better tested and documented.
-
-This release also includes several [unitaryHACK 2026](https://unitaryhack.dev/) contributions: @Samfresh-ai added starter circuits to the playground, @manasa-manoj-nbr added an auto-generated Python API reference, and @ashmitjsg completed the Qiskit backend bounty as the companion [unitaryfoundation/clifft-qiskit](https://github.com/unitaryfoundation/clifft-qiskit) package. Users starting from Qiskit or Cirq can now find both [clifft-qiskit](https://github.com/unitaryfoundation/clifft-qiskit) and [clifft-cirq](https://github.com/unitaryfoundation/clifft-cirq) from the [front-end integrations guide](getting-started/integrations.md).
-
-## What's New in 0.4.0
-
-Clifft 0.4.0 expands strong simulation with `clifft.record_probabilities()`, the deterministic-record counterpart to `sample()` — it returns the joint probability of a given measurement record for circuits with measurements and classical feedback. The complementary unitary-circuit query, formerly `clifft.probabilities()`, is now `clifft.basis_probabilities()`. There are no compatibility aliases; existing callers must rename.
-
-`basis_probabilities()` is also roughly 17× faster on representative inputs.
-
-Looking for GPU acceleration? An early proof-of-concept CUDA backend lives at [haoliri0/clifft-cuda](https://github.com/haoliri0/clifft-cuda). It is a separate, community-maintained experiment; integration into upstream Clifft is being tracked in [issue #64](https://github.com/unitaryfoundation/clifft/issues/64).
-
 [Full Changelog](https://github.com/unitaryfoundation/clifft/blob/main/CHANGELOG.md){ .md-button }


### PR DESCRIPTION
## Summary

- add the v0.6.0 changelog section covering correlated Pauli noise channels and front-end integrations
- add a curated What's New in 0.6.0 section to the docs home page
- retire the older 0.5.0 and 0.4.0 homepage summaries and the CUDA experiment note so the homepage highlights only the current release
- set the release date to July 14, 2026

## Validation

- uv run pre-commit run --all-files
- uv run --group docs mkdocs build --strict
- uv run pytest --codeblocks docs/ README.md -v (25 passed, 7 skipped)

## Release note

Merging this PR prepares the release notes only. It does not create or push the v0.6.0 tag or publish a release.