### PR TITLE
docs: focus agent instructions on repository constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,95 +1,70 @@
-# Clifft AI Agent Instructions
+# Clifft Agent Instructions
 
-Instructions for AI coding assistants working on this repository.
+This file records repository-specific constraints that are easy to miss from
+the code alone. Use `README.md`, `docs/development/`, and `just --list` for
+project orientation and routine build, test, and contribution instructions.
 
-## Project Overview
+## Source of Truth and Architecture Changes
 
-Clifft is a multi-level Ahead-Of-Time (AOT) compiler and Schrodinger Virtual
-Machine (SVM) for quantum circuits. It supports Clifford + T gates and beyond,
-with a focus on high-performance simulation.
+Use `src/clifft/`, `tests/`, `docs/`, and `README.md` as the source of truth.
+Inspect the current implementation and tests before resolving architectural
+ambiguity.
 
-## Source of Truth
+If a proposed change contradicts an architectural invariant or the current
+architecture cannot support it:
 
-Use the code under `src/clifft/`, the tests under `tests/`, and the
-documentation under `docs/` and `README.md` as the source
-of truth. If something appears architecturally ambiguous, inspect the current
-implementation and tests first, then ask the human before making a speculative
-change.
-
-## Architecture Change Protocol
-
-Do not rewrite architecture-facing docs to justify a code change. If you
-discover a technical contradiction or a scenario where the current architecture
-cannot support a proposed change:
-
-1. **Stop.** Do not silently implement a workaround.
-2. Explain the discrepancy and propose a fix.
-3. Wait for confirmation before proceeding.
+1. Stop instead of implementing a workaround or rewriting architecture-facing
+   documentation to justify the change.
+2. Explain the discrepancy and propose an explicit architectural change.
+3. Wait for human confirmation before implementation.
 
 ## Architectural Invariants
 
-These constraints must not be violated:
-
-- **32-Byte Instruction:** The VM `Instruction` union must remain exactly 32
-  bytes (`static_assert(sizeof(Instruction) == 32)`).
-- **Stim is Immutable:** Fetch Stim via CMake `FetchContent`. Do not fork,
+- **Legacy SVM instruction ABI:** The legacy VM `Instruction` must remain
+  exactly 32 bytes (`static_assert(sizeof(Instruction) == 32)`). New executors
+  must use separate instruction or plan types rather than expanding it.
+- **Stim is immutable:** Fetch Stim through CMake `FetchContent`. Do not fork,
   vendor, or patch Stim source.
-- **Single Memory Allocation:** The VM's `SchrodingerState` allocates its
-  coefficient array once at construction, sized by `peak_rank`. The one
-  sanctioned exception is the trap boundary: `resume()` may grow (never
-  shrink) the array before re-entering the dispatch, when a trap
-  continuation was compiled with a larger peak rank. No allocation ever
-  happens inside the dispatch loop or a kernel.
-- **Deterministic RNG:** Do not use `std::uniform_real_distribution` (it is
-  implementation-defined). Use `(rng() >> 11) * 0x1.0p-53` for `[0, 1)`.
-- **No Global Topology in the VM:** All multi-qubit Pauli interference must
-  be localized into local operations by the compiler, not evaluated at
-  runtime.
+- **Allocation-free hot execution:** The legacy `SchrodingerState` coefficient
+  array is allocated once at construction from `peak_rank`. New executors must
+  likewise preallocate coefficient, record, symbolic-state, and scratch storage
+  before entering hot dispatch or kernels. The sanctioned exception is an
+  explicit trap or continuation boundary, where storage may grow but never
+  shrink before dispatch resumes. No allocation is allowed inside an ordinary
+  dispatch loop or kernel.
+- **Deterministic RNG:** Do not use `std::uniform_real_distribution`; its output
+  is implementation-defined. Use `(rng() >> 11) * 0x1.0p-53` for `[0, 1)`.
+- **No runtime topology planning:** The compiler or planner must precompute
+  coordinate changes, Pauli pairings, phase behavior, active-width transitions,
+  and symbolic dependencies. The legacy SVM continues to execute localized
+  operations. A symbolic-coordinate executor may apply compiler-precomputed
+  multi-coordinate active-Pauli actions directly, but runtime code must not
+  perform tableau evolution, commutation analysis, localization, or dependency
+  discovery.
 
-## Git Workflow
+## Repository-Specific Source and Test Rules
 
-1. Never commit directly to `main`. Create a feature branch.
-2. Make atomic commits with conventional prefixes (`feat:`, `fix:`, `test:`,
-   `docs:`).
-3. Run `uv run pre-commit run --all-files` before every commit.
-4. Include an `Assisted-by:` trailer in commit messages:
-   ```
-   Assisted-by: Claude (Opus 4.6) <noreply@anthropic.com>
-   ```
+- Keep source files ASCII-only: use `pi`, `|0>`, and `Schrodinger` rather than
+  Unicode alternatives.
+- Comments should explain why, not restate what the code does.
+- Do not put issue numbers, task phases, or planning details in code comments
+  or test names.
+- Catch2 `TEST_CASE` names must avoid special characters such as `[]`, `()`,
+  and `,`.
+- Validate Python-facing unitaries against Qiskit Aer and stochastic Clifford
+  behavior against Stim when those independent references apply.
 
-## Build & Test
+## Git and AI-Assisted Contribution Rules
 
-```bash
-# Python package (recommended)
-uv pip install -e .
-uv run pytest tests/python/ -v
+- Never commit directly to `main`; use a feature branch.
+- Keep commits atomic and use conventional prefixes such as `feat:`, `fix:`,
+  `test:`, and `docs:`.
+- Run `uv run pre-commit run --all-files` before every commit, in addition to
+  the tests appropriate for the change.
+- Include an `Assisted-by:` trailer identifying the agent that actually
+  assisted. Each agent must use its own name, model, and provider address; do
+  not copy a named example literally. Format:
 
-# C++ standalone
-cmake -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build -j
-ctest --test-dir build --output-on-failure
-```
-
-## C++ Coding Standards
-
-- **Standard:** C++20
-- **Namespace:** All code in `namespace clifft { ... }`
-- **Comments:** Explain *why*, not *what*. Omit if self-explanatory.
-- **ASCII-only source:** No Unicode in source files. Use `pi` not the Greek
-  letter, `|0>` not angle brackets, `Schrodinger` not the umlaut form.
-- **No plan references in code:** Do not include task numbers, phase
-  references, or planning details in comments or test names.
-
-## Testing
-
-- **C++ (Catch2):** Isolate and test components natively. Avoid special
-  characters in `TEST_CASE` names (no `[]`, `()`, or `,`).
-- **Python (pytest):** Validate against Qiskit-Aer for unitaries and Stim
-  for stochastic circuits.
-- Code coverage (`just py-cov`, `just cpp-cov`) is available but not
-  required on every commit.
-
-## When Stuck
-
-If you cannot resolve an issue after a few attempts, stop and explain the
-error clearly. Do not attempt large speculative refactors — ask for guidance.
+  ```text
+  Assisted-by: AGENT_NAME (MODEL_NAME) <PROVIDER_NOREPLY_EMAIL>
+  ```


### PR DESCRIPTION
## Summary

- trim duplicated project orientation, build commands, and general testing guidance from `AGENTS.md`
- update the runtime-topology invariant to permit compiler-precomputed symbolic-coordinate actions while prohibiting runtime topology planning, consistent with discussion #236
- extend the allocation rule to future executors and keep the legacy 32-byte instruction ABI explicitly scoped
- require each assisting agent to identify itself in the `Assisted-by:` trailer instead of copying a named example

## Test plan

- [ ] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`) — not run; instruction-only change
- [ ] Python tests pass (`uv run pytest tests/python/ -v`) — not run; instruction-only change
- [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`) — not run; `AGENTS.md` is not part of the rendered documentation
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project Apache-2.0 license.
- [ ] If this contribution was AI-assisted, I have reviewed the generated changes and included an `Assisted-by:` git trailer in the commit message.

The contributor-agreement boxes are left for human review.