### PR TITLE
fix(ci): pin NumPy for mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
-        additional_dependencies: [numpy>=1.26]
+        additional_dependencies: [numpy==1.26.4]
         args: [--config-file=pyproject.toml]
 
   # General file hygiene


### PR DESCRIPTION
## Summary

- pin the mypy hook to NumPy 1.26.4, the oldest supported NumPy release
- keep fresh Python 3.12 hook environments reproducible

A fresh hook environment currently resolves `numpy>=1.26` to NumPy 2.4.x. Its typing surface produces 312 errors with the repository’s mypy 1.11.2 hook under Python 3.12, including on the current default branch.

## Testing

- `PRE_COMMIT_HOME=/private/tmp/clifft-precommit-main-pin uv tool run --python 3.12 pre-commit run --all-files`