### PR TITLE
perf(noncomp): reuse noise arena for continuations

### DIFF
--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -386,18 +386,18 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
             std::to_string(rewrite.classified_measurements.size()) +
             " classified measurement(s); every classified measurement needs exactly one flag");
     }
-    Circuit patched = std::move(rewrite.circuit);
-    for (size_t i = 0; i < herald_flags.size(); ++i) {
-        if (herald_flags[i] != 0) {
-            const ClassifiedMeasurement& measurement = rewrite.classified_measurements[i];
-            assert(measurement.noise_node.has_value() &&
-                   "classified measurement must have a READOUT_NOISE node to patch for herald");
-            patched.nodes[*measurement.noise_node].args[0] = 0.5;
-        }
-    }
-
     std::optional<size_t> forced_traceout_slot;
     CompiledModule module = [&]() {
+        Circuit patched = std::move(rewrite.circuit);
+        for (size_t i = 0; i < herald_flags.size(); ++i) {
+            if (herald_flags[i] != 0) {
+                const ClassifiedMeasurement& measurement = rewrite.classified_measurements[i];
+                assert(measurement.noise_node.has_value() &&
+                       "classified measurement must have a READOUT_NOISE node to patch for herald");
+                patched.nodes[*measurement.noise_node].args[0] = 0.5;
+            }
+        }
+
         // When the rewrite names a forced trace-out node, ask trace() to report
         // the hidden slot it assigns to that reset.
         std::optional<InstrumentTraceOptions> forced_trace_options;

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -396,39 +396,41 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
         }
     }
 
-    // When the rewrite names a forced trace-out node, ask trace() to report
-    // the hidden slot it assigns to that reset.
-    HirModule hir = [&]() -> HirModule {
-        if (rewrite.forced_traceout_node.has_value()) {
-            InstrumentTraceOptions opts = instrument_options;
-            opts.forced_traceout_node = rewrite.forced_traceout_node;
-            return trace(patched, &opts);
-        }
-        return trace(patched, &instrument_options);
-    }();
-
     std::optional<size_t> forced_traceout_slot;
-    if (rewrite.forced_traceout_node.has_value()) {
-        if (!hir.forced_traceout_slot.has_value()) {
-            throw std::logic_error(
-                "sample_noncomputational: trace() did not encounter the forced "
-                "trace-out reset at node " +
-                std::to_string(*rewrite.forced_traceout_node) +
-                "; the rewrite and trace() must walk the same stream");
+    CompiledModule module = [&]() {
+        // When the rewrite names a forced trace-out node, ask trace() to report
+        // the hidden slot it assigns to that reset.
+        std::optional<InstrumentTraceOptions> forced_trace_options;
+        const InstrumentTraceOptions* trace_options = &instrument_options;
+        if (rewrite.forced_traceout_node.has_value()) {
+            forced_trace_options = instrument_options;
+            forced_trace_options->forced_traceout_node = rewrite.forced_traceout_node;
+            trace_options = &*forced_trace_options;
         }
-        forced_traceout_slot = hir.forced_traceout_slot;
-    }
+        HirModule hir = trace(patched, trace_options);
+
+        if (rewrite.forced_traceout_node.has_value()) {
+            if (!hir.forced_traceout_slot.has_value()) {
+                throw std::logic_error(
+                    "sample_noncomputational: trace() did not encounter the forced "
+                    "trace-out reset at node " +
+                    std::to_string(*rewrite.forced_traceout_node) +
+                    "; the rewrite and trace() must walk the same stream");
+            }
+            forced_traceout_slot = hir.forced_traceout_slot;
+        }
 
 #ifndef NDEBUG
-    const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
+        const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
 #endif
-    trajectory_hir_pass_manager().run(hir);
+        trajectory_hir_pass_manager().run(hir);
 #ifndef NDEBUG
-    assert(record_sequence(hir) == pre_pass_records &&
-           "a trajectory-pipeline HIR pass reordered or removed a record op");
+        assert(record_sequence(hir) == pre_pass_records &&
+               "a trajectory-pipeline HIR pass reordered or removed a record op");
 #endif
 
-    CompiledModule module = lower(std::move(hir));
+        return lower(std::move(hir));
+    }();
     trajectory_bytecode_pass_manager().run(module);
     check_max_rank(module, max_rank);
     if (module.instrument_offsets.size() != rewrite.site_targets.size()) {

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -428,7 +428,7 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
            "a trajectory-pipeline HIR pass reordered or removed a record op");
 #endif
 
-    CompiledModule module = lower(hir);
+    CompiledModule module = lower(std::move(hir));
     trajectory_bytecode_pass_manager().run(module);
     check_max_rank(module, max_rank);
     if (module.instrument_offsets.size() != rewrite.site_targets.size()) {

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -921,23 +921,25 @@ NB_MODULE(_clifft_core, m) {
            bool normalize_syndromes, clifft::HirPassManager* hir_passes,
            clifft::BytecodePassManager* bytecode_passes) {
             nb::gil_scoped_release release;
-            clifft::Circuit circuit = clifft::parse(stim_text);
-            clifft::HirModule hir = clifft::trace(circuit);
-            if (hir_passes)
-                hir_passes->run(hir);
+            auto program = [&]() {
+                clifft::Circuit circuit = clifft::parse(stim_text);
+                clifft::HirModule hir = clifft::trace(circuit);
+                if (hir_passes)
+                    hir_passes->run(hir);
 
-            if (normalize_syndromes) {
-                if (!expected_detectors.empty() || !expected_observables.empty()) {
-                    throw std::invalid_argument(
-                        "Cannot provide expected parities when normalize_syndromes=True");
+                if (normalize_syndromes) {
+                    if (!expected_detectors.empty() || !expected_observables.empty()) {
+                        throw std::invalid_argument(
+                            "Cannot provide expected parities when normalize_syndromes=True");
+                    }
+                    auto ref = clifft::compute_reference_syndrome(hir);
+                    expected_detectors = std::move(ref.detectors);
+                    expected_observables = std::move(ref.observables);
                 }
-                auto ref = clifft::compute_reference_syndrome(hir);
-                expected_detectors = std::move(ref.detectors);
-                expected_observables = std::move(ref.observables);
-            }
 
-            auto program = clifft::lower(std::move(hir), postselection_mask, expected_detectors,
-                                         expected_observables);
+                return clifft::lower(std::move(hir), postselection_mask, expected_detectors,
+                                     expected_observables);
+            }();
             if (bytecode_passes)
                 bytecode_passes->run(program);
             return program;


### PR DESCRIPTION
## Summary

- consume the temporary HIR when lowering trajectory continuations
- reuse exactly sized noise-mask storage during leak/loss recompilation
- scope consumed HIR modules in both the continuation compiler and Python compile binding so downstream code cannot accidentally reuse their partially moved state
- preserve compact fallback behavior for overallocated arenas

This is a follow-up to #234. Each consuming call now forms the terminal operation of a local compilation scope.

## Testing

- 1,109 C++ tests passed
- 862 Python tests passed
- all pre-commit hooks passed