### PR TITLE
chore(circuit): add a unitary gate trait

### DIFF
--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -163,6 +163,8 @@ enum class GateArity : uint8_t {
 // Booleans default to false so designated initializers only name true fields.
 struct GateTraits {
     GateArity arity;
+    // Unitary gate action (Clifford or not); excludes measurements, resets, noise, and annotations.
+    bool unitary = false;
     bool clifford = false;
     bool measurement = false;
     bool reset = false;
@@ -186,63 +188,63 @@ constexpr auto A = GateArity::ANNOTATION;
 // clang-format off
 inline constexpr GateTraits kGateTraitsData[] = {
     // Single-qubit Cliffords
-    {.arity = S, .clifford = true, .name = "H"},
-    {.arity = S, .clifford = true, .name = "S"},
-    {.arity = S, .clifford = true, .name = "S_DAG"},
-    {.arity = S, .clifford = true, .name = "X"},
-    {.arity = S, .clifford = true, .name = "Y"},
-    {.arity = S, .clifford = true, .name = "Z"},
-    {.arity = S, .clifford = true, .name = "SQRT_X"},
-    {.arity = S, .clifford = true, .name = "SQRT_X_DAG"},
-    {.arity = S, .clifford = true, .name = "SQRT_Y"},
-    {.arity = S, .clifford = true, .name = "SQRT_Y_DAG"},
-    {.arity = S, .clifford = true, .name = "H_XY"},
-    {.arity = S, .clifford = true, .name = "H_YZ"},
-    {.arity = S, .clifford = true, .name = "H_NXY"},
-    {.arity = S, .clifford = true, .name = "H_NXZ"},
-    {.arity = S, .clifford = true, .name = "H_NYZ"},
-    {.arity = S, .clifford = true, .name = "C_XYZ"},
-    {.arity = S, .clifford = true, .name = "C_ZYX"},
-    {.arity = S, .clifford = true, .name = "C_NXYZ"},
-    {.arity = S, .clifford = true, .name = "C_NZYX"},
-    {.arity = S, .clifford = true, .name = "C_XNYZ"},
-    {.arity = S, .clifford = true, .name = "C_XYNZ"},
-    {.arity = S, .clifford = true, .name = "C_ZNYX"},
-    {.arity = S, .clifford = true, .name = "C_ZYNX"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "H"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "S"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "S_DAG"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "X"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "Y"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "Z"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "SQRT_X"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "SQRT_X_DAG"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "SQRT_Y"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "SQRT_Y_DAG"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "H_XY"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "H_YZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "H_NXY"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "H_NXZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "H_NYZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_XYZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_ZYX"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_NXYZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_NZYX"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_XNYZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_XYNZ"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_ZNYX"},
+    {.arity = S, .unitary = true, .clifford = true, .name = "C_ZYNX"},
     // Non-Clifford
-    {.arity = S, .name = "T"},
-    {.arity = S, .name = "T_DAG"},
+    {.arity = S, .unitary = true, .name = "T"},
+    {.arity = S, .unitary = true, .name = "T_DAG"},
     // Parameterized rotations
-    {.arity = S, .name = "R_X"},
-    {.arity = S, .name = "R_Y"},
-    {.arity = S, .name = "R_Z"},
-    {.arity = S, .name = "U3"},
-    {.arity = P, .name = "R_XX"},
-    {.arity = P, .name = "R_YY"},
-    {.arity = P, .name = "R_ZZ"},
-    {.arity = ML, .name = "R_PAULI"},
+    {.arity = S, .unitary = true, .name = "R_X"},
+    {.arity = S, .unitary = true, .name = "R_Y"},
+    {.arity = S, .unitary = true, .name = "R_Z"},
+    {.arity = S, .unitary = true, .name = "U3"},
+    {.arity = P, .unitary = true, .name = "R_XX"},
+    {.arity = P, .unitary = true, .name = "R_YY"},
+    {.arity = P, .unitary = true, .name = "R_ZZ"},
+    {.arity = ML, .unitary = true, .name = "R_PAULI"},
     // Two-qubit Cliffords
-    {.arity = P, .clifford = true, .name = "CX"},
-    {.arity = P, .clifford = true, .name = "CY"},
-    {.arity = P, .clifford = true, .name = "CZ"},
-    {.arity = P, .clifford = true, .name = "SWAP"},
-    {.arity = P, .clifford = true, .name = "ISWAP"},
-    {.arity = P, .clifford = true, .name = "ISWAP_DAG"},
-    {.arity = P, .clifford = true, .name = "SQRT_XX"},
-    {.arity = P, .clifford = true, .name = "SQRT_XX_DAG"},
-    {.arity = P, .clifford = true, .name = "SQRT_YY"},
-    {.arity = P, .clifford = true, .name = "SQRT_YY_DAG"},
-    {.arity = P, .clifford = true, .name = "SQRT_ZZ"},
-    {.arity = P, .clifford = true, .name = "SQRT_ZZ_DAG"},
-    {.arity = P, .clifford = true, .name = "CXSWAP"},
-    {.arity = P, .clifford = true, .name = "CZSWAP"},
-    {.arity = P, .clifford = true, .name = "SWAPCX"},
-    {.arity = P, .clifford = true, .name = "XCX"},
-    {.arity = P, .clifford = true, .name = "XCY"},
-    {.arity = P, .clifford = true, .name = "XCZ"},
-    {.arity = P, .clifford = true, .name = "YCX"},
-    {.arity = P, .clifford = true, .name = "YCY"},
-    {.arity = P, .clifford = true, .name = "YCZ"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "CX"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "CY"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "CZ"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SWAP"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "ISWAP"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "ISWAP_DAG"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SQRT_XX"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SQRT_XX_DAG"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SQRT_YY"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SQRT_YY_DAG"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SQRT_ZZ"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SQRT_ZZ_DAG"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "CXSWAP"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "CZSWAP"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "SWAPCX"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "XCX"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "XCY"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "XCZ"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "YCX"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "YCY"},
+    {.arity = P, .unitary = true, .clifford = true, .name = "YCZ"},
     // Measurements
     {.arity = S, .measurement = true, .name = "M"},
     {.arity = S, .measurement = true, .name = "MX"},
@@ -261,8 +263,8 @@ inline constexpr GateTraits kGateTraitsData[] = {
     // Deterministic padding
     {.arity = S, .measurement = true, .name = "MPAD"},
     // Identity no-ops
-    {.arity = S, .identity_noop = true, .name = "I"},
-    {.arity = P, .identity_noop = true, .name = "II"},
+    {.arity = S, .unitary = true, .identity_noop = true, .name = "I"},
+    {.arity = P, .unitary = true, .identity_noop = true, .name = "II"},
     {.arity = S, .identity_noop = true, .name = "I_ERROR"},
     {.arity = P, .identity_noop = true, .name = "II_ERROR"},
     // Noise channels
@@ -288,9 +290,9 @@ inline constexpr GateTraits kGateTraitsData[] = {
     // Simulation-only probes
     {.arity = ML, .name = "EXP_VAL"},
     // Parse-time rewrites: no AST nodes carry these types
-    {.arity = P, .parser_desugared = true, .name = "CH"},
-    {.arity = T, .parser_desugared = true, .name = "CCX"},
-    {.arity = T, .parser_desugared = true, .name = "CCZ"},
+    {.arity = P, .unitary = true, .parser_desugared = true, .name = "CH"},
+    {.arity = T, .unitary = true, .parser_desugared = true, .name = "CCX"},
+    {.arity = T, .unitary = true, .parser_desugared = true, .name = "CCZ"},
     // Sentinel
     {.arity = S, .name = "UNKNOWN"},
 };
@@ -299,6 +301,26 @@ inline constexpr GateTraits kGateTraitsData[] = {
 static_assert(sizeof(kGateTraitsData) / sizeof(kGateTraitsData[0]) ==
                   static_cast<size_t>(GateType::UNKNOWN) + 1,
               "kGateTraitsData must have one entry per GateType");
+
+constexpr bool clifford_implies_unitary() {
+    for (const GateTraits& t : kGateTraitsData) {
+        if (t.clifford && !t.unitary) {
+            return false;
+        }
+    }
+    return true;
+}
+constexpr bool unitary_excludes_channels() {
+    for (const GateTraits& t : kGateTraitsData) {
+        if (t.unitary && (t.measurement || t.reset || t.measure_reset || t.noise)) {
+            return false;
+        }
+    }
+    return true;
+}
+static_assert(clifford_implies_unitary(), "every Clifford gate is a unitary");
+static_assert(unitary_excludes_channels(),
+              "a unitary gate is not a measurement, reset, or noise channel");
 
 }  // namespace detail
 
@@ -312,6 +334,9 @@ inline constexpr GateArity gate_arity(GateType g) {
 }
 inline constexpr bool is_clifford(GateType g) {
     return gate_traits(g).clifford;
+}
+inline constexpr bool is_unitary(GateType g) {
+    return gate_traits(g).unitary;
 }
 inline constexpr bool is_measurement(GateType g) {
     return gate_traits(g).measurement;

--- a/src/clifft/noncomp/model.cc
+++ b/src/clifft/noncomp/model.cc
@@ -16,16 +16,16 @@ namespace {
 
 // A transition instrument models the noncomputational side effects of a
 // physical qubit operation, so it may key only a gate that represents
-// one. This allowlist defaults to false: a newly added GateType is
-// rejected until it is deliberately classified here, rather than being
-// silently accepted. Excludes annotations, identity no-ops, the
-// classical measurement pad (MPAD), the expectation-value probe, and
-// noise channels (whose composition with a level transition is
-// deliberately left unmodeled). Parser-desugared gates are rejected as
-// hook keys before this predicate is consulted.
+// one. Classification lives in the gate table's trait flags, whose
+// defaults reject a new GateType until it is deliberately classified
+// there. Excludes annotations, identity no-ops, the classical
+// measurement pad (MPAD), the expectation-value probe, and noise
+// channels (whose composition with a level transition is deliberately
+// left unmodeled). Parser-desugared gates are rejected as hook keys
+// before this predicate is consulted.
 bool supports_transition(GateType g) {
-    if (is_clifford(g)) {
-        return true;  // single- and two-qubit Clifford gates
+    if (is_unitary(g) && !is_identity_noop(g)) {
+        return true;  // unitary gates, Clifford or not
     }
     if (is_reset(g)) {
         return true;  // R, RX, RY
@@ -33,23 +33,7 @@ bool supports_transition(GateType g) {
     if (is_measurement(g) && g != GateType::MPAD) {
         return true;  // M, MX, MY, MR, MRX, MRY, MPP
     }
-    switch (g) {
-        // Non-Clifford unitaries: no trait flag distinguishes these, so
-        // they are named explicitly.
-        case GateType::T:
-        case GateType::T_DAG:
-        case GateType::R_X:
-        case GateType::R_Y:
-        case GateType::R_Z:
-        case GateType::U3:
-        case GateType::R_XX:
-        case GateType::R_YY:
-        case GateType::R_ZZ:
-        case GateType::R_PAULI:
-            return true;
-        default:
-            return false;
-    }
+    return false;
 }
 
 }  // namespace

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1825,6 +1825,34 @@ TEST_CASE("GateTraits: UNKNOWN sentinel", "[gate_data]") {
     CHECK(gate_name(GateType::UNKNOWN) == "UNKNOWN");
 }
 
+TEST_CASE("GateTraits: unitary classification", "[gate_data]") {
+    // Identity no-ops and parser-desugared gates are rejected upstream of
+    // the gate-hook path, so the hook tests never consult their unitary
+    // flag; check the classification directly.
+    CHECK(is_unitary(GateType::I));
+    CHECK(is_unitary(GateType::II));
+    CHECK(is_unitary(GateType::CH));
+    CHECK(is_unitary(GateType::CCX));
+    CHECK(is_unitary(GateType::CCZ));
+    // I_ERROR / II_ERROR model error events, not gates.
+    CHECK(!is_unitary(GateType::I_ERROR));
+    CHECK(!is_unitary(GateType::II_ERROR));
+    // Representative unitaries and non-unitaries.
+    CHECK(is_unitary(GateType::H));
+    CHECK(is_unitary(GateType::CX));
+    CHECK(is_unitary(GateType::T));
+    CHECK(is_unitary(GateType::R_PAULI));
+    CHECK(!is_unitary(GateType::M));
+    CHECK(!is_unitary(GateType::MPAD));
+    CHECK(!is_unitary(GateType::R));
+    CHECK(!is_unitary(GateType::DEPOLARIZE1));
+    CHECK(!is_unitary(GateType::TICK));
+    CHECK(!is_unitary(GateType::EXP_VAL));
+    CHECK(!is_unitary(GateType::LEVEL_TRANSITION));
+    CHECK(!is_unitary(GateType::LOSS));
+    CHECK(!is_unitary(GateType::UNKNOWN));
+}
+
 // =============================================================================
 // Parameterized rotation gate parsing
 // =============================================================================


### PR DESCRIPTION
> [!NOTE]
> Prototype PR into the `codex/noncomputational-structural-mvp` feature branch — lighter review bar than main.

Adds a `unitary` flag to the gate table and uses it to replace the hand-enumerated non-Clifford unitary list in `supports_transition`. **No behavior change.**

## Design

- Positive trait (`unitary`) rather than a stored `non_clifford` complement: what the consumer needs is "is this a unitary gate" (Clifford or not), and complements stored in truth tables drift. If a future consumer needs the non-Clifford set, it's derivable as `is_unitary(g) && !is_clifford(g)`. Matches the vendored Stim table's shape (`GATE_IS_UNITARY`).
- The taxonomy is now machine-checked: `static_assert(clifford_implies_unitary())` and `static_assert(unitary_excludes_channels())` over the constexpr table turn a misclassified future gate into a compile error.
- Classification decisions: all 44 Cliffords + T/T_DAG + the 8 parameterized rotations get `.unitary = true`; `I`/`II` too (they are unitaries — their hook exclusion stays behavioral via `is_identity_noop`); parser-desugared `CH`/`CCX`/`CCZ` too (semantically unitary; the upstream desugared guard keeps them out of hooks as before); `I_ERROR`/`II_ERROR` stay untagged (they model error events, not gates).
- A newly added `GateType` still defaults to rejection until deliberately classified — now on its own table row instead of a distant allowlist in `noncomp/model.cc`.

## Verification

- Mutation check 1: removing `.unitary` from the `T` row is caught at **runtime** by the existing `model: every registered gate hook names a gate the parser can produce` test (hooked count 63 ≠ 64).
- Review follow-up: that hook test cannot reach `I`/`II` or the parser-desugared `CH`/`CCX`/`CCZ` (both rejected upstream of `supports_transition`), so a direct `GateTraits: unitary classification` test now checks those rows, the `I_ERROR`/`II_ERROR` contrast, and representative non-unitaries straight off the traits — mutation-verified (flipping the `I` and `CCX` rows fails exactly those two CHECKs).
- Mutation check 2: removing `.unitary` from a Clifford row fails the build with `static assertion failed: every Clifford gate is a unitary`.
- Suites identical to the unmodified baseline: Debug C++ 208,494 assertions / 1,099 cases green, `ctest -E Bench` 1099/1099, Debug Python wheel 924 passed, pre-commit `--all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)