### PR TITLE
refactor(svm): clarify instrument kernel helpers

### DIFF
--- a/src/clifft/svm/svm_instrument_kernels.cc
+++ b/src/clifft/svm/svm_instrument_kernels.cc
@@ -13,18 +13,6 @@
 
 namespace clifft {
 
-namespace {
-
-// Map pair number ii to the array index whose bit v is zero by inserting a
-// zero bit at v. This is the portable equivalent of scatter_bits_1 used by
-// ISA-specific kernels.
-inline uint64_t pair_index(uint64_t ii, uint16_t v) {
-    const uint64_t low_mask = (1ULL << v) - 1;
-    return (ii & low_mask) | ((ii & ~low_mask) << 1);
-}
-
-}  // namespace
-
 InstrumentPopulations exec_instrument_damp_eval(SchrodingerState& state, uint16_t v, double r_g,
                                                 double r_e) {
     assert(v < state.active_k && v < 64 && "instrument damp_eval: axis must be active");
@@ -46,7 +34,7 @@ InstrumentPopulations exec_instrument_damp_eval(SchrodingerState& state, uint16_
     double pop1 = 0.0;
     parallel_reduce(static_cast<int64_t>(pairs), state.active_k, pop0, pop1,
                     [&](int64_t ii, double& acc0, double& acc1) {
-                        const uint64_t i0 = pair_index(static_cast<uint64_t>(ii), v);
+                        const uint64_t i0 = insert_zero_bit(static_cast<uint64_t>(ii), v);
                         const uint64_t i1 = i0 | v_bit;
                         acc0 += std::norm(arr[i0]);
                         acc1 += std::norm(arr[i1]);
@@ -75,7 +63,7 @@ void exec_instrument_collapse_active(SchrodingerState& state, uint16_t v, uint8_
     double discarded = 0.0;
     parallel_reduce(static_cast<int64_t>(pairs), state.active_k, kept, discarded,
                     [&](int64_t ii, double& k_acc, double& d_acc) {
-                        const uint64_t i0 = pair_index(static_cast<uint64_t>(ii), v);
+                        const uint64_t i0 = insert_zero_bit(static_cast<uint64_t>(ii), v);
                         const uint64_t i1 = i0 | v_bit;
                         const uint64_t keep = (b == 0) ? i0 : i1;
                         const uint64_t drop = (b == 0) ? i1 : i0;

--- a/src/clifft/svm/svm_instrument_kernels.h
+++ b/src/clifft/svm/svm_instrument_kernels.h
@@ -8,17 +8,21 @@
 //   K_jump[d,s] = sqrt(p[d,s]) |d><s|
 //   K_stay     = r_g P_g + r_e P_e
 //
-// where p_s is the sum of p[d,s] over destination levels d. These kernels need
-// only p_g, p_e, r_g, and r_e. The caller separately draws the destination.
-// A no-jump branch scales the g and e amplitudes by r_g and r_e. On an active
-// axis, a jump collapses the qubit to its source before the caller applies any
-// computational destination change or reports a trap. A dormant random qubit
-// may defer that collapse to the continuation.
+// where p_s is the sum of p[d,s] over destination levels d. The kernels use
+// only p_g, p_e, r_g, and r_e; the caller separately draws the destination.
+//
+// A no-jump result scales the g and e amplitudes by r_g and r_e. When a
+// transition fires, an active qubit is first projected onto its source level;
+// the caller then applies any computational destination change or reports a
+// trap. If a dormant qubit's source is not definite, it has no active array
+// axis on which to perform the projection, so a continuation performs it
+// after the VM traps.
 //
 // These functions do not draw random numbers. instrument_fire_branch() uses a
-// uniform value supplied by the caller. Active-axis kernels account for p_x[v]
-// when mapping physical g and e to array halves; the caller handles the
-// instruction's sign flag and any destination Pauli update.
+// uniform value supplied by the caller. On an active axis, p_x[v] determines
+// which array half represents physical g and e; the kernels handle that
+// mapping. The caller handles the instruction's sign flag and any destination
+// Pauli update.
 //
 // This internal header is shared by the dispatcher and kernel tests.
 

--- a/src/clifft/svm/svm_math.h
+++ b/src/clifft/svm/svm_math.h
@@ -61,9 +61,15 @@ inline void bit_swap(std::span<uint64_t> m1, uint32_t i1, std::span<uint64_t> m2
 // For 1-axis ops: pdep_mask = ~(1ULL << axis), deposits i into all bits
 // except the axis bit. For 2-axis ops: pdep_mask = ~(c_bit | t_bit).
 //
-// These functions change implementation based on __BMI2__ compiler flags,
-// so they live inside CLIFFT_SIMD_NAMESPACE to avoid ODR violations when
-// compiled into separate scalar and AVX2 translation units.
+// The portable bit-insertion helper is shared by generic kernels. The scatter
+// helpers change implementation based on __BMI2__ compiler flags, so they live
+// inside CLIFFT_SIMD_NAMESPACE to avoid ODR violations when compiled into
+// separate scalar and AVX2 translation units.
+
+inline uint64_t insert_zero_bit(uint64_t val, uint16_t pos) {
+    const uint64_t mask = (1ULL << pos) - 1;
+    return (val & mask) | ((val & ~mask) << 1);
+}
 
 #if defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
 #define CLIFFT_HAS_PDEP 1
@@ -73,11 +79,6 @@ inline void bit_swap(std::span<uint64_t> m1, uint32_t i1, std::span<uint64_t> m2
 
 #ifdef CLIFFT_SIMD_NAMESPACE
 namespace CLIFFT_SIMD_NAMESPACE {
-
-inline uint64_t insert_zero_bit(uint64_t val, uint16_t pos) {
-    uint64_t mask = (1ULL << pos) - 1;
-    return (val & mask) | ((val & ~mask) << 1);
-}
 
 inline uint64_t scatter_bits_1(uint64_t val, [[maybe_unused]] uint64_t pdep_mask,
                                [[maybe_unused]] uint16_t bit_pos) {


### PR DESCRIPTION
## Summary
- clarify the source projection and caller responsibilities in the instrument-kernel overview
- expose the ISA-independent `insert_zero_bit` helper to generic SVM kernels
- remove the duplicate `pair_index` implementation while keeping ISA-specific scatter selection isolated

## Testing
- `uv run pre-commit run --all-files`
- `cmake --build build -j`
- `ctest --test-dir build -E '^Bench:' --output-on-failure -j4` (1100 passed)\n\nBenchmark tests were intentionally excluded.