### PR TITLE
feat(sampling): add forced record replay

### DIFF
--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <numbers>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -16,6 +17,8 @@ namespace {
 
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
+
+constexpr double kLogHalf = -std::numbers::ln2;
 
 uint32_t index(SymbolId id) {
     return static_cast<uint32_t>(id);
@@ -230,7 +233,7 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) 
                     bool branch = false;
                     if constexpr (ForceRecords) {
                         branch = (forced_records[typed.record] != 0) ^ correction;
-                        result.log_probability += std::log(0.5);
+                        result.log_probability += kLogHalf;
                     } else {
                         branch = sample_dormant_branch();
                     }

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -72,6 +72,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                     num_expression_terms += typed.sign.terms().size();
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli> ||
                                      std::is_same_v<T, MeasureDormantRandom>) {
+                    // The current measurement branch is stored separately so
+                    // replay can solve for it from the requested record.
                     num_expression_terms += typed.outcome.terms().size() - 1;
                 } else if constexpr (std::is_same_v<T, RecordClassical>) {
                     num_expression_terms += typed.outcome.terms().size();
@@ -209,13 +211,13 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) 
                     bool branch = false;
                     if constexpr (ForceRecords) {
                         branch = (forced_records[typed.record] != 0) ^ correction;
-                        const ForcedBranchResult forced =
+                        const std::optional<double> log_increment =
                             force_active_branch(probabilities, branch);
-                        if (!forced.reachable) {
+                        if (!log_increment.has_value()) {
                             result.reachable = false;
                             return;
                         }
-                        result.log_probability += forced.log_increment;
+                        result.log_probability += *log_increment;
                     } else {
                         branch = sample_active_branch(probabilities);
                     }
@@ -288,21 +290,21 @@ bool Executor::sample_active_branch(MeasurementProbabilities probabilities) noex
     return false;
 }
 
-Executor::ForcedBranchResult Executor::force_active_branch(MeasurementProbabilities probabilities,
-                                                           bool branch) noexcept {
+std::optional<double> Executor::force_active_branch(MeasurementProbabilities probabilities,
+                                                    bool branch) noexcept {
     const MeasurementBranchClassification classification =
         classify_measurement_branch(probabilities);
     dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
     switch (classification.kind) {
         case MeasurementBranchKind::Random:
-            return {true, std::log(probabilities.for_branch(branch) / probabilities.total())};
+            return std::log(probabilities.for_branch(branch) / probabilities.total());
         case MeasurementBranchKind::DeterministicZero:
-            return {!branch, 0.0};
+            return branch ? std::nullopt : std::optional<double>{0.0};
         case MeasurementBranchKind::DeterministicOne:
-            return {branch, 0.0};
+            return branch ? std::optional<double>{0.0} : std::nullopt;
     }
     assert(false && "unhandled measurement branch classification");
-    return {false, 0.0};
+    return std::nullopt;
 }
 
 bool Executor::sample_dormant_branch() noexcept {

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -70,8 +71,9 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                               std::is_same_v<T, PromoteDormantRotation>) {
                     num_expression_terms += typed.sign.terms().size();
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli> ||
-                                     std::is_same_v<T, MeasureDormantRandom> ||
-                                     std::is_same_v<T, RecordClassical>) {
+                                     std::is_same_v<T, MeasureDormantRandom>) {
+                    num_expression_terms += typed.outcome.terms().size() - 1;
+                } else if constexpr (std::is_same_v<T, RecordClassical>) {
                     num_expression_terms += typed.outcome.terms().size();
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                     num_expression_terms += typed.value.terms().size();
@@ -109,12 +111,12 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
                     actions_.emplace_back(ExecuteActiveMeasurement{
                         prepare_measurement(typed.pauli, planned.active_before, typed.active_pivot),
-                        prepare_expression(typed.outcome), index(typed.branch),
-                        index(typed.record)});
+                        prepare_measurement_correction(typed.outcome, index(typed.branch)),
+                        index(typed.branch), index(typed.record)});
                 } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
-                    actions_.emplace_back(
-                        ExecuteDormantMeasurement{prepare_expression(typed.outcome),
-                                                  index(typed.branch), index(typed.record)});
+                    actions_.emplace_back(ExecuteDormantMeasurement{
+                        prepare_measurement_correction(typed.outcome, index(typed.branch)),
+                        index(typed.branch), index(typed.record)});
                 } else if constexpr (std::is_same_v<T, RecordClassical>) {
                     actions_.emplace_back(ExecuteClassicalRecord{prepare_expression(typed.outcome),
                                                                  index(typed.record)});
@@ -142,6 +144,19 @@ ExecutablePlan::PreparedExpression ExecutablePlan::prepare_expression(
     return {begin, static_cast<uint32_t>(expression.terms().size()), expression.constant()};
 }
 
+ExecutablePlan::PreparedExpression ExecutablePlan::prepare_measurement_correction(
+    const AffineBool& outcome, uint32_t branch) {
+    const uint32_t begin = static_cast<uint32_t>(expression_terms_.size());
+    for (SymbolId term : outcome.terms()) {
+        if (index(term) != branch) {
+            expression_terms_.push_back(index(term));
+        }
+    }
+    assert(expression_terms_.size() == static_cast<size_t>(begin) + outcome.terms().size() - 1 &&
+           "validated measurement outcome must contain its branch exactly once");
+    return {begin, static_cast<uint32_t>(outcome.terms().size() - 1), outcome.constant()};
+}
+
 Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
     : plan_(plan),
       state_(plan.max_active_width_, plan.initial_active_width_, plan.global_weight_),
@@ -150,6 +165,21 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       rng_(seed) {}
 
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
+    initialize_shot(presampled_values);
+    (void)execute_actions<false>({});
+}
+
+ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
+                                   std::span<const uint8_t> presampled_values) noexcept {
+    assert(forced_records.size() == records_.size() &&
+           "one forced value is required for every plan record");
+    assert(std::ranges::all_of(forced_records, [](uint8_t value) { return value <= 1; }) &&
+           "forced records must be Boolean");
+    initialize_shot(presampled_values);
+    return execute_actions<true>(forced_records);
+}
+
+void Executor::initialize_shot(std::span<const uint8_t> presampled_values) noexcept {
     assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
            "one value is required for every presampled symbol");
     state_.reset();
@@ -159,7 +189,11 @@ void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
         assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
         symbols_[plan_.presampled_symbols_[i]] = presampled_values[i];
     }
+}
 
+template <bool ForceRecords>
+ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) noexcept {
+    ReplayResult result;
     for (const ExecutablePlan::Action& action : plan_.actions_) {
         std::visit(
             [&](const auto& typed) noexcept {
@@ -171,17 +205,42 @@ void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement>) {
                     const MeasurementProbabilities probabilities =
                         measurement_probabilities(state_, typed.measurement);
-                    const bool branch = sample_active_branch(probabilities);
+                    const bool correction = evaluate(typed.correction);
+                    bool branch = false;
+                    if constexpr (ForceRecords) {
+                        branch = (forced_records[typed.record] != 0) ^ correction;
+                        const ForcedBranchResult forced =
+                            force_active_branch(probabilities, branch);
+                        if (!forced.reachable) {
+                            result.reachable = false;
+                            return;
+                        }
+                        result.log_probability += forced.log_increment;
+                    } else {
+                        branch = sample_active_branch(probabilities);
+                    }
                     symbols_[typed.branch] = static_cast<uint8_t>(branch);
                     collapse_measurement(state_, typed.measurement, branch,
                                          probabilities.for_branch(branch));
-                    records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
+                    records_[typed.record] = static_cast<uint8_t>(branch ^ correction);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDormantMeasurement>) {
-                    const bool branch = sample_dormant_branch();
+                    const bool correction = evaluate(typed.correction);
+                    bool branch = false;
+                    if constexpr (ForceRecords) {
+                        branch = (forced_records[typed.record] != 0) ^ correction;
+                        result.log_probability += std::log(0.5);
+                    } else {
+                        branch = sample_dormant_branch();
+                    }
                     symbols_[typed.branch] = static_cast<uint8_t>(branch);
-                    records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
+                    records_[typed.record] = static_cast<uint8_t>(branch ^ correction);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
                     records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
+                    if constexpr (ForceRecords) {
+                        if (records_[typed.record] != forced_records[typed.record]) {
+                            result.reachable = false;
+                        }
+                    }
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteSymbolDefinition>) {
                     symbols_[typed.symbol] = static_cast<uint8_t>(evaluate(typed.value));
                 } else {
@@ -189,7 +248,13 @@ void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
                 }
             },
             action);
+        if constexpr (ForceRecords) {
+            if (!result.reachable) {
+                return result;
+            }
+        }
     }
+    return result;
 }
 
 bool Executor::evaluate(ExecutablePlan::PreparedExpression expression) const noexcept {
@@ -221,6 +286,23 @@ bool Executor::sample_active_branch(MeasurementProbabilities probabilities) noex
     }
     assert(false && "unhandled measurement branch classification");
     return false;
+}
+
+Executor::ForcedBranchResult Executor::force_active_branch(MeasurementProbabilities probabilities,
+                                                           bool branch) noexcept {
+    const MeasurementBranchClassification classification =
+        classify_measurement_branch(probabilities);
+    dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
+    switch (classification.kind) {
+        case MeasurementBranchKind::Random:
+            return {true, std::log(probabilities.for_branch(branch) / probabilities.total())};
+        case MeasurementBranchKind::DeterministicZero:
+            return {!branch, 0.0};
+        case MeasurementBranchKind::DeterministicOne:
+            return {branch, 0.0};
+    }
+    assert(false && "unhandled measurement branch classification");
+    return {false, 0.0};
 }
 
 bool Executor::sample_dormant_branch() noexcept {

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -14,6 +14,7 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <variant>
 #include <vector>
@@ -33,9 +34,10 @@ struct MeasurementBranchClassification {
     bool clamped_dust = false;
 };
 
+// Describes whether a requested record can occur and, if so, its conditional
+// joint log probability. The probability is meaningful only when reachable.
 struct ReplayResult {
     bool reachable = true;
-    // Meaningful only when reachable is true.
     double log_probability = 0.0;
 };
 
@@ -78,9 +80,10 @@ class ExecutablePlan {
 
     struct ExecuteActiveMeasurement {
         PreparedMeasurement measurement;
-        // The physical record is branch XOR this expression. Removing the
-        // newly defined branch at preparation time lets replay invert that
-        // relation without runtime dependency discovery.
+        // The physical record is the raw measurement branch XOR this
+        // correction. The correction contains the known sign flips from
+        // earlier stochastic events, so replay can recover the raw branch
+        // needed to produce a requested record.
         PreparedExpression correction;
         uint32_t branch = 0;
         uint32_t record = 0;
@@ -134,9 +137,12 @@ class Executor {
     // Values correspond to presampled plan symbols in ascending SymbolId order.
     void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;
 
-    // Forces one Boolean value for every plan record slot, ordered as visible
-    // records followed by hidden records. The reported probability is
-    // conditional on any supplied presampled symbols. Replay consumes no RNG.
+    // Replays the plan while forcing each record to a supplied Boolean value.
+    // This reconstructs the corresponding branch state and computes its joint
+    // log probability, enabling differential validation and exact record
+    // probability queries. Records are ordered as visible followed by hidden;
+    // the probability is conditional on supplied presampled symbols. Replay
+    // consumes no RNG.
     [[nodiscard]] ReplayResult replay_shot(
         std::span<const uint8_t> forced_records,
         std::span<const uint8_t> presampled_values = {}) noexcept;
@@ -154,11 +160,6 @@ class Executor {
     [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
 
   private:
-    struct ForcedBranchResult {
-        bool reachable = true;
-        double log_increment = 0.0;
-    };
-
     void initialize_shot(std::span<const uint8_t> presampled_values) noexcept;
 
     template <bool ForceRecords>
@@ -166,8 +167,8 @@ class Executor {
 
     [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
     [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
-    [[nodiscard]] ForcedBranchResult force_active_branch(MeasurementProbabilities probabilities,
-                                                         bool branch) noexcept;
+    [[nodiscard]] std::optional<double> force_active_branch(MeasurementProbabilities probabilities,
+                                                            bool branch) noexcept;
     [[nodiscard]] bool sample_dormant_branch() noexcept;
 
     const ExecutablePlan& plan_;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -142,7 +142,8 @@ class Executor {
     // log probability, enabling differential validation and exact record
     // probability queries. Records are ordered as visible followed by hidden;
     // the probability is conditional on supplied presampled symbols. Replay
-    // consumes no RNG.
+    // consumes no RNG. After an unreachable result, state and record accessors
+    // expose only the executed prefix, not completed-shot output.
     [[nodiscard]] ReplayResult replay_shot(
         std::span<const uint8_t> forced_records,
         std::span<const uint8_t> presampled_values = {}) noexcept;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -33,6 +33,12 @@ struct MeasurementBranchClassification {
     bool clamped_dust = false;
 };
 
+struct ReplayResult {
+    bool reachable = true;
+    // Meaningful only when reachable is true.
+    double log_probability = 0.0;
+};
+
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept;
 
@@ -72,13 +78,16 @@ class ExecutablePlan {
 
     struct ExecuteActiveMeasurement {
         PreparedMeasurement measurement;
-        PreparedExpression outcome;
+        // The physical record is branch XOR this expression. Removing the
+        // newly defined branch at preparation time lets replay invert that
+        // relation without runtime dependency discovery.
+        PreparedExpression correction;
         uint32_t branch = 0;
         uint32_t record = 0;
     };
 
     struct ExecuteDormantMeasurement {
-        PreparedExpression outcome;
+        PreparedExpression correction;
         uint32_t branch = 0;
         uint32_t record = 0;
     };
@@ -98,6 +107,7 @@ class ExecutablePlan {
                      ExecuteDormantMeasurement, ExecuteClassicalRecord, ExecuteSymbolDefinition>;
 
     PreparedExpression prepare_expression(const AffineBool& expression);
+    PreparedExpression prepare_measurement_correction(const AffineBool& outcome, uint32_t branch);
 
     uint32_t initial_active_width_ = 0;
     uint32_t max_active_width_ = 0;
@@ -124,6 +134,13 @@ class Executor {
     // Values correspond to presampled plan symbols in ascending SymbolId order.
     void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;
 
+    // Forces one Boolean value for every plan record slot, ordered as visible
+    // records followed by hidden records. The reported probability is
+    // conditional on any supplied presampled symbols. Replay consumes no RNG.
+    [[nodiscard]] ReplayResult replay_shot(
+        std::span<const uint8_t> forced_records,
+        std::span<const uint8_t> presampled_values = {}) noexcept;
+
     [[nodiscard]] std::span<const uint8_t> visible_records() const {
         return std::span<const uint8_t>(records_).first(plan_.num_visible_records_);
     }
@@ -137,8 +154,20 @@ class Executor {
     [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
 
   private:
+    struct ForcedBranchResult {
+        bool reachable = true;
+        double log_increment = 0.0;
+    };
+
+    void initialize_shot(std::span<const uint8_t> presampled_values) noexcept;
+
+    template <bool ForceRecords>
+    [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records) noexcept;
+
     [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
     [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
+    [[nodiscard]] ForcedBranchResult force_active_branch(MeasurementProbabilities probabilities,
+                                                         bool branch) noexcept;
     [[nodiscard]] bool sample_dormant_branch() noexcept;
 
     const ExecutablePlan& plan_;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -35,6 +35,7 @@ using clifft::sampling::PlannedAction;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RecordSlot;
+using clifft::sampling::ReplayResult;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
@@ -87,6 +88,35 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
         REQUIRE(std::ranges::equal(
             executor.visible_records(),
             std::span<const uint8_t>(legacy.meas_record).first(legacy_program.num_measurements)));
+    }
+}
+
+void require_replay_matches_legacy(std::string_view circuit_text,
+                                   std::span<const uint8_t> forced_records, size_t num_records) {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(circuit_text));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    REQUIRE(executable.num_hidden_records() == 0);
+    REQUIRE(executable.num_visible_records() > 0);
+    REQUIRE(forced_records.size() == num_records * executable.num_visible_records());
+
+    const clifft::CompiledModule legacy_program = clifft::lower(hir);
+    const std::vector<double> legacy =
+        clifft::record_probabilities(legacy_program, forced_records, num_records);
+    REQUIRE(legacy.size() == num_records);
+
+    Executor executor(executable);
+    const size_t stride = executable.num_visible_records();
+    for (size_t i = 0; i < num_records; ++i) {
+        const std::span<const uint8_t> record = forced_records.subspan(i * stride, stride);
+        const ReplayResult replay = executor.replay_shot(record);
+        CAPTURE(circuit_text, i, record);
+        if (legacy[i] == clifft::kUnreachableLogProb) {
+            REQUIRE_FALSE(replay.reachable);
+        } else {
+            REQUIRE(replay.reachable);
+            REQUIRE_THAT(replay.log_probability, Catch::Matchers::WithinAbs(legacy[i], 1e-12));
+            REQUIRE(std::ranges::equal(executor.visible_records(), record));
+        }
     }
 }
 
@@ -204,6 +234,115 @@ TEST_CASE("Sampling executor applies sampled symbols to later state actions") {
     REQUIRE(saw_one);
 }
 
+TEST_CASE("Sampling replay inverts affine records and preserves branch dependencies") {
+    SamplingPlan plan;
+    plan.num_qubits = 2;
+    plan.max_active_width = 1;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.actions = {
+        PlannedAction{
+            0, 0,
+            MeasureDormantRandom{0, SymbolId{0}, AffineBool(true, {SymbolId{0}}), RecordSlot{0}}},
+        PlannedAction{0, 1, PromoteDormantRotation{0.5, AffineBool::symbol(SymbolId{0})}},
+        PlannedAction{1, 1, RotateActivePauli{{0, 1}, 0.5, AffineBool::symbol(SymbolId{0})}},
+    };
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable);
+    for (uint8_t forced_record : {uint8_t{0}, uint8_t{1}}) {
+        const ReplayResult replay = executor.replay_shot(std::array<uint8_t, 1>{forced_record});
+        const bool branch = forced_record == 0;
+        CAPTURE(forced_record, branch);
+        REQUIRE(replay.reachable);
+        REQUIRE_THAT(replay.log_probability, Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
+        REQUIRE(executor.visible_records()[0] == forced_record);
+        REQUIRE(executor.symbols()[0] == branch);
+        const double expected_imag = branch ? 0.5 : -0.5;
+        for (uint64_t basis = 0; basis < executor.state().size(); ++basis) {
+            REQUIRE_THAT(executor.state().real_data()[basis],
+                         Catch::Matchers::WithinAbs(0.5, 1e-12));
+            REQUIRE_THAT(executor.state().imag_data()[basis],
+                         Catch::Matchers::WithinAbs(expected_imag, 1e-12));
+        }
+    }
+    for (uint32_t shot = 0; shot < 16; ++shot) {
+        executor.run_shot();
+        REQUIRE(executor.visible_records()[0] == (executor.symbols()[0] ^ 1U));
+    }
+}
+
+TEST_CASE("Sampling replay checks all records conditional on presampled symbols") {
+    SamplingPlan plan;
+    plan.num_visible_records = 1;
+    plan.num_hidden_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.actions = {
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
+        PlannedAction{0, 0, RecordClassical{AffineBool(true), RecordSlot{1}}},
+    };
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable);
+    const ReplayResult matching =
+        executor.replay_shot(std::array<uint8_t, 2>{1, 1}, std::array<uint8_t, 1>{1});
+    REQUIRE(matching.reachable);
+    REQUIRE(matching.log_probability == 0.0);
+    REQUIRE(executor.visible_records()[0] == 1);
+    REQUIRE(executor.hidden_records()[0] == 1);
+
+    const ReplayResult mismatching =
+        executor.replay_shot(std::array<uint8_t, 2>{0, 1}, std::array<uint8_t, 1>{1});
+    REQUIRE_FALSE(mismatching.reachable);
+    REQUIRE(executor.visible_records()[0] == 1);
+    // The hidden write follows the inconsistent visible record and is skipped.
+    REQUIRE(executor.hidden_records()[0] == 0);
+}
+
+TEST_CASE("Sampling replay applies active measurement dust policy") {
+    const ExecutablePlan dusty(active_then_dormant_plan(1e-10));
+    Executor survivor(dusty);
+    const ReplayResult survivor_result = survivor.replay_shot(std::array<uint8_t, 2>{0, 1});
+    REQUIRE(survivor_result.reachable);
+    REQUIRE_THAT(survivor_result.log_probability, Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
+    REQUIRE(survivor.dust_clamps() == 1);
+
+    Executor dust_branch(dusty);
+    const ReplayResult dust_result = dust_branch.replay_shot(std::array<uint8_t, 2>{1, 0});
+    REQUIRE_FALSE(dust_result.reachable);
+    REQUIRE(dust_branch.dust_clamps() == 1);
+
+    const ExecutablePlan exact(active_then_dormant_plan(0.0));
+    Executor impossible_exact(exact);
+    const ReplayResult exact_result = impossible_exact.replay_shot(std::array<uint8_t, 2>{1, 0});
+    REQUIRE_FALSE(exact_result.reachable);
+    REQUIRE(impossible_exact.dust_clamps() == 0);
+}
+
+TEST_CASE("Sampling replay accumulates active and dormant log probabilities") {
+    SamplingPlan plan = active_then_dormant_plan(0.5);
+    std::get<MeasureActivePauli>(plan.actions[1].action).outcome ^= true;
+    const ExecutablePlan executable(plan);
+    Executor executor(executable);
+    const ReplayResult replay = executor.replay_shot(std::array<uint8_t, 2>{0, 1});
+    REQUIRE(replay.reachable);
+    REQUIRE_THAT(replay.log_probability, Catch::Matchers::WithinAbs(std::log(0.25), 1e-15));
+    REQUIRE(executor.symbols()[0] == 1);
+    REQUIRE(executor.visible_records()[0] == 0);
+}
+
+TEST_CASE("Sampling replay does not advance measurement RNG") {
+    const ExecutablePlan executable(active_then_dormant_plan(0.0));
+    Executor executor(executable, 456);
+    const ReplayResult replay = executor.replay_shot(std::array<uint8_t, 2>{0, 1});
+    REQUIRE(replay.reachable);
+
+    clifft::Xoshiro256PlusPlus expected_rng(456);
+    const bool expected_dormant_branch = expected_rng.next_double() >= 0.5;
+    executor.run_shot();
+    REQUIRE(executor.visible_records()[1] == expected_dormant_branch);
+}
+
 TEST_CASE("Sampling executor skips RNG for deterministic active measurements") {
     const ExecutablePlan executable(active_then_dormant_plan(0.0));
     Executor executor(executable, 456);
@@ -281,4 +420,35 @@ TEST_CASE("Sampling executor matches legacy records for supported circuits") {
     constexpr std::string_view kArbitraryRotation = "H 0\nT 0\nR_Z(0.3) 0\nM 0\nM 0\n";
     REQUIRE(has_arbitrary_angle_active_rotation(plan_from(kArbitraryRotation), 0.3));
     require_matches_legacy(kArbitraryRotation, 64, 8901);
+}
+
+TEST_CASE("Sampling replay matches legacy record probabilities") {
+    require_replay_matches_legacy("H 0\nM 0\nM 0\n", std::array<uint8_t, 4>{0, 0, 0, 1}, 2);
+    require_replay_matches_legacy("H 0\nM 0\nM 0\n", std::array<uint8_t, 4>{1, 0, 1, 1}, 2);
+    require_replay_matches_legacy("H 0\nT 0\nR_Z(0.3) 0\nM 0\n", std::array<uint8_t, 2>{0, 1}, 2);
+    require_replay_matches_legacy("H 0\nH 1\nT 0\nT 1\nCX 0 1\nMPP Y0*Z1\n",
+                                  std::array<uint8_t, 2>{0, 1}, 2);
+    require_replay_matches_legacy("H 0\nCX 0 1\nM 0 1\n",
+                                  std::array<uint8_t, 8>{0, 0, 0, 1, 1, 0, 1, 1}, 4);
+}
+
+TEST_CASE("Sampling replay probabilities normalize for a small active circuit") {
+    constexpr std::string_view kCircuit = "H 0\nH 1\nT 0\nT 1\nCX 0 1\nMPP Y0*Z1\nM 0\n";
+    const ExecutablePlan executable(plan_from(kCircuit));
+    REQUIRE(executable.num_visible_records() == 2);
+    Executor executor(executable);
+
+    double total = 0.0;
+    uint32_t reachable = 0;
+    for (uint8_t first : {uint8_t{0}, uint8_t{1}}) {
+        for (uint8_t second : {uint8_t{0}, uint8_t{1}}) {
+            const ReplayResult replay = executor.replay_shot(std::array<uint8_t, 2>{first, second});
+            if (replay.reachable) {
+                total += std::exp(replay.log_probability);
+                ++reachable;
+            }
+        }
+    }
+    REQUIRE(reachable >= 2);
+    REQUIRE_THAT(total, Catch::Matchers::WithinAbs(1.0, 1e-12));
 }


### PR DESCRIPTION
Closes #260.

Parent tracker: #247
Architecture discussion: #236

## Summary

- lower measurement outcomes to branch-free affine corrections during executable-plan preparation
- add allocation-free, exception-free forced replay for visible and hidden records without consuming RNG
- preserve the active-measurement dust policy and report conditional joint log probabilities
- compile sampling and replay as separate template specializations so ordinary sampling has no runtime replay-mode branch

## Validation

- differential replay probabilities and reachability against the legacy SVM for repeated measurements, arbitrary-angle rotations, multi-coordinate MPP, and entangled records
- active/dormant probability accumulation, affine branch inversion, deterministic mismatch, dust, and RNG-preservation tests
- small record-space normalization check
- full native non-benchmark suite: 1,191 cases and 357,905 assertions
- focused release-build replay tests
- pre-commit hooks