### PR TITLE
feat(playground): explain noncomputational annotations in-app

### DIFF
--- a/playground/src/App.css
+++ b/playground/src/App.css
@@ -201,6 +201,21 @@ html, body, #root {
   flex-shrink: 0;
 }
 
+/* --- Compile error banner --- */
+.compile-error-banner {
+  padding: 6px 12px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--error-red);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.compile-error-banner a {
+  color: var(--accent);
+}
+
 /* --- Workspace --- */
 .workspace {
   flex: 1;

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -13,8 +13,9 @@ import { KHistoryChart } from "./components/KHistoryChart";
 import { HistogramChart } from "./components/HistogramChart";
 import { ExpValTable } from "./components/ExpValTable";
 import { GuidedTour } from "./components/GuidedTour";
+import { NoncompNotice } from "./components/NoncompNotice";
 import { registerLanguages } from "./languages";
-import { isCompileSuccess, isSimulateSuccess } from "./types";
+import { isCompileSuccess, isSimulateSuccess, isNoncompAnnotationError } from "./types";
 import type { CompileResult, CompileSuccess, SimulateResult, SourceOrigin } from "./types";
 
 const DEFAULT_SOURCE = `H 0
@@ -463,6 +464,8 @@ export default function App() {
     compileResult && isCompileSuccess(compileResult) ? compileResult : null;
   const baselineStats: CompileSuccess | null =
     baselineResult && isCompileSuccess(baselineResult) ? baselineResult : null;
+  const compileErrorMessage: string | null =
+    compileResult && !isCompileSuccess(compileResult) ? compileResult.error : null;
 
   // Format a stat with optional before->after arrow (only in diff mode)
   const formatStat = (label: string, optimized: number, baseline: number | undefined) => {
@@ -525,6 +528,11 @@ export default function App() {
           {formatStat("Measurements", stats.num_measurements, baselineStats?.num_measurements)}
           {formatStat("HIR ops", stats.hir_ops.length, baselineStats?.hir_ops.length)}
           {formatStat("Bytecode", stats.bytecode.length, baselineStats?.bytecode.length)}
+        </div>
+      )}
+      {compileErrorMessage && isNoncompAnnotationError(compileErrorMessage) && (
+        <div className="compile-error-banner">
+          <NoncompNotice />
         </div>
       )}
 

--- a/playground/src/components/HistogramChart.tsx
+++ b/playground/src/components/HistogramChart.tsx
@@ -8,9 +8,10 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
-import { isSimulateSuccess } from "../types";
+import { isSimulateSuccess, isNoncompAnnotationError } from "../types";
 import type { SimulateResult } from "../types";
 import type { ChartColors } from "../hooks/useTheme";
+import { NoncompNotice } from "./NoncompNotice";
 
 interface Props {
   result: SimulateResult | null;
@@ -55,6 +56,8 @@ export function HistogramChart({ result, elapsedMs, colors }: Props) {
             with many qubits but few T gates have low peak rank and should work
             fine. Use the native Python CLI for high-rank circuits.
           </>
+        ) : isNoncompAnnotationError(result.error) ? (
+          <NoncompNotice />
         ) : (
           result.error
         )}

--- a/playground/src/components/NoncompNotice.tsx
+++ b/playground/src/components/NoncompNotice.tsx
@@ -1,0 +1,20 @@
+const LEAKAGE_LOSS_GUIDE_URL = "https://unitaryfoundation.github.io/clifft/guide/leakage-and-loss/";
+
+// Friendly explanation shown in place of the raw compiler error when a
+// pasted circuit uses LOSS or LEVEL_TRANSITION. Those annotations require a
+// noncomp.Model and aren't reachable from the browser playground.
+export function NoncompNotice() {
+  return (
+    <>
+      <strong>
+        Leakage & loss annotations (LOSS, LEVEL_TRANSITION) aren't supported in the playground.
+      </strong>
+      <br />
+      See the{" "}
+      <a href={LEAKAGE_LOSS_GUIDE_URL} target="_blank" rel="noopener noreferrer">
+        leakage & loss guide
+      </a>{" "}
+      for the Python API.
+    </>
+  );
+}

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -52,6 +52,14 @@ export function isSimulateSuccess(r: SimulateResult): r is SimulateSuccess {
   return !('error' in r) || r.error === undefined;
 }
 
+// Matches the C++ frontend's rejection of LOSS / LEVEL_TRANSITION outside
+// clifft.noncomp.sample, e.g. "LOSS is a noncomputational annotation; run
+// the circuit through clifft.noncomp.sample instead of compiling it
+// directly". A substring check keeps this robust to which gate triggered it.
+export function isNoncompAnnotationError(error: string): boolean {
+  return error.includes("noncomputational annotation");
+}
+
 export interface ClifftModule {
   get_available_passes: () => string;
   compile_to_json: (source: string, passes_json: string) => string;


### PR DESCRIPTION
> [!NOTE]
> Prototype PR into the `bc-cleanup-noncomputational-mvp` feature branch — lighter review bar than main.

Pasting a circuit with `LOSS` or `LEVEL_TRANSITION` into the playground currently surfaces the raw C++ error, which tells users to "run the circuit through clifft.noncomp.sample" — a dead end in the browser (no noncomp entry in wasm, and no way to define a `noncomp.Model` from pasted text). This renders playground-appropriate guidance instead.

## What changed

- **`NoncompNotice`** — one shared component: *"Leakage & loss annotations (LOSS, LEVEL_TRANSITION) aren't supported in the playground. See the leakage & loss guide for the Python API."* with the guide linked (external-link idiom matched to the app's existing one).
- **Both surfaces the error reaches** (traced, not assumed): the compile path (`App.tsx` — new scoped banner below the toolbar; general compile errors keep their existing rendering) and the simulate path (`HistogramChart.tsx` — one more branch beside the existing `MemoryLimitExceeded` special case; the Simulate button isn't gated on compile success, so a LOSS circuit reaches this path too).
- **Detection**: `isNoncompAnnotationError` in `types.ts` matches the C++ message on `"noncomputational annotation"`, robust to which gate triggered it. The C++ message itself is untouched — it remains correct guidance on the Python/C++ surfaces.

## Notes

- The guide URL (`…/guide/leakage-and-loss/`) was verified against `mkdocs.yml` (site_url + nav) and the live site's directory-URL convention; it 404s **today** only because the leakage guide exists solely on this feature branch — it resolves once the branch reaches main and docs deploy.
- No C++/wasm changes; no CMake churn.

## Validation

- `npm ci`, `npx tsc -b`, `npm run lint` — clean (mirrors the CI playground job)
- `npm run build` — succeeds; grepped the bundle to confirm copy, URL, and detection string survived bundling
- `pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)