### PR TITLE
docs: prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.0] - 2026-07-31
+
+Clifft 0.7.0 adds experimental simulation of leakage and loss through the new
+`clifft.noncomp` Python API. It samples trajectories across two computational
+levels, two leaked levels, and loss, with state-dependent transitions,
+state-selective measurement, and back-action on the computational state.
+Transitions can be attached to gates or placed explicitly in the circuit, and
+results include measurement records, detector and observable values, heralds,
+and final per-qubit status.
+
+The [Leakage and Loss guide](https://unitaryfoundation.github.io/clifft/guide/leakage-and-loss/)
+introduces the model and API. The [Delayed Loss tutorial](https://unitaryfoundation.github.io/clifft/guide/delayed-loss/)
+applies it to a surface-code memory experiment, where losses of the same data
+qubit at different times produce the same final herald but different detector
+histories.
+
+### CI
+
+- pin NumPy for mypy hook (#221) by @bachase in [#221](https://github.com/unitaryfoundation/clifft/pull/221)
+
+### Documentation
+
+- add delayed-loss surface-code tutorial (#233) by @bachase in [#233](https://github.com/unitaryfoundation/clifft/pull/233)
+
+### Features
+
+- add leakage and loss simulation (#231) by @bachase in [#231](https://github.com/unitaryfoundation/clifft/pull/231)
+
+### Testing
+
+- align and simplify unit coverage (#230) by @bachase in [#230](https://github.com/unitaryfoundation/clifft/pull/230)
+
 ## [0.6.0] - 2026-07-14
 
 Clifft 0.6.0 adds Stim-compatible correlated Pauli noise chains through

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,8 +96,17 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 
 [Use Qiskit or Cirq](getting-started/integrations.md){ .md-button }
 
-## What's New in 0.6.0
+## What's New in 0.7.0
 
-Clifft 0.6.0 adds Stim-compatible correlated Pauli noise chains through `CORRELATED_ERROR` / `E` and `ELSE_CORRELATED_ERROR`. A new [front-end integrations guide](getting-started/integrations.md) also shows how to run supported Qiskit and Cirq circuits with the separately maintained `clifft-qiskit` and `clifft-cirq` companion packages.
+Clifft 0.7.0 adds experimental simulation of leakage and loss through the new
+`clifft.noncomp` Python API. Define state-dependent transitions among two
+computational levels, two leaked levels, and loss; attach them to gates or
+explicit circuit instructions; and sample measurement, detector, observable,
+herald, and final-status data while accounting for quantum back-action.
+
+The [Leakage and Loss guide](guide/leakage-and-loss.md) introduces the model
+and API. The [Delayed Loss tutorial](guide/delayed-loss.md) follows data-qubit
+loss through a surface-code memory experiment and shows why the time of a loss
+matters even when the final herald is the same.
 
 [Full Changelog](https://github.com/unitaryfoundation/clifft/blob/main/CHANGELOG.md){ .md-button }


### PR DESCRIPTION
## Summary

- add the curated v0.7.0 changelog section for experimental leakage and loss simulation
- update the documentation home page with the 0.7.0 release summary
- link the leakage and loss guide and delayed-loss surface-code tutorial
- classify the NumPy pin for the mypy hook as a CI change

## Validation

- TestPyPI 0.7.0.dev1 release completed successfully
- uv run pre-commit run --all-files
- strict MkDocs build

## Release note

Merging this PR prepares the release notes only. It does not create or push the v0.7.0 tag, publish to production PyPI, or create a GitHub Release.