### PR TITLE
feat: eliminate phases consumed by terminal measurements

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -90,11 +90,14 @@ def define_env(env: Any) -> None:
             "default_enabled": True,
             "preserves_record_order": True,
             "python_name": "PeepholeFusionPass",
-            "summary": "Algebraic T-gate cancellation and fusion.",
+            "summary": "Algebraic T-gate fusion and terminal-phase elimination.",
             "detail": (
                 "Scans the HIR to cancel or fuse T/T_dag gates acting on the "
                 "same virtual Pauli axis using the symplectic inner product as "
-                "a commutation check. T+T fuses to S, T+T_dag cancels to identity."
+                "a commutation check. T+T fuses to S, T+T_dag cancels to identity. "
+                "It also removes a T gate or Pauli phase rotation when a later "
+                "same-axis measurement consumes the phase; intervening Pauli "
+                "noise is left in place."
             ),
         },
         {

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -338,6 +338,74 @@ inline bool is_blocked(const HeisenbergOp& op_i, const HeisenbergOp& op_j, const
     }
 }
 
+/// Delete phase operations whose only remaining quantum effect is a phase in
+/// the eigenspaces of a later measurement on the same unsigned Pauli axis.
+///
+/// Pauli noise is transparent for this purpose even when it anti-commutes
+/// with the phase axis: branch by branch it only reverses the rotation
+/// direction, and the matching measurement discards either direction. Other
+/// phase operations and measurements may be crossed only when they commute
+/// with the candidate. Classical record consumers are inspected but never
+/// moved. All other operations are conservative barriers.
+size_t eliminate_terminal_measurement_phases(HirModule& hir, std::vector<uint8_t>& deleted) {
+    size_t eliminated = 0;
+
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        if (deleted[i])
+            continue;
+        const OpType candidate_type = hir.ops[i].op_type();
+        if (candidate_type != OpType::T_GATE && candidate_type != OpType::PHASE_ROTATION)
+            continue;
+
+        const MaskView candidate_x = hir.destab_mask(hir.ops[i]);
+        const MaskView candidate_z = hir.stab_mask(hir.ops[i]);
+
+        for (size_t j = i + 1; j < hir.ops.size(); ++j) {
+            if (deleted[j])
+                continue;
+            const HeisenbergOp& next = hir.ops[j];
+
+            switch (next.op_type()) {
+                case OpType::NOISE:
+                case OpType::DETECTOR:
+                case OpType::OBSERVABLE:
+                case OpType::READOUT_NOISE:
+                    continue;
+
+                case OpType::MEASURE:
+                    if (hir.destab_mask(next) == candidate_x &&
+                        hir.stab_mask(next) == candidate_z) {
+                        deleted[i] = true;
+                        ++eliminated;
+                        break;
+                    }
+                    if (!anti_commute(candidate_x, candidate_z, hir.destab_mask(next),
+                                      hir.stab_mask(next))) {
+                        continue;
+                    }
+                    break;
+
+                case OpType::T_GATE:
+                case OpType::PHASE_ROTATION:
+                    if (!anti_commute(candidate_x, candidate_z, hir.destab_mask(next),
+                                      hir.stab_mask(next))) {
+                        continue;
+                    }
+                    break;
+
+                case OpType::CONDITIONAL_PAULI:
+                case OpType::EXP_VAL:
+                case OpType::INSTRUMENT:
+                case OpType::NUM_OP_TYPES:
+                    break;
+            }
+            break;
+        }
+    }
+
+    return eliminated;
+}
+
 }  // namespace
 
 void PeepholeFusionPass::run(HirModule& hir) {
@@ -537,6 +605,12 @@ void PeepholeFusionPass::run(HirModule& hir) {
                 ++fusions_;
                 changed = true;
             }
+        }
+
+        const size_t terminal_eliminations = eliminate_terminal_measurement_phases(hir, deleted);
+        if (terminal_eliminations != 0) {
+            cancellations_ += terminal_eliminations;
+            changed = true;
         }
 
         // Compact: remove deleted ops via erase-remove idiom

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -365,39 +365,26 @@ size_t eliminate_terminal_measurement_phases(HirModule& hir, std::vector<uint8_t
                 continue;
             const HeisenbergOp& next = hir.ops[j];
 
-            switch (next.op_type()) {
-                case OpType::NOISE:
-                case OpType::DETECTOR:
-                case OpType::OBSERVABLE:
-                case OpType::READOUT_NOISE:
-                    continue;
+            // These are the two deliberate differences from ordinary
+            // commutation: terminal phases may cross every Pauli-noise branch,
+            // while conditional Paulis remain conservative barriers.
+            if (next.op_type() == OpType::NOISE) {
+                continue;
+            }
 
-                case OpType::MEASURE:
-                    if (hir.destab_mask(next) == candidate_x &&
-                        hir.stab_mask(next) == candidate_z) {
-                        deleted[i] = true;
-                        ++eliminated;
-                        break;
-                    }
-                    if (!anti_commute(candidate_x, candidate_z, hir.destab_mask(next),
-                                      hir.stab_mask(next))) {
-                        continue;
-                    }
-                    break;
+            if (next.op_type() == OpType::CONDITIONAL_PAULI) {
+                break;
+            }
 
-                case OpType::T_GATE:
-                case OpType::PHASE_ROTATION:
-                    if (!anti_commute(candidate_x, candidate_z, hir.destab_mask(next),
-                                      hir.stab_mask(next))) {
-                        continue;
-                    }
-                    break;
+            if (next.op_type() == OpType::MEASURE && hir.destab_mask(next) == candidate_x &&
+                hir.stab_mask(next) == candidate_z) {
+                deleted[i] = true;
+                ++eliminated;
+                break;
+            }
 
-                case OpType::CONDITIONAL_PAULI:
-                case OpType::EXP_VAL:
-                case OpType::INSTRUMENT:
-                case OpType::NUM_OP_TYPES:
-                    break;
+            if (!is_blocked(hir.ops[i], next, hir)) {
+                continue;
             }
             break;
         }

--- a/src/clifft/optimizer/peephole.h
+++ b/src/clifft/optimizer/peephole.h
@@ -29,8 +29,8 @@ void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z
 }  // namespace internal
 
 /// Peephole fusion pass: scans the HIR to algebraically cancel or fuse
-/// T/T_dag gates acting on the same virtual Pauli axis using the
-/// symplectic inner product as a commutation check.
+/// T/T_dag gates acting on the same virtual Pauli axis, and removes Pauli
+/// phases consumed by a later same-axis measurement.
 class PeepholeFusionPass : public HirPass {
   public:
     void run(HirModule& hir) override;

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -561,8 +561,8 @@ NB_MODULE(_clifft_core, m) {
 
     nb::class_<clifft::PeepholeFusionPass, clifft::HirPass>(
         m, "PeepholeFusionPass",
-        "Symplectic peephole fusion: cancels and fuses T/T-dag gates on the "
-        "same virtual Pauli axis.")
+        "Symplectic peephole optimization: cancels and fuses T/T-dag gates, "
+        "and removes terminal phases consumed by same-axis measurements.")
         .def(nb::init<>())
         .def_prop_ro("cancellations", &clifft::PeepholeFusionPass::cancellations)
         .def_prop_ro("fusions", &clifft::PeepholeFusionPass::fusions)

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -10,6 +10,7 @@ import pytest
 from conftest import (
     assert_statevectors_componentwise_equal,
     assert_statevectors_equiv,
+    cross_binomial_tolerance,
     random_clifford_t_circuit,
     random_dense_clifford_t_circuit,
 )
@@ -88,6 +89,73 @@ class TestPeepholeAlgebraicIdentities:
         sv_baseline = _clifft_statevector(circuit)
         sv_optimized = _clifft_statevector(circuit, optimize=True)
         assert_statevectors_equiv(sv_optimized, sv_baseline)
+
+
+class TestTerminalMeasurementPhaseElimination:
+    """Phases diagonal in a later measurement basis are unobservable."""
+
+    @pytest.mark.parametrize("pauli_branch", ["", "X 0", "Y 0", "Z 0"])
+    def test_exact_deterministic_pauli_branches(self, pauli_branch: str) -> None:
+        """Every branch agrees exactly, including downstream feedback."""
+        branch = f"{pauli_branch}\n" if pauli_branch else ""
+        circuit = "H 0\n" "R_Z(0.37) 0\n" f"{branch}" "M 0\n" "CX rec[-1] 1\n" "M 1"
+        records = ["00", "01", "10", "11"]
+        baseline = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
+        optimized = clifft.compile(
+            circuit,
+            hir_passes=_peephole_pass_manager(),
+            bytecode_passes=None,
+        )
+
+        np.testing.assert_allclose(
+            clifft.record_probabilities(optimized, records),
+            clifft.record_probabilities(baseline, records),
+            atol=1e-12,
+        )
+        assert baseline.peak_rank == 1
+        assert optimized.peak_rank == 0
+
+    def test_noisy_broadcast_distribution_and_classical_outputs(self) -> None:
+        """The real noisy rewrite preserves the complete record distribution."""
+        circuit = (
+            "H 0 1\n"
+            "R_Z(0.17) 0 1\n"
+            "DEPOLARIZE1(0.2) 0 1\n"
+            "M 0 1\n"
+            "DETECTOR rec[-2]\n"
+            "DETECTOR rec[-1]\n"
+            "CX rec[-1] 2\n"
+            "M 2\n"
+            "OBSERVABLE_INCLUDE(0) rec[-1]"
+        )
+        baseline = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
+        optimized = clifft.compile(
+            circuit,
+            hir_passes=_peephole_pass_manager(),
+            bytecode_passes=None,
+        )
+        assert baseline.peak_rank == 2
+        assert optimized.peak_rank == 0
+
+        shots = 30_000
+        baseline_result = clifft.sample(baseline, shots, seed=238)
+        optimized_result = clifft.sample(optimized, shots, seed=239)
+
+        weights = 1 << np.arange(3, dtype=np.uint64)
+        baseline_bins = np.asarray(baseline_result.measurements, dtype=np.uint64) @ weights
+        optimized_bins = np.asarray(optimized_result.measurements, dtype=np.uint64) @ weights
+        baseline_probs = np.bincount(baseline_bins.astype(np.int64), minlength=8) / shots
+        optimized_probs = np.bincount(optimized_bins.astype(np.int64), minlength=8) / shots
+
+        for baseline_p, optimized_p in zip(baseline_probs, optimized_probs, strict=True):
+            pooled = float((baseline_p + optimized_p) / 2.0)
+            tolerance = cross_binomial_tolerance(pooled, shots, sigma=6.0)
+            assert abs(float(baseline_p - optimized_p)) <= tolerance
+
+        for result in (baseline_result, optimized_result):
+            np.testing.assert_array_equal(result.detectors[:, 0], result.measurements[:, 0])
+            np.testing.assert_array_equal(result.detectors[:, 1], result.measurements[:, 1])
+            np.testing.assert_array_equal(result.observables[:, 0], result.measurements[:, 2])
 
 
 # Componentwise global-phase preservation of S absorption.

--- a/tests/python/test_source_map.py
+++ b/tests/python/test_source_map.py
@@ -52,6 +52,20 @@ def test_optimizer_preserves_source_map() -> None:
     assert op.as_dict()["op_type"] == "MEASURE"
 
 
+def test_terminal_phase_elimination_removes_only_its_source_entry() -> None:
+    """Deleting a terminal phase keeps remaining HIR provenance aligned."""
+    hir = clifft.trace(clifft.parse("H 0\nR_Z(0.02) 0\nX_ERROR(0.01) 0\nM 0"))
+    assert hir.source_map == [[2], [3], [4]]
+
+    pm = clifft.HirPassManager()
+    pm.add(clifft.PeepholeFusionPass())
+    pm.run(hir)
+
+    assert hir.source_map == [[3], [4]]
+    assert len(hir.source_map) == hir.num_ops
+    assert [op.as_dict()["op_type"] for op in hir] == ["NOISE", "MEASURE"]
+
+
 def test_empty_circuit_produces_empty_maps() -> None:
     """Empty circuit yields empty source_map and k_history."""
     prog = clifft.lower(clifft.trace(clifft.parse("")))

--- a/tests/test_backend_instruments.cc
+++ b/tests/test_backend_instruments.cc
@@ -262,3 +262,21 @@ TEST_CASE("fences: prefix compilation is bit-identical across different suffixes
         REQUIRE(std::memcmp(&a.bytecode[i], &b.bytecode[i], sizeof(Instruction)) == 0);
     }
 }
+
+TEST_CASE("fences: terminal phase elimination does not cross an instrument") {
+    const auto options = source_dependent_jump_options();
+    const char* with_matching_measurement = "H 0\nR_Z(0.02) 0\nLEVEL_TRANSITION[jump] 0\nM 0";
+    const char* with_other_suffix = "H 0\nR_Z(0.02) 0\nLEVEL_TRANSITION[jump] 0\nH 0\nM 0";
+
+    auto a = compile_instruments_full(with_matching_measurement, options);
+    auto b = compile_instruments_full(with_other_suffix, options);
+
+    REQUIRE(a.instrument_offsets.size() == 1);
+    REQUIRE(b.instrument_offsets.size() == 1);
+    const uint32_t offset = a.instrument_offsets[0];
+    REQUIRE(b.instrument_offsets[0] == offset);
+
+    for (uint32_t i = 0; i <= offset; ++i) {
+        REQUIRE(std::memcmp(&a.bytecode[i], &b.bytecode[i], sizeof(Instruction)) == 0);
+    }
+}

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -159,6 +159,98 @@ TEST_CASE("Peephole: NOISE channel does not block when commuting", "[optimizer]"
     REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
 }
 
+TEST_CASE("Peephole: terminal phase is removed across Pauli noise", "[optimizer]") {
+    auto hir = hir_from("H 0\nR_Z(0.02) 0\nX_ERROR(0.01) 0\nM 0");
+    REQUIRE(hir.ops.size() == 3);
+    REQUIRE(!can_swap(hir.ops[0], hir.ops[1], hir));
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == 2);
+    REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.ops[1].op_type() == OpType::MEASURE);
+    REQUIRE(pass.cancellations() == 1);
+}
+
+TEST_CASE("Peephole: terminal phases are removed from broadcast layers", "[optimizer]") {
+    auto hir = hir_from(
+        "H 0 1 2\n"
+        "R_Z(0.02) 0 1 2\n"
+        "X_ERROR(0.01) 0 1 2\n"
+        "M 0 1 2");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == 6);
+    for (size_t i = 0; i < 3; ++i) {
+        REQUIRE(hir.ops[i].op_type() == OpType::NOISE);
+        REQUIRE(hir.ops[i + 3].op_type() == OpType::MEASURE);
+    }
+    REQUIRE(pass.cancellations() == 3);
+}
+
+TEST_CASE("Peephole: terminal multi-Pauli phase is removed across correlated noise",
+          "[optimizer]") {
+    auto hir = hir_from(
+        "H 0 1\n"
+        "R_PAULI(0.02) Z0*Z1\n"
+        "CORRELATED_ERROR(0.01) X0\n"
+        "MPP Z0*Z1");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == 2);
+    REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.ops[1].op_type() == OpType::MEASURE);
+    REQUIRE(pass.cancellations() == 1);
+}
+
+TEST_CASE("Peephole: terminal T is removed before measurement-reset", "[optimizer]") {
+    auto hir = hir_from("H 0\nT 0\nY_ERROR(0.01) 0\nMR 0");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == 3);
+    REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.ops[1].op_type() == OpType::MEASURE);
+    REQUIRE(hir.ops[2].op_type() == OpType::CONDITIONAL_PAULI);
+    REQUIRE(pass.cancellations() == 1);
+}
+
+TEST_CASE("Peephole: terminal phase elimination respects barriers", "[optimizer]") {
+    SECTION("anti-commuting measurement") {
+        auto hir = hir_from("R_Z(0.02) 0\nMX 0\nM 0");
+        PeepholeFusionPass pass;
+        pass.run(hir);
+        REQUIRE(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    }
+
+    SECTION("anti-commuting phase") {
+        auto hir = hir_from("R_Z(0.02) 0\nR_X(0.03) 0\nM 0");
+        PeepholeFusionPass pass;
+        pass.run(hir);
+        REQUIRE(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    }
+
+    SECTION("conditional Pauli") {
+        auto hir = hir_from("M 1\nR_Z(0.02) 0\nCX rec[-1] 0\nM 0");
+        PeepholeFusionPass pass;
+        pass.run(hir);
+        REQUIRE(hir.ops[1].op_type() == OpType::PHASE_ROTATION);
+    }
+
+    SECTION("expectation value") {
+        auto hir = hir_from("R_Z(0.02) 0\nEXP_VAL Z0\nM 0");
+        PeepholeFusionPass pass;
+        pass.run(hir);
+        REQUIRE(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    }
+}
+
 TEST_CASE("Peephole: different axes do not fuse", "[optimizer]") {
     // H between the two Ts rotates the second to X-axis
     auto hir = hir_from("T 0\nH 0\nT 0");

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -132,6 +132,19 @@ TEST_CASE("trajectory: a certain leak reports the trapped classified status") {
     }
 }
 
+TEST_CASE("trajectory: a phase before a trap keeps the continuation prefix stable") {
+    ModelSpec spec;
+    spec.leak_from_g = 1.0;
+    spec.leak_from_e = 1.0;
+    auto model = make_driver_model(spec);
+    auto circuit = parse("H 0\nR_Z(0.02) 0\nLEVEL_TRANSITION[leak] 0\nM 0");
+
+    auto result = sample_noncomputational(circuit, model, 10, 238);
+    for (uint8_t measurement : result.measurements) {
+        REQUIRE(measurement == 1);
+    }
+}
+
 TEST_CASE("trajectory: a known |1> initial preloads the frame without a distinct module") {
     // Initial state entirely on e: every shot must measure 1 through the
     // frame preload alone.


### PR DESCRIPTION
## Summary

- eliminate terminal `T_GATE` and `PHASE_ROTATION` operations when a later same-axis measurement consumes their phase
- support broadcast layers and multi-qubit Pauli rotations while scanning safely across Pauli noise, commuting coherent operations, and classical bookkeeping
- retain conservative barriers at instruments, expectation values, conditional Paulis, anti-commuting coherent operations, and incompatible measurements
- preserve HIR and source-map ordering without changing `can_swap()` or reordering stochastic instructions

This reduces the compiled peak rank for affected circuits without changing their joint measurement, detector, or observable distributions. It implements the first optimization proposed in #238 and incorporates the broadcast-layer case found during implementation.

Closes #238.

## Test plan

- [x] C++ tests pass (`1110/1110`; `ctest --test-dir /tmp/clifft-terminal-phase-build --output-on-failure`)
- [x] Python tests pass (`868 passed`; `uv run pytest tests/python/ -v`)
- [x] Doc examples pass (`30 passed, 7 skipped`; `uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

Coverage includes exact deterministic distribution oracles, noisy broadcast integration, correlated multi-Pauli errors, source-map compaction, optimizer barriers, and a live noncomputational trap/continuation case.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.
