### PR TITLE
ci: cache wasm object files with ccache in the emsdk container

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -11,17 +11,44 @@ runs:
         path: build-wasm
         key: wasm-${{ runner.os }}-${{ hashFiles('src/wasm/**', 'src/clifft/**', 'cmake/**') }}
 
+    - name: Restore compiler cache
+      if: steps.wasm-cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/wasm-ccache
+        key: wasm-ccache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          wasm-ccache-${{ runner.os }}-
+
+    - name: Install ccache
+      if: steps.wasm-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -fsSL -o /tmp/ccache.tar.xz \
+          https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
+        echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  /tmp/ccache.tar.xz" | sha256sum --check
+        mkdir -p "$RUNNER_TEMP/ccache-bin"
+        tar -C "$RUNNER_TEMP/ccache-bin" --strip-components=1 -xf /tmp/ccache.tar.xz
+
     - name: Build Wasm module
       if: steps.wasm-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
+        mkdir -p "$RUNNER_TEMP/wasm-ccache"
         docker run --rm \
           -u "$(id -u):$(id -g)" \
           -v "${{ github.workspace }}:/src" \
+          -v "$RUNNER_TEMP/ccache-bin/ccache:/usr/local/bin/ccache:ro" \
+          -v "$RUNNER_TEMP/wasm-ccache:/ccache" \
+          -e CCACHE_DIR=/ccache \
+          -e CCACHE_MAXSIZE=200M \
           -w /src \
           emscripten/emsdk:3.1.74 \
           bash -c '
             emcmake cmake -B build-wasm -S src/wasm \
               -DCMAKE_BUILD_TYPE=Release \
-              -DFETCHCONTENT_QUIET=ON && \
-            cmake --build build-wasm -j$(nproc)'
+              -DFETCHCONTENT_QUIET=ON \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && \
+            cmake --build build-wasm -j$(nproc) && \
+            ccache -s'

--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: build-wasm
-        key: wasm-${{ runner.os }}-${{ hashFiles('src/wasm/**', 'src/clifft/**', 'cmake/**') }}
+        key: wasm-${{ runner.os }}-${{ hashFiles('src/wasm/**', 'src/clifft/**', 'cmake/**', '.github/actions/build-wasm/**') }}
 
     - name: Restore compiler cache
       if: steps.wasm-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

The wasm job's build cache is all-or-nothing: the key hashes `src/wasm/**`, `src/clifft/**`, and `cmake/**`, so any core change forces a full rebuild of every translation unit (181s in a recent run, and most feature PRs touch `src/clifft/`). This adds a ccache layer inside the pinned emsdk container so unchanged translation units hit an object cache even when the build-directory key misses.

- Mounts a pinned static ccache 4.10.2 binary (sha256-verified download) into the container
- Persists the ccache directory via `actions/cache` with a prefix restore key (capped at 200 MB; actual size ~8 MB)
- Prints `ccache -s` after each build for observability
- The exact-key fast path (skip the build entirely) is unchanged
- The build-directory key also hashes the action definition itself, so a recipe change (including this PR landing on main) forces one intentional rebuild that seeds the shared compiler cache immediately, instead of skipping the new steps until the next core-touching merge

## Verification

Local, against `emscripten/emsdk:3.1.74` with the exact container invocation: cold build 130/130 misses in 57s (8 cores); fresh build directory + warm ccache 130/130 direct hits in 15s; artifacts produced normally.

In CI, exercised via two temporary cache-key perturbations (since force-pushed away):

- Cold path ([run](https://github.com/unitaryfoundation/clifft/actions/runs/31047268725)): sha256 check passed, 131/131 compile calls all missed, build step 190s (vs 181s baseline — negligible cold overhead), both cache layers saved.
- Warm path ([run](https://github.com/unitaryfoundation/clifft/actions/runs/31047650216)): prefix restore key recovered the cold run's cache, **131/131 direct hits, build step 49s** — the core-change scenario drops from ~3 min to under a minute.

The final push (action file added to the cache key) exercises the warm path once more on its own run, since the new key misses the old build-directory cache by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)