### PR TITLE
docs(noncomp): clarify Python sampling contract

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -304,6 +304,9 @@ with its entangled partner. The semantics and the rank cost are in
   a parity of levels outside the qubit subspace has no faithful single-bit
   record. Expand the parity readout into an explicit ancilla circuit; the
   ancilla's ladder gates then drop per the rules above.
+- **`EXP_VAL` is not supported.** `NonComputationalSample` has no
+  expectation-value output, so circuits containing these probes are rejected
+  before sampling.
 - **A classifier is required** whenever a model capable of leakage or loss
   meets a circuit containing any physical-qubit measurement. This is a
   model-level capability check, not a per-site reachability analysis.

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -84,7 +84,7 @@ void register_noncomp(nb::module_& m) {
         },
         nb::arg("initial_state"), nb::arg("transitions"), nb::arg("classifier_matrix") = nb::none(),
         nb::arg("reset_restores_lost") = false, nb::arg("damping") = "exact",
-        "Build a default 5-level NonComputationalModel from raw matrices. See "
+        "Build the built-in five-level NonComputationalModel from raw matrices. See "
         "clifft.noncomp.Model.");
 
     m.def(
@@ -96,9 +96,9 @@ void register_noncomp(nb::module_& m) {
                 nb::gil_scoped_release release;
                 r = clifft::sample_noncomputational(circuit, model, shots, seed, max_rank);
             }
-            // Pass the raw status bytes through: QubitStatus is uint8_t with values
-            // Computational=0, LeakG=1, LeakE=2, Lost=3, matching Python's QubitStatus
-            // enum exactly. No coarsening: leaked substates are individually preserved.
+            // Convert statuses to the uint8 codes exposed by Python. The values
+            // Computational=0, LeakG=1, LeakE=2, Lost=3 match Python's
+            // QubitStatus enum, including the distinct leaked substates.
             std::vector<uint8_t> status(r.final_status.size());
             for (size_t i = 0; i < r.final_status.size(); ++i) {
                 status[i] = static_cast<uint8_t>(r.final_status[i]);

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -2,8 +2,7 @@
 
 This module is experimental: the API may change between minor releases.
 
-Drives a structural leakage/loss trajectory model on top of the ordinary Clifft
-sampler:
+Samples five-level leakage/loss trajectories using Clifft's VM:
 
     import clifft
     from clifft import noncomp
@@ -17,13 +16,13 @@ sampler:
     r.measurements   # np.uint8 [shots, num_measurements]
     r.final_status   # np.uint8 [shots, num_qubits], values in QubitStatus
 
-This API supports exactly the built-in five-level set, named by ``Level``
-(g, e, leak_g, leak_e, lost); matrix rows and columns are indexed by
-``Level``. A classifier has two or three symbols with stochastic columns: the
-first two symbols are the record bit, an optional third symbol heralds the
-measurement (reported per slot in ``heralds``; the visible record stays binary
-with a uniformly drawn bit). Substochastic (reject) columns and richer
-alphabets raise.
+This API supports exactly the built-in five-level set: ``Level.G``, ``Level.E``,
+``Level.LEAK_G``, ``Level.LEAK_E``, and ``Level.LOST``. Matrix rows and columns
+are indexed by ``Level``. A classifier has two or three symbols, and each
+column must sum to one. The first two symbols are the record bit; an optional
+third symbol heralds the measurement (reported per slot in ``heralds`` while
+the visible record stays binary with a uniformly drawn bit). Classifiers with
+other alphabet sizes are rejected.
 """
 
 from __future__ import annotations
@@ -55,7 +54,7 @@ class QubitStatus(IntEnum):
 
     These are per-qubit *status* codes, not matrix indices. ``Level`` names
     matrix rows and columns (indices 0--4); ``QubitStatus`` names per-qubit
-    outcomes (indices 0--3). The two enums share member names (``LEAK_G``,
+    outcomes (codes 0--3). The two enums share member names (``LEAK_G``,
     ``LEAK_E``, ``LOST``) with *different* integer values -- never substitute
     one for the other.
 
@@ -132,14 +131,15 @@ class Model:
         reset_restores_lost: if true, a reset on a lost qubit restores it to
             a computational state; if false (default), the reset acts on the
             vacated site and is dropped.
-        damping: handling of sites whose no-fire back-action is genuinely
-            non-Clifford (a source-dependent transition on a coherent qubit
-            outside the amplitude array). ``"exact"`` (the default) expands
-            the qubit into the array, adding one to the circuit's rank at that
-            site; ``"neglect"`` keeps the rank and omits the no-fire
-            back-action, a survivorship tilt of order ``|p_g - p_e|`` with no
-            effect on source-independent rates. Only meaningful at coherent
-            dormant sites.
+        damping: handling of the no-transition update when the total
+            transition probability differs between ``g`` and ``e`` for a
+            coherent qubit that is not yet represented in the state vector.
+            ``"exact"`` (the default) adds the qubit to the state vector at
+            that site, increasing peak rank by one. ``"neglect"`` avoids the
+            expansion but omits the state update caused by observing that no
+            transition occurred. It is exact when ``g`` and ``e`` have the
+            same total transition probability; otherwise the bias is of order
+            ``|p_g - p_e|``.
 
     An operation with no representable effect on a leaked or lost operand --
     e.g. a two-qubit gate onto a vacated site -- is dropped, acting as the
@@ -212,9 +212,9 @@ class NonComputationalSample:
         final_status: uint8 array (shots, num_qubits) of :class:`QubitStatus`.
             Reports the definite noncomputational level per shot: ``LEAK_G``
             and ``LEAK_E`` are individually distinguishable. Computational
-            qubits report as :attr:`QubitStatus.COMPUTATIONAL`: transitions
-            with computational destinations resolve entirely inside the
-            simulator, so no final level is claimed.
+            qubits report as :attr:`QubitStatus.COMPUTATIONAL` rather than
+            ``G`` or ``E`` because their state remains quantum in the VM and
+            may not be a definite level.
         heralds: uint8 array (shots, num_measurements); 1 where the classifier
             sampled the herald (third) symbol for that slot, else 0.
         shots, num_qubits, num_measurements, num_detectors, num_observables: ints.
@@ -295,9 +295,10 @@ def sample(
     incidental once the qubit has left the computational subspace. A model that
     can leak or lose qubits requires a classifier when the circuit measures a
     qubit, and parity measurements (``MPP``) are not supported with such models —
-    both are rejected before sampling begins. Raises ``ValueError`` when one of
-    these contracts is violated, when an annotation is malformed, or when
-    ``max_rank`` is exceeded.
+    both are rejected before sampling begins. ``EXP_VAL`` probes are not
+    supported because :class:`NonComputationalSample` has no expectation-value
+    output. Raises ``ValueError`` when one of these contracts is violated, when
+    an annotation is malformed, or when ``max_rank`` is exceeded.
 
     ``seed`` makes runs reproducible: the same seed with the same arguments
     returns identical results, so vary it across seeded batches. When

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -40,9 +40,6 @@ def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
     )
 
 
-# --- Model construction ----------------------------------------------------
-
-
 def test_level_names_and_indices():
     assert (int(noncomp.Level.G), int(noncomp.Level.LEAK_G), int(noncomp.Level.LOST)) == (0, 2, 4)
 
@@ -121,9 +118,6 @@ def test_whitespace_transition_key_raises():
         noncomp.Model(initial_state=ALL_G, transitions={" padded": t})
 
 
-# --- End-to-end sampling ---------------------------------------------------
-
-
 def test_lossless_matches_plain_record_shape():
     model = noncomp.Model(initial_state=ALL_G)
     r = noncomp.sample("H 0\nM 0\n", model, shots=512, seed=2)
@@ -171,9 +165,6 @@ def test_reset_reload_policy_changes_lost_site():
     )
     r = noncomp.sample(circuit, restore, shots=8, seed=7)
     assert (r.final_status == COMPUTATIONAL).all()
-
-
-# --- Classifier and record semantics ---------------------------------------
 
 
 def test_leaked_classifier_bit_in_measurements():
@@ -347,9 +338,6 @@ def test_ternary_herald_feeds_detector_and_observable():
     assert np.array_equal(sym[~heralded, 0], meas[~heralded])
 
 
-# --- Record layout invariants ----------------------------------------------
-
-
 def test_hidden_trace_out_does_not_shift_visible_count():
     plain = noncomp.Model(initial_state=ALL_G)
     rp = noncomp.sample("H 0\nCX 0 1\nM 0\nM 1\n", plain, shots=8, seed=16)
@@ -428,9 +416,6 @@ def test_deterministic_in_seed_with_noncomputational_initials():
         assert not np.array_equal(a.measurements, c.measurements) or not np.array_equal(
             a.final_status, c.final_status
         )
-
-
-# --- Policy knobs -----------------------------------------------------------
 
 
 def test_policy_knob_strings_validate():
@@ -614,9 +599,6 @@ def test_computational_readout_confusion_misreports_the_record():
     assert 650 <= zeros <= 950  # expected 800; ~6 sigma band
 
 
-# --- Correlated-chain passthrough on noncomputational operands -------------
-
-
 def _lose_model() -> noncomp.Model:
     """S loses its qubit with certainty; the classifier reads out
     faithfully on g/e and reads 0 on the lost column."""
@@ -689,9 +671,6 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_recapture():
     assert (result.final_status[:, 0] == COMPUTATIONAL).all()
 
 
-# --- MX / MY classify on vacated carriers ------------------------------------
-
-
 def test_mx_classified_deterministic():
     """MX on a certainly-lost qubit reads the classifier's lost column.
 
@@ -716,9 +695,6 @@ def test_mx_inverted_complements_classifier_bit():
     assert (r.measurements[:, 0] == 0).all()  # inverted: 1 -> 0
 
 
-# --- Classifier capability contract -----------------------------------------
-
-
 def test_capable_model_with_measurement_requires_classifier():
     """A model that can lose qubits requires a classifier when the circuit measures."""
     transitions = {"S": transition_to(LOST)}
@@ -738,9 +714,6 @@ def test_mpad_does_not_require_classifier():
     assert (result.final_status[:, 0] == LOST_KIND).all()
 
 
-# --- Parity-measurement capability contract ---------------------------------
-
-
 def test_capable_model_rejects_mpp():
     """MPP is not supported when the model can leak or lose qubits."""
     transitions = {"S": transition_to(LOST)}
@@ -753,9 +726,6 @@ def test_capable_model_rejects_mpp():
 def test_exp_val_probe_is_rejected():
     with pytest.raises(ValueError, match="EXP_VAL probes are not supported"):
         noncomp.sample("EXP_VAL Z0\n", noncomp.Model(), shots=1, seed=5)
-
-
-# --- Memory-X smoke -----------------------------------------------------------
 
 
 def test_memory_x_smoke():
@@ -780,9 +750,6 @@ def test_contract_validated_for_zero_shots():
         noncomp.sample("S 0\nM 0", model, shots=0, seed=1)
 
 
-# --- Error message quality ----------------------------------------------------
-
-
 def test_malformed_transition_error_names_key():
     """A bad transition matrix error must include the offending key in the message."""
     bad = [[0.0] * 5 for _ in range(5)]
@@ -790,9 +757,6 @@ def test_malformed_transition_error_names_key():
 
     with pytest.raises(ValueError, match="'CZ'"):
         noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LEAK_G), "CZ": bad})
-
-
-# --- Plain-pipeline redirect points to clifft.noncomp.sample -----------------
 
 
 def test_compile_annotated_circuit_raises_invalid_argument_with_noncomp_sample_hint():
@@ -810,9 +774,6 @@ def test_sample_type_hints_resolve_at_runtime():
 
     hints = get_type_hints(noncomp.sample)
     assert "circuit" in hints
-
-
-# --- QubitStatus enum ----------------------------------------------------------
 
 
 def test_qubit_status_values():
@@ -847,9 +808,6 @@ def test_fine_grained_leak_e_status():
     assert (r.final_status == noncomp.QubitStatus.LEAK_E).all()
 
 
-# --- Default initial state ----------------------------------------------------
-
-
 def test_model_default_initial_state_constructs():
     model = noncomp.Model()
     assert isinstance(model, noncomp.Model)
@@ -858,9 +816,6 @@ def test_model_default_initial_state_constructs():
 def test_model_default_initial_state_reads_zero():
     r = noncomp.sample("M 0", noncomp.Model(), shots=4, seed=1)
     assert np.all(r.measurements == 0)
-
-
-# --- Model repr ---------------------------------------------------------------
 
 
 def test_model_repr_contains_keys_and_damping():
@@ -872,9 +827,6 @@ def test_model_repr_contains_keys_and_damping():
     assert "S" in r
     assert "seep" in r
     assert "neglect" in r
-
-
-# --- Ternary herald on a measure-reset ----------------------------------------
 
 
 def test_ternary_herald_on_measure_reset():
@@ -928,9 +880,6 @@ def test_ternary_herald_on_measure_reset():
 
     # Final status is COMPUTATIONAL: the MR reset cleared the leak level.
     assert np.all(r.final_status[:, 0] == COMPUTATIONAL), "final status was not COMPUTATIONAL"
-
-
-# --- Entropy-seeded runs -------------------------------------------------------
 
 
 def test_seed_none_smoke():

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -2,8 +2,7 @@
 
 Covers model construction, end-to-end sampling, classifier/record semantics,
 and record-layout invariants through the clifft.noncomp surface. The model uses
-the default five-level set (g=0, e=1, leak_g=2, leak_e=3, lost=4); matrices are
-positional over those levels, so no level ids appear in the API.
+the built-in five-level set; matrices use the fixed clifft.noncomp.Level order.
 """
 
 from __future__ import annotations
@@ -41,7 +40,7 @@ def leak_model(classifier: noncomp.Classifier | None = None) -> noncomp.Model:
     )
 
 
-# --- 1. Model construction -------------------------------------------------
+# --- Model construction ----------------------------------------------------
 
 
 def test_level_names_and_indices():
@@ -122,7 +121,7 @@ def test_whitespace_transition_key_raises():
         noncomp.Model(initial_state=ALL_G, transitions={" padded": t})
 
 
-# --- 2. End-to-end sampling ------------------------------------------------
+# --- End-to-end sampling ---------------------------------------------------
 
 
 def test_lossless_matches_plain_record_shape():
@@ -174,7 +173,7 @@ def test_reset_reload_policy_changes_lost_site():
     assert (r.final_status == COMPUTATIONAL).all()
 
 
-# --- 3. Classifier / record semantics --------------------------------------
+# --- Classifier and record semantics ---------------------------------------
 
 
 def test_leaked_classifier_bit_in_measurements():
@@ -348,7 +347,7 @@ def test_ternary_herald_feeds_detector_and_observable():
     assert np.array_equal(sym[~heralded, 0], meas[~heralded])
 
 
-# --- 4. Record layout invariants -------------------------------------------
+# --- Record layout invariants ----------------------------------------------
 
 
 def test_hidden_trace_out_does_not_shift_visible_count():
@@ -431,7 +430,7 @@ def test_deterministic_in_seed_with_noncomputational_initials():
         )
 
 
-# --- 8. Policy knobs --------------------------------------------------------
+# --- Policy knobs -----------------------------------------------------------
 
 
 def test_policy_knob_strings_validate():
@@ -615,7 +614,7 @@ def test_computational_readout_confusion_misreports_the_record():
     assert 650 <= zeros <= 950  # expected 800; ~6 sigma band
 
 
-# --- 9. Correlated-chain passthrough on noncomputational operands ----------
+# --- Correlated-chain passthrough on noncomputational operands -------------
 
 
 def _lose_model() -> noncomp.Model:
@@ -751,6 +750,11 @@ def test_capable_model_rejects_mpp():
         noncomp.sample("S 0\nMPP Z0*Z1\n", model, shots=4, seed=5)
 
 
+def test_exp_val_probe_is_rejected():
+    with pytest.raises(ValueError, match="EXP_VAL probes are not supported"):
+        noncomp.sample("EXP_VAL Z0\n", noncomp.Model(), shots=1, seed=5)
+
+
 # --- Memory-X smoke -----------------------------------------------------------
 
 
@@ -776,7 +780,7 @@ def test_contract_validated_for_zero_shots():
         noncomp.sample("S 0\nM 0", model, shots=0, seed=1)
 
 
-# --- 10. Error message quality -----------------------------------------------
+# --- Error message quality ----------------------------------------------------
 
 
 def test_malformed_transition_error_names_key():
@@ -788,7 +792,7 @@ def test_malformed_transition_error_names_key():
         noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LEAK_G), "CZ": bad})
 
 
-# --- 11. Plain-pipeline redirect points to clifft.noncomp.sample -------------
+# --- Plain-pipeline redirect points to clifft.noncomp.sample -----------------
 
 
 def test_compile_annotated_circuit_raises_invalid_argument_with_noncomp_sample_hint():
@@ -808,7 +812,7 @@ def test_sample_type_hints_resolve_at_runtime():
     assert "circuit" in hints
 
 
-# --- Item 1: QubitStatus enum (fine-grained status) --------------------------
+# --- QubitStatus enum ----------------------------------------------------------
 
 
 def test_qubit_status_values():
@@ -843,7 +847,7 @@ def test_fine_grained_leak_e_status():
     assert (r.final_status == noncomp.QubitStatus.LEAK_E).all()
 
 
-# --- Item 3: Model() with no initial_state defaults to ground state ----------
+# --- Default initial state ----------------------------------------------------
 
 
 def test_model_default_initial_state_constructs():
@@ -856,7 +860,7 @@ def test_model_default_initial_state_reads_zero():
     assert np.all(r.measurements == 0)
 
 
-# --- Item 5: Model.__repr__ --------------------------------------------------
+# --- Model repr ---------------------------------------------------------------
 
 
 def test_model_repr_contains_keys_and_damping():


### PR DESCRIPTION
## Summary

- simplify the public Python overview and damping/final-status descriptions
- document and test that noncomputational sampling rejects EXP_VAL probes
- align native binding comments with their actual behavior
- remove stale review numbering from the Python API tests
- add the EXP_VAL limitation to the leakage and loss guide

## Validation

- uv run pytest tests/python/ -q
- uv run pytest --codeblocks docs/ README.md -q
- uv run pre-commit run --all-files