### PR TITLE
fix(parser): reject invalid inverted targets

### DIFF
--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -61,6 +61,18 @@ bool is_discarded_annotation(std::string_view name) {
     return name == "QUBIT_COORDS" || name == "SHIFT_COORDS";
 }
 
+[[noreturn]] void throw_invalid_target_modifiers(std::string_view target,
+                                                 std::string_view gate_name, uint32_t line_num) {
+    throw ParseError("Target " + std::string(target) + " has invalid modifiers for gate type '" +
+                         std::string(gate_name) + "'",
+                     line_num);
+}
+
+std::string_view target_token_at(std::string_view targets, size_t pos) {
+    const size_t end = targets.find_first_of("* \t\r\n", pos);
+    return targets.substr(pos, end == std::string_view::npos ? end : end - pos);
+}
+
 // Trim whitespace from both ends.
 std::string_view trim(std::string_view s) {
     while (!s.empty() && std::isspace(static_cast<unsigned char>(s.front()))) {
@@ -461,9 +473,7 @@ class Parser {
                                  line_num);
             }
             if (target.is_inverted()) {
-                throw ParseError(
-                    "Gate " + std::string(gate_name) + " does not accept inverted targets",
-                    line_num);
+                throw_invalid_target_modifiers(token, gate_name, line_num);
             }
             targets.push_back(target);
         }
@@ -687,6 +697,16 @@ class Parser {
                     line_num);
             }
 
+            if (gate == GateType::READOUT_NOISE && token[0] == '!') {
+                throw ParseError(
+                    "READOUT_NOISE targets do not support inversion; swap the two flip "
+                    "probabilities instead",
+                    line_num);
+            }
+            if (!is_measurement(gate) && token[0] == '!') {
+                throw_invalid_target_modifiers(token, clifft::gate_name(gate), line_num);
+            }
+
             // Validate rec targets are only used for CX/CZ feedback forms
             // and READOUT_NOISE record flips.
             bool is_rec_token = token.starts_with("rec[") || (token.size() > 1 && token[0] == '!' &&
@@ -701,21 +721,6 @@ class Parser {
             if (!is_rec_token && gate == GateType::READOUT_NOISE) {
                 throw ParseError("READOUT_NOISE targets must be rec references", line_num);
             }
-            // '!' marks measurement-record inversion, which has no meaning
-            // on a transition or loss site. (Record targets on these gates
-            // are rejected by the rec-token check above.)
-            if ((gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) && token[0] == '!') {
-                throw ParseError(
-                    std::string(clifft::gate_name(gate)) + " targets must be plain qubit indices",
-                    line_num);
-            }
-            if (is_rec_token && gate == GateType::READOUT_NOISE && token[0] == '!') {
-                throw ParseError(
-                    "READOUT_NOISE targets do not support inversion; swap the two flip "
-                    "probabilities instead",
-                    line_num);
-            }
-
             Target target = parse_target(token, line_num, circuit);
             targets.push_back(target);
         }
@@ -935,11 +940,11 @@ class Parser {
         return inverted ? result.inverted() : result;
     }
 
-    std::vector<Target> parse_pauli_product(std::string_view product_str,
-                                            std::string_view gate_name, uint32_t line_num,
-                                            Circuit& circuit) {
+    std::vector<Target> parse_pauli_product(std::string_view product_str, GateType gate,
+                                            uint32_t line_num, Circuit& circuit) {
         std::vector<Target> pauli_targets;
         std::unordered_set<uint32_t> seen_qubits;
+        const std::string_view gate_name = clifft::gate_name(gate);
 
         size_t pos = 0;
         while (pos < product_str.size()) {
@@ -951,6 +956,19 @@ class Parser {
                 }
                 pos++;
                 continue;
+            }
+
+            bool inverted = false;
+            if (product_str[pos] == '!') {
+                if (!is_measurement(gate)) {
+                    throw_invalid_target_modifiers(target_token_at(product_str, pos), gate_name,
+                                                   line_num);
+                }
+                inverted = true;
+                pos++;
+                if (pos >= product_str.size() || product_str[pos] == '*') {
+                    throw ParseError("Expected Pauli target after '!'", line_num);
+                }
             }
 
             char pauli_char = product_str[pos];
@@ -980,7 +998,7 @@ class Parser {
 
             if (num_start == pos) {
                 std::string msg = "Expected qubit index after Pauli letter";
-                if (gate_name == "R_PAULI") {
+                if (gate == GateType::R_PAULI) {
                     msg += " in R_PAULI";
                 }
                 throw ParseError(msg, line_num);
@@ -1002,7 +1020,7 @@ class Parser {
             }
 
             if (pauli_targets.size() >= kMaxTargetsPerInstruction) {
-                if (gate_name == "R_PAULI") {
+                if (gate == GateType::R_PAULI) {
                     throw ParseError("Too many Pauli terms in R_PAULI product", line_num);
                 }
                 throw ParseError("Too many Pauli terms in product (limit: " +
@@ -1010,7 +1028,11 @@ class Parser {
                                  line_num);
             }
 
-            pauli_targets.push_back(Target::pauli(qubit, pauli_flag));
+            Target target = Target::pauli(qubit, pauli_flag);
+            if (inverted) {
+                target = target.inverted();
+            }
+            pauli_targets.push_back(target);
             circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
         }
 
@@ -1022,10 +1044,11 @@ class Parser {
     }
 
     std::vector<std::vector<Target>> parse_pauli_products(std::string_view targets_str,
-                                                          std::string_view gate_name,
-                                                          uint32_t line_num, Circuit& circuit) {
+                                                          GateType gate, uint32_t line_num,
+                                                          Circuit& circuit) {
         std::vector<std::vector<Target>> products;
         std::string_view remaining = targets_str;
+        const std::string_view gate_name = clifft::gate_name(gate);
 
         while (true) {
             std::string_view product_str = next_token(remaining);
@@ -1038,7 +1061,7 @@ class Parser {
                                  line_num);
             }
 
-            products.push_back(parse_pauli_product(product_str, gate_name, line_num, circuit));
+            products.push_back(parse_pauli_product(product_str, gate, line_num, circuit));
         }
 
         if (products.empty()) {
@@ -1055,7 +1078,6 @@ class Parser {
         struct FoldedTerm {
             uint32_t qubit;
             uint8_t xz_bits;
-            bool inverted;
         };
 
         std::vector<FoldedTerm> terms;
@@ -1078,13 +1100,9 @@ class Parser {
                 break;
             }
 
-            bool inverted = false;
             if (targets_str[pos] == '!') {
-                inverted = true;
-                ++pos;
-                if (pos >= targets_str.size()) {
-                    throw ParseError("Expected Pauli target after '!'", line_num);
-                }
+                throw_invalid_target_modifiers(target_token_at(targets_str, pos), gate_name,
+                                               line_num);
             }
 
             char pauli_char = targets_str[pos];
@@ -1138,11 +1156,10 @@ class Parser {
                     throw ParseError(
                         "Too many Pauli terms in " + std::string(gate_name) + " product", line_num);
                 }
-                terms.push_back({qubit, 0, false});
+                terms.push_back({qubit, 0});
             }
             FoldedTerm& term = terms[it->second];
             term.xz_bits ^= xz_bits;
-            term.inverted ^= inverted;
             circuit.num_qubits = std::max(circuit.num_qubits, qubit + 1);
         }
 
@@ -1165,9 +1182,6 @@ class Parser {
             }
 
             Target target = Target::pauli(term.qubit, pauli_flag);
-            if (term.inverted) {
-                target = target.inverted();
-            }
             targets.push_back(target);
         }
 
@@ -1183,7 +1197,7 @@ class Parser {
 
     // Parse MPP instruction with multiple Pauli products.
     void parse_mpp(std::string_view targets_str, uint32_t line_num, Circuit& circuit, double arg) {
-        auto products = parse_pauli_products(targets_str, "MPP", line_num, circuit);
+        auto products = parse_pauli_products(targets_str, GateType::MPP, line_num, circuit);
         for (auto& pauli_targets : products) {
             // Decompose noisy MPP: MPP(p) -> MPP + READOUT_NOISE
             bool is_noisy_meas = arg > 0.0;
@@ -1206,7 +1220,7 @@ class Parser {
     // Same Pauli product syntax as MPP but no noise argument.
     // Increments num_exp_vals (not num_measurements).
     void parse_exp_val(std::string_view targets_str, uint32_t line_num, Circuit& circuit) {
-        auto products = parse_pauli_products(targets_str, "EXP_VAL", line_num, circuit);
+        auto products = parse_pauli_products(targets_str, GateType::EXP_VAL, line_num, circuit);
         for (auto& pauli_targets : products) {
             // Emit one AstNode per product.
             AstNode node{GateType::EXP_VAL, std::move(pauli_targets), {}, line_num};
@@ -1230,7 +1244,7 @@ class Parser {
             throw ParseError("R_PAULI takes exactly one Pauli product", line_num);
         }
 
-        auto pauli_targets = parse_pauli_product(product_str, "R_PAULI", line_num, circuit);
+        auto pauli_targets = parse_pauli_product(product_str, GateType::R_PAULI, line_num, circuit);
 
         circuit.nodes.push_back({GateType::R_PAULI, std::move(pauli_targets), args, line_num});
     }

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -697,29 +697,31 @@ class Parser {
                     line_num);
             }
 
-            if (gate == GateType::READOUT_NOISE && token[0] == '!') {
+            const bool inverted = token.front() == '!';
+            const bool is_rec_token =
+                token.starts_with("rec[") || (inverted && token.substr(1).starts_with("rec["));
+
+            if (gate == GateType::READOUT_NOISE && !is_rec_token) {
+                throw ParseError("READOUT_NOISE targets must be rec references", line_num);
+            }
+            if (gate == GateType::READOUT_NOISE && inverted) {
                 throw ParseError(
                     "READOUT_NOISE targets do not support inversion; swap the two flip "
                     "probabilities instead",
                     line_num);
             }
-            if (!is_measurement(gate) && token[0] == '!') {
+            if (!is_measurement(gate) && inverted) {
                 throw_invalid_target_modifiers(token, clifft::gate_name(gate), line_num);
             }
 
             // Validate rec targets are only used for CX/CZ feedback forms
             // and READOUT_NOISE record flips.
-            bool is_rec_token = token.starts_with("rec[") || (token.size() > 1 && token[0] == '!' &&
-                                                              token.substr(1).starts_with("rec["));
             if (is_rec_token && gate != GateType::CX && gate != GateType::CZ &&
                 gate != GateType::READOUT_NOISE) {
                 throw ParseError(
                     "rec targets are only supported as feedback controls for CX/CZ gates "
                     "and as READOUT_NOISE targets",
                     line_num);
-            }
-            if (!is_rec_token && gate == GateType::READOUT_NOISE) {
-                throw ParseError("READOUT_NOISE targets must be rec references", line_num);
             }
             Target target = parse_target(token, line_num, circuit);
             targets.push_back(target);

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -16,6 +16,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace clifft;
@@ -29,6 +30,15 @@ static std::string make_pauli_channel3_args(double default_prob = 0.0) {
         args += std::to_string(default_prob);
     }
     return args;
+}
+
+static void check_parse_error(std::string_view circuit, std::string_view expected) {
+    try {
+        (void)parse(circuit);
+        FAIL("Expected ParseError");
+    } catch (const ParseError& error) {
+        CHECK(std::string_view(error.what()) == expected);
+    }
 }
 
 TEST_CASE("Parse empty circuit", "[parser]") {
@@ -536,6 +546,32 @@ TEST_CASE("Parse inverted measurement targets", "[parser]") {
     REQUIRE(circuit.nodes[0].targets[0].is_inverted());
     REQUIRE(!circuit.nodes[1].targets[0].is_inverted());
     REQUIRE(circuit.nodes[2].targets[0].is_inverted());
+}
+
+TEST_CASE("Parse inverted MPP targets", "[parser]") {
+    auto circuit = parse("MPP !X0*Y1 Z2*!X3");
+
+    REQUIRE(circuit.nodes.size() == 2);
+    REQUIRE(circuit.nodes[0].targets.size() == 2);
+    CHECK(circuit.nodes[0].targets[0].is_inverted());
+    CHECK(!circuit.nodes[0].targets[1].is_inverted());
+    REQUIRE(circuit.nodes[1].targets.size() == 2);
+    CHECK(!circuit.nodes[1].targets[0].is_inverted());
+    CHECK(circuit.nodes[1].targets[1].is_inverted());
+}
+
+TEST_CASE("Inverted targets are rejected on non-measurement gates", "[parser]") {
+    check_parse_error("H !0", "Line 1: Target !0 has invalid modifiers for gate type 'H'");
+    CHECK_THROWS_AS(parse("CX !0 1"), ParseError);
+    CHECK_THROWS_AS(parse("R !0"), ParseError);
+    CHECK_THROWS_AS(parse("X_ERROR(0.1) !0"), ParseError);
+    CHECK_THROWS_AS(parse("M 0\nCX !rec[-1] 1"), ParseError);
+    check_parse_error("CORRELATED_ERROR(0.1) !X0",
+                      "Line 1: Target !X0 has invalid modifiers for gate type "
+                      "'CORRELATED_ERROR'");
+    check_parse_error("R_PAULI(0.25) !X0",
+                      "Line 1: Target !X0 has invalid modifiers for gate type 'R_PAULI'");
+    CHECK_THROWS_AS(parse("EXP_VAL !X0"), ParseError);
 }
 
 TEST_CASE("Error: unknown gate", "[parser]") {
@@ -1506,14 +1542,14 @@ TEST_CASE("Parse correlated error chain permits blank and comment lines", "[pars
 }
 
 TEST_CASE("Parse correlated error folds duplicate terms", "[parser][noise]") {
-    auto circuit = parse("E(1) X0 Z0 X1 X1 !Z2");
+    auto circuit = parse("E(1) X0 Z0 X1 X1 Z2");
     REQUIRE(circuit.nodes.size() == 1);
     REQUIRE(circuit.nodes[0].targets.size() == 2);
     CHECK(circuit.nodes[0].targets[0].pauli() == Target::kPauliY);
     CHECK(circuit.nodes[0].targets[0].value() == 0);
     CHECK(circuit.nodes[0].targets[1].pauli() == Target::kPauliZ);
     CHECK(circuit.nodes[0].targets[1].value() == 2);
-    CHECK(circuit.nodes[0].targets[1].is_inverted());
+    CHECK(!circuit.nodes[0].targets[1].is_inverted());
 }
 
 TEST_CASE("Parse correlated error accepts empty product", "[parser][noise]") {

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1995,6 +1995,8 @@ TEST_CASE("READOUT_NOISE rejects bad argument counts and non-rec targets") {
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE rec[-1]\n"), ParseError);
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(0.1, 0.2, 0.3) rec[-1]\n"), ParseError);
     CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(0.1) 0\n"), ParseError);
+    check_parse_error("READOUT_NOISE(0.1) !5",
+                      "Line 1: READOUT_NOISE targets must be rec references");
 }
 
 TEST_CASE("READOUT_NOISE rejects invalid probabilities") {
@@ -2007,7 +2009,9 @@ TEST_CASE("READOUT_NOISE rejects inverted rec targets") {
     // An inverted record target has no distinct meaning for a conditional
     // flip (it would only swap the two probabilities), so it is refused
     // rather than silently ignored.
-    CHECK_THROWS_AS(parse("M 0\nREADOUT_NOISE(1, 0) !rec[-1]\n"), ParseError);
+    check_parse_error("M 0\nREADOUT_NOISE(1, 0) !rec[-1]\n",
+                      "Line 2: READOUT_NOISE targets do not support inversion; swap the two flip "
+                      "probabilities instead");
 }
 
 TEST_CASE("LEVEL_TRANSITION parses a tag and plain qubit targets") {


### PR DESCRIPTION
## Summary

- reject inverted targets on non-measurement gates with Stim-compatible errors
- preserve valid inversion on result-producing measurements, including MPP Pauli products
- reject meaningless inversion in correlated-error and non-measurement Pauli-product syntax

## Testing

- ctest --test-dir build-issue212 -E '^Bench:' --output-on-failure -j4 (1,118 passed)
- uv run pre-commit run --all-files

Closes #212