### PR TITLE
refactor(noncomp): rename exact driver to trajectory driver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
-        additional_dependencies: [numpy>=1.26]
+        additional_dependencies: [numpy==1.26.4]
         args: [--config-file=pyproject.toml]
 
   # General file hygiene

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(clifft_core STATIC
     noncomp/model.cc
     noncomp/status_walk.cc
     noncomp/rewriter.cc
-    noncomp/exact_driver.cc
+    noncomp/trajectory_driver.cc
     noncomp/sample.cc
 )
 

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -119,7 +119,7 @@ inline constexpr PauliMaskHandle kNoMask = static_cast<PauliMaskHandle>(~uint32_
 //         - p_computational_dest[s][E].
 //
 // The last quantity aggregates destinations LeakG, LeakE, and Lost. A fire
-// into that remainder traps to the exact-mode driver, which consults the
+// into that remainder traps to the trajectory driver, which consults the
 // original matrix to choose the specific noncomputational destination.
 // Columns whose source is already noncomputational are handled classically
 // by the driver and never enter this HIR representation. The no-fire

--- a/src/clifft/noncomp/instrument_options.cc
+++ b/src/clifft/noncomp/instrument_options.cc
@@ -15,7 +15,7 @@ InstrumentTraceOptions instrument_trace_options(const NonComputationalModel& mod
         // p_computational_dest retains its G/E destination entries. Their
         // difference is the aggregate LeakG/LeakE/Lost trap probability.
         // Columns sourced at a noncomputational level stay in the model and
-        // are consulted classically by the exact-mode driver.
+        // are consulted classically by the trajectory driver.
         for (int s = 0; s < 2; ++s) {
             probabilities.p_fire[s] = instrument.column_sum(computational[s]);
             for (int d = 0; d < 2; ++d) {

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -164,7 +164,7 @@ void process_ordinary_node(const AstNode& node, uint32_t op_index,
 
 }  // namespace
 
-ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,
+ContinuationRewrite rewrite_continuation(const Circuit& annotated, const TrajectoryEvents& events,
                                          bool force_last_traceout,
                                          const NonComputationalModel& model) {
     if (events.initial_status.size() != annotated.num_qubits) {
@@ -197,7 +197,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactSh
     out = annotated.metadata_only_copy();
     out.nodes.reserve(annotated.nodes.size() + events.jumps.size() * 2);
 
-    // Do not emit an X for an initial |1>. Exact mode supplies it through the
+    // Do not emit an X for an initial |1>. The driver supplies it through the
     // per-shot Pauli frame, keeping the circuit nodes identical across shots
     // and continuations.
     std::vector<QubitStatus> status = events.initial_status;

--- a/src/clifft/noncomp/rewriter.h
+++ b/src/clifft/noncomp/rewriter.h
@@ -81,7 +81,7 @@ struct ClassicalOutcome {
 // lost qubits. These fields also form the continuation cache key, except for
 // ClassicalOutcome::source_level. Shots with equal events can therefore share
 // one compiled continuation.
-struct ExactShotEvents {
+struct TrajectoryEvents {
     std::vector<QubitStatus> initial_status;
     std::vector<ResolvedJump> jumps;
     std::vector<ClassicalOutcome> classical_outcomes;
@@ -121,7 +121,7 @@ struct ContinuationRewrite {
 // measurement to the source level reported by the trap. Throws
 // std::invalid_argument when the policy rejects an operation or the events do
 // not describe this circuit.
-ContinuationRewrite rewrite_continuation(const Circuit& annotated, const ExactShotEvents& events,
+ContinuationRewrite rewrite_continuation(const Circuit& annotated, const TrajectoryEvents& events,
                                          bool force_last_traceout,
                                          const NonComputationalModel& model);
 

--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -1,7 +1,7 @@
 #include "clifft/noncomp/sample.h"
 
-#include "clifft/noncomp/exact_driver.h"
 #include "clifft/noncomp/seed.h"
+#include "clifft/noncomp/trajectory_driver.h"
 #include "clifft/util/xoshiro.h"
 
 #include <array>
@@ -30,7 +30,7 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
         root.w[3] = w[3];
     }
 
-    return run_exact_driver(circuit, model, shots, root, max_rank);
+    return run_trajectory_driver(circuit, model, shots, root, max_rank);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/seed.h
+++ b/src/clifft/noncomp/seed.h
@@ -19,8 +19,8 @@ namespace clifft {
 
 // Driver-side draws (initial levels, trap destinations, classical
 // consults, herald flags) vs. the in-VM Born measurement randomness.
-inline constexpr uint64_t kExactDriverDomain = 0x11;
-inline constexpr uint64_t kExactSvmDomain = 0x12;
+inline constexpr uint64_t kTrajectoryDriverDomain = 0x11;
+inline constexpr uint64_t kTrajectorySvmDomain = 0x12;
 
 struct SeedRoot {
     uint64_t w[4];

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -1,4 +1,4 @@
-// Exact-mode driver implementation; exact_driver.h is the entry point.
+// Trajectory driver implementation; trajectory_driver.h is the entry point.
 //
 // Transition annotations on computational qubits remain VM instruments. When
 // one produces an outcome that the current module cannot finish, the VM stops
@@ -11,7 +11,7 @@
 // and herald flags) use one per-shot stream. VM measurements, noise, and
 // in-VM transition decisions use a separate per-shot stream; see seed.h.
 
-#include "clifft/noncomp/exact_driver.h"
+#include "clifft/noncomp/trajectory_driver.h"
 
 #include "clifft/backend/backend.h"
 #include "clifft/frontend/frontend.h"
@@ -130,7 +130,7 @@ Level draw_from_column(const TransitionInstrument& instrument, Level source,
 // instead of appending: a trap at op 2 can make op 3 driver-resolvable even
 // if op 5 was already sampled, changing the required order from [op 5] to
 // [op 3, op 5]. The rewriter consumes this vector sequentially.
-void extend_classical_outcomes(const Circuit& annotated, ExactShotEvents& events,
+void extend_classical_outcomes(const Circuit& annotated, TrajectoryEvents& events,
                                const NonComputationalModel& model, Xoshiro256PlusPlus& rng) {
     std::map<AnnotationTarget, Level> jump_dest;
     for (const ResolvedJump& jump : events.jumps) {
@@ -210,7 +210,7 @@ void extend_classical_outcomes(const Circuit& annotated, ExactShotEvents& events
 // driver-drawn transition outcomes. QubitStatus::Computational does not
 // distinguish g from e, so those initial levels share a compiled module; an
 // initial e is supplied separately through the shot's Pauli frame.
-std::string cache_key(const ExactShotEvents& events) {
+std::string cache_key(const TrajectoryEvents& events) {
     std::string key;
     key.reserve(events.initial_status.size() * 2 + 10 + events.jumps.size() * 9 +
                 events.classical_outcomes.size() * 10);
@@ -280,10 +280,10 @@ void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_ra
 }
 
 // Build the HIR pass pipeline from default passes that preserve measurement
-// record order. Exact mode may force a hidden trace-out measurement, so moving
+// record order. A trajectory may force a hidden trace-out measurement, so moving
 // an entangled measurement before that collapse would change the result. The
 // same pipeline is used for every continuation to preserve matching prefixes.
-HirPassManager exact_hir_pass_manager() {
+HirPassManager trajectory_hir_pass_manager() {
     HirPassManager pm;
     for (const auto& info : kRegisteredPasses) {
         if (info.kind == PassKind::HIR && info.default_enabled && info.record_order.preserved) {
@@ -294,7 +294,7 @@ HirPassManager exact_hir_pass_manager() {
 }
 
 // Apply the same record-order requirement to bytecode passes.
-BytecodePassManager exact_bytecode_pass_manager() {
+BytecodePassManager trajectory_bytecode_pass_manager() {
     BytecodePassManager pm;
     for (const auto& info : kRegisteredPasses) {
         if (info.kind == PassKind::Bytecode && info.default_enabled &&
@@ -459,9 +459,10 @@ void validate_model_contract(const Circuit& annotated, const NonComputationalMod
 
 }  // namespace
 
-NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputationalModel& model,
-                                        uint32_t shots, const SeedRoot& root,
-                                        std::optional<uint32_t> max_rank) {
+NonComputationalSample run_trajectory_driver(const Circuit& circuit,
+                                             const NonComputationalModel& model, uint32_t shots,
+                                             const SeedRoot& root,
+                                             std::optional<uint32_t> max_rank) {
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
@@ -540,7 +541,7 @@ NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputa
 
     // Cache one rewrite for each event record. Rewriting is deterministic and
     // consumes no randomness, so cache hits do not change sampling.
-    auto get_entry = [&](const ExactShotEvents& events, bool force_last) -> ContinuationEntry& {
+    auto get_entry = [&](const TrajectoryEvents& events, bool force_last) -> ContinuationEntry& {
         const std::string key = cache_key(events);
         auto [it, inserted] = cache.try_emplace(key);
         ContinuationEntry& entry = it->second;
@@ -605,13 +606,13 @@ NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputa
 #ifndef NDEBUG
             const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
 #endif
-            exact_hir_pass_manager().run(hir);
+            trajectory_hir_pass_manager().run(hir);
 #ifndef NDEBUG
             assert(record_sequence(hir) == pre_pass_records &&
-                   "an exact-pipeline HIR pass reordered or removed a record op");
+                   "a trajectory-pipeline HIR pass reordered or removed a record op");
 #endif
             CompiledModule module = lower(hir);
-            exact_bytecode_pass_manager().run(module);
+            trajectory_bytecode_pass_manager().run(module);
             check_max_rank(module, max_rank);
             if (module.instrument_offsets.size() != entry.rw.site_targets.size()) {
                 throw std::logic_error(
@@ -648,7 +649,7 @@ NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputa
 
     // Common starting continuation for a shot with computational initial
     // statuses and no recorded jumps.
-    ExactShotEvents no_events;
+    TrajectoryEvents no_events;
     no_events.initial_status.assign(circuit.num_qubits, QubitStatus::Computational);
 
     // Reuse one state across shots. resume() can grow it for larger
@@ -670,11 +671,11 @@ NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputa
     std::optional<SchrodingerState> state_storage;
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
-        const auto dw = derive_state(root, shot, kExactDriverDomain);
+        const auto dw = derive_state(root, shot, kTrajectoryDriverDomain);
         Xoshiro256PlusPlus driver_rng(0);
         driver_rng.seed_full(dw[0], dw[1], dw[2], dw[3]);
 
-        ExactShotEvents events;
+        TrajectoryEvents events;
         events.initial_status.reserve(circuit.num_qubits);
         // QubitStatus::Computational does not distinguish g from e. Keep the
         // sampled levels separately so an initial e can set the Pauli frame
@@ -744,7 +745,7 @@ NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputa
             }
         }
         SchrodingerState& state = *state_storage;
-        const auto sw = derive_state(root, shot, kExactSvmDomain);
+        const auto sw = derive_state(root, shot, kTrajectorySvmDomain);
         state.reseed_full(sw[0], sw[1], sw[2], sw[3]);
         assert(state.meas_record.size() >= module->total_meas_slots &&
                "the rebuild block above guarantees meas_record capacity; "

--- a/src/clifft/noncomp/trajectory_driver.h
+++ b/src/clifft/noncomp/trajectory_driver.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// Exact-mode driver for level transitions such as leak, loss, and decay.
+// Trajectory driver for level transitions such as leak, loss, and decay.
 //
 // Each shot samples its initial levels, then runs transitions on computational
 // qubits as VM instruments. If the VM cannot finish a transition, it stops and
@@ -22,8 +22,9 @@
 
 namespace clifft {
 
-NonComputationalSample run_exact_driver(const Circuit& circuit, const NonComputationalModel& model,
-                                        uint32_t shots, const SeedRoot& root,
-                                        std::optional<uint32_t> max_rank);
+NonComputationalSample run_trajectory_driver(const Circuit& circuit,
+                                             const NonComputationalModel& model, uint32_t shots,
+                                             const SeedRoot& root,
+                                             std::optional<uint32_t> max_rank);
 
 }  // namespace clifft

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -252,12 +252,12 @@ const char* svm_backend() {
 }
 
 // Plain sampling cannot return a partial shot. Instrument programs that stop
-// at a trap must be run by the exact driver, which handles resume().
+// at a trap must be run by the trajectory driver, which handles resume().
 static void throw_on_pending_trap(const SchrodingerState& state) {
     if (state.pending_trap.has_value()) {
         throw std::runtime_error(
             "a shot halted at a resumable instrument trap; instrument programs require the "
-            "exact-mode driver (execute/resume), not the plain sampling entry points");
+            "trajectory driver (execute/resume), not the plain sampling entry points");
     }
 }
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -132,14 +132,14 @@ class Model:
         reset_restores_lost: if true, a reset on a lost qubit restores it to
             a computational state; if false (default), the reset acts on the
             vacated site and is dropped.
-        damping: exact-mode handling of sites whose no-fire back-action is
-            genuinely non-Clifford (a source-dependent transition on a
-            coherent qubit outside the amplitude array). ``"exact"`` (the
-            default) expands the qubit into the array, adding one to the
-            circuit's rank at that site; ``"neglect"`` keeps the rank and
-            omits the no-fire back-action, a survivorship tilt of order
-            ``|p_g - p_e|`` with no effect on source-independent rates.
-            Only meaningful at coherent dormant sites.
+        damping: handling of sites whose no-fire back-action is genuinely
+            non-Clifford (a source-dependent transition on a coherent qubit
+            outside the amplitude array). ``"exact"`` (the default) expands
+            the qubit into the array, adding one to the circuit's rank at that
+            site; ``"neglect"`` keeps the rank and omits the no-fire
+            back-action, a survivorship tilt of order ``|p_g - p_e|`` with no
+            effect on source-independent rates. Only meaningful at coherent
+            dormant sites.
 
     An operation with no representable effect on a leaked or lost operand --
     e.g. a two-qubit gate onto a vacated site -- is dropped, acting as the
@@ -304,13 +304,13 @@ def sample(
     ``None``, each call draws a fresh 256-bit root from OS entropy, so
     repeated or parallel unseeded calls sample fresh randomness.
 
-    ``max_rank`` caps the compiled peak rank under exact-mode compilation;
-    the cap is enforced at each continuation compile, failing with the
-    offending circuit line named instead of attempting a ``2**k``
-    allocation. The cap applies to each compiled module, including branches
-    a given shot never takes (such as the no-fire suffix past a
-    certain-fire annotation), so it is conservative: a rejected circuit may
-    keep every reachable trajectory within the cap. Unlimited when ``None``.
+    ``max_rank`` caps the compiled peak rank for each trajectory; the cap is
+    enforced at each continuation compile, failing with the offending circuit
+    line named instead of attempting a ``2**k`` allocation. The cap applies to
+    each compiled module, including branches a given shot never takes (such as
+    the no-fire suffix past a certain-fire annotation), so it is conservative:
+    a rejected circuit may keep every reachable trajectory within the cap.
+    Unlimited when ``None``.
     """
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ add_executable(clifft_tests
     test_noncomp_status_walk.cc
     test_noncomp_rewriter.cc
     test_noncomp_continuation.cc
-    test_exact_driver.cc
+    test_trajectory_driver.cc
     test_noncomp_validation.cc
 )
 

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -440,7 +440,7 @@ def test_policy_knob_strings_validate():
         noncomp.Model(initial_state=ALL_G, damping="bogus")
 
 
-def test_loss_only_exact_mode_stays_at_stabilizer_cost():
+def test_loss_only_exact_damping_stays_at_stabilizer_cost():
     """Equal per-source rates (LOSS always qualifies) take the trap-form
     lowering under damping="exact", so a loss-only model compiles at the
     neglect rank -- max_rank=0 passes -- while the physics stays exact:

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -201,9 +201,9 @@ def test_two_site_exact_damping_composition_matches_enumerator():
     observable.  Compare sampled record/status frequencies against the
     enumerator's exact distribution within the file's existing BAND tolerance.
 
-    This exercises the composed-continuation path from the exact side: each
-    site adds one branch at run time, and the no-fire filter at each site
-    accumulates multiplicatively.
+    This exercises composed continuations under exact damping: each site adds
+    one branch at run time, and the no-fire filter at each site accumulates
+    multiplicatively.
     """
     import utils_noncomp_enumerator as en
 

--- a/tests/python/test_noncomp_trajectory_probes.py
+++ b/tests/python/test_noncomp_trajectory_probes.py
@@ -1,7 +1,7 @@
-"""Closed-form micro-probes for the exact sampling mode.
+"""Closed-form micro-probes for noncomputational trajectory sampling.
 
 Each probe checks, in closed form built on the first-principles oracle, a
-distinct property the exact mode must satisfy: zero fires from a gate-determined
+distinct property the sampler must satisfy: zero fires from a gate-determined
 source, destination-collapse correlations with an entangled partner, and the
 sqrt(1 - p) no-fire coherence that separates ``damping="exact"`` from
 ``damping="neglect"``.

--- a/tests/python/test_noncomp_trajectory_tvd.py
+++ b/tests/python/test_noncomp_trajectory_tvd.py
@@ -1,9 +1,9 @@
-"""Distributional cross-check of the exact mode against the dense reference.
+"""Distributional cross-check of trajectory sampling against the dense reference.
 
 The enumerator (``utils_noncomp_enumerator``) computes the exact joint
 distribution of the visible record from first principles; the tests here
 first self-check it against hand-derived closed forms, then compare
-clifft's exact-mode sampling to it on a distance-3 repetition-code round
+clifft's trajectory sampling to it on a distance-3 repetition-code round
 at cold-atom-magnitude rates, by total variation distance with a
 shot-noise band calibrated from the reference distribution itself.
 """

--- a/tests/python/utils_noncomp_enumerator.py
+++ b/tests/python/utils_noncomp_enumerator.py
@@ -6,8 +6,8 @@ visible measurement record, by branching a pure statevector over every
 classical event -- initial levels, transition fires, Born outcomes -- with
 explicit probability weights. Transition sites apply the physical per-site
 channel (source-conditioned collapse plus the sqrt(1 - p) no-fire filter),
-so the result is the dense reference the exact sampling mode must match to
-shot noise; ``damping="neglect"`` reproduces that mode's one documented
+so the result is the dense reference the trajectory sampler must match to
+shot noise; ``damping="neglect"`` reproduces that policy's one documented
 omission by skipping the no-fire filter while keeping fire weights exact.
 
 Deliberately independent of clifft: its own line parser (a small subset)

--- a/tests/test_execute_instruments.cc
+++ b/tests/test_execute_instruments.cc
@@ -5,7 +5,7 @@
 // certain-fire channels (p = 1, which also exercises the eval-only
 // route the fused form cannot take), source-dependence contrasts on
 // definite preparations, and same-seed reproducibility. Distributional
-// validation belongs to the exact-mode validation campaign.
+// validation belongs to the trajectory-driver tests.
 
 #include "clifft/backend/backend.h"
 #include "clifft/frontend/frontend.h"

--- a/tests/test_instrument_kernels.cc
+++ b/tests/test_instrument_kernels.cc
@@ -1,13 +1,12 @@
 // Directed and dense-oracle tests for the instrument kernels.
 //
-// The kernels are the array-level pieces of an exact state-dependent jump
-// site: fused damp+evaluate on an active
-// axis, in-place forced collapse of an active axis, fused expand+damp for
-// a dormant-random qubit, frame-level forced collapse of a dormant-random
-// qubit, and the pure fire-branch draw helper. None of them rolls the
-// PRNG, so every test is deterministic: the oracle is a dense reference
-// that applies the instrument's Kraus operators to a copy of the
-// gamma-scaled amplitudes.
+// The kernels are the array-level pieces of a state-dependent transition
+// site: fused damp+evaluate on an active axis, in-place forced collapse of an
+// active axis, fused expand+damp for a dormant-random qubit, frame-level forced
+// collapse of a dormant-random qubit, and the pure fire-branch draw helper.
+// None of them rolls the PRNG, so every test is deterministic: the oracle is a
+// dense reference that applies the instrument's Kraus operators to a copy of
+// the gamma-scaled amplitudes.
 //
 // These tests exercise the kernels directly, without the dispatcher
 // (which is wired up in a separate step).

--- a/tests/test_noncomp_continuation.cc
+++ b/tests/test_noncomp_continuation.cc
@@ -1,11 +1,10 @@
-// Exact-mode continuation rewrite: the circuit-level half of the trap
-// protocol. rewrite_continuation() rebuilds the full circuit under a
-// shot's resolved events -- prefix verbatim (bit-identical compilation is
-// what re-entry relies on), annotations kept wherever their qubit is
-// still computational, classical-source consults consumed with pre-drawn
-// outcomes, and the trapped jump's carrier edit inserted at the suffix
-// start, with its hidden trace-out slot reported when the driver must
-// force it.
+// Continuation rewriting is the circuit-level half of the trap protocol.
+// rewrite_continuation() rebuilds the full circuit under a shot's resolved
+// events -- prefix verbatim (bit-identical compilation is what re-entry relies
+// on), annotations kept wherever their qubit is still computational,
+// classical-source consults consumed with pre-drawn outcomes, and the trapped
+// jump's carrier edit inserted at the suffix start, with its hidden trace-out
+// slot reported when the driver must force it.
 
 #include "clifft/circuit/parser.h"
 #include "clifft/noncomp/model.h"
@@ -68,7 +67,7 @@ TEST_CASE("continuation: empty events reproduce the annotated circuit verbatim")
     auto annotated =
         expand_transition_hooks(parse("H 0\nLEVEL_TRANSITION[leak] 0\nCX 0 1\nM 0\nM 1"), model);
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = computational_initials(2);
 
     auto result = rewrite_continuation(annotated, events, /*force_last_traceout=*/false, model);
@@ -86,7 +85,7 @@ TEST_CASE("continuation: a trapped jump keeps its annotation and inserts the tra
     auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nCX 0 1\nM 0\nM 1");
     auto annotated = expand_transition_hooks(circuit, model);
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = computational_initials(2);
     // This explicit annotation remains node 1 because the model has no gate hooks.
     events.jumps.push_back({{/*op_index=*/1, /*qubit=*/0}, /*destination_level=*/Level::LeakE});
@@ -116,7 +115,7 @@ TEST_CASE("continuation: classical-source consults consume pre-drawn outcomes") 
         parse("LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 0\nM 0");
     auto annotated = expand_transition_hooks(circuit, model);
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = computational_initials(1);
     events.jumps.push_back({{0, 0}, Level::LeakE});
     events.classical_outcomes.push_back({{/*op_index=*/1, /*qubit=*/0},
@@ -143,7 +142,7 @@ TEST_CASE("continuation: the forced trace-out node names the trace-out R in the 
     auto circuit = parse("R 1\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0");
     auto annotated = expand_transition_hooks(circuit, model);
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = computational_initials(2);
     events.jumps.push_back({{2, 0}, Level::LeakE});
 
@@ -162,7 +161,7 @@ TEST_CASE("continuation: the forced trace-out node is correct with multiple prio
     auto circuit = parse("R 1\nR 2\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0");
     auto annotated = expand_transition_hooks(circuit, model);
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = computational_initials(3);
     events.jumps.push_back({{3, 0}, Level::LeakE});  // the annotation is node 3
 
@@ -178,18 +177,18 @@ TEST_CASE("continuation: events that do not describe the circuit reject") {
     auto model = demo_model();
     auto annotated = expand_transition_hooks(parse("LEVEL_TRANSITION[leak] 0\nM 0"), model);
 
-    ExactShotEvents base;
+    TrajectoryEvents base;
     base.initial_status = computational_initials(1);
 
     SECTION("a jump with no matching computational transition") {
-        ExactShotEvents events = base;
+        TrajectoryEvents events = base;
         events.jumps.push_back({{5, 0}, Level::LeakE});
         REQUIRE_THROWS_WITH(
             rewrite_continuation(annotated, events, false, model),
             ContainsSubstring("do not match transition annotations on computational qubits"));
     }
     SECTION("an outcome with no matching leaked or lost transition") {
-        ExactShotEvents events = base;
+        TrajectoryEvents events = base;
         events.classical_outcomes.push_back({{0, 0}, std::nullopt, Level::G});
         REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),
                             ContainsSubstring("more leaked or lost transition outcomes"));
@@ -197,7 +196,7 @@ TEST_CASE("continuation: events that do not describe the circuit reject") {
     SECTION("an outcome drawn at a different source level") {
         // A leaked initial means op 0 uses a pre-drawn outcome; this outcome
         // incorrectly claims it was drawn at a computational level.
-        ExactShotEvents events = base;
+        TrajectoryEvents events = base;
         events.initial_status[0] = QubitStatus::LeakE;
         events.classical_outcomes.push_back({{/*op_index=*/0, /*qubit=*/0},
                                              /*destination=*/std::nullopt,
@@ -209,7 +208,7 @@ TEST_CASE("continuation: events that do not describe the circuit reject") {
         // Every recorded jump emits a carrier reset, so the forced form
         // always has one to point at. Rewritten stream: [LEVEL_TRANSITION,
         // R (trace-out), MPAD], so the trace-out R is at node index 1.
-        ExactShotEvents events = base;
+        TrajectoryEvents events = base;
         events.jumps.push_back({{0, 0}, Level::LeakE});
         auto result = rewrite_continuation(annotated, events, true, model);
         REQUIRE(result.forced_traceout_node == 1);  // index in the rewritten stream

--- a/tests/test_noncomp_rewriter.cc
+++ b/tests/test_noncomp_rewriter.cc
@@ -4,7 +4,7 @@
 // carrier edits for recorded jumps, and the transition-hook expansion consumed
 // by the rewriter. Noncomputational statuses come from initial statuses or
 // recorded events; a coherent qubit's annotation stays a runtime instrument
-// site (the driver's territory, tested in test_exact_driver).
+// site (the driver's territory, tested in test_trajectory_driver).
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/circuit/gate_data.h"
@@ -39,7 +39,6 @@ using clifft::AstNode;
 using clifft::Circuit;
 using clifft::ContinuationRewrite;
 using clifft::default_hir_pass_manager;
-using clifft::ExactShotEvents;
 using clifft::expand_transition_hooks;
 using clifft::GateType;
 using clifft::HirModule;
@@ -52,6 +51,7 @@ using clifft::parse;
 using clifft::QubitStatus;
 using clifft::rewrite_continuation;
 using clifft::trace;
+using clifft::TrajectoryEvents;
 using clifft::TransitionInstrument;
 using clifft::test::certain_transition_from_computational;
 using clifft::test::classifier_matrix_with_column;
@@ -97,7 +97,7 @@ size_t count_gate(const Circuit& c, GateType gate) {
 // Expand hooks and rewrite under the given initial statuses and events.
 ContinuationRewrite rewritten(const Circuit& c, const NonComputationalModel& model,
                               const std::vector<Level>& initial_levels,
-                              ExactShotEvents events = {}) {
+                              TrajectoryEvents events = {}) {
     Circuit annotated = expand_transition_hooks(c, model);
     events.initial_status = initials(initial_levels);
     return rewrite_continuation(annotated, events, false, model);
@@ -115,7 +115,7 @@ TEST_CASE("rewrite: a coherent qubit's recorded jump to lost gets a trace-out R"
     transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
     NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.jumps.push_back({{/*op_index=*/1, /*qubit=*/0}, /*destination_level=*/Level::Lost});
     ContinuationRewrite rw = rewritten(c, model, {Level::G}, events);
     // H and the site kept; one trace-out R follows the site.
@@ -131,7 +131,7 @@ TEST_CASE("rewrite: a recorded jump to the zero level inserts R without X") {
     transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
     NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.jumps.push_back({{1, 0}, /*destination_level=*/Level::G});
     ContinuationRewrite rw = rewritten(c, model, {Level::G}, events);
     REQUIRE(count_gate(rw.circuit, GateType::R) == 1);  // materialize at |0>
@@ -144,7 +144,7 @@ TEST_CASE("rewrite: an inserted trace-out R survives compilation as one hidden m
     transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
     NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.jumps.push_back({{1, 0}, Level::Lost});
     ContinuationRewrite rw = rewritten(c, model, {Level::G}, events);
 
@@ -166,7 +166,7 @@ TEST_CASE("rewrite: an inserted R does not shift visible measurements or detecto
     transitions.emplace("lk", certain_transition_from_computational(Level::Lost));
     NonComputationalModel model = make_rewriter_model(std::move(transitions));
 
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.jumps.push_back({{3, 1}, Level::Lost});
     ContinuationRewrite rw = rewritten(c, model, {Level::G, Level::G}, events);
     ContinuationRewrite base = rewritten(c, model, {Level::G, Level::G});
@@ -651,7 +651,7 @@ TEST_CASE("rewrite: a malformed LOSS annotation rejects instead of reading past 
     // rather than index into it.
     NonComputationalModel model = make_rewriter_model({});
     Circuit c = parse("LOSS(0.5) 0\nM 0\n");
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = initials({Level::G});
 
     SECTION("no arguments") {
@@ -689,7 +689,7 @@ TEST_CASE("rewrite: a correlated chain whose head operand is lost survives the r
 TEST_CASE("rewrite_continuation: unknown transition tag throws") {
     Circuit c = parse("LEVEL_TRANSITION[nosuch] 0\n");
     NonComputationalModel model = make_rewriter_model({});
-    ExactShotEvents events;
+    TrajectoryEvents events;
     events.initial_status = {QubitStatus::Computational};
     Circuit annotated = expand_transition_hooks(c, model);
     REQUIRE_THROWS_WITH(rewrite_continuation(annotated, events, false, model),

--- a/tests/test_noncomp_validation.cc
+++ b/tests/test_noncomp_validation.cc
@@ -190,7 +190,7 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
     Circuit annotated = expand_transition_hooks(c, model);
     // The recorded jump is what the driver stores when the site traps: the
     // deterministic loss on qubit 0 at the expanded annotation.
-    clifft::ExactShotEvents events;
+    clifft::TrajectoryEvents events;
     events.initial_status.assign(2, clifft::QubitStatus::Computational);
     events.jumps.push_back(
         {{/*op_index=*/3, /*qubit=*/0}, /*destination_level=*/clifft::Level::Lost});
@@ -206,7 +206,7 @@ TEST_CASE("validation: losing a Bell-pair qubit inserts the hidden trace-out R a
     // The visible measurement count is unchanged (the record layout is
     // stable). The baseline is the same rewrite with no jump recorded, so
     // both sides carry the identical live instrument site.
-    clifft::ExactShotEvents no_events;
+    clifft::TrajectoryEvents no_events;
     no_events.initial_status = events.initial_status;
     Circuit base_c = rewrite_continuation(annotated, no_events, false, model).circuit;
     clifft::InstrumentTraceOptions options = clifft::instrument_trace_options(model);

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -1,4 +1,4 @@
-// End-to-end tests for exact-mode sampling: the driver loop, continuation
+// End-to-end tests for trajectory sampling: the driver loop, continuation
 // cache, frame-preloaded initials, and trap resolution behind
 // sample_noncomputational.
 //
@@ -94,8 +94,8 @@ NonComputationalModel make_lose_model() {
 
 }  // namespace
 
-TEST_CASE("exact: an untrapped run reproduces plain sampling behavior") {
-    // No annotations at all: the exact path is one shared module executed
+TEST_CASE("trajectory: an untrapped run reproduces plain sampling behavior") {
+    // No annotations at all: the trajectory path is one shared module executed
     // per shot. A Bell pair's measurements must be perfectly correlated.
     ModelSpec spec;
     auto model = make_driver_model(spec);
@@ -115,7 +115,7 @@ TEST_CASE("exact: an untrapped run reproduces plain sampling behavior") {
     }
 }
 
-TEST_CASE("exact: a certain leak reports the trapped classified status") {
+TEST_CASE("trajectory: a certain leak reports the trapped classified status") {
     // From |1> (X prep), the site fires every shot; the leaked qubit's
     // measurement classifies (leaked column reads 1) and the sidecar
     // carries the leaked status. Qubit 1 is untouched.
@@ -133,7 +133,7 @@ TEST_CASE("exact: a certain leak reports the trapped classified status") {
     }
 }
 
-TEST_CASE("exact: a known |1> initial preloads the frame without a distinct module") {
+TEST_CASE("trajectory: a known |1> initial preloads the frame without a distinct module") {
     // Initial state entirely on e: every shot must measure 1 through the
     // frame preload alone.
     ModelSpec spec;
@@ -147,7 +147,7 @@ TEST_CASE("exact: a known |1> initial preloads the frame without a distinct modu
     }
 }
 
-TEST_CASE("exact: a noncomputational initial compiles its own continuation") {
+TEST_CASE("trajectory: a noncomputational initial compiles its own continuation") {
     // Initial state entirely on the lost level: no trap ever fires (the
     // annotation is a classical consult), the measurement classifies from
     // the lost column, and the final status stays Lost.
@@ -163,7 +163,7 @@ TEST_CASE("exact: a noncomputational initial compiles its own continuation") {
     }
 }
 
-TEST_CASE("exact: seepage after a trap recaptures through a classical consult") {
+TEST_CASE("trajectory: seepage after a trap recaptures through a classical consult") {
     // Certain leak, then certain seepage back to e at the next site, then
     // a measurement: every shot reads 1 with a computational final
     // status. The recapture path exercises pre-drawn classical outcomes
@@ -181,7 +181,7 @@ TEST_CASE("exact: seepage after a trap recaptures through a classical consult") 
     }
 }
 
-TEST_CASE("exact: an in-line computational fire is never reported as a known level") {
+TEST_CASE("trajectory: an in-line computational fire is never reported as a known level") {
     // From g, the flip site fires g -> e inside the VM on ~half the
     // shots; the driver never learns which shots fired, so the sidecar
     // must not claim a known level for either population. The
@@ -201,7 +201,7 @@ TEST_CASE("exact: an in-line computational fire is never reported as a known lev
     REQUIRE(ones < 140);
 }
 
-TEST_CASE("exact: a later trap composes with an earlier in-line fire") {
+TEST_CASE("trajectory: a later trap composes with an earlier in-line fire") {
     // The flip site fires g -> e inside the VM; the leak site then fires
     // only from e (p = 1), so exactly the flipped shots trap. Per shot, a
     // leaked status must coincide with a classified 1 and a computational
@@ -228,7 +228,7 @@ TEST_CASE("exact: a later trap composes with an earlier in-line fire") {
     REQUIRE(leaked < 140);
 }
 
-TEST_CASE("exact: a source-independent rate matches its closed form") {
+TEST_CASE("trajectory: a source-independent rate matches its closed form") {
     // A source-independent rate (p_g = p_e) has the closed form
     // p(leak) = 0.3 regardless of the carrier state; a leaked qubit
     // reads 1 while a computational |0> reads 0. (The distributional
@@ -246,7 +246,7 @@ TEST_CASE("exact: a source-independent rate matches its closed form") {
     REQUIRE(std::abs(mean - 0.3) < 0.04);
 }
 
-TEST_CASE("exact: same seed reproduces identical runs") {
+TEST_CASE("trajectory: same seed reproduces identical runs") {
     ModelSpec spec;
     spec.leak_from_e = 0.5;
     spec.initial = {0.5, 0.5, 0.0, 0.0, 0.0};
@@ -262,7 +262,7 @@ TEST_CASE("exact: same seed reproduces identical runs") {
     }
 }
 
-TEST_CASE("exact: the driver and SVM seed streams are domain-separated") {
+TEST_CASE("trajectory: the driver and SVM seed streams are domain-separated") {
     // The host draws (initial levels, trap destinations, classifier consults)
     // and the in-VM Born draws run on independent streams; handing the same
     // per-shot state to both would correlate them. Guard the documented domain
@@ -271,14 +271,14 @@ TEST_CASE("exact: the driver and SVM seed streams are domain-separated") {
     for (uint64_t seed : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
         const SeedRoot root = seed_root_from_seed(seed);
         for (uint64_t shot = 0; shot < 16; ++shot) {
-            const std::array<uint64_t, 4> host = derive_state(root, shot, kExactDriverDomain);
-            const std::array<uint64_t, 4> svm = derive_state(root, shot, kExactSvmDomain);
+            const std::array<uint64_t, 4> host = derive_state(root, shot, kTrajectoryDriverDomain);
+            const std::array<uint64_t, 4> svm = derive_state(root, shot, kTrajectorySvmDomain);
             REQUIRE(host != svm);
         }
     }
 }
 
-TEST_CASE("exact: a cross-domain word alias does not expand to a full-state collision") {
+TEST_CASE("trajectory: a cross-domain word alias does not expand to a full-state collision") {
     // Shots 1302581290 (driver) and 4231854694 (SVM) alias on derived word 0
     // for every root: the root and the word-0 tag terms cancel in the
     // comparison. They probe the word index folded into the domain tag --
@@ -287,15 +287,15 @@ TEST_CASE("exact: a cross-domain word alias does not expand to a full-state coll
     for (uint64_t seed : {0ULL, 1ULL, 0x9E3779B97F4A7C15ULL}) {
         const SeedRoot root = seed_root_from_seed(seed);
         const std::array<uint64_t, 4> driver =
-            derive_state(root, 1302581290ULL, kExactDriverDomain);
-        const std::array<uint64_t, 4> svm = derive_state(root, 4231854694ULL, kExactSvmDomain);
+            derive_state(root, 1302581290ULL, kTrajectoryDriverDomain);
+        const std::array<uint64_t, 4> svm = derive_state(root, 4231854694ULL, kTrajectorySvmDomain);
         REQUIRE(driver[0] == svm[0]);
         REQUIRE(driver != svm);
     }
 }
 
-TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
-    // Each dormant-random exact site adds one to k: three H-prefixed
+TEST_CASE("trajectory: max_rank rejects an over-budget compile naming the line") {
+    // Each dormant-random site under exact damping adds one to k: three H-prefixed
     // sites push the peak to 3, over a cap of 2.
     ModelSpec spec;
     spec.leak_from_e = 0.2;
@@ -310,7 +310,7 @@ TEST_CASE("exact: max_rank rejects an over-budget compile naming the line") {
         ContainsSubstring("exceeds max_rank 2") && ContainsSubstring("circuit line"));
 }
 
-TEST_CASE("exact: a trap-form fire keeps the fire-side correlation") {
+TEST_CASE("trajectory: a trap-form fire keeps the fire-side correlation") {
     // The decisive regression check for the forced trace-out. Qubit 0 is Bell-entangled
     // with qubit 1 and dormant-random at the site; under neglect the fire
     // traps with the carrier uncollapsed. The channel is certain but
@@ -346,7 +346,7 @@ TEST_CASE("exact: a trap-form fire keeps the fire-side correlation") {
     REQUIRE(saw_one);
 }
 
-TEST_CASE("exact: a trap may insert a classical consult between pre-drawn ones") {
+TEST_CASE("trajectory: a trap may insert a classical consult between pre-drawn ones") {
     // Both qubits start leaked; R 0; X 0 recaptures q0 to a definite |1>,
     // so q0's first annotation is quantum and traps (certain leak from
     // e), while q1's later annotation was already pre-drawn as a
@@ -372,7 +372,7 @@ TEST_CASE("exact: a trap may insert a classical consult between pre-drawn ones")
     }
 }
 
-TEST_CASE("exact: a chain of two forced traps keeps both correlations") {
+TEST_CASE("trajectory: a chain of two forced traps keeps both correlations") {
     // Two independent Bell pairs, each with a certain source-dependent
     // leak under neglect: every shot traps twice, forcing two trace-outs
     // at two different hidden slots, and the second continuation's prefix
@@ -403,7 +403,7 @@ TEST_CASE("exact: a chain of two forced traps keeps both correlations") {
     }
 }
 
-TEST_CASE("exact: a neglect fire onto a computational destination stays correlated") {
+TEST_CASE("trajectory: a neglect fire onto a computational destination stays correlated") {
     // Under neglect every fire traps, including computational
     // destinations. A certain source-swap channel (g -> e, e -> g) on a
     // Bell-entangled dormant-random qubit: the continuation's forced
@@ -436,7 +436,7 @@ TEST_CASE("exact: a neglect fire onto a computational destination stays correlat
     REQUIRE(saw_one);
 }
 
-TEST_CASE("exact: herald flags drawn in one continuation are reused by the next") {
+TEST_CASE("trajectory: herald flags drawn in one continuation are reused by the next") {
     // The reuse invariant, made observable: with p_herald = 0.5 and a
     // deterministic not-heralded bit (P(1 | leak, not heralded) = 1), a
     // slot whose sidecar flag says not-heralded must always record 1 --
@@ -474,7 +474,7 @@ TEST_CASE("exact: herald flags drawn in one continuation are reused by the next"
     REQUIRE(heralded < 280);
 }
 
-TEST_CASE("exact: spectator noise between two traps fires exactly once") {
+TEST_CASE("trajectory: spectator noise between two traps fires exactly once") {
     // Certain X errors on a spectator qubit, one between the two traps
     // and one after: the noise-gap cursor must fire each exactly once
     // across the two re-anchors, flipping the spectator twice back to 0.
@@ -496,7 +496,7 @@ TEST_CASE("exact: spectator noise between two traps fires exactly once") {
     }
 }
 
-TEST_CASE("exact: a detector and observable span the trap boundary") {
+TEST_CASE("trajectory: a detector and observable span the trap boundary") {
     // The detector compares a pre-trap measurement (executed on the main
     // line) with a post-trap classified one (written by the
     // continuation): both read 1, so the parity is 0 on every shot, and
@@ -519,7 +519,7 @@ TEST_CASE("exact: a detector and observable span the trap boundary") {
     }
 }
 
-TEST_CASE("exact: a hand-written multi-target annotation traps on one target") {
+TEST_CASE("trajectory: a hand-written multi-target annotation traps on one target") {
     // A single LEVEL_TRANSITION node with two targets materializes one
     // site per target; the trap maps back through site_targets to the
     // right (op, qubit), and the continuation's split keeps the sibling
@@ -538,7 +538,7 @@ TEST_CASE("exact: a hand-written multi-target annotation traps on one target") {
     }
 }
 
-TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
+TEST_CASE("trajectory: neglect keeps rank flat while exact damping expands") {
     ModelSpec spec;
     spec.leak_from_e = 0.3;  // source-dependent: the damp is non-scalar
     spec.damping = DampingPolicy::Neglect;
@@ -557,7 +557,7 @@ TEST_CASE("exact: neglect keeps rank flat while the exact default expands") {
         ContainsSubstring("exceeds max_rank 0"));
 }
 
-TEST_CASE("exact: ternary heralds ride the cache key") {
+TEST_CASE("trajectory: ternary heralds ride the cache key") {
     // A three-symbol classifier whose leaked column always heralds: every
     // trapped shot's classified slot reports a herald, and the record bit
     // stays roughly fair across shots.
@@ -584,7 +584,7 @@ TEST_CASE("exact: ternary heralds ride the cache key") {
     REQUIRE(ones < 140);
 }
 
-TEST_CASE("exact: a hand-built malformed LOSS rejects up front") {
+TEST_CASE("trajectory: a hand-built malformed LOSS rejects up front") {
     // A live LOSS site rides through the continuation rewrite verbatim,
     // and trace() must never be the first to look at its arguments (a
     // missing one would read as probability zero). Every annotation
@@ -607,7 +607,7 @@ TEST_CASE("exact: a hand-built malformed LOSS rejects up front") {
     }
 }
 
-TEST_CASE("exact: hand-built annotation targets reject up front") {
+TEST_CASE("trajectory: hand-built annotation targets reject up front") {
     Circuit circuit = parse("M 0");
 
     SECTION("out-of-range target with computational initials") {
@@ -636,7 +636,7 @@ TEST_CASE("exact: hand-built annotation targets reject up front") {
     }
 }
 
-TEST_CASE("exact: a smaller starting module must not shrink the reused state") {
+TEST_CASE("trajectory: a smaller starting module must not shrink the reused state") {
     // A leaked initial compiles a from-the-top continuation with more
     // hidden record slots (the MR restore) but a smaller peak rank than
     // the main line, whose expand_damp site needs the array. A shot
@@ -655,7 +655,7 @@ TEST_CASE("exact: a smaller starting module must not shrink the reused state") {
     REQUIRE(result.shots == 64);
 }
 
-TEST_CASE("exact: a zero-fire LOSS before a firing LOSS does not shift site ids") {
+TEST_CASE("trajectory: a zero-fire LOSS before a firing LOSS does not shift site ids") {
     // LOSS(0) can never fire from a computational qubit; trace() skips it.
     // The rewriter must skip it too, so LOSS(1) gets site id 0 and the
     // driver maps the trap correctly.
@@ -673,7 +673,7 @@ TEST_CASE("exact: a zero-fire LOSS before a firing LOSS does not shift site ids"
     }
 }
 
-TEST_CASE("exact: a seepage-only transition before a firing site does not shift site ids") {
+TEST_CASE("trajectory: a seepage-only transition before a firing site does not shift site ids") {
     // A LEVEL_TRANSITION whose computational columns are both zero (seepage
     // from leak_e to e only) cannot fire on a computational qubit; trace()
     // skips it. The rewriter must skip it too so the firing LOSS(1) that
@@ -696,7 +696,7 @@ TEST_CASE("exact: a seepage-only transition before a firing site does not shift 
     }
 }
 
-TEST_CASE("exact: a seepage-only transition on q0 does not corrupt q1's site id") {
+TEST_CASE("trajectory: a seepage-only transition on q0 does not corrupt q1's site id") {
     // Cross-qubit arrangement: the seepage-only LEVEL_TRANSITION on q0 must
     // not occupy a site slot, so the firing LOSS(1) on q1 keeps site id 0.
     // In Release, a stale site id would read the wrong trap record and
@@ -723,7 +723,7 @@ TEST_CASE("exact: a seepage-only transition on q0 does not corrupt q1's site id"
     }
 }
 
-TEST_CASE("exact: a seepage-only transition still seeps a noncomputational qubit") {
+TEST_CASE("trajectory: a seepage-only transition still seeps a noncomputational qubit") {
     // A zero-fire annotation is skipped for a computational pre-status, but
     // must still execute its classical consult for a noncomputational qubit.
     // Here leak_e is the starting level; the seep fires (classical consult
@@ -751,7 +751,7 @@ TEST_CASE("exact: a seepage-only transition still seeps a noncomputational qubit
 // Correlated-chain passthrough on noncomputational operands
 // =========================================================================
 
-TEST_CASE("exact: a correlated-chain head with a lost operand does not orphan the ELSE") {
+TEST_CASE("trajectory: a correlated-chain head with a lost operand does not orphan the ELSE") {
     // q0 is lost before the E node: the head must keep its slot in the
     // else-conditioning rather than being dropped. E(1) fires with
     // certainty, so the ELSE never fires. q0 final status is Lost; its
@@ -773,7 +773,7 @@ TEST_CASE("exact: a correlated-chain head with a lost operand does not orphan th
     }
 }
 
-TEST_CASE("exact: a fired head with a lost operand prevents the ELSE from firing") {
+TEST_CASE("trajectory: a fired head with a lost operand prevents the ELSE from firing") {
     // Conditioning check: E(1) fires (head always fires, operating on the
     // vacated q0 carrier), so the ELSE must NOT fire -- if the head were
     // dropped the ELSE would become the new head and fire, flipping q1.
@@ -791,7 +791,7 @@ TEST_CASE("exact: a fired head with a lost operand prevents the ELSE from firing
     }
 }
 
-TEST_CASE("exact: a correlated-chain head with a leaked operand does not orphan the ELSE") {
+TEST_CASE("trajectory: a correlated-chain head with a leaked operand does not orphan the ELSE") {
     // The leaked counterpart to the lost-operand regression test: unlike a lost qubit, a
     // leaked qubit's carrier is still parked in the state, so the head's
     // X0 lands there as a frame flip nothing reads. The conditioning must
@@ -816,7 +816,7 @@ TEST_CASE("exact: a correlated-chain head with a leaked operand does not orphan 
     }
 }
 
-TEST_CASE("exact: a fired head with a leaked operand prevents the ELSE from firing") {
+TEST_CASE("trajectory: a fired head with a leaked operand prevents the ELSE from firing") {
     auto leak = certain_transition_from_computational(Level::LeakG);
     const RawProbabilityMatrix cl = {{1.0, 0.0, 0.0, 0.0, 1.0}, {0.0, 1.0, 1.0, 1.0, 0.0}};
     auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
@@ -834,7 +834,7 @@ TEST_CASE("exact: a fired head with a leaked operand prevents the ELSE from firi
     }
 }
 
-TEST_CASE("exact: a mixed-operand chain member keeps the healthy qubit's Pauli") {
+TEST_CASE("trajectory: a mixed-operand chain member keeps the healthy qubit's Pauli") {
     // E(1) X0 X1 with only q1 lost: q0 is computational and its X must
     // land; dropping the mixed-operand node whole would suppress the X on q0.
     // q0 record reads 1 (X flipped it); q1 record reads 0 (identity classifier).
@@ -851,7 +851,7 @@ TEST_CASE("exact: a mixed-operand chain member keeps the healthy qubit's Pauli")
     }
 }
 
-TEST_CASE("exact: a certain correlated X0 X1 error applies X to both qubits") {
+TEST_CASE("trajectory: a certain correlated X0 X1 error applies X to both qubits") {
     // Baseline: all computational, E(1) fires with certainty applying X0 X1.
     // Both qubits start at |0> so both measure 1 after X.
     ModelSpec spec;  // all computational, no loss
@@ -889,7 +889,7 @@ NonComputationalModel make_classify_lost_model(std::vector<double> lost_col,
 
 }  // namespace
 
-TEST_CASE("exact: MX on a certainly-lost qubit reads the classifier bit") {
+TEST_CASE("trajectory: MX on a certainly-lost qubit reads the classifier bit") {
     // lose column [0, 1]: the lost qubit reads 1 every shot; final status Lost.
     auto model = make_classify_lost_model({0.0, 1.0});
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX 0");
@@ -900,7 +900,7 @@ TEST_CASE("exact: MX on a certainly-lost qubit reads the classifier bit") {
     }
 }
 
-TEST_CASE("exact: MY on a certainly-lost qubit reads the classifier bit") {
+TEST_CASE("trajectory: MY on a certainly-lost qubit reads the classifier bit") {
     // Identical semantics to MX: the readout basis is incidental on a vacated carrier.
     auto model = make_classify_lost_model({0.0, 1.0});
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMY 0");
@@ -911,7 +911,7 @@ TEST_CASE("exact: MY on a certainly-lost qubit reads the classifier bit") {
     }
 }
 
-TEST_CASE("exact: inverted MX !0 on a lost qubit complements the classifier bit") {
+TEST_CASE("trajectory: inverted MX !0 on a lost qubit complements the classifier bit") {
     // lose column [0, 1]: classifier says 1; inversion flips to 0 every shot.
     auto model = make_classify_lost_model({0.0, 1.0});
     auto circuit = parse("LEVEL_TRANSITION[lose] 0\nMX !0");
@@ -922,7 +922,7 @@ TEST_CASE("exact: inverted MX !0 on a lost qubit complements the classifier bit"
     }
 }
 
-TEST_CASE("exact: ternary herald column on MX sets sidecar flag and patches record") {
+TEST_CASE("trajectory: ternary herald column on MX sets sidecar flag and patches record") {
     // Three-symbol classifier for the lost level: {0, 0, 1} always heralds.
     // The herald flag must be 1 on every shot; the record carries an
     // unbiased bit (matches the existing M-herald test in make_lose_model).
@@ -943,7 +943,7 @@ TEST_CASE("exact: ternary herald column on MX sets sidecar flag and patches reco
     }
 }
 
-TEST_CASE("exact: computational X-basis behavior is untouched by MX classify change") {
+TEST_CASE("trajectory: computational X-basis behavior is untouched by MX classify change") {
     // RX prepares |+>; MX measures in the X basis and records 0 deterministically.
     // No noncomputational model capability: the classifier path must never fire.
     ModelSpec spec;  // all computational
@@ -956,7 +956,7 @@ TEST_CASE("exact: computational X-basis behavior is untouched by MX classify cha
     }
 }
 
-TEST_CASE("exact: memory-X smoke measures two qubits after a low-rate leak hook") {
+TEST_CASE("trajectory: memory-X smoke measures two qubits after a low-rate leak hook") {
     // The motivating use case: a stim-style memory-X circuit that ends in MX
     // on data qubits runs cleanly under a leakage model.
     auto leak = zero_transition_matrix();
@@ -992,7 +992,7 @@ TEST_CASE("exact: memory-X smoke measures two qubits after a low-rate leak hook"
 // Up-front model capability contract
 // =========================================================================
 
-TEST_CASE("exact: capable model rejects MPP before sampling") {
+TEST_CASE("trajectory: capable model rejects MPP before sampling") {
     // A capable model (non-zero loss) plus an MPP measurement must throw
     // before any shots are drawn, with a message naming 'MPP', 'not supported',
     // and 'ancilla'.
@@ -1003,7 +1003,7 @@ TEST_CASE("exact: capable model rejects MPP before sampling") {
                             ContainsSubstring("ancilla"));
 }
 
-TEST_CASE("exact: computational-only model permits MPP") {
+TEST_CASE("trajectory: computational-only model permits MPP") {
     // A model with no capability (initial all-g, no leak/loss transitions)
     // leaves MPP supported.
     ModelSpec spec;  // all computational
@@ -1017,7 +1017,7 @@ TEST_CASE("exact: computational-only model permits MPP") {
     }
 }
 
-TEST_CASE("exact: capable model with measurement requires classifier") {
+TEST_CASE("trajectory: capable model with measurement requires classifier") {
     // A model with a LEVEL_TRANSITION annotation that can fire into a
     // noncomputational level, paired with a measurement, must throw when
     // no classifier is present.
@@ -1031,7 +1031,7 @@ TEST_CASE("exact: capable model with measurement requires classifier") {
                         ContainsSubstring("classifier is required"));
 }
 
-TEST_CASE("exact: capable model without measurement does not require classifier") {
+TEST_CASE("trajectory: capable model without measurement does not require classifier") {
     // A capable model without a classifier is fine if the circuit has no measurements.
     auto lose = certain_transition_from_computational(Level::Lost);
     NonComputationalPolicy policy;
@@ -1043,7 +1043,7 @@ TEST_CASE("exact: capable model without measurement does not require classifier"
     REQUIRE(result.shots == 10);
 }
 
-TEST_CASE("exact: computational-only model with MX does not require classifier") {
+TEST_CASE("trajectory: computational-only model with MX does not require classifier") {
     // A non-capable model (no loss/leak transitions, all-g initial) plus
     // MX requires no classifier.
     ModelSpec spec;  // all computational, no loss
@@ -1056,7 +1056,7 @@ TEST_CASE("exact: computational-only model with MX does not require classifier")
     }
 }
 
-TEST_CASE("exact: coarse capability boundary requires a classifier for any measurement") {
+TEST_CASE("trajectory: coarse capability boundary requires a classifier for any measurement") {
     // The contract is a capability boundary, not per-qubit reachability.
     // The annotation on q0 makes the model capable; q1 is measured but
     // never touches a vacated carrier in any reachable shot. The capability
@@ -1071,7 +1071,7 @@ TEST_CASE("exact: coarse capability boundary requires a classifier for any measu
                         ContainsSubstring("classifier is required"));
 }
 
-TEST_CASE("exact: the model contract is validated even for zero shots") {
+TEST_CASE("trajectory: the model contract is validated even for zero shots") {
     // Validation is shot-count independent: a zero-shot call still checks
     // the circuit/model contract, and a valid pair returns empty results.
     auto lose = certain_transition_from_computational(Level::Lost);
@@ -1111,7 +1111,7 @@ NonComputationalModel make_leak_seep_model() {
 
 }  // namespace
 
-TEST_CASE("exact: same-qubit re-trap: leak then recapture then leak again") {
+TEST_CASE("trajectory: same-qubit re-trap: leak then recapture then leak again") {
     // X 0 preps |e>. LEVEL_TRANSITION[leak] traps (e->leak_e, certainly).
     // LEVEL_TRANSITION[seep] recaptures back to e (classical consult).
     // The second LEVEL_TRANSITION[leak] traps again (e->leak_e).
@@ -1129,7 +1129,7 @@ TEST_CASE("exact: same-qubit re-trap: leak then recapture then leak again") {
     }
 }
 
-TEST_CASE("exact: multi-target annotation jumps both targets in one shot") {
+TEST_CASE("trajectory: multi-target annotation jumps both targets in one shot") {
     // LEVEL_TRANSITION[lose] on both q0 and q1 in a single annotation; the
     // lose channel is source-independent (g->lost p=1, e->lost p=1), so both
     // qubits lose in every shot. Both records read 0 (identity classifier's
@@ -1156,7 +1156,7 @@ TEST_CASE("exact: multi-target annotation jumps both targets in one shot") {
 // LOSS on already-leaked and already-lost qubits
 // =========================================================================
 
-TEST_CASE("exact: certain LOSS on a pure leak_g initial vacates the carrier") {
+TEST_CASE("trajectory: certain LOSS on a pure leak_g initial vacates the carrier") {
     // Initial mass entirely on leak_g (index 2): the qubit is already
     // noncomputational. LOSS(1) on a leaked qubit still vacates it (the
     // channel fires from any non-lost level). Every shot: status Lost,
@@ -1173,7 +1173,7 @@ TEST_CASE("exact: certain LOSS on a pure leak_g initial vacates the carrier") {
     }
 }
 
-TEST_CASE("exact: certain LOSS on a pure lost initial is a no-op") {
+TEST_CASE("trajectory: certain LOSS on a pure lost initial is a no-op") {
     // Initial mass entirely on lost (index 4): LOSS is a no-op on an
     // already-lost qubit. Status Lost, record 0 on every shot.
     ModelSpec spec;
@@ -1188,7 +1188,8 @@ TEST_CASE("exact: certain LOSS on a pure lost initial is a no-op") {
     }
 }
 
-TEST_CASE("exact: LOSS on a lost qubit spends no draw -- a later consult sees the same stream") {
+TEST_CASE(
+    "trajectory: LOSS on a lost qubit spends no draw -- a later consult sees the same stream") {
     // A LOSS(1) on an already-lost qubit records its no-op without
     // consuming any driver randomness. The discriminator is a stochastic
     // consult AFTER it: the recover channel returns the lost qubit to e
@@ -1223,7 +1224,8 @@ TEST_CASE("exact: LOSS on a lost qubit spends no draw -- a later consult sees th
     REQUIRE(saw_one);
 }
 
-TEST_CASE("exact: a non-restoring lost MRX spends no hidden draw -- M and MRX read identically") {
+TEST_CASE(
+    "trajectory: a non-restoring lost MRX spends no hidden draw -- M and MRX read identically") {
     // Both circuits lose qubit 0 with certainty and classify its record
     // slot from the same lost column, so they compile to the same module
     // -- unless MRX's X-basis reset half were emitted on the vacated
@@ -1256,7 +1258,7 @@ TEST_CASE("exact: a non-restoring lost MRX spends no hidden draw -- M and MRX re
 // Classified records driving feedback
 // =========================================================================
 
-TEST_CASE("exact: classified record drives a CX feedback gate") {
+TEST_CASE("trajectory: classified record drives a CX feedback gate") {
     // "lose" is hooked on S: g and e both jump to lost with certainty.
     // Classifier: classified symbol 0 always reads 0, classified symbol 1
     // always reads 1; the lost column has weight on symbol 1, so rec[-1]
@@ -1288,7 +1290,7 @@ TEST_CASE("exact: classified record drives a CX feedback gate") {
 // Carrier re-preparation on restore
 // =========================================================================
 
-TEST_CASE("exact: a reset truly re-prepares a restored-lost qubit") {
+TEST_CASE("trajectory: a reset truly re-prepares a restored-lost qubit") {
     // "lose" is hooked on S (g and e both -> lost with certainty).
     // reset_restores_lost=true means R 0 reloads the lost carrier.
     // H 0 before S scrambles the pre-loss state: if R did NOT re-prepare
@@ -1317,7 +1319,7 @@ TEST_CASE("exact: a reset truly re-prepares a restored-lost qubit") {
 // max_rank boundary behavior
 // =========================================================================
 
-TEST_CASE("exact: max_rank succeeds exactly at the required rank") {
+TEST_CASE("trajectory: max_rank succeeds exactly at the required rank") {
     // Reuses the over-cap circuit from the rejection test: three H-prefixed
     // source-dependent sites push peak rank to 3 (over a cap of 2). The
     // same circuit must succeed with max_rank = 3 (the actual required rank).
@@ -1339,7 +1341,7 @@ TEST_CASE("exact: max_rank succeeds exactly at the required rank") {
 // Seed sensitivity
 // =========================================================================
 
-TEST_CASE("exact: different seeds produce different records") {
+TEST_CASE("trajectory: different seeds produce different records") {
     // A stochastic config (leak p=0.35 from e after H) sampled at two
     // different seeds must differ: a constant-output implementation that
     // ignores the seed would collide here with probability 2^(-measurements).
@@ -1357,7 +1359,7 @@ TEST_CASE("exact: different seeds produce different records") {
     REQUIRE(a.measurements != b.measurements);
 }
 
-TEST_CASE("exact: max_rank is not checked against the unreachable all-computational module") {
+TEST_CASE("trajectory: max_rank is not checked against the unreachable all-computational module") {
     // When every qubit starts lost, the no-event module is never used;
     // its rank must not trigger a max_rank rejection.
     // The lost column reads symbol 1 with certainty: a raw readout of the
@@ -1427,7 +1429,7 @@ RawProbabilityMatrix comp_confusion(double p01, double p10) {
 
 }  // namespace
 
-TEST_CASE("exact: a partial classifier bit matches its frequency") {
+TEST_CASE("trajectory: a partial classifier bit matches its frequency") {
     Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
     std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
@@ -1444,7 +1446,7 @@ TEST_CASE("exact: a partial classifier bit matches its frequency") {
     REQUIRE(ones < 1150);
 }
 
-TEST_CASE("exact: the herald symbol fills the sidecar rather than the record") {
+TEST_CASE("trajectory: the herald symbol fills the sidecar rather than the record") {
     // Qubit 1 leaks and its column always heralds; qubit 0 stays
     // computational. The heralded slot's visible record bit is a uniform
     // draw, so the record layout is unchanged and both values occur.
@@ -1468,7 +1470,7 @@ TEST_CASE("exact: the herald symbol fills the sidecar rather than the record") {
     REQUIRE(ones < kShots * 70 / 100);
 }
 
-TEST_CASE("exact: a partial herald column matches its frequency") {
+TEST_CASE("trajectory: a partial herald column matches its frequency") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
@@ -1486,7 +1488,7 @@ TEST_CASE("exact: a partial herald column matches its frequency") {
     REQUIRE(heralded < 770);
 }
 
-TEST_CASE("exact: the record bit is uniform given a herald and fixed otherwise") {
+TEST_CASE("trajectory: the record bit is uniform given a herald and fixed otherwise") {
     // Column {0.5, 0, 0.5}: a non-heralded draw is always symbol 0, while a
     // heralded slot's bit is uniform. This checks the (herald, bit) joint: if
     // heralded slots kept the not-heralded flip probability (0), their bits
@@ -1517,7 +1519,7 @@ TEST_CASE("exact: the record bit is uniform given a herald and fixed otherwise")
     REQUIRE(heralded_ones < heralded * 65 / 100);
 }
 
-TEST_CASE("exact: a two-symbol classifier leaves the herald sidecar zero") {
+TEST_CASE("trajectory: a two-symbol classifier leaves the herald sidecar zero") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
@@ -1533,7 +1535,7 @@ TEST_CASE("exact: a two-symbol classifier leaves the herald sidecar zero") {
     }
 }
 
-TEST_CASE("exact: a circuit with EXP_VAL probes rejects") {
+TEST_CASE("trajectory: a circuit with EXP_VAL probes rejects") {
     Circuit c;
     c.num_qubits = 1;
     c.num_exp_vals = 1;  // EXP_VAL output is not carried by the noncomp sidecar
@@ -1541,7 +1543,7 @@ TEST_CASE("exact: a circuit with EXP_VAL probes rejects") {
     REQUIRE_THROWS_WITH(sample_noncomputational(c, model, 4, 1), ContainsSubstring("EXP_VAL"));
 }
 
-TEST_CASE("exact: a measure-and-reset on a leaked qubit injects and restores") {
+TEST_CASE("trajectory: a measure-and-reset on a leaked qubit injects and restores") {
     // MR on the leaked qubit records the classifier bit AND resets the site to
     // |0>; the following M then deterministically reads 0 -- proving the reset
     // actually ran in the SVM, not just in the trajectory bookkeeping.
@@ -1560,7 +1562,7 @@ TEST_CASE("exact: a measure-and-reset on a leaked qubit injects and restores") {
     }
 }
 
-TEST_CASE("exact: a lost-qubit measurement feeds the detector the classifier bit") {
+TEST_CASE("trajectory: a lost-qubit measurement feeds the detector the classifier bit") {
     // A lost qubit (vacated site) is still measured; the classifier supplies
     // the record bit just as for a leaked qubit, so the detector reads it.
     Circuit c = parse("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n");
@@ -1579,7 +1581,7 @@ TEST_CASE("exact: a lost-qubit measurement feeds the detector the classifier bit
     }
 }
 
-TEST_CASE("exact: a leaked measurement feeds the observable the classifier bit") {
+TEST_CASE("trajectory: a leaked measurement feeds the observable the classifier bit") {
     Circuit c = parse("H 0\nS 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n");
     std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("S", certain_transition_from_computational(Level::LeakG));
@@ -1597,7 +1599,7 @@ TEST_CASE("exact: a leaked measurement feeds the observable the classifier bit")
     }
 }
 
-TEST_CASE("exact: a jump to the ground level forces the measurement to 0") {
+TEST_CASE("trajectory: a jump to the ground level forces the measurement to 0") {
     // The S transition collapses the H-prepared |+> to the g level; without
     // the materializing collapse the M would read 1 on ~half the shots. The
     // fire resolves entirely inside the VM; the sidecar reports the bare
@@ -1616,7 +1618,7 @@ TEST_CASE("exact: a jump to the ground level forces the measurement to 0") {
     }
 }
 
-TEST_CASE("exact: a jump to the excited level forces the measurement to 1") {
+TEST_CASE("trajectory: a jump to the excited level forces the measurement to 1") {
     Circuit c = parse("H 0\nS 0\nM 0\n");
     std::map<std::string, RawProbabilityMatrix> transitions;
     transitions.emplace("S", certain_transition_from_computational(Level::E));
@@ -1632,7 +1634,7 @@ TEST_CASE("exact: a jump to the excited level forces the measurement to 1") {
     }
 }
 
-TEST_CASE("exact: a partial jump to ground matches the analytic mixture") {
+TEST_CASE("trajectory: a partial jump to ground matches the analytic mixture") {
     // With probability p the S transition collapses the H-prepared |+> to g;
     // otherwise the carrier stays coherent. P(M = 1) = (1 - p) / 2 = 0.35.
     Circuit c = parse("H 0\nS 0\nM 0\n");
@@ -1653,7 +1655,7 @@ TEST_CASE("exact: a partial jump to ground matches the analytic mixture") {
     REQUIRE(ones < 1580);
 }
 
-TEST_CASE("exact: a measurement records the pre-relaxation bit") {
+TEST_CASE("trajectory: a measurement records the pre-relaxation bit") {
     // The transition's source column is read at op entry and its jump applies
     // after the base op: the first M reads the original |1>, the relaxation
     // then materializes g, and the second M reads the relaxed 0.
@@ -1673,7 +1675,7 @@ TEST_CASE("exact: a measurement records the pre-relaxation bit") {
     }
 }
 
-TEST_CASE("exact: recapturing a lost qubit clears the stale residual") {
+TEST_CASE("trajectory: recapturing a lost qubit clears the stale residual") {
     // The first M loses the |1> qubit (its trace-out reset clears the
     // carrier). The second M is classified (lost at entry) and its
     // attached recapture jump materializes g; the third M must read the
@@ -1697,7 +1699,7 @@ TEST_CASE("exact: recapturing a lost qubit clears the stale residual") {
     }
 }
 
-TEST_CASE("exact: a multi-round circuit runs through loss") {
+TEST_CASE("trajectory: a multi-round circuit runs through loss") {
     // The data qubit is lost up front; both syndrome CXs drop (identity on
     // the ancilla, which keeps reading 0) and the final data measurement
     // reads the classifier's lost bit -- dropping ops on a vacated site is
@@ -1719,7 +1721,7 @@ TEST_CASE("exact: a multi-round circuit runs through loss") {
     }
 }
 
-TEST_CASE("exact: computational confusion misreports into the detector") {
+TEST_CASE("trajectory: computational confusion misreports into the detector") {
     // A certain 0->1 misreport: the record and the detector read 1 on every
     // shot even though the qubit is |0> -- the flip is in-circuit, not
     // postprocessing.
@@ -1734,7 +1736,7 @@ TEST_CASE("exact: computational confusion misreports into the detector") {
     }
 }
 
-TEST_CASE("exact: asymmetric confusion matches its rates") {
+TEST_CASE("trajectory: asymmetric confusion matches its rates") {
     // True bit is 1 (X-prepared); it is misread as 0 with probability 0.2.
     Circuit c = parse("X 0\nM 0\n");
     NonComputationalModel model =
@@ -1750,7 +1752,7 @@ TEST_CASE("exact: asymmetric confusion matches its rates") {
     REQUIRE(zeros < 950);
 }
 
-TEST_CASE("exact: hand-written LOSS and LEVEL_TRANSITION run end to end") {
+TEST_CASE("trajectory: hand-written LOSS and LEVEL_TRANSITION run end to end") {
     // Qubit 0 is lost by a local LOSS; its measurement takes the classifier's
     // lost bit. Qubit 1 leaks via a local named LEVEL_TRANSITION; its measurement
     // takes the leak_g bit.

--- a/tests/test_trap_resume.cc
+++ b/tests/test_trap_resume.cc
@@ -1,4 +1,4 @@
-// Trap and resume: the runtime half of the exact-jump protocol.
+// Trap and resume: the runtime half of the trajectory protocol.
 //
 // execute() halts at a leaked/lost instrument fire with state.pending_trap
 // set and the carrier collapsed onto the drawn source wherever the form
@@ -283,7 +283,7 @@ TEST_CASE("trap+resume: plain sampling rejects a shot that traps") {
     InstrumentTraceOptions options;
     auto module = compile_instruments_raw("LOSS(1.0) 0\nM 0", options);
     REQUIRE_THROWS_WITH(sample(module, /*shots=*/4, /*seed=*/9),
-                        ContainsSubstring("exact-mode driver"));
+                        ContainsSubstring("trajectory driver"));
 }
 
 TEST_CASE("trap+resume: resume validates the handoff") {


### PR DESCRIPTION
## Summary

- rename the noncomputational driver, entry point, event record, and seed stream labels from historical exact-mode terminology to trajectory terminology
- rename the C++ driver tests and Python trajectory probe/TVD suites, including their test prefixes
- sweep source comments, diagnostics, and API/test documentation while preserving exact-damping and mathematically exact terminology

The seed domain values are unchanged; this is a naming and documentation refactor.

## Verification

- `uv run pre-commit run --all-files`
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j 4`
- C++ trajectory, rewrite, continuation, validation, and trap/resume tests: 137 passed
- Python trajectory probes/TVD and renamed exact-damping regression: 12 passed