### PR TITLE
feat(sampling): plan rotations and measurements from HIR

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(clifft_core STATIC
     optimizer/statevector_squeeze_pass.cc
     backend/backend.cc
     sampling/plan.cc
+    sampling/planner.cc
     api/basis_probabilities.cc
     api/record_probabilities.cc
     api/reference_syndrome.cc

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -389,10 +389,8 @@ void SamplingPlan::validate() const {
                     }
                     validate_expression(*this, typed.sign, action_index, definition, false);
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
-                    if (planned.active_after != planned.active_before + 1 ||
-                        typed.dormant_pivot < planned.active_before ||
-                        typed.dormant_pivot >= num_qubits) {
-                        invalid_plan("dormant promotion has an invalid width or pivot");
+                    if (planned.active_after != planned.active_before + 1) {
+                        invalid_plan("dormant promotion has an invalid width");
                     }
                     if (!is_finite_robust(typed.half_turns)) {
                         invalid_plan("dormant promotion angle is not finite");
@@ -485,8 +483,7 @@ std::string SamplingPlan::inspect() const {
                         << " half_turns=" << typed.half_turns
                         << " sign=" << format_expression(typed.sign);
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
-                    out << "promote_dormant pivot=" << typed.dormant_pivot
-                        << " half_turns=" << typed.half_turns
+                    out << "promote_dormant half_turns=" << typed.half_turns
                         << " sign=" << format_expression(typed.sign);
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
                     out << "measure_active " << format_pauli(typed.pauli)

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -99,7 +99,7 @@ struct RotateActivePauli {
 // it. The planner has already rewritten later operations into the new basis.
 struct PromoteDormantRotation {
     double half_turns = 0.0;
-    // When true for a shot, negate the promoted generator and half_turns.
+    // When true for a shot, negate the promoted generator, equivalently negating half_turns.
     AffineBool sign;
 };
 

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -95,9 +95,9 @@ struct RotateActivePauli {
     AffineBool sign;
 };
 
-// Promotes one dormant coordinate and applies the rotation that introduced it.
+// Promotes the next active coordinate and applies the rotation that introduced
+// it. The planner has already rewritten later operations into the new basis.
 struct PromoteDormantRotation {
-    uint32_t dormant_pivot = 0;
     double half_turns = 0.0;
     // When true for a shot, negate the promoted generator and half_turns.
     AffineBool sign;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/planner.h"
 
+#include "clifft/util/hir_introspection.h"
 #include "clifft/util/numeric.h"
 #include "clifft/util/stim_mask.h"
 
@@ -42,47 +43,10 @@ struct PendingMeasurement {
 
 using PendingOperation = std::variant<PendingRotation, PendingMeasurement>;
 
-std::string op_type_name(OpType type) {
-    switch (type) {
-        case OpType::T_GATE:
-            return "T_GATE";
-        case OpType::MEASURE:
-            return "MEASURE";
-        case OpType::CONDITIONAL_PAULI:
-            return "CONDITIONAL_PAULI";
-        case OpType::NOISE:
-            return "NOISE";
-        case OpType::READOUT_NOISE:
-            return "READOUT_NOISE";
-        case OpType::PHASE_ROTATION:
-            return "PHASE_ROTATION";
-        case OpType::DETECTOR:
-            return "DETECTOR";
-        case OpType::OBSERVABLE:
-            return "OBSERVABLE";
-        case OpType::EXP_VAL:
-            return "EXP_VAL";
-        case OpType::INSTRUMENT:
-            return "INSTRUMENT";
-        case OpType::NUM_OP_TYPES:
-            return "NUM_OP_TYPES";
-    }
-    return "UNKNOWN";
-}
-
-[[noreturn]] void unsupported_operation(OpType type, size_t index) {
-    throw std::invalid_argument("sampling planner does not support HIR operation " +
-                                op_type_name(type) + " at index " + std::to_string(index));
-}
-
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
-    const MaskView x = hir.destab_mask(op);
-    const MaskView z = hir.stab_mask(op);
-    for (uint32_t q = 0; q < hir.num_qubits; ++q) {
-        result.xs[q] = x.bit_get(q);
-        result.zs[q] = z.bit_get(q);
-    }
+    mask_view_to_stim(hir.destab_mask(op), hir.num_qubits, result.xs);
+    mask_view_to_stim(hir.stab_mask(op), hir.num_qubits, result.zs);
     return result;
 }
 
@@ -360,7 +324,9 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
             case OpType::EXP_VAL:
             case OpType::INSTRUMENT:
             case OpType::NUM_OP_TYPES:
-                unsupported_operation(op.op_type(), i);
+                throw std::invalid_argument("sampling planner does not support HIR operation " +
+                                            op_type_to_str(op.op_type()) + " at index " +
+                                            std::to_string(i));
         }
     }
     return pending;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -1,0 +1,485 @@
+#include "clifft/sampling/planner.h"
+
+#include "clifft/util/numeric.h"
+#include "clifft/util/stim_mask.h"
+
+#include "stim.h"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <numbers>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace clifft::sampling {
+
+namespace {
+
+using Pauli = stim::PauliString<kStimWidth>;
+using Tableau = stim::Tableau<kStimWidth>;
+
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
+struct PendingRotation {
+    Pauli body;
+    double half_turns = 0.0;
+    AffineBool sign;
+};
+
+struct PendingMeasurement {
+    Pauli body;
+    AffineBool sign;
+    RecordSlot record{};
+};
+
+using PendingOperation = std::variant<PendingRotation, PendingMeasurement>;
+
+std::string op_type_name(OpType type) {
+    switch (type) {
+        case OpType::T_GATE:
+            return "T_GATE";
+        case OpType::MEASURE:
+            return "MEASURE";
+        case OpType::CONDITIONAL_PAULI:
+            return "CONDITIONAL_PAULI";
+        case OpType::NOISE:
+            return "NOISE";
+        case OpType::READOUT_NOISE:
+            return "READOUT_NOISE";
+        case OpType::PHASE_ROTATION:
+            return "PHASE_ROTATION";
+        case OpType::DETECTOR:
+            return "DETECTOR";
+        case OpType::OBSERVABLE:
+            return "OBSERVABLE";
+        case OpType::EXP_VAL:
+            return "EXP_VAL";
+        case OpType::INSTRUMENT:
+            return "INSTRUMENT";
+        case OpType::NUM_OP_TYPES:
+            return "NUM_OP_TYPES";
+    }
+    return "UNKNOWN";
+}
+
+[[noreturn]] void unsupported_operation(OpType type, size_t index) {
+    throw std::invalid_argument("sampling planner does not support HIR operation " +
+                                op_type_name(type) + " at index " + std::to_string(index));
+}
+
+Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
+    Pauli result(hir.num_qubits);
+    const MaskView x = hir.destab_mask(op);
+    const MaskView z = hir.stab_mask(op);
+    for (uint32_t q = 0; q < hir.num_qubits; ++q) {
+        result.xs[q] = x.bit_get(q);
+        result.zs[q] = z.bit_get(q);
+    }
+    return result;
+}
+
+Pauli single_x(uint32_t num_qubits, uint32_t q) {
+    Pauli result(num_qubits);
+    result.xs[q] = true;
+    return result;
+}
+
+Pauli single_z(uint32_t num_qubits, uint32_t q) {
+    Pauli result(num_qubits);
+    result.zs[q] = true;
+    return result;
+}
+
+Pauli positive_body_xor(const Pauli& left, const Pauli& right) {
+    Pauli result(left);
+    result.xs ^= right.xs;
+    result.zs ^= right.zs;
+    result.sign = false;
+    return result;
+}
+
+bool anticommutes(const Pauli& left, const Pauli& right) {
+    return !left.ref().commutes(right.ref());
+}
+
+std::optional<uint32_t> first_x_at_or_above(const Pauli& pauli, uint32_t begin) {
+    for (uint32_t q = begin; q < pauli.num_qubits; ++q) {
+        if (pauli.xs[q]) {
+            return q;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<uint32_t> first_x_below(const Pauli& pauli, uint32_t end) {
+    for (uint32_t q = 0; q < end; ++q) {
+        if (pauli.xs[q]) {
+            return q;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<uint32_t> first_z_below(const Pauli& pauli, uint32_t end) {
+    for (uint32_t q = 0; q < end; ++q) {
+        if (pauli.zs[q]) {
+            return q;
+        }
+    }
+    return std::nullopt;
+}
+
+ActivePauli active_projection(const Pauli& pauli, uint32_t active_width) {
+    ActivePauli result;
+    for (uint32_t q = 0; q < active_width; ++q) {
+        result.x |= static_cast<uint64_t>(pauli.xs[q]) << q;
+        result.z |= static_cast<uint64_t>(pauli.zs[q]) << q;
+    }
+    return result;
+}
+
+Tableau dormant_promotion_frame(const Pauli& promoted, uint32_t active_width,
+                                 uint32_t dormant_pivot) {
+    const uint32_t n = static_cast<uint32_t>(promoted.num_qubits);
+    Tableau frame(n);
+    const Pauli old_stabilizer = single_z(n, dormant_pivot);
+
+    // The rows express the new coordinate generators in the old basis. Making
+    // the promoted Pauli the next X generator turns its rotation into a
+    // single-coordinate expansion; the stabilizer products keep every other
+    // generator in a canonical symplectic pair.
+    for (uint32_t q = 0; q < active_width; ++q) {
+        Pauli x = single_x(n, q);
+        Pauli z = single_z(n, q);
+        if (anticommutes(x, promoted)) {
+            x = positive_body_xor(x, old_stabilizer);
+        }
+        if (anticommutes(z, promoted)) {
+            z = positive_body_xor(z, old_stabilizer);
+        }
+        frame.xs[q] = x;
+        frame.zs[q] = z;
+    }
+
+    frame.xs[active_width] = promoted;
+    frame.zs[active_width] = old_stabilizer;
+
+    uint32_t new_q = active_width + 1;
+    for (uint32_t old_q = active_width; old_q < n; ++old_q) {
+        if (old_q == dormant_pivot) {
+            continue;
+        }
+        Pauli x = single_x(n, old_q);
+        Pauli z = single_z(n, old_q);
+        if (anticommutes(x, promoted)) {
+            x = positive_body_xor(x, old_stabilizer);
+        }
+        if (anticommutes(z, promoted)) {
+            z = positive_body_xor(z, old_stabilizer);
+        }
+        frame.xs[new_q] = x;
+        frame.zs[new_q] = z;
+        ++new_q;
+    }
+
+    if (!frame.satisfies_invariants()) {
+        throw std::logic_error("sampling planner produced an invalid promotion frame");
+    }
+    return frame;
+}
+
+Tableau dormant_measurement_frame(const Pauli& measured, uint32_t dormant_pivot) {
+    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
+    Tableau frame(n);
+    const Pauli old_stabilizer = single_z(n, dormant_pivot);
+
+    // Replacing one dormant Z generator with the measured Pauli represents the
+    // collapsed eigenspace without changing the dense coefficient state.
+    for (uint32_t q = 0; q < n; ++q) {
+        if (q == dormant_pivot) {
+            continue;
+        }
+        Pauli x = single_x(n, q);
+        Pauli z = single_z(n, q);
+        if (anticommutes(x, measured)) {
+            x = positive_body_xor(x, old_stabilizer);
+        }
+        if (anticommutes(z, measured)) {
+            z = positive_body_xor(z, old_stabilizer);
+        }
+        frame.xs[q] = x;
+        frame.zs[q] = z;
+    }
+
+    frame.xs[dormant_pivot] = old_stabilizer;
+    frame.zs[dormant_pivot] = measured;
+
+    if (!frame.satisfies_invariants()) {
+        throw std::logic_error("sampling planner produced an invalid dormant measurement frame");
+    }
+    return frame;
+}
+
+Tableau active_measurement_frame(const Pauli& measured, uint32_t active_width, uint32_t pivot) {
+    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
+    Tableau frame(n);
+    const bool diagonal = !first_x_below(measured, active_width).has_value();
+    const Pauli pivot_x = single_x(n, pivot);
+    const Pauli pivot_z = single_z(n, pivot);
+
+    // Moving the measured Pauli to the last active Z generator gives the
+    // direct measurement kernel one coordinate to remove. Future operations
+    // are rewritten into the remaining packed coordinates below.
+    frame.zs[active_width - 1] = measured;
+    frame.xs[active_width - 1] = diagonal ? pivot_x : pivot_z;
+
+    uint32_t new_q = 0;
+    for (uint32_t old_q = 0; old_q < active_width; ++old_q) {
+        if (old_q == pivot) {
+            continue;
+        }
+        Pauli x = single_x(n, old_q);
+        Pauli z = single_z(n, old_q);
+        if (diagonal) {
+            if (measured.zs[old_q]) {
+                x = positive_body_xor(x, pivot_x);
+            }
+        } else {
+            if (measured.xs[old_q]) {
+                z = positive_body_xor(z, pivot_z);
+            }
+            if (measured.zs[old_q]) {
+                x = positive_body_xor(x, pivot_z);
+            }
+        }
+        frame.xs[new_q] = x;
+        frame.zs[new_q] = z;
+        ++new_q;
+    }
+
+    if (!frame.satisfies_invariants()) {
+        throw std::logic_error("sampling planner produced an invalid active measurement frame");
+    }
+    return frame;
+}
+
+template <typename Function>
+void visit_pending_pauli(PendingOperation& operation, Function&& function) {
+    std::visit(
+        [&](auto& typed) {
+            using T = std::decay_t<decltype(typed)>;
+            if constexpr (std::is_same_v<T, PendingRotation> ||
+                          std::is_same_v<T, PendingMeasurement>) {
+                function(typed.body, typed.sign);
+            } else {
+                static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
+            }
+        },
+        operation);
+}
+
+void transform_future_operations(std::vector<PendingOperation>& pending, size_t begin,
+                                 const Tableau& new_basis_in_old_coordinates) {
+    // Planning owns coordinate evolution. Runtime actions therefore receive
+    // already-transformed Paulis and never need to discover dependencies or
+    // perform tableau evolution in the dispatch loop.
+    const Tableau old_to_new = new_basis_in_old_coordinates.inverse();
+    for (size_t i = begin; i < pending.size(); ++i) {
+        visit_pending_pauli(pending[i], [&](Pauli& body, AffineBool& sign) {
+            Pauli transformed = old_to_new(body);
+            sign ^= static_cast<bool>(transformed.sign);
+            transformed.sign = false;
+            body = std::move(transformed);
+        });
+    }
+}
+
+void propagate_branch(std::vector<PendingOperation>& pending, size_t begin,
+                      uint32_t branch_coordinate, SymbolId branch) {
+    // The sampled minus eigenspace differs by X on the replaced Z coordinate.
+    // Anticommuting future Paulis therefore acquire this branch in their sign.
+    for (size_t i = begin; i < pending.size(); ++i) {
+        visit_pending_pauli(pending[i], [&](const Pauli& body, AffineBool& sign) {
+            if (body.zs[branch_coordinate]) {
+                sign ^= AffineBool::symbol(branch);
+            }
+        });
+    }
+}
+
+SymbolId append_branch(SamplingPlan& plan, uint32_t defining_action) {
+    const SymbolId branch{static_cast<uint32_t>(plan.symbols.size())};
+    plan.symbols.push_back(SymbolInfo{SymbolKind::Branch, defining_action, std::nullopt});
+    return branch;
+}
+
+void multiply_phase(std::complex<double>& weight, double angle) {
+    weight *= std::complex<double>(std::cos(angle), std::sin(angle));
+}
+
+std::vector<PendingOperation> queue_supported_operations(const HirModule& hir,
+                                                         SamplingPlan& plan) {
+    std::vector<PendingOperation> pending;
+    pending.reserve(hir.ops.size());
+
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        const HeisenbergOp& op = hir.ops[i];
+        switch (op.op_type()) {
+            case OpType::T_GATE: {
+                const double half_turns = op.is_dagger() ? -0.25 : 0.25;
+                pending.emplace_back(
+                    PendingRotation{pauli_from_hir(hir, op), half_turns, AffineBool(hir.sign(op))});
+                multiply_phase(plan.global_weight,
+                               (op.is_dagger() ? -1.0 : 1.0) * std::numbers::pi / 8.0);
+                break;
+            }
+            case OpType::PHASE_ROTATION: {
+                pending.emplace_back(PendingRotation{pauli_from_hir(hir, op), op.alpha(),
+                                                     AffineBool(hir.sign(op))});
+                const double signed_alpha = hir.sign(op) ? -op.alpha() : op.alpha();
+                multiply_phase(plan.global_weight, signed_alpha * std::numbers::pi / 2.0);
+                break;
+            }
+            case OpType::MEASURE:
+                pending.emplace_back(PendingMeasurement{
+                    pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
+                    RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}});
+                break;
+            case OpType::CONDITIONAL_PAULI:
+            case OpType::NOISE:
+            case OpType::READOUT_NOISE:
+            case OpType::DETECTOR:
+            case OpType::OBSERVABLE:
+            case OpType::EXP_VAL:
+            case OpType::INSTRUMENT:
+            case OpType::NUM_OP_TYPES:
+                unsupported_operation(op.op_type(), i);
+        }
+    }
+    return pending;
+}
+
+void process_rotation(std::vector<PendingOperation>& pending, size_t index,
+                      const PendingRotation& rotation, SamplingPlan& plan, uint32_t& active_width) {
+    const std::optional<uint32_t> dormant_pivot =
+        first_x_at_or_above(rotation.body, active_width);
+    if (!dormant_pivot.has_value()) {
+        plan.actions.push_back(PlannedAction{
+            active_width, active_width,
+            RotateActivePauli{active_projection(rotation.body, active_width),
+                              rotation.half_turns, rotation.sign}});
+        return;
+    }
+
+    if (active_width + 1 >= kDenseActiveWidthLimit) {
+        throw std::overflow_error("sampling planner active width would reach " +
+                                  std::to_string(active_width + 1) +
+                                  ", but the dense-state limit is " +
+                                  std::to_string(kDenseActiveWidthLimit));
+    }
+
+    const Tableau frame =
+        dormant_promotion_frame(rotation.body, active_width, *dormant_pivot);
+    transform_future_operations(pending, index + 1, frame);
+    plan.actions.push_back(PlannedAction{
+        active_width, active_width + 1,
+        PromoteDormantRotation{active_width, rotation.half_turns, rotation.sign}});
+    ++active_width;
+    plan.max_active_width = std::max(plan.max_active_width, active_width);
+}
+
+void process_measurement(std::vector<PendingOperation>& pending, size_t index,
+                         const PendingMeasurement& measurement, SamplingPlan& plan,
+                         uint32_t& active_width) {
+    const std::optional<uint32_t> dormant_pivot =
+        first_x_at_or_above(measurement.body, active_width);
+    if (dormant_pivot.has_value()) {
+        const Tableau frame = dormant_measurement_frame(measurement.body, *dormant_pivot);
+        transform_future_operations(pending, index + 1, frame);
+
+        const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
+        const SymbolId branch = append_branch(plan, action_index);
+        propagate_branch(pending, index + 1, *dormant_pivot, branch);
+        plan.actions.push_back(PlannedAction{
+            active_width, active_width,
+            MeasureDormantRandom{*dormant_pivot, branch,
+                                 measurement.sign ^ AffineBool::symbol(branch),
+                                 measurement.record}});
+        return;
+    }
+
+    const ActivePauli active = active_projection(measurement.body, active_width);
+    if (active.is_identity()) {
+        plan.actions.push_back(PlannedAction{
+            active_width, active_width,
+            RecordClassical{measurement.sign, measurement.record}});
+        return;
+    }
+
+    std::optional<uint32_t> pivot = first_x_below(measurement.body, active_width);
+    if (!pivot.has_value()) {
+        pivot = first_z_below(measurement.body, active_width);
+    }
+    if (!pivot.has_value()) {
+        throw std::logic_error("sampling planner could not select an active measurement pivot");
+    }
+
+    Pauli active_body(measurement.body.num_qubits);
+    for (uint32_t q = 0; q < active_width; ++q) {
+        active_body.xs[q] = measurement.body.xs[q];
+        active_body.zs[q] = measurement.body.zs[q];
+    }
+    const Tableau frame = active_measurement_frame(active_body, active_width, *pivot);
+    transform_future_operations(pending, index + 1, frame);
+
+    const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
+    const SymbolId branch = append_branch(plan, action_index);
+    propagate_branch(pending, index + 1, active_width - 1, branch);
+    plan.actions.push_back(PlannedAction{
+        active_width, active_width - 1,
+        MeasureActivePauli{active, *pivot, branch,
+                           measurement.sign ^ AffineBool::symbol(branch), measurement.record}});
+    --active_width;
+}
+
+}  // namespace
+
+SamplingPlan plan_sampling(const HirModule& hir) {
+    SamplingPlan plan;
+    plan.num_qubits = hir.num_qubits;
+    plan.num_visible_records = hir.num_measurements;
+    plan.num_hidden_records = hir.num_hidden_measurements;
+    plan.num_noise_sites = static_cast<uint32_t>(hir.noise_sites.size());
+    plan.num_instrument_sites = static_cast<uint32_t>(hir.instrument_sites.size());
+    plan.global_weight = hir.global_weight;
+
+    std::vector<PendingOperation> pending = queue_supported_operations(hir, plan);
+    uint32_t active_width = plan.initial_active_width;
+    for (size_t i = 0; i < pending.size(); ++i) {
+        std::visit(
+            [&](const auto& operation) {
+                using T = std::decay_t<decltype(operation)>;
+                if constexpr (std::is_same_v<T, PendingRotation>) {
+                    process_rotation(pending, i, operation, plan, active_width);
+                } else if constexpr (std::is_same_v<T, PendingMeasurement>) {
+                    process_measurement(pending, i, operation, plan, active_width);
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
+                }
+            },
+            pending[i]);
+    }
+
+    plan.validate();
+    return plan;
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -63,6 +63,9 @@ Pauli single_z(uint32_t num_qubits, uint32_t q) {
 }
 
 Pauli positive_body_xor(const Pauli& left, const Pauli& right) {
+    // Callers only combine canonical generator rows whose nonidentity supports
+    // are disjoint. Overlapping supports could contribute a phase that this
+    // body-only helper intentionally does not compute.
     Pauli result(left);
     result.xs ^= right.xs;
     result.zs ^= right.zs;
@@ -353,7 +356,7 @@ void process_rotation(std::vector<PendingOperation>& pending, size_t index,
     transform_future_operations(pending, index + 1, frame);
     plan.actions.push_back(
         PlannedAction{active_width, active_width + 1,
-                      PromoteDormantRotation{active_width, rotation.half_turns, rotation.sign}});
+                      PromoteDormantRotation{rotation.half_turns, rotation.sign}});
     ++active_width;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
 }

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -147,7 +147,7 @@ ActivePauli active_projection(const Pauli& pauli, uint32_t active_width) {
 }
 
 Tableau dormant_promotion_frame(const Pauli& promoted, uint32_t active_width,
-                                 uint32_t dormant_pivot) {
+                                uint32_t dormant_pivot) {
     const uint32_t n = static_cast<uint32_t>(promoted.num_qubits);
     Tableau frame(n);
     const Pauli old_stabilizer = single_z(n, dormant_pivot);
@@ -325,8 +325,7 @@ void multiply_phase(std::complex<double>& weight, double angle) {
     weight *= std::complex<double>(std::cos(angle), std::sin(angle));
 }
 
-std::vector<PendingOperation> queue_supported_operations(const HirModule& hir,
-                                                         SamplingPlan& plan) {
+std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, SamplingPlan& plan) {
     std::vector<PendingOperation> pending;
     pending.reserve(hir.ops.size());
 
@@ -342,16 +341,16 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir,
                 break;
             }
             case OpType::PHASE_ROTATION: {
-                pending.emplace_back(PendingRotation{pauli_from_hir(hir, op), op.alpha(),
-                                                     AffineBool(hir.sign(op))});
+                pending.emplace_back(
+                    PendingRotation{pauli_from_hir(hir, op), op.alpha(), AffineBool(hir.sign(op))});
                 const double signed_alpha = hir.sign(op) ? -op.alpha() : op.alpha();
                 multiply_phase(plan.global_weight, signed_alpha * std::numbers::pi / 2.0);
                 break;
             }
             case OpType::MEASURE:
-                pending.emplace_back(PendingMeasurement{
-                    pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
-                    RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}});
+                pending.emplace_back(
+                    PendingMeasurement{pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
+                                       RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}});
                 break;
             case OpType::CONDITIONAL_PAULI:
             case OpType::NOISE:
@@ -369,29 +368,26 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir,
 
 void process_rotation(std::vector<PendingOperation>& pending, size_t index,
                       const PendingRotation& rotation, SamplingPlan& plan, uint32_t& active_width) {
-    const std::optional<uint32_t> dormant_pivot =
-        first_x_at_or_above(rotation.body, active_width);
+    const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(rotation.body, active_width);
     if (!dormant_pivot.has_value()) {
-        plan.actions.push_back(PlannedAction{
-            active_width, active_width,
-            RotateActivePauli{active_projection(rotation.body, active_width),
-                              rotation.half_turns, rotation.sign}});
+        plan.actions.push_back(
+            PlannedAction{active_width, active_width,
+                          RotateActivePauli{active_projection(rotation.body, active_width),
+                                            rotation.half_turns, rotation.sign}});
         return;
     }
 
     if (active_width + 1 >= kDenseActiveWidthLimit) {
-        throw std::overflow_error("sampling planner active width would reach " +
-                                  std::to_string(active_width + 1) +
-                                  ", but the dense-state limit is " +
-                                  std::to_string(kDenseActiveWidthLimit));
+        throw std::overflow_error(
+            "sampling planner active width would reach " + std::to_string(active_width + 1) +
+            ", but the dense-state limit is " + std::to_string(kDenseActiveWidthLimit));
     }
 
-    const Tableau frame =
-        dormant_promotion_frame(rotation.body, active_width, *dormant_pivot);
+    const Tableau frame = dormant_promotion_frame(rotation.body, active_width, *dormant_pivot);
     transform_future_operations(pending, index + 1, frame);
-    plan.actions.push_back(PlannedAction{
-        active_width, active_width + 1,
-        PromoteDormantRotation{active_width, rotation.half_turns, rotation.sign}});
+    plan.actions.push_back(
+        PlannedAction{active_width, active_width + 1,
+                      PromoteDormantRotation{active_width, rotation.half_turns, rotation.sign}});
     ++active_width;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
 }
@@ -408,19 +404,18 @@ void process_measurement(std::vector<PendingOperation>& pending, size_t index,
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
         const SymbolId branch = append_branch(plan, action_index);
         propagate_branch(pending, index + 1, *dormant_pivot, branch);
-        plan.actions.push_back(PlannedAction{
-            active_width, active_width,
-            MeasureDormantRandom{*dormant_pivot, branch,
-                                 measurement.sign ^ AffineBool::symbol(branch),
-                                 measurement.record}});
+        plan.actions.push_back(
+            PlannedAction{active_width, active_width,
+                          MeasureDormantRandom{*dormant_pivot, branch,
+                                               measurement.sign ^ AffineBool::symbol(branch),
+                                               measurement.record}});
         return;
     }
 
     const ActivePauli active = active_projection(measurement.body, active_width);
     if (active.is_identity()) {
         plan.actions.push_back(PlannedAction{
-            active_width, active_width,
-            RecordClassical{measurement.sign, measurement.record}});
+            active_width, active_width, RecordClassical{measurement.sign, measurement.record}});
         return;
     }
 
@@ -445,8 +440,8 @@ void process_measurement(std::vector<PendingOperation>& pending, size_t index,
     propagate_branch(pending, index + 1, active_width - 1, branch);
     plan.actions.push_back(PlannedAction{
         active_width, active_width - 1,
-        MeasureActivePauli{active, *pivot, branch,
-                           measurement.sign ^ AffineBool::symbol(branch), measurement.record}});
+        MeasureActivePauli{active, *pivot, branch, measurement.sign ^ AffineBool::symbol(branch),
+                           measurement.record}});
     --active_width;
 }
 

--- a/src/clifft/sampling/planner.h
+++ b/src/clifft/sampling/planner.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "clifft/frontend/hir.h"
+#include "clifft/sampling/plan.h"
+
+namespace clifft::sampling {
+
+// Builds the executor-independent sampling plan for the supported optimized
+// HIR subset. The planner performs all stabilizer-coordinate changes and
+// symbolic dependency discovery before execution.
+//
+// The initial subset accepts T gates, phase rotations, and measurements. It
+// throws std::invalid_argument for every other HIR operation.
+[[nodiscard]] SamplingPlan plan_sampling(const HirModule& hir);
+
+}  // namespace clifft::sampling

--- a/src/clifft/util/hir_introspection.h
+++ b/src/clifft/util/hir_introspection.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// String-formatting utilities that depend only on the HIR. Keep these
+// separate from VM introspection so compiler-side users do not acquire a
+// dependency on the legacy backend.
+
+#include "clifft/frontend/hir.h"
+
+#include <optional>
+#include <string>
+
+namespace clifft {
+
+// Format a Pauli mask (X bits, Z bits, sign) as a human-readable string.
+// Example: "+X0*Z3" for destab bit 0 and stab bit 3.
+std::string format_pauli_mask(PauliMaskView mask);
+
+std::string op_type_to_str(OpType type);
+
+// Format a HIR op as a human-readable string. For mask-carrying ops the
+// caller passes the op's mask via `hir.mask_view(op)`; for non-mask ops
+// (NOISE, READOUT_NOISE, DETECTOR, OBSERVABLE) the caller passes
+// std::nullopt and the mask argument is unused.
+std::string format_hir_op(const HeisenbergOp& op, std::optional<PauliMaskView> mask);
+
+}  // namespace clifft

--- a/src/clifft/util/introspection.h
+++ b/src/clifft/util/introspection.h
@@ -1,27 +1,14 @@
 #pragma once
 
-// Shared string-formatting utilities for HIR and VM bytecode introspection.
-// Used by both Python (nanobind) and Wasm (Embind) bindings.
+// Shared string-formatting utilities for VM bytecode introspection. This
+// header also re-exports the HIR-only helpers used by the bindings.
 
 #include "clifft/backend/backend.h"
-#include "clifft/frontend/hir.h"
+#include "clifft/util/hir_introspection.h"
 
-#include <optional>
 #include <string>
 
 namespace clifft {
-
-// Format a Pauli mask (X bits, Z bits, sign) as a human-readable string.
-// Example: "+X0*Z3" for destab bit 0 and stab bit 3.
-std::string format_pauli_mask(PauliMaskView mask);
-
-std::string op_type_to_str(OpType type);
-
-// Format a HIR op as a human-readable string. For mask-carrying ops the
-// caller passes the op's mask via `hir.mask_view(op)`; for non-mask ops
-// (NOISE, READOUT_NOISE, DETECTOR, OBSERVABLE) the caller passes
-// std::nullopt and the mask argument is unused.
-std::string format_hir_op(const HeisenbergOp& op, std::optional<PauliMaskView> mask);
 
 std::string opcode_to_str(Opcode op);
 

--- a/src/clifft/util/stim_mask.h
+++ b/src/clifft/util/stim_mask.h
@@ -33,4 +33,18 @@ inline void stim_to_mask_view(const stim::simd_bits_range_ref<kStimWidth>& bits,
         dst.words[w] = 0;
 }
 
+/// Copy the first `n` bits of a MaskView into a Stim bit range. The source
+/// must be at least `(n + 63) / 64` words wide. Destination padding is cleared
+/// so a reused Stim value cannot retain bits outside the logical mask.
+inline void mask_view_to_stim(MaskView src, uint32_t n, stim::simd_bits_range_ref<kStimWidth> dst) {
+    const uint32_t words = (n + 63) / 64;
+    assert(words <= src.num_words() && "mask_view_to_stim: source too narrow");
+    assert(words <= dst.num_u64_padded() && "mask_view_to_stim: destination too narrow");
+    dst.clear();
+    for (uint32_t w = 0; w < words; ++w)
+        dst.u64[w] = src.words[w];
+    if (words != 0 && n % 64 != 0)
+        dst.u64[words - 1] &= (uint64_t{1} << (n % 64)) - 1;
+}
+
 }  // namespace clifft

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/backend/backend.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/basis_probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/api/record_probabilities.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/svm/svm.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(clifft_tests
     test_trap_resume.cc
     test_backend.cc
     test_sampling_plan.cc
+    test_sampling_planner.cc
     test_svm.cc
     test_state_reset.cc
     test_forced_kernels.cc

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -45,7 +45,7 @@ SamplingPlan valid_plan() {
         SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
     };
     plan.actions = {
-        PlannedAction{0, 1, PromoteDormantRotation{0, 0.25, AffineBool::symbol(noise)}},
+        PlannedAction{0, 1, PromoteDormantRotation{0.25, AffineBool::symbol(noise)}},
         PlannedAction{1, 0,
                       MeasureActivePauli{ActivePauli{1, 0}, 0, branch,
                                          AffineBool::symbol(branch) ^ AffineBool::symbol(noise),
@@ -277,12 +277,6 @@ TEST_CASE("Sampling plan rejects invalid dimensions and action contracts") {
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
-    SECTION("dormant promotion pivot is out of range") {
-        SamplingPlan plan = valid_plan();
-        std::get<PromoteDormantRotation>(plan.actions[0].action).dormant_pivot = 2;
-        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
-    }
-
     SECTION("active measurement does not decrease width") {
         SamplingPlan plan = valid_plan();
         plan.actions[1].active_after = 1;
@@ -383,7 +377,7 @@ TEST_CASE("Sampling plan safely rejects a transition stream above dense width") 
     plan.max_active_width = clifft::kDenseActiveWidthLimit - 1;
     for (uint32_t width = 0; width < kMalformedWidth; ++width) {
         plan.actions.push_back(
-            PlannedAction{width, width + 1, PromoteDormantRotation{width, 0.25, AffineBool{}}});
+            PlannedAction{width, width + 1, PromoteDormantRotation{0.25, AffineBool{}}});
     }
     plan.actions.push_back(PlannedAction{kMalformedWidth, kMalformedWidth,
                                          RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}});
@@ -416,8 +410,8 @@ TEST_CASE("Sampling plan predicts only state touching dense passes") {
     REQUIRE(clifft::sampling::predicted_dense_passes(plan.actions[0].action) == 1);
     REQUIRE(clifft::sampling::predicted_dense_passes(
                 RotateActivePauli{ActivePauli{}, 0.5, AffineBool{}}) == 0);
-    REQUIRE(clifft::sampling::predicted_dense_passes(
-                PromoteDormantRotation{0, 0.25, AffineBool{}}) == 1);
+    REQUIRE(clifft::sampling::predicted_dense_passes(PromoteDormantRotation{0.25, AffineBool{}}) ==
+            1);
     REQUIRE(clifft::sampling::predicted_dense_passes(MeasureActivePauli{}) == 1);
     REQUIRE(clifft::sampling::predicted_dense_passes(MeasureDormantRandom{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(RecordClassical{}) == 0);

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -35,6 +35,12 @@ const T& action_as(const SamplingPlan& plan, size_t index) {
     return std::get<T>(plan.actions.at(index).action);
 }
 
+void require_global_phase(const SamplingPlan& plan, double angle) {
+    const std::complex<double> expected{std::cos(angle), std::sin(angle)};
+    REQUIRE_THAT(plan.global_weight.real(), Catch::Matchers::WithinAbs(expected.real(), 1e-12));
+    REQUIRE_THAT(plan.global_weight.imag(), Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
+}
+
 }  // namespace
 
 TEST_CASE("Sampling planner preserves empty module metadata") {
@@ -61,7 +67,6 @@ TEST_CASE("Sampling planner promotes rotations and keeps later active support") 
     REQUIRE(plan.max_active_width == 1);
     REQUIRE(plan.actions.size() == 2);
     const auto& promotion = action_as<PromoteDormantRotation>(plan, 0);
-    REQUIRE(promotion.dormant_pivot == 0);
     REQUIRE(promotion.half_turns == 0.25);
     REQUIRE(promotion.sign == AffineBool(false));
     const auto& rotation = action_as<RotateActivePauli>(plan, 1);
@@ -134,6 +139,25 @@ TEST_CASE("Sampling planner correlates arbitrary repeated dormant measurements")
             REQUIRE(repeated.outcome == first.outcome);
         }
     }
+}
+
+TEST_CASE("Sampling planner correlates mixed active and dormant measurements") {
+    HirModule hir(2, 3);
+    hir.num_measurements = 2;
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_measure(hir, X(0) | X(1), 0, false, MeasRecordIdx{0});
+    clifft::test::append_measure(hir, X(0) | X(1), 0, false, MeasRecordIdx{1});
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.actions.size() == 3);
+    const auto& first = action_as<MeasureDormantRandom>(plan, 1);
+    REQUIRE(plan.actions[1].active_before == 1);
+    REQUIRE(plan.actions[1].active_after == 1);
+    REQUIRE(first.branch == SymbolId{0});
+    REQUIRE(first.outcome == AffineBool::symbol(SymbolId{0}));
+    const auto& repeated = action_as<RecordClassical>(plan, 2);
+    REQUIRE(repeated.outcome == first.outcome);
 }
 
 TEST_CASE("Sampling planner accepts traced rotation and measurement HIR") {
@@ -216,10 +240,31 @@ TEST_CASE("Sampling planner retains balanced rotation global factors") {
     REQUIRE(plan.actions.size() == 2);
     REQUIRE(action_as<RotateActivePauli>(plan, 0).pauli.is_identity());
     REQUIRE(action_as<RotateActivePauli>(plan, 1).pauli.is_identity());
-    const std::complex<double> expected{std::cos(std::numbers::pi / 8.0),
-                                        std::sin(std::numbers::pi / 8.0)};
-    REQUIRE_THAT(plan.global_weight.real(), Catch::Matchers::WithinAbs(expected.real(), 1e-12));
-    REQUIRE_THAT(plan.global_weight.imag(), Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
+    require_global_phase(plan, std::numbers::pi / 8.0);
+}
+
+TEST_CASE("Sampling planner preserves sign flipped rotation global factors") {
+    SECTION("T gate factor is sign independent") {
+        HirModule hir(1, 1);
+        clifft::test::append_tgate(hir, 0, Z(0), true);
+
+        const SamplingPlan plan = plan_sampling(hir);
+
+        REQUIRE(action_as<RotateActivePauli>(plan, 0).pauli.is_identity());
+        REQUIRE(action_as<RotateActivePauli>(plan, 0).sign == AffineBool(true));
+        require_global_phase(plan, std::numbers::pi / 8.0);
+    }
+
+    SECTION("phase rotation factor follows signed axis") {
+        HirModule hir(1, 1);
+        clifft::test::append_phase_rotation(hir, 0, Z(0), true, 0.5);
+
+        const SamplingPlan plan = plan_sampling(hir);
+
+        REQUIRE(action_as<RotateActivePauli>(plan, 0).pauli.is_identity());
+        REQUIRE(action_as<RotateActivePauli>(plan, 0).sign == AffineBool(true));
+        require_global_phase(plan, -std::numbers::pi / 4.0);
+    }
 }
 
 TEST_CASE("Sampling planner rejects unsupported operations explicitly") {

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -1,0 +1,263 @@
+#include "clifft/sampling/planner.h"
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "test_helpers.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <complex>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+using clifft::HirModule;
+using clifft::MeasRecordIdx;
+using clifft::NoiseSite;
+using clifft::sampling::AffineBool;
+using clifft::sampling::MeasureActivePauli;
+using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::RotateActivePauli;
+using clifft::sampling::SamplingPlan;
+using clifft::sampling::SymbolId;
+using clifft::sampling::plan_sampling;
+using clifft::test::X;
+using clifft::test::Z;
+
+namespace {
+
+template <typename T>
+const T& action_as(const SamplingPlan& plan, size_t index) {
+    return std::get<T>(plan.actions.at(index).action);
+}
+
+}  // namespace
+
+TEST_CASE("Sampling planner preserves empty module metadata") {
+    HirModule hir(3, 0);
+    hir.global_weight = {0.25, -0.5};
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.num_qubits == 3);
+    REQUIRE(plan.global_weight == std::complex<double>{0.25, -0.5});
+    REQUIRE(plan.initial_active_width == 0);
+    REQUIRE(plan.max_active_width == 0);
+    REQUIRE(plan.actions.empty());
+    REQUIRE(plan.symbols.empty());
+}
+
+TEST_CASE("Sampling planner promotes rotations and keeps later active support") {
+    HirModule hir(1, 2);
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_phase_rotation(hir, X(0), 0, false, 0.5);
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.max_active_width == 1);
+    REQUIRE(plan.actions.size() == 2);
+    const auto& promotion = action_as<PromoteDormantRotation>(plan, 0);
+    REQUIRE(promotion.dormant_pivot == 0);
+    REQUIRE(promotion.half_turns == 0.25);
+    REQUIRE(promotion.sign == AffineBool(false));
+    const auto& rotation = action_as<RotateActivePauli>(plan, 1);
+    REQUIRE(rotation.pauli.x == 1);
+    REQUIRE(rotation.pauli.z == 0);
+    REQUIRE(rotation.half_turns == 0.5);
+}
+
+TEST_CASE("Sampling planner emits direct multi-coordinate active Paulis") {
+    HirModule hir(2, 3);
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_tgate(hir, X(0) | X(1), 0, false);
+    clifft::test::append_phase_rotation(hir, X(1), 0, false, 0.5);
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.max_active_width == 2);
+    REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[0].action));
+    REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[1].action));
+    const auto& rotation = action_as<RotateActivePauli>(plan, 2);
+    REQUIRE(rotation.pauli.x == 3);
+    REQUIRE(rotation.pauli.z == 0);
+}
+
+TEST_CASE("Sampling planner preserves high physical Pauli coordinates") {
+    HirModule hir(129, 2);
+    hir.append_tgate(false, [](clifft::MutablePauliMaskView slot) {
+        slot.x().bit_set(128, true);
+    });
+    hir.append_phase_rotation(0.5, [](clifft::MutablePauliMaskView slot) {
+        slot.x().bit_set(128, true);
+    });
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.max_active_width == 1);
+    REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[0].action));
+    const auto& rotation = action_as<RotateActivePauli>(plan, 1);
+    REQUIRE(rotation.pauli.x == 1);
+    REQUIRE(rotation.pauli.z == 0);
+}
+
+TEST_CASE("Sampling planner records repeat dormant measurements consistently") {
+    HirModule hir(1, 2);
+    hir.num_measurements = 2;
+    clifft::test::append_measure(hir, X(0), 0, false, MeasRecordIdx{0});
+    clifft::test::append_measure(hir, X(0), 0, false, MeasRecordIdx{1});
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.actions.size() == 2);
+    REQUIRE(plan.symbols.size() == 1);
+    const auto& first = action_as<MeasureDormantRandom>(plan, 0);
+    REQUIRE(first.branch == SymbolId{0});
+    REQUIRE(first.outcome == AffineBool::symbol(SymbolId{0}));
+    const auto& second = action_as<RecordClassical>(plan, 1);
+    REQUIRE(second.outcome == AffineBool::symbol(SymbolId{0}));
+}
+
+TEST_CASE("Sampling planner correlates arbitrary repeated dormant measurements") {
+    for (uint64_t x = 1; x < 4; ++x) {
+        for (uint64_t z = 0; z < 4; ++z) {
+            CAPTURE(x, z);
+            HirModule hir(2, 2);
+            hir.num_measurements = 2;
+            clifft::test::append_measure(hir, x, z, true, MeasRecordIdx{0});
+            clifft::test::append_measure(hir, x, z, true, MeasRecordIdx{1});
+
+            const SamplingPlan plan = plan_sampling(hir);
+
+            const auto& first = action_as<MeasureDormantRandom>(plan, 0);
+            const auto& repeated = action_as<RecordClassical>(plan, 1);
+            REQUIRE(repeated.outcome == first.outcome);
+        }
+    }
+}
+
+TEST_CASE("Sampling planner accepts traced rotation and measurement HIR") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse("H 0\nT 0\nM 0\n"));
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.actions.size() == 2);
+    REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[0].action));
+    REQUIRE(std::holds_alternative<MeasureActivePauli>(plan.actions[1].action));
+    REQUIRE(plan.symbols.size() == 1);
+}
+
+TEST_CASE("Sampling planner collapses active measurements and propagates branches") {
+    HirModule hir(1, 3);
+    hir.num_measurements = 2;
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_measure(hir, 0, Z(0), false, MeasRecordIdx{0});
+    clifft::test::append_measure(hir, 0, Z(0), false, MeasRecordIdx{1});
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.actions.size() == 3);
+    const auto& measurement = action_as<MeasureActivePauli>(plan, 1);
+    REQUIRE(measurement.pauli.x == 0);
+    REQUIRE(measurement.pauli.z == 1);
+    REQUIRE(measurement.active_pivot == 0);
+    REQUIRE(measurement.branch == SymbolId{0});
+    REQUIRE(measurement.outcome == AffineBool::symbol(SymbolId{0}));
+    REQUIRE(plan.actions[1].active_before == 1);
+    REQUIRE(plan.actions[1].active_after == 0);
+    const auto& repeated = action_as<RecordClassical>(plan, 2);
+    REQUIRE(repeated.outcome == AffineBool::symbol(SymbolId{0}));
+}
+
+TEST_CASE("Sampling planner correlates arbitrary repeated active measurements") {
+    for (uint64_t x = 0; x < 4; ++x) {
+        for (uint64_t z = 0; z < 4; ++z) {
+            if (x == 0 && z == 0) {
+                continue;
+            }
+            CAPTURE(x, z);
+            HirModule hir(2, 4);
+            hir.num_measurements = 2;
+            clifft::test::append_tgate(hir, X(0), 0, false);
+            clifft::test::append_tgate(hir, X(1), 0, false);
+            clifft::test::append_measure(hir, x, z, true, MeasRecordIdx{0});
+            clifft::test::append_measure(hir, x, z, true, MeasRecordIdx{1});
+
+            const SamplingPlan plan = plan_sampling(hir);
+
+            const auto& first = action_as<MeasureActivePauli>(plan, 2);
+            const auto& repeated = action_as<RecordClassical>(plan, 3);
+            REQUIRE(repeated.outcome == first.outcome);
+        }
+    }
+}
+
+TEST_CASE("Sampling planner keeps geometric Pauli signs") {
+    HirModule hir(1, 2);
+    clifft::test::append_tgate(hir, X(0), Z(0), false);
+    clifft::test::append_phase_rotation(hir, X(0), 0, false, 0.5);
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    const auto& rotation = action_as<RotateActivePauli>(plan, 1);
+    REQUIRE(rotation.pauli.x == 1);
+    REQUIRE(rotation.pauli.z == 1);
+    REQUIRE(rotation.sign == AffineBool(true));
+}
+
+TEST_CASE("Sampling planner retains balanced rotation global factors") {
+    HirModule hir(1, 2);
+    hir.global_weight = {std::cos(-std::numbers::pi / 4.0),
+                         std::sin(-std::numbers::pi / 4.0)};
+    clifft::test::append_phase_rotation(hir, 0, Z(0), false, 0.5);
+    clifft::test::append_tgate(hir, 0, Z(0), false);
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.actions.size() == 2);
+    REQUIRE(action_as<RotateActivePauli>(plan, 0).pauli.is_identity());
+    REQUIRE(action_as<RotateActivePauli>(plan, 1).pauli.is_identity());
+    const std::complex<double> expected{std::cos(std::numbers::pi / 8.0),
+                                        std::sin(std::numbers::pi / 8.0)};
+    REQUIRE_THAT(plan.global_weight.real(),
+                 Catch::Matchers::WithinAbs(expected.real(), 1e-12));
+    REQUIRE_THAT(plan.global_weight.imag(),
+                 Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
+}
+
+TEST_CASE("Sampling planner rejects unsupported operations explicitly") {
+    HirModule hir(1, 0);
+    hir.noise_sites.push_back(NoiseSite{});
+    hir.append_noise(clifft::NoiseSiteIdx{0});
+
+    REQUIRE_THROWS_WITH(plan_sampling(hir),
+                        "sampling planner does not support HIR operation NOISE at index 0");
+}
+
+TEST_CASE("Sampling planner reports the dense active width limit") {
+    HirModule hir(60, 60);
+    for (uint32_t q = 0; q < 60; ++q) {
+        clifft::test::append_tgate(hir, X(q), 0, false);
+    }
+
+    REQUIRE_THROWS_WITH(
+        plan_sampling(hir),
+        "sampling planner active width would reach 60, but the dense-state limit is 60");
+}
+
+TEST_CASE("Sampling planner output is deterministic") {
+    HirModule hir(2, 4);
+    hir.num_measurements = 2;
+    clifft::test::append_tgate(hir, X(0), 0, false);
+    clifft::test::append_phase_rotation(hir, X(0) | X(1), Z(1), true, -0.25);
+    clifft::test::append_measure(hir, X(1), Z(0), false, MeasRecordIdx{0});
+    clifft::test::append_measure(hir, X(1), Z(0), true, MeasRecordIdx{1});
+
+    const SamplingPlan first = plan_sampling(hir);
+    const SamplingPlan second = plan_sampling(hir);
+
+    REQUIRE(first.inspect() == second.inspect());
+}

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -1,7 +1,7 @@
-#include "clifft/sampling/planner.h"
-
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/sampling/planner.h"
+
 #include "test_helpers.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -19,12 +19,12 @@ using clifft::NoiseSite;
 using clifft::sampling::AffineBool;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::plan_sampling;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
-using clifft::sampling::plan_sampling;
 using clifft::test::X;
 using clifft::test::Z;
 
@@ -88,12 +88,9 @@ TEST_CASE("Sampling planner emits direct multi-coordinate active Paulis") {
 
 TEST_CASE("Sampling planner preserves high physical Pauli coordinates") {
     HirModule hir(129, 2);
-    hir.append_tgate(false, [](clifft::MutablePauliMaskView slot) {
-        slot.x().bit_set(128, true);
-    });
-    hir.append_phase_rotation(0.5, [](clifft::MutablePauliMaskView slot) {
-        slot.x().bit_set(128, true);
-    });
+    hir.append_tgate(false, [](clifft::MutablePauliMaskView slot) { slot.x().bit_set(128, true); });
+    hir.append_phase_rotation(
+        0.5, [](clifft::MutablePauliMaskView slot) { slot.x().bit_set(128, true); });
 
     const SamplingPlan plan = plan_sampling(hir);
 
@@ -210,8 +207,7 @@ TEST_CASE("Sampling planner keeps geometric Pauli signs") {
 
 TEST_CASE("Sampling planner retains balanced rotation global factors") {
     HirModule hir(1, 2);
-    hir.global_weight = {std::cos(-std::numbers::pi / 4.0),
-                         std::sin(-std::numbers::pi / 4.0)};
+    hir.global_weight = {std::cos(-std::numbers::pi / 4.0), std::sin(-std::numbers::pi / 4.0)};
     clifft::test::append_phase_rotation(hir, 0, Z(0), false, 0.5);
     clifft::test::append_tgate(hir, 0, Z(0), false);
 
@@ -222,10 +218,8 @@ TEST_CASE("Sampling planner retains balanced rotation global factors") {
     REQUIRE(action_as<RotateActivePauli>(plan, 1).pauli.is_identity());
     const std::complex<double> expected{std::cos(std::numbers::pi / 8.0),
                                         std::sin(std::numbers::pi / 8.0)};
-    REQUIRE_THAT(plan.global_weight.real(),
-                 Catch::Matchers::WithinAbs(expected.real(), 1e-12));
-    REQUIRE_THAT(plan.global_weight.imag(),
-                 Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
+    REQUIRE_THAT(plan.global_weight.real(), Catch::Matchers::WithinAbs(expected.real(), 1e-12));
+    REQUIRE_THAT(plan.global_weight.imag(), Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
 }
 
 TEST_CASE("Sampling planner rejects unsupported operations explicitly") {

--- a/tests/test_stim_contract.cc
+++ b/tests/test_stim_contract.cc
@@ -12,10 +12,14 @@
 // 5. Tableau.then() composes tableaux correctly
 // 6. Tableau.inverse() computes the inverse correctly
 
+#include "clifft/util/stim_mask.h"
+
 #include "stim.h"
 
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <random>
+#include <span>
 #include <utility>
 
 TEST_CASE("Stim contract: TableauSimulator Heisenberg rewinding", "[stim][contract]") {
@@ -136,6 +140,18 @@ TEST_CASE("Stim contract: mask extraction for HIR", "[stim][contract]") {
 
     REQUIRE(x_mask == 0b0001);  // X on qubit 0
     REQUIRE(z_mask == 0b0100);  // Z on qubit 2
+}
+
+TEST_CASE("Stim contract: mask insertion clears padding", "[stim][contract]") {
+    const std::array<uint64_t, 2> source{0x0123456789abcdefULL, ~uint64_t{0}};
+    stim::PauliString<clifft::kStimWidth> pauli(129);
+    pauli.xs.invert_bits();
+
+    clifft::mask_view_to_stim(clifft::MaskView{std::span<const uint64_t>(source)}, 65, pauli.xs);
+
+    REQUIRE(pauli.xs.u64[0] == source[0]);
+    REQUIRE(pauli.xs.u64[1] == 1);
+    REQUIRE(pauli.xs.u64[2] == 0);
 }
 
 TEST_CASE("Stim contract: Tableau composition", "[stim][contract]") {


### PR DESCRIPTION
## Summary

- add an internal deterministic optimized-HIR to SamplingPlan planner for T gates, phase rotations, and measurements
- compute stabilizer-coordinate promotions and measurement compaction during planning, then rewrite all future Paulis into the new coordinates
- preserve geometric signs, balanced-rotation global factors, stable record slots, and measurement-branch dependencies
- emit direct multi-coordinate active-Pauli actions without active Clifford sweep actions
- reject every unsupported HIR operation with an actionable operation type and index
- leave the legacy compiler, SVM, public Program API, and production routing unchanged

This completes the structural planner work in #248 on top of the semantic plan foundation from #249. Instrument boundaries remain represented by the plan IR; instrument and continuation planning are deliberately still unsupported by this first planner subset.

Closes #248

## Testing

- `uv run pre-commit run --all-files`
- `cmake --build build --target clifft_tests -j4`
- `./build/tests/clifft_tests "Sampling planner*" --reporter compact` — 79 assertions in 14 test cases
- `./build/tests/clifft_tests "~[bench]" --reporter compact` — 209008 assertions in 1164 test cases

`just build-wasm` could not run locally because the Docker daemon was unavailable; the planner is included in the normal core source list used by native and WASM builds.