### PR TITLE
feat(sampling): add semantic plan foundation

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(clifft_core STATIC
     optimizer/remove_noise_pass.cc
     optimizer/statevector_squeeze_pass.cc
     backend/backend.cc
+    sampling/plan.cc
     api/basis_probabilities.cc
     api/record_probabilities.cc
     api/reference_syndrome.cc

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -84,7 +84,8 @@ class VirtualRegisterManager {
 inline void validate_peak_rank(uint32_t peak) {
     if (peak >= kDenseActiveWidthLimit) {
         throw std::runtime_error("peak active rank (" + std::to_string(peak) +
-                                 ") >= 60: would overflow the SVM amplitude array byte size "
+                                 ") >= " + std::to_string(kDenseActiveWidthLimit) +
+                                 ": would overflow the SVM amplitude array byte size "
                                  "(2^peak_rank * 16 must fit in size_t)");
     }
 }

--- a/src/clifft/backend/compiler_context.h
+++ b/src/clifft/backend/compiler_context.h
@@ -9,6 +9,7 @@
 #include "clifft/backend/backend.h"
 #include "clifft/backend/source_map.h"
 #include "clifft/frontend/hir.h"
+#include "clifft/util/numeric.h"
 
 #include "stim.h"
 
@@ -81,7 +82,7 @@ class VirtualRegisterManager {
 /// at the boundary, preventing a regression where a uint16_t narrowing
 /// at the call site silently wraps a 65,536-axis peak to 0.
 inline void validate_peak_rank(uint32_t peak) {
-    if (peak >= 60) {
+    if (peak >= kDenseActiveWidthLimit) {
         throw std::runtime_error("peak active rank (" + std::to_string(peak) +
                                  ") >= 60: would overflow the SVM amplitude array byte size "
                                  "(2^peak_rank * 16 must fit in size_t)");

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -1,0 +1,477 @@
+#include "clifft/sampling/plan.h"
+
+#include "clifft/util/numeric.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace clifft::sampling {
+
+namespace {
+
+uint32_t index(SymbolId id) {
+    return static_cast<uint32_t>(id);
+}
+
+uint32_t index(RecordSlot slot) {
+    return static_cast<uint32_t>(slot);
+}
+
+uint32_t index(NoiseSiteId site) {
+    return static_cast<uint32_t>(site);
+}
+
+uint32_t index(InstrumentSiteId site) {
+    return static_cast<uint32_t>(site);
+}
+
+std::vector<SymbolId> xor_terms(const std::vector<SymbolId>& left,
+                                const std::vector<SymbolId>& right) {
+    std::vector<SymbolId> result;
+    result.reserve(left.size() + right.size());
+    size_t i = 0;
+    size_t j = 0;
+    while (i < left.size() || j < right.size()) {
+        if (j == right.size() || (i < left.size() && index(left[i]) < index(right[j]))) {
+            result.push_back(left[i++]);
+        } else if (i == left.size() || index(right[j]) < index(left[i])) {
+            result.push_back(right[j++]);
+        } else {
+            ++i;
+            ++j;
+        }
+    }
+    return result;
+}
+
+std::vector<SymbolId> canonicalize_terms(std::vector<SymbolId> terms) {
+    std::sort(terms.begin(), terms.end(),
+              [](SymbolId left, SymbolId right) { return index(left) < index(right); });
+    std::vector<SymbolId> result;
+    for (size_t begin = 0; begin < terms.size();) {
+        size_t end = begin + 1;
+        while (end < terms.size() && terms[end] == terms[begin]) {
+            ++end;
+        }
+        if ((end - begin) % 2 != 0) {
+            result.push_back(terms[begin]);
+        }
+        begin = end;
+    }
+    return result;
+}
+
+std::string format_expression(const AffineBool& expression) {
+    std::ostringstream out;
+    bool wrote = false;
+    if (expression.constant()) {
+        out << '1';
+        wrote = true;
+    }
+    for (SymbolId term : expression.terms()) {
+        if (wrote) {
+            out << " ^ ";
+        }
+        out << 's' << index(term);
+        wrote = true;
+    }
+    if (!wrote) {
+        out << '0';
+    }
+    return out.str();
+}
+
+std::string_view symbol_kind_name(SymbolKind kind) {
+    switch (kind) {
+        case SymbolKind::Exogenous:
+            return "exogenous";
+        case SymbolKind::Derived:
+            return "derived";
+        case SymbolKind::Branch:
+            return "branch";
+    }
+    return "unknown";
+}
+
+std::string format_words(const std::vector<uint64_t>& words) {
+    std::ostringstream out;
+    out << '[';
+    for (size_t i = 0; i < words.size(); ++i) {
+        if (i != 0) {
+            out << ',';
+        }
+        out << "0x" << std::hex << std::setw(16) << std::setfill('0') << words[i];
+    }
+    out << ']';
+    return out.str();
+}
+
+std::string format_pauli(const ActivePauli& pauli) {
+    std::ostringstream out;
+    out << "width=" << pauli.width << " x=" << format_words(pauli.x)
+        << " z=" << format_words(pauli.z);
+    return out.str();
+}
+
+[[noreturn]] void invalid_plan(std::string message) {
+    throw std::invalid_argument("invalid SamplingPlan: " + std::move(message));
+}
+
+void validate_pauli(const ActivePauli& pauli, uint32_t expected_width, uint32_t action_index) {
+    if (pauli.width != expected_width) {
+        invalid_plan("action " + std::to_string(action_index) + " Pauli width " +
+                     std::to_string(pauli.width) + " does not match active width " +
+                     std::to_string(expected_width));
+    }
+    const size_t words = (static_cast<size_t>(pauli.width) + 63) / 64;
+    if (pauli.x.size() != words || pauli.z.size() != words) {
+        invalid_plan("action " + std::to_string(action_index) +
+                     " Pauli word count does not match its width");
+    }
+    if (words != 0 && pauli.width % 64 != 0) {
+        const uint64_t tail_mask = (uint64_t{1} << (pauli.width % 64)) - 1;
+        if ((pauli.x.back() & ~tail_mask) != 0 || (pauli.z.back() & ~tail_mask) != 0) {
+            invalid_plan("action " + std::to_string(action_index) +
+                         " Pauli has bits outside its active width");
+        }
+    }
+}
+
+std::optional<SymbolId> defined_symbol(const SamplingAction& action) {
+    return std::visit(
+        [](const auto& typed) -> std::optional<SymbolId> {
+            using T = std::decay_t<decltype(typed)>;
+            if constexpr (std::is_same_v<T, MeasureActivePauli> ||
+                          std::is_same_v<T, MeasureDormantRandom>) {
+                return typed.branch;
+            } else if constexpr (std::is_same_v<T, DefineSymbol>) {
+                return typed.symbol;
+            } else {
+                return std::nullopt;
+            }
+        },
+        action);
+}
+
+void validate_expression(const SamplingPlan& plan, const AffineBool& expression,
+                         uint32_t action_index, std::optional<SymbolId> current_definition,
+                         bool allow_current_definition) {
+    if (!expression.is_canonical()) {
+        invalid_plan("action " + std::to_string(action_index) +
+                     " has a noncanonical affine expression");
+    }
+    for (SymbolId term : expression.terms()) {
+        const uint32_t symbol_index = index(term);
+        if (symbol_index >= plan.symbols.size()) {
+            invalid_plan("action " + std::to_string(action_index) + " references symbol s" +
+                         std::to_string(symbol_index) + " out of range");
+        }
+        const SymbolInfo& info = plan.symbols[symbol_index];
+        if (info.kind == SymbolKind::Exogenous) {
+            continue;
+        }
+        if (!info.defining_action.has_value()) {
+            invalid_plan("symbol s" + std::to_string(symbol_index) + " has no defining action");
+        }
+        const bool current_is_allowed = allow_current_definition && current_definition == term &&
+                                        *info.defining_action == action_index;
+        if (*info.defining_action >= action_index && !current_is_allowed) {
+            invalid_plan("action " + std::to_string(action_index) + " references symbol s" +
+                         std::to_string(symbol_index) + " before assignment");
+        }
+    }
+}
+
+void validate_record(const SamplingPlan& plan, RecordSlot record, uint32_t action_index) {
+    const uint64_t total = static_cast<uint64_t>(plan.num_visible_records) +
+                           static_cast<uint64_t>(plan.num_hidden_records);
+    if (index(record) >= total) {
+        invalid_plan("action " + std::to_string(action_index) + " record slot " +
+                     std::to_string(index(record)) + " out of range");
+    }
+}
+
+}  // namespace
+
+AffineBool::AffineBool(bool constant) : constant_(constant) {}
+
+AffineBool::AffineBool(bool constant, std::vector<SymbolId> terms)
+    : constant_(constant), terms_(canonicalize_terms(std::move(terms))) {}
+
+AffineBool AffineBool::symbol(SymbolId id) {
+    return AffineBool(false, {id});
+}
+
+bool AffineBool::is_canonical() const {
+    for (size_t i = 1; i < terms_.size(); ++i) {
+        if (index(terms_[i - 1]) >= index(terms_[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+AffineBool& AffineBool::operator^=(const AffineBool& other) {
+    constant_ ^= other.constant_;
+    terms_ = xor_terms(terms_, other.terms_);
+    return *this;
+}
+
+AffineBool& AffineBool::operator^=(bool value) {
+    constant_ ^= value;
+    return *this;
+}
+
+AffineBool operator^(AffineBool left, const AffineBool& right) {
+    left ^= right;
+    return left;
+}
+
+AffineBool operator^(AffineBool left, bool right) {
+    left ^= right;
+    return left;
+}
+
+AffineBool operator^(bool left, AffineBool right) {
+    right ^= left;
+    return right;
+}
+
+bool ActivePauli::is_identity() const {
+    return std::ranges::all_of(x, [](uint64_t word) { return word == 0; }) &&
+           std::ranges::all_of(z, [](uint64_t word) { return word == 0; });
+}
+
+uint32_t predicted_dense_passes(const SamplingAction& action) {
+    return std::visit(
+        [](const auto& typed) -> uint32_t {
+            using T = std::decay_t<decltype(typed)>;
+            if constexpr (std::is_same_v<T, RotateActivePauli>) {
+                return typed.pauli.is_identity() ? 0 : 1;
+            } else if constexpr (std::is_same_v<T, PromoteDormantRotation> ||
+                                 std::is_same_v<T, MeasureActivePauli>) {
+                return 1;
+            } else {
+                return 0;
+            }
+        },
+        action);
+}
+
+void SamplingPlan::validate() const {
+    if (initial_active_width > num_qubits) {
+        invalid_plan("initial active width exceeds qubit count");
+    }
+    if (max_active_width > num_qubits || max_active_width < initial_active_width) {
+        invalid_plan("maximum active width is inconsistent with plan dimensions");
+    }
+    if (static_cast<uint64_t>(num_visible_records) + num_hidden_records >
+        std::numeric_limits<uint32_t>::max()) {
+        invalid_plan("record count exceeds uint32 range");
+    }
+    if (!is_finite_robust(global_weight.real()) || !is_finite_robust(global_weight.imag())) {
+        invalid_plan("global weight is not finite");
+    }
+
+    std::vector<std::optional<uint32_t>> actual_definitions(symbols.size());
+    for (uint32_t action_index = 0; action_index < actions.size(); ++action_index) {
+        const auto symbol = defined_symbol(actions[action_index].action);
+        if (!symbol.has_value()) {
+            continue;
+        }
+        const uint32_t symbol_index = index(*symbol);
+        if (symbol_index >= symbols.size()) {
+            invalid_plan("action " + std::to_string(action_index) + " defines symbol s" +
+                         std::to_string(symbol_index) + " out of range");
+        }
+        if (actual_definitions[symbol_index].has_value()) {
+            invalid_plan("symbol s" + std::to_string(symbol_index) + " is defined more than once");
+        }
+        actual_definitions[symbol_index] = action_index;
+    }
+
+    for (uint32_t symbol_index = 0; symbol_index < symbols.size(); ++symbol_index) {
+        const SymbolInfo& info = symbols[symbol_index];
+        if (info.noise_site.has_value() &&
+            (info.kind != SymbolKind::Exogenous || index(*info.noise_site) >= num_noise_sites)) {
+            invalid_plan("symbol s" + std::to_string(symbol_index) +
+                         " has an invalid noise-site identity");
+        }
+        if (info.kind == SymbolKind::Exogenous) {
+            if (info.defining_action.has_value() || actual_definitions[symbol_index].has_value()) {
+                invalid_plan("exogenous symbol s" + std::to_string(symbol_index) +
+                             " must be presampled");
+            }
+            continue;
+        }
+        if (!info.defining_action.has_value() ||
+            info.defining_action != actual_definitions[symbol_index]) {
+            invalid_plan("symbol s" + std::to_string(symbol_index) +
+                         " definition metadata does not match its action");
+        }
+        const SamplingAction& action = actions[*info.defining_action].action;
+        if (info.kind == SymbolKind::Branch &&
+            !std::holds_alternative<MeasureActivePauli>(action) &&
+            !std::holds_alternative<MeasureDormantRandom>(action)) {
+            invalid_plan("branch symbol s" + std::to_string(symbol_index) +
+                         " must be defined by a measurement");
+        }
+        if (info.kind == SymbolKind::Derived && !std::holds_alternative<DefineSymbol>(action)) {
+            invalid_plan("derived symbol s" + std::to_string(symbol_index) +
+                         " must be defined by DefineSymbol");
+        }
+    }
+
+    uint32_t active_width = initial_active_width;
+    uint32_t observed_max = active_width;
+    for (uint32_t action_index = 0; action_index < actions.size(); ++action_index) {
+        const PlannedAction& planned = actions[action_index];
+        if (planned.active_before != active_width || planned.active_before > num_qubits ||
+            planned.active_after > num_qubits) {
+            invalid_plan("action " + std::to_string(action_index) +
+                         " breaks the active-width chain");
+        }
+
+        const std::optional<SymbolId> definition = defined_symbol(planned.action);
+        std::visit(
+            [&](const auto& typed) {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, RotateActivePauli>) {
+                    if (planned.active_after != planned.active_before) {
+                        invalid_plan("active rotation changes active width");
+                    }
+                    validate_pauli(typed.pauli, planned.active_before, action_index);
+                    if (!is_finite_robust(typed.half_turns)) {
+                        invalid_plan("active rotation angle is not finite");
+                    }
+                    validate_expression(*this, typed.negative, action_index, definition, false);
+                } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
+                    if (planned.active_after != planned.active_before + 1 ||
+                        typed.dormant_pivot < planned.active_before ||
+                        typed.dormant_pivot >= num_qubits) {
+                        invalid_plan("dormant promotion has an invalid width or pivot");
+                    }
+                    if (!is_finite_robust(typed.half_turns)) {
+                        invalid_plan("dormant promotion angle is not finite");
+                    }
+                    validate_expression(*this, typed.negative, action_index, definition, false);
+                } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
+                    if (planned.active_before == 0 ||
+                        planned.active_after + 1 != planned.active_before ||
+                        typed.active_pivot >= planned.active_before) {
+                        invalid_plan("active measurement has an invalid width or pivot");
+                    }
+                    validate_pauli(typed.pauli, planned.active_before, action_index);
+                    if (typed.pauli.is_identity()) {
+                        invalid_plan("active measurement Pauli is identity");
+                    }
+                    validate_expression(*this, typed.outcome, action_index, definition, true);
+                    validate_record(*this, typed.record, action_index);
+                } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
+                    if (planned.active_after != planned.active_before ||
+                        typed.dormant_pivot < planned.active_before ||
+                        typed.dormant_pivot >= num_qubits) {
+                        invalid_plan("dormant measurement has an invalid width or pivot");
+                    }
+                    validate_expression(*this, typed.outcome, action_index, definition, true);
+                    validate_record(*this, typed.record, action_index);
+                } else if constexpr (std::is_same_v<T, RecordClassical>) {
+                    if (planned.active_after != planned.active_before) {
+                        invalid_plan("classical record changes active width");
+                    }
+                    validate_expression(*this, typed.outcome, action_index, definition, false);
+                    validate_record(*this, typed.record, action_index);
+                } else if constexpr (std::is_same_v<T, DefineSymbol>) {
+                    if (planned.active_after != planned.active_before) {
+                        invalid_plan("symbol definition changes active width");
+                    }
+                    validate_expression(*this, typed.value, action_index, definition, false);
+                } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
+                    if (planned.active_after != planned.active_before ||
+                        index(typed.site) >= num_instrument_sites) {
+                        invalid_plan("instrument boundary has an invalid width or site id");
+                    }
+                }
+            },
+            planned.action);
+
+        active_width = planned.active_after;
+        observed_max = std::max(observed_max, active_width);
+    }
+    if (observed_max != max_active_width) {
+        invalid_plan("declared maximum active width does not match the action stream");
+    }
+}
+
+std::string SamplingPlan::inspect() const {
+    validate();
+
+    std::ostringstream out;
+    out << std::setprecision(17);
+    out << "sampling_plan qubits=" << num_qubits << " initial_k=" << initial_active_width
+        << " max_k=" << max_active_width << " visible_records=" << num_visible_records
+        << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
+        << " instrument_sites=" << num_instrument_sites
+        << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
+    out << "global_weight=" << global_weight.real() << ',' << global_weight.imag() << '\n';
+    out << "symbols=" << symbols.size() << '\n';
+    for (uint32_t i = 0; i < symbols.size(); ++i) {
+        out << "  s" << i << " kind=" << symbol_kind_name(symbols[i].kind);
+        if (symbols[i].defining_action.has_value()) {
+            out << " action=" << *symbols[i].defining_action;
+        } else {
+            out << " presampled";
+        }
+        if (symbols[i].noise_site.has_value()) {
+            out << " noise_site=" << index(*symbols[i].noise_site);
+        }
+        out << '\n';
+    }
+    out << "actions=" << actions.size() << '\n';
+    for (uint32_t i = 0; i < actions.size(); ++i) {
+        const PlannedAction& planned = actions[i];
+        out << "  " << i << " k=" << planned.active_before << "->" << planned.active_after
+            << " dense_passes=" << predicted_dense_passes(planned.action) << ' ';
+        std::visit(
+            [&](const auto& typed) {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, RotateActivePauli>) {
+                    out << "rotate_active " << format_pauli(typed.pauli)
+                        << " half_turns=" << typed.half_turns
+                        << " negative=" << format_expression(typed.negative);
+                } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
+                    out << "promote_dormant pivot=" << typed.dormant_pivot
+                        << " half_turns=" << typed.half_turns
+                        << " negative=" << format_expression(typed.negative);
+                } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
+                    out << "measure_active " << format_pauli(typed.pauli)
+                        << " pivot=" << typed.active_pivot << " branch=s" << index(typed.branch)
+                        << " outcome=" << format_expression(typed.outcome)
+                        << " record=" << index(typed.record);
+                } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
+                    out << "measure_dormant pivot=" << typed.dormant_pivot << " branch=s"
+                        << index(typed.branch) << " outcome=" << format_expression(typed.outcome)
+                        << " record=" << index(typed.record);
+                } else if constexpr (std::is_same_v<T, RecordClassical>) {
+                    out << "record_classical outcome=" << format_expression(typed.outcome)
+                        << " record=" << index(typed.record);
+                } else if constexpr (std::is_same_v<T, DefineSymbol>) {
+                    out << "define_symbol s" << index(typed.symbol)
+                        << " value=" << format_expression(typed.value);
+                } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
+                    out << "instrument_boundary site=" << index(typed.site);
+                }
+            },
+            planned.action);
+        out << '\n';
+    }
+    return out.str();
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 namespace clifft::sampling {
@@ -89,8 +90,8 @@ std::string format_expression(const AffineBool& expression) {
 
 std::string_view symbol_kind_name(SymbolKind kind) {
     switch (kind) {
-        case SymbolKind::Exogenous:
-            return "exogenous";
+        case SymbolKind::Presampled:
+            return "presampled";
         case SymbolKind::Derived:
             return "derived";
         case SymbolKind::Branch:
@@ -99,23 +100,15 @@ std::string_view symbol_kind_name(SymbolKind kind) {
     return "unknown";
 }
 
-std::string format_words(const std::vector<uint64_t>& words) {
+std::string format_mask(uint64_t mask) {
     std::ostringstream out;
-    out << '[';
-    for (size_t i = 0; i < words.size(); ++i) {
-        if (i != 0) {
-            out << ',';
-        }
-        out << "0x" << std::hex << std::setw(16) << std::setfill('0') << words[i];
-    }
-    out << ']';
+    out << "0x" << std::hex << std::setw(16) << std::setfill('0') << mask;
     return out.str();
 }
 
 std::string format_pauli(const ActivePauli& pauli) {
     std::ostringstream out;
-    out << "width=" << pauli.width << " x=" << format_words(pauli.x)
-        << " z=" << format_words(pauli.z);
+    out << "x=" << format_mask(pauli.x) << " z=" << format_mask(pauli.z);
     return out.str();
 }
 
@@ -124,22 +117,21 @@ std::string format_pauli(const ActivePauli& pauli) {
 }
 
 void validate_pauli(const ActivePauli& pauli, uint32_t expected_width, uint32_t action_index) {
-    if (pauli.width != expected_width) {
-        invalid_plan("action " + std::to_string(action_index) + " Pauli width " +
-                     std::to_string(pauli.width) + " does not match active width " +
-                     std::to_string(expected_width));
-    }
-    const size_t words = (static_cast<size_t>(pauli.width) + 63) / 64;
-    if (pauli.x.size() != words || pauli.z.size() != words) {
+    const uint64_t width_mask =
+        expected_width == 0 ? uint64_t{0} : (uint64_t{1} << expected_width) - 1;
+    if ((pauli.x & ~width_mask) != 0 || (pauli.z & ~width_mask) != 0) {
         invalid_plan("action " + std::to_string(action_index) +
-                     " Pauli word count does not match its width");
+                     " Pauli has bits outside its active width");
     }
-    if (words != 0 && pauli.width % 64 != 0) {
-        const uint64_t tail_mask = (uint64_t{1} << (pauli.width % 64)) - 1;
-        if ((pauli.x.back() & ~tail_mask) != 0 || (pauli.z.back() & ~tail_mask) != 0) {
-            invalid_plan("action " + std::to_string(action_index) +
-                         " Pauli has bits outside its active width");
-        }
+}
+
+void validate_measurement_pivot(const MeasureActivePauli& measurement, uint32_t action_index) {
+    const uint64_t pivot_bit = uint64_t{1} << measurement.active_pivot;
+    const bool valid = measurement.pauli.x != 0 ? (measurement.pauli.x & pivot_bit) != 0
+                                                : (measurement.pauli.z & pivot_bit) != 0;
+    if (!valid) {
+        invalid_plan("action " + std::to_string(action_index) +
+                     " measurement pivot is outside the relevant Pauli support");
     }
 }
 
@@ -173,7 +165,7 @@ void validate_expression(const SamplingPlan& plan, const AffineBool& expression,
                          std::to_string(symbol_index) + " out of range");
         }
         const SymbolInfo& info = plan.symbols[symbol_index];
-        if (info.kind == SymbolKind::Exogenous) {
+        if (info.kind == SymbolKind::Presampled) {
             continue;
         }
         if (!info.defining_action.has_value()) {
@@ -188,12 +180,17 @@ void validate_expression(const SamplingPlan& plan, const AffineBool& expression,
     }
 }
 
-void validate_record(const SamplingPlan& plan, RecordSlot record, uint32_t action_index) {
+void validate_record(const SamplingPlan& plan, RecordSlot record, uint32_t action_index,
+                     std::unordered_set<uint32_t>& written_records) {
     const uint64_t total = static_cast<uint64_t>(plan.num_visible_records) +
                            static_cast<uint64_t>(plan.num_hidden_records);
     if (index(record) >= total) {
         invalid_plan("action " + std::to_string(action_index) + " record slot " +
                      std::to_string(index(record)) + " out of range");
+    }
+    if (!written_records.insert(index(record)).second) {
+        invalid_plan("action " + std::to_string(action_index) + " writes record slot " +
+                     std::to_string(index(record)) + " more than once");
     }
 }
 
@@ -244,8 +241,7 @@ AffineBool operator^(bool left, AffineBool right) {
 }
 
 bool ActivePauli::is_identity() const {
-    return std::ranges::all_of(x, [](uint64_t word) { return word == 0; }) &&
-           std::ranges::all_of(z, [](uint64_t word) { return word == 0; });
+    return x == 0 && z == 0;
 }
 
 uint32_t predicted_dense_passes(const SamplingAction& action) {
@@ -270,6 +266,10 @@ void SamplingPlan::validate() const {
     }
     if (max_active_width > num_qubits || max_active_width < initial_active_width) {
         invalid_plan("maximum active width is inconsistent with plan dimensions");
+    }
+    if (max_active_width >= kDenseActiveWidthLimit) {
+        invalid_plan("maximum active width must be below " +
+                     std::to_string(kDenseActiveWidthLimit) + " for dense coefficient storage");
     }
     if (static_cast<uint64_t>(num_visible_records) + num_hidden_records >
         std::numeric_limits<uint32_t>::max()) {
@@ -299,13 +299,13 @@ void SamplingPlan::validate() const {
     for (uint32_t symbol_index = 0; symbol_index < symbols.size(); ++symbol_index) {
         const SymbolInfo& info = symbols[symbol_index];
         if (info.noise_site.has_value() &&
-            (info.kind != SymbolKind::Exogenous || index(*info.noise_site) >= num_noise_sites)) {
+            (info.kind != SymbolKind::Presampled || index(*info.noise_site) >= num_noise_sites)) {
             invalid_plan("symbol s" + std::to_string(symbol_index) +
                          " has an invalid noise-site identity");
         }
-        if (info.kind == SymbolKind::Exogenous) {
+        if (info.kind == SymbolKind::Presampled) {
             if (info.defining_action.has_value() || actual_definitions[symbol_index].has_value()) {
-                invalid_plan("exogenous symbol s" + std::to_string(symbol_index) +
+                invalid_plan("presampled symbol s" + std::to_string(symbol_index) +
                              " must be presampled");
             }
             continue;
@@ -330,6 +330,9 @@ void SamplingPlan::validate() const {
 
     uint32_t active_width = initial_active_width;
     uint32_t observed_max = active_width;
+    std::unordered_set<uint32_t> written_records;
+    written_records.reserve(std::min<size_t>(
+        actions.size(), static_cast<uint64_t>(num_visible_records) + num_hidden_records));
     for (uint32_t action_index = 0; action_index < actions.size(); ++action_index) {
         const PlannedAction& planned = actions[action_index];
         if (planned.active_before != active_width || planned.active_before > num_qubits ||
@@ -350,7 +353,7 @@ void SamplingPlan::validate() const {
                     if (!is_finite_robust(typed.half_turns)) {
                         invalid_plan("active rotation angle is not finite");
                     }
-                    validate_expression(*this, typed.negative, action_index, definition, false);
+                    validate_expression(*this, typed.sign, action_index, definition, false);
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
                     if (planned.active_after != planned.active_before + 1 ||
                         typed.dormant_pivot < planned.active_before ||
@@ -360,7 +363,7 @@ void SamplingPlan::validate() const {
                     if (!is_finite_robust(typed.half_turns)) {
                         invalid_plan("dormant promotion angle is not finite");
                     }
-                    validate_expression(*this, typed.negative, action_index, definition, false);
+                    validate_expression(*this, typed.sign, action_index, definition, false);
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
                     if (planned.active_before == 0 ||
                         planned.active_after + 1 != planned.active_before ||
@@ -371,8 +374,9 @@ void SamplingPlan::validate() const {
                     if (typed.pauli.is_identity()) {
                         invalid_plan("active measurement Pauli is identity");
                     }
+                    validate_measurement_pivot(typed, action_index);
                     validate_expression(*this, typed.outcome, action_index, definition, true);
-                    validate_record(*this, typed.record, action_index);
+                    validate_record(*this, typed.record, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
                     if (planned.active_after != planned.active_before ||
                         typed.dormant_pivot < planned.active_before ||
@@ -380,13 +384,13 @@ void SamplingPlan::validate() const {
                         invalid_plan("dormant measurement has an invalid width or pivot");
                     }
                     validate_expression(*this, typed.outcome, action_index, definition, true);
-                    validate_record(*this, typed.record, action_index);
+                    validate_record(*this, typed.record, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, RecordClassical>) {
                     if (planned.active_after != planned.active_before) {
                         invalid_plan("classical record changes active width");
                     }
                     validate_expression(*this, typed.outcome, action_index, definition, false);
-                    validate_record(*this, typed.record, action_index);
+                    validate_record(*this, typed.record, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                     if (planned.active_after != planned.active_before) {
                         invalid_plan("symbol definition changes active width");
@@ -414,8 +418,8 @@ std::string SamplingPlan::inspect() const {
 
     std::ostringstream out;
     out << std::setprecision(17);
-    out << "sampling_plan qubits=" << num_qubits << " initial_k=" << initial_active_width
-        << " max_k=" << max_active_width << " visible_records=" << num_visible_records
+    out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
+        << " max_width=" << max_active_width << " visible_records=" << num_visible_records
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
         << " instrument_sites=" << num_instrument_sites
         << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
@@ -425,8 +429,6 @@ std::string SamplingPlan::inspect() const {
         out << "  s" << i << " kind=" << symbol_kind_name(symbols[i].kind);
         if (symbols[i].defining_action.has_value()) {
             out << " action=" << *symbols[i].defining_action;
-        } else {
-            out << " presampled";
         }
         if (symbols[i].noise_site.has_value()) {
             out << " noise_site=" << index(*symbols[i].noise_site);
@@ -436,19 +438,20 @@ std::string SamplingPlan::inspect() const {
     out << "actions=" << actions.size() << '\n';
     for (uint32_t i = 0; i < actions.size(); ++i) {
         const PlannedAction& planned = actions[i];
-        out << "  " << i << " k=" << planned.active_before << "->" << planned.active_after
-            << " dense_passes=" << predicted_dense_passes(planned.action) << ' ';
+        out << "  " << i << " active_width=" << planned.active_before << "->"
+            << planned.active_after << " dense_passes=" << predicted_dense_passes(planned.action)
+            << ' ';
         std::visit(
             [&](const auto& typed) {
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, RotateActivePauli>) {
                     out << "rotate_active " << format_pauli(typed.pauli)
                         << " half_turns=" << typed.half_turns
-                        << " negative=" << format_expression(typed.negative);
+                        << " sign=" << format_expression(typed.sign);
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
                     out << "promote_dormant pivot=" << typed.dormant_pivot
                         << " half_turns=" << typed.half_turns
-                        << " negative=" << format_expression(typed.negative);
+                        << " sign=" << format_expression(typed.sign);
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
                     out << "measure_active " << format_pauli(typed.pauli)
                         << " pivot=" << typed.active_pivot << " branch=s" << index(typed.branch)

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -126,6 +126,7 @@ void validate_pauli(const ActivePauli& pauli, uint32_t expected_width, uint32_t 
 }
 
 void validate_measurement_pivot(const MeasureActivePauli& measurement, uint32_t action_index) {
+    // Pair updates need an X-support pivot; diagonal updates remove a Z-support coordinate.
     const uint64_t pivot_bit = uint64_t{1} << measurement.active_pivot;
     const bool valid = measurement.pauli.x != 0 ? (measurement.pauli.x & pivot_bit) != 0
                                                 : (measurement.pauli.z & pivot_bit) != 0;
@@ -339,6 +340,13 @@ void SamplingPlan::validate() const {
             planned.active_after > num_qubits) {
             invalid_plan("action " + std::to_string(action_index) +
                          " breaks the active-width chain");
+        }
+        const uint32_t action_max_width = std::max(planned.active_before, planned.active_after);
+        if (action_max_width >= kDenseActiveWidthLimit) {
+            invalid_plan("action " + std::to_string(action_index) + " reaches active width " +
+                         std::to_string(action_max_width) +
+                         ", but dense storage requires widths below " +
+                         std::to_string(kDenseActiveWidthLimit));
         }
 
         const std::optional<SymbolId> definition = defined_symbol(planned.action);

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -16,6 +16,9 @@ namespace clifft::sampling {
 
 namespace {
 
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
 uint32_t index(SymbolId id) {
     return static_cast<uint32_t>(id);
 }
@@ -34,6 +37,8 @@ uint32_t index(InstrumentSiteId site) {
 
 std::vector<SymbolId> xor_terms(const std::vector<SymbolId>& left,
                                 const std::vector<SymbolId>& right) {
+    // Canonical inputs are sorted and unique, so XOR is their symmetric
+    // difference: a term present in both inputs cancels.
     std::vector<SymbolId> result;
     result.reserve(left.size() + right.size());
     size_t i = 0;
@@ -52,6 +57,8 @@ std::vector<SymbolId> xor_terms(const std::vector<SymbolId>& left,
 }
 
 std::vector<SymbolId> canonicalize_terms(std::vector<SymbolId> terms) {
+    // XOR retains exactly the terms with odd multiplicity. Sorting also gives
+    // expressions one deterministic representation.
     std::sort(terms.begin(), terms.end(),
               [](SymbolId left, SymbolId right) { return index(left) < index(right); });
     std::vector<SymbolId> result;
@@ -145,8 +152,13 @@ std::optional<SymbolId> defined_symbol(const SamplingAction& action) {
                 return typed.branch;
             } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                 return typed.symbol;
-            } else {
+            } else if constexpr (std::is_same_v<T, RotateActivePauli> ||
+                                 std::is_same_v<T, PromoteDormantRotation> ||
+                                 std::is_same_v<T, RecordClassical> ||
+                                 std::is_same_v<T, InstrumentBoundary>) {
                 return std::nullopt;
+            } else {
+                static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
             }
         },
         action);
@@ -263,8 +275,13 @@ uint32_t predicted_dense_passes(const SamplingAction& action) {
             } else if constexpr (std::is_same_v<T, PromoteDormantRotation> ||
                                  std::is_same_v<T, MeasureActivePauli>) {
                 return 1;
-            } else {
+            } else if constexpr (std::is_same_v<T, MeasureDormantRandom> ||
+                                 std::is_same_v<T, RecordClassical> ||
+                                 std::is_same_v<T, DefineSymbol> ||
+                                 std::is_same_v<T, InstrumentBoundary>) {
                 return 0;
+            } else {
+                static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
             }
         },
         action);
@@ -418,6 +435,8 @@ void SamplingPlan::validate() const {
                         index(typed.site) >= num_instrument_sites) {
                         invalid_plan("instrument boundary has an invalid width or site id");
                     }
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
                 }
             },
             planned.action);
@@ -486,6 +505,8 @@ std::string SamplingPlan::inspect() const {
                         << " value=" << format_expression(typed.value);
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     out << "instrument_boundary site=" << index(typed.site);
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
                 }
             },
             planned.action);

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -181,6 +181,15 @@ void validate_expression(const SamplingPlan& plan, const AffineBool& expression,
     }
 }
 
+void validate_measurement_outcome(const SamplingPlan& plan, const AffineBool& outcome,
+                                  SymbolId branch, uint32_t action_index) {
+    validate_expression(plan, outcome, action_index, branch, true);
+    if (std::ranges::find(outcome.terms(), branch) == outcome.terms().end()) {
+        invalid_plan("action " + std::to_string(action_index) +
+                     " measurement outcome omits branch s" + std::to_string(index(branch)));
+    }
+}
+
 void validate_record(const SamplingPlan& plan, RecordSlot record, uint32_t action_index,
                      std::unordered_set<uint32_t>& written_records) {
     const uint64_t total = static_cast<uint64_t>(plan.num_visible_records) +
@@ -383,7 +392,7 @@ void SamplingPlan::validate() const {
                         invalid_plan("active measurement Pauli is identity");
                     }
                     validate_measurement_pivot(typed, action_index);
-                    validate_expression(*this, typed.outcome, action_index, definition, true);
+                    validate_measurement_outcome(*this, typed.outcome, typed.branch, action_index);
                     validate_record(*this, typed.record, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
                     if (planned.active_after != planned.active_before ||
@@ -391,7 +400,7 @@ void SamplingPlan::validate() const {
                         typed.dormant_pivot >= num_qubits) {
                         invalid_plan("dormant measurement has an invalid width or pivot");
                     }
-                    validate_expression(*this, typed.outcome, action_index, definition, true);
+                    validate_measurement_outcome(*this, typed.outcome, typed.branch, action_index);
                     validate_record(*this, typed.record, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, RecordClassical>) {
                     if (planned.active_after != planned.active_before) {

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -5,6 +5,8 @@
 // This representation deliberately does not reuse the legacy SVM Instruction.
 // It describes sampling semantics; CPU layout, SIMD selection, dispatch, and
 // device lowering belong to later execution-specific layers.
+// Executors must lower it to a packed, allocation-free runtime plan rather
+// than traversing these variants and vectors in per-shot hot loops.
 //
 // The symbolic-expression and stabilizer-coordinate action split is an
 // independent Clifft implementation informed by the published SymFT design.
@@ -24,13 +26,13 @@ enum class NoiseSiteId : uint32_t {};
 enum class InstrumentSiteId : uint32_t {};
 
 enum class SymbolKind : uint8_t {
-    Exogenous,
+    Presampled,
     Derived,
     Branch,
 };
 
-// An affine Boolean expression over plan symbols. Terms are stored in strict
-// ascending order; XOR construction removes duplicates.
+// An XOR (parity) expression over plan symbols, possibly inverted. Terms are
+// stored in strict ascending order; XOR construction removes duplicates.
 class AffineBool {
   public:
     AffineBool() = default;
@@ -57,13 +59,13 @@ class AffineBool {
 [[nodiscard]] AffineBool operator^(bool left, AffineBool right);
 
 // The Hermitian Pauli body for one action, expressed only in the active
-// coordinates visible immediately before that action. Y phases are implied by
-// paired X/Z bits. Its sign is carried by the action's AffineBool so
-// shot-dependent signs never enter this mask.
+// coordinates visible immediately before that action. The unsigned operator is
+// i^popcount(x & z) X^x Z^z; an action's AffineBool carries its possibly
+// shot-dependent sign. Dense active width is below kDenseActiveWidthLimit, so
+// each mask fits in one word even when the physical circuit has many qubits.
 struct ActivePauli {
-    uint32_t width = 0;
-    std::vector<uint64_t> x;
-    std::vector<uint64_t> z;
+    uint64_t x = 0;
+    uint64_t z = 0;
 
     [[nodiscard]] bool is_identity() const;
 };
@@ -72,14 +74,16 @@ struct ActivePauli {
 struct RotateActivePauli {
     ActivePauli pauli;
     double half_turns = 0.0;
-    AffineBool negative;
+    // True means the Pauli enters the rotation with a minus sign.
+    AffineBool sign;
 };
 
 // Promotes one dormant coordinate and applies the rotation that introduced it.
 struct PromoteDormantRotation {
     uint32_t dormant_pivot = 0;
     double half_turns = 0.0;
-    AffineBool negative;
+    // True means the promoted Pauli enters with a minus sign.
+    AffineBool sign;
 };
 
 // Samples one active Pauli branch and removes the selected active pivot. The
@@ -115,9 +119,11 @@ struct DefineSymbol {
     AffineBool value;
 };
 
-// Divides ahead-of-time execution segments. A future continuation must accept
-// the live state established here; it need not reproduce an arbitrary prior
-// plan prefix byte-for-byte.
+// Divides ahead-of-time execution segments. A continuation must preserve the
+// live coefficients, active-coordinate meaning and order, active width,
+// symbol and record values, and RNG position established here. It need not
+// reproduce an arbitrary prior plan prefix byte-for-byte. The boundary itself
+// is width-neutral; any state transition belongs to a following action.
 struct InstrumentBoundary {
     InstrumentSiteId site{};
 };
@@ -133,13 +139,13 @@ struct PlannedAction {
 };
 
 struct SymbolInfo {
-    SymbolKind kind = SymbolKind::Exogenous;
+    SymbolKind kind = SymbolKind::Presampled;
 
-    // Exogenous symbols are presampled and have no defining action. Branch and
+    // Presampled symbols have no defining action. Branch and
     // derived symbols name the action that makes them available.
     std::optional<uint32_t> defining_action;
 
-    // Exogenous symbols may identify the stable HIR noise site that supplies
+    // Presampled symbols may identify the stable HIR noise site that supplies
     // them. Other presampled event kinds can add their own source identity
     // without changing expression semantics.
     std::optional<NoiseSiteId> noise_site;
@@ -147,6 +153,10 @@ struct SymbolInfo {
 
 struct SamplingPlan {
     uint32_t num_qubits = 0;
+
+    // Active width is the new subsystem's name for legacy active_k. The
+    // planner computes its maximum (legacy peak_rank) while emitting actions,
+    // before runtime lowering uses it to preallocate coefficient storage.
     uint32_t initial_active_width = 0;
     uint32_t max_active_width = 0;
     uint32_t num_visible_records = 0;

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -88,7 +88,8 @@ struct PromoteDormantRotation {
 
 // Samples one active Pauli branch and removes the selected active pivot. The
 // branch symbol is the effective eigenvalue label used by state updates; the
-// outcome expression is the user-visible record bit after symbolic signs.
+// outcome expression contains that branch and yields the user-visible record
+// bit after symbolic sign corrections.
 struct MeasureActivePauli {
     ActivePauli pauli;
     uint32_t active_pivot = 0;
@@ -98,8 +99,8 @@ struct MeasureActivePauli {
 };
 
 // Introduces an unbiased effective eigenvalue label while replacing a dormant
-// stabilizer. The outcome expression is the separately recorded bit, and the
-// active vector is untouched.
+// stabilizer. The outcome expression contains that branch and yields the
+// separately recorded bit; the active vector is untouched.
 struct MeasureDormantRandom {
     uint32_t dormant_pivot = 0;
     SymbolId branch{};

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -1,18 +1,24 @@
 #pragma once
 
-// Private semantic plan for the symbolic-coordinate sampling path.
+// SamplingPlan is a private semantic IR produced after a circuit is compiled
+// to HIR and optimized. It captures the action sequence needed to sample the
+// circuit, including stochastic events as Boolean symbols, changes to the
+// active state, record writes, and instrument boundaries. This separates
+// compile-once planning from values determined for each shot.
 //
-// This representation deliberately does not reuse the legacy SVM Instruction.
-// It describes sampling semantics; CPU layout, SIMD selection, dispatch, and
-// device lowering belong to later execution-specific layers.
-// Executors must lower it to a packed, allocation-free runtime plan rather
-// than traversing these variants and vectors in per-shot hot loops.
+// The plan is executor-independent. CPU layout, SIMD selection, dispatch, and
+// device lowering belong to execution-specific layers, which should lower it
+// to packed, preallocated storage before entering per-shot hot loops.
 //
-// The symbolic-expression and stabilizer-coordinate action split is an
-// independent Clifft implementation informed by the published SymFT design.
+// The symbolic-expression and stabilizer-coordinate split is informed by:
+// SymFT: Universal Fault-Tolerant Quantum Circuit Simulation via Symbolic
+// Clifford--Pauli Frames and Stabilizer Coordinates, arXiv:2607.28600.
+
+#include "clifft/util/numeric.h"
 
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <variant>
@@ -20,19 +26,24 @@
 
 namespace clifft::sampling {
 
+// A symbol is a plan-local Boolean value assigned once per shot. It represents
+// a presampled stochastic event, a sampled measurement branch, or a named
+// parity derived from earlier symbols.
 enum class SymbolId : uint32_t {};
 enum class RecordSlot : uint32_t {};
 enum class NoiseSiteId : uint32_t {};
 enum class InstrumentSiteId : uint32_t {};
 
 enum class SymbolKind : uint8_t {
-    Presampled,
-    Derived,
-    Branch,
+    Presampled,  // Available before the action stream, such as sampled noise.
+    Derived,     // Computed as a parity of previously available symbols.
+    Branch,      // Sampled while applying a measurement action.
 };
 
-// An XOR (parity) expression over plan symbols, possibly inverted. Terms are
-// stored in strict ascending order; XOR construction removes duplicates.
+// A parity expression over plan symbols, optionally XORed with true. For
+// example, s0 ^ s2 ^ true can track how sampled noise and a measurement branch
+// combine into a later sign or record bit. Terms are stored in strict ascending
+// order; XOR construction removes duplicates.
 class AffineBool {
   public:
     AffineBool() = default;
@@ -58,11 +69,17 @@ class AffineBool {
 [[nodiscard]] AffineBool operator^(AffineBool left, bool right);
 [[nodiscard]] AffineBool operator^(bool left, AffineBool right);
 
-// The Hermitian Pauli body for one action, expressed only in the active
-// coordinates visible immediately before that action. The unsigned operator is
-// i^popcount(x & z) X^x Z^z; an action's AffineBool carries its possibly
-// shot-dependent sign. Dense active width is below kDenseActiveWidthLimit, so
-// each mask fits in one word even when the physical circuit has many qubits.
+// Operations requiring coefficient-state work are expressed over active
+// stabilizer coordinates. An active coordinate is represented explicitly in
+// the dense 2^k coefficient state; it is not an "active physical qubit."
+// ActivePauli stores the unsigned Hermitian operator
+// i^popcount(x & z) X^x Z^z. Each action carries a separate AffineBool that can
+// change its sign for each shot.
+//
+// The dense-width limit is exclusive, so all valid masks fit in one word even
+// when the physical circuit contains many qubits.
+static_assert(kDenseActiveWidthLimit <= std::numeric_limits<uint64_t>::digits);
+
 struct ActivePauli {
     uint64_t x = 0;
     uint64_t z = 0;
@@ -74,7 +91,7 @@ struct ActivePauli {
 struct RotateActivePauli {
     ActivePauli pauli;
     double half_turns = 0.0;
-    // True means the Pauli enters the rotation with a minus sign.
+    // When true for a shot, use -P, equivalently negating half_turns.
     AffineBool sign;
 };
 
@@ -82,14 +99,14 @@ struct RotateActivePauli {
 struct PromoteDormantRotation {
     uint32_t dormant_pivot = 0;
     double half_turns = 0.0;
-    // True means the promoted Pauli enters with a minus sign.
+    // When true for a shot, negate the promoted generator and half_turns.
     AffineBool sign;
 };
 
-// Samples one active Pauli branch and removes the selected active pivot. The
-// branch symbol is the effective eigenvalue label used by state updates; the
-// outcome expression contains that branch and yields the user-visible record
-// bit after symbolic sign corrections.
+// Measuring a Pauli supported on the active coordinates requires sampling and
+// collapsing the coefficient state. The selected pivot is then removed, so the
+// active width decreases by one. The branch symbol holds the sampled eigenvalue
+// bit; outcome combines it with symbolic corrections to produce the record bit.
 struct MeasureActivePauli {
     ActivePauli pauli;
     uint32_t active_pivot = 0;
@@ -98,9 +115,10 @@ struct MeasureActivePauli {
     RecordSlot record{};
 };
 
-// Introduces an unbiased effective eigenvalue label while replacing a dormant
-// stabilizer. The outcome expression contains that branch and yields the
-// separately recorded bit; the active vector is untouched.
+// A random Pauli measurement supported outside the active coefficient state
+// samples an unbiased branch and replaces the selected dormant stabilizer. It
+// leaves the active state unchanged. The outcome combines the branch with
+// symbolic corrections to produce the record bit.
 struct MeasureDormantRandom {
     uint32_t dormant_pivot = 0;
     SymbolId branch{};
@@ -108,13 +126,16 @@ struct MeasureDormantRandom {
     RecordSlot record{};
 };
 
-// Records a deterministic classical expression without touching the state.
+// Writes a deterministic expression to visible or hidden circuit record
+// history without touching the state. Use DefineSymbol instead when an
+// internal parity needs a reusable name but no record slot.
 struct RecordClassical {
     AffineBool outcome;
     RecordSlot record{};
 };
 
-// Materializes an affine expression as a reusable derived symbol.
+// Names an affine expression for reuse by later actions without adding a
+// circuit record entry.
 struct DefineSymbol {
     SymbolId symbol{};
     AffineBool value;
@@ -123,8 +144,8 @@ struct DefineSymbol {
 // Divides ahead-of-time execution segments. A continuation must preserve the
 // live coefficients, active-coordinate meaning and order, active width,
 // symbol and record values, and RNG position established here. It need not
-// reproduce an arbitrary prior plan prefix byte-for-byte. The boundary itself
-// is width-neutral; any state transition belongs to a following action.
+// reproduce an arbitrary prior plan prefix byte-for-byte. The marker does not
+// itself change the active state; any transition belongs to a following action.
 struct InstrumentBoundary {
     InstrumentSiteId site{};
 };
@@ -139,25 +160,28 @@ struct PlannedAction {
     SamplingAction action;
 };
 
+// SamplingPlan::validate enforces the legal field combinations and verifies
+// that definition metadata agrees with the referenced action.
 struct SymbolInfo {
     SymbolKind kind = SymbolKind::Presampled;
 
-    // Presampled symbols have no defining action. Branch and
-    // derived symbols name the action that makes them available.
+    // This is nullopt for Presampled. For Branch and Derived it identifies the
+    // unique action that assigns the symbol.
     std::optional<uint32_t> defining_action;
 
-    // Presampled symbols may identify the stable HIR noise site that supplies
-    // them. Other presampled event kinds can add their own source identity
-    // without changing expression semantics.
+    // For a Presampled noise symbol, this identifies its stable HIR noise site.
+    // Nullopt means the presampled event has no noise-site identity. Branch and
+    // Derived symbols must always use nullopt.
     std::optional<NoiseSiteId> noise_site;
 };
 
 struct SamplingPlan {
     uint32_t num_qubits = 0;
 
-    // Active width is the new subsystem's name for legacy active_k. The
-    // planner computes its maximum (legacy peak_rank) while emitting actions,
-    // before runtime lowering uses it to preallocate coefficient storage.
+    // Active width is the number of stabilizer coordinates represented in the
+    // dense coefficient state, which contains 2^active_width entries. It is the
+    // descriptive name for legacy active_k. The planner computes its maximum
+    // while emitting actions so runtime lowering can preallocate storage.
     uint32_t initial_active_width = 0;
     uint32_t max_active_width = 0;
     uint32_t num_visible_records = 0;

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -1,0 +1,172 @@
+#pragma once
+
+// Private semantic plan for the symbolic-coordinate sampling path.
+//
+// This representation deliberately does not reuse the legacy SVM Instruction.
+// It describes sampling semantics; CPU layout, SIMD selection, dispatch, and
+// device lowering belong to later execution-specific layers.
+//
+// The symbolic-expression and stabilizer-coordinate action split is an
+// independent Clifft implementation informed by the published SymFT design.
+
+#include <complex>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace clifft::sampling {
+
+enum class SymbolId : uint32_t {};
+enum class RecordSlot : uint32_t {};
+enum class NoiseSiteId : uint32_t {};
+enum class InstrumentSiteId : uint32_t {};
+
+enum class SymbolKind : uint8_t {
+    Exogenous,
+    Derived,
+    Branch,
+};
+
+// An affine Boolean expression over plan symbols. Terms are stored in strict
+// ascending order; XOR construction removes duplicates.
+class AffineBool {
+  public:
+    AffineBool() = default;
+    explicit AffineBool(bool constant);
+    AffineBool(bool constant, std::vector<SymbolId> terms);
+
+    [[nodiscard]] static AffineBool symbol(SymbolId id);
+    [[nodiscard]] bool constant() const { return constant_; }
+    [[nodiscard]] const std::vector<SymbolId>& terms() const { return terms_; }
+    [[nodiscard]] bool is_canonical() const;
+
+    AffineBool& operator^=(const AffineBool& other);
+    AffineBool& operator^=(bool value);
+
+    friend bool operator==(const AffineBool&, const AffineBool&) = default;
+
+  private:
+    bool constant_ = false;
+    std::vector<SymbolId> terms_;
+};
+
+[[nodiscard]] AffineBool operator^(AffineBool left, const AffineBool& right);
+[[nodiscard]] AffineBool operator^(AffineBool left, bool right);
+[[nodiscard]] AffineBool operator^(bool left, AffineBool right);
+
+// The Hermitian Pauli body for one action, expressed only in the active
+// coordinates visible immediately before that action. Y phases are implied by
+// paired X/Z bits. Its sign is carried by the action's AffineBool so
+// shot-dependent signs never enter this mask.
+struct ActivePauli {
+    uint32_t width = 0;
+    std::vector<uint64_t> x;
+    std::vector<uint64_t> z;
+
+    [[nodiscard]] bool is_identity() const;
+};
+
+// Applies exp(-i * pi * half_turns * P / 2) to the current active state.
+struct RotateActivePauli {
+    ActivePauli pauli;
+    double half_turns = 0.0;
+    AffineBool negative;
+};
+
+// Promotes one dormant coordinate and applies the rotation that introduced it.
+struct PromoteDormantRotation {
+    uint32_t dormant_pivot = 0;
+    double half_turns = 0.0;
+    AffineBool negative;
+};
+
+// Samples one active Pauli branch and removes the selected active pivot. The
+// branch symbol is the effective eigenvalue label used by state updates; the
+// outcome expression is the user-visible record bit after symbolic signs.
+struct MeasureActivePauli {
+    ActivePauli pauli;
+    uint32_t active_pivot = 0;
+    SymbolId branch{};
+    AffineBool outcome;
+    RecordSlot record{};
+};
+
+// Introduces an unbiased effective eigenvalue label while replacing a dormant
+// stabilizer. The outcome expression is the separately recorded bit, and the
+// active vector is untouched.
+struct MeasureDormantRandom {
+    uint32_t dormant_pivot = 0;
+    SymbolId branch{};
+    AffineBool outcome;
+    RecordSlot record{};
+};
+
+// Records a deterministic classical expression without touching the state.
+struct RecordClassical {
+    AffineBool outcome;
+    RecordSlot record{};
+};
+
+// Materializes an affine expression as a reusable derived symbol.
+struct DefineSymbol {
+    SymbolId symbol{};
+    AffineBool value;
+};
+
+// Divides ahead-of-time execution segments. A future continuation must accept
+// the live state established here; it need not reproduce an arbitrary prior
+// plan prefix byte-for-byte.
+struct InstrumentBoundary {
+    InstrumentSiteId site{};
+};
+
+using SamplingAction =
+    std::variant<RotateActivePauli, PromoteDormantRotation, MeasureActivePauli,
+                 MeasureDormantRandom, RecordClassical, DefineSymbol, InstrumentBoundary>;
+
+struct PlannedAction {
+    uint32_t active_before = 0;
+    uint32_t active_after = 0;
+    SamplingAction action;
+};
+
+struct SymbolInfo {
+    SymbolKind kind = SymbolKind::Exogenous;
+
+    // Exogenous symbols are presampled and have no defining action. Branch and
+    // derived symbols name the action that makes them available.
+    std::optional<uint32_t> defining_action;
+
+    // Exogenous symbols may identify the stable HIR noise site that supplies
+    // them. Other presampled event kinds can add their own source identity
+    // without changing expression semantics.
+    std::optional<NoiseSiteId> noise_site;
+};
+
+struct SamplingPlan {
+    uint32_t num_qubits = 0;
+    uint32_t initial_active_width = 0;
+    uint32_t max_active_width = 0;
+    uint32_t num_visible_records = 0;
+    uint32_t num_hidden_records = 0;
+    uint32_t num_noise_sites = 0;
+    uint32_t num_instrument_sites = 0;
+    std::complex<double> global_weight = {1.0, 0.0};
+
+    std::vector<SymbolInfo> symbols;
+    std::vector<PlannedAction> actions;
+
+    // Throws std::invalid_argument when the plan is structurally inconsistent.
+    // This checks active-width transitions, masks, stable ids, record slots,
+    // symbol definitions, and assignment-before-use.
+    void validate() const;
+
+    // Deterministic, executor-independent inspection for tests and diagnostics.
+    [[nodiscard]] std::string inspect() const;
+};
+
+[[nodiscard]] uint32_t predicted_dense_passes(const SamplingAction& action);
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -71,13 +71,13 @@ class AffineBool {
 
 // Operations requiring coefficient-state work are expressed over active
 // stabilizer coordinates. An active coordinate is represented explicitly in
-// the dense 2^k coefficient state; it is not an "active physical qubit."
-// ActivePauli stores the unsigned Hermitian operator
-// i^popcount(x & z) X^x Z^z. Each action carries a separate AffineBool that can
-// change its sign for each shot.
+// the dense 2^k coefficient state. ActivePauli stores the unsigned Hermitian
+// operator i^popcount(x & z) X^x Z^z. Each action carries a separate AffineBool
+// that can change its sign for each shot.
 //
-// The dense-width limit is exclusive, so all valid masks fit in one word even
-// when the physical circuit contains many qubits.
+// Exponential storage requirements currently restrict dense active widths to
+// below kDenseActiveWidthLimit, which fits in one uint64_t. This assertion
+// requires reconsidering the mask representation if that limit ever grows.
 static_assert(kDenseActiveWidthLimit <= std::numeric_limits<uint64_t>::digits);
 
 struct ActivePauli {
@@ -202,6 +202,8 @@ struct SamplingPlan {
     [[nodiscard]] std::string inspect() const;
 };
 
+// Estimates full coefficient-state traversals for a direct, unfused lowering.
+// This is a planning diagnostic; an executor may fuse or specialize actions.
 [[nodiscard]] uint32_t predicted_dense_passes(const SamplingAction& action);
 
 }  // namespace clifft::sampling

--- a/src/clifft/svm/svm_internal.h
+++ b/src/clifft/svm/svm_internal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clifft/svm/svm.h"
+#include "clifft/util/numeric.h"
 
 #include <cstdlib>
 
@@ -43,7 +44,7 @@ inline void aligned_free_portable(void* ptr) {
 // interference sit around 1e-30 to 1e-24; this threshold safely swallows
 // that dust while preserving genuine probabilities (e.g. R_ZZ angles
 // producing probabilities ~1e-16).
-inline constexpr double kDustEpsilon = 1e-18;
+inline constexpr double kDustEpsilon = kMeasurementDustEpsilon;
 
 // Minimum active_k for the AVX2 3D waterfall loops in 2-qubit gates.
 // Below this rank the array fits in L1 cache and the flat pdep loop

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -18,7 +18,7 @@ namespace clifft {
 
 SchrodingerState::SchrodingerState(StateConfig cfg) : peak_rank_(cfg.peak_rank), rng_(0) {
     uint32_t peak_rank = cfg.peak_rank;
-    if (peak_rank >= 60) {
+    if (peak_rank >= kDenseActiveWidthLimit) {
         throw std::invalid_argument(
             "peak_rank >= 60 would overflow the amplitude array's byte size (2^peak_rank * 16 "
             "must fit in size_t); peak_rank " +
@@ -149,7 +149,7 @@ void SchrodingerState::free_array() noexcept {
 void SchrodingerState::grow_for_continuation(uint32_t peak_rank) {
     assert(pending_trap.has_value() &&
            "the amplitude array may grow only at the trap boundary, under a pending trap");
-    if (peak_rank >= 60) {
+    if (peak_rank >= kDenseActiveWidthLimit) {
         throw std::invalid_argument(
             "peak_rank >= 60 would overflow the amplitude array's byte size (2^peak_rank * 16 "
             "must fit in size_t); peak_rank " +

--- a/src/clifft/svm/svm_state.cc
+++ b/src/clifft/svm/svm_state.cc
@@ -20,8 +20,9 @@ SchrodingerState::SchrodingerState(StateConfig cfg) : peak_rank_(cfg.peak_rank),
     uint32_t peak_rank = cfg.peak_rank;
     if (peak_rank >= kDenseActiveWidthLimit) {
         throw std::invalid_argument(
-            "peak_rank >= 60 would overflow the amplitude array's byte size (2^peak_rank * 16 "
-            "must fit in size_t); peak_rank " +
+            "peak_rank >= " + std::to_string(kDenseActiveWidthLimit) +
+            " would overflow the amplitude array's byte size (2^peak_rank * 16 must fit in "
+            "size_t); peak_rank " +
             std::to_string(peak_rank) + " is too large");
     }
     if (cfg.seed.has_value()) {
@@ -151,8 +152,9 @@ void SchrodingerState::grow_for_continuation(uint32_t peak_rank) {
            "the amplitude array may grow only at the trap boundary, under a pending trap");
     if (peak_rank >= kDenseActiveWidthLimit) {
         throw std::invalid_argument(
-            "peak_rank >= 60 would overflow the amplitude array's byte size (2^peak_rank * 16 "
-            "must fit in size_t); peak_rank " +
+            "peak_rank >= " + std::to_string(kDenseActiveWidthLimit) +
+            " would overflow the amplitude array's byte size (2^peak_rank * 16 must fit in "
+            "size_t); peak_rank " +
             std::to_string(peak_rank) + " is too large");
     }
     if ((1ULL << peak_rank) <= array_size_) {

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -8,6 +8,11 @@
 
 namespace clifft {
 
+// Relative epsilon shared by sampling backends when analytically-zero branch
+// probabilities contain floating-point dust. This is part of Clifft's record
+// reachability semantics, including forced-outcome replay.
+inline constexpr double kMeasurementDustEpsilon = 1e-18;
+
 // The IEEE 754 bit trick below assumes that layout. Make it explicit.
 static_assert(std::numeric_limits<double>::is_iec559,
               "Clifft probability validation requires IEEE 754 doubles");

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -8,6 +8,11 @@
 
 namespace clifft {
 
+// Dense active states contain 2^k complex<double> coefficients. At k=60 the
+// byte size no longer fits in a 64-bit size_t, so every dense executor and its
+// planner must reject that width before allocation or bit-index arithmetic.
+inline constexpr uint32_t kDenseActiveWidthLimit = 60;
+
 // Relative epsilon shared by sampling backends when analytically-zero branch
 // probabilities contain floating-point dust. This is part of Clifft's record
 // reachability semantics, including forced-outcome replay.

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/single_axis_fusion_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/backend/backend.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/basis_probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/record_probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(clifft_tests
     test_execute_instruments.cc
     test_trap_resume.cc
     test_backend.cc
+    test_sampling_plan.cc
     test_svm.cc
     test_state_reset.cc
     test_forced_kernels.cc

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -1,0 +1,144 @@
+#include "clifft/sampling/plan.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using clifft::sampling::ActivePauli;
+using clifft::sampling::AffineBool;
+using clifft::sampling::DefineSymbol;
+using clifft::sampling::InstrumentBoundary;
+using clifft::sampling::InstrumentSiteId;
+using clifft::sampling::MeasureActivePauli;
+using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::NoiseSiteId;
+using clifft::sampling::PlannedAction;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::RecordSlot;
+using clifft::sampling::RotateActivePauli;
+using clifft::sampling::SamplingPlan;
+using clifft::sampling::SymbolId;
+using clifft::sampling::SymbolInfo;
+using clifft::sampling::SymbolKind;
+
+namespace {
+
+SamplingPlan valid_plan() {
+    const SymbolId noise{0};
+    const SymbolId branch{1};
+    const SymbolId derived{2};
+
+    SamplingPlan plan;
+    plan.num_qubits = 2;
+    plan.max_active_width = 1;
+    plan.num_visible_records = 1;
+    plan.num_hidden_records = 1;
+    plan.num_noise_sites = 1;
+    plan.num_instrument_sites = 1;
+    plan.symbols = {
+        SymbolInfo{SymbolKind::Exogenous, std::nullopt, NoiseSiteId{0}},
+        SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
+        SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
+    };
+    plan.actions = {
+        PlannedAction{0, 1, PromoteDormantRotation{0, 0.25, AffineBool::symbol(noise)}},
+        PlannedAction{1, 0,
+                      MeasureActivePauli{ActivePauli{1, {1}, {0}}, 0, branch,
+                                         AffineBool::symbol(branch) ^ AffineBool::symbol(noise),
+                                         RecordSlot{0}}},
+        PlannedAction{0, 0, DefineSymbol{derived, AffineBool::symbol(branch) ^ true}},
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(derived), RecordSlot{1}}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}}},
+    };
+    return plan;
+}
+
+}  // namespace
+
+TEST_CASE("Sampling plan affine expressions are canonical") {
+    const SymbolId s0{0};
+    const SymbolId s1{1};
+    const SymbolId s2{2};
+    AffineBool expression(false, {s2, s0, s2, s1, s1});
+
+    REQUIRE(expression == AffineBool::symbol(s0));
+    REQUIRE((expression ^ expression) == AffineBool(false));
+    REQUIRE((true ^ expression).constant());
+    REQUIRE((true ^ expression).terms() == std::vector<SymbolId>{s0});
+}
+
+TEST_CASE("Sampling plan validates symbolic and active state invariants") {
+    SamplingPlan plan = valid_plan();
+    REQUIRE_NOTHROW(plan.validate());
+
+    const std::string text = plan.inspect();
+    REQUIRE(text.find("sampling_plan qubits=2 initial_k=0 max_k=1") != std::string::npos);
+    REQUIRE(text.find("s0 kind=exogenous presampled noise_site=0") != std::string::npos);
+    REQUIRE(text.find("1 k=1->0 dense_passes=1 measure_active") != std::string::npos);
+    REQUIRE(text.find("outcome=s0 ^ s1 record=0") != std::string::npos);
+    REQUIRE(text.find("4 k=0->0 dense_passes=0 instrument_boundary site=0") != std::string::npos);
+}
+
+TEST_CASE("Sampling plan rejects symbolic use before assignment") {
+    SamplingPlan plan = valid_plan();
+    auto& promotion = std::get<PromoteDormantRotation>(plan.actions[0].action);
+    promotion.negative = AffineBool::symbol(SymbolId{1});
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan rejects inconsistent symbol definitions") {
+    SamplingPlan plan = valid_plan();
+    plan.symbols[2].defining_action = 3;
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan rejects Pauli bits above active width") {
+    SamplingPlan plan = valid_plan();
+    auto& measurement = std::get<MeasureActivePauli>(plan.actions[1].action);
+    measurement.pauli.x[0] = 2;
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan rejects record slots outside stable storage") {
+    SamplingPlan plan = valid_plan();
+    auto& record = std::get<RecordClassical>(plan.actions[3].action);
+    record.record = RecordSlot{2};
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan distinguishes dormant branch labels from records") {
+    const SymbolId branch{0};
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.actions = {
+        PlannedAction{
+            0, 0,
+            MeasureDormantRandom{0, branch, AffineBool::symbol(branch) ^ true, RecordSlot{0}}},
+    };
+
+    REQUIRE_NOTHROW(plan.validate());
+    REQUIRE(plan.inspect().find("branch=s0 outcome=1 ^ s0 record=0") != std::string::npos);
+}
+
+TEST_CASE("Sampling plan predicts only state touching dense passes") {
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.initial_active_width = 1;
+    plan.max_active_width = 1;
+    plan.actions = {
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, {1}, {0}}, 0.25, AffineBool{}}},
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, {0}, {0}}, 0.5, AffineBool{}}},
+    };
+
+    REQUIRE_NOTHROW(plan.validate());
+    REQUIRE(clifft::sampling::predicted_dense_passes(plan.actions[0].action) == 1);
+    REQUIRE(clifft::sampling::predicted_dense_passes(plan.actions[1].action) == 0);
+}

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -38,14 +38,14 @@ SamplingPlan valid_plan() {
     plan.num_noise_sites = 1;
     plan.num_instrument_sites = 1;
     plan.symbols = {
-        SymbolInfo{SymbolKind::Exogenous, std::nullopt, NoiseSiteId{0}},
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
         SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
         SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
     };
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{0, 0.25, AffineBool::symbol(noise)}},
         PlannedAction{1, 0,
-                      MeasureActivePauli{ActivePauli{1, {1}, {0}}, 0, branch,
+                      MeasureActivePauli{ActivePauli{1, 0}, 0, branch,
                                          AffineBool::symbol(branch) ^ AffineBool::symbol(noise),
                                          RecordSlot{0}}},
         PlannedAction{0, 0, DefineSymbol{derived, AffineBool::symbol(branch) ^ true}},
@@ -74,17 +74,18 @@ TEST_CASE("Sampling plan validates symbolic and active state invariants") {
     REQUIRE_NOTHROW(plan.validate());
 
     const std::string text = plan.inspect();
-    REQUIRE(text.find("sampling_plan qubits=2 initial_k=0 max_k=1") != std::string::npos);
-    REQUIRE(text.find("s0 kind=exogenous presampled noise_site=0") != std::string::npos);
-    REQUIRE(text.find("1 k=1->0 dense_passes=1 measure_active") != std::string::npos);
+    REQUIRE(text.find("sampling_plan qubits=2 initial_width=0 max_width=1") != std::string::npos);
+    REQUIRE(text.find("s0 kind=presampled noise_site=0") != std::string::npos);
+    REQUIRE(text.find("1 active_width=1->0 dense_passes=1 measure_active") != std::string::npos);
     REQUIRE(text.find("outcome=s0 ^ s1 record=0") != std::string::npos);
-    REQUIRE(text.find("4 k=0->0 dense_passes=0 instrument_boundary site=0") != std::string::npos);
+    REQUIRE(text.find("4 active_width=0->0 dense_passes=0 instrument_boundary site=0") !=
+            std::string::npos);
 }
 
 TEST_CASE("Sampling plan rejects symbolic use before assignment") {
     SamplingPlan plan = valid_plan();
     auto& promotion = std::get<PromoteDormantRotation>(plan.actions[0].action);
-    promotion.negative = AffineBool::symbol(SymbolId{1});
+    promotion.sign = AffineBool::symbol(SymbolId{1});
 
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
@@ -99,7 +100,7 @@ TEST_CASE("Sampling plan rejects inconsistent symbol definitions") {
 TEST_CASE("Sampling plan rejects Pauli bits above active width") {
     SamplingPlan plan = valid_plan();
     auto& measurement = std::get<MeasureActivePauli>(plan.actions[1].action);
-    measurement.pauli.x[0] = 2;
+    measurement.pauli.x = 2;
 
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
@@ -108,6 +109,47 @@ TEST_CASE("Sampling plan rejects record slots outside stable storage") {
     SamplingPlan plan = valid_plan();
     auto& record = std::get<RecordClassical>(plan.actions[3].action);
     record.record = RecordSlot{2};
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan rejects duplicate record writes") {
+    SamplingPlan plan = valid_plan();
+    auto& record = std::get<RecordClassical>(plan.actions[3].action);
+    record.record = RecordSlot{0};
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan rejects measurement pivots outside Pauli support") {
+    const SymbolId branch{0};
+    SamplingPlan plan;
+    plan.num_qubits = 2;
+    plan.initial_active_width = 2;
+    plan.max_active_width = 2;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.actions = {
+        PlannedAction{2, 1,
+                      MeasureActivePauli{ActivePauli{1, 0}, 1, branch, AffineBool::symbol(branch),
+                                         RecordSlot{0}}},
+    };
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+
+    auto& measurement = std::get<MeasureActivePauli>(plan.actions[0].action);
+    measurement.pauli = ActivePauli{0, 1};
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+
+    measurement.active_pivot = 0;
+    REQUIRE_NOTHROW(plan.validate());
+}
+
+TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
+    SamplingPlan plan;
+    plan.num_qubits = 60;
+    plan.initial_active_width = 60;
+    plan.max_active_width = 60;
 
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
@@ -134,8 +176,8 @@ TEST_CASE("Sampling plan predicts only state touching dense passes") {
     plan.initial_active_width = 1;
     plan.max_active_width = 1;
     plan.actions = {
-        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, {1}, {0}}, 0.25, AffineBool{}}},
-        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, {0}, {0}}, 0.5, AffineBool{}}},
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}},
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{0, 0}, 0.5, AffineBool{}}},
     };
 
     REQUIRE_NOTHROW(plan.validate());

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -1,4 +1,5 @@
 #include "clifft/sampling/plan.h"
+#include "clifft/util/numeric.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <stdexcept>
@@ -147,11 +148,35 @@ TEST_CASE("Sampling plan rejects measurement pivots outside Pauli support") {
 
 TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
     SamplingPlan plan;
-    plan.num_qubits = 60;
-    plan.initial_active_width = 60;
-    plan.max_active_width = 60;
+    plan.num_qubits = clifft::kDenseActiveWidthLimit;
+    plan.initial_active_width = clifft::kDenseActiveWidthLimit;
+    plan.max_active_width = clifft::kDenseActiveWidthLimit;
 
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan safely rejects a transition stream above dense width") {
+    constexpr uint32_t kMalformedWidth = clifft::kDenseActiveWidthLimit + 10;
+    SamplingPlan plan;
+    plan.num_qubits = kMalformedWidth;
+    plan.max_active_width = clifft::kDenseActiveWidthLimit - 1;
+    for (uint32_t width = 0; width < kMalformedWidth; ++width) {
+        plan.actions.push_back(
+            PlannedAction{width, width + 1, PromoteDormantRotation{width, 0.25, AffineBool{}}});
+    }
+    plan.actions.push_back(PlannedAction{kMalformedWidth, kMalformedWidth,
+                                         RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}});
+
+    try {
+        plan.validate();
+        FAIL("malformed active-width stream should be rejected");
+    } catch (const std::invalid_argument& error) {
+        const std::string message = error.what();
+        const std::string expected =
+            "action " + std::to_string(clifft::kDenseActiveWidthLimit - 1) +
+            " reaches active width " + std::to_string(clifft::kDenseActiveWidthLimit);
+        REQUIRE(message.find(expected) != std::string::npos);
+    }
 }
 
 TEST_CASE("Sampling plan distinguishes dormant branch labels from records") {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -2,6 +2,7 @@
 #include "clifft/util/numeric.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -56,6 +57,30 @@ SamplingPlan valid_plan() {
     return plan;
 }
 
+SamplingPlan valid_rotation_plan() {
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.initial_active_width = 1;
+    plan.max_active_width = 1;
+    plan.actions = {
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}},
+    };
+    return plan;
+}
+
+SamplingPlan valid_dormant_measurement_plan() {
+    const SymbolId branch{0};
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.actions = {
+        PlannedAction{0, 0,
+                      MeasureDormantRandom{0, branch, AffineBool::symbol(branch), RecordSlot{0}}},
+    };
+    return plan;
+}
+
 }  // namespace
 
 TEST_CASE("Sampling plan affine expressions are canonical") {
@@ -91,11 +116,67 @@ TEST_CASE("Sampling plan rejects symbolic use before assignment") {
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
 
-TEST_CASE("Sampling plan rejects inconsistent symbol definitions") {
-    SamplingPlan plan = valid_plan();
-    plan.symbols[2].defining_action = 3;
+TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
+    SECTION("definition metadata disagrees with the action") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[2].defining_action = 3;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
 
-    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    SECTION("presampled symbol names a defining action") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[0].defining_action = 0;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("noise site is out of range") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[0].noise_site = NoiseSiteId{1};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("non-presampled symbol names a noise site") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[1].noise_site = NoiseSiteId{0};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("action defines an out-of-range symbol") {
+        SamplingPlan plan = valid_plan();
+        std::get<DefineSymbol>(plan.actions[2].action).symbol = SymbolId{3};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("two actions define the same symbol") {
+        SamplingPlan plan = valid_plan();
+        std::get<DefineSymbol>(plan.actions[2].action).symbol = SymbolId{1};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("branch kind is defined by a derived-symbol action") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[2].kind = SymbolKind::Branch;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("derived kind is defined by a measurement") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[1].kind = SymbolKind::Derived;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("expression references an out-of-range symbol") {
+        SamplingPlan plan = valid_plan();
+        std::get<PromoteDormantRotation>(plan.actions[0].action).sign =
+            AffineBool::symbol(SymbolId{3});
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("derived symbol references itself") {
+        SamplingPlan plan = valid_plan();
+        std::get<DefineSymbol>(plan.actions[2].action).value = AffineBool::symbol(SymbolId{2});
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
 }
 
 TEST_CASE("Sampling plan rejects Pauli bits above active width") {
@@ -152,15 +233,138 @@ TEST_CASE("Sampling plan requires sampled branches in measurement outcomes") {
     active_measurement.outcome = AffineBool::symbol(SymbolId{0});
     REQUIRE_THROWS_AS(active.validate(), std::invalid_argument);
 
-    const SymbolId branch{0};
-    SamplingPlan dormant;
-    dormant.num_qubits = 1;
-    dormant.num_visible_records = 1;
-    dormant.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
-    dormant.actions = {
-        PlannedAction{0, 0, MeasureDormantRandom{0, branch, AffineBool{}, RecordSlot{0}}},
-    };
+    SamplingPlan dormant = valid_dormant_measurement_plan();
+    std::get<MeasureDormantRandom>(dormant.actions[0].action).outcome = AffineBool{};
     REQUIRE_THROWS_AS(dormant.validate(), std::invalid_argument);
+}
+
+TEST_CASE("Sampling plan rejects invalid dimensions and action contracts") {
+    SECTION("initial width exceeds the circuit") {
+        SamplingPlan plan;
+        plan.initial_active_width = 1;
+        plan.max_active_width = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("maximum width is below the initial width") {
+        SamplingPlan plan;
+        plan.num_qubits = 1;
+        plan.initial_active_width = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("declared maximum is not reached") {
+        SamplingPlan plan = valid_plan();
+        plan.max_active_width = 2;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("action stream breaks the width chain") {
+        SamplingPlan plan = valid_plan();
+        plan.actions[1].active_before = 0;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("active rotation changes width") {
+        SamplingPlan plan = valid_rotation_plan();
+        plan.actions[0].active_after = 0;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("dormant promotion does not increase width") {
+        SamplingPlan plan = valid_plan();
+        plan.actions[0].active_after = 0;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("dormant promotion pivot is out of range") {
+        SamplingPlan plan = valid_plan();
+        std::get<PromoteDormantRotation>(plan.actions[0].action).dormant_pivot = 2;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("active measurement does not decrease width") {
+        SamplingPlan plan = valid_plan();
+        plan.actions[1].active_after = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("dormant measurement changes width") {
+        SamplingPlan plan = valid_dormant_measurement_plan();
+        plan.actions[0].active_after = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("classical record changes width") {
+        SamplingPlan plan = valid_plan();
+        plan.actions[3].active_after = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("symbol definition changes width") {
+        SamplingPlan plan = valid_plan();
+        plan.actions[2].active_after = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("instrument boundary changes width") {
+        SamplingPlan plan = valid_plan();
+        plan.actions[4].active_after = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("active measurement Pauli is identity") {
+        SamplingPlan plan = valid_plan();
+        std::get<MeasureActivePauli>(plan.actions[1].action).pauli = ActivePauli{};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("active measurement pivot is out of range") {
+        SamplingPlan plan = valid_plan();
+        std::get<MeasureActivePauli>(plan.actions[1].action).active_pivot = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("dormant measurement pivot is out of range") {
+        SamplingPlan plan = valid_dormant_measurement_plan();
+        std::get<MeasureDormantRandom>(plan.actions[0].action).dormant_pivot = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("instrument site is out of range") {
+        SamplingPlan plan = valid_plan();
+        std::get<InstrumentBoundary>(plan.actions[4].action).site = InstrumentSiteId{1};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+}
+
+TEST_CASE("Sampling plan rejects invalid numeric metadata") {
+    SECTION("record count overflows stable slots") {
+        SamplingPlan plan;
+        plan.num_visible_records = std::numeric_limits<uint32_t>::max();
+        plan.num_hidden_records = 1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("global weight is not finite") {
+        SamplingPlan plan;
+        plan.global_weight = {std::numeric_limits<double>::infinity(), 0.0};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("active rotation angle is not finite") {
+        SamplingPlan plan = valid_rotation_plan();
+        std::get<RotateActivePauli>(plan.actions[0].action).half_turns =
+            std::numeric_limits<double>::quiet_NaN();
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("dormant promotion angle is not finite") {
+        SamplingPlan plan = valid_plan();
+        std::get<PromoteDormantRotation>(plan.actions[0].action).half_turns =
+            std::numeric_limits<double>::infinity();
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
 }
 
 TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
@@ -198,31 +402,25 @@ TEST_CASE("Sampling plan safely rejects a transition stream above dense width") 
 
 TEST_CASE("Sampling plan distinguishes dormant branch labels from records") {
     const SymbolId branch{0};
-    SamplingPlan plan;
-    plan.num_qubits = 1;
-    plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
-    plan.actions = {
-        PlannedAction{
-            0, 0,
-            MeasureDormantRandom{0, branch, AffineBool::symbol(branch) ^ true, RecordSlot{0}}},
-    };
+    SamplingPlan plan = valid_dormant_measurement_plan();
+    std::get<MeasureDormantRandom>(plan.actions[0].action).outcome =
+        AffineBool::symbol(branch) ^ true;
 
     REQUIRE_NOTHROW(plan.validate());
     REQUIRE(plan.inspect().find("branch=s0 outcome=1 ^ s0 record=0") != std::string::npos);
 }
 
 TEST_CASE("Sampling plan predicts only state touching dense passes") {
-    SamplingPlan plan;
-    plan.num_qubits = 1;
-    plan.initial_active_width = 1;
-    plan.max_active_width = 1;
-    plan.actions = {
-        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}},
-        PlannedAction{1, 1, RotateActivePauli{ActivePauli{0, 0}, 0.5, AffineBool{}}},
-    };
-
+    SamplingPlan plan = valid_rotation_plan();
     REQUIRE_NOTHROW(plan.validate());
     REQUIRE(clifft::sampling::predicted_dense_passes(plan.actions[0].action) == 1);
-    REQUIRE(clifft::sampling::predicted_dense_passes(plan.actions[1].action) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(
+                RotateActivePauli{ActivePauli{}, 0.5, AffineBool{}}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(
+                PromoteDormantRotation{0, 0.25, AffineBool{}}) == 1);
+    REQUIRE(clifft::sampling::predicted_dense_passes(MeasureActivePauli{}) == 1);
+    REQUIRE(clifft::sampling::predicted_dense_passes(MeasureDormantRandom{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(RecordClassical{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(DefineSymbol{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(InstrumentBoundary{}) == 0);
 }

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -146,6 +146,23 @@ TEST_CASE("Sampling plan rejects measurement pivots outside Pauli support") {
     REQUIRE_NOTHROW(plan.validate());
 }
 
+TEST_CASE("Sampling plan requires sampled branches in measurement outcomes") {
+    SamplingPlan active = valid_plan();
+    auto& active_measurement = std::get<MeasureActivePauli>(active.actions[1].action);
+    active_measurement.outcome = AffineBool::symbol(SymbolId{0});
+    REQUIRE_THROWS_AS(active.validate(), std::invalid_argument);
+
+    const SymbolId branch{0};
+    SamplingPlan dormant;
+    dormant.num_qubits = 1;
+    dormant.num_visible_records = 1;
+    dormant.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    dormant.actions = {
+        PlannedAction{0, 0, MeasureDormantRandom{0, branch, AffineBool{}, RecordSlot{0}}},
+    };
+    REQUIRE_THROWS_AS(dormant.validate(), std::invalid_argument);
+}
+
 TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
     SamplingPlan plan;
     plan.num_qubits = clifft::kDenseActiveWidthLimit;


### PR DESCRIPTION
## Summary

- add a private `SamplingPlan` representation separate from the legacy 32-byte SVM instruction
- define canonical affine Boolean expressions and explicit exogenous, branch, and derived symbol lifetimes
- distinguish effective measurement branch labels from recorded outcomes
- model active rotations and measurements, dormant promotion and measurement, classical records, and instrument boundaries
- validate active-width transitions, Pauli bounds, stable record/site identities, symbol definitions, and assignment-before-use
- add deterministic plan inspection with predicted dense-array passes
- share the existing measurement dust threshold as a backend-independent semantic constant
- include the new source in native and wasm builds

This is the semantic foundation for #248, not the HIR-to-plan algorithm. It deliberately leaves the production compiler and SVM routing unchanged. The next scoped PR can implement stabilizer-coordinate planning against this validated representation.

The design is an independent Clifft implementation informed by the SymFT architecture described in #236.

## Validation

- `cmake --build build -j 4`
- `ctest --test-dir build -R 'Sampling plan' --output-on-failure` — 8 tests passed
- `ctest --test-dir build --output-on-failure -j 4` — 1,141 tests passed
- `uv run pre-commit run --all-files`

Part of #248.