### PR TITLE
refactor(noncomp): clarify trajectory driver internals

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -325,10 +325,12 @@ version of the circuit rewritten and compiled for the event history observed
 so far. The shot then resumes after the event. `noncomp.sample` therefore takes
 the circuit and model together and compiles internally.
 
-Each continuation uses the default optimization passes that preserve
-measurement-record order. `noncomp.sample` does not currently accept custom
-pass managers: a continuation must preserve both the bytecode prefix already
-executed by the shot and the order of hidden trace-out measurements.
+Each continuation uses a fixed pipeline containing the default optimization
+passes that preserve measurement-record order. `noncomp.sample` does not
+currently accept custom pass managers. Supporting them would require checking
+two properties: hidden measurement records must stay in order, and recompiling
+after a trajectory rewrite must reproduce the bytecode prefix already executed
+by the shot.
 
 Continuations are cached by event history and shared across shots. For ternary
 classifiers, the cache also holds one module per herald-flag assignment

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -325,12 +325,20 @@ version of the circuit rewritten and compiled for the event history observed
 so far. The shot then resumes after the event. `noncomp.sample` therefore takes
 the circuit and model together and compiles internally.
 
-Each continuation uses a fixed pipeline containing the default optimization
-passes that preserve measurement-record order. `noncomp.sample` does not
-currently accept custom pass managers. Supporting them would require checking
-two properties: hidden measurement records must stay in order, and recompiling
-after a trajectory rewrite must reproduce the bytecode prefix already executed
-by the shot.
+Each continuation uses the default optimization passes that preserve
+measurement-record order. At the HIR stage, this means
+`PeepholeFusionPass`; `StatevectorSqueezePass` is omitted because it can move
+measurements. All of the default bytecode passes currently preserve record
+order and are applied. See [Optimization Passes](../reference/passes.md) for
+the full list.
+
+This restriction matters because resolving a trapped transition may add a
+forced, hidden trace-out measurement. Moving another measurement across that
+collapse can change correlations. Record-order preservation is necessary but
+not sufficient for resuming a shot: recompiling a continuation must also
+reproduce the bytecode prefix already executed, because `resume()` reuses the
+existing VM state directly. `noncomp.sample` therefore uses a fixed internal
+pipeline and does not currently accept custom pass managers.
 
 Continuations are cached by event history and shared across shots. For ternary
 classifiers, the cache also holds one module per herald-flag assignment

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -325,6 +325,11 @@ version of the circuit rewritten and compiled for the event history observed
 so far. The shot then resumes after the event. `noncomp.sample` therefore takes
 the circuit and model together and compiles internally.
 
+Each continuation uses the default optimization passes that preserve
+measurement-record order. `noncomp.sample` does not currently accept custom
+pass managers: a continuation must preserve both the bytecode prefix already
+executed by the shot and the order of hidden trace-out measurements.
+
 Continuations are cached by event history and shared across shots. For ternary
 classifiers, the cache also holds one module per herald-flag assignment
 observed for that history. Typical low-rate models reuse the no-jump

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -72,6 +72,7 @@ def define_env(env: Any) -> None:
             "name": "PeepholeFusionPass",
             "kind": "HIR",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "PeepholeFusionPass",
             "summary": "Algebraic T-gate cancellation and fusion.",
             "detail": (
@@ -84,6 +85,7 @@ def define_env(env: Any) -> None:
             "name": "StatevectorSqueezePass",
             "kind": "HIR",
             "default_enabled": True,
+            "preserves_record_order": False,
             "python_name": "StatevectorSqueezePass",
             "summary": "Minimizes peak active dimension by reordering HIR operations.",
             "detail": (
@@ -98,6 +100,7 @@ def define_env(env: Any) -> None:
             "name": "RemoveNoisePass",
             "kind": "HIR",
             "default_enabled": False,
+            "preserves_record_order": True,
             "python_name": "RemoveNoisePass",
             "summary": "Strips all noise from the HIR.",
             "detail": (
@@ -112,6 +115,7 @@ def define_env(env: Any) -> None:
             "name": "DropNonUnitaryPass",
             "kind": "HIR",
             "default_enabled": False,
+            "preserves_record_order": False,
             "python_name": "DropNonUnitaryPass",
             "summary": "Drops non-evolution operations from the HIR.",
             "detail": (
@@ -126,6 +130,7 @@ def define_env(env: Any) -> None:
             "name": "NoiseBlockPass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "NoiseBlockPass",
             "summary": "Coalesces contiguous noise instructions into blocks.",
             "detail": (
@@ -140,6 +145,7 @@ def define_env(env: Any) -> None:
             "name": "MultiGatePass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "MultiGatePass",
             "summary": "Fuses star-graph CNOT/CZ patterns into single array sweeps.",
             "detail": (
@@ -154,6 +160,7 @@ def define_env(env: Any) -> None:
             "name": "ExpandTPass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "ExpandTPass",
             "summary": "Fuses EXPAND + T-phase into a single array pass.",
             "detail": (
@@ -167,6 +174,7 @@ def define_env(env: Any) -> None:
             "name": "ExpandRotPass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "ExpandRotPass",
             "summary": "Fuses EXPAND + continuous rotation into a single array pass.",
             "detail": (
@@ -179,6 +187,7 @@ def define_env(env: Any) -> None:
             "name": "SwapMeasPass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "SwapMeasPass",
             "summary": "Fuses SWAP + measurement into one operation.",
             "detail": (
@@ -193,6 +202,7 @@ def define_env(env: Any) -> None:
             "name": "TileAxisFusionPass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "TileAxisFusionPass",
             "summary": "Fuses 2-qubit tile sequences into precomputed 4x4 unitaries.",
             "detail": (
@@ -208,6 +218,7 @@ def define_env(env: Any) -> None:
             "name": "SingleAxisFusionPass",
             "kind": "Bytecode",
             "default_enabled": True,
+            "preserves_record_order": True,
             "python_name": "SingleAxisFusionPass",
             "summary": "Fuses single-axis operation chains into precomputed 2x2 unitaries.",
             "detail": (

--- a/docs/reference/passes.md
+++ b/docs/reference/passes.md
@@ -36,6 +36,27 @@ bpm.add(clifft.NoiseBlockPass())
 bpm.add(clifft.MultiGatePass())
 ```
 
+## Measurement-Record Order
+
+Some workflows require measurements to remain in their original order,
+including hidden measurements introduced by the compiler. In particular,
+`clifft.noncomp.sample` may force the result of a hidden trace-out measurement
+when it resumes a trapped transition. Moving another measurement across that
+collapse can change quantum correlations.
+
+`clifft.noncomp.sample` therefore applies only passes that are both enabled by
+default and marked as preserving measurement-record order. Its HIR pipeline
+uses `PeepholeFusionPass` but omits `StatevectorSqueezePass`; all default
+bytecode passes currently preserve record order and are applied.
+
+Record-order preservation is necessary but does not by itself make a
+continuation compatible with an already-running VM state. Recompilation must
+also reproduce the bytecode prefix that the state executed. For this reason,
+`clifft.noncomp.sample` uses a fixed internal pipeline and does not currently
+accept custom pass managers. See
+[Leakage and Loss](../guide/leakage-and-loss.md#why-there-is-no-compile-step)
+for how continuations are compiled and resumed.
+
 ---
 
 ## HIR Passes
@@ -47,6 +68,7 @@ bpm.add(clifft.MultiGatePass())
 |---|---|
 | **Kind** | HIR (pre-lowering) |
 | **Default** | {{ '✅ Enabled' if p['default_enabled'] else '❌ Disabled' }} |
+| **Preserves measurement-record order** | {{ 'Yes' if p['preserves_record_order'] else 'No' }} |
 | **Python** | `clifft.{{ p['python_name'] }}()` |
 
 {{ p['detail'] }}
@@ -64,6 +86,7 @@ bpm.add(clifft.MultiGatePass())
 |---|---|
 | **Kind** | Bytecode (post-lowering) |
 | **Default** | {{ '✅ Enabled' if p['default_enabled'] else '❌ Disabled' }} |
+| **Preserves measurement-record order** | {{ 'Yes' if p['preserves_record_order'] else 'No' }} |
 | **Python** | `clifft.{{ p['python_name'] }}()` |
 
 {{ p['detail'] }}

--- a/src/clifft/api/record_probabilities.cc
+++ b/src/clifft/api/record_probabilities.cc
@@ -24,10 +24,12 @@ namespace {
 
 [[nodiscard]] bool is_unsupported_record_probabilities_opcode(Opcode opcode) {
     // Allowed: all gate / expand / array opcodes, EXP_VAL probes, feedback
-    // (OP_APPLY_PAULI), and any sampling-mode measurement opcode (rewritten
-    // to its FORCED sibling before execution). Forced opcodes shouldn't
-    // appear in user-compiled programs; reject defensively so the rewrite
-    // is the only path that produces them.
+    // (OP_APPLY_PAULI), and any opcode with a forced-measurement counterpart.
+    // Forced opcodes shouldn't appear in user-compiled programs; reject
+    // defensively so the rewrite is the only path that produces them.
+    if (forced_measurement_opcode(opcode).has_value()) {
+        return false;
+    }
     switch (opcode) {
         case Opcode::OP_FRAME_CNOT:
         case Opcode::OP_FRAME_CZ:
@@ -54,13 +56,16 @@ namespace {
         case Opcode::OP_EXPAND_ROT:
         case Opcode::OP_EXP_VAL:
         case Opcode::OP_APPLY_PAULI:
+            return false;
+
+        // Sampling measurements reach this group only if their forced-opcode
+        // mapping is removed. Keep them unsupported rather than silently
+        // executing an unforced measurement.
         case Opcode::OP_MEAS_DORMANT_STATIC:
         case Opcode::OP_MEAS_DORMANT_RANDOM:
         case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
         case Opcode::OP_MEAS_ACTIVE_INTERFERE:
         case Opcode::OP_SWAP_MEAS_INTERFERE:
-            return false;
-
         case Opcode::OP_MEAS_DORMANT_STATIC_FORCED:
         case Opcode::OP_MEAS_DORMANT_RANDOM_FORCED:
         case Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED:

--- a/src/clifft/api/record_probabilities.cc
+++ b/src/clifft/api/record_probabilities.cc
@@ -99,24 +99,9 @@ void assert_record_probabilities_program_is_supported(const CompiledModule& prog
 // and FLAG_IDENTITY are preserved.
 void rewrite_for_forced_execution(std::vector<Instruction>& bytecode) {
     for (auto& instr : bytecode) {
-        switch (instr.opcode) {
-            case Opcode::OP_MEAS_DORMANT_STATIC:
-                instr.opcode = Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
-                break;
-            case Opcode::OP_MEAS_DORMANT_RANDOM:
-                instr.opcode = Opcode::OP_MEAS_DORMANT_RANDOM_FORCED;
-                break;
-            case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
-                instr.opcode = Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED;
-                break;
-            case Opcode::OP_MEAS_ACTIVE_INTERFERE:
-                instr.opcode = Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED;
-                break;
-            case Opcode::OP_SWAP_MEAS_INTERFERE:
-                instr.opcode = Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;
-                break;
-            default:
-                break;
+        if (const std::optional<Opcode> forced = forced_measurement_opcode(instr.opcode);
+            forced.has_value()) {
+            instr.opcode = *forced;
         }
     }
 }

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <optional>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 namespace clifft {
@@ -59,14 +60,14 @@ enum class Opcode : uint8_t {
     OP_MEAS_ACTIVE_INTERFERE,  // X-basis fold, halves array (k -> k-1)
     OP_SWAP_MEAS_INTERFERE,    // Fused ARRAY_SWAP + MEAS_ACTIVE_INTERFERE
 
-    // Forced-outcome measurement variants. Synthesized at runtime by
-    // record_probabilities() via a bytecode rewrite; never emitted by the
-    // compiler. Each forced variant reads the desired outcome from a
-    // side buffer (one byte per record slot) instead of sampling from
-    // the PRNG, and accumulates the log-probability of that outcome
-    // into a running scalar. Renormalization is kept (same as the
-    // sampling variants) to prevent the state norm from underflowing
-    // float64 on deep trajectories.
+    // Forced-outcome measurement variants. Synthesized by internal bytecode
+    // rewrites, including record_probabilities() and trapped trajectory
+    // continuations; never emitted by the compiler. Each forced variant reads
+    // the desired outcome from a side buffer (one byte per record slot)
+    // instead of sampling from the PRNG, and accumulates the log-probability of
+    // that outcome into a running scalar. Renormalization is kept (same as the
+    // sampling variants) to prevent the state norm from underflowing float64 on
+    // deep trajectories.
     OP_MEAS_DORMANT_STATIC_FORCED,
     OP_MEAS_DORMANT_RANDOM_FORCED,
     OP_MEAS_ACTIVE_DIAGONAL_FORCED,
@@ -99,6 +100,25 @@ enum class Opcode : uint8_t {
     OP_EXP_VAL,        // Read-only expectation value probe (full virtual Pauli mask)
     NUM_OPCODES        // Sentinel: must remain last for binding completeness checks
 };
+
+// Return the forced-outcome counterpart of a sampling measurement opcode.
+// Other opcodes have no forced form.
+[[nodiscard]] constexpr std::optional<Opcode> forced_measurement_opcode(Opcode opcode) {
+    switch (opcode) {
+        case Opcode::OP_MEAS_DORMANT_STATIC:
+            return Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
+        case Opcode::OP_MEAS_DORMANT_RANDOM:
+            return Opcode::OP_MEAS_DORMANT_RANDOM_FORCED;
+        case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
+            return Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED;
+        case Opcode::OP_MEAS_ACTIVE_INTERFERE:
+            return Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED;
+        case Opcode::OP_SWAP_MEAS_INTERFERE:
+            return Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;
+        default:
+            return std::nullopt;
+    }
+}
 
 // =============================================================================
 // 32-Byte VM Instruction Bytecode
@@ -187,6 +207,8 @@ struct alignas(32) Instruction {
 };
 
 static_assert(sizeof(Instruction) == 32, "Instruction must be exactly 32 bytes");
+static_assert(std::is_trivially_copyable_v<Instruction>,
+              "Instruction must remain trivially copyable bytecode");
 
 // =============================================================================
 // Instruction Factories

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -319,9 +319,10 @@ void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_ra
 
 // Build the HIR pass pipeline from default passes that preserve measurement
 // record order. A trajectory may force a hidden trace-out measurement, so moving
-// an entangled measurement before that collapse would change the result. Every
-// continuation uses this fixed pipeline; debug builds separately verify that
-// recompilation reproduces the bytecode prefix already executed by the shot.
+// an entangled measurement before that collapse would change the result. Record
+// order alone does not make a continuation compatible with a running state:
+// every continuation uses this fixed pipeline, and debug builds also verify
+// that recompilation reproduces the bytecode prefix the state executed.
 HirPassManager trajectory_hir_pass_manager() {
     HirPassManager pm;
     for (const auto& info : kRegisteredPasses) {

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -45,17 +45,30 @@ namespace {
 // LEVEL_TRANSITION or a uniform loss probability for LOSS. A null instrument
 // identifies the LOSS representation.
 struct AnnotationChannel {
+    [[nodiscard]] static AnnotationChannel for_instrument(const TransitionInstrument& instrument) {
+        return AnnotationChannel(&instrument, 0.0);
+    }
+
+    [[nodiscard]] static AnnotationChannel for_loss(double probability) {
+        return AnnotationChannel(nullptr, probability);
+    }
+
     const TransitionInstrument* instrument;
     double loss_probability;
 
     bool is_loss() const { return instrument == nullptr; }
+
+  private:
+    AnnotationChannel(const TransitionInstrument* instrument_in, double loss_probability_in)
+        : instrument(instrument_in), loss_probability(loss_probability_in) {}
 };
 
 [[nodiscard]] AnnotationChannel resolve_annotation(const AstNode& node,
                                                    const NonComputationalModel& model,
                                                    uint32_t op_index) {
     if (node.gate == GateType::LOSS) {
-        return {nullptr, loss_probability(node.args, op_index, "sample_noncomputational")};
+        return AnnotationChannel::for_loss(
+            loss_probability(node.args, op_index, "sample_noncomputational"));
     }
     const TransitionInstrument* instrument = model.transition_named(node.tag);
     if (instrument == nullptr) {
@@ -63,7 +76,7 @@ struct AnnotationChannel {
                                     "] at op " + std::to_string(op_index) +
                                     " does not name a transition in the model");
     }
-    return {instrument, 0.0};
+    return AnnotationChannel::for_instrument(*instrument);
 }
 
 // Resolving validates the LOSS arguments or transition name; the remaining
@@ -306,8 +319,9 @@ void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_ra
 
 // Build the HIR pass pipeline from default passes that preserve measurement
 // record order. A trajectory may force a hidden trace-out measurement, so moving
-// an entangled measurement before that collapse would change the result. The
-// same pipeline is used for every continuation to preserve matching prefixes.
+// an entangled measurement before that collapse would change the result. Every
+// continuation uses this fixed pipeline; debug builds separately verify that
+// recompilation reproduces the bytecode prefix already executed by the shot.
 HirPassManager trajectory_hir_pass_manager() {
     HirPassManager pm;
     for (const auto& info : kRegisteredPasses) {

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -1,11 +1,12 @@
-// Trajectory driver implementation; trajectory_driver.h is the entry point.
+// Drives simulation of circuits with noncomputational transitions.
 //
-// Transition annotations on computational qubits remain VM instruments. When
-// one produces an outcome that the current module cannot finish, the VM stops
-// and reports a trap. The driver records the jump, rewrites and compiles the
-// matching continuation, and resumes after that transition. Transitions reached
-// while a qubit is leaked or lost are drawn here before the continuation is
-// compiled.
+// Transition annotations compile to VM instructions. The VM applies an outcome
+// directly when the current compiled circuit can continue from it. Otherwise it
+// stops at the transition and reports a trap. The driver records the event,
+// rewrites and compiles a compatible continuation, and resumes the existing VM
+// state after the trapped instruction. Transitions reached while a qubit is
+// already leaked or lost are sampled here before compiling the next
+// continuation.
 //
 // Driver draws (initial levels, transition destinations, classical outcomes,
 // and herald flags) use one per-shot stream. VM measurements, noise, and
@@ -41,26 +42,53 @@ namespace clifft {
 namespace {
 
 // The channel described by one transition annotation: a named instrument for
-// LEVEL_TRANSITION or a uniform loss probability for LOSS.
+// LEVEL_TRANSITION or a uniform loss probability for LOSS. A null instrument
+// identifies the LOSS representation.
 struct AnnotationChannel {
-    const TransitionInstrument* instrument = nullptr;  // null for LOSS
-    double loss_p = 0.0;
+    const TransitionInstrument* instrument;
+    double loss_probability;
+
+    bool is_loss() const { return instrument == nullptr; }
 };
 
-AnnotationChannel resolve_annotation(const AstNode& node, const NonComputationalModel& model,
-                                     uint32_t op_index) {
-    AnnotationChannel channel;
+[[nodiscard]] AnnotationChannel resolve_annotation(const AstNode& node,
+                                                   const NonComputationalModel& model,
+                                                   uint32_t op_index) {
     if (node.gate == GateType::LOSS) {
-        channel.loss_p = loss_probability(node.args, op_index, "sample_noncomputational");
-        return channel;
+        return {nullptr, loss_probability(node.args, op_index, "sample_noncomputational")};
     }
-    channel.instrument = model.transition_named(node.tag);
-    if (channel.instrument == nullptr) {
+    const TransitionInstrument* instrument = model.transition_named(node.tag);
+    if (instrument == nullptr) {
         throw std::invalid_argument("sample_noncomputational: LEVEL_TRANSITION[" + node.tag +
                                     "] at op " + std::to_string(op_index) +
                                     " does not name a transition in the model");
     }
-    return channel;
+    return {instrument, 0.0};
+}
+
+// Resolving validates the LOSS arguments or transition name; the remaining
+// checks enforce the target shape expected by the driver and rewriter.
+void validate_annotation(const AstNode& node, const NonComputationalModel& model, uint32_t op_index,
+                         uint32_t num_qubits) {
+    (void)resolve_annotation(node, model, op_index);
+    if (node.targets.empty()) {
+        throw std::invalid_argument(
+            "sample_noncomputational: annotation '" + std::string(gate_name(node.gate)) +
+            "' at op " + std::to_string(op_index) + " requires at least one qubit target");
+    }
+    for (const Target& target : node.targets) {
+        if (target.is_rec() || target.has_pauli() || target.is_inverted()) {
+            throw std::invalid_argument("sample_noncomputational: annotation '" +
+                                        std::string(gate_name(node.gate)) + "' at op " +
+                                        std::to_string(op_index) + " requires plain qubit targets");
+        }
+        if (target.value() >= num_qubits) {
+            throw std::invalid_argument("sample_noncomputational: annotation '" +
+                                        std::string(gate_name(node.gate)) + "' target qubit " +
+                                        std::to_string(target.value()) + " is out of range at op " +
+                                        std::to_string(op_index));
+        }
+    }
 }
 
 // Draw one qubit's initial level. If floating-point rounding leaves the draw
@@ -86,7 +114,7 @@ Level draw_initial_level(const NonComputationalModel& model, Xoshiro256PlusPlus&
 // Draw among the destination levels accepted by `admit`, renormalizing their
 // probabilities. If rounding leaves the draw just past the accumulated total,
 // return the last accepted level with nonzero probability. Consumes one RNG
-// draw.
+// draw. `admit(Level)` returns true for destinations included in the draw.
 template <typename Admit>
 Level draw_from_column(const TransitionInstrument& instrument, Level source,
                        Xoshiro256PlusPlus& rng, Admit&& admit) {
@@ -158,50 +186,47 @@ void extend_classical_outcomes(const Circuit& annotated, TrajectoryEvents& event
                     if (jump != jump_dest.end()) {
                         status[qubit] = status_for(jump->second);
                     }
-                    continue;
-                }
-                const Level source = noncomp_level(pre);
-                const AnnotationTarget annotation_target{op_index, qubit};
-                const auto seen = drawn.find(annotation_target);
-                if (seen != drawn.end()) {
-                    if (seen->second.source_level != source) {
-                        throw std::logic_error(
-                            "sample_noncomputational: classical outcome reuse at op " +
-                            std::to_string(op_index) + ", qubit " + std::to_string(qubit) +
-                            " no longer matches the qubit's source level (drawn at level '" +
-                            level_name(seen->second.source_level) + "', qubit now has level '" +
-                            level_name(source) + "')");
+                } else {
+                    const Level source = noncomp_level(pre);
+                    const AnnotationTarget annotation_target{op_index, qubit};
+                    const auto seen = drawn.find(annotation_target);
+                    ClassicalOutcome outcome{annotation_target, std::nullopt, source};
+                    if (seen != drawn.end()) {
+                        if (seen->second.source_level != source) {
+                            throw std::logic_error(
+                                "sample_noncomputational: classical outcome reuse at op " +
+                                std::to_string(op_index) + ", qubit " + std::to_string(qubit) +
+                                " no longer matches the qubit's source level (drawn at level '" +
+                                level_name(seen->second.source_level) + "', qubit now has level '" +
+                                level_name(source) + "')");
+                        }
+                        outcome = seen->second;
+                    } else {
+                        const AnnotationChannel channel = resolve_annotation(node, model, op_index);
+                        if (!channel.is_loss()) {
+                            const double total = channel.instrument->column_sum(source);
+                            if (rng.next_double() < total) {
+                                outcome.destination = draw_from_column(
+                                    *channel.instrument, source, rng, [](Level) { return true; });
+                            }
+                        } else if (!is_lost(pre) && rng.next_double() < channel.loss_probability) {
+                            // LOSS can move a leaked qubit to Lost. An already-lost
+                            // qubit records a no-op without spending a draw.
+                            outcome.destination = Level::Lost;
+                        }
                     }
-                    ordered.push_back(seen->second);
-                    if (seen->second.destination.has_value()) {
-                        status[qubit] = status_for(*seen->second.destination);
+                    ordered.push_back(outcome);
+                    if (outcome.destination.has_value()) {
+                        status[qubit] = status_for(*outcome.destination);
                     }
-                    continue;
-                }
-                const AnnotationChannel channel = resolve_annotation(node, model, op_index);
-                ClassicalOutcome outcome{annotation_target, std::nullopt, source};
-                if (channel.instrument != nullptr) {
-                    const double total = channel.instrument->column_sum(source);
-                    if (rng.next_double() < total) {
-                        outcome.destination = draw_from_column(*channel.instrument, source, rng,
-                                                               [](Level) { return true; });
-                    }
-                } else if (!is_lost(pre) && rng.next_double() < channel.loss_p) {
-                    // LOSS can move a leaked qubit to Lost. An already-lost
-                    // qubit records a no-op without spending a draw.
-                    outcome.destination = Level::Lost;
-                }
-                ordered.push_back(outcome);
-                if (outcome.destination.has_value()) {
-                    status[qubit] = status_for(*outcome.destination);
                 }
             }
-            continue;
+        } else {
+            // Apply the same status update the rewriter uses for ordinary
+            // operations.
+            advance_ordinary_node(node, op_index, status, model.policy(),
+                                  "sample_noncomputational");
         }
-        // Apply the same status update the rewriter uses for ordinary
-        // operations.
-        advance_ordinary_node(annotated.nodes[op_index], op_index, status, model.policy(),
-                              "sample_noncomputational");
     }
     events.classical_outcomes = std::move(ordered);
 }
@@ -320,40 +345,21 @@ std::vector<uint32_t> record_sequence(const HirModule& hir) {
 }
 #endif
 
-// Return the forced-outcome version of a measurement opcode. Both versions
-// write the same slot, but the forced version reads the result from
-// state.forced_record. Return NUM_OPCODES for other instructions.
-Opcode forced_opcode(Opcode op) {
-    switch (op) {
-        case Opcode::OP_MEAS_DORMANT_STATIC:
-            return Opcode::OP_MEAS_DORMANT_STATIC_FORCED;
-        case Opcode::OP_MEAS_DORMANT_RANDOM:
-            return Opcode::OP_MEAS_DORMANT_RANDOM_FORCED;
-        case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
-            return Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED;
-        case Opcode::OP_MEAS_ACTIVE_INTERFERE:
-            return Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED;
-        case Opcode::OP_SWAP_MEAS_INTERFERE:
-            return Opcode::OP_SWAP_MEAS_INTERFERE_FORCED;
-        default:
-            return Opcode::NUM_OPCODES;
-    }
-}
-
-// Replace the hidden trace-out measurement at `slot` with its forced-outcome
-// opcode. resume() then reads the VM-selected source from
-// state.forced_record[slot] instead of drawing another result. Bytecode passes
-// do not renumber measurement slots, so the slot remains valid after
-// optimization.
+// A trap-form instrument reports a source but leaves the qubit uncollapsed.
+// The rewritten continuation inserts a reset to apply that collapse and
+// prepare the selected destination. Its hidden measurement must reuse the
+// source already selected by the VM rather than draw a second outcome, so
+// replace that measurement with its forced-outcome opcode. Bytecode passes do
+// not renumber measurement slots, so `slot` remains valid after optimization.
 void swap_traceout_to_forced(CompiledModule& module, size_t slot) {
     size_t found = 0;
     for (Instruction& instr : module.bytecode) {
-        const Opcode forced = forced_opcode(instr.opcode);
-        if (forced == Opcode::NUM_OPCODES) {
+        const std::optional<Opcode> forced = forced_measurement_opcode(instr.opcode);
+        if (!forced.has_value()) {
             continue;
         }
         if (instr.classical.classical_idx == slot) {
-            instr.opcode = forced;
+            instr.opcode = *forced;
             ++found;
         }
     }
@@ -364,19 +370,24 @@ void swap_traceout_to_forced(CompiledModule& module, size_t slot) {
     }
 }
 
+#ifndef NDEBUG
 // Compare instructions while allowing the expected sampling-to-forced opcode
-// change. Every other byte must match the module that already executed.
+// change. Bytewise equality is deliberate: resume requires the continuation
+// prefix to match the module that already executed, not merely to be
+// semantically equivalent.
 bool equal_modulo_forced_swap(const Instruction& fresh, const Instruction& executed) {
     if (std::memcmp(&fresh, &executed, sizeof(Instruction)) == 0) {
         return true;
     }
-    if (forced_opcode(fresh.opcode) != executed.opcode) {
+    const std::optional<Opcode> forced = forced_measurement_opcode(fresh.opcode);
+    if (!forced.has_value() || *forced != executed.opcode) {
         return false;
     }
     Instruction swapped = fresh;
     swapped.opcode = executed.opcode;
     return std::memcmp(&swapped, &executed, sizeof(Instruction)) == 0;
 }
+#endif
 
 // Validate the circuit features that require model-wide knowledge. If the
 // model can ever leak or lose a qubit, parity measurements are unsupported and
@@ -482,27 +493,7 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
          ++op_index) {
         const AstNode& node = annotated.nodes[op_index];
         if (node.gate == GateType::LEVEL_TRANSITION || node.gate == GateType::LOSS) {
-            resolve_annotation(node, model, op_index);
-            if (node.targets.empty()) {
-                throw std::invalid_argument(
-                    "sample_noncomputational: annotation '" + std::string(gate_name(node.gate)) +
-                    "' at op " + std::to_string(op_index) + " requires at least one qubit target");
-            }
-            for (const Target& target : node.targets) {
-                if (target.is_rec() || target.has_pauli() || target.is_inverted()) {
-                    throw std::invalid_argument("sample_noncomputational: annotation '" +
-                                                std::string(gate_name(node.gate)) + "' at op " +
-                                                std::to_string(op_index) +
-                                                " requires plain qubit targets");
-                }
-                if (target.value() >= annotated.num_qubits) {
-                    throw std::invalid_argument("sample_noncomputational: annotation '" +
-                                                std::string(gate_name(node.gate)) +
-                                                "' target qubit " + std::to_string(target.value()) +
-                                                " is out of range at op " +
-                                                std::to_string(op_index));
-                }
-            }
+            validate_annotation(node, model, op_index, annotated.num_qubits);
         }
         // The parser emits one node per target for ordinary measurements, and
         // the rewrite relies on that shape when assigning record slots. MPP is
@@ -781,10 +772,10 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                    "the VM reports the collapsed source as a computational axis index");
             const Level source = static_cast<Level>(trap.source);
             Level dest = Level::Lost;
-            if (channel.instrument != nullptr && trap.destination_pending) {
+            if (!channel.is_loss() && trap.destination_pending) {
                 dest = draw_from_column(*channel.instrument, source, driver_rng,
                                         [](Level) { return true; });
-            } else if (channel.instrument != nullptr) {
+            } else if (!channel.is_loss()) {
                 dest = draw_from_column(*channel.instrument, source, driver_rng,
                                         [](Level to) { return !is_computational(to); });
             }

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -268,10 +268,12 @@ void execute(const CompiledModule& program, SchrodingerState& state);
 /// instruction after the trapped site. Requires state.pending_trap and clears
 /// it before execution resumes.
 ///
-/// The bytecode before `offset` must match what the state already executed, and
-/// visible measurement slots must keep the same indices. resume() validates the
-/// trapped-site offset and qubit/output counts, but the caller is responsible
-/// for providing a compatible continuation.
+/// The bytecode before `offset` must match what the state already executed.
+/// The state retains that prefix's active-axis layout, Pauli frame, measurement
+/// records, and RNG state; resume() does not translate between different but
+/// equivalent compilations. Visible measurement slots must also keep the same
+/// indices. resume() validates the trapped-site offset and qubit/output counts,
+/// but the caller is responsible for providing a compatible continuation.
 ///
 /// Before re-entering dispatch, resume() may grow the amplitude and measurement
 /// buffers. It also restarts noise sampling at the first remaining noise site.

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -304,9 +304,11 @@ def sample(
     ``None``, each call draws a fresh 256-bit root from OS entropy, so
     repeated or parallel unseeded calls sample fresh randomness.
 
-    Continuations are compiled with a fixed pipeline containing the default
-    optimization passes that preserve measurement-record order. This API does
-    not currently accept custom pass managers.
+    Continuations are compiled with the default optimization passes that
+    preserve measurement-record order; this omits
+    :class:`StatevectorSqueezePass`. A continuation may force a hidden trace-out
+    measurement, whose order relative to other measurements can affect quantum
+    correlations. This API does not currently accept custom pass managers.
 
     ``max_rank`` caps the compiled peak rank for each trajectory; the cap is
     enforced at each continuation compile, failing with the offending circuit

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -304,10 +304,9 @@ def sample(
     ``None``, each call draws a fresh 256-bit root from OS entropy, so
     repeated or parallel unseeded calls sample fresh randomness.
 
-    Continuations are compiled with the default optimization passes that
-    preserve measurement-record order. Custom pass managers are not currently
-    accepted because every continuation must preserve the bytecode prefix
-    already executed by the shot.
+    Continuations are compiled with a fixed pipeline containing the default
+    optimization passes that preserve measurement-record order. This API does
+    not currently accept custom pass managers.
 
     ``max_rank`` caps the compiled peak rank for each trajectory; the cap is
     enforced at each continuation compile, failing with the offending circuit

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -304,6 +304,11 @@ def sample(
     ``None``, each call draws a fresh 256-bit root from OS entropy, so
     repeated or parallel unseeded calls sample fresh randomness.
 
+    Continuations are compiled with the default optimization passes that
+    preserve measurement-record order. Custom pass managers are not currently
+    accepted because every continuation must preserve the bytecode prefix
+    already executed by the shot.
+
     ``max_rank`` caps the compiled peak rank for each trajectory; the cap is
     enforced at each continuation compile, failing with the offending circuit
     line named instead of attempting a ``2**k`` allocation. The cap applies to

--- a/tests/python/test_pass_docs.py
+++ b/tests/python/test_pass_docs.py
@@ -26,14 +26,19 @@ def _extract_cpp_passes() -> dict[str, dict[str, object]]:
         name_match = re.search(r'\.name\s*=\s*"([^"]+)"', entry)
         kind_match = re.search(r"\.kind\s*=\s*PassKind::(\w+)", entry)
         default_match = re.search(r"\.default_enabled\s*=\s*(true|false)", entry)
+        record_order_match = re.search(
+            r"\.record_order\s*=\s*k(Preserves|Breaks)RecordOrder", entry
+        )
 
         assert name_match, f"Registered pass entry missing .name: {entry}"
         assert kind_match, f"Registered pass entry missing .kind: {entry}"
         assert default_match, f"Registered pass entry missing .default_enabled: {entry}"
+        assert record_order_match, f"Registered pass entry missing .record_order: {entry}"
 
         passes[name_match.group(1)] = {
             "kind": kind_match.group(1),
             "default_enabled": default_match.group(1) == "true",
+            "preserves_record_order": record_order_match.group(1) == "Preserves",
         }
 
     return passes
@@ -79,7 +84,7 @@ class TestOptimizationPassDocCompleteness:
             f"Remove these stale docs entries."
         )
 
-    def test_pass_kind_and_default_enabled_metadata_match(self) -> None:
+    def test_pass_metadata_matches(self) -> None:
         cpp_passes = _extract_cpp_passes()
         docs_passes = _extract_docs_passes()
 
@@ -94,13 +99,28 @@ class TestOptimizationPassDocCompleteness:
                 f"{name} has default_enabled={docs_metadata['default_enabled']!r} in "
                 f"docs/macros.py but {cpp_metadata['default_enabled']!r} in pass_registry.h."
             )
+            assert (
+                docs_metadata["preserves_record_order"] == cpp_metadata["preserves_record_order"]
+            ), (
+                f"{name} has preserves_record_order="
+                f"{docs_metadata['preserves_record_order']!r} in docs/macros.py but "
+                f"{cpp_metadata['preserves_record_order']!r} in pass_registry.h."
+            )
 
 
 class TestOptimizationPassDocStructure:
     """Validate optimization pass docs entries have the required fields."""
 
     def test_pass_entries_have_required_fields(self) -> None:
-        required_fields = {"name", "kind", "default_enabled", "python_name", "summary", "detail"}
+        required_fields = {
+            "name",
+            "kind",
+            "default_enabled",
+            "preserves_record_order",
+            "python_name",
+            "summary",
+            "detail",
+        }
 
         for name, metadata in _extract_docs_passes().items():
             missing = required_fields - set(metadata)


### PR DESCRIPTION
## Summary
- clarify the trajectory driver's execution and annotation-validation flow
- make classical/computational outcome handling explicit without changing sampling behavior
- centralize sampling-to-forced measurement opcode mapping and replace the NUM_OPCODES sentinel with std::optional
- limit bytewise continuation-prefix comparison to debug builds and assert that VM instructions remain trivially copyable
- document the trajectory-safe optimization policy in the Python API and leakage/loss guide

Cache behavior and cache documentation are intentionally unchanged.

## Validation
- Debug C++ build
- Release clifft_core build
- 1,100 non-benchmark C++ tests
- 74 focused Python noncomputational tests
- uv run pre-commit run --all-files