### PR TITLE
perf(backend): reuse noise arena when lowering

### DIFF
--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -654,6 +654,30 @@ std::complex<double> frame_composition_phase(stim::Tableau<kStimWidth> composed,
 
 namespace {
 
+size_t validate_reusable_noise_channel_masks(const HirModule& hir) {
+    std::vector<bool> seen(hir.noise_channel_masks.size());
+    size_t count = 0;
+    for (const auto& op : hir.ops) {
+        if (op.op_type() != OpType::NOISE)
+            continue;
+        const auto site_idx = static_cast<size_t>(op.noise_site_idx());
+        if (site_idx >= hir.noise_sites.size())
+            throw std::runtime_error("noise site index out of bounds during consuming lowering");
+        for (const auto& channel : hir.noise_sites[site_idx].channels) {
+            const auto handle = static_cast<size_t>(channel.mask);
+            if (handle >= seen.size())
+                throw std::runtime_error(
+                    "noise channel mask handle out of bounds during consuming lowering");
+            if (seen[handle])
+                throw std::runtime_error(
+                    "duplicate noise channel mask handle during consuming lowering");
+            seen[handle] = true;
+            ++count;
+        }
+    }
+    return count;
+}
+
 CompiledModule lower_impl(const HirModule& hir,
                           std::optional<PauliMaskArena> reusable_noise_channel_masks,
                           std::span<const uint8_t> postselection_mask,
@@ -1137,8 +1161,10 @@ CompiledModule lower(HirModule&& hir, std::span<const uint8_t> postselection_mas
                      std::span<const uint8_t> expected_detectors,
                      std::span<const uint8_t> expected_observables) {
     // Noise-removing passes release the arena as a zero-width empty object.
-    // Rebuild the correctly sized empty pool when there is nothing to reuse.
-    if (hir.noise_channel_masks.num_words() != (hir.num_qubits + 63) / 64) {
+    // Overallocated frontend arenas are also copied into a compact pool.
+    const size_t actual_channel_count = validate_reusable_noise_channel_masks(hir);
+    if (hir.noise_channel_masks.num_words() != (hir.num_qubits + 63) / 64 ||
+        hir.noise_channel_masks.size() != actual_channel_count) {
         return lower_impl(hir, std::nullopt, postselection_mask, expected_detectors,
                           expected_observables);
     }

--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -652,9 +652,13 @@ std::complex<double> frame_composition_phase(stim::Tableau<kStimWidth> composed,
 // lower(): Full pipeline wiring
 // =========================================================================
 
-CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselection_mask,
-                     std::span<const uint8_t> expected_detectors,
-                     std::span<const uint8_t> expected_observables) {
+namespace {
+
+CompiledModule lower_impl(const HirModule& hir,
+                          std::optional<PauliMaskArena> reusable_noise_channel_masks,
+                          std::span<const uint8_t> postselection_mask,
+                          std::span<const uint8_t> expected_detectors,
+                          std::span<const uint8_t> expected_observables) {
     using internal::CompilerContext;
     using internal::localize_pauli;
     using internal::LocalizedBasis;
@@ -687,7 +691,14 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
         num_noise_channels += site.channels.size();
     ctx.constant_pool.pauli_masks = PauliMaskArena(n, num_apply_paulis);
     ctx.constant_pool.exp_val_masks = PauliMaskArena(n, num_exp_val_masks);
-    ctx.constant_pool.noise_channel_masks = PauliMaskArena(n, num_noise_channels);
+    const bool reuse_noise_masks = reusable_noise_channel_masks.has_value();
+    if (reuse_noise_masks) {
+        ctx.constant_pool.noise_channel_masks = std::move(*reusable_noise_channel_masks);
+    } else {
+        ctx.constant_pool.noise_channel_masks = PauliMaskArena(n, num_noise_channels);
+    }
+    const PauliMaskArena& source_noise_channel_masks =
+        reuse_noise_masks ? ctx.constant_pool.noise_channel_masks : hir.noise_channel_masks;
     ctx.constant_pool.instrument_destination_flip_masks =
         PauliMaskArena(n, hir.instrument_sites.size());
     size_t next_cp_pauli = 0;
@@ -857,8 +868,9 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
 
                 NoiseSite mapped_site;
                 for (const auto& ch : hir_site.channels) {
-                    auto in_view = hir.noise_channel_masks.at(ch.mask);
-                    auto out_handle = static_cast<PauliMaskHandle>(next_cp_noise++);
+                    auto in_view = source_noise_channel_masks.at(ch.mask);
+                    auto out_handle =
+                        reuse_noise_masks ? ch.mask : static_cast<PauliMaskHandle>(next_cp_noise++);
                     auto out_slot = ctx.constant_pool.noise_channel_masks.mut_at(out_handle);
                     ctx.virtual_frame.map_noise_channel(in_view.x(), in_view.z(), out_slot.x(),
                                                         out_slot.z(), n);
@@ -1110,6 +1122,29 @@ CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselectio
     rebuild_instrument_offsets(result);
 
     return result;
+}
+
+}  // namespace
+
+CompiledModule lower(const HirModule& hir, std::span<const uint8_t> postselection_mask,
+                     std::span<const uint8_t> expected_detectors,
+                     std::span<const uint8_t> expected_observables) {
+    return lower_impl(hir, std::nullopt, postselection_mask, expected_detectors,
+                      expected_observables);
+}
+
+CompiledModule lower(HirModule&& hir, std::span<const uint8_t> postselection_mask,
+                     std::span<const uint8_t> expected_detectors,
+                     std::span<const uint8_t> expected_observables) {
+    // Noise-removing passes release the arena as a zero-width empty object.
+    // Rebuild the correctly sized empty pool when there is nothing to reuse.
+    if (hir.noise_channel_masks.num_words() != (hir.num_qubits + 63) / 64) {
+        return lower_impl(hir, std::nullopt, postselection_mask, expected_detectors,
+                          expected_observables);
+    }
+    auto noise_channel_masks = std::move(hir.noise_channel_masks);
+    return lower_impl(hir, std::move(noise_channel_masks), postselection_mask, expected_detectors,
+                      expected_observables);
 }
 
 void rebuild_instrument_offsets(CompiledModule& module) {

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -443,4 +443,11 @@ void rebuild_instrument_offsets(CompiledModule& module);
                                    std::span<const uint8_t> expected_detectors = {},
                                    std::span<const uint8_t> expected_observables = {});
 
+/// Consuming lowering overload. Reuses HIR-owned noise mask storage for the
+/// compiled constant pool, avoiding a second full arena during lowering.
+[[nodiscard]] CompiledModule lower(HirModule&& hir,
+                                   std::span<const uint8_t> postselection_mask = {},
+                                   std::span<const uint8_t> expected_detectors = {},
+                                   std::span<const uint8_t> expected_observables = {});
+
 }  // namespace clifft

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -443,8 +443,9 @@ void rebuild_instrument_offsets(CompiledModule& module);
                                    std::span<const uint8_t> expected_detectors = {},
                                    std::span<const uint8_t> expected_observables = {});
 
-/// Consuming lowering overload. Reuses HIR-owned noise mask storage for the
-/// compiled constant pool, avoiding a second full arena during lowering.
+/// Consuming lowering overload. Reuses exactly sized HIR-owned noise mask
+/// storage for the compiled constant pool, avoiding a second full arena during
+/// lowering. Overallocated arenas are copied into a compact pool instead.
 [[nodiscard]] CompiledModule lower(HirModule&& hir,
                                    std::span<const uint8_t> postselection_mask = {},
                                    std::span<const uint8_t> expected_detectors = {},

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -204,7 +204,8 @@ class VirtualFrame {
 
     /// Map a noise channel's (X, Z) masks through the current virtual frame
     /// and write the result into `out_x` and `out_z`. Sign is unused for
-    /// noise channels.
+    /// noise channels. Inputs may alias outputs; both inputs are copied before
+    /// either output is cleared.
     void map_noise_channel(MaskView in_x, MaskView in_z, MutableMaskView out_x,
                            MutableMaskView out_z, uint32_t n) {
         // Flush eagerly here. A noise op typically maps several channels

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -216,8 +216,6 @@ class VirtualFrame {
         // mappings see an empty queue (cheap early-out).
         flush();
 
-        out_x.zero_out();
-        out_z.zero_out();
         const uint32_t words = (n + 63) / 64;
 
         // Take the tableau row by view, not by value: materialized_.xs[q]
@@ -232,17 +230,22 @@ class VirtualFrame {
             }
         };
 
+        // Copy both inputs before clearing the outputs so lowering can map
+        // an arena slot in place.
+        noise_x_scratch_.assign(in_x.words.begin(), in_x.words.end());
+        noise_z_scratch_.assign(in_z.words.begin(), in_z.words.end());
+        out_x.zero_out();
+        out_z.zero_out();
+
         // Iterate set X-bits via a working copy. Reuses member-owned scratch
         // storage so QEC circuits that map thousands of noise channels per
         // compile don't pay a heap round-trip per channel.
-        noise_x_scratch_.assign(in_x.words.begin(), in_x.words.end());
         MutableMaskView x_iter{std::span<uint64_t>(noise_x_scratch_)};
         while (!x_iter.is_zero()) {
             uint32_t q = x_iter.lowest_bit();
             xor_row(materialized_.xs[q]);
             x_iter.clear_lowest_bit();
         }
-        noise_z_scratch_.assign(in_z.words.begin(), in_z.words.end());
         MutableMaskView z_iter{std::span<uint64_t>(noise_z_scratch_)};
         while (!z_iter.is_zero()) {
             uint32_t q = z_iter.lowest_bit();

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -936,8 +936,8 @@ NB_MODULE(_clifft_core, m) {
                 expected_observables = std::move(ref.observables);
             }
 
-            auto program =
-                clifft::lower(hir, postselection_mask, expected_detectors, expected_observables);
+            auto program = clifft::lower(std::move(hir), postselection_mask, expected_detectors,
+                                         expected_observables);
             if (bytecode_passes)
                 bytecode_passes->run(program);
             return program;

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1563,29 +1563,40 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
 }
 
 TEST_CASE("Lower: consuming overload maps noise masks in place") {
-    HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/1);
+    HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/2);
 
     NoiseSite site;
-    site.channels.push_back({clifft::test::claim_noise_channel_mask(hir, X(0), 0), 0.25});
+    const auto x_handle = clifft::test::claim_noise_channel_mask(hir, X(0), 0);
+    const auto z_handle = clifft::test::claim_noise_channel_mask(hir, 0, Z(0));
+    // Reverse handle order so preserving the HIR handles distinguishes the
+    // consuming reuse path from the compact allocating path.
+    site.channels.push_back({z_handle, 0.25});
+    site.channels.push_back({x_handle, 0.5});
     hir.noise_sites.push_back(site);
 
-    // The pending H maps X to Z. This specifically checks that an aliased
-    // input slot is copied before the output slot is cleared.
+    // The pending H swaps X and Z. This specifically checks that each aliased
+    // input slot is copied before its output slot is cleared.
     clifft::test::append_tgate(hir, X(0), 0, false);
     hir.append_noise(NoiseSiteIdx{0});
 
     auto expected = lower(hir);
     auto actual = lower(std::move(hir));
 
-    CHECK(actual.constant_pool.noise_channel_masks.size() == 1);
+    REQUIRE(expected.constant_pool.noise_sites[0].channels.size() == 2);
+    REQUIRE(actual.constant_pool.noise_sites[0].channels.size() == 2);
+    CHECK(actual.constant_pool.noise_channel_masks.size() == 2);
+    CHECK(actual.constant_pool.noise_sites[0].channels[0].mask == z_handle);
+    CHECK(actual.constant_pool.noise_sites[0].channels[1].mask == x_handle);
 
-    const auto expected_handle = expected.constant_pool.noise_sites[0].channels[0].mask;
-    const auto actual_handle = actual.constant_pool.noise_sites[0].channels[0].mask;
-    const auto expected_mask = expected.constant_pool.noise_channel_masks.at(expected_handle);
-    const auto actual_mask = actual.constant_pool.noise_channel_masks.at(actual_handle);
-    CHECK(actual_mask.x() == expected_mask.x());
-    CHECK(actual_mask.z() == expected_mask.z());
-    CHECK(actual_mask.sign() == expected_mask.sign());
+    for (size_t i = 0; i < 2; ++i) {
+        const auto expected_handle = expected.constant_pool.noise_sites[0].channels[i].mask;
+        const auto actual_handle = actual.constant_pool.noise_sites[0].channels[i].mask;
+        const auto expected_mask = expected.constant_pool.noise_channel_masks.at(expected_handle);
+        const auto actual_mask = actual.constant_pool.noise_channel_masks.at(actual_handle);
+        CHECK(actual_mask.x() == expected_mask.x());
+        CHECK(actual_mask.z() == expected_mask.z());
+        CHECK(actual_mask.sign() == expected_mask.sign());
+    }
 }
 
 TEST_CASE("Lower: consuming overload compacts overallocated noise arena") {

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1563,11 +1563,9 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
 }
 
 TEST_CASE("Lower: consuming overload maps noise masks in place") {
-    HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/2);
+    HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/1);
 
     NoiseSite site;
-    // Leave slot zero unused so the consuming path must preserve the HIR handle.
-    clifft::test::claim_noise_channel_mask(hir, 0, 0);
     site.channels.push_back({clifft::test::claim_noise_channel_mask(hir, X(0), 0), 0.25});
     hir.noise_sites.push_back(site);
 
@@ -1579,7 +1577,7 @@ TEST_CASE("Lower: consuming overload maps noise masks in place") {
     auto expected = lower(hir);
     auto actual = lower(std::move(hir));
 
-    CHECK(actual.constant_pool.noise_channel_masks.size() == 2);
+    CHECK(actual.constant_pool.noise_channel_masks.size() == 1);
 
     const auto expected_handle = expected.constant_pool.noise_sites[0].channels[0].mask;
     const auto actual_handle = actual.constant_pool.noise_sites[0].channels[0].mask;
@@ -1588,6 +1586,37 @@ TEST_CASE("Lower: consuming overload maps noise masks in place") {
     CHECK(actual_mask.x() == expected_mask.x());
     CHECK(actual_mask.z() == expected_mask.z());
     CHECK(actual_mask.sign() == expected_mask.sign());
+}
+
+TEST_CASE("Lower: consuming overload compacts overallocated noise arena") {
+    auto hir = clifft::trace(parse("PAULI_CHANNEL_1(0, 0.25, 0) 0"));
+    REQUIRE(hir.noise_channel_masks.size() == 3);
+
+    auto actual = lower(std::move(hir));
+
+    CHECK(actual.constant_pool.noise_channel_masks.size() == 1);
+}
+
+TEST_CASE("Lower: consuming overload rejects out of bounds noise handles") {
+    HirModule hir(1, /*pauli_capacity=*/0, /*noise_channel_capacity=*/1);
+    NoiseSite site;
+    site.channels.push_back({PauliMaskHandle{1}, 0.25});
+    hir.noise_sites.push_back(site);
+    hir.append_noise(NoiseSiteIdx{0});
+
+    CHECK_THROWS_AS(lower(std::move(hir)), std::runtime_error);
+}
+
+TEST_CASE("Lower: consuming overload rejects duplicate noise handles") {
+    HirModule hir(1, /*pauli_capacity=*/0, /*noise_channel_capacity=*/1);
+    const auto handle = clifft::test::claim_noise_channel_mask(hir, X(0), 0);
+    NoiseSite site;
+    site.channels.push_back({handle, 0.1});
+    site.channels.push_back({handle, 0.2});
+    hir.noise_sites.push_back(site);
+    hir.append_noise(NoiseSiteIdx{0});
+
+    CHECK_THROWS_AS(lower(std::move(hir)), std::runtime_error);
 }
 
 TEST_CASE("Lower: consuming overload restores width after noise removal") {

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1561,3 +1561,41 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
     CHECK(cv.z() == Z(0));
     CHECK_THAT(ch.prob, Catch::Matchers::WithinAbs(0.25, 1e-12));
 }
+
+TEST_CASE("Lower: consuming overload maps noise masks in place") {
+    HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/2);
+
+    NoiseSite site;
+    // Leave slot zero unused so the consuming path must preserve the HIR handle.
+    clifft::test::claim_noise_channel_mask(hir, 0, 0);
+    site.channels.push_back({clifft::test::claim_noise_channel_mask(hir, X(0), 0), 0.25});
+    hir.noise_sites.push_back(site);
+
+    // The pending H maps X to Z. This specifically checks that an aliased
+    // input slot is copied before the output slot is cleared.
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    hir.append_noise(NoiseSiteIdx{0});
+
+    auto expected = lower(hir);
+    auto actual = lower(std::move(hir));
+
+    CHECK(actual.constant_pool.noise_channel_masks.size() == 2);
+
+    const auto expected_handle = expected.constant_pool.noise_sites[0].channels[0].mask;
+    const auto actual_handle = actual.constant_pool.noise_sites[0].channels[0].mask;
+    const auto expected_mask = expected.constant_pool.noise_channel_masks.at(expected_handle);
+    const auto actual_mask = actual.constant_pool.noise_channel_masks.at(actual_handle);
+    CHECK(actual_mask.x() == expected_mask.x());
+    CHECK(actual_mask.z() == expected_mask.z());
+    CHECK(actual_mask.sign() == expected_mask.sign());
+}
+
+TEST_CASE("Lower: consuming overload restores width after noise removal") {
+    auto hir = clifft::trace(parse("X_ERROR(0.1) 0"));
+    RemoveNoisePass strip;
+    strip.run(hir);
+
+    auto actual = lower(std::move(hir));
+
+    CHECK(actual.constant_pool.noise_channel_masks.num_words() == 1);
+}


### PR DESCRIPTION
## Summary

When I ran simulation for some large-distance QEC circuits using clifft, I noticed the single-thread memory consumption can be very high. After some profiling, I found reusing the existing noise arena during consuming lowering can reduce the peak memory usage by half on some workloads. 

The lowering pass now moves HIR-owned noise masks into the compiled constant pool instead of allocating a second full arena. This reduces peak memory for large noisy circuits while preserving the existing runtime behavior.

## Benchmarks

Measured with GCC 15, `RelWithDebInfo`, native CPU baseline, one pinned CPU core, and the consuming lowering path. Values are median results.

| Workload | Baseline peak RSS | Branch peak RSS | Memory change | Baseline time | Branch time | Time change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| DEPOLARIZE2, 1024 qubits, 5,000 shots | 49.18 MiB | 30.70 MiB | -37.6% | 67.488 ms | 65.274 ms | -3.3% |
| DEPOLARIZE2, 2,048 qubits, 10,000 shots | 171.27 MiB | 98.01 MiB | -42.8% | 395.225 ms | 386.187 ms | -2.3% |

The change lowers peak memory substantially and shows no compile-time regression on either memory-heavy workload.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
  - 1,106 non-benchmark tests passed
- [x] Python tests pass (`uv run pytest tests/python/ -v`)
  - 862 passed using the GCC 15 workaround
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
  - 30 passed, 7 skipped
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)
  - All hooks passed using the no-project workaround

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
