### PR TITLE
feat(sampling): add scalar plan executor

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(clifft_core STATIC
     backend/backend.cc
     sampling/plan.cc
     sampling/planner.cc
+    sampling/executor.cc
     sampling/kernels.cc
     sampling/state.cc
     api/basis_probabilities.cc

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -39,10 +39,12 @@ MeasurementBranchClassification classify_measurement_branch(
            "measurement probabilities must be finite, nonnegative, and nonzero");
     const double epsilon = kMeasurementDustEpsilon * total;
     if (probabilities.one <= epsilon) {
-        return {.kind = MeasurementBranchKind::Zero, .clamped_dust = probabilities.one > 0.0};
+        return {.kind = MeasurementBranchKind::DeterministicZero,
+                .clamped_dust = probabilities.one > 0.0};
     }
     if (probabilities.zero <= epsilon) {
-        return {.kind = MeasurementBranchKind::One, .clamped_dust = probabilities.zero > 0.0};
+        return {.kind = MeasurementBranchKind::DeterministicOne,
+                .clamped_dust = probabilities.zero > 0.0};
     }
     return {.kind = MeasurementBranchKind::Random};
 }
@@ -210,10 +212,10 @@ bool Executor::sample_active_branch(MeasurementProbabilities probabilities) noex
     switch (classification.kind) {
         case MeasurementBranchKind::Random:
             return rng_.next_double() * probabilities.total() >= probabilities.zero;
-        case MeasurementBranchKind::Zero:
+        case MeasurementBranchKind::DeterministicZero:
             dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
             return false;
-        case MeasurementBranchKind::One:
+        case MeasurementBranchKind::DeterministicOne:
             dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
             return true;
     }

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -39,12 +39,10 @@ MeasurementBranchClassification classify_measurement_branch(
            "measurement probabilities must be finite, nonnegative, and nonzero");
     const double epsilon = kMeasurementDustEpsilon * total;
     if (probabilities.one <= epsilon) {
-        return {.kind = MeasurementBranchKind::Zero,
-                .clamped_dust = probabilities.one > 0.0};
+        return {.kind = MeasurementBranchKind::Zero, .clamped_dust = probabilities.one > 0.0};
     }
     if (probabilities.zero <= epsilon) {
-        return {.kind = MeasurementBranchKind::One,
-                .clamped_dust = probabilities.zero > 0.0};
+        return {.kind = MeasurementBranchKind::One, .clamped_dust = probabilities.zero > 0.0};
     }
     return {.kind = MeasurementBranchKind::Random};
 }
@@ -108,20 +106,19 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                                                            prepare_expression(typed.sign)});
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
                     actions_.emplace_back(ExecuteActiveMeasurement{
-                        prepare_measurement(typed.pauli, planned.active_before,
-                                            typed.active_pivot),
+                        prepare_measurement(typed.pauli, planned.active_before, typed.active_pivot),
                         prepare_expression(typed.outcome), index(typed.branch),
                         index(typed.record)});
                 } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
-                    actions_.emplace_back(ExecuteDormantMeasurement{
-                        prepare_expression(typed.outcome), index(typed.branch),
-                        index(typed.record)});
+                    actions_.emplace_back(
+                        ExecuteDormantMeasurement{prepare_expression(typed.outcome),
+                                                  index(typed.branch), index(typed.record)});
                 } else if constexpr (std::is_same_v<T, RecordClassical>) {
-                    actions_.emplace_back(ExecuteClassicalRecord{
-                        prepare_expression(typed.outcome), index(typed.record)});
+                    actions_.emplace_back(ExecuteClassicalRecord{prepare_expression(typed.outcome),
+                                                                 index(typed.record)});
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
-                    actions_.emplace_back(ExecuteSymbolDefinition{
-                        prepare_expression(typed.value), index(typed.symbol)});
+                    actions_.emplace_back(ExecuteSymbolDefinition{prepare_expression(typed.value),
+                                                                  index(typed.symbol)});
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     throw std::invalid_argument(
                         "sampling executable does not yet support instrument boundary site " +
@@ -169,8 +166,7 @@ void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
                     apply_rotation(state_, typed.rotation, evaluate(typed.sign));
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecutePromotion>) {
                     apply_promotion(state_, typed.promotion, evaluate(typed.sign));
-                } else if constexpr (std::is_same_v<T,
-                                                    ExecutablePlan::ExecuteActiveMeasurement>) {
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement>) {
                     const MeasurementProbabilities probabilities =
                         measurement_probabilities(state_, typed.measurement);
                     const bool branch = sample_active_branch(probabilities);
@@ -178,16 +174,13 @@ void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
                     collapse_measurement(state_, typed.measurement, branch,
                                          probabilities.for_branch(branch));
                     records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
-                } else if constexpr (std::is_same_v<
-                                         T, ExecutablePlan::ExecuteDormantMeasurement>) {
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDormantMeasurement>) {
                     const bool branch = sample_dormant_branch();
                     symbols_[typed.branch] = static_cast<uint8_t>(branch);
                     records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
-                } else if constexpr (std::is_same_v<T,
-                                                    ExecutablePlan::ExecuteClassicalRecord>) {
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
                     records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
-                } else if constexpr (std::is_same_v<
-                                         T, ExecutablePlan::ExecuteSymbolDefinition>) {
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteSymbolDefinition>) {
                     symbols_[typed.symbol] = static_cast<uint8_t>(evaluate(typed.value));
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled executable action alternative");

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -1,0 +1,235 @@
+#include "clifft/sampling/executor.h"
+
+#include "clifft/util/numeric.h"
+
+#include <algorithm>
+#include <cassert>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace clifft::sampling {
+
+namespace {
+
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
+uint32_t index(SymbolId id) {
+    return static_cast<uint32_t>(id);
+}
+
+uint32_t index(RecordSlot slot) {
+    return static_cast<uint32_t>(slot);
+}
+
+uint32_t index(InstrumentSiteId site) {
+    return static_cast<uint32_t>(site);
+}
+
+}  // namespace
+
+MeasurementBranchClassification classify_measurement_branch(
+    MeasurementProbabilities probabilities) noexcept {
+    const double total = probabilities.total();
+    assert(is_finite_robust(probabilities.zero) && probabilities.zero >= 0.0 &&
+           is_finite_robust(probabilities.one) && probabilities.one >= 0.0 &&
+           is_finite_robust(total) && total > 0.0 &&
+           "measurement probabilities must be finite, nonnegative, and nonzero");
+    const double epsilon = kMeasurementDustEpsilon * total;
+    if (probabilities.one <= epsilon) {
+        return {.kind = MeasurementBranchKind::Zero,
+                .clamped_dust = probabilities.one > 0.0};
+    }
+    if (probabilities.zero <= epsilon) {
+        return {.kind = MeasurementBranchKind::One,
+                .clamped_dust = probabilities.zero > 0.0};
+    }
+    return {.kind = MeasurementBranchKind::Random};
+}
+
+ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
+    : initial_active_width_(plan.initial_active_width),
+      max_active_width_(plan.max_active_width),
+      num_visible_records_(plan.num_visible_records),
+      num_hidden_records_(plan.num_hidden_records),
+      global_weight_(plan.global_weight) {
+    plan.validate();
+    if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::length_error("sampling executable symbol count exceeds uint32 range");
+    }
+    num_symbols_ = static_cast<uint32_t>(plan.symbols.size());
+
+    size_t num_expression_terms = 0;
+    for (const PlannedAction& planned : plan.actions) {
+        std::visit(
+            [&](const auto& typed) {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, RotateActivePauli> ||
+                              std::is_same_v<T, PromoteDormantRotation>) {
+                    num_expression_terms += typed.sign.terms().size();
+                } else if constexpr (std::is_same_v<T, MeasureActivePauli> ||
+                                     std::is_same_v<T, MeasureDormantRandom> ||
+                                     std::is_same_v<T, RecordClassical>) {
+                    num_expression_terms += typed.outcome.terms().size();
+                } else if constexpr (std::is_same_v<T, DefineSymbol>) {
+                    num_expression_terms += typed.value.terms().size();
+                } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
+                    // Rejected below after all structural validation has run.
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
+                }
+            },
+            planned.action);
+    }
+    if (num_expression_terms > std::numeric_limits<uint32_t>::max()) {
+        throw std::length_error("sampling executable expression storage exceeds uint32 range");
+    }
+    expression_terms_.reserve(num_expression_terms);
+    actions_.reserve(plan.actions.size());
+    presampled_symbols_.reserve(plan.symbols.size());
+    for (uint32_t symbol = 0; symbol < plan.symbols.size(); ++symbol) {
+        if (plan.symbols[symbol].kind == SymbolKind::Presampled) {
+            presampled_symbols_.push_back(symbol);
+        }
+    }
+
+    for (const PlannedAction& planned : plan.actions) {
+        std::visit(
+            [&](const auto& typed) {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, RotateActivePauli>) {
+                    actions_.emplace_back(ExecuteRotation{
+                        prepare_rotation(typed.pauli, planned.active_before, typed.half_turns),
+                        prepare_expression(typed.sign)});
+                } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
+                    actions_.emplace_back(ExecutePromotion{prepare_promotion(typed.half_turns),
+                                                           prepare_expression(typed.sign)});
+                } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
+                    actions_.emplace_back(ExecuteActiveMeasurement{
+                        prepare_measurement(typed.pauli, planned.active_before,
+                                            typed.active_pivot),
+                        prepare_expression(typed.outcome), index(typed.branch),
+                        index(typed.record)});
+                } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
+                    actions_.emplace_back(ExecuteDormantMeasurement{
+                        prepare_expression(typed.outcome), index(typed.branch),
+                        index(typed.record)});
+                } else if constexpr (std::is_same_v<T, RecordClassical>) {
+                    actions_.emplace_back(ExecuteClassicalRecord{
+                        prepare_expression(typed.outcome), index(typed.record)});
+                } else if constexpr (std::is_same_v<T, DefineSymbol>) {
+                    actions_.emplace_back(ExecuteSymbolDefinition{
+                        prepare_expression(typed.value), index(typed.symbol)});
+                } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
+                    throw std::invalid_argument(
+                        "sampling executable does not yet support instrument boundary site " +
+                        std::to_string(index(typed.site)));
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
+                }
+            },
+            planned.action);
+    }
+}
+
+ExecutablePlan::PreparedExpression ExecutablePlan::prepare_expression(
+    const AffineBool& expression) {
+    const uint32_t begin = static_cast<uint32_t>(expression_terms_.size());
+    for (SymbolId term : expression.terms()) {
+        expression_terms_.push_back(index(term));
+    }
+    return {begin, static_cast<uint32_t>(expression.terms().size()), expression.constant()};
+}
+
+Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
+    : plan_(plan),
+      state_(plan.max_active_width_, plan.initial_active_width_, plan.global_weight_),
+      symbols_(plan.num_symbols_, 0),
+      records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
+      rng_(seed) {}
+
+void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
+    assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
+           "one value is required for every presampled symbol");
+    state_.reset();
+    std::fill(symbols_.begin(), symbols_.end(), uint8_t{0});
+    std::fill(records_.begin(), records_.end(), uint8_t{0});
+    for (size_t i = 0; i < presampled_values.size(); ++i) {
+        assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
+        symbols_[plan_.presampled_symbols_[i]] = presampled_values[i];
+    }
+
+    for (const ExecutablePlan::Action& action : plan_.actions_) {
+        std::visit(
+            [&](const auto& typed) noexcept {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation>) {
+                    apply_rotation(state_, typed.rotation, evaluate(typed.sign));
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecutePromotion>) {
+                    apply_promotion(state_, typed.promotion, evaluate(typed.sign));
+                } else if constexpr (std::is_same_v<T,
+                                                    ExecutablePlan::ExecuteActiveMeasurement>) {
+                    const MeasurementProbabilities probabilities =
+                        measurement_probabilities(state_, typed.measurement);
+                    const bool branch = sample_active_branch(probabilities);
+                    symbols_[typed.branch] = static_cast<uint8_t>(branch);
+                    collapse_measurement(state_, typed.measurement, branch,
+                                         probabilities.for_branch(branch));
+                    records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
+                } else if constexpr (std::is_same_v<
+                                         T, ExecutablePlan::ExecuteDormantMeasurement>) {
+                    const bool branch = sample_dormant_branch();
+                    symbols_[typed.branch] = static_cast<uint8_t>(branch);
+                    records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
+                } else if constexpr (std::is_same_v<T,
+                                                    ExecutablePlan::ExecuteClassicalRecord>) {
+                    records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
+                } else if constexpr (std::is_same_v<
+                                         T, ExecutablePlan::ExecuteSymbolDefinition>) {
+                    symbols_[typed.symbol] = static_cast<uint8_t>(evaluate(typed.value));
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled executable action alternative");
+                }
+            },
+            action);
+    }
+}
+
+bool Executor::evaluate(ExecutablePlan::PreparedExpression expression) const noexcept {
+    assert(static_cast<uint64_t>(expression.term_begin) + expression.term_count <=
+               plan_.expression_terms_.size() &&
+           "prepared affine expression must stay inside term storage");
+    bool value = expression.constant;
+    for (uint32_t i = 0; i < expression.term_count; ++i) {
+        const uint32_t symbol = plan_.expression_terms_[expression.term_begin + i];
+        assert(symbol < symbols_.size() && symbols_[symbol] <= 1 &&
+               "prepared affine term must refer to a Boolean symbol");
+        value ^= symbols_[symbol] != 0;
+    }
+    return value;
+}
+
+bool Executor::sample_active_branch(MeasurementProbabilities probabilities) noexcept {
+    const MeasurementBranchClassification classification =
+        classify_measurement_branch(probabilities);
+    switch (classification.kind) {
+        case MeasurementBranchKind::Random:
+            return rng_.next_double() * probabilities.total() >= probabilities.zero;
+        case MeasurementBranchKind::Zero:
+            dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
+            return false;
+        case MeasurementBranchKind::One:
+            dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
+            return true;
+    }
+    assert(false && "unhandled measurement branch classification");
+    return false;
+}
+
+bool Executor::sample_dormant_branch() noexcept {
+    return rng_.next_double() >= 0.5;
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -1,5 +1,11 @@
 #pragma once
 
+// Executes a backend-neutral SamplingPlan on the CPU without runtime topology
+// work. ExecutablePlan prepares direct-Pauli kernel descriptors and packed
+// affine expressions once; Executor then evaluates per-shot symbols, evolves
+// the active-coordinate coefficient state, samples measurements, and writes
+// records using only preallocated storage.
+
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
 #include "clifft/sampling/state.h"
@@ -14,12 +20,12 @@
 
 namespace clifft::sampling {
 
-// Classifies an active measurement before ordinary sampling or forced replay
-// chooses a branch.
+// Zero and one identify the selected Pauli eigenvalue branch before affine
+// sign corrections turn that branch into a physical measurement record.
 enum class MeasurementBranchKind : uint8_t {
     Random,
-    Zero,
-    One,
+    DeterministicZero,
+    DeterministicOne,
 };
 
 struct MeasurementBranchClassification {
@@ -30,7 +36,7 @@ struct MeasurementBranchClassification {
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept;
 
-// Owns the execution-specific lowering of one validated SamplingPlan. Kernel
+// Owns the CPU lowering of one validated SamplingPlan. Direct-Pauli kernel
 // descriptors and affine-expression term ranges are prepared once here so a
 // shot only reads fixed storage.
 class ExecutablePlan {
@@ -100,17 +106,22 @@ class ExecutablePlan {
     uint32_t num_symbols_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::vector<uint32_t> expression_terms_;
+    // Maps each dense presampled input position to its plan-local SymbolId.
+    // The constructor records those ids in ascending order.
     std::vector<uint32_t> presampled_symbols_;
     std::vector<Action> actions_;
 };
 
-// Holds every mutable value needed to execute repeated shots of one prepared
-// plan. The plan must outlive the executor. Construction allocates all state,
-// symbol, and record storage; run_shot only resets and overwrites it.
+// Holds the dense active-coordinate coefficients and global scalar, Boolean
+// symbols carrying stochastic frame dependencies, visible and hidden records,
+// measurement RNG, and numerical-dust telemetry for repeated shots. The plan
+// must outlive the executor. Construction allocates all storage; run_shot only
+// resets and overwrites it.
 class Executor {
   public:
     explicit Executor(const ExecutablePlan& plan, uint64_t seed = 0);
 
+    // Values correspond to presampled plan symbols in ascending SymbolId order.
     void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;
 
     [[nodiscard]] std::span<const uint8_t> visible_records() const {
@@ -121,6 +132,8 @@ class Executor {
     }
     [[nodiscard]] std::span<const uint8_t> symbols() const { return symbols_; }
     [[nodiscard]] const State& state() const { return state_; }
+    // Counts positive branch probability mass classified as numerical dust.
+    // This telemetry accumulates across shots.
     [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
 
   private:

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "clifft/sampling/kernels.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/state.h"
+#include "clifft/util/xoshiro.h"
+
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <variant>
+#include <vector>
+
+namespace clifft::sampling {
+
+// Classifies an active measurement before ordinary sampling or forced replay
+// chooses a branch.
+enum class MeasurementBranchKind : uint8_t {
+    Random,
+    Zero,
+    One,
+};
+
+struct MeasurementBranchClassification {
+    MeasurementBranchKind kind = MeasurementBranchKind::Random;
+    bool clamped_dust = false;
+};
+
+[[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
+    MeasurementProbabilities probabilities) noexcept;
+
+// Owns the execution-specific lowering of one validated SamplingPlan. Kernel
+// descriptors and affine-expression term ranges are prepared once here so a
+// shot only reads fixed storage.
+class ExecutablePlan {
+  public:
+    explicit ExecutablePlan(const SamplingPlan& plan);
+
+    [[nodiscard]] uint32_t num_visible_records() const { return num_visible_records_; }
+    [[nodiscard]] uint32_t num_hidden_records() const { return num_hidden_records_; }
+    [[nodiscard]] uint32_t num_symbols() const { return num_symbols_; }
+    [[nodiscard]] uint32_t num_presampled_symbols() const {
+        return static_cast<uint32_t>(presampled_symbols_.size());
+    }
+    [[nodiscard]] size_t num_actions() const { return actions_.size(); }
+
+  private:
+    friend class Executor;
+
+    struct PreparedExpression {
+        uint32_t term_begin = 0;
+        uint32_t term_count = 0;
+        bool constant = false;
+    };
+
+    struct ExecuteRotation {
+        PreparedRotation rotation;
+        PreparedExpression sign;
+    };
+
+    struct ExecutePromotion {
+        PreparedPromotion promotion;
+        PreparedExpression sign;
+    };
+
+    struct ExecuteActiveMeasurement {
+        PreparedMeasurement measurement;
+        PreparedExpression outcome;
+        uint32_t branch = 0;
+        uint32_t record = 0;
+    };
+
+    struct ExecuteDormantMeasurement {
+        PreparedExpression outcome;
+        uint32_t branch = 0;
+        uint32_t record = 0;
+    };
+
+    struct ExecuteClassicalRecord {
+        PreparedExpression outcome;
+        uint32_t record = 0;
+    };
+
+    struct ExecuteSymbolDefinition {
+        PreparedExpression value;
+        uint32_t symbol = 0;
+    };
+
+    using Action =
+        std::variant<ExecuteRotation, ExecutePromotion, ExecuteActiveMeasurement,
+                     ExecuteDormantMeasurement, ExecuteClassicalRecord, ExecuteSymbolDefinition>;
+
+    PreparedExpression prepare_expression(const AffineBool& expression);
+
+    uint32_t initial_active_width_ = 0;
+    uint32_t max_active_width_ = 0;
+    uint32_t num_visible_records_ = 0;
+    uint32_t num_hidden_records_ = 0;
+    uint32_t num_symbols_ = 0;
+    std::complex<double> global_weight_ = {1.0, 0.0};
+    std::vector<uint32_t> expression_terms_;
+    std::vector<uint32_t> presampled_symbols_;
+    std::vector<Action> actions_;
+};
+
+// Holds every mutable value needed to execute repeated shots of one prepared
+// plan. The plan must outlive the executor. Construction allocates all state,
+// symbol, and record storage; run_shot only resets and overwrites it.
+class Executor {
+  public:
+    explicit Executor(const ExecutablePlan& plan, uint64_t seed = 0);
+
+    void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;
+
+    [[nodiscard]] std::span<const uint8_t> visible_records() const {
+        return std::span<const uint8_t>(records_).first(plan_.num_visible_records_);
+    }
+    [[nodiscard]] std::span<const uint8_t> hidden_records() const {
+        return std::span<const uint8_t>(records_).subspan(plan_.num_visible_records_);
+    }
+    [[nodiscard]] std::span<const uint8_t> symbols() const { return symbols_; }
+    [[nodiscard]] const State& state() const { return state_; }
+    [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
+
+  private:
+    [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
+    [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
+    [[nodiscard]] bool sample_dormant_branch() noexcept;
+
+    const ExecutablePlan& plan_;
+    State state_;
+    std::vector<uint8_t> symbols_;
+    std::vector<uint8_t> records_;
+    Xoshiro256PlusPlus rng_;
+    uint64_t dust_clamps_ = 0;
+};
+
+}  // namespace clifft::sampling

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(clifft_tests
     test_backend.cc
     test_sampling_plan.cc
     test_sampling_planner.cc
+    test_sampling_executor.cc
     test_sampling_kernels.cc
     test_svm.cc
     test_state_reset.cc

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
@@ -16,6 +17,7 @@
 #include <optional>
 #include <span>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 using clifft::sampling::AffineBool;
@@ -33,6 +35,7 @@ using clifft::sampling::PlannedAction;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RecordSlot;
+using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
 using clifft::sampling::SymbolInfo;
@@ -85,6 +88,27 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
             executor.visible_records(),
             std::span<const uint8_t>(legacy.meas_record).first(legacy_program.num_measurements)));
     }
+}
+
+SamplingPlan plan_from(std::string_view circuit_text) {
+    return clifft::sampling::plan_sampling(clifft::trace(clifft::parse(circuit_text)));
+}
+
+bool has_multi_coordinate_active_measurement(const SamplingPlan& plan) {
+    return std::ranges::any_of(plan.actions, [](const PlannedAction& action) {
+        const auto* measurement = std::get_if<MeasureActivePauli>(&action.action);
+        return measurement != nullptr &&
+               std::popcount(measurement->pauli.x | measurement->pauli.z) > 1;
+    });
+}
+
+bool has_arbitrary_angle_active_rotation(const SamplingPlan& plan, double half_turns) {
+    return std::ranges::any_of(plan.actions, [half_turns](const PlannedAction& action) {
+        if (const auto* rotation = std::get_if<RotateActivePauli>(&action.action)) {
+            return rotation->half_turns == half_turns;
+        }
+        return false;
+    });
 }
 
 }  // namespace
@@ -245,4 +269,16 @@ TEST_CASE("Sampling executor matches legacy records for supported circuits") {
     require_matches_legacy("H 0\nT 0\nM 0\nM 0\n", 64, 3567);
     require_matches_legacy("H 0\nT_DAG 0\nS 0\nM 0\n", 64, 4567);
     require_matches_legacy("H 0\nH 1\nT 0\nT 1\nCX 0 1\nM 0 1\n", 64, 5678);
+
+    constexpr std::string_view kMultiCoordinateX = "H 0\nH 1\nT 0\nT 1\nMPP X0*X1\n";
+    REQUIRE(has_multi_coordinate_active_measurement(plan_from(kMultiCoordinateX)));
+    require_matches_legacy(kMultiCoordinateX, 64, 6789);
+
+    constexpr std::string_view kMultiCoordinateYZ = "H 0\nH 1\nT 0\nT 1\nCX 0 1\nMPP Y0*Z1\n";
+    REQUIRE(has_multi_coordinate_active_measurement(plan_from(kMultiCoordinateYZ)));
+    require_matches_legacy(kMultiCoordinateYZ, 64, 7890);
+
+    constexpr std::string_view kArbitraryRotation = "H 0\nT 0\nR_Z(0.3) 0\nM 0\nM 0\n";
+    REQUIRE(has_arbitrary_angle_active_rotation(plan_from(kArbitraryRotation), 0.3));
+    require_matches_legacy(kArbitraryRotation, 64, 8901);
 }

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -91,15 +91,15 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
 
 TEST_CASE("Sampling executor classifies measurement dust without drawing") {
     const auto zero = classify_measurement_branch(MeasurementProbabilities{1.0, 0.0});
-    REQUIRE(zero.kind == MeasurementBranchKind::Zero);
+    REQUIRE(zero.kind == MeasurementBranchKind::DeterministicZero);
     REQUIRE_FALSE(zero.clamped_dust);
 
     const auto dusty_zero = classify_measurement_branch(MeasurementProbabilities{1.0, 1e-30});
-    REQUIRE(dusty_zero.kind == MeasurementBranchKind::Zero);
+    REQUIRE(dusty_zero.kind == MeasurementBranchKind::DeterministicZero);
     REQUIRE(dusty_zero.clamped_dust);
 
     const auto dusty_one = classify_measurement_branch(MeasurementProbabilities{1e-30, 1.0});
-    REQUIRE(dusty_one.kind == MeasurementBranchKind::One);
+    REQUIRE(dusty_one.kind == MeasurementBranchKind::DeterministicOne);
     REQUIRE(dusty_one.clamped_dust);
 
     const auto random = classify_measurement_branch(MeasurementProbabilities{0.25, 0.75});
@@ -140,6 +140,44 @@ TEST_CASE("Sampling executor evaluates presampled and derived affine symbols") {
     REQUIRE(executor.hidden_records().data() == hidden);
     REQUIRE(executor.symbols().data() == symbols);
     REQUIRE(executor.state().real_data() == real);
+}
+
+TEST_CASE("Sampling executor applies sampled symbols to later state actions") {
+    SamplingPlan plan;
+    plan.num_qubits = 2;
+    plan.max_active_width = 1;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.actions = {
+        PlannedAction{
+            0, 0,
+            MeasureDormantRandom{0, SymbolId{0}, AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
+        PlannedAction{0, 1, PromoteDormantRotation{0.5, AffineBool::symbol(SymbolId{0})}},
+        PlannedAction{
+            1, 1,
+            clifft::sampling::RotateActivePauli{{0, 1}, 0.5, AffineBool::symbol(SymbolId{0})}},
+    };
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, 42);
+    bool saw_zero = false;
+    bool saw_one = false;
+    for (uint32_t shot = 0; shot < 64; ++shot) {
+        executor.run_shot();
+        const bool branch = executor.visible_records()[0] != 0;
+        saw_zero |= !branch;
+        saw_one |= branch;
+        const double expected_imag = branch ? 0.5 : -0.5;
+        for (uint64_t basis = 0; basis < executor.state().size(); ++basis) {
+            CAPTURE(shot, branch, basis);
+            REQUIRE_THAT(executor.state().real_data()[basis],
+                         Catch::Matchers::WithinAbs(0.5, 1e-12));
+            REQUIRE_THAT(executor.state().imag_data()[basis],
+                         Catch::Matchers::WithinAbs(expected_imag, 1e-12));
+        }
+    }
+    REQUIRE(saw_zero);
+    REQUIRE(saw_one);
 }
 
 TEST_CASE("Sampling executor skips RNG for deterministic active measurements") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -5,10 +5,10 @@
 #include "clifft/sampling/planner.h"
 #include "clifft/svm/svm.h"
 
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <algorithm>
 #include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
 #include <complex>
 #include <cstdint>
@@ -52,11 +52,11 @@ SamplingPlan active_then_dormant_plan(double promotion_half_turns) {
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{promotion_half_turns, AffineBool(false)}},
         PlannedAction{1, 0,
-                      MeasureActivePauli{{0, 1}, 0, SymbolId{0},
-                                         AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
-        PlannedAction{0, 0,
-                      MeasureDormantRandom{1, SymbolId{1}, AffineBool::symbol(SymbolId{1}),
-                                           RecordSlot{1}}},
+                      MeasureActivePauli{
+                          {0, 1}, 0, SymbolId{0}, AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
+        PlannedAction{
+            0, 0,
+            MeasureDormantRandom{1, SymbolId{1}, AffineBool::symbol(SymbolId{1}), RecordSlot{1}}},
     };
     return plan;
 }
@@ -81,9 +81,9 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
 
         CAPTURE(circuit_text, shot);
         REQUIRE(executor.visible_records().size() == legacy_program.num_measurements);
-        REQUIRE(std::ranges::equal(executor.visible_records(),
-                                   std::span<const uint8_t>(legacy.meas_record).first(
-                                       legacy_program.num_measurements)));
+        REQUIRE(std::ranges::equal(
+            executor.visible_records(),
+            std::span<const uint8_t>(legacy.meas_record).first(legacy_program.num_measurements)));
     }
 }
 
@@ -115,13 +115,10 @@ TEST_CASE("Sampling executor evaluates presampled and derived affine symbols") {
         SymbolInfo{SymbolKind::Derived, 0, std::nullopt},
     };
     plan.actions = {
-        PlannedAction{0, 0,
-                      DefineSymbol{SymbolId{1},
-                                   AffineBool(true, std::vector<SymbolId>{SymbolId{0}})}},
-        PlannedAction{0, 0,
-                      RecordClassical{AffineBool::symbol(SymbolId{1}), RecordSlot{0}}},
-        PlannedAction{0, 0,
-                      RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{1}}},
+        PlannedAction{
+            0, 0, DefineSymbol{SymbolId{1}, AffineBool(true, std::vector<SymbolId>{SymbolId{0}})}},
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{1}), RecordSlot{0}}},
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{1}}},
     };
 
     const ExecutablePlan executable(plan);

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1,0 +1,213 @@
+#include "clifft/backend/backend.h"
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/sampling/executor.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/svm/svm.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <numbers>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+using clifft::sampling::AffineBool;
+using clifft::sampling::classify_measurement_branch;
+using clifft::sampling::DefineSymbol;
+using clifft::sampling::ExecutablePlan;
+using clifft::sampling::Executor;
+using clifft::sampling::InstrumentBoundary;
+using clifft::sampling::InstrumentSiteId;
+using clifft::sampling::MeasureActivePauli;
+using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::MeasurementBranchKind;
+using clifft::sampling::MeasurementProbabilities;
+using clifft::sampling::PlannedAction;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::RecordSlot;
+using clifft::sampling::SamplingPlan;
+using clifft::sampling::SymbolId;
+using clifft::sampling::SymbolInfo;
+using clifft::sampling::SymbolKind;
+
+namespace {
+
+SamplingPlan active_then_dormant_plan(double promotion_half_turns) {
+    SamplingPlan plan;
+    plan.num_qubits = 2;
+    plan.max_active_width = 1;
+    plan.num_visible_records = 2;
+    plan.symbols = {
+        SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
+        SymbolInfo{SymbolKind::Branch, 2, std::nullopt},
+    };
+    plan.actions = {
+        PlannedAction{0, 1, PromoteDormantRotation{promotion_half_turns, AffineBool(false)}},
+        PlannedAction{1, 0,
+                      MeasureActivePauli{{0, 1}, 0, SymbolId{0},
+                                         AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
+        PlannedAction{0, 0,
+                      MeasureDormantRandom{1, SymbolId{1}, AffineBool::symbol(SymbolId{1}),
+                                           RecordSlot{1}}},
+    };
+    return plan;
+}
+
+void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint64_t seed) {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(circuit_text));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    Executor executor(executable, seed);
+
+    const clifft::CompiledModule legacy_program = clifft::lower(hir);
+    clifft::SchrodingerState legacy({.peak_rank = legacy_program.peak_rank,
+                                     .num_measurements = legacy_program.total_meas_slots,
+                                     .num_qubits = legacy_program.num_qubits,
+                                     .seed = seed});
+
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        if (shot > 0) {
+            legacy.reset();
+        }
+        clifft::execute(legacy_program, legacy);
+        executor.run_shot();
+
+        CAPTURE(circuit_text, shot);
+        REQUIRE(executor.visible_records().size() == legacy_program.num_measurements);
+        REQUIRE(std::ranges::equal(executor.visible_records(),
+                                   std::span<const uint8_t>(legacy.meas_record).first(
+                                       legacy_program.num_measurements)));
+    }
+}
+
+}  // namespace
+
+TEST_CASE("Sampling executor classifies measurement dust without drawing") {
+    const auto zero = classify_measurement_branch(MeasurementProbabilities{1.0, 0.0});
+    REQUIRE(zero.kind == MeasurementBranchKind::Zero);
+    REQUIRE_FALSE(zero.clamped_dust);
+
+    const auto dusty_zero = classify_measurement_branch(MeasurementProbabilities{1.0, 1e-30});
+    REQUIRE(dusty_zero.kind == MeasurementBranchKind::Zero);
+    REQUIRE(dusty_zero.clamped_dust);
+
+    const auto dusty_one = classify_measurement_branch(MeasurementProbabilities{1e-30, 1.0});
+    REQUIRE(dusty_one.kind == MeasurementBranchKind::One);
+    REQUIRE(dusty_one.clamped_dust);
+
+    const auto random = classify_measurement_branch(MeasurementProbabilities{0.25, 0.75});
+    REQUIRE(random.kind == MeasurementBranchKind::Random);
+}
+
+TEST_CASE("Sampling executor evaluates presampled and derived affine symbols") {
+    SamplingPlan plan;
+    plan.num_visible_records = 1;
+    plan.num_hidden_records = 1;
+    plan.symbols = {
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
+        SymbolInfo{SymbolKind::Derived, 0, std::nullopt},
+    };
+    plan.actions = {
+        PlannedAction{0, 0,
+                      DefineSymbol{SymbolId{1},
+                                   AffineBool(true, std::vector<SymbolId>{SymbolId{0}})}},
+        PlannedAction{0, 0,
+                      RecordClassical{AffineBool::symbol(SymbolId{1}), RecordSlot{0}}},
+        PlannedAction{0, 0,
+                      RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{1}}},
+    };
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, 42);
+    executor.run_shot(std::array<uint8_t, 1>{0});
+    REQUIRE(executor.visible_records()[0] == 1);
+    REQUIRE(executor.hidden_records()[0] == 0);
+    REQUIRE(executor.symbols()[1] == 1);
+
+    const uint8_t* const visible = executor.visible_records().data();
+    const uint8_t* const hidden = executor.hidden_records().data();
+    const uint8_t* const symbols = executor.symbols().data();
+    const double* const real = executor.state().real_data();
+    executor.run_shot(std::array<uint8_t, 1>{1});
+    REQUIRE(executor.visible_records()[0] == 0);
+    REQUIRE(executor.hidden_records()[0] == 1);
+    REQUIRE(executor.symbols()[1] == 0);
+    REQUIRE(executor.visible_records().data() == visible);
+    REQUIRE(executor.hidden_records().data() == hidden);
+    REQUIRE(executor.symbols().data() == symbols);
+    REQUIRE(executor.state().real_data() == real);
+}
+
+TEST_CASE("Sampling executor skips RNG for deterministic active measurements") {
+    const ExecutablePlan executable(active_then_dormant_plan(0.0));
+    Executor executor(executable, 456);
+    clifft::Xoshiro256PlusPlus expected_rng(456);
+    const bool expected_dormant_branch = expected_rng.next_double() >= 0.5;
+    const bool branch_if_active_had_drawn = expected_rng.next_double() >= 0.5;
+    REQUIRE(expected_dormant_branch != branch_if_active_had_drawn);
+
+    executor.run_shot();
+
+    REQUIRE(executor.visible_records()[0] == 0);
+    REQUIRE(executor.visible_records()[1] == expected_dormant_branch);
+    REQUIRE(executor.dust_clamps() == 0);
+}
+
+TEST_CASE("Sampling executor clamps positive active measurement dust") {
+    const ExecutablePlan executable(active_then_dormant_plan(1e-10));
+    Executor executor(executable, 456);
+    clifft::Xoshiro256PlusPlus expected_rng(456);
+    const bool expected_dormant_branch = expected_rng.next_double() >= 0.5;
+    const bool branch_if_active_had_drawn = expected_rng.next_double() >= 0.5;
+    REQUIRE(expected_dormant_branch != branch_if_active_had_drawn);
+
+    executor.run_shot();
+
+    REQUIRE(executor.visible_records()[0] == 0);
+    REQUIRE(executor.visible_records()[1] == expected_dormant_branch);
+    REQUIRE(executor.dust_clamps() == 1);
+}
+
+TEST_CASE("Sampling executor retains exact identity rotation scalars") {
+    clifft::HirModule hir(1, 1);
+    hir.append_tgate(false, [](clifft::MutablePauliMaskView slot) {
+        slot.z().bit_set(0, true);
+        slot.set_sign(true);
+    });
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    Executor executor(executable);
+
+    executor.run_shot();
+
+    const std::complex<double> expected{std::cos(std::numbers::pi / 4.0),
+                                        std::sin(std::numbers::pi / 4.0)};
+    REQUIRE_THAT(executor.state().global_scalar().real(),
+                 Catch::Matchers::WithinAbs(expected.real(), 1e-12));
+    REQUIRE_THAT(executor.state().global_scalar().imag(),
+                 Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
+}
+
+TEST_CASE("Sampling executor rejects instrument boundaries before dispatch") {
+    SamplingPlan plan;
+    plan.num_instrument_sites = 1;
+    plan.actions = {PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}}}};
+
+    REQUIRE_THROWS_WITH(ExecutablePlan(plan),
+                        "sampling executable does not yet support instrument boundary site 0");
+}
+
+TEST_CASE("Sampling executor matches legacy records for supported circuits") {
+    require_matches_legacy("M 0\n", 32, 1234);
+    require_matches_legacy("H 0\nM 0\nM 0\n", 64, 2345);
+    require_matches_legacy("H 0\nT 0\nM 0\n", 64, 3456);
+    require_matches_legacy("H 0\nT 0\nM 0\nM 0\n", 64, 3567);
+    require_matches_legacy("H 0\nT_DAG 0\nS 0\nM 0\n", 64, 4567);
+    require_matches_legacy("H 0\nH 1\nT 0\nT 1\nCX 0 1\nM 0 1\n", 64, 5678);
+}


### PR DESCRIPTION
Closes #257.

## Summary

- lower a validated SamplingPlan once into prepared kernel descriptors and flattened affine-expression terms
- add a reusable scalar executor with preallocated coefficient, symbol, and visible/hidden record storage
- keep shot reset, dispatch, affine evaluation, measurement sampling, and kernels allocation- and exception-free
- centralize active-measurement dust classification for reuse by forced replay
- leave the production SVM and WASM playground routing unchanged

## Validation

- exact seeded differential records against the legacy SVM for deterministic, dormant, active, repeated, signed, and multi-coordinate circuits
- focused executor tests: 732 assertions across 7 cases
- native correctness suite excluding opt-in benchmarks: 357155 assertions across 1183 cases
- uv run pre-commit run --all-files