### PR TITLE
fix(ci): align pre-commit with locked workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
 - [ ] Python tests pass (`uv run pytest tests/python/ -v`)
 - [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
-- [ ] Pre-commit checks pass (`uv run --frozen pre-commit run --all-files --show-diff-on-failure`)
+- [ ] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)
 
 ## Contributor agreement
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`)
 - [ ] Python tests pass (`uv run pytest tests/python/ -v`)
 - [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
-- [ ] Pre-commit checks pass (`uv run pre-commit run --all-files`)
+- [ ] Pre-commit checks pass (`uv run --frozen pre-commit run --all-files --show-diff-on-failure`)
 
 ## Contributor agreement
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml', 'uv.lock') }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-
 
       - name: Run pre-commit
-        run: uv tool run pre-commit run --all-files
+        run: uv run --frozen pre-commit run --all-files --show-diff-on-failure
 
   playground-lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             ${{ runner.os }}-pre-commit-
 
       - name: Run pre-commit
-        run: uv run --frozen pre-commit run --all-files --show-diff-on-failure
+        run: uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
 
   playground-lint:
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Clifft pre-commit hooks
-# Run with: uv run --frozen pre-commit run --all-files --show-diff-on-failure
+# Run with: uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
 
 repos:
   # C++ formatting with clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Clifft pre-commit hooks
-# Run with: uv run pre-commit run --all-files
+# Run with: uv run --frozen pre-commit run --all-files --show-diff-on-failure
 
 repos:
   # C++ formatting with clang-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ architecture cannot support it:
 - Never commit directly to `main`; use a feature branch.
 - Keep commits atomic and use conventional prefixes such as `feat:`, `fix:`,
   `test:`, and `docs:`.
-- Run `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
+- Run `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
   before every commit, in addition to the tests appropriate for the change.
 - Include an `Assisted-by:` trailer identifying the agent that actually
   assisted. Each agent must use its own name, model, and provider address; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ architecture cannot support it:
 - Never commit directly to `main`; use a feature branch.
 - Keep commits atomic and use conventional prefixes such as `feat:`, `fix:`,
   `test:`, and `docs:`.
-- Run `uv run pre-commit run --all-files` before every commit, in addition to
-  the tests appropriate for the change.
+- Run `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
+  before every commit, in addition to the tests appropriate for the change.
 - Include an `Assisted-by:` trailer identifying the agent that actually
   assisted. Each agent must use its own name, model, and provider address; do
   not copy a named example literally. Format:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -55,7 +55,7 @@ We use pre-commit hooks to enforce formatting and linting:
 uv run pre-commit install
 
 # Run all checks manually
-uv run pre-commit run --all-files
+uv run --frozen pre-commit run --all-files --show-diff-on-failure
 ```
 
 ### C++

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -55,7 +55,7 @@ We use pre-commit hooks to enforce formatting and linting:
 uv run pre-commit install
 
 # Run all checks manually
-uv run --frozen pre-commit run --all-files --show-diff-on-failure
+uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
 ```
 
 ### C++

--- a/justfile
+++ b/justfile
@@ -117,7 +117,7 @@ cov: py-cov cpp-cov
 # -------------------------
 
 lint:
-  uv run pre-commit run --all-files
+  uv run --frozen pre-commit run --all-files --show-diff-on-failure
 
 # -------------------------
 # Profiling

--- a/justfile
+++ b/justfile
@@ -117,7 +117,7 @@ cov: py-cov cpp-cov
 # -------------------------
 
 lint:
-  uv run --frozen pre-commit run --all-files --show-diff-on-failure
+  uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
 
 # -------------------------
 # Profiling


### PR DESCRIPTION
## Summary

- run pre-commit from the locked dev dependency group in CI without building Clifft
- include uv.lock in the pre-commit cache key
- use one canonical lint invocation across CI, local tooling, and contributor guidance

## Test plan

- uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
- uv sync --frozen --only-group dev --dry-run

Closes #251