### PR TITLE
ci: cut PR critical path with parallel pytest and leaner setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
         run: cd playground && npm run lint
 
   build-and-test:
-    needs: lint
     runs-on: ubuntu-24.04
     env:
       CMAKE_BUILD_TYPE: Debug
@@ -99,8 +98,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+      - name: Install ninja
+        run: |
+          curl -fsSL -o /tmp/ninja-linux.zip \
+            https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+          echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  /tmp/ninja-linux.zip" | sha256sum --check
+          sudo unzip -o -q /tmp/ninja-linux.zip -d /usr/local/bin
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -191,18 +194,17 @@ jobs:
         run: uv run python tools/ci/audit_python_exports.py
 
       - name: Run Python tests (default ISA)
-        run: uv run --locked pytest tests/python/ -v
+        run: uv run --locked pytest tests/python/ -n auto -v
 
       - name: Run Python tests (scalar ISA)
         env:
           CLIFFT_FORCE_ISA: scalar
-        run: uv run --locked pytest tests/python/ -v
+        run: uv run --locked pytest tests/python/ -n auto -v
 
       - name: Test documentation code examples
         run: uv run --locked pytest --codeblocks docs/ README.md -v
 
   release-cpp-smoke:
-    needs: lint
     runs-on: ubuntu-24.04
     env:
       CMAKE_BUILD_TYPE: Release
@@ -215,7 +217,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+        run: sudo apt-get update && sudo apt-get install -y ninja-build qemu-user
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -263,9 +265,6 @@ jobs:
       - name: Audit Python extension exports
         run: .smoke-venv/bin/python tools/ci/audit_python_exports.py
 
-      - name: Install qemu-user
-        run: sudo apt-get install -y qemu-user
-
       # Run a small QEMU-emulated CPU matrix against the release-baseline
       # Python install. Catches AVX-512 leakage into the AVX-2 dispatch
       # path (would SIGILL the emulated CPU) and validates that
@@ -283,7 +282,6 @@ jobs:
 
   cross-platform:
     if: github.event_name == 'push'
-    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -350,4 +348,4 @@ jobs:
         run: uv run python tools/ci/audit_python_exports.py
 
       - name: Run Python tests
-        run: uv run --locked pytest tests/python/ -v
+        run: uv run --locked pytest tests/python/ -n auto -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=4.1",
     "pytest-benchmark>=4.0",
+    "pytest-xdist>=3.5",
     "pre-commit>=3.6",
     "mypy>=1.8",
     "ruff>=0.3",

--- a/uv.lock
+++ b/uv.lock
@@ -128,6 +128,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-codeblocks" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "qiskit" },
     { name = "qiskit-aer" },
     { name = "ruff" },
@@ -156,6 +157,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=4.0" },
     { name = "pytest-codeblocks", specifier = ">=0.17.0" },
     { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "qiskit", specifier = ">=1.0" },
     { name = "qiskit-aer", specifier = ">=0.14" },
     { name = "ruff", specifier = ">=0.3" },
@@ -287,6 +289,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -997,6 +1008,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Warm-cache PR runs take ~4m40s wall, and the critical path is queue → `lint` (21s) → `build-and-test` (4m03s). Inside `build-and-test`, the two single-process Python test passes account for 135s of the 243s. Three changes, expected to bring the PR wall time to ~2m40s:

- **Run the Python suite under pytest-xdist (`-n auto`)** in `build-and-test` (both ISA passes) and `cross-platform`. The 879-test suite is embarrassingly parallel; each 67s pass should drop to ~20–25s on the 4-vCPU runners. The docs-codeblocks step stays serial (blocks within a file can depend on execution order).
- **Drop the `needs: lint` gate** from `build-and-test`, `release-cpp-smoke`, and `cross-platform`. Standard-runner minutes are free for public repos (confirmed via the billing API: 0 billable ms on recent runs, including macOS/Windows), so the gate only added ~30s of latency to every green run. Lint still runs and still fails the run on violations.
- **Leaner setup on the critical path**: `build-and-test` installs ninja from the pinned v1.12.1 release binary with sha256 verification instead of `apt-get update && install` (~7s). `release-cpp-smoke` keeps apt (it needs the index for qemu-user anyway) but folds qemu-user into the one install step.

## Verification

- Full suite passes locally under `-n auto`: 879 passed in 8.6s (Release extension)
- `uv lock --check` and `uv tool run pre-commit run --all-files` pass
- ninja sha256 independently verified against the GitHub release asset

One behavior note: the `multicore`-marked OpenMP tests now share the runner's 4 vCPUs with other xdist workers — they pass, just without dedicated cores. pytest-benchmark auto-disables its timing under xdist, which is fine since PR CI doesn't consume those numbers ([bench] history runs in the nightly workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)