### PR TITLE
feat(noncomp): add inline leakage annotation

### DIFF
--- a/docs/guide/compilation.md
+++ b/docs/guide/compilation.md
@@ -3,9 +3,9 @@
 Clifft compiles Stim-format circuit text into an executable SVM program. For most users, `clifft.compile()` is the only compilation API needed. Lower-level APIs are available when you want to inspect intermediate representations, customize optimization passes, or build your own compilation flow.
 
 !!! note "Leakage and loss"
-    Circuits containing `LOSS` or `LEVEL_TRANSITION` annotations use
-    `clifft.noncomp.sample()` instead. It compiles the remaining circuit as
-    noncomputational transitions occur. See
+    Circuits containing `LEAKAGE`, `LOSS`, or `LEVEL_TRANSITION` annotations
+    use `clifft.noncomp.sample()` instead. It compiles the remaining circuit
+    as noncomputational transitions occur. See
     [Leakage and Loss](leakage-and-loss.md).
 
 !!! tip "Using Qiskit or Cirq?"

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -149,6 +149,10 @@ three ways to place them:
   arbitrary transition name or hookable gate name can be referenced
   explicitly. Use an inline reference at selected circuit positions or with a
   transition whose name is not a gate.
+- **Inline leakage.** `LEAKAGE(p) 0` moves `g` to `leak_g` and `e` to
+  `leak_e` with probability `p`. An already leaked or lost site is unchanged.
+  Use it for the common source-preserving leakage channel without defining a
+  five-by-five matrix.
 - **Inline loss.** `LOSS(p) 0` loses the carrier at site 0 with probability
   `p` from any occupied level. Use it for a self-contained loss probability
   that needs no matrix in the model.
@@ -195,6 +199,7 @@ model = noncomp.Model(
 circuit = """
     H 0
     CZ 0 1
+    LEAKAGE(0.01) 0
     LOSS(0.005) 1
     LEVEL_TRANSITION[manual_leak] 0
     M 0 1
@@ -322,7 +327,7 @@ semantics and rank cost are described in
   active do not add further rank. `"neglect"` omits this cost and the no-jump
   back-action, introducing an error of order
   $\lvert p_g - p_e \rvert$ per transition position. There is no error when
-  $p_g = p_e$, so `LOSS(p)` is always exact. See the
+  $p_g = p_e$, so `LEAKAGE(p)` and `LOSS(p)` are always exact. See the
   [performance model](performance.md) for how rank affects simulation cost.
 - **`seed`**: same contract as ordinary sampling: a fixed seed is fully
   reproducible, `None` uses hardware entropy.

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -177,6 +177,7 @@ channel probabilities.
 
 | Instruction | Notes |
 |-------------|-------|
+| `LEAKAGE(p)` | Moves `g` to `leak_g` and `e` to `leak_e` with probability `p`; other levels are unchanged |
 | `LOSS(p)` | Loses each target with probability `p`, from any occupied level |
 | `LEVEL_TRANSITION[name]` | Fires the model's named transition matrix on each target |
 

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -361,8 +361,11 @@ inline constexpr bool is_noise_gate(GateType g) {
 inline constexpr bool is_exp_val(GateType g) {
     return g == GateType::EXP_VAL;
 }
+inline constexpr bool is_inline_noncomputational_annotation(GateType g) {
+    return g == GateType::LEAKAGE || g == GateType::LOSS;
+}
 inline constexpr bool is_noncomputational_annotation(GateType g) {
-    return g == GateType::LEVEL_TRANSITION || g == GateType::LEAKAGE || g == GateType::LOSS;
+    return g == GateType::LEVEL_TRANSITION || is_inline_noncomputational_annotation(g);
 }
 inline constexpr std::string_view gate_name(GateType g) {
     return gate_traits(g).name;

--- a/src/clifft/circuit/gate_data.h
+++ b/src/clifft/circuit/gate_data.h
@@ -135,6 +135,7 @@ enum class GateType : uint16_t {
     // Noncomputational trajectory annotations (consumed by the
     // noncomputational sampling layer; trace() rejects them)
     LEVEL_TRANSITION,  // Per-site level transition; the tag names a model matrix
+    LEAKAGE,           // Per-site source-preserving leakage with an inline probability
     LOSS,              // Per-site uniform loss with an inline probability
 
     // Simulation-only probes
@@ -286,6 +287,7 @@ inline constexpr GateTraits kGateTraitsData[] = {
     {.arity = A, .name = "TICK"},
     // Noncomputational trajectory annotations
     {.arity = S, .name = "LEVEL_TRANSITION"},
+    {.arity = S, .name = "LEAKAGE"},
     {.arity = S, .name = "LOSS"},
     // Simulation-only probes
     {.arity = ML, .name = "EXP_VAL"},
@@ -358,6 +360,9 @@ inline constexpr bool is_noise_gate(GateType g) {
 }
 inline constexpr bool is_exp_val(GateType g) {
     return g == GateType::EXP_VAL;
+}
+inline constexpr bool is_noncomputational_annotation(GateType g) {
+    return g == GateType::LEVEL_TRANSITION || g == GateType::LEAKAGE || g == GateType::LOSS;
 }
 inline constexpr std::string_view gate_name(GateType g) {
     return gate_traits(g).name;

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -360,7 +360,7 @@ class Parser {
                                  line_num);
             }
         }
-        if (gate == GateType::LEAKAGE || gate == GateType::LOSS) {
+        if (is_inline_noncomputational_annotation(gate)) {
             const std::string name{clifft::gate_name(gate)};
             if (args.size() != 1) {
                 throw ParseError(name + " requires exactly 1 argument (the probability)", line_num);

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -360,13 +360,13 @@ class Parser {
                                  line_num);
             }
         }
-        if (gate == GateType::LOSS) {
+        if (gate == GateType::LEAKAGE || gate == GateType::LOSS) {
+            const std::string name{clifft::gate_name(gate)};
             if (args.size() != 1) {
-                throw ParseError("LOSS requires exactly 1 argument (the loss probability)",
-                                 line_num);
+                throw ParseError(name + " requires exactly 1 argument (the probability)", line_num);
             }
             if (!is_probability(args[0])) {
-                throw ParseError("LOSS probability must be finite and lie in [0, 1]", line_num);
+                throw ParseError(name + " probability must be finite and lie in [0, 1]", line_num);
             }
         }
         if (gate == GateType::READOUT_NOISE) {

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -821,7 +821,7 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     InstrumentSite site;
                     site.qubit = qubit;
                     std::string site_description;
-                    if (node.gate == GateType::LEAKAGE || node.gate == GateType::LOSS) {
+                    if (is_inline_noncomputational_annotation(node.gate)) {
                         // Both inline channels have an equal rate from G and E
                         // and destinations entirely in the trap remainder. A
                         // missing argument is a malformed node, not a zero-rate

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -371,6 +371,7 @@ size_t count_pauli_masks(const Circuit& circuit) {
                 count += 1;
                 break;
             case GateType::LEVEL_TRANSITION:
+            case GateType::LEAKAGE:
             case GateType::LOSS:
                 // Two masks per materialized instrument site: the rewound
                 // source projector on the op, and the rewound X destination flip in
@@ -807,6 +808,7 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
             }
 
             case GateType::LEVEL_TRANSITION:
+            case GateType::LEAKAGE:
             case GateType::LOSS: {
                 if (instruments == nullptr) {
                     throw std::invalid_argument(
@@ -819,19 +821,22 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     InstrumentSite site;
                     site.qubit = qubit;
                     std::string site_description;
-                    if (node.gate == GateType::LOSS) {
-                        // Uniform loss: source-independent rate, destination
-                        // entirely the trap remainder. A missing argument is
-                        // a malformed node, not a zero-probability loss.
+                    if (node.gate == GateType::LEAKAGE || node.gate == GateType::LOSS) {
+                        // Both inline channels have an equal rate from G and E
+                        // and destinations entirely in the trap remainder. A
+                        // missing argument is a malformed node, not a zero-rate
+                        // annotation.
                         if (node.args.size() != 1) {
                             throw std::runtime_error(
-                                "trace: LOSS at line " + std::to_string(node.source_line) +
-                                " requires exactly one argument (the loss probability)");
+                                "trace: " + std::string(gate_name(node.gate)) + " at line " +
+                                std::to_string(node.source_line) +
+                                " requires exactly one argument (the probability)");
                         }
                         const double p = node.args[0];
                         site.probabilities.p_fire[0] = p;
                         site.probabilities.p_fire[1] = p;
-                        site_description = "LOSS at line " + std::to_string(node.source_line);
+                        site_description = std::string(gate_name(node.gate)) + " at line " +
+                                           std::to_string(node.source_line);
                     } else {
                         const auto it = instruments->transitions.find(node.tag);
                         if (it == instruments->transitions.end()) {

--- a/src/clifft/frontend/frontend.h
+++ b/src/clifft/frontend/frontend.h
@@ -26,8 +26,9 @@
 namespace clifft {
 
 // Opt-in instrument materialization for trace(). `transitions` maps a
-// LEVEL_TRANSITION tag to its spec; LOSS needs no entry (its probability
-// is inline and its destination is entirely the trap remainder).
+// LEVEL_TRANSITION tag to its spec; LEAKAGE and LOSS need no entry (their
+// probabilities are inline and their destinations are entirely in the trap
+// remainder).
 struct InstrumentTraceOptions {
     // The front-end remains model-free: the noncomputational layer compresses
     // each five-level matrix into InstrumentProbabilities before tracing.
@@ -53,8 +54,8 @@ struct InstrumentTraceOptions {
 // - Emits HeisenbergOps for T/T_DAG gates with rewound Pauli masks
 // - Emits HeisenbergOps for measurements
 // - Emits HeisenbergOps for classical feedback (CX/CZ with rec targets)
-// - With `instruments` supplied, materializes LEVEL_TRANSITION and LOSS
-//   annotations into INSTRUMENT ops (one per target, at their circuit
+// - With `instruments` supplied, materializes LEVEL_TRANSITION, LEAKAGE, and
+//   LOSS annotations into INSTRUMENT ops (one per target, at their circuit
 //   positions, mask = the rewound source projector Z_q); without it,
 //   annotations reject with a pointer to sample_noncomputational.
 //

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -275,7 +275,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const Traject
                 // LEVEL_TRANSITION[tag] can fire when either column_sum(G) or
                 // column_sum(E) is nonzero. These exact 0.0 comparisons match
                 // frontend.cc.
-                if (gate == GateType::LEAKAGE || gate == GateType::LOSS) {
+                if (is_inline_noncomputational_annotation(gate)) {
                     if (inline_transition_probability(gate, node.args, op_index,
                                                       "rewrite_continuation") == 0.0) {
                         continue;

--- a/src/clifft/noncomp/rewriter.cc
+++ b/src/clifft/noncomp/rewriter.cc
@@ -213,7 +213,7 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const Traject
         const AstNode& node = annotated.nodes[op_index];
         const GateType gate = node.gate;
 
-        if (gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) {
+        if (is_noncomputational_annotation(gate)) {
             for (const Target& target : node.targets) {
                 const uint32_t qubit = target.value();
                 if (qubit >= status.size()) {
@@ -271,11 +271,13 @@ ContinuationRewrite rewrite_continuation(const Circuit& annotated, const Traject
                 // the same sites, so skipping both the node and site_targets
                 // entry keeps their site IDs aligned.
                 //
-                // LOSS(p) can fire when p != 0. LEVEL_TRANSITION[tag] can fire
-                // when either column_sum(G) or column_sum(E) is nonzero. These
-                // exact 0.0 comparisons match frontend.cc.
-                if (gate == GateType::LOSS) {
-                    if (loss_probability(node.args, op_index, "rewrite_continuation") == 0.0) {
+                // Inline LEAKAGE/LOSS can fire when p != 0.
+                // LEVEL_TRANSITION[tag] can fire when either column_sum(G) or
+                // column_sum(E) is nonzero. These exact 0.0 comparisons match
+                // frontend.cc.
+                if (gate == GateType::LEAKAGE || gate == GateType::LOSS) {
+                    if (inline_transition_probability(gate, node.args, op_index,
+                                                      "rewrite_continuation") == 0.0) {
                         continue;
                     }
                 } else {

--- a/src/clifft/noncomp/status_walk.cc
+++ b/src/clifft/noncomp/status_walk.cc
@@ -11,22 +11,21 @@ namespace clifft {
 
 double inline_transition_probability(GateType gate, const std::vector<double>& args,
                                      uint32_t op_index, std::string_view caller) {
-    if (gate != GateType::LEAKAGE && gate != GateType::LOSS) {
+    if (!is_inline_noncomputational_annotation(gate)) {
         throw std::invalid_argument(
             std::string(caller) + ": inline transition probability requested for '" +
             std::string(gate_name(gate)) + "' at op " + std::to_string(op_index));
     }
-    const std::string name{gate_name(gate)};
     if (args.size() != 1) {
-        throw std::invalid_argument(std::string(caller) + ": " + name + " at op " +
-                                    std::to_string(op_index) +
+        throw std::invalid_argument(std::string(caller) + ": " + std::string(gate_name(gate)) +
+                                    " at op " + std::to_string(op_index) +
                                     " requires exactly one argument (the probability)");
     }
     const double p = args[0];
     if (!is_probability(p)) {
-        throw std::invalid_argument(std::string(caller) + ": " + name + " probability at op " +
-                                    std::to_string(op_index) + " = " + std::to_string(p) +
-                                    " is not finite or is out of [0, 1]");
+        throw std::invalid_argument(std::string(caller) + ": " + std::string(gate_name(gate)) +
+                                    " probability at op " + std::to_string(op_index) + " = " +
+                                    std::to_string(p) + " is not finite or is out of [0, 1]");
     }
     return p;
 }

--- a/src/clifft/noncomp/status_walk.cc
+++ b/src/clifft/noncomp/status_walk.cc
@@ -9,16 +9,22 @@
 
 namespace clifft {
 
-double loss_probability(const std::vector<double>& args, uint32_t op_index,
-                        std::string_view caller) {
+double inline_transition_probability(GateType gate, const std::vector<double>& args,
+                                     uint32_t op_index, std::string_view caller) {
+    if (gate != GateType::LEAKAGE && gate != GateType::LOSS) {
+        throw std::invalid_argument(
+            std::string(caller) + ": inline transition probability requested for '" +
+            std::string(gate_name(gate)) + "' at op " + std::to_string(op_index));
+    }
+    const std::string name{gate_name(gate)};
     if (args.size() != 1) {
-        throw std::invalid_argument(std::string(caller) + ": LOSS at op " +
+        throw std::invalid_argument(std::string(caller) + ": " + name + " at op " +
                                     std::to_string(op_index) +
-                                    " requires exactly one argument (the loss probability)");
+                                    " requires exactly one argument (the probability)");
     }
     const double p = args[0];
     if (!is_probability(p)) {
-        throw std::invalid_argument(std::string(caller) + ": LOSS probability at op " +
+        throw std::invalid_argument(std::string(caller) + ": " + name + " probability at op " +
                                     std::to_string(op_index) + " = " + std::to_string(p) +
                                     " is not finite or is out of [0, 1]");
     }

--- a/src/clifft/noncomp/status_walk.h
+++ b/src/clifft/noncomp/status_walk.h
@@ -19,10 +19,10 @@
 
 namespace clifft {
 
-// The validated loss probability of a LOSS annotation node's argument list:
-// exactly one argument, finite, in [0, 1]. `caller` prefixes diagnostics.
-double loss_probability(const std::vector<double>& args, uint32_t op_index,
-                        std::string_view caller);
+// The validated probability of a LEAKAGE or LOSS annotation node's argument
+// list: exactly one argument, finite, in [0, 1]. `caller` prefixes diagnostics.
+double inline_transition_probability(GateType gate, const std::vector<double>& args,
+                                     uint32_t op_index, std::string_view caller);
 
 // The role a qubit operand plays in an operation. A CX/CZ with a record
 // control is a virtual frame correction, not a physical gate application.

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -72,7 +72,7 @@ struct AnnotationChannel {
 [[nodiscard]] AnnotationChannel resolve_annotation(const AstNode& node,
                                                    const NonComputationalModel& model,
                                                    uint32_t op_index) {
-    if (node.gate == GateType::LEAKAGE || node.gate == GateType::LOSS) {
+    if (is_inline_noncomputational_annotation(node.gate)) {
         const double p = inline_transition_probability(node.gate, node.args, op_index,
                                                        "sample_noncomputational");
         return node.gate == GateType::LEAKAGE ? AnnotationChannel::for_leakage(p)
@@ -236,19 +236,27 @@ void extend_classical_outcomes(const Circuit& annotated, TrajectoryEvents& event
                         outcome = seen->second;
                     } else {
                         const AnnotationChannel channel = resolve_annotation(node, model, op_index);
-                        if (channel.kind == AnnotationChannelKind::Instrument) {
-                            const double total = channel.instrument->column_sum(source);
-                            if (rng.next_double() < total) {
-                                outcome.destination = draw_from_column(
-                                    *channel.instrument, source, rng, [](Level) { return true; });
+                        switch (channel.kind) {
+                            case AnnotationChannelKind::Instrument: {
+                                const double total = channel.instrument->column_sum(source);
+                                if (rng.next_double() < total) {
+                                    outcome.destination =
+                                        draw_from_column(*channel.instrument, source, rng,
+                                                         [](Level) { return true; });
+                                }
+                                break;
                             }
-                        } else if (channel.kind == AnnotationChannelKind::Loss && !is_lost(pre) &&
-                                   rng.next_double() < channel.probability) {
-                            // LOSS can move a leaked qubit to Lost. An already-lost
-                            // qubit records a no-op without spending a draw. LEAKAGE
-                            // is a no-op on every noncomputational source and also
-                            // spends no draw.
-                            outcome.destination = Level::Lost;
+                            case AnnotationChannelKind::Leakage:
+                                // LEAKAGE is a no-op on every noncomputational source
+                                // and spends no draw.
+                                break;
+                            case AnnotationChannelKind::Loss:
+                                // LOSS can move a leaked qubit to Lost. An already-lost
+                                // qubit records a no-op without spending a draw.
+                                if (!is_lost(pre) && rng.next_double() < channel.probability) {
+                                    outcome.destination = Level::Lost;
+                                }
+                                break;
                         }
                     }
                     ordered.push_back(outcome);
@@ -499,8 +507,8 @@ void validate_model_contract(const Circuit& annotated, const NonComputationalMod
     if (!noncomp_capable) {
         for (uint32_t i = 0; i < static_cast<uint32_t>(annotated.nodes.size()); ++i) {
             const AstNode& node = annotated.nodes[i];
-            if ((node.gate == GateType::LEAKAGE || node.gate == GateType::LOSS) &&
-                !node.args.empty() && node.args[0] > 0.0) {
+            if (is_inline_noncomputational_annotation(node.gate) && !node.args.empty() &&
+                node.args[0] > 0.0) {
                 noncomp_capable = true;
                 break;
             }
@@ -766,16 +774,22 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                    "the VM reports the collapsed source as a computational axis index");
             const Level source = static_cast<Level>(trap.source);
             Level dest;
-            if (channel.kind == AnnotationChannelKind::Leakage) {
-                dest = source == Level::G ? Level::LeakG : Level::LeakE;
-            } else if (channel.kind == AnnotationChannelKind::Loss) {
-                dest = Level::Lost;
-            } else if (trap.destination_pending) {
-                dest = draw_from_column(*channel.instrument, source, driver_rng,
-                                        [](Level) { return true; });
-            } else {
-                dest = draw_from_column(*channel.instrument, source, driver_rng,
-                                        [](Level to) { return !is_computational(to); });
+            switch (channel.kind) {
+                case AnnotationChannelKind::Instrument:
+                    if (trap.destination_pending) {
+                        dest = draw_from_column(*channel.instrument, source, driver_rng,
+                                                [](Level) { return true; });
+                    } else {
+                        dest = draw_from_column(*channel.instrument, source, driver_rng,
+                                                [](Level to) { return !is_computational(to); });
+                    }
+                    break;
+                case AnnotationChannelKind::Leakage:
+                    dest = source == Level::G ? Level::LeakG : Level::LeakE;
+                    break;
+                case AnnotationChannelKind::Loss:
+                    dest = Level::Lost;
+                    break;
             }
 
             events.jumps.push_back({{op_index, qubit}, dest});

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -42,34 +42,46 @@ namespace clifft {
 
 namespace {
 
+enum class AnnotationChannelKind { Instrument, Leakage, Loss };
+
 // The channel described by one transition annotation: a named instrument for
-// LEVEL_TRANSITION or a uniform loss probability for LOSS. A null instrument
-// identifies the LOSS representation.
+// LEVEL_TRANSITION or an inline probability for LEAKAGE/LOSS.
 struct AnnotationChannel {
     [[nodiscard]] static AnnotationChannel for_instrument(const TransitionInstrument& instrument) {
-        return AnnotationChannel(&instrument, 0.0);
+        return AnnotationChannel(AnnotationChannelKind::Instrument, &instrument, 0.0);
+    }
+
+    [[nodiscard]] static AnnotationChannel for_leakage(double probability) {
+        return AnnotationChannel(AnnotationChannelKind::Leakage, nullptr, probability);
     }
 
     [[nodiscard]] static AnnotationChannel for_loss(double probability) {
-        return AnnotationChannel(nullptr, probability);
+        return AnnotationChannel(AnnotationChannelKind::Loss, nullptr, probability);
     }
 
+    AnnotationChannelKind kind;
     const TransitionInstrument* instrument;
-    double loss_probability;
-
-    bool is_loss() const { return instrument == nullptr; }
+    double probability;
 
   private:
-    AnnotationChannel(const TransitionInstrument* instrument_in, double loss_probability_in)
-        : instrument(instrument_in), loss_probability(loss_probability_in) {}
+    AnnotationChannel(AnnotationChannelKind kind_in, const TransitionInstrument* instrument_in,
+                      double probability_in)
+        : kind(kind_in), instrument(instrument_in), probability(probability_in) {}
 };
 
 [[nodiscard]] AnnotationChannel resolve_annotation(const AstNode& node,
                                                    const NonComputationalModel& model,
                                                    uint32_t op_index) {
-    if (node.gate == GateType::LOSS) {
-        return AnnotationChannel::for_loss(
-            loss_probability(node.args, op_index, "sample_noncomputational"));
+    if (node.gate == GateType::LEAKAGE || node.gate == GateType::LOSS) {
+        const double p = inline_transition_probability(node.gate, node.args, op_index,
+                                                       "sample_noncomputational");
+        return node.gate == GateType::LEAKAGE ? AnnotationChannel::for_leakage(p)
+                                              : AnnotationChannel::for_loss(p);
+    }
+    if (node.gate != GateType::LEVEL_TRANSITION) {
+        throw std::invalid_argument("sample_noncomputational: unsupported annotation '" +
+                                    std::string(gate_name(node.gate)) + "' at op " +
+                                    std::to_string(op_index));
     }
     const TransitionInstrument* instrument = model.transition_named(node.tag);
     if (instrument == nullptr) {
@@ -80,7 +92,7 @@ struct AnnotationChannel {
     return AnnotationChannel::for_instrument(*instrument);
 }
 
-// Resolving validates the LOSS arguments or transition name; the remaining
+// Resolving validates the inline arguments or transition name; the remaining
 // checks enforce the target shape expected by the driver and rewriter.
 void validate_annotation(const AstNode& node, const NonComputationalModel& model, uint32_t op_index,
                          uint32_t num_qubits) {
@@ -198,7 +210,7 @@ void extend_classical_outcomes(const Circuit& annotated, TrajectoryEvents& event
     for (uint32_t op_index = 0; op_index < annotated.nodes.size(); ++op_index) {
         const AstNode& node = annotated.nodes[op_index];
         const GateType gate = node.gate;
-        if (gate == GateType::LEVEL_TRANSITION || gate == GateType::LOSS) {
+        if (is_noncomputational_annotation(gate)) {
             for (const Target& target : node.targets) {
                 const uint32_t qubit = target.value();
                 const QubitStatus pre = status[qubit];
@@ -224,15 +236,18 @@ void extend_classical_outcomes(const Circuit& annotated, TrajectoryEvents& event
                         outcome = seen->second;
                     } else {
                         const AnnotationChannel channel = resolve_annotation(node, model, op_index);
-                        if (!channel.is_loss()) {
+                        if (channel.kind == AnnotationChannelKind::Instrument) {
                             const double total = channel.instrument->column_sum(source);
                             if (rng.next_double() < total) {
                                 outcome.destination = draw_from_column(
                                     *channel.instrument, source, rng, [](Level) { return true; });
                             }
-                        } else if (!is_lost(pre) && rng.next_double() < channel.loss_probability) {
+                        } else if (channel.kind == AnnotationChannelKind::Loss && !is_lost(pre) &&
+                                   rng.next_double() < channel.probability) {
                             // LOSS can move a leaked qubit to Lost. An already-lost
-                            // qubit records a no-op without spending a draw.
+                            // qubit records a no-op without spending a draw. LEAKAGE
+                            // is a no-op on every noncomputational source and also
+                            // spends no draw.
                             outcome.destination = Level::Lost;
                         }
                     }
@@ -484,7 +499,8 @@ void validate_model_contract(const Circuit& annotated, const NonComputationalMod
     if (!noncomp_capable) {
         for (uint32_t i = 0; i < static_cast<uint32_t>(annotated.nodes.size()); ++i) {
             const AstNode& node = annotated.nodes[i];
-            if (node.gate == GateType::LOSS && !node.args.empty() && node.args[0] > 0.0) {
+            if ((node.gate == GateType::LEAKAGE || node.gate == GateType::LOSS) &&
+                !node.args.empty() && node.args[0] > 0.0) {
                 noncomp_capable = true;
                 break;
             }
@@ -572,7 +588,7 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
     for (uint32_t op_index = 0; op_index < static_cast<uint32_t>(annotated.nodes.size());
          ++op_index) {
         const AstNode& node = annotated.nodes[op_index];
-        if (node.gate == GateType::LEVEL_TRANSITION || node.gate == GateType::LOSS) {
+        if (is_noncomputational_annotation(node.gate)) {
             validate_annotation(node, model, op_index, annotated.num_qubits);
         }
         // The parser emits one node per target for ordinary measurements, and
@@ -749,11 +765,15 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
             assert(trap.source <= 1 &&
                    "the VM reports the collapsed source as a computational axis index");
             const Level source = static_cast<Level>(trap.source);
-            Level dest = Level::Lost;
-            if (!channel.is_loss() && trap.destination_pending) {
+            Level dest;
+            if (channel.kind == AnnotationChannelKind::Leakage) {
+                dest = source == Level::G ? Level::LeakG : Level::LeakE;
+            } else if (channel.kind == AnnotationChannelKind::Loss) {
+                dest = Level::Lost;
+            } else if (trap.destination_pending) {
                 dest = draw_from_column(*channel.instrument, source, driver_rng,
                                         [](Level) { return true; });
-            } else if (!channel.is_loss()) {
+            } else {
                 dest = draw_from_column(*channel.instrument, source, driver_rng,
                                         [](Level to) { return !is_computational(to); });
             }

--- a/src/clifft/noncomp/transition_hooks.h
+++ b/src/clifft/noncomp/transition_hooks.h
@@ -5,10 +5,10 @@
 // A gate hook is a model transition named after a gate, such as "CZ". For
 // every occurrence of that gate, expand_transition_hooks() inserts a
 // LEVEL_TRANSITION immediately afterward for each qubit the gate acts on
-// directly. Existing LEVEL_TRANSITION and LOSS annotations are copied
-// unchanged. Record-controlled feedback receives no transition because it
-// does not physically execute the gate. Later stages therefore only need to
-// handle explicit annotations.
+// directly. Existing LEVEL_TRANSITION, LEAKAGE, and LOSS annotations are
+// copied unchanged. Record-controlled feedback receives no transition because
+// it does not physically execute the gate. Later stages therefore only need
+// to handle explicit annotations.
 
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/model.h"

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -279,6 +279,7 @@ NB_MODULE(_clifft_core, m) {
         .value("TICK", clifft::GateType::TICK)
         // Noncomputational trajectory annotations
         .value("LEVEL_TRANSITION", clifft::GateType::LEVEL_TRANSITION)
+        .value("LEAKAGE", clifft::GateType::LEAKAGE)
         .value("LOSS", clifft::GateType::LOSS)
         // Simulation-only probes
         .value("EXP_VAL", clifft::GateType::EXP_VAL)

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -126,9 +126,10 @@ class Model:
             no-ops. Annotate those positions explicitly instead. Any key --
             whether an arbitrary name or a hookable gate name -- can be
             referenced directly from the circuit with
-            ``LEVEL_TRANSITION[key] q``, and ``LOSS(p) q`` applies a uniform
-            loss inline. A transition fires at its circuit position, with the
-            source taken from the qubit's state there.
+            ``LEVEL_TRANSITION[key] q``. ``LEAKAGE(p) q`` applies
+            source-preserving leakage inline, while ``LOSS(p) q`` applies
+            uniform loss. A transition fires at its circuit position, with
+            the source taken from the qubit's state there.
         classifier: Optional [Classifier][clifft.noncomp.Classifier] supplying
             leaked/lost measurement outcomes and computational readout
             confusion.

--- a/tests/python/test_introspection.py
+++ b/tests/python/test_introspection.py
@@ -319,6 +319,10 @@ class TestAstNodeAnnotations:
         node = clifft.parse("LOSS(0.1) 0\nM 0").nodes[0]
         assert node.gate == clifft.GateType.LOSS
 
+    def test_leakage_gate_type_is_bound(self) -> None:
+        node = clifft.parse("LEAKAGE(0.1) 0\nM 0").nodes[0]
+        assert node.gate == clifft.GateType.LEAKAGE
+
     def test_level_transition_gate_type_is_bound(self) -> None:
         node = clifft.parse("LEVEL_TRANSITION[cz_leak] 0\nM 0").nodes[0]
         assert node.gate == clifft.GateType.LEVEL_TRANSITION
@@ -331,8 +335,14 @@ class TestAstNodeAnnotations:
         node = clifft.parse("LOSS(0.1) 0\nM 0").nodes[0]
         assert node.tag == ""
 
+    def test_leakage_tag_is_empty(self) -> None:
+        node = clifft.parse("LEAKAGE(0.1) 0\nM 0").nodes[0]
+        assert node.tag == ""
+
     def test_repr_works_for_annotation_nodes(self) -> None:
         circuit = clifft.parse("LOSS(0.1) 0\nM 0")
         assert repr(circuit.nodes[0]) == "LOSS 0"
+        leakage = clifft.parse("LEAKAGE(0.1) 0\nM 0")
+        assert repr(leakage.nodes[0]) == "LEAKAGE 0"
         circuit2 = clifft.parse("LEVEL_TRANSITION[cz_leak] 0\nM 0")
         assert repr(circuit2.nodes[0]) == "LEVEL_TRANSITION 0"

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -74,7 +74,7 @@ def test_non_hookable_instruction_key_raises():
 
 
 def test_local_annotations_run_end_to_end():
-    """Hand-written LOSS and LEVEL_TRANSITION annotations drive the trajectory."""
+    """Hand-written transition annotations drive the trajectory."""
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"leak": transition_to(LEAK_G)},
@@ -88,6 +88,37 @@ def test_local_annotations_run_end_to_end():
     )
     s = noncomp.sample("H 0\nLOSS(1) 0\nM 0", lossy, shots=32, seed=3)
     assert np.all(s.measurements[:, 0] == 0)  # lost slot fixed by the classifier
+
+
+def test_leakage_preserves_computational_source_level():
+    result = noncomp.sample("X 1\nLEAKAGE(1) 0 1", noncomp.Model(), shots=32, seed=208)
+    assert (result.final_status[:, 0] == noncomp.QubitStatus.LEAK_G).all()
+    assert (result.final_status[:, 1] == noncomp.QubitStatus.LEAK_E).all()
+
+
+@pytest.mark.parametrize(
+    ("initial", "expected"),
+    [
+        ([0, 0, 1, 0, 0], noncomp.QubitStatus.LEAK_G),
+        ([0, 0, 0, 1, 0], noncomp.QubitStatus.LEAK_E),
+        ([0, 0, 0, 0, 1], noncomp.QubitStatus.LOST),
+    ],
+)
+def test_leakage_leaves_noncomputational_sources_unchanged(initial, expected):
+    result = noncomp.sample(
+        "LEAKAGE(1) 0", noncomp.Model(initial_state=initial), shots=16, seed=209
+    )
+    assert (result.final_status[:, 0] == expected).all()
+
+
+def test_multi_target_leakage_samples_targets_independently():
+    p = 0.3
+    shots = 10_000
+    result = noncomp.sample(f"LEAKAGE({p}) 0 1", noncomp.Model(), shots=shots, seed=210)
+    leaked = result.final_status != noncomp.QubitStatus.COMPUTATIONAL
+    assert abs(float(leaked[:, 0].mean()) - p) < 0.025
+    assert abs(float(leaked[:, 1].mean()) - p) < 0.025
+    assert abs(float(np.logical_and(leaked[:, 0], leaked[:, 1]).mean()) - p * p) < 0.02
 
 
 def test_sample_accepts_a_parsed_circuit():
@@ -780,12 +811,13 @@ def test_malformed_transition_error_names_key():
         noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LEAK_G), "CZ": bad})
 
 
-def test_compile_annotated_circuit_raises_invalid_argument_with_noncomp_sample_hint():
-    """clifft.compile() on a LOSS-annotated circuit raises ValueError naming noncomp.sample."""
+@pytest.mark.parametrize("annotation", ["LEAKAGE(0.1) 0", "LOSS(0.1) 0"])
+def test_compile_annotated_circuit_raises_invalid_argument_with_noncomp_sample_hint(annotation):
+    """Ordinary compilation directs noncomputational annotations to noncomp.sample."""
     import clifft
 
     with pytest.raises(ValueError, match="noncomp.sample"):
-        clifft.compile("LOSS(0.1) 0\nM 0")
+        clifft.compile(f"{annotation}\nM 0")
 
 
 def test_sample_type_hints_resolve_at_runtime():

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -97,6 +97,41 @@ def test_transition_probability_on_known_source():
     assert abs(leaked - 0.4) < BAND
 
 
+def test_inline_leakage_matches_exact_enumerator():
+    """Source-preserving leakage agrees on entangled records and statuses."""
+    import utils_noncomp_enumerator as en
+
+    p = 0.35
+    circuit = f"H 0\nCX 0 1\nLEAKAGE({p}) 0 1\nM 0\nM 1\n"
+    classifier_matrix = [[1.0, 0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0]]
+    reference = en.enumerate_exact(
+        circuit,
+        initial=[1, 0, 0, 0, 0],
+        transitions={},
+        classifier=classifier_matrix,
+    )
+    assert reference.dropped_mass < 1e-12
+
+    result = noncomp.sample(
+        circuit,
+        noncomp.Model(classifier=noncomp.Classifier(classifier_matrix)),
+        shots=SHOTS,
+        seed=208,
+    )
+    empirical_records = en.empirical_record_probs(np.asarray(result.measurements))
+    assert en.tvd(reference.record_probs, empirical_records) < BAND
+
+    status_pairs = [
+        (en.LEAK_G, noncomp.QubitStatus.LEAK_G),
+        (en.LEAK_E, noncomp.QubitStatus.LEAK_E),
+    ]
+    for q in range(2):
+        for level, status in status_pairs:
+            expected = reference.noncomp_level_probs[q].get(level, 0.0)
+            observed = float((result.final_status[:, q] == status).mean())
+            assert abs(observed - expected) < BAND
+
+
 @pytest.mark.parametrize("col,expected", [([0.0, 1.0], 1.0), ([1.0, 0.0], 0.0), ([0.5, 0.5], 0.5)])
 def test_classifier_replacement_distribution(col, expected):
     # Always leak to leak_g, then the classifier's column sets the record bit.

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -132,6 +132,29 @@ def test_inline_leakage_matches_exact_enumerator():
             assert abs(observed - expected) < BAND
 
 
+def test_inline_leakage_measure_reset_reprepares_parked_factor():
+    """MR restores a leaked carrier at zero in both reference and sampler."""
+    import utils_noncomp_enumerator as en
+
+    circuit = "X 0\nLEAKAGE(1) 0\nMR 0\nM 0\n"
+    classifier_matrix = [[1.0, 0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0]]
+    reference = en.enumerate_exact(
+        circuit,
+        initial=[1.0, 0.0, 0.0, 0.0, 0.0],
+        transitions={},
+        classifier=classifier_matrix,
+    )
+    assert reference.record_probs == {(1, 0): 1.0}
+
+    result = noncomp.sample(
+        circuit,
+        noncomp.Model(classifier=noncomp.Classifier(classifier_matrix)),
+        shots=32,
+        seed=209,
+    )
+    assert np.array_equal(np.asarray(result.measurements), np.tile([1, 0], (32, 1)))
+
+
 @pytest.mark.parametrize("col,expected", [([0.0, 1.0], 1.0), ([1.0, 0.0], 0.0), ([0.5, 0.5], 0.5)])
 def test_classifier_replacement_distribution(col, expected):
     # Always leak to leak_g, then the classifier's column sets the record bit.

--- a/tests/python/utils_noncomp_enumerator.py
+++ b/tests/python/utils_noncomp_enumerator.py
@@ -236,17 +236,27 @@ def enumerate_exact(
                         p_bit = classifier[bit][level]
                         if p_bit <= 0.0:
                             continue
-                        status = list(br.status)
                         if op.kind == "measure_reset" and level != LOST:
+                            status = list(br.status)
                             status[q] = G  # reset restores the leaked qubit
-                        nxt.append(
-                            _Branch(
-                                br.weight * p_bit,
-                                br.state,
-                                tuple(status),
-                                br.record + (bit,),
+                            for w, post, parked_bit in _hidden_collapse(br, q, n):
+                                nxt.append(
+                                    _Branch(
+                                        br.weight * p_bit * w,
+                                        _prep_zero(post, q, parked_bit, n),
+                                        tuple(status),
+                                        br.record + (bit,),
+                                    )
+                                )
+                        else:
+                            nxt.append(
+                                _Branch(
+                                    br.weight * p_bit,
+                                    br.state,
+                                    br.status,
+                                    br.record + (bit,),
+                                )
                             )
-                        )
                 continue
 
             if op.kind == "leakage":

--- a/tests/python/utils_noncomp_enumerator.py
+++ b/tests/python/utils_noncomp_enumerator.py
@@ -14,9 +14,10 @@ Deliberately independent of clifft: its own line parser (a small subset)
 and its own statement of the semantics -- operations touching a leaked or
 lost operand drop whole (measurements never drop; a classifier column
 supplies their record bit), R restores a leaked qubit and never a lost
-one, LOSS is a source-independent trace-out. Exponential in circuit
-size by construction; the branch cap guards against feeding it a scenario
-it was never meant to hold.
+one, LEAKAGE preserves the computational source label, and LOSS is a
+source-independent trace-out. Exponential in circuit size by construction;
+the branch cap guards against feeding it a scenario it was never meant to
+hold.
 
 Level ids match ``clifft.noncomp.Level``: g=0, e=1, leak_g=2, leak_e=3,
 lost=4.
@@ -40,7 +41,8 @@ _MAX_BRANCHES = 200_000
 
 @dataclass
 class _Op:
-    kind: str  # "gate" | "reset" | "measure" | "measure_reset" | "transition" | "loss"
+    # gate | reset | measure | measure_reset | transition | leakage | loss
+    kind: str
     targets: list[int]
     gate: str = ""
     tag: str = ""
@@ -82,6 +84,10 @@ def parse_circuit(text: str) -> tuple[list[_Op], int]:
             m = re.fullmatch(r"LOSS\(([^)]+)\)", name)
             assert m is not None, line
             ops.extend(_Op("loss", [q], prob=float(m.group(1))) for q in qubits)
+        elif name.startswith("LEAKAGE("):
+            m = re.fullmatch(r"LEAKAGE\(([^)]+)\)", name)
+            assert m is not None, line
+            ops.extend(_Op("leakage", [q], prob=float(m.group(1))) for q in qubits)
         else:
             raise ValueError(f"enumerator does not support: {line}")
     return ops, max_q + 1
@@ -241,6 +247,23 @@ def enumerate_exact(
                                 br.record + (bit,),
                             )
                         )
+                continue
+
+            if op.kind == "leakage":
+                if level not in _COMPUTATIONAL:
+                    nxt.append(br)
+                    continue
+                p = op.prob
+                if p < 1.0:
+                    nxt.append(_Branch(br.weight * (1.0 - p), br.state, br.status, br.record))
+                if p > 0.0:
+                    for source in _COMPUTATIONAL:
+                        w, post = oracle.collapse(br.state, q, source, n)
+                        if w <= 0.0:
+                            continue
+                        status = list(br.status)
+                        status[q] = LEAK_G if source == G else LEAK_E
+                        nxt.append(_Branch(br.weight * p * w, post, tuple(status), br.record))
                 continue
 
             if op.kind == "loss":

--- a/tests/python/utils_qiskit.py
+++ b/tests/python/utils_qiskit.py
@@ -129,6 +129,9 @@ _SKIP_GATES = frozenset(
         "CORRELATED_ERROR",
         "E",
         "ELSE_CORRELATED_ERROR",
+        "LEVEL_TRANSITION",
+        "LEAKAGE",
+        "LOSS",
         "MPP",  # Pauli product measurements need special handling
     }
 )

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1848,6 +1848,8 @@ TEST_CASE("Standalone READOUT_NOISE lowers one- and two-argument forms") {
 TEST_CASE("Trace rejects noncomputational annotations with a pointer to the entry point") {
     REQUIRE_THROWS_WITH(trace(parse("LEVEL_TRANSITION[t] 0\n")),
                         Catch::Matchers::ContainsSubstring("noncomp.sample"));
+    REQUIRE_THROWS_WITH(trace(parse("LEAKAGE(0.1) 0\n")),
+                        Catch::Matchers::ContainsSubstring("noncomp.sample"));
     REQUIRE_THROWS_WITH(trace(parse("LOSS(0.1) 0\n")),
                         Catch::Matchers::ContainsSubstring("noncomp.sample"));
 }

--- a/tests/test_frontend_instruments.cc
+++ b/tests/test_frontend_instruments.cc
@@ -1,7 +1,7 @@
 // Frontend materialization and fence tests for INSTRUMENT ops.
 //
-// trace() with InstrumentTraceOptions materializes LEVEL_TRANSITION and
-// LOSS annotations into OpType::INSTRUMENT ops carrying the rewound
+// trace() with InstrumentTraceOptions materializes LEVEL_TRANSITION,
+// LEAKAGE, and LOSS annotations into OpType::INSTRUMENT ops carrying the rewound
 // source projector Z_q, with per-source probabilities in the
 // InstrumentSite side-table. Without options the annotations reject as
 // before. Instruments are optimization fences: no pass moves anything
@@ -61,6 +61,8 @@ bool mask_is(const HirModule& hir, const HeisenbergOp& op, uint32_t qubit, bool 
 TEST_CASE("trace: annotations still reject without instrument options") {
     REQUIRE_THROWS_WITH(trace(parse("LEVEL_TRANSITION[jump] 0")),
                         ContainsSubstring("noncomputational annotation"));
+    REQUIRE_THROWS_WITH(trace(parse("LEAKAGE(0.1) 0")),
+                        ContainsSubstring("noncomputational annotation"));
     REQUIRE_THROWS_WITH(trace(parse("LOSS(0.1) 0")),
                         ContainsSubstring("noncomputational annotation"));
 }
@@ -107,8 +109,27 @@ TEST_CASE("trace: the instrument mask is the rewound source projector") {
 }
 
 TEST_CASE("trace: LOSS materializes a source-independent all-trap site per target") {
-    const InstrumentTraceOptions options;  // LOSS needs no named specs
+    const InstrumentTraceOptions options;  // Inline annotations need no named specs
     auto hir = hir_with_instruments("LOSS(0.25) 0 1", options);
+
+    REQUIRE(hir.ops.size() == 2);
+    REQUIRE(hir.instrument_sites.size() == 2);
+    for (int i = 0; i < 2; ++i) {
+        const InstrumentSite& site = hir.instrument_sites[static_cast<size_t>(i)];
+        const InstrumentProbabilities& probabilities = site.probabilities;
+        REQUIRE(site.qubit == static_cast<uint32_t>(i));
+        REQUIRE_THAT(probabilities.p_fire[0], WithinAbs(0.25, kTol));
+        REQUIRE_THAT(probabilities.p_fire[1], WithinAbs(0.25, kTol));
+        REQUIRE_THAT(probabilities.p_noncomputational_dest(0), WithinAbs(0.25, kTol));
+        REQUIRE_THAT(probabilities.p_noncomputational_dest(1), WithinAbs(0.25, kTol));
+        REQUIRE(mask_is(hir, hir.ops[static_cast<size_t>(i)], static_cast<uint32_t>(i), false, true,
+                        false));
+    }
+}
+
+TEST_CASE("trace: LEAKAGE materializes a source-preserving all-trap site per target") {
+    const InstrumentTraceOptions options;
+    auto hir = hir_with_instruments("LEAKAGE(0.25) 0 1", options);
 
     REQUIRE(hir.ops.size() == 2);
     REQUIRE(hir.instrument_sites.size() == 2);
@@ -129,7 +150,8 @@ TEST_CASE("trace: a zero-rate site is elided") {
     InstrumentTraceOptions options;
     options.transitions.emplace("nothing", InstrumentProbabilities{});
 
-    auto hir = hir_with_instruments("LOSS(0) 0\nLEVEL_TRANSITION[nothing] 0", options);
+    auto hir =
+        hir_with_instruments("LEAKAGE(0) 0\nLOSS(0) 0\nLEVEL_TRANSITION[nothing] 0", options);
     REQUIRE(hir.ops.empty());
     REQUIRE(hir.instrument_sites.empty());
     REQUIRE(hir.is_deterministic());

--- a/tests/test_noncomp_model.cc
+++ b/tests/test_noncomp_model.cc
@@ -150,7 +150,7 @@ TEST_CASE(
 }
 
 TEST_CASE("NonComputationalModel: rejects non-hookable instruction keys") {
-    for (const std::string key : {"DEPOLARIZE1", "TICK", "LOSS"}) {
+    for (const std::string key : {"DEPOLARIZE1", "TICK", "LEAKAGE", "LOSS"}) {
         REQUIRE_THROWS_WITH(
             NonComputationalModel::from_spec(default_initial_state(),
                                              {{key, zero_transition_matrix()}}, std::nullopt,

--- a/tests/test_parser.cc
+++ b/tests/test_parser.cc
@@ -1883,6 +1883,7 @@ TEST_CASE("GateTraits: unitary classification", "[gate_data]") {
     CHECK(!is_unitary(GateType::TICK));
     CHECK(!is_unitary(GateType::EXP_VAL));
     CHECK(!is_unitary(GateType::LEVEL_TRANSITION));
+    CHECK(!is_unitary(GateType::LEAKAGE));
     CHECK(!is_unitary(GateType::LOSS));
     CHECK(!is_unitary(GateType::UNKNOWN));
 }
@@ -2054,4 +2055,25 @@ TEST_CASE("LOSS parses its probability and rejects bad forms") {
     CHECK_THROWS_AS(parse("LOSS(1.5) 0\n"), ParseError);  // out of range
     CHECK_THROWS_AS(parse("LOSS(0.1, 0.2) 0\n"), ParseError);
     CHECK_THROWS_AS(parse("LOSS(0.1) !0\n"), ParseError);  // inverted target
+}
+
+TEST_CASE("LEAKAGE parses its probability and rejects bad forms") {
+    auto c = parse("LEAKAGE(0.25) 0 1\n");
+    REQUIRE(c.nodes.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
+        REQUIRE(c.nodes[i].gate == GateType::LEAKAGE);
+        REQUIRE(c.nodes[i].args == std::vector<double>{0.25});
+        REQUIRE(c.nodes[i].targets[0].value() == i);
+    }
+    REQUIRE(c.num_qubits == 2);
+    REQUIRE(c.num_measurements == 0);
+
+    CHECK_THROWS_AS(parse("LEAKAGE 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LEAKAGE(-0.1) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LEAKAGE(1.5) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LEAKAGE(nan) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LEAKAGE(inf) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LEAKAGE(0.1, 0.2) 0\n"), ParseError);
+    CHECK_THROWS_AS(parse("LEAKAGE(0.1) !0\n"), ParseError);
+    CHECK_THROWS_AS(parse("M 0\nLEAKAGE(0.1) rec[-1]\n"), ParseError);
 }

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -596,12 +596,12 @@ TEST_CASE("trajectory: ternary heralds keep a uniform visible bit") {
     REQUIRE(ones < 140);
 }
 
-TEST_CASE("trajectory: a hand-built malformed LOSS rejects up front") {
-    // A live LOSS site rides through the continuation rewrite verbatim,
+TEST_CASE("trajectory: hand-built malformed inline transitions reject up front") {
+    // A live inline site rides through the continuation rewrite verbatim,
     // and trace() must never be the first to look at its arguments (a
-    // missing one would read as probability zero). Every annotation
-    // validates before the first compile instead. The parser guarantees
-    // LOSS(p) for parsed circuits; these are programmatically built.
+    // missing one would read as probability zero). Every annotation validates
+    // before the first compile instead. The parser guarantees the argument for
+    // parsed circuits; these nodes are programmatically built.
     ModelSpec spec;
     auto model = make_driver_model(spec);
     Circuit circuit = parse("H 0\nM 0");
@@ -616,6 +616,19 @@ TEST_CASE("trajectory: a hand-built malformed LOSS rejects up front") {
                              AstNode{GateType::LOSS, {Target::qubit(0)}, {7.0}, 0});
         REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
                             ContainsSubstring("out of [0, 1]"));
+    }
+    SECTION("LEAKAGE missing the probability argument") {
+        circuit.nodes.insert(circuit.nodes.begin() + 1,
+                             AstNode{GateType::LEAKAGE, {Target::qubit(0)}, {}, 0});
+        REQUIRE_THROWS_WITH(
+            sample_noncomputational(circuit, model, 4, 1),
+            ContainsSubstring("LEAKAGE") && ContainsSubstring("exactly one argument"));
+    }
+    SECTION("LEAKAGE probability outside [0, 1]") {
+        circuit.nodes.insert(circuit.nodes.begin() + 1,
+                             AstNode{GateType::LEAKAGE, {Target::qubit(0)}, {7.0}, 0});
+        REQUIRE_THROWS_WITH(sample_noncomputational(circuit, model, 4, 1),
+                            ContainsSubstring("LEAKAGE") && ContainsSubstring("out of [0, 1]"));
     }
 }
 
@@ -1163,6 +1176,73 @@ TEST_CASE("trajectory: multi-target annotation jumps both targets in one shot") 
         REQUIRE(result.final_status[shot * 2] == QubitStatus::Lost);
         REQUIRE(result.final_status[shot * 2 + 1] == QubitStatus::Lost);
     }
+}
+
+// Inline leakage
+
+TEST_CASE("trajectory: certain LEAKAGE preserves the computational source level") {
+    ModelSpec spec;
+    auto model = make_driver_model(spec);
+    auto circuit = parse("X 1\nLEAKAGE(1) 0 1");
+
+    auto result = sample_noncomputational(circuit, model, 20, 137);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        REQUIRE(result.final_status[shot * 2] == QubitStatus::LeakG);
+        REQUIRE(result.final_status[shot * 2 + 1] == QubitStatus::LeakE);
+    }
+}
+
+TEST_CASE("trajectory: LEAKAGE leaves noncomputational sources unchanged") {
+    SECTION("leak_g") {
+        ModelSpec spec;
+        spec.initial = pure_initial_state(Level::LeakG);
+        auto result =
+            sample_noncomputational(parse("LEAKAGE(1) 0"), make_driver_model(spec), 20, 139);
+        for (const QubitStatus status : result.final_status) {
+            REQUIRE(status == QubitStatus::LeakG);
+        }
+    }
+    SECTION("leak_e") {
+        ModelSpec spec;
+        spec.initial = pure_initial_state(Level::LeakE);
+        auto result =
+            sample_noncomputational(parse("LEAKAGE(1) 0"), make_driver_model(spec), 20, 141);
+        for (const QubitStatus status : result.final_status) {
+            REQUIRE(status == QubitStatus::LeakE);
+        }
+    }
+    SECTION("lost") {
+        ModelSpec spec;
+        spec.initial = pure_initial_state(Level::Lost);
+        auto result =
+            sample_noncomputational(parse("LEAKAGE(1) 0"), make_driver_model(spec), 20, 143);
+        for (const QubitStatus status : result.final_status) {
+            REQUIRE(status == QubitStatus::Lost);
+        }
+    }
+}
+
+TEST_CASE("trajectory: LEAKAGE on a leaked qubit spends no driver draw") {
+    const uint64_t seed = 145;
+    auto recover = zero_transition_matrix();
+    recover[level_index(Level::E)][level_index(Level::LeakG)] = 0.5;
+    auto model =
+        NonComputationalModel::from_spec(pure_initial_state(Level::LeakG), {{"recover", recover}},
+                                         std::nullopt, NonComputationalPolicy{});
+
+    auto plain = sample_noncomputational(parse("LEVEL_TRANSITION[recover] 0"), model, 128, seed);
+    auto redundant = sample_noncomputational(parse("LEAKAGE(1) 0\nLEVEL_TRANSITION[recover] 0"),
+                                             model, 128, seed);
+    REQUIRE(plain.final_status == redundant.final_status);
+
+    bool saw_leaked = false;
+    bool saw_recovered = false;
+    for (const QubitStatus status : plain.final_status) {
+        saw_leaked |= status == QubitStatus::LeakG;
+        saw_recovered |= status == QubitStatus::Computational;
+    }
+    REQUIRE(saw_leaked);
+    REQUIRE(saw_recovered);
 }
 
 // LOSS on already-leaked and already-lost qubits


### PR DESCRIPTION
## Summary

- add `LEAKAGE(p)` parsing, Python introspection, gate reference, and leakage/loss guide coverage
- preserve the computational source when leakage fires (`G` to `LeakG`, `E` to `LeakE`) using the existing instrument and continuation machinery
- leave already leaked or lost targets unchanged without spending a driver RNG draw, and sample multiple targets independently
- direct ordinary compilation to `clifft.noncomp.sample()` and cover behavior against the independent exact enumerator
- make classified measure-reset operations in the exact enumerator discard the parked factor and reprepare `|0>`, matching the trajectory rewriter

Closes #208.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build-issue208 -E '^Bench:' --output-on-failure -j4`; 1,129 passed)
- [x] Python tests pass (`uv run pytest tests/python/ -q`; 879 passed)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -q`; 30 passed, 7 skipped)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [ ] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.

The commits include `Assisted-by: ChatGPT (GPT-5.6 Sol)` trailers. The contributor checkboxes are left for the submitter to confirm.
