### PR TITLE
fix: guard trajectory continuation prefixes

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -365,11 +365,12 @@ and resumes the shot after the jump. `noncomp.sample` therefore takes the
 circuit and model together and compiles internally.
 
 Each continuation uses the default optimization passes that preserve
-measurement-record order. At the HIR stage, this means
+measurement-record order and explicitly opt in to instrument-prefix stability.
+At the HIR stage, this means
 `PeepholeFusionPass`; `StatevectorSqueezePass` is omitted because it can move
-measurements. All of the default bytecode passes currently preserve record
-order and are applied. See [Optimization Passes](../reference/passes.md) for
-the full list.
+measurements. All of the default bytecode passes currently preserve both
+properties and are applied. See [Optimization Passes](../reference/passes.md)
+for the full list.
 
 This restriction matters because resolving a trapped transition may add a
 forced, hidden trace-out measurement. Moving another measurement across that
@@ -377,6 +378,8 @@ collapse can change correlations. Record-order preservation is necessary but
 not sufficient for resuming a shot: recompiling the remainder must also
 reproduce the bytecode prefix already executed, because `resume()` reuses the
 existing VM state directly. `noncomp.sample` therefore uses a fixed internal
-pipeline and does not currently accept custom pass managers. The theory page
+pipeline and validates the bytecode and referenced constant-pool data in each
+recompiled prefix before resuming. It does not currently accept custom pass
+managers. The theory page
 explains
 [how this composes with Clifft](../theory/noncomputational.md#how-this-composes-with-clifft).

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -89,6 +89,7 @@ def define_env(env: Any) -> None:
             "kind": "HIR",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "PeepholeFusionPass",
             "summary": "Algebraic T-gate fusion and terminal-phase elimination.",
             "detail": (
@@ -105,6 +106,7 @@ def define_env(env: Any) -> None:
             "kind": "HIR",
             "default_enabled": True,
             "preserves_record_order": False,
+            "preserves_instrument_prefix": False,
             "python_name": "StatevectorSqueezePass",
             "summary": "Minimizes peak active dimension by reordering HIR operations.",
             "detail": (
@@ -120,6 +122,7 @@ def define_env(env: Any) -> None:
             "kind": "HIR",
             "default_enabled": False,
             "preserves_record_order": False,
+            "preserves_instrument_prefix": False,
             "python_name": "RemoveNoisePass",
             "summary": "Strips all noise from the HIR.",
             "detail": (
@@ -135,6 +138,7 @@ def define_env(env: Any) -> None:
             "kind": "HIR",
             "default_enabled": False,
             "preserves_record_order": False,
+            "preserves_instrument_prefix": False,
             "python_name": "DropNonUnitaryPass",
             "summary": "Drops non-evolution operations from the HIR.",
             "detail": (
@@ -150,6 +154,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "NoiseBlockPass",
             "summary": "Coalesces contiguous noise instructions into blocks.",
             "detail": (
@@ -165,6 +170,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "MultiGatePass",
             "summary": "Fuses star-graph CNOT/CZ patterns into single array sweeps.",
             "detail": (
@@ -180,6 +186,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "ExpandTPass",
             "summary": "Fuses EXPAND + T-phase into a single array pass.",
             "detail": (
@@ -194,6 +201,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "ExpandRotPass",
             "summary": "Fuses EXPAND + continuous rotation into a single array pass.",
             "detail": (
@@ -207,6 +215,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "SwapMeasPass",
             "summary": "Fuses SWAP + measurement into one operation.",
             "detail": (
@@ -222,6 +231,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "TileAxisFusionPass",
             "summary": "Fuses 2-qubit tile sequences into precomputed 4x4 unitaries.",
             "detail": (
@@ -238,6 +248,7 @@ def define_env(env: Any) -> None:
             "kind": "Bytecode",
             "default_enabled": True,
             "preserves_record_order": True,
+            "preserves_instrument_prefix": True,
             "python_name": "SingleAxisFusionPass",
             "summary": "Fuses single-axis operation chains into precomputed 2x2 unitaries.",
             "detail": (

--- a/docs/reference/passes.md
+++ b/docs/reference/passes.md
@@ -36,7 +36,7 @@ bpm.add(clifft.NoiseBlockPass())
 bpm.add(clifft.MultiGatePass())
 ```
 
-## Measurement-Record Order
+## Trajectory Safety Metadata
 
 Some workflows require measurements to remain in their original order,
 including hidden measurements introduced by the compiler. In particular,
@@ -44,16 +44,19 @@ including hidden measurements introduced by the compiler. In particular,
 when it resumes a trapped transition. Moving another measurement across that
 collapse can change quantum correlations.
 
-`clifft.noncomp.sample` therefore applies only passes that are both enabled by
-default and marked as preserving measurement-record order. Its HIR pipeline
-uses `PeepholeFusionPass` but omits `StatevectorSqueezePass`; all default
-bytecode passes currently preserve record order and are applied.
+`clifft.noncomp.sample` therefore applies only passes that are enabled by
+default, preserve measurement-record order, and preserve instrument prefixes.
+Its HIR pipeline uses `PeepholeFusionPass` but omits
+`StatevectorSqueezePass`; all default bytecode passes currently preserve both
+properties and are applied.
 
 Record-order preservation is necessary but does not by itself make a
-continuation compatible with an already-running VM state. Recompilation must
-also reproduce the bytecode prefix that the state executed. For this reason,
-`clifft.noncomp.sample` uses a fixed internal pipeline and does not currently
-accept custom pass managers. See
+continuation compatible with an already-running VM state. Trajectory passes
+must also opt in to instrument-prefix stability: changing the circuit after an
+instrument may not change optimized output through that instrument. The
+runtime checks each recompiled prefix, including referenced constant-pool data,
+before resuming. For this reason, `clifft.noncomp.sample` uses a fixed internal
+pipeline and does not currently accept custom pass managers. See
 [Leakage and Loss](../guide/leakage-and-loss.md#why-there-is-no-compile-step)
 for how continuations are compiled and resumed.
 
@@ -69,6 +72,7 @@ for how continuations are compiled and resumed.
 | **Kind** | HIR (pre-lowering) |
 | **Default** | {{ '✅ Enabled' if p['default_enabled'] else '❌ Disabled' }} |
 | **Preserves measurement-record order** | {{ 'Yes' if p['preserves_record_order'] else 'No' }} |
+| **Preserves instrument prefix** | {{ 'Yes' if p['preserves_instrument_prefix'] else 'No' }} |
 | **Python** | `clifft.{{ p['python_name'] }}()` |
 
 {{ p['detail'] }}
@@ -87,6 +91,7 @@ for how continuations are compiled and resumed.
 | **Kind** | Bytecode (post-lowering) |
 | **Default** | {{ '✅ Enabled' if p['default_enabled'] else '❌ Disabled' }} |
 | **Preserves measurement-record order** | {{ 'Yes' if p['preserves_record_order'] else 'No' }} |
+| **Preserves instrument prefix** | {{ 'Yes' if p['preserves_instrument_prefix'] else 'No' }} |
 | **Python** | `clifft.{{ p['python_name'] }}()` |
 
 {{ p['detail'] }}

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(clifft_core STATIC
     noncomp/model.cc
     noncomp/status_walk.cc
     noncomp/rewriter.cc
+    noncomp/continuation_prefix.cc
     noncomp/trajectory_driver.cc
     noncomp/sample.cc
 )

--- a/src/clifft/backend/backend.h
+++ b/src/clifft/backend/backend.h
@@ -281,6 +281,8 @@ struct FusedU2Node {
 
     // Resulting 2-bit (p_z << 1) | p_x frame state after the sequence.
     uint8_t out_states[4];
+
+    [[nodiscard]] bool operator==(const FusedU2Node&) const = default;
 };
 
 // Pre-computed 4x4 unitary for OP_ARRAY_U4 (2-axis tile fusion).
@@ -298,8 +300,12 @@ struct FusedU4Node {
 
         // Resulting 4-bit frame state: (pz_hi << 3) | (px_hi << 2) | (pz_lo << 1) | px_lo
         uint8_t out_state;
+
+        [[nodiscard]] bool operator==(const Entry&) const = default;
     };
     Entry entries[16];  // Indexed by 4-bit incoming frame state
+
+    [[nodiscard]] bool operator==(const FusedU4Node&) const = default;
 };
 
 // Compiled instrument site: probabilities are physical
@@ -316,6 +322,8 @@ struct CompiledInstrumentSite {
     PauliMaskHandle destination_flip_mask{};
 
     InstrumentProbabilities probabilities;
+
+    [[nodiscard]] bool operator==(const CompiledInstrumentSite&) const = default;
 };
 
 struct ConstantPool {

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -70,10 +70,14 @@ enum class ExpValIdx : uint32_t {};
 struct NoiseChannel {
     PauliMaskHandle mask;
     double prob;
+
+    [[nodiscard]] bool operator==(const NoiseChannel&) const = default;
 };
 
 struct NoiseSite {
     std::vector<NoiseChannel> channels;
+
+    [[nodiscard]] bool operator==(const NoiseSite&) const = default;
 };
 
 /// Readout noise entry: classical bit-flip on a measurement result. The
@@ -86,6 +90,7 @@ struct ReadoutNoiseEntry {
     double prob_one_to_zero;  // Flip probability when the recorded bit is 1
 
     [[nodiscard]] bool is_symmetric() const { return prob_zero_to_one == prob_one_to_zero; }
+    [[nodiscard]] bool operator==(const ReadoutNoiseEntry&) const = default;
 };
 
 /// Index into HirModule::readout_noise side-table
@@ -141,6 +146,8 @@ struct InstrumentProbabilities {
     // destination d. Dividing by p_fire[s] gives the destination
     // probability conditioned on a fire from s.
     double p_computational_dest[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
+
+    [[nodiscard]] bool operator==(const InstrumentProbabilities&) const = default;
 
     [[nodiscard]] double p_noncomputational_dest(uint8_t source) const {
         assert(source < 2 && "instrument source must be G or E");

--- a/src/clifft/noncomp/continuation_prefix.cc
+++ b/src/clifft/noncomp/continuation_prefix.cc
@@ -33,8 +33,7 @@ namespace {
     }
     const PauliMaskView a_mask = a.at(a_handle);
     const PauliMaskView b_mask = b.at(b_handle);
-    return a_mask.x() == b_mask.x() && a_mask.z() == b_mask.z() &&
-           a_mask.sign() == b_mask.sign();
+    return a_mask.x() == b_mask.x() && a_mask.z() == b_mask.z() && a_mask.sign() == b_mask.sign();
 }
 
 [[nodiscard]] bool same_u2(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
@@ -72,8 +71,7 @@ namespace {
                 }
             }
         }
-        if (!same_complex(x.entries[state].gamma_multiplier,
-                          y.entries[state].gamma_multiplier) ||
+        if (!same_complex(x.entries[state].gamma_multiplier, y.entries[state].gamma_multiplier) ||
             x.entries[state].out_state != y.entries[state].out_state) {
             return false;
         }
@@ -155,8 +153,7 @@ namespace {
                      b.instrument_destination_flip_masks, y.destination_flip_mask);
 }
 
-[[nodiscard]] bool same_instruction(const Instruction& continuation,
-                                    const Instruction& executed) {
+[[nodiscard]] bool same_instruction(const Instruction& continuation, const Instruction& executed) {
     if (std::memcmp(&continuation, &executed, sizeof(Instruction)) == 0) {
         return true;
     }
@@ -178,8 +175,7 @@ namespace {
             return same_u4(a, b, instr.u4.cp_idx);
         case Opcode::OP_APPLY_PAULI:
             return same_mask(a.pauli_masks, static_cast<PauliMaskHandle>(instr.pauli.cp_mask_idx),
-                             b.pauli_masks,
-                             static_cast<PauliMaskHandle>(instr.pauli.cp_mask_idx));
+                             b.pauli_masks, static_cast<PauliMaskHandle>(instr.pauli.cp_mask_idx));
         case Opcode::OP_NOISE:
             return same_noise_site(a, b, instr.pauli.cp_mask_idx);
         case Opcode::OP_NOISE_BLOCK:

--- a/src/clifft/noncomp/continuation_prefix.cc
+++ b/src/clifft/noncomp/continuation_prefix.cc
@@ -33,8 +33,12 @@ namespace {
     }
     const PauliMaskView a_mask = a.at(a_handle);
     const PauliMaskView b_mask = b.at(b_handle);
-    return a_mask.x() == b_mask.x() && a_mask.z() == b_mask.z() && a_mask.sign() == b_mask.sign();
+    return a_mask == b_mask;
 }
+
+// Defaulted equality on the pool value types is an evolution tripwire: a new
+// field automatically joins the comparison. The explicit checks below retain
+// bit-exact treatment for the floating-point fields that exist today.
 
 [[nodiscard]] bool same_u2(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
     if (idx >= a.fused_u2_nodes.size() || idx >= b.fused_u2_nodes.size()) {
@@ -42,6 +46,9 @@ namespace {
     }
     const FusedU2Node& x = a.fused_u2_nodes[idx];
     const FusedU2Node& y = b.fused_u2_nodes[idx];
+    if (!(x == y)) {
+        return false;
+    }
     for (size_t state = 0; state < 4; ++state) {
         for (size_t cell = 0; cell < 4; ++cell) {
             if (!same_complex(x.matrices[state][cell], y.matrices[state][cell])) {
@@ -62,6 +69,9 @@ namespace {
     }
     const FusedU4Node& x = a.fused_u4_nodes[idx];
     const FusedU4Node& y = b.fused_u4_nodes[idx];
+    if (!(x == y)) {
+        return false;
+    }
     for (size_t state = 0; state < 16; ++state) {
         for (size_t row = 0; row < 4; ++row) {
             for (size_t col = 0; col < 4; ++col) {
@@ -89,7 +99,7 @@ namespace {
     }
     const NoiseSite& x = a.noise_sites[idx];
     const NoiseSite& y = b.noise_sites[idx];
-    if (x.channels.size() != y.channels.size()) {
+    if (!(x == y)) {
         return false;
     }
     for (size_t i = 0; i < x.channels.size(); ++i) {
@@ -122,12 +132,15 @@ namespace {
     }
     const ReadoutNoiseEntry& x = a.readout_noise[idx];
     const ReadoutNoiseEntry& y = b.readout_noise[idx];
-    return x.meas_idx == y.meas_idx && same_bits(x.prob_zero_to_one, y.prob_zero_to_one) &&
+    return x == y && same_bits(x.prob_zero_to_one, y.prob_zero_to_one) &&
            same_bits(x.prob_one_to_zero, y.prob_one_to_zero);
 }
 
 [[nodiscard]] bool same_probabilities(const InstrumentProbabilities& a,
                                       const InstrumentProbabilities& b) {
+    if (!(a == b)) {
+        return false;
+    }
     for (size_t source = 0; source < 2; ++source) {
         if (!same_bits(a.p_fire[source], b.p_fire[source])) {
             return false;
@@ -148,7 +161,7 @@ namespace {
     }
     const CompiledInstrumentSite& x = a.instrument_sites[idx];
     const CompiledInstrumentSite& y = b.instrument_sites[idx];
-    return x.site_id == y.site_id && same_probabilities(x.probabilities, y.probabilities) &&
+    return x == y && same_probabilities(x.probabilities, y.probabilities) &&
            same_mask(a.instrument_destination_flip_masks, x.destination_flip_mask,
                      b.instrument_destination_flip_masks, y.destination_flip_mask);
 }

--- a/src/clifft/noncomp/continuation_prefix.cc
+++ b/src/clifft/noncomp/continuation_prefix.cc
@@ -1,0 +1,277 @@
+#include "clifft/noncomp/continuation_prefix.h"
+
+#include <bit>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace clifft {
+
+namespace {
+
+[[nodiscard]] bool same_bits(double a, double b) {
+    return std::bit_cast<uint64_t>(a) == std::bit_cast<uint64_t>(b);
+}
+
+[[nodiscard]] bool same_complex(std::complex<double> a, std::complex<double> b) {
+    return same_bits(a.real(), b.real()) && same_bits(a.imag(), b.imag());
+}
+
+[[nodiscard]] bool same_mask(const PauliMaskArena& a, PauliMaskHandle a_handle,
+                             const PauliMaskArena& b, PauliMaskHandle b_handle) {
+    if (a_handle == kNoMask || b_handle == kNoMask) {
+        return a_handle == b_handle;
+    }
+    const size_t a_idx = static_cast<size_t>(a_handle);
+    const size_t b_idx = static_cast<size_t>(b_handle);
+    if (a_idx >= a.size() || b_idx >= b.size() || a.num_words() != b.num_words()) {
+        return false;
+    }
+    const PauliMaskView a_mask = a.at(a_handle);
+    const PauliMaskView b_mask = b.at(b_handle);
+    return a_mask.x() == b_mask.x() && a_mask.z() == b_mask.z() &&
+           a_mask.sign() == b_mask.sign();
+}
+
+[[nodiscard]] bool same_u2(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
+    if (idx >= a.fused_u2_nodes.size() || idx >= b.fused_u2_nodes.size()) {
+        return false;
+    }
+    const FusedU2Node& x = a.fused_u2_nodes[idx];
+    const FusedU2Node& y = b.fused_u2_nodes[idx];
+    for (size_t state = 0; state < 4; ++state) {
+        for (size_t cell = 0; cell < 4; ++cell) {
+            if (!same_complex(x.matrices[state][cell], y.matrices[state][cell])) {
+                return false;
+            }
+        }
+        if (!same_complex(x.gamma_multipliers[state], y.gamma_multipliers[state]) ||
+            x.out_states[state] != y.out_states[state]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_u4(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
+    if (idx >= a.fused_u4_nodes.size() || idx >= b.fused_u4_nodes.size()) {
+        return false;
+    }
+    const FusedU4Node& x = a.fused_u4_nodes[idx];
+    const FusedU4Node& y = b.fused_u4_nodes[idx];
+    for (size_t state = 0; state < 16; ++state) {
+        for (size_t row = 0; row < 4; ++row) {
+            for (size_t col = 0; col < 4; ++col) {
+                if (!same_complex(x.entries[state].matrix[row][col],
+                                  y.entries[state].matrix[row][col])) {
+                    return false;
+                }
+            }
+        }
+        if (!same_complex(x.entries[state].gamma_multiplier,
+                          y.entries[state].gamma_multiplier) ||
+            x.entries[state].out_state != y.entries[state].out_state) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_noise_site(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
+    if (idx >= a.noise_sites.size() || idx >= b.noise_sites.size() ||
+        idx >= a.noise_hazards.size() || idx >= b.noise_hazards.size()) {
+        return false;
+    }
+    if (!same_bits(a.noise_hazards[idx], b.noise_hazards[idx])) {
+        return false;
+    }
+    const NoiseSite& x = a.noise_sites[idx];
+    const NoiseSite& y = b.noise_sites[idx];
+    if (x.channels.size() != y.channels.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < x.channels.size(); ++i) {
+        if (!same_bits(x.channels[i].prob, y.channels[i].prob) ||
+            !same_mask(a.noise_channel_masks, x.channels[i].mask, b.noise_channel_masks,
+                       y.channels[i].mask)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_noise_block(const ConstantPool& a, const ConstantPool& b, uint32_t start,
+                                    uint32_t count) {
+    const uint64_t end = static_cast<uint64_t>(start) + count;
+    if (end > a.noise_sites.size() || end > b.noise_sites.size()) {
+        return false;
+    }
+    for (uint64_t idx = start; idx < end; ++idx) {
+        if (!same_noise_site(a, b, static_cast<uint32_t>(idx))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_readout(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
+    if (idx >= a.readout_noise.size() || idx >= b.readout_noise.size()) {
+        return false;
+    }
+    const ReadoutNoiseEntry& x = a.readout_noise[idx];
+    const ReadoutNoiseEntry& y = b.readout_noise[idx];
+    return x.meas_idx == y.meas_idx && same_bits(x.prob_zero_to_one, y.prob_zero_to_one) &&
+           same_bits(x.prob_one_to_zero, y.prob_one_to_zero);
+}
+
+[[nodiscard]] bool same_probabilities(const InstrumentProbabilities& a,
+                                      const InstrumentProbabilities& b) {
+    for (size_t source = 0; source < 2; ++source) {
+        if (!same_bits(a.p_fire[source], b.p_fire[source])) {
+            return false;
+        }
+        for (size_t destination = 0; destination < 2; ++destination) {
+            if (!same_bits(a.p_computational_dest[source][destination],
+                           b.p_computational_dest[source][destination])) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_instrument(const ConstantPool& a, const ConstantPool& b, uint32_t idx) {
+    if (idx >= a.instrument_sites.size() || idx >= b.instrument_sites.size()) {
+        return false;
+    }
+    const CompiledInstrumentSite& x = a.instrument_sites[idx];
+    const CompiledInstrumentSite& y = b.instrument_sites[idx];
+    return x.site_id == y.site_id && same_probabilities(x.probabilities, y.probabilities) &&
+           same_mask(a.instrument_destination_flip_masks, x.destination_flip_mask,
+                     b.instrument_destination_flip_masks, y.destination_flip_mask);
+}
+
+[[nodiscard]] bool same_instruction(const Instruction& continuation,
+                                    const Instruction& executed) {
+    if (std::memcmp(&continuation, &executed, sizeof(Instruction)) == 0) {
+        return true;
+    }
+    const std::optional<Opcode> forced = forced_measurement_opcode(continuation.opcode);
+    if (!forced.has_value() || *forced != executed.opcode) {
+        return false;
+    }
+    Instruction swapped = continuation;
+    swapped.opcode = executed.opcode;
+    return std::memcmp(&swapped, &executed, sizeof(Instruction)) == 0;
+}
+
+[[nodiscard]] bool same_referenced_constants(const Instruction& instr, const ConstantPool& a,
+                                             const ConstantPool& b) {
+    switch (instr.opcode) {
+        case Opcode::OP_ARRAY_U2:
+            return same_u2(a, b, instr.u2.cp_idx);
+        case Opcode::OP_ARRAY_U4:
+            return same_u4(a, b, instr.u4.cp_idx);
+        case Opcode::OP_APPLY_PAULI:
+            return same_mask(a.pauli_masks, static_cast<PauliMaskHandle>(instr.pauli.cp_mask_idx),
+                             b.pauli_masks,
+                             static_cast<PauliMaskHandle>(instr.pauli.cp_mask_idx));
+        case Opcode::OP_NOISE:
+            return same_noise_site(a, b, instr.pauli.cp_mask_idx);
+        case Opcode::OP_NOISE_BLOCK:
+            return same_noise_block(a, b, instr.pauli.cp_mask_idx, instr.pauli.condition_idx);
+        case Opcode::OP_READOUT_NOISE:
+            return same_readout(a, b, instr.pauli.cp_mask_idx);
+        case Opcode::OP_DETECTOR:
+        case Opcode::OP_POSTSELECT:
+            return instr.pauli.cp_mask_idx < a.detector_targets.size() &&
+                   instr.pauli.cp_mask_idx < b.detector_targets.size() &&
+                   a.detector_targets[instr.pauli.cp_mask_idx] ==
+                       b.detector_targets[instr.pauli.cp_mask_idx];
+        case Opcode::OP_OBSERVABLE:
+            return instr.pauli.cp_mask_idx < a.observable_targets.size() &&
+                   instr.pauli.cp_mask_idx < b.observable_targets.size() &&
+                   a.observable_targets[instr.pauli.cp_mask_idx] ==
+                       b.observable_targets[instr.pauli.cp_mask_idx];
+        case Opcode::OP_EXP_VAL:
+            return same_mask(
+                a.exp_val_masks, static_cast<PauliMaskHandle>(instr.exp_val.cp_exp_val_idx),
+                b.exp_val_masks, static_cast<PauliMaskHandle>(instr.exp_val.cp_exp_val_idx));
+        case Opcode::OP_INSTRUMENT_ACTIVE:
+        case Opcode::OP_INSTRUMENT_DORMANT_STATIC:
+        case Opcode::OP_INSTRUMENT_EXPAND:
+        case Opcode::OP_INSTRUMENT_DORMANT_NEGLECT:
+            return same_instrument(a, b, instr.instrument.cp_site_idx);
+
+        case Opcode::OP_FRAME_CNOT:
+        case Opcode::OP_FRAME_CZ:
+        case Opcode::OP_FRAME_H:
+        case Opcode::OP_FRAME_S:
+        case Opcode::OP_FRAME_S_DAG:
+        case Opcode::OP_FRAME_SWAP:
+        case Opcode::OP_ARRAY_CNOT:
+        case Opcode::OP_ARRAY_CZ:
+        case Opcode::OP_ARRAY_SWAP:
+        case Opcode::OP_ARRAY_MULTI_CNOT:
+        case Opcode::OP_ARRAY_MULTI_CZ:
+        case Opcode::OP_ARRAY_H:
+        case Opcode::OP_ARRAY_S:
+        case Opcode::OP_ARRAY_S_DAG:
+        case Opcode::OP_ARRAY_T:
+        case Opcode::OP_ARRAY_T_DAG:
+        case Opcode::OP_ARRAY_ROT:
+        case Opcode::OP_EXPAND:
+        case Opcode::OP_EXPAND_T:
+        case Opcode::OP_EXPAND_T_DAG:
+        case Opcode::OP_EXPAND_ROT:
+        case Opcode::OP_MEAS_DORMANT_STATIC:
+        case Opcode::OP_MEAS_DORMANT_RANDOM:
+        case Opcode::OP_MEAS_ACTIVE_DIAGONAL:
+        case Opcode::OP_MEAS_ACTIVE_INTERFERE:
+        case Opcode::OP_SWAP_MEAS_INTERFERE:
+        case Opcode::OP_MEAS_DORMANT_STATIC_FORCED:
+        case Opcode::OP_MEAS_DORMANT_RANDOM_FORCED:
+        case Opcode::OP_MEAS_ACTIVE_DIAGONAL_FORCED:
+        case Opcode::OP_MEAS_ACTIVE_INTERFERE_FORCED:
+        case Opcode::OP_SWAP_MEAS_INTERFERE_FORCED:
+            return true;
+        case Opcode::NUM_OPCODES:
+            return false;
+    }
+    return false;
+}
+
+}  // namespace
+
+void validate_continuation_prefix(const CompiledModule& continuation,
+                                  const CompiledModule& executed, uint32_t prefix_end) {
+    if (continuation.num_qubits != executed.num_qubits) {
+        throw std::logic_error(
+            "sample_noncomputational: continuation prefix changed the module's qubit count");
+    }
+    if (prefix_end > continuation.bytecode.size() || prefix_end > executed.bytecode.size()) {
+        throw std::logic_error("sample_noncomputational: continuation prefix length " +
+                               std::to_string(prefix_end) +
+                               " exceeds the compiled bytecode being compared");
+    }
+    for (uint32_t i = 0; i < prefix_end; ++i) {
+        if (!same_instruction(continuation.bytecode[i], executed.bytecode[i])) {
+            throw std::logic_error(
+                "sample_noncomputational: continuation bytecode prefix diverged at instruction " +
+                std::to_string(i));
+        }
+        if (!same_referenced_constants(continuation.bytecode[i], continuation.constant_pool,
+                                       executed.constant_pool)) {
+            throw std::logic_error(
+                "sample_noncomputational: continuation constant-pool prefix diverged at "
+                "instruction " +
+                std::to_string(i));
+        }
+    }
+}
+
+}  // namespace clifft

--- a/src/clifft/noncomp/continuation_prefix.h
+++ b/src/clifft/noncomp/continuation_prefix.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "clifft/backend/backend.h"
+
+#include <cstdint>
+
+namespace clifft {
+
+/// Require a newly compiled continuation to reproduce the executed bytecode
+/// prefix and every constant-pool value referenced by it. The one permitted
+/// bytecode difference is a sampling measurement that was changed to its
+/// forced-outcome variant in the executed module.
+///
+/// Throws std::logic_error on divergence. This check is part of the release
+/// runtime contract because resume() reuses the live VM state produced by the
+/// executed module.
+void validate_continuation_prefix(const CompiledModule& continuation,
+                                  const CompiledModule& executed, uint32_t prefix_end);
+
+}  // namespace clifft

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -16,6 +16,7 @@
 
 #include "clifft/backend/backend.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/noncomp/continuation_prefix.h"
 #include "clifft/noncomp/instrument_options.h"
 #include "clifft/noncomp/rewriter.h"
 #include "clifft/noncomp/seed.h"
@@ -30,7 +31,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstring>
 #include <map>
 #include <optional>
 #include <stdexcept>
@@ -310,27 +310,25 @@ void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_ra
 }
 
 // Build the HIR pass pipeline from default passes that preserve measurement
-// record order. A trajectory may force a hidden trace-out measurement, so moving
-// an entangled measurement before that collapse would change the result. Record
-// order alone does not make a continuation compatible with a running state:
-// every continuation uses this fixed pipeline, and debug builds also verify
-// that recompilation reproduces the bytecode prefix the state executed.
+// record order and explicitly guarantee instrument-prefix stability. A
+// trajectory may force a hidden trace-out measurement, so moving an entangled
+// measurement before that collapse would change the result.
 HirPassManager trajectory_hir_pass_manager() {
     HirPassManager pm;
     for (const auto& info : kRegisteredPasses) {
-        if (info.kind == PassKind::HIR && info.default_enabled && info.record_order.preserved) {
+        if (info.kind == PassKind::HIR && info.default_enabled && is_trajectory_compatible(info)) {
             pm.add_pass(info.make_hir());
         }
     }
     return pm;
 }
 
-// Apply the same record-order requirement to bytecode passes.
+// Apply both trajectory requirements to bytecode passes.
 BytecodePassManager trajectory_bytecode_pass_manager() {
     BytecodePassManager pm;
     for (const auto& info : kRegisteredPasses) {
         if (info.kind == PassKind::Bytecode && info.default_enabled &&
-            info.record_order.preserved) {
+            is_trajectory_compatible(info)) {
             pm.add_pass(info.make_bc());
         }
     }
@@ -376,25 +374,6 @@ void swap_traceout_to_forced(CompiledModule& module, size_t slot) {
                                " measurement instructions; expected exactly one");
     }
 }
-
-#ifndef NDEBUG
-// Compare instructions while allowing the expected sampling-to-forced opcode
-// change. Bytewise equality is deliberate: resume requires the continuation
-// prefix to match the module that already executed, not merely to be
-// semantically equivalent.
-bool equal_modulo_forced_swap(const Instruction& fresh, const Instruction& executed) {
-    if (std::memcmp(&fresh, &executed, sizeof(Instruction)) == 0) {
-        return true;
-    }
-    const std::optional<Opcode> forced = forced_measurement_opcode(fresh.opcode);
-    if (!forced.has_value() || *forced != executed.opcode) {
-        return false;
-    }
-    Instruction swapped = fresh;
-    swapped.opcode = executed.opcode;
-    return std::memcmp(&swapped, &executed, sizeof(Instruction)) == 0;
-}
-#endif
 
 CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
                                           const std::vector<uint8_t>& herald_flags,
@@ -467,22 +446,9 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
         swap_traceout_to_forced(module, *forced_traceout_slot);
     }
 
-#ifndef NDEBUG
-    // The continuation must reproduce every instruction the shot already
-    // executed, except for the forced trace-out opcode handled above.
     if (executed_prefix_module != nullptr) {
-        assert(prefix_end <= module.bytecode.size() &&
-               prefix_end <= executed_prefix_module->bytecode.size());
-        for (uint32_t i = 0; i < prefix_end; ++i) {
-            assert(
-                equal_modulo_forced_swap(module.bytecode[i], executed_prefix_module->bytecode[i]) &&
-                "continuation prefix diverged from the executed module");
-        }
+        validate_continuation_prefix(module, *executed_prefix_module, prefix_end);
     }
-#else
-    (void)executed_prefix_module;
-    (void)prefix_end;
-#endif
 
     return CompiledContinuation{
         .module = std::move(module),

--- a/src/clifft/optimizer/pass_factory.cc
+++ b/src/clifft/optimizer/pass_factory.cc
@@ -59,6 +59,8 @@ std::string pass_registry_json() {
         out += p.default_enabled ? "true" : "false";
         out += ",\"preserves_record_order\":";
         out += p.record_order.preserved ? "true" : "false";
+        out += ",\"preserves_instrument_prefix\":";
+        out += p.instrument_prefix.preserved ? "true" : "false";
         out += "}";
     }
     out += ']';

--- a/src/clifft/optimizer/pass_registry.h
+++ b/src/clifft/optimizer/pass_registry.h
@@ -43,14 +43,34 @@ struct RecordOrder {
 inline constexpr RecordOrder kPreservesRecordOrder{true};
 inline constexpr RecordOrder kBreaksRecordOrder{false};
 
+// Whether changing the input after an INSTRUMENT can change the pass output
+// through that instrument. A resumed trajectory recompiles a changed suffix
+// while reusing the state produced by the already-executed prefix, so such
+// passes must make an explicit stability guarantee. For bytecode passes, the
+// guarantee includes constant-pool data referenced by prefix instructions.
+// There is intentionally no default: adding a pass requires its author to
+// opt in or keep it out of the trajectory pipeline.
+struct InstrumentPrefixStability {
+    bool preserved;
+    constexpr explicit InstrumentPrefixStability(bool preserved_in) : preserved(preserved_in) {}
+};
+
+inline constexpr InstrumentPrefixStability kPreservesInstrumentPrefix{true};
+inline constexpr InstrumentPrefixStability kMayChangeInstrumentPrefix{false};
+
 struct PassInfo {
     std::string_view name;
     PassKind kind;
     bool default_enabled;
     RecordOrder record_order;
+    InstrumentPrefixStability instrument_prefix;
     HirPassFactory make_hir = nullptr;
     BytecodePassFactory make_bc = nullptr;
 };
+
+[[nodiscard]] constexpr bool is_trajectory_compatible(const PassInfo& info) {
+    return info.record_order.preserved && info.instrument_prefix.preserved;
+}
 
 template <typename T>
 std::unique_ptr<HirPass> make_hir() {
@@ -70,57 +90,68 @@ inline const PassInfo kRegisteredPasses[] = {
      .kind = PassKind::HIR,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_hir = make_hir<PeepholeFusionPass>},
     {.name = "StatevectorSqueezePass",
      .kind = PassKind::HIR,
      .default_enabled = true,
      .record_order = kBreaksRecordOrder,
+     .instrument_prefix = kMayChangeInstrumentPrefix,
      .make_hir = make_hir<StatevectorSqueezePass>},
     {.name = "RemoveNoisePass",
      .kind = PassKind::HIR,
      .default_enabled = false,
      .record_order = kBreaksRecordOrder,
+     .instrument_prefix = kMayChangeInstrumentPrefix,
      .make_hir = make_hir<RemoveNoisePass>},
     {.name = "DropNonUnitaryPass",
      .kind = PassKind::HIR,
      .default_enabled = false,
      .record_order = kBreaksRecordOrder,
+     .instrument_prefix = kMayChangeInstrumentPrefix,
      .make_hir = make_hir<DropNonUnitaryPass>},
     // Bytecode passes
     {.name = "NoiseBlockPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<NoiseBlockPass>},
     {.name = "MultiGatePass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<MultiGatePass>},
     {.name = "ExpandTPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<ExpandTPass>},
     {.name = "ExpandRotPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<ExpandRotPass>},
     {.name = "SwapMeasPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<SwapMeasPass>},
     {.name = "TileAxisFusionPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<TileAxisFusionPass>},
     {.name = "SingleAxisFusionPass",
      .kind = PassKind::Bytecode,
      .default_enabled = true,
      .record_order = kPreservesRecordOrder,
+     .instrument_prefix = kPreservesInstrumentPrefix,
      .make_bc = make_bc<SingleAxisFusionPass>},
 };
 

--- a/src/clifft/util/pauli_arena.h
+++ b/src/clifft/util/pauli_arena.h
@@ -40,6 +40,10 @@ class PauliMaskView {
     const uint8_t* sign_;
 };
 
+[[nodiscard]] inline bool operator==(PauliMaskView a, PauliMaskView b) {
+    return a.x() == b.x() && a.z() == b.z() && a.sign() == b.sign();
+}
+
 /// Mutable view of a single (X, Z, sign) entry in an arena. Implicitly
 /// converts to PauliMaskView for read-only call sites.
 class MutablePauliMaskView {

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -301,7 +301,7 @@ def sample(
     probes are not supported with such models.
 
     Continuations are compiled with the default optimization passes that
-    preserve measurement-record order, omitting
+    preserve measurement-record order and instrument-prefix stability, omitting
     [StatevectorSqueezePass][clifft.StatevectorSqueezePass]. Reordering can
     change the placement of internal collapse outcomes relative to later
     records. This API does not currently accept custom pass managers.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(clifft_tests
     test_noncomp_status_walk.cc
     test_noncomp_rewriter.cc
     test_noncomp_continuation.cc
+    test_continuation_prefix.cc
     test_trajectory_driver.cc
     test_noncomp_validation.cc
 )

--- a/tests/python/test_pass_docs.py
+++ b/tests/python/test_pass_docs.py
@@ -29,16 +29,21 @@ def _extract_cpp_passes() -> dict[str, dict[str, object]]:
         record_order_match = re.search(
             r"\.record_order\s*=\s*k(Preserves|Breaks)RecordOrder", entry
         )
+        prefix_match = re.search(
+            r"\.instrument_prefix\s*=\s*k(Preserves|MayChange)InstrumentPrefix", entry
+        )
 
         assert name_match, f"Registered pass entry missing .name: {entry}"
         assert kind_match, f"Registered pass entry missing .kind: {entry}"
         assert default_match, f"Registered pass entry missing .default_enabled: {entry}"
         assert record_order_match, f"Registered pass entry missing .record_order: {entry}"
+        assert prefix_match, f"Registered pass entry missing .instrument_prefix: {entry}"
 
         passes[name_match.group(1)] = {
             "kind": kind_match.group(1),
             "default_enabled": default_match.group(1) == "true",
             "preserves_record_order": record_order_match.group(1) == "Preserves",
+            "preserves_instrument_prefix": prefix_match.group(1) == "Preserves",
         }
 
     return passes
@@ -106,6 +111,14 @@ class TestOptimizationPassDocCompleteness:
                 f"{docs_metadata['preserves_record_order']!r} in docs/macros.py but "
                 f"{cpp_metadata['preserves_record_order']!r} in pass_registry.h."
             )
+            assert (
+                docs_metadata["preserves_instrument_prefix"]
+                == cpp_metadata["preserves_instrument_prefix"]
+            ), (
+                f"{name} has preserves_instrument_prefix="
+                f"{docs_metadata['preserves_instrument_prefix']!r} in docs/macros.py but "
+                f"{cpp_metadata['preserves_instrument_prefix']!r} in pass_registry.h."
+            )
 
 
 class TestOptimizationPassDocStructure:
@@ -117,6 +130,7 @@ class TestOptimizationPassDocStructure:
             "kind",
             "default_enabled",
             "preserves_record_order",
+            "preserves_instrument_prefix",
             "python_name",
             "summary",
             "detail",

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -1593,9 +1593,7 @@ TEST_CASE("Lower: consuming overload maps noise masks in place") {
         const auto actual_handle = actual.constant_pool.noise_sites[0].channels[i].mask;
         const auto expected_mask = expected.constant_pool.noise_channel_masks.at(expected_handle);
         const auto actual_mask = actual.constant_pool.noise_channel_masks.at(actual_handle);
-        CHECK(actual_mask.x() == expected_mask.x());
-        CHECK(actual_mask.z() == expected_mask.z());
-        CHECK(actual_mask.sign() == expected_mask.sign());
+        CHECK(actual_mask == expected_mask);
     }
 }
 

--- a/tests/test_continuation_prefix.cc
+++ b/tests/test_continuation_prefix.cc
@@ -1,0 +1,185 @@
+#include "clifft/backend/backend.h"
+#include "clifft/noncomp/continuation_prefix.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+using namespace clifft;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+CompiledModule module_with_prefix_constants() {
+    CompiledModule module;
+    module.num_qubits = 2;
+    ConstantPool& pool = module.constant_pool;
+
+    pool.fused_u2_nodes.emplace_back();
+    pool.fused_u2_nodes[0].matrices[0][0] = {1.0, 0.25};
+    pool.fused_u2_nodes[0].gamma_multipliers[0] = {0.5, -0.5};
+    pool.fused_u2_nodes[0].out_states[0] = 1;
+
+    pool.fused_u4_nodes.emplace_back();
+    pool.fused_u4_nodes[0].entries[0].matrix[0][0] = {0.75, 0.125};
+    pool.fused_u4_nodes[0].entries[0].gamma_multiplier = {0.0, 1.0};
+    pool.fused_u4_nodes[0].entries[0].out_state = 2;
+
+    pool.pauli_masks = PauliMaskArena(2, 1);
+    pool.pauli_masks.mut_at(PauliMaskHandle{0}).x().bit_set(0, true);
+    pool.exp_val_masks = PauliMaskArena(2, 1);
+    pool.exp_val_masks.mut_at(PauliMaskHandle{0}).z().bit_set(1, true);
+
+    pool.noise_channel_masks = PauliMaskArena(2, 2);
+    pool.noise_channel_masks.mut_at(PauliMaskHandle{0}).x().bit_set(0, true);
+    pool.noise_channel_masks.mut_at(PauliMaskHandle{1}).z().bit_set(1, true);
+    pool.noise_sites = {
+        NoiseSite{{NoiseChannel{PauliMaskHandle{0}, 0.125}}},
+        NoiseSite{{NoiseChannel{PauliMaskHandle{1}, 0.25}}},
+    };
+    pool.noise_hazards = {0.13353139262452263, 0.42121346507630353};
+
+    pool.readout_noise = {ReadoutNoiseEntry{3, 0.1, 0.2}};
+    pool.detector_targets = {{0, 2}};
+    pool.observable_targets = {{1, 3}};
+
+    pool.instrument_destination_flip_masks = PauliMaskArena(2, 1);
+    pool.instrument_destination_flip_masks.mut_at(PauliMaskHandle{0}).x().bit_set(1, true);
+    CompiledInstrumentSite site;
+    site.site_id = 4;
+    site.destination_flip_mask = PauliMaskHandle{0};
+    site.probabilities.p_fire[0] = 0.2;
+    site.probabilities.p_fire[1] = 0.3;
+    site.probabilities.p_computational_dest[0][0] = 0.05;
+    site.probabilities.p_computational_dest[1][1] = 0.1;
+    pool.instrument_sites.push_back(site);
+
+    module.bytecode = {
+        make_array_u2(0, 0),
+        make_array_u4(0, 1, 0),
+        make_apply_pauli(0, 0),
+        make_noise(0),
+        make_noise_block(1, 1),
+        make_readout_noise(0),
+        make_detector(0, 0, ExpectedParity::Zero),
+        make_observable(0, 0),
+        make_exp_val(0, 0),
+        make_instrument(Opcode::OP_INSTRUMENT_ACTIVE, 0, 0, false, 0.8, 0.7),
+    };
+    return module;
+}
+
+}  // namespace
+
+TEST_CASE("continuation prefix validates bytecode and referenced constants") {
+    const CompiledModule executed = module_with_prefix_constants();
+    CompiledModule continuation = executed;
+    const uint32_t prefix_end = static_cast<uint32_t>(executed.bytecode.size());
+
+    SECTION("matching modules pass") {
+        REQUIRE_NOTHROW(validate_continuation_prefix(continuation, executed, prefix_end));
+    }
+    SECTION("bytecode divergence rejects") {
+        continuation.bytecode[0].axis_1 = 1;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("bytecode prefix diverged at instruction 0"));
+    }
+    SECTION("fused U2 data divergence rejects") {
+        continuation.constant_pool.fused_u2_nodes[0].matrices[0][0] = {0.0, 0.0};
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 0"));
+    }
+    SECTION("fused U4 data divergence rejects") {
+        continuation.constant_pool.fused_u4_nodes[0].entries[0].out_state = 3;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 1"));
+    }
+    SECTION("conditional Pauli mask divergence rejects") {
+        continuation.constant_pool.pauli_masks.mut_at(PauliMaskHandle{0}).z().bit_set(0, true);
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 2"));
+    }
+    SECTION("individual noise-site divergence rejects") {
+        continuation.constant_pool.noise_sites[0].channels[0].prob = 0.5;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 3"));
+    }
+    SECTION("noise-block mask divergence rejects") {
+        continuation.constant_pool.noise_channel_masks.mut_at(PauliMaskHandle{1}).x().bit_set(1,
+                                                                                            true);
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 4"));
+    }
+    SECTION("noise hazard divergence rejects") {
+        continuation.constant_pool.noise_hazards[1] = 0.5;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 4"));
+    }
+    SECTION("readout data divergence rejects") {
+        continuation.constant_pool.readout_noise[0].prob_one_to_zero = 0.4;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 5"));
+    }
+    SECTION("detector targets divergence rejects") {
+        continuation.constant_pool.detector_targets[0][0] = 1;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 6"));
+    }
+    SECTION("observable targets divergence rejects") {
+        continuation.constant_pool.observable_targets[0][0] = 0;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 7"));
+    }
+    SECTION("expectation mask divergence rejects") {
+        continuation.constant_pool.exp_val_masks.mut_at(PauliMaskHandle{0}).x().bit_set(1, true);
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 8"));
+    }
+    SECTION("instrument data divergence rejects") {
+        continuation.constant_pool.instrument_sites[0].probabilities.p_fire[0] = 0.4;
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 9"));
+    }
+    SECTION("instrument destination mask divergence rejects") {
+        continuation.constant_pool.instrument_destination_flip_masks
+            .mut_at(PauliMaskHandle{0})
+            .z()
+            .bit_set(1, true);
+        REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
+                            ContainsSubstring("constant-pool prefix diverged at instruction 9"));
+    }
+}
+
+TEST_CASE("continuation prefix permits only the expected forced opcode change") {
+    CompiledModule continuation;
+    continuation.num_qubits = 1;
+    continuation.bytecode.push_back(make_meas(Opcode::OP_MEAS_DORMANT_RANDOM, 0, 2, false));
+    CompiledModule executed = continuation;
+    executed.bytecode[0].opcode = Opcode::OP_MEAS_DORMANT_RANDOM_FORCED;
+
+    REQUIRE_NOTHROW(validate_continuation_prefix(continuation, executed, 1));
+
+    executed.bytecode[0].classical.classical_idx = 3;
+    REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, 1),
+                        ContainsSubstring("bytecode prefix diverged"));
+}
+
+TEST_CASE("continuation prefix ignores constants referenced only by the suffix") {
+    CompiledModule executed = module_with_prefix_constants();
+    CompiledModule continuation = executed;
+    continuation.constant_pool.instrument_sites[0].probabilities.p_fire[0] = 0.9;
+
+    REQUIRE_NOTHROW(validate_continuation_prefix(continuation, executed, 1));
+}
+
+TEST_CASE("continuation prefix rejects invalid comparison bounds") {
+    CompiledModule executed;
+    CompiledModule continuation;
+    executed.num_qubits = continuation.num_qubits = 1;
+
+    REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, 1),
+                        ContainsSubstring("prefix length 1 exceeds"));
+
+    continuation.num_qubits = 2;
+    REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, 0),
+                        ContainsSubstring("changed the module's qubit count"));
+}

--- a/tests/test_continuation_prefix.cc
+++ b/tests/test_continuation_prefix.cc
@@ -104,8 +104,9 @@ TEST_CASE("continuation prefix validates bytecode and referenced constants") {
                             ContainsSubstring("constant-pool prefix diverged at instruction 3"));
     }
     SECTION("noise-block mask divergence rejects") {
-        continuation.constant_pool.noise_channel_masks.mut_at(PauliMaskHandle{1}).x().bit_set(1,
-                                                                                            true);
+        continuation.constant_pool.noise_channel_masks.mut_at(PauliMaskHandle{1})
+            .x()
+            .bit_set(1, true);
         REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),
                             ContainsSubstring("constant-pool prefix diverged at instruction 4"));
     }
@@ -140,8 +141,7 @@ TEST_CASE("continuation prefix validates bytecode and referenced constants") {
                             ContainsSubstring("constant-pool prefix diverged at instruction 9"));
     }
     SECTION("instrument destination mask divergence rejects") {
-        continuation.constant_pool.instrument_destination_flip_masks
-            .mut_at(PauliMaskHandle{0})
+        continuation.constant_pool.instrument_destination_flip_masks.mut_at(PauliMaskHandle{0})
             .z()
             .bit_set(1, true);
         REQUIRE_THROWS_WITH(validate_continuation_prefix(continuation, executed, prefix_end),

--- a/tests/test_mask_view.cc
+++ b/tests/test_mask_view.cc
@@ -248,6 +248,20 @@ TEST_CASE("PauliMaskArena: const view stays live after sign mutation through mut
     REQUIRE_FALSE(cv.sign());
 }
 
+TEST_CASE("PauliMaskArena: const views compare by value") {
+    PauliMaskArena a(128, 1);
+    PauliMaskArena b(128, 1);
+    REQUIRE(a.at(PauliMaskHandle{0}) == b.at(PauliMaskHandle{0}));
+
+    a.mut_at(PauliMaskHandle{0}).x().bit_set(65, true);
+    REQUIRE_FALSE(a.at(PauliMaskHandle{0}) == b.at(PauliMaskHandle{0}));
+    b.mut_at(PauliMaskHandle{0}).x().bit_set(65, true);
+    REQUIRE(a.at(PauliMaskHandle{0}) == b.at(PauliMaskHandle{0}));
+
+    a.mut_at(PauliMaskHandle{0}).set_sign(true);
+    REQUIRE_FALSE(a.at(PauliMaskHandle{0}) == b.at(PauliMaskHandle{0}));
+}
+
 // =========================================================================
 // lowest_bit_at_or_above / lowest_bit_below
 // =========================================================================

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -745,6 +745,26 @@ TEST_CASE("Pass registry: default managers use registry") {
     REQUIRE(prog.num_qubits == 2);
 }
 
+TEST_CASE("Pass registry: trajectory compatibility requires both guarantees") {
+    const std::vector<std::string_view> prefix_stable = {
+        "PeepholeFusionPass", "NoiseBlockPass", "MultiGatePass",      "ExpandTPass",
+        "ExpandRotPass",      "SwapMeasPass",   "TileAxisFusionPass", "SingleAxisFusionPass",
+    };
+    const std::vector<std::string_view> may_change_prefix = {
+        "StatevectorSqueezePass", "RemoveNoisePass", "DropNonUnitaryPass"};
+
+    for (const auto& info : clifft::kRegisteredPasses) {
+        const bool expected_stable =
+            std::find(prefix_stable.begin(), prefix_stable.end(), info.name) != prefix_stable.end();
+        const bool expected_unstable = std::find(may_change_prefix.begin(), may_change_prefix.end(),
+                                                 info.name) != may_change_prefix.end();
+        REQUIRE(expected_stable != expected_unstable);
+        CHECK(info.instrument_prefix.preserved == expected_stable);
+        CHECK(clifft::is_trajectory_compatible(info) ==
+              (info.record_order.preserved && expected_stable));
+    }
+}
+
 TEST_CASE("Pass registry: JSON round-trip is valid") {
     std::string json = clifft::pass_registry_json();
     REQUIRE(json.front() == '[');
@@ -753,6 +773,7 @@ TEST_CASE("Pass registry: JSON round-trip is valid") {
     REQUIRE(json.find("SingleAxisFusionPass") != std::string::npos);
     REQUIRE(json.find("RemoveNoisePass") != std::string::npos);
     REQUIRE(json.find("DropNonUnitaryPass") != std::string::npos);
+    REQUIRE(json.find("preserves_instrument_prefix") != std::string::npos);
 }
 
 // =============================================================================

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -746,6 +746,23 @@ TEST_CASE("Pass registry: default managers use registry") {
 }
 
 TEST_CASE("Pass registry: trajectory compatibility requires both guarantees") {
+    constexpr clifft::PassInfo record_only{
+        .name = "record-only",
+        .kind = clifft::PassKind::HIR,
+        .default_enabled = true,
+        .record_order = clifft::kPreservesRecordOrder,
+        .instrument_prefix = clifft::kMayChangeInstrumentPrefix,
+    };
+    constexpr clifft::PassInfo prefix_only{
+        .name = "prefix-only",
+        .kind = clifft::PassKind::HIR,
+        .default_enabled = true,
+        .record_order = clifft::kBreaksRecordOrder,
+        .instrument_prefix = clifft::kPreservesInstrumentPrefix,
+    };
+    static_assert(!clifft::is_trajectory_compatible(record_only));
+    static_assert(!clifft::is_trajectory_compatible(prefix_only));
+
     const std::vector<std::string_view> prefix_stable = {
         "PeepholeFusionPass", "NoiseBlockPass", "MultiGatePass",      "ExpandTPass",
         "ExpandRotPass",      "SwapMeasPass",   "TileAxisFusionPass", "SingleAxisFusionPass",


### PR DESCRIPTION
## Summary

- require optimization passes to explicitly declare instrument-prefix stability before joining the trajectory pipeline
- validate recompiled bytecode and all constant-pool data referenced by the executed prefix before resuming a live VM state
- document the trajectory safety contract and add focused registry and runtime coverage

## Testing

- cmake --build build -j 8
- ctest --test-dir build --output-on-failure -j 8 (1,140 passed)
- uv run pytest tests/python/ -q (879 passed)
- uv run pre-commit run --all-files

Closes #223