### PR TITLE
chore(noncomp)!: widen per-shot seed derivation to 256-bit streams

### DIFF
--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -505,10 +505,9 @@ void validate_model_contract(const Circuit& annotated, const NonComputationalMod
 
 }  // namespace
 
-NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
-                                                     const NonComputationalModel& model,
-                                                     uint32_t shots, uint64_t global_seed,
-                                                     std::optional<uint32_t> max_rank) {
+NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputationalModel& model,
+                                        uint32_t shots, const SeedRoot& root,
+                                        std::optional<uint32_t> max_rank) {
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
@@ -724,7 +723,9 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
     std::optional<SchrodingerState> state_storage;
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
-        Xoshiro256PlusPlus driver_rng(derive_seed(global_seed, shot, kExactDriverDomain));
+        const auto dw = derive_state(root, shot, kExactDriverDomain);
+        Xoshiro256PlusPlus driver_rng(0);
+        driver_rng.seed_full(dw[0], dw[1], dw[2], dw[3]);
 
         ExactShotEvents events;
         events.initial_status.reserve(circuit.num_qubits);
@@ -801,7 +802,8 @@ NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
             }
         }
         SchrodingerState& state = *state_storage;
-        state.reseed(derive_seed(global_seed, shot, kExactSvmDomain));
+        const auto sw = derive_state(root, shot, kExactSvmDomain);
+        state.reseed(sw[0], sw[1], sw[2], sw[3]);
         assert(state.meas_record.size() >= module->total_meas_slots &&
                "the rebuild block above guarantees meas_record capacity; "
                "meas_record never shrinks");

--- a/src/clifft/noncomp/exact_driver.cc
+++ b/src/clifft/noncomp/exact_driver.cc
@@ -803,7 +803,7 @@ NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputa
         }
         SchrodingerState& state = *state_storage;
         const auto sw = derive_state(root, shot, kExactSvmDomain);
-        state.reseed(sw[0], sw[1], sw[2], sw[3]);
+        state.reseed_full(sw[0], sw[1], sw[2], sw[3]);
         assert(state.meas_record.size() >= module->total_meas_slots &&
                "the rebuild block above guarantees meas_record capacity; "
                "meas_record never shrinks");

--- a/src/clifft/noncomp/exact_driver.h
+++ b/src/clifft/noncomp/exact_driver.h
@@ -20,15 +20,15 @@
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/sample.h"
+#include "clifft/noncomp/seed.h"
 
 #include <cstdint>
 #include <optional>
 
 namespace clifft {
 
-NonComputationalSample sample_noncomputational_exact(const Circuit& circuit,
-                                                     const NonComputationalModel& model,
-                                                     uint32_t shots, uint64_t global_seed,
-                                                     std::optional<uint32_t> max_rank);
+NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputationalModel& model,
+                                        uint32_t shots, const SeedRoot& root,
+                                        std::optional<uint32_t> max_rank);
 
 }  // namespace clifft

--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -4,6 +4,7 @@
 #include "clifft/noncomp/seed.h"
 #include "clifft/util/xoshiro.h"
 
+#include <array>
 #include <stdexcept>
 
 namespace clifft {
@@ -22,12 +23,11 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
     if (seed.has_value()) {
         root = seed_root_from_seed(*seed);
     } else if (shots > 0) {
-        Xoshiro256PlusPlus e;
-        e.seed_from_entropy();
-        root.w[0] = e();
-        root.w[1] = e();
-        root.w[2] = e();
-        root.w[3] = e();
+        const std::array<uint64_t, 4> w = entropy_seed_words();
+        root.w[0] = w[0];
+        root.w[1] = w[1];
+        root.w[2] = w[2];
+        root.w[3] = w[3];
     }
 
     return run_exact_driver(circuit, model, shots, root, max_rank);

--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -1,6 +1,7 @@
 #include "clifft/noncomp/sample.h"
 
 #include "clifft/noncomp/exact_driver.h"
+#include "clifft/noncomp/seed.h"
 #include "clifft/util/xoshiro.h"
 
 #include <stdexcept>
@@ -17,16 +18,19 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
             "sampling");
     }
 
-    uint64_t global_seed = 0;
+    SeedRoot root{};
     if (seed.has_value()) {
-        global_seed = *seed;
+        root = seed_root_from_seed(*seed);
     } else if (shots > 0) {
-        Xoshiro256PlusPlus entropy;
-        entropy.seed_from_entropy();
-        global_seed = entropy();
+        Xoshiro256PlusPlus e;
+        e.seed_from_entropy();
+        root.w[0] = e();
+        root.w[1] = e();
+        root.w[2] = e();
+        root.w[3] = e();
     }
 
-    return sample_noncomputational_exact(circuit, model, shots, global_seed, max_rank);
+    return run_exact_driver(circuit, model, shots, root, max_rank);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/seed.h
+++ b/src/clifft/noncomp/seed.h
@@ -1,29 +1,49 @@
 #pragma once
 
-// Per-shot seed derivation for noncomputational sampling. One global
-// seed fans out into independent sub-streams, one per (shot, domain)
-// pair; every domain tag lives here so their pairwise distinctness is
-// visible in one place. Tags are arbitrary distinct constants.
+// Per-shot RNG derivation: a 256-bit root (expanded from the user seed,
+// or drawn from OS entropy when unseeded) fans out into one 256-bit
+// generator state per (shot, domain). Distinct shots in a domain provably
+// get distinct states (word 0 is a bijection of the shot index); any other
+// coincidence needs four unrelated 64-bit collisions at once (~2^-256).
+// The word index is folded into the domain tag so those four conditions
+// cannot collapse into one.
 
+#include "clifft/util/xoshiro.h"
+
+#include <array>
 #include <cstdint>
 
 namespace clifft {
 
-// Exact-driver streams: the driver's own draws between VM runs (initial
-// levels, trap destinations, classical consults, herald flags) and the
-// in-VM measurement randomness of the modules it executes.
+// Driver-side draws (initial levels, trap destinations, classical
+// consults, herald flags) vs. the in-VM Born measurement randomness.
 inline constexpr uint64_t kExactDriverDomain = 0x11;
 inline constexpr uint64_t kExactSvmDomain = 0x12;
 
-// SplitMix64 finalizer over a mix of the global seed, shot, and domain.
-// Full-avalanche mixing: adjacent shots and sibling domains land in
-// statistically unrelated generator states, which is the xoshiro
-// authors' recommended seeding procedure.
-inline uint64_t derive_seed(uint64_t global, uint64_t shot, uint64_t domain) {
-    uint64_t z = global ^ (shot * 0x9E3779B97F4A7C15ULL) ^ (domain * 0xBF58476D1CE4E5B9ULL);
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
-    return z ^ (z >> 31);
+struct SeedRoot {
+    uint64_t w[4];
+};
+
+// Deterministic expansion of a user seed (SplitMix64 chain).
+inline SeedRoot seed_root_from_seed(uint64_t seed) {
+    SeedRoot root;
+    uint64_t z = seed;
+    for (uint64_t& word : root.w) {
+        word = splitmix64(z);
+    }
+    return root;
+}
+
+inline std::array<uint64_t, 4> derive_state(const SeedRoot& root, uint64_t shot, uint64_t domain) {
+    std::array<uint64_t, 4> s;
+    for (uint64_t k = 0; k < 4; ++k) {
+        uint64_t z = root.w[k] ^ (shot * 0x9E3779B97F4A7C15ULL) ^
+                     (((domain << 2) | k) * 0xBF58476D1CE4E5B9ULL);
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        s[k] = z ^ (z >> 31);
+    }
+    return s;
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/seed.h
+++ b/src/clifft/noncomp/seed.h
@@ -1,12 +1,12 @@
 #pragma once
 
-// Per-shot RNG derivation: a 256-bit root (expanded from the user seed,
-// or drawn from OS entropy when unseeded) fans out into one 256-bit
-// generator state per (shot, domain). Distinct shots in a domain provably
-// get distinct states (word 0 is a bijection of the shot index); any other
-// coincidence needs four unrelated 64-bit collisions at once (~2^-256).
-// The word index is folded into the domain tag so those four conditions
-// cannot collapse into one.
+// Per-shot RNG derivation: a 256-bit root (OS entropy when unseeded; a
+// deterministic expansion of the 64-bit user seed otherwise) fans out into
+// one 256-bit generator state per (shot, domain). For a fixed root and
+// domain, distinct shots produce distinct states (word 0 is a bijection of
+// the shot index). Word-indexed domain tags keep a single cross-domain
+// word alias from expanding into a full-state collision, and independent
+// entropy roots collide on a fixed pair of states with probability ~2^-256.
 
 #include "clifft/util/xoshiro.h"
 

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -64,8 +64,12 @@ class SchrodingerState {
     // Does NOT reseed the PRNG -- the RNG streams forward naturally.
     void reset();
 
-    // Explicitly reseed the PRNG (for deterministic test replay).
+    // Explicitly reseed the PRNG, either from a single 64-bit seed or as
+    // the full 256-bit generator state.
     void reseed(uint64_t seed) { rng_.seed(seed); }
+    void reseed(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) {
+        rng_.seed_full(s0, s1, s2, s3);
+    }
     void reseed_from_entropy() { rng_.seed_from_entropy(); }
 
     // Access coefficient array

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -64,10 +64,10 @@ class SchrodingerState {
     // Does NOT reseed the PRNG -- the RNG streams forward naturally.
     void reset();
 
-    // Explicitly reseed the PRNG, either from a single 64-bit seed or as
-    // the full 256-bit generator state.
+    // Explicitly reseed the PRNG from a single 64-bit seed (reseed) or as
+    // the full 256-bit generator state (reseed_full).
     void reseed(uint64_t seed) { rng_.seed(seed); }
-    void reseed(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) {
+    void reseed_full(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) {
         rng_.seed_full(s0, s1, s2, s3);
     }
     void reseed_from_entropy() { rng_.seed_from_entropy(); }

--- a/src/clifft/util/xoshiro.cc
+++ b/src/clifft/util/xoshiro.cc
@@ -4,7 +4,7 @@
 
 namespace clifft {
 
-void Xoshiro256PlusPlus::seed_from_entropy() {
+std::array<uint64_t, 4> entropy_seed_words() {
     // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
     // See https://github.com/quantumlib/Stim/issues/26
 #if defined(__linux__) && defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
@@ -13,7 +13,12 @@ void Xoshiro256PlusPlus::seed_from_entropy() {
     std::random_device rd;
 #endif
     auto rd64 = [&rd]() -> uint64_t { return (static_cast<uint64_t>(rd()) << 32) | rd(); };
-    seed_full(rd64(), rd64(), rd64(), rd64());
+    return {rd64(), rd64(), rd64(), rd64()};
+}
+
+void Xoshiro256PlusPlus::seed_from_entropy() {
+    const auto w = entropy_seed_words();
+    seed_full(w[0], w[1], w[2], w[3]);
 }
 
 }  // namespace clifft

--- a/src/clifft/util/xoshiro.h
+++ b/src/clifft/util/xoshiro.h
@@ -19,6 +19,7 @@
 // reseeding ~100x cheaper. Uses pure bitwise math to guarantee identical
 // sequences across GCC/Clang/MSVC.
 
+#include <array>
 #include <bit>
 #include <cstdint>
 
@@ -86,5 +87,9 @@ class Xoshiro256PlusPlus {
   private:
     uint64_t s_[4];
 };
+
+// Reads 256 bits from OS entropy (std::random_device), shared by generator
+// seeding and root derivation.
+std::array<uint64_t, 4> entropy_seed_words();
 
 }  // namespace clifft

--- a/src/clifft/util/xoshiro.h
+++ b/src/clifft/util/xoshiro.h
@@ -24,6 +24,15 @@
 
 namespace clifft {
 
+// SplitMix64, per the reference seeding recipe above: expands one 64-bit
+// state (advanced in place) into a stream of well-mixed 64-bit words.
+inline uint64_t splitmix64(uint64_t& state) {
+    uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+    return z ^ (z >> 31);
+}
+
 class Xoshiro256PlusPlus {
   public:
     explicit Xoshiro256PlusPlus(uint64_t seed_val = 0) { seed(seed_val); }
@@ -76,13 +85,6 @@ class Xoshiro256PlusPlus {
 
   private:
     uint64_t s_[4];
-
-    static inline uint64_t splitmix64(uint64_t& state) {
-        uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
-        z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
-        z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
-        return z ^ (z >> 31);
-    }
 };
 
 }  // namespace clifft

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1140,8 +1140,7 @@ NB_MODULE(_clifft_core, m) {
              nb::arg("num_detectors") = 0, nb::arg("num_observables") = 0,
              nb::arg("num_exp_vals") = 0, nb::arg("seed") = nb::none())
         .def("reset", &clifft::SchrodingerState::reset)
-        .def("reseed", nb::overload_cast<uint64_t>(&clifft::SchrodingerState::reseed),
-             nb::arg("seed"))
+        .def("reseed", &clifft::SchrodingerState::reseed, nb::arg("seed"))
         .def_prop_ro("dust_clamps", [](const clifft::SchrodingerState& s) { return s.dust_clamps; })
         .def_prop_ro(
             "meas_record",

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1140,7 +1140,8 @@ NB_MODULE(_clifft_core, m) {
              nb::arg("num_detectors") = 0, nb::arg("num_observables") = 0,
              nb::arg("num_exp_vals") = 0, nb::arg("seed") = nb::none())
         .def("reset", &clifft::SchrodingerState::reset)
-        .def("reseed", &clifft::SchrodingerState::reseed, nb::arg("seed"))
+        .def("reseed", nb::overload_cast<uint64_t>(&clifft::SchrodingerState::reseed),
+             nb::arg("seed"))
         .def_prop_ro("dust_clamps", [](const clifft::SchrodingerState& s) { return s.dust_clamps; })
         .def_prop_ro(
             "meas_record",

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -299,6 +299,11 @@ def sample(
     these contracts is violated, when an annotation is malformed, or when
     ``max_rank`` is exceeded.
 
+    ``seed`` makes runs reproducible: the same seed with the same arguments
+    returns identical results, so vary it across seeded batches. When
+    ``None``, each call draws a fresh 256-bit root from OS entropy, so
+    repeated or parallel unseeded calls sample fresh randomness.
+
     ``max_rank`` caps the compiled peak rank under exact-mode compilation;
     the cap is enforced at each continuation compile, failing with the
     offending circuit line named instead of attempting a ``2**k``

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -267,20 +267,30 @@ TEST_CASE("exact: the driver and SVM seed streams are domain-separated") {
     // and the in-VM Born draws run on independent streams; handing the same
     // per-shot state to both would correlate them. Guard the documented domain
     // split at its source: for every shot, the same (root, shot) with
-    // different domains yields unrelated states, and the streams they start
-    // diverge on the very first draw.
+    // different domains yields unrelated states.
     for (uint64_t seed : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
         const SeedRoot root = seed_root_from_seed(seed);
         for (uint64_t shot = 0; shot < 16; ++shot) {
             const std::array<uint64_t, 4> host = derive_state(root, shot, kExactDriverDomain);
             const std::array<uint64_t, 4> svm = derive_state(root, shot, kExactSvmDomain);
             REQUIRE(host != svm);
-            Xoshiro256PlusPlus host_rng(0);
-            host_rng.seed_full(host[0], host[1], host[2], host[3]);
-            Xoshiro256PlusPlus svm_rng(0);
-            svm_rng.seed_full(svm[0], svm[1], svm[2], svm[3]);
-            REQUIRE(host_rng.next_double() != svm_rng.next_double());
         }
+    }
+}
+
+TEST_CASE("exact: a cross-domain word alias does not expand to a full-state collision") {
+    // Shots 1302581290 (driver) and 4231854694 (SVM) alias on derived word 0
+    // for every root: the root and the word-0 tag terms cancel in the
+    // comparison. They probe the word index folded into the domain tag --
+    // without it, the alias would repeat in all four words and the two
+    // 256-bit states would coincide.
+    for (uint64_t seed : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
+        const SeedRoot root = seed_root_from_seed(seed);
+        const std::array<uint64_t, 4> driver =
+            derive_state(root, 1302581290ULL, kExactDriverDomain);
+        const std::array<uint64_t, 4> svm = derive_state(root, 4231854694ULL, kExactSvmDomain);
+        REQUIRE(driver[0] == svm[0]);
+        REQUIRE(driver != svm);
     }
 }
 

--- a/tests/test_exact_driver.cc
+++ b/tests/test_exact_driver.cc
@@ -15,6 +15,7 @@
 
 #include "noncomp_test_helpers.h"
 
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -264,17 +265,20 @@ TEST_CASE("exact: same seed reproduces identical runs") {
 TEST_CASE("exact: the driver and SVM seed streams are domain-separated") {
     // The host draws (initial levels, trap destinations, classifier consults)
     // and the in-VM Born draws run on independent streams; handing the same
-    // per-shot seed to both would correlate them. Guard the documented domain
-    // split at its source: for every shot, the same (global, shot) with
-    // different domains yields unrelated seeds, and the streams they start
+    // per-shot state to both would correlate them. Guard the documented domain
+    // split at its source: for every shot, the same (root, shot) with
+    // different domains yields unrelated states, and the streams they start
     // diverge on the very first draw.
-    for (uint64_t global : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
+    for (uint64_t seed : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
+        const SeedRoot root = seed_root_from_seed(seed);
         for (uint64_t shot = 0; shot < 16; ++shot) {
-            const uint64_t host = derive_seed(global, shot, kExactDriverDomain);
-            const uint64_t svm = derive_seed(global, shot, kExactSvmDomain);
+            const std::array<uint64_t, 4> host = derive_state(root, shot, kExactDriverDomain);
+            const std::array<uint64_t, 4> svm = derive_state(root, shot, kExactSvmDomain);
             REQUIRE(host != svm);
-            Xoshiro256PlusPlus host_rng(host);
-            Xoshiro256PlusPlus svm_rng(svm);
+            Xoshiro256PlusPlus host_rng(0);
+            host_rng.seed_full(host[0], host[1], host[2], host[3]);
+            Xoshiro256PlusPlus svm_rng(0);
+            svm_rng.seed_full(svm[0], svm[1], svm[2], svm[3]);
             REQUIRE(host_rng.next_double() != svm_rng.next_double());
         }
     }


### PR DESCRIPTION
> [!NOTE]
> Prototype PR into the `codex/noncomputational-structural-mvp` feature branch — lighter review bar than main.

Widens noncomputational per-shot RNG derivation from 64-bit seeds to full 256-bit generator states, and renames the internal driver entry point.

## What changed

- **`seed.h`**: a 256-bit `SeedRoot` (deterministic SplitMix64 expansion of the user seed, or the OS-entropy words directly when unseeded) fans out into one 256-bit generator state per `(shot, domain)` via `derive_state`; `derive_seed` is deleted. The word index is folded into the domain tag so a single cross-domain word alias cannot expand into a full-state collision.
- **Rename**: `sample_noncomputational_exact` → `run_exact_driver` (internal header; file names unchanged, so the wasm source lists are untouched).
- **`xoshiro.h/.cc`**: `splitmix64` hoisted to namespace scope (bit-identical body); new `entropy_seed_words()` helper reads 256 bits from `std::random_device` (glibc workaround preserved), shared by `seed_from_entropy()` and the noncomp root, so the unseeded root is literally the OS-entropy words.
- **`svm.h`**: new `reseed_full(s0,s1,s2,s3)` beside `reseed(seed)` — distinct name keeps `&SchrodingerState::reseed` unambiguous, so the Python bindings are untouched.
- **Python**: `sample()` docstring now states the seed contract — identical seed + arguments reproduce exactly; `None` draws a fresh 256-bit entropy root per call, so parallel unseeded batches sample fresh randomness.

## Why

The 64-bit derivation was provably collision-free within one call (per-domain injectivity, exhaustively verified across the full `uint32` shot range) but keyed each unseeded call by only 64 bits, and its XOR-linear domain tags cancel in cross-batch same-domain comparisons — so a cross-batch seed coincidence duplicated *both* of a shot's streams at first order (~27k duplicated-trajectory pairs per 10^12 unseeded shots; statistically negligible but real). The widened scheme keeps the provable within-call property (word 0 remains a bijection of the shot index) and moves every cross-stream coincidence class to ~2^-256 for entropy roots, matching the plain sampler's seeding strength.

## Verification

- Same-domain injectivity argument carries per word; spot-checked (2M shots, zero word-0 collisions).
- Independent exhaustive scans (two reviewers) over the full `uint32` shot range: real cross-domain word-0 aliases exist (e.g. driver shot 1,302,581,290 ↔ SVM shot 4,231,854,694) but **no full 256-bit state collision**; that alias pair is now a committed regression test, and a mutation check (removing `| k` from the tag) makes exactly that test fail.
- Within one root, a cross-domain full-state collision is impossible (the four per-word tag-XOR targets are pairwise distinct, so one `iA^jA` cannot match all four).
- Compiled `Xoshiro256PlusPlus(12345)` output compared word-for-word against an independent reference implementation: bit-identical, so seeded **plain-sampler** sequences are unchanged.
- Debug C++: all tests passed (208,494 assertions in 1,099 cases, `~[bench]`), `ctest -E Bench` 1099/1099. Debug Python wheel: 924 passed. pre-commit `--all-files` clean.

**BREAKING**: fixed-seed *noncomputational* sample sequences change (seeded runs remain deterministic; the derived streams differ). No test seed re-picks were needed — the fixed-seed tests assert tolerance bands and validation paths, not specific sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)