### PR TITLE
feat(sampling): expose experimental Python backend

### DIFF
--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -24,6 +24,20 @@
 
 ::: clifft.sample_k_survivors
 
+## Symbolic Sampling Backend (experimental)
+
+This explicit opt-in surface exercises the new scalar symbolic-coordinate
+backend without changing the default `clifft.compile` and `clifft.sample`
+pipeline. It currently accepts noiseless rotations and measurements only.
+
+::: clifft.experimental.compile
+
+::: clifft.experimental.sample
+
+::: clifft.experimental.record_probabilities
+
+::: clifft.experimental.Program
+
 ## Leakage and Loss (experimental)
 
 Sampling under a five-level leakage/loss model. See the

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -24,20 +24,6 @@
 
 ::: clifft.sample_k_survivors
 
-## Symbolic Sampling Backend (experimental)
-
-This explicit opt-in surface exercises the new scalar symbolic-coordinate
-backend without changing the default `clifft.compile` and `clifft.sample`
-pipeline. It currently accepts noiseless rotations and measurements only.
-
-::: clifft.experimental.compile
-
-::: clifft.experimental.sample
-
-::: clifft.experimental.record_probabilities
-
-::: clifft.experimental.Program
-
 ## Leakage and Loss (experimental)
 
 Sampling under a five-level leakage/loss model. See the

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -170,10 +170,6 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
       rng_(seed) {}
 
-Executor::Executor(const ExecutablePlan& plan, std::nullopt_t) : Executor(plan, uint64_t{0}) {
-    rng_.seed_from_entropy();
-}
-
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
     initialize_shot(presampled_values);
     (void)execute_actions<false>({});
@@ -344,7 +340,8 @@ std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
         Executor executor(plan, *seed);
         run(executor);
     } else {
-        Executor executor(plan, std::nullopt);
+        Executor executor(plan);
+        executor.reseed_from_entropy();
         run(executor);
     }
     return records;

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -321,6 +321,10 @@ bool Executor::sample_dormant_branch() noexcept {
 
 std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
                                     std::optional<uint64_t> seed) {
+    if (plan.num_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "batch sampling does not yet support plans with presampled symbols");
+    }
     const size_t stride = plan.num_visible_records();
     if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
         throw std::length_error("sampling output size exceeds size_t range");
@@ -349,6 +353,10 @@ std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
 std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
                                              std::span<const uint8_t> forced_records,
                                              size_t num_records) {
+    if (plan.num_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "record probabilities do not yet support plans with presampled symbols");
+    }
     if (plan.num_hidden_records() != 0) {
         throw std::invalid_argument(
             "record probabilities do not yet support plans with hidden records");

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -54,7 +54,8 @@ MeasurementBranchClassification classify_measurement_branch(
 }
 
 ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
-    : initial_active_width_(plan.initial_active_width),
+    : num_qubits_(plan.num_qubits),
+      initial_active_width_(plan.initial_active_width),
       max_active_width_(plan.max_active_width),
       num_visible_records_(plan.num_visible_records),
       num_hidden_records_(plan.num_hidden_records),
@@ -168,6 +169,10 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       symbols_(plan.num_symbols_, 0),
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
       rng_(seed) {}
+
+Executor::Executor(const ExecutablePlan& plan, std::nullopt_t) : Executor(plan, uint64_t{0}) {
+    rng_.seed_from_entropy();
+}
 
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
     initialize_shot(presampled_values);
@@ -312,6 +317,65 @@ std::optional<double> Executor::force_active_branch(MeasurementProbabilities pro
 
 bool Executor::sample_dormant_branch() noexcept {
     return rng_.next_double() >= 0.5;
+}
+
+std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
+                                    std::optional<uint64_t> seed) {
+    const size_t stride = plan.num_visible_records();
+    if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
+        throw std::length_error("sampling output size exceeds size_t range");
+    }
+    std::vector<uint8_t> records(static_cast<size_t>(shots) * stride);
+    if (shots == 0) {
+        return records;
+    }
+
+    auto run = [&](Executor& executor) {
+        for (uint32_t shot = 0; shot < shots; ++shot) {
+            executor.run_shot();
+            std::ranges::copy(executor.visible_records(), records.begin() + shot * stride);
+        }
+    };
+    if (seed.has_value()) {
+        Executor executor(plan, *seed);
+        run(executor);
+    } else {
+        Executor executor(plan, std::nullopt);
+        run(executor);
+    }
+    return records;
+}
+
+std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
+                                             std::span<const uint8_t> forced_records,
+                                             size_t num_records) {
+    if (plan.num_hidden_records() != 0) {
+        throw std::invalid_argument(
+            "record probabilities do not yet support plans with hidden records");
+    }
+    const size_t stride = plan.num_visible_records();
+    if (stride == 0) {
+        throw std::invalid_argument(
+            "record probabilities require a plan with at least one visible record");
+    }
+    if (num_records > std::numeric_limits<size_t>::max() / stride ||
+        forced_records.size() != num_records * stride) {
+        throw std::invalid_argument(
+            "record buffer length must equal num_records times visible records");
+    }
+    if (!std::ranges::all_of(forced_records, [](uint8_t value) { return value <= 1; })) {
+        throw std::invalid_argument("record bytes must be Boolean");
+    }
+
+    std::vector<double> log_probabilities(num_records);
+    Executor executor(plan);
+    for (size_t record = 0; record < num_records; ++record) {
+        const ReplayResult replay =
+            executor.replay_shot(forced_records.subspan(record * stride, stride));
+        log_probabilities[record] =
+            replay.reachable ? replay.log_probability : std::numeric_limits<double>::lowest();
+    }
+    return log_probabilities;
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -185,14 +185,16 @@ class Executor {
 
 // Samples a fixed number of shots into row-major visible-record storage. The
 // plan and executor are prepared once, and all output is allocated before the
-// first shot enters hot execution.
+// first shot enters hot execution. Plans with presampled symbols are rejected
+// until their sampling distribution is part of the executable contract.
 [[nodiscard]] std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
                                                   std::optional<uint64_t> seed = std::nullopt);
 
 // Replays each row-major visible record and returns its joint log probability.
 // Unreachable records map to the lowest finite double because release builds
-// assume finite arithmetic. Plans with hidden records are rejected because
-// this API does not yet marginalize over hidden outcomes.
+// assume finite arithmetic. Plans with presampled symbols or hidden records
+// are rejected because this API does not yet marginalize over either source
+// of hidden stochastic state.
 [[nodiscard]] std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
                                                            std::span<const uint8_t> forced_records,
                                                            size_t num_records);

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -51,6 +51,7 @@ class ExecutablePlan {
   public:
     explicit ExecutablePlan(const SamplingPlan& plan);
 
+    [[nodiscard]] uint32_t num_qubits() const { return num_qubits_; }
     [[nodiscard]] uint32_t num_visible_records() const { return num_visible_records_; }
     [[nodiscard]] uint32_t num_hidden_records() const { return num_hidden_records_; }
     [[nodiscard]] uint32_t num_symbols() const { return num_symbols_; }
@@ -112,6 +113,7 @@ class ExecutablePlan {
     PreparedExpression prepare_expression(const AffineBool& expression);
     PreparedExpression prepare_measurement_correction(const AffineBool& outcome, uint32_t branch);
 
+    uint32_t num_qubits_ = 0;
     uint32_t initial_active_width_ = 0;
     uint32_t max_active_width_ = 0;
     uint32_t num_visible_records_ = 0;
@@ -133,6 +135,7 @@ class ExecutablePlan {
 class Executor {
   public:
     explicit Executor(const ExecutablePlan& plan, uint64_t seed = 0);
+    Executor(const ExecutablePlan& plan, std::nullopt_t);
 
     // Values correspond to presampled plan symbols in ascending SymbolId order.
     void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;
@@ -179,5 +182,19 @@ class Executor {
     Xoshiro256PlusPlus rng_;
     uint64_t dust_clamps_ = 0;
 };
+
+// Samples a fixed number of shots into row-major visible-record storage. The
+// plan and executor are prepared once, and all output is allocated before the
+// first shot enters hot execution.
+[[nodiscard]] std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
+                                                  std::optional<uint64_t> seed = std::nullopt);
+
+// Replays each row-major visible record and returns its joint log probability.
+// Unreachable records map to the lowest finite double because release builds
+// assume finite arithmetic. Plans with hidden records are rejected because
+// this API does not yet marginalize over hidden outcomes.
+[[nodiscard]] std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
+                                                           std::span<const uint8_t> forced_records,
+                                                           size_t num_records);
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -135,7 +135,9 @@ class ExecutablePlan {
 class Executor {
   public:
     explicit Executor(const ExecutablePlan& plan, uint64_t seed = 0);
-    Executor(const ExecutablePlan& plan, std::nullopt_t);
+
+    // Replace the deterministic seed with OS entropy before executing shots.
+    void reseed_from_entropy() { rng_.seed_from_entropy(); }
 
     // Values correspond to presampled plan symbols in ascending SymbolId order.
     void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -20,6 +20,8 @@
 #include "clifft/optimizer/statevector_squeeze_pass.h"
 #include "clifft/optimizer/swap_meas_pass.h"
 #include "clifft/optimizer/tile_axis_fusion_pass.h"
+#include "clifft/sampling/executor.h"
+#include "clifft/sampling/planner.h"
 #include "clifft/svm/svm.h"
 #include "clifft/util/config.h"
 #include "clifft/util/introspection.h"
@@ -891,6 +893,61 @@ NB_MODULE(_clifft_core, m) {
                    " instructions, peak_rank=" + std::to_string(p.peak_rank) + ", " +
                    std::to_string(p.num_measurements) + " measurements)";
         });
+
+    nb::class_<clifft::sampling::ExecutablePlan>(m, "_ExperimentalSamplingProgram")
+        .def_prop_ro("num_qubits", &clifft::sampling::ExecutablePlan::num_qubits)
+        .def_prop_ro("num_measurements", &clifft::sampling::ExecutablePlan::num_visible_records)
+        .def_prop_ro("num_hidden_measurements",
+                     &clifft::sampling::ExecutablePlan::num_hidden_records)
+        .def_prop_ro("num_actions", &clifft::sampling::ExecutablePlan::num_actions)
+        .def("__repr__", [](const clifft::sampling::ExecutablePlan& p) {
+            return "ExperimentalSamplingProgram(" + std::to_string(p.num_actions()) + " actions, " +
+                   std::to_string(p.num_visible_records()) + " measurements)";
+        });
+
+    m.def(
+        "_compile_experimental_sampling",
+        [](const std::string& stim_text, clifft::HirPassManager* hir_passes) {
+            nb::gil_scoped_release release;
+            clifft::HirModule hir = clifft::trace(clifft::parse(stim_text));
+            if (hir_passes != nullptr) {
+                hir_passes->run(hir);
+            }
+            return clifft::sampling::ExecutablePlan(clifft::sampling::plan_sampling(hir));
+        },
+        nb::arg("stim_text"), nb::arg("hir_passes") = nb::none(),
+        "Compile a circuit into the experimental scalar sampling backend.");
+
+    m.def(
+        "_sample_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
+           std::optional<uint64_t> seed) {
+            std::vector<uint8_t> records;
+            {
+                nb::gil_scoped_release release;
+                records = clifft::sampling::sample_records(program, shots, seed);
+            }
+            return vec_to_numpy(std::move(records), {shots, program.num_visible_records()});
+        },
+        nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
+        "Sample an experimental scalar sampling program.");
+
+    m.def(
+        "_record_probabilities_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program,
+           nb::ndarray<nb::numpy, const uint8_t, nb::shape<-1, -1>, nb::c_contig> records) {
+            std::vector<double> log_probabilities;
+            {
+                nb::gil_scoped_release release;
+                log_probabilities = clifft::sampling::record_log_probabilities(
+                    program, std::span<const uint8_t>(records.data(), records.size()),
+                    records.shape(0));
+            }
+            const size_t size = log_probabilities.size();
+            return vec_to_numpy(std::move(log_probabilities), {size});
+        },
+        nb::arg("program"), nb::arg("records"),
+        "Return experimental scalar sampling record log probabilities.");
 
     m.def(
         "lower",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -11,7 +11,7 @@ rather than the full Hilbert space.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TypeAlias, cast
+from typing import Protocol, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -110,6 +110,11 @@ from clifft._sample_result import SampleResult
 
 BasisBitstrings: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
 MeasurementRecords: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
+
+
+class _MeasurementProgram(Protocol):
+    @property
+    def num_measurements(self) -> int: ...
 
 
 def _basis_masks_from_bitstrings(
@@ -220,7 +225,7 @@ def basis_probabilities(
 
 
 def _records_from_outcomes(
-    program: Program,
+    program: _MeasurementProgram,
     records: MeasurementRecords,
 ) -> npt.NDArray[np.uint8]:
     """Convert string or array measurement records into a 2D uint8 array.

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -1,0 +1,80 @@
+"""Explicitly selected experimental Clifft APIs.
+
+The interfaces in this module may change between releases. They provide an
+early validation surface for backends that are not yet used by the default
+``clifft.compile`` and ``clifft.sample`` pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import TypeAlias, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from clifft import MeasurementRecords, _records_from_outcomes
+from clifft._clifft_core import (
+    HirPassManager,
+    _compile_experimental_sampling,
+    _ExperimentalSamplingProgram,
+    _record_probabilities_experimental_sampling,
+    _sample_experimental_sampling,
+    default_hir_pass_manager,
+)
+from clifft._sample_result import SampleResult
+
+Program: TypeAlias = _ExperimentalSamplingProgram
+
+
+class _DefaultPasses:
+    """Sentinel marker for the experimental compiler's default HIR passes."""
+
+
+_DEFAULT_PASSES = _DefaultPasses()
+
+
+def compile(
+    stim_text: str,
+    *,
+    hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+) -> Program:
+    """Compile Stim text for the experimental scalar sampling backend.
+
+    Only the currently implemented noiseless rotation-and-measurement subset
+    is accepted. Unsupported operations fail during compilation. The default
+    HIR optimization pipeline matches :func:`clifft.compile`; pass ``None`` to
+    skip it.
+    """
+    if isinstance(hir_passes, _DefaultPasses):
+        hir_passes = default_hir_pass_manager()
+    return cast(Program, _compile_experimental_sampling(stim_text, hir_passes))
+
+
+def sample(program: Program, shots: int, seed: int | None = None) -> SampleResult:
+    """Sample a prepared experimental program without changing Clifft's default backend."""
+    measurements = cast(npt.NDArray[np.uint8], _sample_experimental_sampling(program, shots, seed))
+    detectors = np.empty((shots, 0), dtype=np.uint8)
+    observables = np.empty((shots, 0), dtype=np.uint8)
+    return SampleResult(measurements, detectors, observables)
+
+
+def record_probabilities(
+    program: Program,
+    records: MeasurementRecords,
+    *,
+    return_log: bool = False,
+) -> npt.NDArray[np.float64]:
+    """Return exact joint probabilities of experimental-program measurement records."""
+    if program.num_measurements == 0:
+        raise ValueError("record_probabilities() requires at least one measurement")
+    record_array = _records_from_outcomes(program, records)
+    log_probabilities = cast(
+        npt.NDArray[np.float64],
+        _record_probabilities_experimental_sampling(program, record_array),
+    )
+    if return_log:
+        return np.where(log_probabilities == np.finfo(np.float64).min, -np.inf, log_probabilities)
+    return np.exp(log_probabilities)
+
+
+__all__ = ["MeasurementRecords", "Program", "compile", "record_probabilities", "sample"]

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -66,7 +66,10 @@ def record_probabilities(
 ) -> npt.NDArray[np.float64]:
     """Return exact joint probabilities of experimental-program measurement records."""
     if program.num_measurements == 0:
-        raise ValueError("record_probabilities() requires at least one measurement")
+        raise ValueError(
+            "record_probabilities() requires a program with at least one "
+            "measurement; use clifft.basis_probabilities() for unitary circuits."
+        )
     record_array = _records_from_outcomes(program, records)
     log_probabilities = cast(
         npt.NDArray[np.float64],

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,9 +1,20 @@
 """Shared test fixtures and utilities for Clifft Python tests."""
 
 from collections.abc import Mapping, Sequence
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
+import pytest
+
+import clifft
+import clifft.experimental as experimental
+
+
+@pytest.fixture(params=[clifft, experimental], ids=["legacy", "experimental"])
+def sampling_api(request: pytest.FixtureRequest) -> Any:
+    """Run supported sampling conformance tests against both Python APIs."""
+    return cast(Any, request.param)
 
 
 def noncomp_transition_matrix(

--- a/tests/python/test_experimental_sampling.py
+++ b/tests/python/test_experimental_sampling.py
@@ -1,0 +1,56 @@
+"""Conformance and boundary tests for the explicitly selected sampling backend."""
+
+import numpy as np
+import pytest
+
+import clifft
+import clifft.experimental as experimental
+
+
+def test_program_is_separate_from_legacy_bytecode() -> None:
+    legacy = clifft.compile("H 0\nT 0\nM 0")
+    program = experimental.compile("H 0\nT 0\nM 0")
+
+    assert isinstance(legacy, clifft.Program)
+    assert isinstance(program, experimental.Program)
+    assert not isinstance(program, clifft.Program)
+    assert program.num_qubits == 1
+    assert program.num_measurements == 1
+    assert program.num_hidden_measurements == 0
+    assert program.num_actions > 0
+
+
+@pytest.mark.parametrize(
+    "circuit",
+    [
+        "H 0\nM 0\nM 0",
+        "H 0\nCX 0 1\nM 0 1",
+        "H 0\nT 0\nS 0\nMX 0",
+        "H 0\nT 0\nR_Z(0.3) 0\nM 0",
+        "H 0\nH 1\nT 0\nT 1\nCX 0 1\nMPP Y0*Z1",
+    ],
+)
+def test_seeded_samples_match_legacy_for_curated_circuits(circuit: str) -> None:
+    legacy = clifft.sample(clifft.compile(circuit), shots=128, seed=1234).measurements
+    actual = experimental.sample(experimental.compile(circuit), shots=128, seed=1234).measurements
+    np.testing.assert_array_equal(actual, legacy)
+
+
+@pytest.mark.parametrize(
+    "circuit,operation",
+    [
+        ("X_ERROR(0.1) 0\nM 0", "NOISE"),
+        ("H 0\nM 0\nCX rec[-1] 1", "CONDITIONAL_PAULI"),
+        ("R 0", "CONDITIONAL_PAULI"),
+        ("M 0\nDETECTOR rec[-1]", "DETECTOR"),
+    ],
+)
+def test_unsupported_capabilities_fail_during_compile(circuit: str, operation: str) -> None:
+    with pytest.raises(ValueError, match=operation):
+        experimental.compile(circuit)
+
+
+def test_record_probabilities_reject_unitary_program() -> None:
+    program = experimental.compile("H 0\nT 0")
+    with pytest.raises(ValueError, match="at least one measurement"):
+        experimental.record_probabilities(program, [])

--- a/tests/python/test_experimental_sampling.py
+++ b/tests/python/test_experimental_sampling.py
@@ -48,9 +48,3 @@ def test_seeded_samples_match_legacy_for_curated_circuits(circuit: str) -> None:
 def test_unsupported_capabilities_fail_during_compile(circuit: str, operation: str) -> None:
     with pytest.raises(ValueError, match=operation):
         experimental.compile(circuit)
-
-
-def test_record_probabilities_reject_unitary_program() -> None:
-    program = experimental.compile("H 0\nT 0")
-    with pytest.raises(ValueError, match="at least one measurement"):
-        experimental.record_probabilities(program, [])

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -21,23 +21,23 @@ import clifft
 # =============================================================================
 
 
-def test_bell_state_basis_probabilities() -> None:
-    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-    probs = clifft.record_probabilities(prog, ["00", "01", "10", "11"])
+def test_bell_state_basis_probabilities(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nCX 0 1\nM 0 1")
+    probs = sampling_api.record_probabilities(prog, ["00", "01", "10", "11"])
     np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
     assert probs.dtype == np.float64
     assert probs.shape == (4,)
 
 
-def test_single_qubit_plus_state() -> None:
-    prog = clifft.compile("H 0\nM 0")
-    probs = clifft.record_probabilities(prog, ["0", "1"])
+def test_single_qubit_plus_state(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nM 0")
+    probs = sampling_api.record_probabilities(prog, ["0", "1"])
     np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
 
 
-def test_unreachable_records_are_zero() -> None:
-    prog = clifft.compile("M 0")
-    probs = clifft.record_probabilities(prog, ["0", "1"])
+def test_unreachable_records_are_zero(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0")
+    probs = sampling_api.record_probabilities(prog, ["0", "1"])
     np.testing.assert_allclose(probs, [1.0, 0.0], atol=1e-12)
 
 
@@ -52,32 +52,32 @@ def test_feedback_circuit_returns_joint_trajectory_probability() -> None:
 # =============================================================================
 
 
-def test_single_string_returns_length_one_array() -> None:
-    prog = clifft.compile("H 0\nM 0")
-    probs = clifft.record_probabilities(prog, "0")
+def test_single_string_returns_length_one_array(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nM 0")
+    probs = sampling_api.record_probabilities(prog, "0")
     assert probs.shape == (1,)
     np.testing.assert_allclose(probs, [0.5], atol=1e-12)
 
 
-def test_sequence_of_strings() -> None:
-    prog = clifft.compile("H 0\nM 0")
-    probs = clifft.record_probabilities(prog, ("0", "1"))
+def test_sequence_of_strings(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nM 0")
+    probs = sampling_api.record_probabilities(prog, ("0", "1"))
     np.testing.assert_allclose(probs, [0.5, 0.5], atol=1e-12)
 
 
 @pytest.mark.parametrize("dtype", [np.bool_, np.uint8])
-def test_array_input_matches_string_input(dtype: np.dtype) -> None:
-    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+def test_array_input_matches_string_input(dtype: np.dtype, sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nCX 0 1\nM 0 1")
     records = np.array([[0, 0], [1, 1]], dtype=dtype)
     np.testing.assert_allclose(
-        clifft.record_probabilities(prog, records),
-        clifft.record_probabilities(prog, ["00", "11"]),
+        sampling_api.record_probabilities(prog, records),
+        sampling_api.record_probabilities(prog, ["00", "11"]),
     )
 
 
-def test_empty_record_batch() -> None:
-    prog = clifft.compile("H 0\nM 0")
-    probs = clifft.record_probabilities(prog, [])
+def test_empty_record_batch(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nM 0")
+    probs = sampling_api.record_probabilities(prog, [])
     assert probs.shape == (0,)
     assert probs.dtype == np.float64
 
@@ -87,18 +87,18 @@ def test_empty_record_batch() -> None:
 # =============================================================================
 
 
-def test_return_log_returns_natural_log() -> None:
-    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-    log_probs = clifft.record_probabilities(prog, ["00", "01", "10", "11"], return_log=True)
+def test_return_log_returns_natural_log(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nCX 0 1\nM 0 1")
+    log_probs = sampling_api.record_probabilities(prog, ["00", "01", "10", "11"], return_log=True)
     assert np.isclose(log_probs[0], np.log(0.5))
     assert log_probs[1] == -np.inf
     assert log_probs[2] == -np.inf
     assert np.isclose(log_probs[3], np.log(0.5))
 
 
-def test_return_log_default_false() -> None:
-    prog = clifft.compile("H 0\nM 0")
-    probs = clifft.record_probabilities(prog, ["0"])
+def test_return_log_default_false(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nM 0")
+    probs = sampling_api.record_probabilities(prog, ["0"])
     # 0.5 (linear), not log(0.5).
     np.testing.assert_allclose(probs, [0.5], atol=1e-12)
 
@@ -108,36 +108,38 @@ def test_return_log_default_false() -> None:
 # =============================================================================
 
 
-def test_matches_probabilities_on_clifford_circuit() -> None:
+def test_matches_probabilities_on_clifford_circuit(sampling_api: Any) -> None:
     bitstrings = ["00", "01", "10", "11"]
     unitary = clifft.compile("H 0\nCX 0 1")
-    measured = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    measured = sampling_api.compile("H 0\nCX 0 1\nM 0 1")
 
     expected = clifft.basis_probabilities(unitary, bitstrings)
-    actual = clifft.record_probabilities(measured, bitstrings)
+    actual = sampling_api.record_probabilities(measured, bitstrings)
     np.testing.assert_allclose(actual, expected, atol=1e-12)
 
 
-def test_matches_probabilities_on_clifford_t_circuit() -> None:
+def test_matches_probabilities_on_clifford_t_circuit(sampling_api: Any) -> None:
     bitstrings = ["0", "1"]
     unitary = clifft.compile("H 0\nT 0\nH 0")
-    measured = clifft.compile("H 0\nT 0\nH 0\nM 0")
+    measured = sampling_api.compile("H 0\nT 0\nH 0\nM 0")
 
     expected = clifft.basis_probabilities(unitary, bitstrings)
-    actual = clifft.record_probabilities(measured, bitstrings)
+    actual = sampling_api.record_probabilities(measured, bitstrings)
     np.testing.assert_allclose(actual, expected, atol=1e-12)
 
 
 @pytest.mark.parametrize("num_qubits,seed", [(2, 101), (3, 202), (4, 303)])
-def test_matches_qiskit_for_random_small_circuits(num_qubits: int, seed: int) -> None:
+def test_matches_qiskit_for_random_small_circuits(
+    num_qubits: int, seed: int, sampling_api: Any
+) -> None:
     circuit = random_dense_clifford_t_circuit(num_qubits, depth=18, seed=seed)
-    measured = clifft.compile(circuit + "\nM " + " ".join(str(q) for q in range(num_qubits)))
+    measured = sampling_api.compile(circuit + "\nM " + " ".join(str(q) for q in range(num_qubits)))
     qiskit_sv = qiskit_statevector(stim_to_qiskit_noiseless(circuit))
 
     bitstrings = [
         "".join(str((i >> q) & 1) for q in range(num_qubits)) for i in range(1 << num_qubits)
     ]
-    actual = clifft.record_probabilities(measured, bitstrings)
+    actual = sampling_api.record_probabilities(measured, bitstrings)
     np.testing.assert_allclose(actual, np.abs(qiskit_sv) ** 2, atol=1e-12)
 
 
@@ -146,17 +148,17 @@ def test_matches_qiskit_for_random_small_circuits(num_qubits: int, seed: int) ->
 # =============================================================================
 
 
-def test_sample_frequencies_match_record_probabilities() -> None:
+def test_sample_frequencies_match_record_probabilities(sampling_api: Any) -> None:
     # Run sample() many shots, count frequencies, compare to record_probabilities().
     # Chi-squared style sanity check; not a deep statistical test.
-    prog = clifft.compile("H 0\nT 0\nH 0\nM 0")
+    prog = sampling_api.compile("H 0\nT 0\nH 0\nM 0")
 
     shots = 200_000
-    measurements = clifft.sample(prog, shots=shots, seed=42).measurements
+    measurements = sampling_api.sample(prog, shots=shots, seed=42).measurements
     freq_1 = float(measurements.sum()) / shots
     freq_0 = 1.0 - freq_1
 
-    probs = clifft.record_probabilities(prog, ["0", "1"])
+    probs = sampling_api.record_probabilities(prog, ["0", "1"])
     # 5 sigma binomial half-width on shots=2e5, p~0.85 is ~0.004.
     assert abs(freq_0 - probs[0]) < 0.01
     assert abs(freq_1 - probs[1]) < 0.01

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -143,6 +143,34 @@ def test_matches_qiskit_for_random_small_circuits(
     np.testing.assert_allclose(actual, np.abs(qiskit_sv) ** 2, atol=1e-12)
 
 
+@pytest.mark.parametrize(
+    "circuit,num_qubits",
+    [
+        ("H 0\nR_Z(0.25) 0\nH 0", 1),
+        ("R_X(0.5) 0", 1),
+        ("R_Y(0.3) 0", 1),
+        ("U3(0.5, 0.25, 0.125) 0", 1),
+        ("H 0\nH 1\nR_ZZ(0.3) 0 1\nH 0\nH 1", 2),
+        ("R_XX(0.4) 0 1", 2),
+        ("R_YY(0.2) 0 1", 2),
+        ("R_PAULI(0.1) X0*Y1*Z2", 3),
+    ],
+    ids=["rz", "rx", "ry", "u3", "rzz", "rxx", "ryy", "r-pauli"],
+)
+def test_matches_qiskit_for_arbitrary_rotation_circuits(
+    circuit: str, num_qubits: int, sampling_api: Any
+) -> None:
+    measured = sampling_api.compile(circuit + "\nM " + " ".join(map(str, range(num_qubits))))
+    qiskit_sv = qiskit_statevector(stim_to_qiskit_noiseless(circuit))
+    bitstrings = [
+        "".join(str((basis >> q) & 1) for q in range(num_qubits))
+        for basis in range(1 << num_qubits)
+    ]
+
+    actual = sampling_api.record_probabilities(measured, bitstrings)
+    np.testing.assert_allclose(actual, np.abs(qiskit_sv) ** 2, atol=1e-12)
+
+
 # =============================================================================
 # Empirical sampling consistency.
 # =============================================================================
@@ -169,20 +197,20 @@ def test_sample_frequencies_match_record_probabilities(sampling_api: Any) -> Non
 # =============================================================================
 
 
-def test_rejects_zero_measurement_program() -> None:
-    prog = clifft.compile("H 0\nT 0")
+def test_rejects_zero_measurement_program(sampling_api: Any) -> None:
+    prog = sampling_api.compile("H 0\nT 0")
     with pytest.raises(ValueError, match="at least one measurement"):
-        clifft.record_probabilities(prog, [])
+        sampling_api.record_probabilities(prog, [])
 
 
-def test_rejects_zero_measurement_program_with_real_records() -> None:
+def test_rejects_zero_measurement_program_with_real_records(sampling_api: Any) -> None:
     # The wrapper formats records against program.num_measurements before
     # calling into C++. Without an explicit zero-measurement guard, this
     # surfaces as a confusing record-length mismatch ("expected 0") instead
     # of pointing the user at basis_probabilities().
-    prog = clifft.compile("H 0")
+    prog = sampling_api.compile("H 0")
     with pytest.raises(ValueError, match="use clifft.basis_probabilities"):
-        clifft.record_probabilities(prog, ["0"])
+        sampling_api.record_probabilities(prog, ["0"])
 
 
 def test_rejects_hidden_measurement_slots() -> None:
@@ -210,47 +238,47 @@ def test_rejects_observable_opcodes() -> None:
         clifft.record_probabilities(prog, ["0"])
 
 
-def test_rejects_record_string_with_wrong_length() -> None:
-    prog = clifft.compile("M 0 1")
+def test_rejects_record_string_with_wrong_length(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0 1")
     with pytest.raises(ValueError, match="length 1, expected 2"):
-        clifft.record_probabilities(prog, "0")
+        sampling_api.record_probabilities(prog, "0")
 
 
-def test_rejects_record_string_with_invalid_chars() -> None:
-    prog = clifft.compile("M 0")
+def test_rejects_record_string_with_invalid_chars(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0")
     with pytest.raises(ValueError, match="expected only '0' and '1'"):
-        clifft.record_probabilities(prog, ["x"])
+        sampling_api.record_probabilities(prog, ["x"])
 
 
-def test_rejects_array_with_wrong_columns() -> None:
-    prog = clifft.compile("M 0 1")
+def test_rejects_array_with_wrong_columns(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0 1")
     arr = np.array([[0, 0, 0]], dtype=np.uint8)
     with pytest.raises(ValueError, match="3 columns, expected 2"):
-        clifft.record_probabilities(prog, arr)
+        sampling_api.record_probabilities(prog, arr)
 
 
-def test_rejects_array_with_non_bit_values() -> None:
-    prog = clifft.compile("M 0")
+def test_rejects_array_with_non_bit_values(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0")
     arr = np.array([[2]], dtype=np.uint8)
     with pytest.raises(ValueError, match="contain only 0 and 1"):
-        clifft.record_probabilities(prog, arr)
+        sampling_api.record_probabilities(prog, arr)
 
 
-def test_rejects_invalid_array_dtype() -> None:
-    prog = clifft.compile("M 0")
+def test_rejects_invalid_array_dtype(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0")
     invalid: Any = np.array([[0]], dtype=np.int64)
     with pytest.raises(TypeError, match="dtype must be bool or uint8"):
-        clifft.record_probabilities(prog, invalid)
+        sampling_api.record_probabilities(prog, invalid)
 
 
-def test_rejects_invalid_array_dim() -> None:
-    prog = clifft.compile("M 0")
+def test_rejects_invalid_array_dim(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0")
     with pytest.raises(ValueError, match="must be 2D"):
-        clifft.record_probabilities(prog, np.array([0, 1], dtype=np.uint8))
+        sampling_api.record_probabilities(prog, np.array([0, 1], dtype=np.uint8))
 
 
-def test_rejects_invalid_input_type() -> None:
-    prog = clifft.compile("M 0")
+def test_rejects_invalid_input_type(sampling_api: Any) -> None:
+    prog = sampling_api.compile("M 0")
     bad: Any = 42
     with pytest.raises(TypeError, match="strings or a 2D"):
-        clifft.record_probabilities(prog, bad)
+        sampling_api.record_probabilities(prog, bad)

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -505,10 +505,10 @@ class TestSamplingValidation:
 class TestNoiseAndQEC:
     """Tests for noise simulation and QEC features."""
 
-    def test_sample_returns_sample_result(self) -> None:
+    def test_sample_returns_sample_result(self, sampling_api: Any) -> None:
         """sample() returns a SampleResult with attribute access and unpacking."""
-        prog = clifft.compile("H 0\nM 0")
-        result = clifft.sample(prog, 10, seed=0)
+        prog = sampling_api.compile("H 0\nM 0")
+        result = sampling_api.sample(prog, 10, seed=0)
         assert isinstance(result, clifft.SampleResult)
         # Attribute access
         assert result.measurements.shape == (10, 1)

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -1,5 +1,7 @@
 """Python integration tests for clifft.compile and clifft.sample."""
 
+from typing import Any
+
 import numpy as np
 import pytest
 from conftest import (
@@ -41,61 +43,61 @@ class TestCompile:
 class TestSample:
     """Tests for clifft.sample()."""
 
-    def test_sample_deterministic_zero(self) -> None:
+    def test_sample_deterministic_zero(self, sampling_api: Any) -> None:
         """Measurement of |0> always gives 0."""
-        prog = clifft.compile("M 0")
-        result = clifft.sample(prog, 100, seed=42)
+        prog = sampling_api.compile("M 0")
+        result = sampling_api.sample(prog, 100, seed=42)
         assert np.all(result.measurements[:, 0] == 0)
 
-    def test_sample_deterministic_one(self) -> None:
+    def test_sample_deterministic_one(self, sampling_api: Any) -> None:
         """Measurement of |1> always gives 1."""
-        prog = clifft.compile("X 0\nM 0")
-        result = clifft.sample(prog, 100, seed=42)
+        prog = sampling_api.compile("X 0\nM 0")
+        result = sampling_api.sample(prog, 100, seed=42)
         assert np.all(result.measurements[:, 0] == 1)
 
-    def test_sample_superposition(self) -> None:
+    def test_sample_superposition(self, sampling_api: Any) -> None:
         """|+> state gives roughly 50/50 distribution."""
-        prog = clifft.compile("H 0\nM 0")
+        prog = sampling_api.compile("H 0\nM 0")
         shots = 1000
-        result = clifft.sample(prog, shots, seed=42)
+        result = sampling_api.sample(prog, shots, seed=42)
         p0 = float(np.mean(result.measurements[:, 0] == 0))
         p1 = float(np.mean(result.measurements[:, 0] == 1))
         tolerance = binomial_tolerance(0.5, shots)
         assert abs(p0 - 0.5) < tolerance, f"p(0)={p0} outside {tolerance:.3f} tolerance"
         assert abs(p1 - 0.5) < tolerance, f"p(1)={p1} outside {tolerance:.3f} tolerance"
 
-    def test_sample_bell_state_correlated(self) -> None:
+    def test_sample_bell_state_correlated(self, sampling_api: Any) -> None:
         """Bell state measurements are always correlated."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             H 0
             CX 0 1
             M 0
             M 1
         """)
-        result = clifft.sample(prog, 500, seed=99)
+        result = sampling_api.sample(prog, 500, seed=99)
         assert np.all(
             result.measurements[:, 0] == result.measurements[:, 1]
         ), "Bell state not correlated"
 
-    def test_sample_reproducible(self) -> None:
+    def test_sample_reproducible(self, sampling_api: Any) -> None:
         """Same seed produces same results."""
-        prog = clifft.compile("H 0\nM 0")
-        result1 = clifft.sample(prog, 100, seed=12345)
-        result2 = clifft.sample(prog, 100, seed=12345)
+        prog = sampling_api.compile("H 0\nM 0")
+        result1 = sampling_api.sample(prog, 100, seed=12345)
+        result2 = sampling_api.sample(prog, 100, seed=12345)
         assert np.array_equal(result1.measurements, result2.measurements)
 
-    def test_sample_different_seeds(self) -> None:
+    def test_sample_different_seeds(self, sampling_api: Any) -> None:
         """Different seeds produce different results."""
-        prog = clifft.compile("H 0\nM 0")
-        result1 = clifft.sample(prog, 100, seed=1)
-        result2 = clifft.sample(prog, 100, seed=2)
+        prog = sampling_api.compile("H 0\nM 0")
+        result1 = sampling_api.sample(prog, 100, seed=1)
+        result2 = sampling_api.sample(prog, 100, seed=2)
         # With 100 random bits, probability of match is 2^-100
         assert not np.array_equal(result1.measurements, result2.measurements)
 
-    def test_sample_shape(self) -> None:
+    def test_sample_shape(self, sampling_api: Any) -> None:
         """Results have correct shape and type."""
-        prog = clifft.compile("H 0\nM 0\nH 1\nM 1")
-        result = clifft.sample(prog, 50, seed=0)
+        prog = sampling_api.compile("H 0\nM 0\nH 1\nM 1")
+        result = sampling_api.sample(prog, 50, seed=0)
         assert isinstance(result.measurements, np.ndarray)
         assert result.measurements.dtype == np.uint8
         assert result.measurements.shape == (50, 2)
@@ -383,7 +385,7 @@ class TestCliffordValidation:
 class TestSamplingValidation:
     """Validate sampling distributions against Stim."""
 
-    def test_deterministic_clifford_sampling(self) -> None:
+    def test_deterministic_clifford_sampling(self, sampling_api: Any) -> None:
         """Deterministic measurements match Stim exactly."""
         import stim
 
@@ -396,8 +398,8 @@ class TestSamplingValidation:
 
         for circuit_str in circuits:
             # Clifft sampling
-            prog = clifft.compile(circuit_str)
-            result = clifft.sample(prog, 100, seed=42)
+            prog = sampling_api.compile(circuit_str)
+            result = sampling_api.sample(prog, 100, seed=42)
 
             # Stim sampling (seed is in compile_sampler, not sample)
             stim_circuit = stim.Circuit(circuit_str)
@@ -417,7 +419,7 @@ class TestSamplingValidation:
                     if "CX" in circuit_str:  # Bell state
                         assert clifft_shot[0] == clifft_shot[1], "Bell correlation broken"
 
-    def test_statistical_distribution_h(self) -> None:
+    def test_statistical_distribution_h(self, sampling_api: Any) -> None:
         """H gate sampling matches Stim statistically."""
         import stim
 
@@ -425,8 +427,8 @@ class TestSamplingValidation:
         shots = 10000
 
         # Clifft sampling
-        prog = clifft.compile(circuit_str)
-        result = clifft.sample(prog, shots, seed=12345)
+        prog = sampling_api.compile(circuit_str)
+        result = sampling_api.sample(prog, shots, seed=12345)
         clifft_p0 = np.mean(result.measurements[:, 0] == 0)
 
         # Stim sampling (seed is in compile_sampler, not sample)
@@ -447,7 +449,7 @@ class TestSamplingValidation:
             abs(clifft_p0 - stim_p0) < cross_tolerance
         ), f"Clifft vs Stim: {clifft_p0} vs {stim_p0}"
 
-    def test_statistical_distribution_bell(self) -> None:
+    def test_statistical_distribution_bell(self, sampling_api: Any) -> None:
         """Bell state sampling matches Stim statistically."""
         import stim
 
@@ -455,8 +457,8 @@ class TestSamplingValidation:
         shots = 10000
 
         # Clifft sampling
-        prog = clifft.compile(circuit_str)
-        result = clifft.sample(prog, shots, seed=999)
+        prog = sampling_api.compile(circuit_str)
+        result = sampling_api.sample(prog, shots, seed=999)
         clifft_00 = np.mean((result.measurements[:, 0] == 0) & (result.measurements[:, 1] == 0))
         clifft_11 = np.mean((result.measurements[:, 0] == 1) & (result.measurements[:, 1] == 1))
 
@@ -478,19 +480,19 @@ class TestSamplingValidation:
         assert abs(stim_00 - 0.5) < tolerance, f"Stim |00>={stim_00} outside {tolerance:.4f} tol"
         assert abs(stim_11 - 0.5) < tolerance, f"Stim |11>={stim_11} outside {tolerance:.4f} tol"
 
-    def test_meas_active_interfere_y_observable(self) -> None:
+    def test_meas_active_interfere_y_observable(self, sampling_api: Any) -> None:
         """OP_MEAS_ACTIVE_INTERFERE correctly computes interference with Y-phases."""
         # H 0; T 0 rotates the state to (|0> + e^{ipi/4}|1>)/sqrt(2)
         # S 0 adds phase: (|0> + e^{i*3pi/4}|1>)/sqrt(2)
         # MX 0 forces an OP_MEAS_ACTIVE_INTERFERE where the rewound observable is Y.
         circuit = "H 0\nT 0\nS 0\nMX 0"
-        prog = clifft.compile(circuit)
+        prog = sampling_api.compile(circuit)
 
         # P(+) = |<+|psi>|^2 = |1 + e^{i3pi/4}|^2 / 4
         #      = (2 - sqrt(2)) / 4 ~ 0.1464
         shots = 10000
         expected_p0 = (2 - np.sqrt(2)) / 4  # ~ 0.1464
-        result = clifft.sample(prog, shots, seed=42)
+        result = sampling_api.sample(prog, shots, seed=42)
         p0 = float(np.mean(result.measurements[:, 0] == 0))
         tolerance = binomial_tolerance(expected_p0, shots)
 

--- a/tests/python/test_statevector_squeeze.py
+++ b/tests/python/test_statevector_squeeze.py
@@ -61,16 +61,19 @@ class TestSqueezeBasicPeakRankReduction:
         assert base.peak_rank == 3
         assert squeezed.peak_rank < base.peak_rank
 
-    def test_squeeze_sampling_correctness(self) -> None:
+    def test_squeeze_sampling_correctness(self, sampling_api: Any) -> None:
         """Sampling results must be statistically identical with and without squeeze."""
         circuit = "H 0\nT 0\nH 1\nT 1\nM 0\nM 1"
         shots = 10_000
 
-        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
-        squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
+        if sampling_api is clifft:
+            base = sampling_api.compile(circuit, hir_passes=None, bytecode_passes=None)
+        else:
+            base = sampling_api.compile(circuit, hir_passes=None)
+        squeezed = sampling_api.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        base_result = clifft.sample(base, shots, seed=42)
-        squeezed_result = clifft.sample(squeezed, shots, seed=42)
+        base_result = sampling_api.sample(base, shots, seed=42)
+        squeezed_result = sampling_api.sample(squeezed, shots, seed=42)
 
         # Both should produce roughly 50/50 coin flips
         for col in range(base_result.measurements.shape[1]):
@@ -81,20 +84,23 @@ class TestSqueezeBasicPeakRankReduction:
                 abs(p1 - p2) < tol
             ), f"qubit {col}: base={p1:.4f}, squeezed={p2:.4f}, tol={tol:.4f}"
 
-    def test_entangled_qubits_correct_behavior(self) -> None:
+    def test_entangled_qubits_correct_behavior(self, sampling_api: Any) -> None:
         """Entangled qubits: squeeze must still produce correct results.
 
         CX 0 1 creates entangled Pauli strings in the Heisenberg picture.
         The squeezer respects anti-commutation barriers and preserves semantics.
         """
         circuit = "H 0\nCX 0 1\nT 0\nT 1\nM 0\nM 1"
-        base = clifft.compile(circuit, hir_passes=None, bytecode_passes=None)
-        squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
+        if sampling_api is clifft:
+            base = sampling_api.compile(circuit, hir_passes=None, bytecode_passes=None)
+        else:
+            base = sampling_api.compile(circuit, hir_passes=None)
+        squeezed = sampling_api.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         # Verify sampling correctness regardless of peak_rank change
         shots = 10_000
-        base_result = clifft.sample(base, shots, seed=42)
-        squeezed_result = clifft.sample(squeezed, shots, seed=42)
+        base_result = sampling_api.sample(base, shots, seed=42)
+        squeezed_result = sampling_api.sample(squeezed, shots, seed=42)
         for col in range(base_result.measurements.shape[1]):
             p1 = float(base_result.measurements[:, col].mean())
             p2 = float(squeezed_result.measurements[:, col].mean())

--- a/tests/python/test_svm_properties.py
+++ b/tests/python/test_svm_properties.py
@@ -4,6 +4,8 @@ These tests cover repeated active-rank expansion and compaction, along with
 small circuits whose output probabilities are known in closed form.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 from conftest import binomial_tolerance
@@ -127,10 +129,12 @@ class TestBiasedAmplitudeStatistics:
         _BIASED_CIRCUITS,
         ids=[c[0] for c in _BIASED_CIRCUITS],
     )
-    def test_biased_single_qubit(self, name: str, circuit: str, expected_p0: float) -> None:
+    def test_biased_single_qubit(
+        self, name: str, circuit: str, expected_p0: float, sampling_api: Any
+    ) -> None:
         """Single-qubit biased circuit matches analytical P(0)."""
-        prog = clifft.compile(circuit)
-        result = clifft.sample(prog, self.SHOTS, seed=42)
+        prog = sampling_api.compile(circuit)
+        result = sampling_api.sample(prog, self.SHOTS, seed=42)
 
         observed_p0 = float(1.0 - result.measurements[:, 0].astype(float).mean())
         tol = binomial_tolerance(expected_p0, self.SHOTS, sigma=5.0)
@@ -140,7 +144,7 @@ class TestBiasedAmplitudeStatistics:
             f"diff={diff:.6f} > tol={tol:.6f}"
         )
 
-    def test_biased_entangled_pair(self) -> None:
+    def test_biased_entangled_pair(self, sampling_api: Any) -> None:
         """Entangled 2-qubit circuit with T-gate bias.
 
         H 0; T 0; H 0; CX 0 1; M 0 1
@@ -148,8 +152,8 @@ class TestBiasedAmplitudeStatistics:
         Both qubits have cos^2(pi/8) marginal, and m0 XOR m1 = 0 always.
         """
         circuit = "H 0\nT 0\nH 0\nCX 0 1\nM 0 1"
-        prog = clifft.compile(circuit)
-        result = clifft.sample(prog, self.SHOTS, seed=42)
+        prog = sampling_api.compile(circuit)
+        result = sampling_api.sample(prog, self.SHOTS, seed=42)
 
         m0 = result.measurements[:, 0].astype(float)
         m1 = result.measurements[:, 1].astype(float)
@@ -168,15 +172,15 @@ class TestBiasedAmplitudeStatistics:
         assert parity_nonzero == 0, f"{parity_nonzero}/{self.SHOTS} shots had m0 != m1"
 
     @pytest.mark.parametrize("seed", range(3))
-    def test_biased_multi_t_rotation(self, seed: int) -> None:
+    def test_biased_multi_t_rotation(self, seed: int, sampling_api: Any) -> None:
         """Verify bias from N sequential T gates matches cos^2(N*pi/8)."""
         for n_t in [1, 2, 3, 5, 7]:
             lines = ["H 0"] + ["T 0"] * n_t + ["H 0", "M 0"]
             circuit = "\n".join(lines)
             expected_p0 = (1.0 + np.cos(n_t * np.pi / 4.0)) / 2.0
 
-            prog = clifft.compile(circuit)
-            result = clifft.sample(prog, self.SHOTS, seed=seed)
+            prog = sampling_api.compile(circuit)
+            result = sampling_api.sample(prog, self.SHOTS, seed=seed)
             observed_p0 = float(1.0 - result.measurements[:, 0].astype(float).mean())
 
             tol = binomial_tolerance(expected_p0, self.SHOTS, sigma=5.0)

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -436,6 +436,20 @@ TEST_CASE("Sampling batch records match legacy seeded execution") {
     REQUIRE(sample_records(executable, 0, uint64_t{5678}).empty());
 }
 
+TEST_CASE("Sampling batch helpers reject presampled symbols") {
+    SamplingPlan plan;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.actions = {
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}}};
+    const ExecutablePlan executable(plan);
+
+    REQUIRE_THROWS_WITH(sample_records(executable, 0, uint64_t{1234}),
+                        "batch sampling does not yet support plans with presampled symbols");
+    REQUIRE_THROWS_WITH(record_log_probabilities(executable, std::array<uint8_t, 1>{0}, 1),
+                        "record probabilities do not yet support plans with presampled symbols");
+}
+
 TEST_CASE("Sampling replay matches legacy record probabilities") {
     require_replay_matches_legacy("H 0\nM 0\nM 0\n", std::array<uint8_t, 4>{0, 0, 0, 1}, 2);
     require_replay_matches_legacy("H 0\nM 0\nM 0\n", std::array<uint8_t, 4>{1, 0, 1, 1}, 2);

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <numbers>
 #include <optional>
 #include <span>
@@ -33,10 +34,12 @@ using clifft::sampling::MeasurementBranchKind;
 using clifft::sampling::MeasurementProbabilities;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::record_log_probabilities;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RecordSlot;
 using clifft::sampling::ReplayResult;
 using clifft::sampling::RotateActivePauli;
+using clifft::sampling::sample_records;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
 using clifft::sampling::SymbolInfo;
@@ -422,6 +425,17 @@ TEST_CASE("Sampling executor matches legacy records for supported circuits") {
     require_matches_legacy(kArbitraryRotation, 64, 8901);
 }
 
+TEST_CASE("Sampling batch records match legacy seeded execution") {
+    constexpr std::string_view kCircuit = "H 0\nH 1\nT 0\nT 1\nCX 0 1\nM 0 1\n";
+    const clifft::HirModule hir = clifft::trace(clifft::parse(kCircuit));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+
+    const std::vector<uint8_t> actual = sample_records(executable, 64, uint64_t{5678});
+    const clifft::SampleResult expected = clifft::sample(clifft::lower(hir), 64, uint64_t{5678});
+    REQUIRE(actual == expected.measurements);
+    REQUIRE(sample_records(executable, 0, uint64_t{5678}).empty());
+}
+
 TEST_CASE("Sampling replay matches legacy record probabilities") {
     require_replay_matches_legacy("H 0\nM 0\nM 0\n", std::array<uint8_t, 4>{0, 0, 0, 1}, 2);
     require_replay_matches_legacy("H 0\nM 0\nM 0\n", std::array<uint8_t, 4>{1, 0, 1, 1}, 2);
@@ -430,6 +444,26 @@ TEST_CASE("Sampling replay matches legacy record probabilities") {
                                   std::array<uint8_t, 2>{0, 1}, 2);
     require_replay_matches_legacy("H 0\nCX 0 1\nM 0 1\n",
                                   std::array<uint8_t, 8>{0, 0, 0, 1, 1, 0, 1, 1}, 4);
+}
+
+TEST_CASE("Sampling batched record probabilities match legacy replay") {
+    constexpr std::string_view kCircuit = "H 0\nCX 0 1\nM 0 1\n";
+    constexpr std::array<uint8_t, 8> kRecords{0, 0, 0, 1, 1, 0, 1, 1};
+    const clifft::HirModule hir = clifft::trace(clifft::parse(kCircuit));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+
+    const std::vector<double> actual = record_log_probabilities(executable, kRecords, 4);
+    const std::vector<double> expected =
+        clifft::record_probabilities(clifft::lower(hir), kRecords, 4);
+    REQUIRE(actual.size() == expected.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+        CAPTURE(i);
+        if (expected[i] == clifft::kUnreachableLogProb) {
+            REQUIRE(actual[i] == std::numeric_limits<double>::lowest());
+        } else {
+            REQUIRE_THAT(actual[i], Catch::Matchers::WithinAbs(expected[i], 1e-12));
+        }
+    }
 }
 
 TEST_CASE("Sampling replay probabilities normalize for a small active circuit") {


### PR DESCRIPTION
## Summary

- add an explicit opt-in `clifft.experimental` program, compiler, sampler, and record-probability API without changing the default backend
- prepare once and reuse one scalar executor across batch sampling and forced-record replay, with output allocated before hot execution
- reuse the existing Python sampling, Stim, exact-probability, HIR-pass, and Qiskit-backed conformance tests against both compatible backends
- keep the experimental namespace out of the generated API documentation for now and reject noise, feedback, resets, detectors, and other unsupported operations at compile time

## Stacking

This PR is stacked on #261 and intentionally targets `codex/sampling-forced-replay`. Retarget it to `main` after #261 merges.

Closes #262.

## Validation

- `uv run pre-commit run --all-files`
- 1,194 native non-benchmark tests
- 55 focused native sampling tests
- 952 Python tests
- 223 focused Python sampling and HIR-pass tests
- strict documentation build

## Implementation note

Release builds assume finite arithmetic, so unreachable native replay results use the lowest finite `double`, matching the legacy convention. The Python wrapper translates that sentinel to `-inf` for log-probability output.