### PR TITLE
ci: speed up cache setup, widen pytest parallelism, harden ccache reuse

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -4,16 +4,17 @@ description: Build Clifft Wasm module via Emscripten with caching
 runs:
   using: composite
   steps:
-    - name: Cache Wasm build
+    - name: Restore Wasm build cache
       id: wasm-cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: build-wasm
         key: wasm-${{ runner.os }}-${{ hashFiles('src/wasm/**', 'src/clifft/**', 'cmake/**', '.github/actions/build-wasm/**') }}
 
     - name: Restore compiler cache
+      id: wasm-ccache
       if: steps.wasm-cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ${{ runner.temp }}/wasm-ccache
         key: wasm-ccache-${{ runner.os }}-${{ github.sha }}
@@ -52,3 +53,19 @@ runs:
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && \
             cmake --build build-wasm -j$(nproc) && \
             ccache -s'
+
+    # Caches saved from PR runs are scoped to the PR ref and cannot be
+    # reused elsewhere; saving only on main limits repo cache eviction.
+    - name: Save compiler cache
+      if: github.ref == 'refs/heads/main' && steps.wasm-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/wasm-ccache
+        key: wasm-ccache-${{ runner.os }}-${{ github.sha }}
+
+    - name: Save Wasm build cache
+      if: github.ref == 'refs/heads/main' && steps.wasm-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: build-wasm
+        key: wasm-${{ runner.os }}-${{ hashFiles('src/wasm/**', 'src/clifft/**', 'cmake/**', '.github/actions/build-wasm/**') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,17 +98,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install ninja
+      - name: Install ninja and ccache
         run: |
           curl -fsSL -o /tmp/ninja-linux.zip \
             https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
           echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  /tmp/ninja-linux.zip" | sha256sum --check
           sudo unzip -o -q /tmp/ninja-linux.zip -d /usr/local/bin
+          curl -fsSL -o /tmp/ccache.tar.xz \
+            https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
+          echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  /tmp/ccache.tar.xz" | sha256sum --check
+          tar -C /tmp -xf /tmp/ccache.tar.xz ccache-4.10.2-linux-x86_64/ccache
+          sudo mv /tmp/ccache-4.10.2-linux-x86_64/ccache /usr/local/bin/ccache
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
+          # Caches saved from PR runs are scoped to the PR ref and cannot be
+          # reused elsewhere; saving only on main limits repo cache eviction.
+          save: ${{ github.ref == 'refs/heads/main' }}
+          evict-old-files: job
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5
@@ -194,12 +203,12 @@ jobs:
         run: uv run python tools/ci/audit_python_exports.py
 
       - name: Run Python tests (default ISA)
-        run: uv run --locked pytest tests/python/ -n auto -v
+        run: uv run --locked pytest tests/python/ -n logical --maxprocesses 4 -v
 
       - name: Run Python tests (scalar ISA)
         env:
           CLIFFT_FORCE_ISA: scalar
-        run: uv run --locked pytest tests/python/ -n auto -v
+        run: uv run --locked pytest tests/python/ -n logical --maxprocesses 4 -v
 
       - name: Test documentation code examples
         run: uv run --locked pytest --codeblocks docs/ README.md -v
@@ -217,12 +226,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build qemu-user
+        run: sudo apt-get update && sudo apt-get install -y ninja-build qemu-user ccache
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
+          # Caches saved from PR runs are scoped to the PR ref and cannot be
+          # reused elsewhere; saving only on main limits repo cache eviction.
+          save: ${{ github.ref == 'refs/heads/main' }}
+          evict-old-files: job
 
       - name: Configure C++ build
         run: |
@@ -310,6 +323,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
+          # Caches saved from PR runs are scoped to the PR ref and cannot be
+          # reused elsewhere; saving only on main limits repo cache eviction.
+          save: ${{ github.ref == 'refs/heads/main' }}
+          evict-old-files: job
 
       - name: Setup uv and Python
         uses: astral-sh/setup-uv@v5
@@ -348,4 +365,4 @@ jobs:
         run: uv run python tools/ci/audit_python_exports.py
 
       - name: Run Python tests
-        run: uv run --locked pytest tests/python/ -n auto -v
+        run: uv run --locked pytest tests/python/ -n logical --maxprocesses 4 -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      # Runner images are rebuilt with fresh file mtimes even when the
+      # compiler is unchanged, so the default mtime-based compiler check
+      # misses across image rollouts; hash the compiler binary instead.
+      CCACHE_COMPILERCHECK: content
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -221,6 +225,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_COMPILERCHECK: content
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -311,6 +316,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_COMPILERCHECK: content
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #254/#255, informed by step-level timing of the post-merge runs. Four changes:

**Pinned ccache install (build-and-test).** The `Setup ccache` step was spending ~19s of its 23s on `apt-get install ccache`; the 301 MB cache download itself takes ~2.5s. The ccache action skips installation when ccache is already on PATH, so build-and-test now installs the pinned 4.10.2 release binary alongside ninja (~1s), and release-cpp-smoke folds `ccache` into its existing apt transaction. Verified on this PR's first run: `Setup ccache` dropped 23s -> 3s.

**`-n logical --maxprocesses 4` for pytest.** With psutil installed, `-n auto` counts *physical* cores -- logs show `created: 2/2 workers` on the 4-vCPU runners. `-n logical` uses all 4, capped explicitly should runner shapes change. A/B on this PR's run: 4/4 workers created, but Linux times were flat (28.7s vs 28.9s baseline) -- hyperthreading buys little for this compute-bound suite. The real target remains the 3-minute Windows pytest step that gates main pushes (5m35s wall); that A/B lands with the first post-merge main run.

**Main-only cache saves + `evict-old-files: job`.** The repo cache is over its 10 GB limit (10.35 GB observed) and GitHub is actively evicting. Caches saved from PR runs are scoped to the PR merge ref and cannot be reused by other PRs or by main, yet each PR run was saving fresh ~300-470 MB ccache entries plus wasm snapshots. PR runs now restore-only (also skipping the ~5s post-job upload); main saves after evicting objects untouched by the job. Caveat: a multi-push PR no longer reuses its own incremental cache -- each push recompiles that PR's delta against main's cache, which is typically small.

**`CCACHE_COMPILERCHECK: content`.** This PR's first run exposed a latent miss mode: it restored the freshest main-saved cache yet built cold (24s -> 1m54s), because the runner had ubuntu-24.04 image `20260720.247.2` while the cache was written on `20260804.265.1` -- GitHub rolls images out gradually, so the fleet is mixed. Both images ship the identical gcc package (`4:13.2.0-7ubuntu1`), but image rebuilds refresh file mtimes and ccache's default compiler check hashes mtime+size, so every lookup missed. Hashing the compiler binary content makes cache reuse survive image rollouts. One-time cost: existing entries are keyed under the mtime check, so each cache key pays one cold rebuild on main before content-checked entries take over.

Deliberately deferred, to be measured separately rather than assumed: ccache `max-size` cap tuning (the Windows cache sits at 99.9% of its 500 MB cap with a 98.65% hit rate, so a blanket cap would hurt), and testing a Release-built Python extension on Windows (trades away Windows-specific Debug-assert coverage; needs an explicit A/B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)