### PR TITLE
fix(optimizer): eliminate terminal phases across resets

### DIFF
--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -338,6 +338,18 @@ inline bool is_blocked(const HeisenbergOp& op_i, const HeisenbergOp& op_j, const
     }
 }
 
+/// Return true when two Pauli strings act nontrivially on any common qubit.
+inline bool has_overlapping_support(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
+    assert(x1.num_words() == z1.num_words() && z1.num_words() == x2.num_words() &&
+           x2.num_words() == z2.num_words());
+    for (uint32_t w = 0; w < x1.num_words(); ++w) {
+        if (((x1.words[w] | z1.words[w]) & (x2.words[w] | z2.words[w])) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /// Delete phase operations whose only remaining quantum effect is a phase in
 /// the eigenspaces of a later measurement on the same unsigned Pauli axis.
 ///
@@ -345,7 +357,9 @@ inline bool is_blocked(const HeisenbergOp& op_i, const HeisenbergOp& op_j, const
 /// with the phase axis: branch by branch it only reverses the rotation
 /// direction, and the matching measurement discards either direction. Other
 /// phase operations and measurements may be crossed only when they commute
-/// with the candidate. Classical record consumers are inspected but never
+/// with the candidate. A conditional Pauli is transparent only when its
+/// quantum support is disjoint and the ordinary quantum/classical dataflow
+/// proof permits a swap. Classical record consumers are inspected but never
 /// moved. All other operations are conservative barriers.
 size_t eliminate_terminal_measurement_phases(HirModule& hir, std::vector<uint8_t>& deleted) {
     size_t eliminated = 0;
@@ -365,14 +379,21 @@ size_t eliminate_terminal_measurement_phases(HirModule& hir, std::vector<uint8_t
                 continue;
             const HeisenbergOp& next = hir.ops[j];
 
-            // These are the two deliberate differences from ordinary
-            // commutation: terminal phases may cross every Pauli-noise branch,
-            // while conditional Paulis remain conservative barriers.
+            // Terminal phases may cross every Pauli-noise branch. Conditional
+            // Paulis require a stronger proof: ordinary commutation/dataflow
+            // safety plus disjoint quantum support. The disjointness keeps
+            // overlapping feedback conservative even when its total Pauli
+            // happens to commute symplectically with the candidate.
             if (next.op_type() == OpType::NOISE) {
                 continue;
             }
 
             if (next.op_type() == OpType::CONDITIONAL_PAULI) {
+                if (!has_overlapping_support(candidate_x, candidate_z, hir.destab_mask(next),
+                                             hir.stab_mask(next)) &&
+                    can_swap(hir.ops[i], next, hir)) {
+                    continue;
+                }
                 break;
             }
 

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -94,6 +94,65 @@ class TestPeepholeAlgebraicIdentities:
 class TestTerminalMeasurementPhaseElimination:
     """Phases diagonal in a later measurement basis are unobservable."""
 
+    def test_measure_reset_corrections_preserve_distribution(self) -> None:
+        """Disjoint MR corrections can be crossed without changing outputs."""
+        exact_circuit = "H 0 1\nR_Z(0.3) 0 1\nMR 0 1"
+        exact_baseline = clifft.compile(exact_circuit, hir_passes=None, bytecode_passes=None)
+        exact_optimized = clifft.compile(
+            exact_circuit,
+            hir_passes=_peephole_pass_manager(),
+            bytecode_passes=None,
+        )
+        assert exact_baseline.peak_rank == 2
+        assert exact_optimized.peak_rank == 0
+
+        records = ["00", "01", "10", "11"]
+        np.testing.assert_allclose(
+            clifft.record_probabilities(exact_optimized, records),
+            clifft.record_probabilities(exact_baseline, records),
+            atol=1e-12,
+        )
+
+        noisy_circuit = (
+            "R 0 1\n"
+            "H 0 1\n"
+            "R_Z(0.3) 0 1\n"
+            "X_ERROR(0.01) 0 1\n"
+            "MR !0 !1\n"
+            "DETECTOR rec[-2] rec[-1]\n"
+            "OBSERVABLE_INCLUDE(0) rec[-1]"
+        )
+        baseline = clifft.compile(noisy_circuit, hir_passes=None, bytecode_passes=None)
+        optimized = clifft.compile(
+            noisy_circuit,
+            hir_passes=_peephole_pass_manager(),
+            bytecode_passes=None,
+        )
+        assert baseline.peak_rank == 2
+        assert optimized.peak_rank == 0
+
+        shots = 30_000
+        baseline_result = clifft.sample(baseline, shots, seed=242)
+        optimized_result = clifft.sample(optimized, shots, seed=243)
+
+        weights = 1 << np.arange(2, dtype=np.uint64)
+        baseline_bins = np.asarray(baseline_result.measurements, dtype=np.uint64) @ weights
+        optimized_bins = np.asarray(optimized_result.measurements, dtype=np.uint64) @ weights
+        baseline_probs = np.bincount(baseline_bins.astype(np.int64), minlength=4) / shots
+        optimized_probs = np.bincount(optimized_bins.astype(np.int64), minlength=4) / shots
+
+        for baseline_p, optimized_p in zip(baseline_probs, optimized_probs, strict=True):
+            pooled = float((baseline_p + optimized_p) / 2.0)
+            tolerance = cross_binomial_tolerance(pooled, shots, sigma=6.0)
+            assert abs(float(baseline_p - optimized_p)) <= tolerance
+
+        for result in (baseline_result, optimized_result):
+            np.testing.assert_array_equal(
+                result.detectors[:, 0],
+                np.logical_xor(result.measurements[:, 0], result.measurements[:, 1]),
+            )
+            np.testing.assert_array_equal(result.observables[:, 0], result.measurements[:, 1])
+
     @pytest.mark.parametrize("pauli_branch", ["", "X 0", "Y 0", "Z 0"])
     def test_exact_deterministic_pauli_branches(self, pauli_branch: str) -> None:
         """Every branch agrees exactly, including downstream feedback."""

--- a/tests/test_backend_instruments.cc
+++ b/tests/test_backend_instruments.cc
@@ -280,3 +280,21 @@ TEST_CASE("fences: terminal phase elimination does not cross an instrument") {
         REQUIRE(std::memcmp(&a.bytecode[i], &b.bytecode[i], sizeof(Instruction)) == 0);
     }
 }
+
+TEST_CASE("fences: disjoint reset correction transparency stops at an instrument") {
+    const auto options = source_dependent_jump_options();
+    const char* with_matching_measurement = "H 1\nR_Z(0.02) 1\nMR 0\nLEVEL_TRANSITION[jump] 0\nM 1";
+    const char* with_other_suffix = "H 1\nR_Z(0.02) 1\nMR 0\nLEVEL_TRANSITION[jump] 0\nMX 1";
+
+    auto a = compile_instruments_full(with_matching_measurement, options);
+    auto b = compile_instruments_full(with_other_suffix, options);
+
+    REQUIRE(a.instrument_offsets.size() == 1);
+    REQUIRE(b.instrument_offsets.size() == 1);
+    const uint32_t offset = a.instrument_offsets[0];
+    REQUIRE(b.instrument_offsets[0] == offset);
+
+    for (uint32_t i = 0; i <= offset; ++i) {
+        REQUIRE(std::memcmp(&a.bytecode[i], &b.bytecode[i], sizeof(Instruction)) == 0);
+    }
+}

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -1,5 +1,6 @@
 // Optimizer unit tests
 
+#include "clifft/backend/backend.h"
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/frontend/hir.h"
@@ -10,6 +11,7 @@
 
 #include "test_helpers.h"
 
+#include <algorithm>
 #include <bit>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -29,6 +31,12 @@ using clifft::test::Z;
 // Helper: parse a .stim circuit string through the front-end to produce HIR.
 static HirModule hir_from(const char* text) {
     return clifft::trace(clifft::parse(text));
+}
+
+static size_t count_ops(const HirModule& hir, OpType type) {
+    return static_cast<size_t>(
+        std::count_if(hir.ops.begin(), hir.ops.end(),
+                      [type](const HeisenbergOp& op) { return op.op_type() == type; }));
 }
 
 // =============================================================================
@@ -221,6 +229,83 @@ TEST_CASE("Peephole: terminal T is removed before measurement-reset", "[optimize
     REQUIRE(pass.cancellations() == 1);
 }
 
+TEST_CASE("Peephole: terminal phases cross disjoint measure-reset corrections", "[optimizer]") {
+    const char* circuits[] = {
+        "R 0 1\nH 0 1\nR_Z(0.3) 0 1\nX_ERROR(0.01) 0 1\nMR 0 1",
+        "R 0 1\nH 0 1\nR_Z(0.3) 0 1\nMR 1 0",
+        "R 0 1\nH 0 1\nR_Z(0.3) 0 1\nMR 0\nMR 1",
+        "R 0 1\nH 0 1\nR_Z(0.3) 0 1\nMR 1\nMR 0",
+        "R 0 1\nR_X(0.3) 0 1\nMRX 0 1",
+        "R 0 1\nR_Y(0.3) 0 1\nMRY 0 1",
+    };
+
+    for (const char* circuit : circuits) {
+        DYNAMIC_SECTION(circuit) {
+            auto hir = hir_from(circuit);
+            REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 2);
+
+            PeepholeFusionPass pass;
+            pass.run(hir);
+
+            REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 0);
+            REQUIRE(pass.cancellations() == 2);
+            REQUIRE(clifft::lower(hir).peak_rank == 0);
+        }
+    }
+}
+
+TEST_CASE("Peephole: terminal phase belonging only to a later reset target is removed",
+          "[optimizer]") {
+    auto hir = hir_from("R 0 1\nH 1\nR_Z(0.3) 1\nMR 0 1");
+    REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 1);
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 0);
+    REQUIRE(pass.cancellations() == 1);
+    REQUIRE(clifft::lower(hir).peak_rank == 0);
+}
+
+TEST_CASE("Peephole: disjoint feedback controlled by a crossed measurement is transparent",
+          "[optimizer]") {
+    auto hir = hir_from(
+        "R 0 1 2\n"
+        "H 1\n"
+        "R_Z(0.3) 1\n"
+        "M 2\n"
+        "DETECTOR rec[-1]\n"
+        "CX rec[-1] 0\n"
+        "M 1");
+    REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 1);
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 0);
+    REQUIRE(count_ops(hir, OpType::CONDITIONAL_PAULI) == 4);
+    REQUIRE(count_ops(hir, OpType::DETECTOR) == 1);
+}
+
+TEST_CASE("Peephole: reset phase elimination preserves inverted records and annotations",
+          "[optimizer]") {
+    auto hir = hir_from(
+        "R 0 1\n"
+        "H 0 1\n"
+        "R_Z(0.3) 0 1\n"
+        "MR !0 !1\n"
+        "DETECTOR rec[-2] rec[-1]\n"
+        "OBSERVABLE_INCLUDE(0) rec[-1]");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 0);
+    REQUIRE(count_ops(hir, OpType::READOUT_NOISE) == 2);
+    REQUIRE(count_ops(hir, OpType::DETECTOR) == 1);
+    REQUIRE(count_ops(hir, OpType::OBSERVABLE) == 1);
+}
+
 TEST_CASE("Peephole: terminal phase elimination respects barriers", "[optimizer]") {
     SECTION("anti-commuting measurement") {
         auto hir = hir_from("R_Z(0.02) 0\nMX 0\nM 0");
@@ -236,11 +321,18 @@ TEST_CASE("Peephole: terminal phase elimination respects barriers", "[optimizer]
         REQUIRE(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
     }
 
-    SECTION("conditional Pauli") {
+    SECTION("anti-commuting conditional Pauli") {
         auto hir = hir_from("M 1\nR_Z(0.02) 0\nCX rec[-1] 0\nM 0");
         PeepholeFusionPass pass;
         pass.run(hir);
         REQUIRE(hir.ops[1].op_type() == OpType::PHASE_ROTATION);
+    }
+
+    SECTION("same-support commuting conditional Pauli") {
+        auto hir = hir_from("M 1\nR_Z(0.02) 0\nCZ rec[-1] 0\nM 0");
+        PeepholeFusionPass pass;
+        pass.run(hir);
+        REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 1);
     }
 
     SECTION("expectation value") {

--- a/tests/test_source_map.cc
+++ b/tests/test_source_map.cc
@@ -121,6 +121,33 @@ TEST_CASE("Source map: T plus T_dag cancellation removes both from map", "[sourc
     }
 }
 
+TEST_CASE("Source map: terminal reset phase elimination removes only phase entries",
+          "[source_map]") {
+    auto hir = hir_optimized(
+        "R 0 1\n"
+        "H 0 1\n"
+        "R_Z(0.3) 0 1\n"
+        "X_ERROR(0.01) 0 1\n"
+        "MR 0 1");
+
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    REQUIRE(hir.ops.size() == 10);
+
+    size_t reset_entries = 0;
+    size_t noise_entries = 0;
+    size_t measure_reset_entries = 0;
+    for (const auto& entry : hir.source_map) {
+        REQUIRE(entry.size() == 1);
+        REQUIRE(entry[0] != 3);
+        reset_entries += entry[0] == 1;
+        noise_entries += entry[0] == 4;
+        measure_reset_entries += entry[0] == 5;
+    }
+    REQUIRE(reset_entries == 4);
+    REQUIRE(noise_entries == 2);
+    REQUIRE(measure_reset_entries == 4);
+}
+
 // =============================================================================
 // Back-End source map and k-history
 // =============================================================================


### PR DESCRIPTION
## Summary

- allow terminal measurement phases to cross conditional Paulis when their quantum supports are disjoint and the existing commutation/dataflow proof permits it
- keep same-support and anti-commuting feedback as conservative barriers
- eliminate both rotations in the issue reproduction, reducing optimized `peak_rank` from 2 to 0
- cover MR target ordering/grouping, MRX/MRY, arbitrary disjoint feedback, instruments, source maps, inverted records, and detector/observable outputs

Closes #242.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build-issue242 -E '^Bench:' --output-on-failure -j4`; 1,124 passed)
- [x] Python tests pass (`uv run pytest tests/python/ -q`; 869 passed)
- [ ] Doc examples pass (not run; no documentation changes)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [ ] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [ ] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.

The commit includes an `Assisted-by: ChatGPT (GPT-5.6 Sol)` trailer. The contributor checkboxes are left for the submitter to confirm.
