### PR TITLE
feat(sampling): complete noisy syndrome lifecycle

### DIFF
--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -3,6 +3,7 @@
 #include "clifft/backend/compiler_context.h"
 #include "clifft/util/canonical_phase.h"
 #include "clifft/util/mask_view.h"
+#include "clifft/util/noise_sampling.h"
 
 #include <algorithm>
 #include <bit>
@@ -917,7 +918,7 @@ CompiledModule lower_impl(const HirModule& hir,
                 // Clamp to 1 - 2^-53 (one ULP below 1.0 in double precision).
                 // This matches the maximum value of random_double() = (rng() >> 11) * 2^-53,
                 // preventing log1p(-1) = -inf when prob_sum rounds to exactly 1.0.
-                ctx.noise_hazards_accum += -std::log1p(-std::min(prob_sum, 1.0 - 0x1.0p-53));
+                ctx.noise_hazards_accum += bernoulli_hazard(prob_sum);
                 ctx.constant_pool.noise_hazards.push_back(ctx.noise_hazards_accum);
                 break;
             }

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -32,6 +32,14 @@ uint32_t index(InstrumentSiteId site) {
     return static_cast<uint32_t>(site);
 }
 
+uint32_t index(DetectorSlot slot) {
+    return static_cast<uint32_t>(slot);
+}
+
+uint32_t index(ObservableSlot slot) {
+    return static_cast<uint32_t>(slot);
+}
+
 }  // namespace
 
 MeasurementBranchClassification classify_measurement_branch(
@@ -59,6 +67,9 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       max_active_width_(plan.max_active_width),
       num_visible_records_(plan.num_visible_records),
       num_hidden_records_(plan.num_hidden_records),
+      num_detectors_(plan.num_detectors),
+      num_observables_(plan.num_observables),
+      has_postselection_(plan.has_postselection),
       global_weight_(plan.global_weight) {
     plan.validate();
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
@@ -83,6 +94,11 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                     num_expression_terms += typed.outcome.terms().size();
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                     num_expression_terms += typed.value.terms().size();
+                } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
+                    num_expression_terms += typed.source.terms().size();
+                } else if constexpr (std::is_same_v<T, WriteDetector> ||
+                                     std::is_same_v<T, WriteObservable>) {
+                    num_expression_terms += typed.outcome.terms().size();
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     // Rejected below after all structural validation has run.
                 } else {
@@ -97,9 +113,24 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     expression_terms_.reserve(num_expression_terms);
     actions_.reserve(plan.actions.size());
     presampled_symbols_.reserve(plan.symbols.size());
+    std::vector<bool> bound_presampled(plan.symbols.size(), false);
+    noise_sites_.reserve(plan.presampled_noise_sites.size());
+    for (const PresampledNoiseSite& site : plan.presampled_noise_sites) {
+        const uint32_t begin = static_cast<uint32_t>(noise_outcomes_.size());
+        double cumulative = 0.0;
+        for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+            cumulative += outcome.probability;
+            noise_outcomes_.push_back({index(outcome.symbol), cumulative});
+            bound_presampled[index(outcome.symbol)] = true;
+        }
+        noise_sites_.push_back({begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin});
+    }
     for (uint32_t symbol = 0; symbol < plan.symbols.size(); ++symbol) {
         if (plan.symbols[symbol].kind == SymbolKind::Presampled) {
             presampled_symbols_.push_back(symbol);
+            if (!bound_presampled[symbol]) {
+                unbound_presampled_symbols_.push_back(symbol);
+            }
         }
     }
 
@@ -129,6 +160,18 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                     actions_.emplace_back(ExecuteSymbolDefinition{prepare_expression(typed.value),
                                                                   index(typed.symbol)});
+                } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
+                    has_readout_noise_ = true;
+                    actions_.emplace_back(ExecuteReadoutNoise{
+                        prepare_expression(typed.source), index(typed.flip), index(typed.record),
+                        typed.prob_zero_to_one, typed.prob_one_to_zero});
+                } else if constexpr (std::is_same_v<T, WriteDetector>) {
+                    actions_.emplace_back(ExecuteDetector{prepare_expression(typed.outcome),
+                                                          index(typed.detector),
+                                                          typed.postselected});
+                } else if constexpr (std::is_same_v<T, WriteObservable>) {
+                    actions_.emplace_back(ExecuteObservable{prepare_expression(typed.outcome),
+                                                            index(typed.observable)});
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     throw std::invalid_argument(
                         "sampling executable does not yet support instrument boundary site " +
@@ -168,10 +211,17 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       state_(plan.max_active_width_, plan.initial_active_width_, plan.global_weight_),
       symbols_(plan.num_symbols_, 0),
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
+      detectors_(plan.num_detectors_, 0),
+      observables_(plan.num_observables_, 0),
       rng_(seed) {}
 
+void Executor::run_shot() noexcept {
+    initialize_shot({}, true);
+    (void)execute_actions<false>({});
+}
+
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
-    initialize_shot(presampled_values);
+    initialize_shot(presampled_values, false);
     (void)execute_actions<false>({});
 }
 
@@ -181,19 +231,49 @@ ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
            "one forced value is required for every plan record");
     assert(std::ranges::all_of(forced_records, [](uint8_t value) { return value <= 1; }) &&
            "forced records must be Boolean");
-    initialize_shot(presampled_values);
+    initialize_shot(presampled_values, false);
     return execute_actions<true>(forced_records);
 }
 
-void Executor::initialize_shot(std::span<const uint8_t> presampled_values) noexcept {
-    assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
-           "one value is required for every presampled symbol");
+void Executor::initialize_shot(std::span<const uint8_t> presampled_values,
+                               bool sample_noise) noexcept {
+    if (sample_noise) {
+        assert(plan_.unbound_presampled_symbols_.empty() &&
+               "automatic execution requires every presampled symbol to have a distribution");
+    } else {
+        assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
+               "one value is required for every presampled symbol");
+    }
     state_.reset();
     std::fill(symbols_.begin(), symbols_.end(), uint8_t{0});
     std::fill(records_.begin(), records_.end(), uint8_t{0});
-    for (size_t i = 0; i < presampled_values.size(); ++i) {
-        assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
-        symbols_[plan_.presampled_symbols_[i]] = presampled_values[i];
+    std::fill(detectors_.begin(), detectors_.end(), uint8_t{0});
+    std::fill(observables_.begin(), observables_.end(), uint8_t{0});
+    discarded_ = false;
+    if (sample_noise) {
+        sample_presampled_noise();
+    } else {
+        for (size_t i = 0; i < presampled_values.size(); ++i) {
+            assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
+            symbols_[plan_.presampled_symbols_[i]] = presampled_values[i];
+        }
+    }
+}
+
+void Executor::sample_presampled_noise() noexcept {
+    for (const ExecutablePlan::PreparedNoiseSite& site : plan_.noise_sites_) {
+        if (site.outcome_count == 0) {
+            continue;
+        }
+        const double draw = rng_.next_double();
+        for (uint32_t i = 0; i < site.outcome_count; ++i) {
+            const ExecutablePlan::PreparedNoiseOutcome& outcome =
+                plan_.noise_outcomes_[site.outcome_begin + i];
+            if (draw < outcome.cumulative_probability) {
+                symbols_[outcome.symbol] = 1;
+                break;
+            }
+        }
     }
 }
 
@@ -249,6 +329,27 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) 
                     }
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteSymbolDefinition>) {
                     symbols_[typed.symbol] = static_cast<uint8_t>(evaluate(typed.value));
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
+                    if constexpr (ForceRecords) {
+                        result.reachable = false;
+                        return;
+                    } else {
+                        const bool source = evaluate(typed.source);
+                        assert(records_[typed.record] == static_cast<uint8_t>(source) &&
+                               "readout source must match the current record value");
+                        const double probability =
+                            source ? typed.prob_one_to_zero : typed.prob_zero_to_one;
+                        const bool flip = probability >= 1.0 ||
+                                          (probability > 0.0 && rng_.next_double() < probability);
+                        symbols_[typed.flip] = static_cast<uint8_t>(flip);
+                        records_[typed.record] ^= static_cast<uint8_t>(flip);
+                    }
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDetector>) {
+                    const bool outcome = evaluate(typed.outcome);
+                    detectors_[typed.detector] = static_cast<uint8_t>(outcome);
+                    discarded_ |= typed.postselected && outcome;
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteObservable>) {
+                    observables_[typed.observable] = static_cast<uint8_t>(evaluate(typed.outcome));
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled executable action alternative");
                 }
@@ -258,6 +359,9 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) 
             if (!result.reachable) {
                 return result;
             }
+        }
+        if (discarded_) {
+            return result;
         }
     }
     return result;
@@ -315,25 +419,43 @@ bool Executor::sample_dormant_branch() noexcept {
     return rng_.next_double() >= 0.5;
 }
 
-std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
-                                    std::optional<uint64_t> seed) {
-    if (plan.num_presampled_symbols() != 0) {
+SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed) {
+    if (plan.num_unbound_presampled_symbols() != 0) {
         throw std::invalid_argument(
-            "batch sampling does not yet support plans with presampled symbols");
+            "batch sampling requires a distribution for every presampled symbol");
     }
-    const size_t stride = plan.num_visible_records();
-    if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
-        throw std::length_error("sampling output size exceeds size_t range");
+    if (plan.has_postselection()) {
+        throw std::invalid_argument(
+            "fixed-row sampling does not support postselection; use sample_survivors");
     }
-    std::vector<uint8_t> records(static_cast<size_t>(shots) * stride);
+
+    auto checked_size = [shots](size_t stride) {
+        if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
+            throw std::length_error("sampling output size exceeds size_t range");
+        }
+        return static_cast<size_t>(shots) * stride;
+    };
+
+    SamplingResult result;
+    result.measurements.resize(checked_size(plan.num_visible_records()));
+    result.detectors.resize(checked_size(plan.num_detectors()));
+    result.observables.resize(checked_size(plan.num_observables()));
     if (shots == 0) {
-        return records;
+        return result;
     }
 
     auto run = [&](Executor& executor) {
         for (uint32_t shot = 0; shot < shots; ++shot) {
             executor.run_shot();
-            std::ranges::copy(executor.visible_records(), records.begin() + shot * stride);
+            std::ranges::copy(executor.visible_records(),
+                              result.measurements.begin() +
+                                  static_cast<size_t>(shot) * plan.num_visible_records());
+            std::ranges::copy(
+                executor.detectors(),
+                result.detectors.begin() + static_cast<size_t>(shot) * plan.num_detectors());
+            std::ranges::copy(
+                executor.observables(),
+                result.observables.begin() + static_cast<size_t>(shot) * plan.num_observables());
         }
     };
     if (seed.has_value()) {
@@ -344,7 +466,72 @@ std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
         executor.reseed_from_entropy();
         run(executor);
     }
-    return records;
+    return result;
+}
+
+std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
+                                    std::optional<uint64_t> seed) {
+    return sample(plan, shots, seed).measurements;
+}
+
+SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
+                                        std::optional<uint64_t> seed, bool keep_records) {
+    if (plan.num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "survivor sampling requires a distribution for every presampled symbol");
+    }
+
+    SamplingSurvivorResult result;
+    result.total_shots = shots;
+    if (shots == 0) {
+        return result;
+    }
+    result.observable_ones.resize(plan.num_observables(), 0);
+    if (keep_records) {
+        auto checked_reserve = [shots](size_t stride) {
+            if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
+                throw std::length_error("survivor output size exceeds size_t range");
+            }
+            return static_cast<size_t>(shots) * stride;
+        };
+        result.measurements.reserve(checked_reserve(plan.num_visible_records()));
+        result.detectors.reserve(checked_reserve(plan.num_detectors()));
+        result.observables.reserve(checked_reserve(plan.num_observables()));
+    }
+    auto run = [&](Executor& executor) {
+        for (uint32_t shot = 0; shot < shots; ++shot) {
+            executor.run_shot();
+            if (executor.discarded()) {
+                continue;
+            }
+            ++result.passed_shots;
+            bool logical_error = false;
+            for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
+                const bool value = executor.observables()[observable] != 0;
+                result.observable_ones[observable] += static_cast<uint64_t>(value);
+                logical_error |= value;
+            }
+            result.logical_errors += static_cast<uint32_t>(logical_error);
+            if (keep_records) {
+                result.measurements.insert(result.measurements.end(),
+                                           executor.visible_records().begin(),
+                                           executor.visible_records().end());
+                result.detectors.insert(result.detectors.end(), executor.detectors().begin(),
+                                        executor.detectors().end());
+                result.observables.insert(result.observables.end(), executor.observables().begin(),
+                                          executor.observables().end());
+            }
+        }
+    };
+    if (seed.has_value()) {
+        Executor executor(plan, *seed);
+        run(executor);
+    } else {
+        Executor executor(plan);
+        executor.reseed_from_entropy();
+        run(executor);
+    }
+    return result;
 }
 
 std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
@@ -353,6 +540,9 @@ std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
     if (plan.num_presampled_symbols() != 0) {
         throw std::invalid_argument(
             "record probabilities do not yet support plans with presampled symbols");
+    }
+    if (plan.has_readout_noise()) {
+        throw std::invalid_argument("record probabilities do not yet support readout noise");
     }
     if (plan.num_hidden_records() != 0) {
         throw std::invalid_argument(

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/executor.h"
 
+#include "clifft/util/noise_sampling.h"
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
@@ -115,15 +116,20 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     presampled_symbols_.reserve(plan.symbols.size());
     std::vector<bool> bound_presampled(plan.symbols.size(), false);
     noise_sites_.reserve(plan.presampled_noise_sites.size());
+    noise_hazards_.reserve(plan.presampled_noise_sites.size());
+    double cumulative_hazard = 0.0;
     for (const PresampledNoiseSite& site : plan.presampled_noise_sites) {
         const uint32_t begin = static_cast<uint32_t>(noise_outcomes_.size());
-        double cumulative = 0.0;
+        double cumulative_probability = 0.0;
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
-            cumulative += outcome.probability;
-            noise_outcomes_.push_back({index(outcome.symbol), cumulative});
+            cumulative_probability += outcome.probability;
+            noise_outcomes_.push_back({index(outcome.symbol), cumulative_probability});
             bound_presampled[index(outcome.symbol)] = true;
         }
-        noise_sites_.push_back({begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin});
+        noise_sites_.push_back(
+            {begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin, cumulative_probability});
+        cumulative_hazard += bernoulli_hazard(cumulative_probability);
+        noise_hazards_.push_back(cumulative_hazard);
     }
     for (uint32_t symbol = 0; symbol < plan.symbols.size(); ++symbol) {
         if (plan.symbols[symbol].kind == SymbolKind::Presampled) {
@@ -213,15 +219,21 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
       detectors_(plan.num_detectors_, 0),
       observables_(plan.num_observables_, 0),
-      rng_(seed) {}
+      rng_(seed) {
+    previous_presampled_ones_.reserve(plan.presampled_symbols_.size());
+}
 
 void Executor::run_shot() noexcept {
-    initialize_shot({}, true);
+    assert(plan_.unbound_presampled_symbols_.empty() &&
+           "automatic execution requires every presampled symbol to have a distribution");
+    reset_shot();
+    sample_presampled_noise();
     (void)execute_actions<false>({});
 }
 
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
-    initialize_shot(presampled_values, false);
+    reset_shot();
+    assign_presampled_values(presampled_values);
     (void)execute_actions<false>({});
 }
 
@@ -231,50 +243,170 @@ ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
            "one forced value is required for every plan record");
     assert(std::ranges::all_of(forced_records, [](uint8_t value) { return value <= 1; }) &&
            "forced records must be Boolean");
-    initialize_shot(presampled_values, false);
+    reset_shot();
+    assign_presampled_values(presampled_values);
     return execute_actions<true>(forced_records);
 }
 
-void Executor::initialize_shot(std::span<const uint8_t> presampled_values,
-                               bool sample_noise) noexcept {
-    if (sample_noise) {
-        assert(plan_.unbound_presampled_symbols_.empty() &&
-               "automatic execution requires every presampled symbol to have a distribution");
-    } else {
-        assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
-               "one value is required for every presampled symbol");
-    }
+void Executor::reset_shot() noexcept {
     state_.reset();
-    std::fill(symbols_.begin(), symbols_.end(), uint8_t{0});
-    std::fill(records_.begin(), records_.end(), uint8_t{0});
-    std::fill(detectors_.begin(), detectors_.end(), uint8_t{0});
-    std::fill(observables_.begin(), observables_.end(), uint8_t{0});
+    // Validation guarantees that every mutable symbol and output is overwritten
+    // before use on a completed shot. Only nonfiring noise symbols need restoring.
+    for (uint32_t symbol : previous_presampled_ones_) {
+        assert(symbol < symbols_.size() && symbols_[symbol] == 1 &&
+               "tracked presampled symbols must be set");
+        symbols_[symbol] = 0;
+    }
+    previous_presampled_ones_.clear();
     discarded_ = false;
-    if (sample_noise) {
-        sample_presampled_noise();
-    } else {
-        for (size_t i = 0; i < presampled_values.size(); ++i) {
-            assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
-            symbols_[plan_.presampled_symbols_[i]] = presampled_values[i];
+}
+
+void Executor::assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept {
+    assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
+           "one value is required for every presampled symbol");
+    for (size_t i = 0; i < presampled_values.size(); ++i) {
+        assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
+        const uint32_t symbol = plan_.presampled_symbols_[i];
+        symbols_[symbol] = presampled_values[i];
+        if (presampled_values[i] != 0) {
+            previous_presampled_ones_.push_back(symbol);
         }
     }
 }
 
 void Executor::sample_presampled_noise() noexcept {
-    for (const ExecutablePlan::PreparedNoiseSite& site : plan_.noise_sites_) {
-        if (site.outcome_count == 0) {
-            continue;
+    uint32_t first_candidate = 0;
+    while (first_candidate < plan_.noise_sites_.size()) {
+        const double current_hazard =
+            first_candidate == 0 ? 0.0 : plan_.noise_hazards_[first_candidate - 1];
+        if (current_hazard >= plan_.noise_hazards_.back()) {
+            return;
         }
-        const double draw = rng_.next_double();
-        for (uint32_t i = 0; i < site.outcome_count; ++i) {
-            const ExecutablePlan::PreparedNoiseOutcome& outcome =
-                plan_.noise_outcomes_[site.outcome_begin + i];
-            if (draw < outcome.cumulative_probability) {
-                symbols_[outcome.symbol] = 1;
-                break;
+        const uint32_t site_index =
+            sample_next_noise_site(plan_.noise_hazards_, first_candidate, rng_.next_double());
+        if (site_index == kNoNoiseSite) {
+            return;
+        }
+        const ExecutablePlan::PreparedNoiseSite& site = plan_.noise_sites_[site_index];
+        assert(site.outcome_count > 0 && site.total_probability > 0.0 &&
+               "a sampled hazard must identify a nonempty noise site");
+        uint32_t outcome_index = site.outcome_begin;
+        if (site.outcome_count > 1) {
+            const double channel_draw = rng_.next_double() * site.total_probability;
+            while (channel_draw >= plan_.noise_outcomes_[outcome_index].cumulative_probability) {
+                ++outcome_index;
+                assert(outcome_index < site.outcome_begin + site.outcome_count &&
+                       "channel draw must select one prepared outcome");
             }
         }
+        const uint32_t symbol = plan_.noise_outcomes_[outcome_index].symbol;
+        assert(symbol < symbols_.size() && symbols_[symbol] == 0 &&
+               "a noise site may define only one fresh symbol per shot");
+        symbols_[symbol] = 1;
+        previous_presampled_ones_.push_back(symbol);
+        first_candidate = site_index + 1;
     }
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    apply_rotation(state_, action.rotation, evaluate(action.sign));
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecutePromotion& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    apply_promotion(state_, action.promotion, evaluate(action.sign));
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
+                              std::span<const uint8_t> forced_records,
+                              ReplayResult& result) noexcept {
+    const MeasurementProbabilities probabilities =
+        measurement_probabilities(state_, action.measurement);
+    const bool correction = evaluate(action.correction);
+    bool branch = false;
+    if constexpr (ForceRecords) {
+        branch = (forced_records[action.record] != 0) ^ correction;
+        const std::optional<double> log_increment = force_active_branch(probabilities, branch);
+        if (!log_increment.has_value()) {
+            result.reachable = false;
+            return;
+        }
+        result.log_probability += *log_increment;
+    } else {
+        branch = sample_active_branch(probabilities);
+    }
+    symbols_[action.branch] = static_cast<uint8_t>(branch);
+    collapse_measurement(state_, action.measurement, branch, probabilities.for_branch(branch));
+    records_[action.record] = static_cast<uint8_t>(branch ^ correction);
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
+                              std::span<const uint8_t> forced_records,
+                              ReplayResult& result) noexcept {
+    const bool correction = evaluate(action.correction);
+    bool branch = false;
+    if constexpr (ForceRecords) {
+        branch = (forced_records[action.record] != 0) ^ correction;
+        result.log_probability += kLogHalf;
+    } else {
+        branch = sample_dormant_branch();
+    }
+    symbols_[action.branch] = static_cast<uint8_t>(branch);
+    records_[action.record] = static_cast<uint8_t>(branch ^ correction);
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
+                              std::span<const uint8_t> forced_records,
+                              ReplayResult& result) noexcept {
+    records_[action.record] = static_cast<uint8_t>(evaluate(action.outcome));
+    if constexpr (ForceRecords) {
+        if (records_[action.record] != forced_records[action.record]) {
+            result.reachable = false;
+        }
+    }
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    symbols_[action.symbol] = static_cast<uint8_t>(evaluate(action.value));
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
+                              std::span<const uint8_t>, ReplayResult& result) noexcept {
+    if constexpr (ForceRecords) {
+        result.reachable = false;
+    } else {
+        const bool source = evaluate(action.source);
+        assert(records_[action.record] == static_cast<uint8_t>(source) &&
+               "readout source must match the current record value");
+        const double probability = source ? action.prob_one_to_zero : action.prob_zero_to_one;
+        const bool flip =
+            probability >= 1.0 || (probability > 0.0 && rng_.next_double() < probability);
+        symbols_[action.flip] = static_cast<uint8_t>(flip);
+        records_[action.record] ^= static_cast<uint8_t>(flip);
+    }
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteDetector& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    const bool outcome = evaluate(action.outcome);
+    detectors_[action.detector] = static_cast<uint8_t>(outcome);
+    discarded_ |= action.postselected && outcome;
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteObservable& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    observables_[action.observable] = static_cast<uint8_t>(evaluate(action.outcome));
 }
 
 template <bool ForceRecords>
@@ -283,76 +415,7 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) 
     for (const ExecutablePlan::Action& action : plan_.actions_) {
         std::visit(
             [&](const auto& typed) noexcept {
-                using T = std::decay_t<decltype(typed)>;
-                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation>) {
-                    apply_rotation(state_, typed.rotation, evaluate(typed.sign));
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecutePromotion>) {
-                    apply_promotion(state_, typed.promotion, evaluate(typed.sign));
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement>) {
-                    const MeasurementProbabilities probabilities =
-                        measurement_probabilities(state_, typed.measurement);
-                    const bool correction = evaluate(typed.correction);
-                    bool branch = false;
-                    if constexpr (ForceRecords) {
-                        branch = (forced_records[typed.record] != 0) ^ correction;
-                        const std::optional<double> log_increment =
-                            force_active_branch(probabilities, branch);
-                        if (!log_increment.has_value()) {
-                            result.reachable = false;
-                            return;
-                        }
-                        result.log_probability += *log_increment;
-                    } else {
-                        branch = sample_active_branch(probabilities);
-                    }
-                    symbols_[typed.branch] = static_cast<uint8_t>(branch);
-                    collapse_measurement(state_, typed.measurement, branch,
-                                         probabilities.for_branch(branch));
-                    records_[typed.record] = static_cast<uint8_t>(branch ^ correction);
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDormantMeasurement>) {
-                    const bool correction = evaluate(typed.correction);
-                    bool branch = false;
-                    if constexpr (ForceRecords) {
-                        branch = (forced_records[typed.record] != 0) ^ correction;
-                        result.log_probability += kLogHalf;
-                    } else {
-                        branch = sample_dormant_branch();
-                    }
-                    symbols_[typed.branch] = static_cast<uint8_t>(branch);
-                    records_[typed.record] = static_cast<uint8_t>(branch ^ correction);
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
-                    records_[typed.record] = static_cast<uint8_t>(evaluate(typed.outcome));
-                    if constexpr (ForceRecords) {
-                        if (records_[typed.record] != forced_records[typed.record]) {
-                            result.reachable = false;
-                        }
-                    }
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteSymbolDefinition>) {
-                    symbols_[typed.symbol] = static_cast<uint8_t>(evaluate(typed.value));
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
-                    if constexpr (ForceRecords) {
-                        result.reachable = false;
-                        return;
-                    } else {
-                        const bool source = evaluate(typed.source);
-                        assert(records_[typed.record] == static_cast<uint8_t>(source) &&
-                               "readout source must match the current record value");
-                        const double probability =
-                            source ? typed.prob_one_to_zero : typed.prob_zero_to_one;
-                        const bool flip = probability >= 1.0 ||
-                                          (probability > 0.0 && rng_.next_double() < probability);
-                        symbols_[typed.flip] = static_cast<uint8_t>(flip);
-                        records_[typed.record] ^= static_cast<uint8_t>(flip);
-                    }
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDetector>) {
-                    const bool outcome = evaluate(typed.outcome);
-                    detectors_[typed.detector] = static_cast<uint8_t>(outcome);
-                    discarded_ |= typed.postselected && outcome;
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteObservable>) {
-                    observables_[typed.observable] = static_cast<uint8_t>(evaluate(typed.outcome));
-                } else {
-                    static_assert(kAlwaysFalse<T>, "Unhandled executable action alternative");
-                }
+                execute_action<ForceRecords>(typed, forced_records, result);
             },
             action);
         if constexpr (ForceRecords) {

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -140,6 +140,7 @@ class ExecutablePlan {
     struct PreparedNoiseSite {
         uint32_t outcome_begin = 0;
         uint32_t outcome_count = 0;
+        double total_probability = 0.0;
     };
 
     using Action =
@@ -168,6 +169,7 @@ class ExecutablePlan {
     std::vector<uint32_t> unbound_presampled_symbols_;
     std::vector<PreparedNoiseOutcome> noise_outcomes_;
     std::vector<PreparedNoiseSite> noise_sites_;
+    std::vector<double> noise_hazards_;
     std::vector<Action> actions_;
 };
 
@@ -183,8 +185,11 @@ class Executor {
     // Replace the deterministic seed with OS entropy before executing shots.
     void reseed_from_entropy() { rng_.seed_from_entropy(); }
 
-    // Values correspond to presampled plan symbols in ascending SymbolId order.
+    // Draw plan-bound quantum noise from this executor's RNG before dispatch.
     void run_shot() noexcept;
+
+    // Use caller-supplied Boolean values for every Presampled symbol in
+    // ascending SymbolId order. This path consumes no quantum-noise RNG draws.
     void run_shot(std::span<const uint8_t> presampled_values) noexcept;
 
     // Replays the plan while forcing each record to a supplied Boolean value.
@@ -214,11 +219,39 @@ class Executor {
     [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
 
   private:
-    void initialize_shot(std::span<const uint8_t> presampled_values, bool sample_noise) noexcept;
+    void reset_shot() noexcept;
+    void assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept;
     void sample_presampled_noise() noexcept;
 
     template <bool ForceRecords>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteRotation& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecutePromotion& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteDetector& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteObservable& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
 
     [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
     [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
@@ -232,6 +265,7 @@ class Executor {
     std::vector<uint8_t> records_;
     std::vector<uint8_t> detectors_;
     std::vector<uint8_t> observables_;
+    std::vector<uint32_t> previous_presampled_ones_;
     Xoshiro256PlusPlus rng_;
     bool discarded_ = false;
     uint64_t dust_clamps_ = 0;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -54,11 +54,18 @@ class ExecutablePlan {
     [[nodiscard]] uint32_t num_qubits() const { return num_qubits_; }
     [[nodiscard]] uint32_t num_visible_records() const { return num_visible_records_; }
     [[nodiscard]] uint32_t num_hidden_records() const { return num_hidden_records_; }
+    [[nodiscard]] uint32_t num_detectors() const { return num_detectors_; }
+    [[nodiscard]] uint32_t num_observables() const { return num_observables_; }
+    [[nodiscard]] bool has_postselection() const { return has_postselection_; }
+    [[nodiscard]] bool has_readout_noise() const { return has_readout_noise_; }
     [[nodiscard]] uint32_t num_symbols() const { return num_symbols_; }
     [[nodiscard]] uint32_t num_presampled_symbols() const {
         return static_cast<uint32_t>(presampled_symbols_.size());
     }
     [[nodiscard]] size_t num_actions() const { return actions_.size(); }
+    [[nodiscard]] uint32_t num_unbound_presampled_symbols() const {
+        return static_cast<uint32_t>(unbound_presampled_symbols_.size());
+    }
 
   private:
     friend class Executor;
@@ -106,9 +113,39 @@ class ExecutablePlan {
         uint32_t symbol = 0;
     };
 
+    struct ExecuteReadoutNoise {
+        PreparedExpression source;
+        uint32_t flip = 0;
+        uint32_t record = 0;
+        double prob_zero_to_one = 0.0;
+        double prob_one_to_zero = 0.0;
+    };
+
+    struct ExecuteDetector {
+        PreparedExpression outcome;
+        uint32_t detector = 0;
+        bool postselected = false;
+    };
+
+    struct ExecuteObservable {
+        PreparedExpression outcome;
+        uint32_t observable = 0;
+    };
+
+    struct PreparedNoiseOutcome {
+        uint32_t symbol = 0;
+        double cumulative_probability = 0.0;
+    };
+
+    struct PreparedNoiseSite {
+        uint32_t outcome_begin = 0;
+        uint32_t outcome_count = 0;
+    };
+
     using Action =
         std::variant<ExecuteRotation, ExecutePromotion, ExecuteActiveMeasurement,
-                     ExecuteDormantMeasurement, ExecuteClassicalRecord, ExecuteSymbolDefinition>;
+                     ExecuteDormantMeasurement, ExecuteClassicalRecord, ExecuteSymbolDefinition,
+                     ExecuteReadoutNoise, ExecuteDetector, ExecuteObservable>;
 
     PreparedExpression prepare_expression(const AffineBool& expression);
     PreparedExpression prepare_measurement_correction(const AffineBool& outcome, uint32_t branch);
@@ -118,12 +155,19 @@ class ExecutablePlan {
     uint32_t max_active_width_ = 0;
     uint32_t num_visible_records_ = 0;
     uint32_t num_hidden_records_ = 0;
+    uint32_t num_detectors_ = 0;
+    uint32_t num_observables_ = 0;
     uint32_t num_symbols_ = 0;
+    bool has_postselection_ = false;
+    bool has_readout_noise_ = false;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::vector<uint32_t> expression_terms_;
     // Maps each dense presampled input position to its plan-local SymbolId.
     // The constructor records those ids in ascending order.
     std::vector<uint32_t> presampled_symbols_;
+    std::vector<uint32_t> unbound_presampled_symbols_;
+    std::vector<PreparedNoiseOutcome> noise_outcomes_;
+    std::vector<PreparedNoiseSite> noise_sites_;
     std::vector<Action> actions_;
 };
 
@@ -140,7 +184,8 @@ class Executor {
     void reseed_from_entropy() { rng_.seed_from_entropy(); }
 
     // Values correspond to presampled plan symbols in ascending SymbolId order.
-    void run_shot(std::span<const uint8_t> presampled_values = {}) noexcept;
+    void run_shot() noexcept;
+    void run_shot(std::span<const uint8_t> presampled_values) noexcept;
 
     // Replays the plan while forcing each record to a supplied Boolean value.
     // This reconstructs the corresponding branch state and computes its joint
@@ -160,13 +205,17 @@ class Executor {
         return std::span<const uint8_t>(records_).subspan(plan_.num_visible_records_);
     }
     [[nodiscard]] std::span<const uint8_t> symbols() const { return symbols_; }
+    [[nodiscard]] std::span<const uint8_t> detectors() const { return detectors_; }
+    [[nodiscard]] std::span<const uint8_t> observables() const { return observables_; }
+    [[nodiscard]] bool discarded() const { return discarded_; }
     [[nodiscard]] const State& state() const { return state_; }
     // Counts positive branch probability mass classified as numerical dust.
     // This telemetry accumulates across shots.
     [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
 
   private:
-    void initialize_shot(std::span<const uint8_t> presampled_values) noexcept;
+    void initialize_shot(std::span<const uint8_t> presampled_values, bool sample_noise) noexcept;
+    void sample_presampled_noise() noexcept;
 
     template <bool ForceRecords>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records) noexcept;
@@ -181,7 +230,10 @@ class Executor {
     State state_;
     std::vector<uint8_t> symbols_;
     std::vector<uint8_t> records_;
+    std::vector<uint8_t> detectors_;
+    std::vector<uint8_t> observables_;
     Xoshiro256PlusPlus rng_;
+    bool discarded_ = false;
     uint64_t dust_clamps_ = 0;
 };
 
@@ -200,5 +252,28 @@ class Executor {
 [[nodiscard]] std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
                                                            std::span<const uint8_t> forced_records,
                                                            size_t num_records);
+
+struct SamplingResult {
+    std::vector<uint8_t> measurements;
+    std::vector<uint8_t> detectors;
+    std::vector<uint8_t> observables;
+};
+
+struct SamplingSurvivorResult {
+    uint32_t total_shots = 0;
+    uint32_t passed_shots = 0;
+    uint32_t logical_errors = 0;
+    std::vector<uint64_t> observable_ones;
+    std::vector<uint8_t> measurements;
+    std::vector<uint8_t> detectors;
+    std::vector<uint8_t> observables;
+};
+
+[[nodiscard]] SamplingResult sample(const ExecutablePlan& plan, uint32_t shots,
+                                    std::optional<uint64_t> seed = std::nullopt);
+
+[[nodiscard]] SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
+                                                      std::optional<uint64_t> seed = std::nullopt,
+                                                      bool keep_records = false);
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -35,6 +35,14 @@ uint32_t index(InstrumentSiteId site) {
     return static_cast<uint32_t>(site);
 }
 
+uint32_t index(DetectorSlot slot) {
+    return static_cast<uint32_t>(slot);
+}
+
+uint32_t index(ObservableSlot slot) {
+    return static_cast<uint32_t>(slot);
+}
+
 std::vector<SymbolId> xor_terms(const std::vector<SymbolId>& left,
                                 const std::vector<SymbolId>& right) {
     // Canonical inputs are sorted and unique, so XOR is their symmetric
@@ -103,6 +111,8 @@ std::string_view symbol_kind_name(SymbolKind kind) {
             return "derived";
         case SymbolKind::Branch:
             return "branch";
+        case SymbolKind::Readout:
+            return "readout";
     }
     return "unknown";
 }
@@ -152,9 +162,13 @@ std::optional<SymbolId> defined_symbol(const SamplingAction& action) {
                 return typed.branch;
             } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                 return typed.symbol;
+            } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
+                return typed.flip;
             } else if constexpr (std::is_same_v<T, RotateActivePauli> ||
                                  std::is_same_v<T, PromoteDormantRotation> ||
                                  std::is_same_v<T, RecordClassical> ||
+                                 std::is_same_v<T, WriteDetector> ||
+                                 std::is_same_v<T, WriteObservable> ||
                                  std::is_same_v<T, InstrumentBoundary>) {
                 return std::nullopt;
             } else {
@@ -213,6 +227,16 @@ void validate_record(const SamplingPlan& plan, RecordSlot record, uint32_t actio
     if (!written_records.insert(index(record)).second) {
         invalid_plan("action " + std::to_string(action_index) + " writes record slot " +
                      std::to_string(index(record)) + " more than once");
+    }
+}
+
+void validate_written_record(const SamplingPlan& plan, RecordSlot record, uint32_t action_index,
+                             const std::unordered_set<uint32_t>& written_records) {
+    const uint64_t total = static_cast<uint64_t>(plan.num_visible_records) +
+                           static_cast<uint64_t>(plan.num_hidden_records);
+    if (index(record) >= total || !written_records.contains(index(record))) {
+        invalid_plan("action " + std::to_string(action_index) + " reads record slot " +
+                     std::to_string(index(record)) + " before assignment");
     }
 }
 
@@ -281,6 +305,9 @@ uint32_t predicted_dense_passes(const SamplingAction& action) {
             } else if constexpr (std::is_same_v<T, MeasureDormantRandom> ||
                                  std::is_same_v<T, RecordClassical> ||
                                  std::is_same_v<T, DefineSymbol> ||
+                                 std::is_same_v<T, ApplyReadoutNoise> ||
+                                 std::is_same_v<T, WriteDetector> ||
+                                 std::is_same_v<T, WriteObservable> ||
                                  std::is_same_v<T, InstrumentBoundary>) {
                 return 0;
             } else {
@@ -307,6 +334,42 @@ void SamplingPlan::validate() const {
     }
     if (!is_finite_robust(global_weight.real()) || !is_finite_robust(global_weight.imag())) {
         invalid_plan("global weight is not finite");
+    }
+
+    if (presampled_noise_sites.size() != num_noise_sites) {
+        invalid_plan("presampled noise-site table does not match declared count");
+    }
+
+    std::vector<bool> bound_noise_symbols(symbols.size(), false);
+    for (uint32_t site_index = 0; site_index < presampled_noise_sites.size(); ++site_index) {
+        const PresampledNoiseSite& site = presampled_noise_sites[site_index];
+        if (index(site.site) != site_index) {
+            invalid_plan("presampled noise sites are not in stable id order");
+        }
+        double total_probability = 0.0;
+        for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+            const uint32_t symbol_index = index(outcome.symbol);
+            if (symbol_index >= symbols.size() ||
+                symbols[symbol_index].kind != SymbolKind::Presampled ||
+                symbols[symbol_index].noise_site != site.site) {
+                invalid_plan("noise site " + std::to_string(site_index) +
+                             " references an incompatible symbol");
+            }
+            if (bound_noise_symbols[symbol_index]) {
+                invalid_plan("presampled noise symbol s" + std::to_string(symbol_index) +
+                             " is bound more than once");
+            }
+            if (!is_probability(outcome.probability) || outcome.probability == 0.0) {
+                invalid_plan("noise site " + std::to_string(site_index) +
+                             " has a nonpositive outcome probability");
+            }
+            bound_noise_symbols[symbol_index] = true;
+            total_probability += outcome.probability;
+        }
+        if (!is_finite_robust(total_probability) || total_probability > 1.0 + 1e-12) {
+            invalid_plan("noise site " + std::to_string(site_index) +
+                         " outcome probabilities exceed one");
+        }
     }
 
     std::vector<std::optional<uint32_t>> actual_definitions(symbols.size());
@@ -338,6 +401,10 @@ void SamplingPlan::validate() const {
                 invalid_plan("presampled symbol s" + std::to_string(symbol_index) +
                              " must be presampled");
             }
+            if (info.noise_site.has_value() && !bound_noise_symbols[symbol_index]) {
+                invalid_plan("noise symbol s" + std::to_string(symbol_index) +
+                             " is absent from its site distribution");
+            }
             continue;
         }
         if (!info.defining_action.has_value() ||
@@ -356,11 +423,19 @@ void SamplingPlan::validate() const {
             invalid_plan("derived symbol s" + std::to_string(symbol_index) +
                          " must be defined by DefineSymbol");
         }
+        if (info.kind == SymbolKind::Readout &&
+            !std::holds_alternative<ApplyReadoutNoise>(action)) {
+            invalid_plan("readout symbol s" + std::to_string(symbol_index) +
+                         " must be defined by ApplyReadoutNoise");
+        }
     }
 
     uint32_t active_width = initial_active_width;
     uint32_t observed_max = active_width;
     std::unordered_set<uint32_t> written_records;
+    std::unordered_set<uint32_t> written_detectors;
+    std::unordered_set<uint32_t> written_observables;
+    bool observed_postselection = false;
     written_records.reserve(std::min<size_t>(
         actions.size(), static_cast<uint64_t>(num_visible_records) + num_hidden_records));
     for (uint32_t action_index = 0; action_index < actions.size(); ++action_index) {
@@ -431,6 +506,29 @@ void SamplingPlan::validate() const {
                         invalid_plan("symbol definition changes active width");
                     }
                     validate_expression(*this, typed.value, action_index, definition, false);
+                } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
+                    if (planned.active_after != planned.active_before ||
+                        !is_probability(typed.prob_zero_to_one) ||
+                        !is_probability(typed.prob_one_to_zero)) {
+                        invalid_plan("readout noise has invalid width or probabilities");
+                    }
+                    validate_expression(*this, typed.source, action_index, definition, false);
+                    validate_written_record(*this, typed.record, action_index, written_records);
+                } else if constexpr (std::is_same_v<T, WriteDetector>) {
+                    if (planned.active_after != planned.active_before ||
+                        index(typed.detector) >= num_detectors ||
+                        !written_detectors.insert(index(typed.detector)).second) {
+                        invalid_plan("detector write has invalid width or slot");
+                    }
+                    validate_expression(*this, typed.outcome, action_index, definition, false);
+                    observed_postselection |= typed.postselected;
+                } else if constexpr (std::is_same_v<T, WriteObservable>) {
+                    if (planned.active_after != planned.active_before ||
+                        index(typed.observable) >= num_observables ||
+                        !written_observables.insert(index(typed.observable)).second) {
+                        invalid_plan("observable write has invalid width or slot");
+                    }
+                    validate_expression(*this, typed.outcome, action_index, definition, false);
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     if (planned.active_after != planned.active_before ||
                         index(typed.site) >= num_instrument_sites) {
@@ -448,6 +546,13 @@ void SamplingPlan::validate() const {
     if (observed_max != max_active_width) {
         invalid_plan("declared maximum active width does not match the action stream");
     }
+    if (written_detectors.size() != num_detectors ||
+        written_observables.size() != num_observables) {
+        invalid_plan("declared detector or observable count does not match the action stream");
+    }
+    if (observed_postselection != has_postselection) {
+        invalid_plan("declared postselection flag does not match detector actions");
+    }
 }
 
 std::string SamplingPlan::inspect() const {
@@ -458,7 +563,8 @@ std::string SamplingPlan::inspect() const {
     out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
         << " max_width=" << max_active_width << " visible_records=" << num_visible_records
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
-        << " instrument_sites=" << num_instrument_sites
+        << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
+        << " observables=" << num_observables << " postselection=" << has_postselection
         << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
     out << "global_weight=" << global_weight.real() << ',' << global_weight.imag() << '\n';
     out << "symbols=" << symbols.size() << '\n';
@@ -469,6 +575,13 @@ std::string SamplingPlan::inspect() const {
         }
         if (symbols[i].noise_site.has_value()) {
             out << " noise_site=" << index(*symbols[i].noise_site);
+        }
+        out << '\n';
+    }
+    for (const PresampledNoiseSite& site : presampled_noise_sites) {
+        out << "  noise_site " << index(site.site) << " outcomes=" << site.outcomes.size();
+        for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+            out << " s" << index(outcome.symbol) << ':' << outcome.probability;
         }
         out << '\n';
     }
@@ -503,6 +616,18 @@ std::string SamplingPlan::inspect() const {
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                     out << "define_symbol s" << index(typed.symbol)
                         << " value=" << format_expression(typed.value);
+                } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
+                    out << "readout_noise s" << index(typed.flip)
+                        << " source=" << format_expression(typed.source)
+                        << " record=" << index(typed.record) << " p01=" << typed.prob_zero_to_one
+                        << " p10=" << typed.prob_one_to_zero;
+                } else if constexpr (std::is_same_v<T, WriteDetector>) {
+                    out << "write_detector outcome=" << format_expression(typed.outcome)
+                        << " detector=" << index(typed.detector)
+                        << " postselected=" << typed.postselected;
+                } else if constexpr (std::is_same_v<T, WriteObservable>) {
+                    out << "write_observable outcome=" << format_expression(typed.outcome)
+                        << " observable=" << index(typed.observable);
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     out << "instrument_boundary site=" << index(typed.site);
                 } else {

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -328,8 +328,8 @@ void SamplingPlan::validate() const {
         invalid_plan("maximum active width must be below " +
                      std::to_string(kDenseActiveWidthLimit) + " for dense coefficient storage");
     }
-    if (static_cast<uint64_t>(num_visible_records) + num_hidden_records >
-        std::numeric_limits<uint32_t>::max()) {
+    const uint64_t total_records = static_cast<uint64_t>(num_visible_records) + num_hidden_records;
+    if (total_records > std::numeric_limits<uint32_t>::max()) {
         invalid_plan("record count exceeds uint32 range");
     }
     if (!is_finite_robust(global_weight.real()) || !is_finite_robust(global_weight.imag())) {
@@ -545,6 +545,9 @@ void SamplingPlan::validate() const {
     }
     if (observed_max != max_active_width) {
         invalid_plan("declared maximum active width does not match the action stream");
+    }
+    if (written_records.size() != total_records) {
+        invalid_plan("declared record count does not match the action stream");
     }
     if (written_detectors.size() != num_detectors ||
         written_observables.size() != num_observables) {

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -33,11 +33,14 @@ enum class SymbolId : uint32_t {};
 enum class RecordSlot : uint32_t {};
 enum class NoiseSiteId : uint32_t {};
 enum class InstrumentSiteId : uint32_t {};
+enum class DetectorSlot : uint32_t {};
+enum class ObservableSlot : uint32_t {};
 
 enum class SymbolKind : uint8_t {
     Presampled,  // Available before the action stream, such as sampled noise.
     Derived,     // Computed as a parity of previously available symbols.
     Branch,      // Sampled while applying a measurement action.
+    Readout,     // Sampled from a record-dependent readout channel.
 };
 
 // A parity expression over plan symbols, optionally XORed with true. For
@@ -141,6 +144,31 @@ struct DefineSymbol {
     AffineBool value;
 };
 
+// Samples whether a completed measurement record flips. The probability may
+// depend on the record before the flip, so unlike Pauli noise this symbol is
+// defined at its circuit position instead of before the action stream.
+struct ApplyReadoutNoise {
+    SymbolId flip{};
+    AffineBool source;
+    RecordSlot record{};
+    double prob_zero_to_one = 0.0;
+    double prob_one_to_zero = 0.0;
+};
+
+// Writes a normalized detector parity. A nonzero postselected detector rejects
+// the shot immediately; later actions and outputs are irrelevant for it.
+struct WriteDetector {
+    AffineBool outcome;
+    DetectorSlot detector{};
+    bool postselected = false;
+};
+
+// Writes one fully accumulated and normalized logical observable parity.
+struct WriteObservable {
+    AffineBool outcome;
+    ObservableSlot observable{};
+};
+
 // Divides ahead-of-time execution segments. A continuation must preserve the
 // live coefficients, active-coordinate meaning and order, active width,
 // symbol and record values, and RNG position established here. It need not
@@ -152,7 +180,8 @@ struct InstrumentBoundary {
 
 using SamplingAction =
     std::variant<RotateActivePauli, PromoteDormantRotation, MeasureActivePauli,
-                 MeasureDormantRandom, RecordClassical, DefineSymbol, InstrumentBoundary>;
+                 MeasureDormantRandom, RecordClassical, DefineSymbol, ApplyReadoutNoise,
+                 WriteDetector, WriteObservable, InstrumentBoundary>;
 
 struct PlannedAction {
     uint32_t active_before = 0;
@@ -175,6 +204,18 @@ struct SymbolInfo {
     std::optional<NoiseSiteId> noise_site;
 };
 
+// One nonidentity outcome of a mutually exclusive Pauli-noise site. The
+// identity outcome has the remaining probability and no symbol.
+struct PresampledNoiseOutcome {
+    SymbolId symbol{};
+    double probability = 0.0;
+};
+
+struct PresampledNoiseSite {
+    NoiseSiteId site{};
+    std::vector<PresampledNoiseOutcome> outcomes;
+};
+
 struct SamplingPlan {
     uint32_t num_qubits = 0;
 
@@ -188,9 +229,13 @@ struct SamplingPlan {
     uint32_t num_hidden_records = 0;
     uint32_t num_noise_sites = 0;
     uint32_t num_instrument_sites = 0;
+    uint32_t num_detectors = 0;
+    uint32_t num_observables = 0;
+    bool has_postselection = false;
     std::complex<double> global_weight = {1.0, 0.0};
 
     std::vector<SymbolInfo> symbols;
+    std::vector<PresampledNoiseSite> presampled_noise_sites;
     std::vector<PlannedAction> actions;
 
     // Throws std::invalid_argument when the plan is structurally inconsistent.

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -155,15 +155,17 @@ struct ApplyReadoutNoise {
     double prob_one_to_zero = 0.0;
 };
 
-// Writes a normalized detector parity. A nonzero postselected detector rejects
-// the shot immediately; later actions and outputs are irrelevant for it.
+// Writes a detector parity after the planner has XORed its expected reference
+// parity into the expression. A nonzero postselected detector rejects the shot
+// immediately; later actions and outputs are irrelevant for it.
 struct WriteDetector {
     AffineBool outcome;
     DetectorSlot detector{};
     bool postselected = false;
 };
 
-// Writes one fully accumulated and normalized logical observable parity.
+// Writes one fully accumulated logical observable after the planner has XORed
+// its expected reference parity into the expression.
 struct WriteObservable {
     AffineBool outcome;
     ObservableSlot observable{};

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -41,12 +41,54 @@ struct PendingMeasurement {
     RecordSlot record{};
 };
 
-using PendingOperation = std::variant<PendingRotation, PendingMeasurement>;
+struct PendingConditionalPauli {
+    Pauli body;
+    RecordSlot controller{};
+};
+
+struct PendingNoiseChannel {
+    Pauli body;
+    SymbolId symbol{};
+};
+
+struct PendingNoise {
+    std::vector<PendingNoiseChannel> channels;
+};
+
+struct PendingReadoutNoise {
+    RecordSlot record{};
+    double prob_zero_to_one = 0.0;
+    double prob_one_to_zero = 0.0;
+};
+
+struct PendingDetector {
+    std::vector<RecordSlot> records;
+    DetectorSlot detector{};
+    bool expected = false;
+    bool postselected = false;
+};
+
+struct PendingObservable {
+    std::vector<RecordSlot> records;
+    ObservableSlot observable{};
+};
+
+using PendingOperation =
+    std::variant<PendingRotation, PendingMeasurement, PendingConditionalPauli, PendingNoise,
+                 PendingReadoutNoise, PendingDetector, PendingObservable>;
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
     mask_view_to_stim(hir.destab_mask(op), hir.num_qubits, result.xs);
     mask_view_to_stim(hir.stab_mask(op), hir.num_qubits, result.zs);
+    return result;
+}
+
+Pauli noise_pauli_from_hir(const HirModule& hir, PauliMaskHandle handle) {
+    Pauli result(hir.num_qubits);
+    const PauliMaskView mask = hir.noise_channel_masks.at(handle);
+    mask_view_to_stim(mask.x(), hir.num_qubits, result.xs);
+    mask_view_to_stim(mask.z(), hir.num_qubits, result.zs);
     return result;
 }
 
@@ -245,7 +287,17 @@ void visit_pending_pauli(PendingOperation& operation, Function&& function) {
             using T = std::decay_t<decltype(typed)>;
             if constexpr (std::is_same_v<T, PendingRotation> ||
                           std::is_same_v<T, PendingMeasurement>) {
-                function(typed.body, typed.sign);
+                function(typed.body, &typed.sign);
+            } else if constexpr (std::is_same_v<T, PendingConditionalPauli>) {
+                function(typed.body, nullptr);
+            } else if constexpr (std::is_same_v<T, PendingNoise>) {
+                for (PendingNoiseChannel& channel : typed.channels) {
+                    function(channel.body, nullptr);
+                }
+            } else if constexpr (std::is_same_v<T, PendingReadoutNoise> ||
+                                 std::is_same_v<T, PendingDetector> ||
+                                 std::is_same_v<T, PendingObservable>) {
+                // Purely classical operations have no coordinate body.
             } else {
                 static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
             }
@@ -260,12 +312,40 @@ void transform_future_operations(std::vector<PendingOperation>& pending, size_t 
     // perform tableau evolution in the dispatch loop.
     const Tableau old_to_new = new_basis_in_old_coordinates.inverse();
     for (size_t i = begin; i < pending.size(); ++i) {
-        visit_pending_pauli(pending[i], [&](Pauli& body, AffineBool& sign) {
+        visit_pending_pauli(pending[i], [&](Pauli& body, AffineBool* sign) {
             Pauli transformed = old_to_new(body);
-            sign ^= static_cast<bool>(transformed.sign);
+            if (sign != nullptr) {
+                *sign ^= static_cast<bool>(transformed.sign);
+            }
             transformed.sign = false;
             body = std::move(transformed);
         });
+    }
+}
+
+void propagate_conditional_pauli(std::vector<PendingOperation>& pending, size_t begin,
+                                 const Pauli& correction, const AffineBool& condition) {
+    for (size_t i = begin; i < pending.size(); ++i) {
+        std::visit(
+            [&](auto& typed) {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, PendingRotation> ||
+                              std::is_same_v<T, PendingMeasurement>) {
+                    if (anticommutes(correction, typed.body)) {
+                        typed.sign ^= condition;
+                    }
+                } else if constexpr (std::is_same_v<T, PendingConditionalPauli> ||
+                                     std::is_same_v<T, PendingNoise> ||
+                                     std::is_same_v<T, PendingReadoutNoise> ||
+                                     std::is_same_v<T, PendingDetector> ||
+                                     std::is_same_v<T, PendingObservable>) {
+                    // Pauli-frame phases do not affect later Pauli corrections or
+                    // classical record consumers.
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
+                }
+            },
+            pending[i]);
     }
 }
 
@@ -274,11 +354,26 @@ void propagate_branch(std::vector<PendingOperation>& pending, size_t begin,
     // The sampled minus eigenspace differs by X on the replaced Z coordinate.
     // Anticommuting future Paulis therefore acquire this branch in their sign.
     for (size_t i = begin; i < pending.size(); ++i) {
-        visit_pending_pauli(pending[i], [&](const Pauli& body, AffineBool& sign) {
-            if (body.zs[branch_coordinate]) {
-                sign ^= AffineBool::symbol(branch);
-            }
-        });
+        std::visit(
+            [&](auto& typed) {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, PendingRotation> ||
+                              std::is_same_v<T, PendingMeasurement>) {
+                    if (typed.body.zs[branch_coordinate]) {
+                        typed.sign ^= AffineBool::symbol(branch);
+                    }
+                } else if constexpr (std::is_same_v<T, PendingConditionalPauli> ||
+                                     std::is_same_v<T, PendingNoise> ||
+                                     std::is_same_v<T, PendingReadoutNoise> ||
+                                     std::is_same_v<T, PendingDetector> ||
+                                     std::is_same_v<T, PendingObservable>) {
+                    // A branch Pauli can only add an irrelevant sign to another
+                    // Pauli-frame correction.
+                } else {
+                    static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
+                }
+            },
+            pending[i]);
     }
 }
 
@@ -292,9 +387,30 @@ void multiply_phase(std::complex<double>& weight, double angle) {
     weight *= std::complex<double>(std::cos(angle), std::sin(angle));
 }
 
-std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, SamplingPlan& plan) {
+std::vector<RecordSlot> record_slots(const std::vector<uint32_t>& records) {
+    std::vector<RecordSlot> result;
+    result.reserve(records.size());
+    for (uint32_t record : records) {
+        result.push_back(RecordSlot{record});
+    }
+    return result;
+}
+
+bool option_bit(std::span<const uint8_t> values, uint32_t index) {
+    return index < values.size() && values[index] != 0;
+}
+
+std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, SamplingPlan& plan,
+                                                         SamplingPlanOptions options) {
     std::vector<PendingOperation> pending;
     pending.reserve(hir.ops.size());
+    plan.presampled_noise_sites.resize(hir.noise_sites.size());
+    for (uint32_t site = 0; site < hir.noise_sites.size(); ++site) {
+        plan.presampled_noise_sites[site].site = NoiseSiteId{site};
+    }
+    std::vector<bool> seen_noise_sites(hir.noise_sites.size(), false);
+
+    uint32_t detector_index = 0;
 
     for (size_t i = 0; i < hir.ops.size(); ++i) {
         const HeisenbergOp& op = hir.ops[i];
@@ -320,10 +436,74 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                                        RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}});
                 break;
             case OpType::CONDITIONAL_PAULI:
-            case OpType::NOISE:
-            case OpType::READOUT_NOISE:
-            case OpType::DETECTOR:
-            case OpType::OBSERVABLE:
+                pending.emplace_back(PendingConditionalPauli{
+                    pauli_from_hir(hir, op),
+                    RecordSlot{static_cast<uint32_t>(op.controlling_meas())}});
+                break;
+            case OpType::NOISE: {
+                const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
+                if (site_index >= hir.noise_sites.size()) {
+                    throw std::invalid_argument("sampling planner noise site is out of range");
+                }
+                if (seen_noise_sites[site_index]) {
+                    throw std::invalid_argument(
+                        "sampling planner encountered a duplicate noise site");
+                }
+                seen_noise_sites[site_index] = true;
+                const NoiseSite& hir_site = hir.noise_sites[site_index];
+                PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];
+                PendingNoise noise;
+                noise.channels.reserve(hir_site.channels.size());
+                plan_site.outcomes.reserve(hir_site.channels.size());
+                for (const NoiseChannel& channel : hir_site.channels) {
+                    if (channel.prob == 0.0) {
+                        continue;
+                    }
+                    const SymbolId symbol{static_cast<uint32_t>(plan.symbols.size())};
+                    plan.symbols.push_back(
+                        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{site_index}});
+                    plan_site.outcomes.push_back(PresampledNoiseOutcome{symbol, channel.prob});
+                    noise.channels.push_back(
+                        PendingNoiseChannel{noise_pauli_from_hir(hir, channel.mask), symbol});
+                }
+                pending.emplace_back(std::move(noise));
+                break;
+            }
+            case OpType::READOUT_NOISE: {
+                const uint32_t entry_index = static_cast<uint32_t>(op.readout_noise_idx());
+                if (entry_index >= hir.readout_noise.size()) {
+                    throw std::invalid_argument("sampling planner readout entry is out of range");
+                }
+                const ReadoutNoiseEntry& entry = hir.readout_noise[entry_index];
+                pending.emplace_back(PendingReadoutNoise{
+                    RecordSlot{entry.meas_idx}, entry.prob_zero_to_one, entry.prob_one_to_zero});
+                break;
+            }
+            case OpType::DETECTOR: {
+                const uint32_t targets_index = static_cast<uint32_t>(op.detector_idx());
+                if (targets_index >= hir.detector_targets.size() ||
+                    detector_index >= hir.num_detectors) {
+                    throw std::invalid_argument("sampling planner detector is out of range");
+                }
+                pending.emplace_back(PendingDetector{
+                    record_slots(hir.detector_targets[targets_index]), DetectorSlot{detector_index},
+                    option_bit(options.expected_detectors, detector_index),
+                    option_bit(options.postselection_mask, detector_index)});
+                ++detector_index;
+                break;
+            }
+            case OpType::OBSERVABLE: {
+                const uint32_t targets_index = op.observable_target_list_idx();
+                const uint32_t observable_index = static_cast<uint32_t>(op.observable_idx());
+                if (targets_index >= hir.observable_targets.size() ||
+                    observable_index >= hir.num_observables) {
+                    throw std::invalid_argument("sampling planner observable is out of range");
+                }
+                pending.emplace_back(
+                    PendingObservable{record_slots(hir.observable_targets[targets_index]),
+                                      ObservableSlot{observable_index}});
+                break;
+            }
             case OpType::EXP_VAL:
             case OpType::INSTRUMENT:
             case OpType::NUM_OP_TYPES:
@@ -331,6 +511,12 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                                             op_type_to_str(op.op_type()) + " at index " +
                                             std::to_string(i));
         }
+    }
+    if (detector_index != hir.num_detectors) {
+        throw std::invalid_argument("sampling planner detector count is inconsistent with HIR");
+    }
+    if (!std::ranges::all_of(seen_noise_sites, [](bool seen) { return seen; })) {
+        throw std::invalid_argument("sampling planner noise-site table is inconsistent with HIR");
     }
     return pending;
 }
@@ -361,9 +547,9 @@ void process_rotation(std::vector<PendingOperation>& pending, size_t index,
     plan.max_active_width = std::max(plan.max_active_width, active_width);
 }
 
-void process_measurement(std::vector<PendingOperation>& pending, size_t index,
-                         const PendingMeasurement& measurement, SamplingPlan& plan,
-                         uint32_t& active_width) {
+AffineBool process_measurement(std::vector<PendingOperation>& pending, size_t index,
+                               const PendingMeasurement& measurement, SamplingPlan& plan,
+                               uint32_t& active_width) {
     const std::optional<uint32_t> dormant_pivot =
         first_x_at_or_above(measurement.body, active_width);
     if (dormant_pivot.has_value()) {
@@ -373,19 +559,18 @@ void process_measurement(std::vector<PendingOperation>& pending, size_t index,
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
         const SymbolId branch = append_branch(plan, action_index);
         propagate_branch(pending, index + 1, *dormant_pivot, branch);
-        plan.actions.push_back(
-            PlannedAction{active_width, active_width,
-                          MeasureDormantRandom{*dormant_pivot, branch,
-                                               measurement.sign ^ AffineBool::symbol(branch),
-                                               measurement.record}});
-        return;
+        const AffineBool outcome = measurement.sign ^ AffineBool::symbol(branch);
+        plan.actions.push_back(PlannedAction{
+            active_width, active_width,
+            MeasureDormantRandom{*dormant_pivot, branch, outcome, measurement.record}});
+        return outcome;
     }
 
     const ActivePauli active = active_projection(measurement.body, active_width);
     if (active.is_identity()) {
         plan.actions.push_back(PlannedAction{
             active_width, active_width, RecordClassical{measurement.sign, measurement.record}});
-        return;
+        return measurement.sign;
     }
 
     std::optional<uint32_t> pivot = first_x_below(measurement.body, active_width);
@@ -407,25 +592,61 @@ void process_measurement(std::vector<PendingOperation>& pending, size_t index,
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     const SymbolId branch = append_branch(plan, action_index);
     propagate_branch(pending, index + 1, active_width - 1, branch);
-    plan.actions.push_back(PlannedAction{
-        active_width, active_width - 1,
-        MeasureActivePauli{active, *pivot, branch, measurement.sign ^ AffineBool::symbol(branch),
-                           measurement.record}});
+    const AffineBool outcome = measurement.sign ^ AffineBool::symbol(branch);
+    plan.actions.push_back(
+        PlannedAction{active_width, active_width - 1,
+                      MeasureActivePauli{active, *pivot, branch, outcome, measurement.record}});
     --active_width;
+    return outcome;
 }
 
 }  // namespace
 
-SamplingPlan plan_sampling(const HirModule& hir) {
+SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     SamplingPlan plan;
     plan.num_qubits = hir.num_qubits;
     plan.num_visible_records = hir.num_measurements;
     plan.num_hidden_records = hir.num_hidden_measurements;
     plan.num_noise_sites = static_cast<uint32_t>(hir.noise_sites.size());
     plan.num_instrument_sites = static_cast<uint32_t>(hir.instrument_sites.size());
+    plan.num_detectors = hir.num_detectors;
+    plan.num_observables = hir.num_observables;
     plan.global_weight = hir.global_weight;
 
-    std::vector<PendingOperation> pending = queue_supported_operations(hir, plan);
+    std::vector<PendingOperation> pending = queue_supported_operations(hir, plan, options);
+    std::vector<std::optional<AffineBool>> record_values(static_cast<size_t>(hir.num_measurements) +
+                                                         hir.num_hidden_measurements);
+    std::vector<AffineBool> observable_values(hir.num_observables);
+
+    auto require_record = [&](RecordSlot record, size_t operation_index) -> const AffineBool& {
+        const uint32_t record_index = static_cast<uint32_t>(record);
+        if (record_index >= record_values.size() || !record_values[record_index].has_value()) {
+            throw std::invalid_argument("sampling planner operation " +
+                                        std::to_string(operation_index) + " reads record " +
+                                        std::to_string(record_index) + " before assignment");
+        }
+        return *record_values[record_index];
+    };
+
+    auto assign_record = [&](RecordSlot record, AffineBool value, size_t operation_index) {
+        const uint32_t record_index = static_cast<uint32_t>(record);
+        if (record_index >= record_values.size()) {
+            throw std::invalid_argument("sampling planner operation " +
+                                        std::to_string(operation_index) + " writes record " +
+                                        std::to_string(record_index) + " out of range");
+        }
+        record_values[record_index] = std::move(value);
+    };
+
+    auto record_parity = [&](const std::vector<RecordSlot>& records,
+                             size_t operation_index) -> AffineBool {
+        AffineBool result;
+        for (RecordSlot record : records) {
+            result ^= require_record(record, operation_index);
+        }
+        return result;
+    };
+
     uint32_t active_width = plan.initial_active_width;
     for (size_t i = 0; i < pending.size(); ++i) {
         std::visit(
@@ -434,12 +655,54 @@ SamplingPlan plan_sampling(const HirModule& hir) {
                 if constexpr (std::is_same_v<T, PendingRotation>) {
                     process_rotation(pending, i, operation, plan, active_width);
                 } else if constexpr (std::is_same_v<T, PendingMeasurement>) {
-                    process_measurement(pending, i, operation, plan, active_width);
+                    const AffineBool outcome =
+                        process_measurement(pending, i, operation, plan, active_width);
+                    assign_record(operation.record, outcome, i);
+                } else if constexpr (std::is_same_v<T, PendingConditionalPauli>) {
+                    propagate_conditional_pauli(pending, i + 1, operation.body,
+                                                require_record(operation.controller, i));
+                } else if constexpr (std::is_same_v<T, PendingNoise>) {
+                    for (const PendingNoiseChannel& channel : operation.channels) {
+                        propagate_conditional_pauli(pending, i + 1, channel.body,
+                                                    AffineBool::symbol(channel.symbol));
+                    }
+                } else if constexpr (std::is_same_v<T, PendingReadoutNoise>) {
+                    const AffineBool source = require_record(operation.record, i);
+                    if (operation.prob_zero_to_one == 0.0 && operation.prob_one_to_zero == 0.0) {
+                        return;
+                    }
+                    const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
+                    const SymbolId flip{static_cast<uint32_t>(plan.symbols.size())};
+                    plan.symbols.push_back(
+                        SymbolInfo{SymbolKind::Readout, action_index, std::nullopt});
+                    plan.actions.push_back(PlannedAction{
+                        active_width, active_width,
+                        ApplyReadoutNoise{flip, source, operation.record,
+                                          operation.prob_zero_to_one, operation.prob_one_to_zero}});
+                    record_values[static_cast<uint32_t>(operation.record)] =
+                        source ^ AffineBool::symbol(flip);
+                } else if constexpr (std::is_same_v<T, PendingDetector>) {
+                    AffineBool outcome = record_parity(operation.records, i);
+                    outcome ^= operation.expected;
+                    plan.actions.push_back(PlannedAction{
+                        active_width, active_width,
+                        WriteDetector{outcome, operation.detector, operation.postselected}});
+                    plan.has_postselection |= operation.postselected;
+                } else if constexpr (std::is_same_v<T, PendingObservable>) {
+                    observable_values[static_cast<uint32_t>(operation.observable)] ^=
+                        record_parity(operation.records, i);
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
                 }
             },
             pending[i]);
+    }
+
+    for (uint32_t observable = 0; observable < observable_values.size(); ++observable) {
+        observable_values[observable] ^= option_bit(options.expected_observables, observable);
+        plan.actions.push_back(PlannedAction{
+            active_width, active_width,
+            WriteObservable{observable_values[observable], ObservableSlot{observable}}});
     }
 
     plan.validate();

--- a/src/clifft/sampling/planner.h
+++ b/src/clifft/sampling/planner.h
@@ -3,14 +3,22 @@
 #include "clifft/frontend/hir.h"
 #include "clifft/sampling/plan.h"
 
+#include <span>
+
 namespace clifft::sampling {
 
 // Builds the executor-independent sampling plan for the supported optimized
 // HIR subset. The planner performs all stabilizer-coordinate changes and
 // symbolic dependency discovery before execution.
 //
-// The initial subset accepts T gates, phase rotations, and measurements. It
-// throws std::invalid_argument for every other HIR operation.
-[[nodiscard]] SamplingPlan plan_sampling(const HirModule& hir);
+struct SamplingPlanOptions {
+    std::span<const uint8_t> postselection_mask;
+    std::span<const uint8_t> expected_detectors;
+    std::span<const uint8_t> expected_observables;
+};
+
+// State-dependent instruments and exact-state probes remain outside this
+// sampling-only plan.
+[[nodiscard]] SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options = {});
 
 }  // namespace clifft::sampling

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clifft/backend/backend.h"
+#include "clifft/util/noise_sampling.h"
 #include "clifft/util/page_allocation.h"
 #include "clifft/util/xoshiro.h"
 
@@ -167,25 +168,18 @@ class SchrodingerState {
         }
     }
 
-    // Advance next_noise_idx by sampling an exponential gap.
-    // Uses the cumulative hazard table to skip silent noise sites in O(1).
+    // Advance next_noise_idx by sampling an exponential gap. The cumulative
+    // hazard lookup is logarithmic regardless of how many silent sites it skips.
     void draw_next_noise(const std::vector<double>& hazards) {
         // Gap exhaustion fast-path: when the sampled exponential gap
-        // exceeds the total accumulated hazard, std::upper_bound returns
-        // end(), making next_noise_idx == size() (out-of-bounds). This is
-        // mathematically correct: a gap larger than the remaining circuit
-        // hazard means no further noise events fire in this shot, so the
-        // VM skips all subsequent OP_NOISE sites in O(1) via the
-        // site_idx != next_noise_idx guard in exec_noise().
+        // exceeds the total accumulated hazard, the helper returns the sentinel.
+        // This is mathematically correct: a gap larger than the remaining circuit
+        // hazard means no further noise events fire in this shot.
         if (hazards.empty() || next_noise_idx >= hazards.size()) {
-            next_noise_idx = static_cast<uint32_t>(-1);
+            next_noise_idx = kNoNoiseSite;
             return;
         }
-        double current_hazard = (next_noise_idx == 0) ? 0.0 : hazards[next_noise_idx - 1];
-        double gap = -std::log(1.0 - random_double());
-        double target_hazard = current_hazard + gap;
-        auto it = std::upper_bound(hazards.begin(), hazards.end(), target_hazard);
-        next_noise_idx = static_cast<uint32_t>(std::distance(hazards.begin(), it));
+        next_noise_idx = sample_next_noise_site(hazards, next_noise_idx, random_double());
     }
 
     // Telemetry: count of times the epsilon threshold caught floating-point

--- a/src/clifft/util/noise_sampling.h
+++ b/src/clifft/util/noise_sampling.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+
+namespace clifft {
+
+inline constexpr uint32_t kNoNoiseSite = std::numeric_limits<uint32_t>::max();
+
+// Converts one independent Bernoulli site into additive hazard space. The
+// clamp keeps a probability rounded to one finite and aligned with the finest
+// probability step of the repository's deterministic [0, 1) RNG conversion.
+[[nodiscard]] inline double bernoulli_hazard(double probability) noexcept {
+    assert(std::isfinite(probability) && probability >= 0.0 &&
+           "noise probability must be finite and nonnegative");
+    return -std::log1p(-std::min(probability, 1.0 - 0x1.0p-53));
+}
+
+// Uses one exponential gap to skip independent silent Bernoulli sites. The
+// cumulative table may contain repeated entries for zero-probability sites;
+// upper_bound skips those without special cases in the hot caller.
+[[nodiscard]] inline uint32_t sample_next_noise_site(std::span<const double> cumulative_hazards,
+                                                     uint32_t first_candidate,
+                                                     double uniform_draw) noexcept {
+    if (first_candidate >= cumulative_hazards.size()) {
+        return kNoNoiseSite;
+    }
+    assert(uniform_draw >= 0.0 && uniform_draw < 1.0 && "noise gap draw must be in [0, 1)");
+    const double current_hazard =
+        first_candidate == 0 ? 0.0 : cumulative_hazards[first_candidate - 1];
+    const double target_hazard = current_hazard - std::log(1.0 - uniform_draw);
+    const auto candidate = std::upper_bound(cumulative_hazards.begin() + first_candidate,
+                                            cumulative_hazards.end(), target_hazard);
+    if (candidate == cumulative_hazards.end()) {
+        return kNoNoiseSite;
+    }
+    return static_cast<uint32_t>(candidate - cumulative_hazards.begin());
+}
+
+}  // namespace clifft

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -899,6 +899,9 @@ NB_MODULE(_clifft_core, m) {
         .def_prop_ro("num_measurements", &clifft::sampling::ExecutablePlan::num_visible_records)
         .def_prop_ro("num_hidden_measurements",
                      &clifft::sampling::ExecutablePlan::num_hidden_records)
+        .def_prop_ro("num_detectors", &clifft::sampling::ExecutablePlan::num_detectors)
+        .def_prop_ro("num_observables", &clifft::sampling::ExecutablePlan::num_observables)
+        .def_prop_ro("has_postselection", &clifft::sampling::ExecutablePlan::has_postselection)
         .def_prop_ro("num_actions", &clifft::sampling::ExecutablePlan::num_actions)
         .def("__repr__", [](const clifft::sampling::ExecutablePlan& p) {
             return "ExperimentalSamplingProgram(" + std::to_string(p.num_actions()) + " actions, " +
@@ -907,30 +910,77 @@ NB_MODULE(_clifft_core, m) {
 
     m.def(
         "_compile_experimental_sampling",
-        [](const std::string& stim_text, clifft::HirPassManager* hir_passes) {
+        [](const std::string& stim_text, std::vector<uint8_t> postselection_mask,
+           std::vector<uint8_t> expected_detectors, std::vector<uint8_t> expected_observables,
+           bool normalize_syndromes, clifft::HirPassManager* hir_passes) {
             nb::gil_scoped_release release;
             clifft::HirModule hir = clifft::trace(clifft::parse(stim_text));
             if (hir_passes != nullptr) {
                 hir_passes->run(hir);
             }
-            return clifft::sampling::ExecutablePlan(clifft::sampling::plan_sampling(hir));
+            if (normalize_syndromes) {
+                if (!expected_detectors.empty() || !expected_observables.empty()) {
+                    throw std::invalid_argument(
+                        "Cannot provide expected parities when normalize_syndromes=True");
+                }
+                clifft::ReferenceSyndrome reference = clifft::compute_reference_syndrome(hir);
+                expected_detectors = std::move(reference.detectors);
+                expected_observables = std::move(reference.observables);
+            }
+            return clifft::sampling::ExecutablePlan(clifft::sampling::plan_sampling(
+                hir, {postselection_mask, expected_detectors, expected_observables}));
         },
-        nb::arg("stim_text"), nb::arg("hir_passes") = nb::none(),
+        nb::arg("stim_text"), nb::arg("postselection_mask") = std::vector<uint8_t>{},
+        nb::arg("expected_detectors") = std::vector<uint8_t>{},
+        nb::arg("expected_observables") = std::vector<uint8_t>{},
+        nb::arg("normalize_syndromes") = false, nb::arg("hir_passes") = nb::none(),
         "Compile a circuit into the experimental scalar sampling backend.");
 
     m.def(
         "_sample_experimental_sampling",
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
            std::optional<uint64_t> seed) {
-            std::vector<uint8_t> records;
+            clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                records = clifft::sampling::sample_records(program, shots, seed);
+                result = clifft::sampling::sample(program, shots, seed);
             }
-            return vec_to_numpy(std::move(records), {shots, program.num_visible_records()});
+            auto measurements = vec_to_numpy(std::move(result.measurements),
+                                             {shots, program.num_visible_records()});
+            auto detectors =
+                vec_to_numpy(std::move(result.detectors), {shots, program.num_detectors()});
+            auto observables =
+                vec_to_numpy(std::move(result.observables), {shots, program.num_observables()});
+            return nb::make_tuple(measurements, detectors, observables);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         "Sample an experimental scalar sampling program.");
+
+    m.def(
+        "_sample_survivors_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
+           std::optional<uint64_t> seed, bool keep_records) {
+            clifft::sampling::SamplingSurvivorResult result;
+            {
+                nb::gil_scoped_release release;
+                result = clifft::sampling::sample_survivors(program, shots, seed, keep_records);
+            }
+            const size_t rows = keep_records ? result.passed_shots : 0;
+            auto measurements =
+                vec_to_numpy(std::move(result.measurements), {rows, program.num_visible_records()});
+            auto detectors =
+                vec_to_numpy(std::move(result.detectors), {rows, program.num_detectors()});
+            auto observables =
+                vec_to_numpy(std::move(result.observables), {rows, program.num_observables()});
+            const size_t num_observable_counts = result.observable_ones.size();
+            auto observable_ones =
+                vec_to_numpy(std::move(result.observable_ones), {num_observable_counts});
+            return nb::make_tuple(measurements, detectors, observables, result.total_shots,
+                                  result.passed_shots, result.logical_errors, observable_ones);
+        },
+        nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
+        nb::arg("keep_records") = false,
+        "Sample survivor counts and optional records from an experimental program.");
 
     m.def(
         "_record_probabilities_experimental_sampling",

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -19,6 +19,7 @@ from clifft._clifft_core import (
     _ExperimentalSamplingProgram,
     _record_probabilities_experimental_sampling,
     _sample_experimental_sampling,
+    _sample_survivors_experimental_sampling,
     default_hir_pass_manager,
 )
 from clifft._sample_result import SampleResult
@@ -36,26 +37,75 @@ _DEFAULT_PASSES = _DefaultPasses()
 def compile(
     stim_text: str,
     *,
+    postselection_mask: list[int] | None = None,
+    expected_detectors: list[int] | None = None,
+    expected_observables: list[int] | None = None,
+    normalize_syndromes: bool = False,
     hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
 ) -> Program:
     """Compile Stim text for the experimental scalar sampling backend.
 
-    Only the currently implemented noiseless rotation-and-measurement subset
-    is accepted. Unsupported operations fail during compilation. The default
-    HIR optimization pipeline matches :func:`clifft.compile`; pass ``None`` to
-    skip it.
+    The default HIR optimization pipeline matches :func:`clifft.compile`;
+    pass ``None`` to skip it. State-dependent instruments and exact-state
+    probes remain unsupported.
     """
     if isinstance(hir_passes, _DefaultPasses):
         hir_passes = default_hir_pass_manager()
-    return cast(Program, _compile_experimental_sampling(stim_text, hir_passes))
+    return cast(
+        Program,
+        _compile_experimental_sampling(
+            stim_text,
+            postselection_mask if postselection_mask is not None else [],
+            expected_detectors if expected_detectors is not None else [],
+            expected_observables if expected_observables is not None else [],
+            normalize_syndromes,
+            hir_passes,
+        ),
+    )
 
 
 def sample(program: Program, shots: int, seed: int | None = None) -> SampleResult:
     """Sample a prepared experimental program without changing Clifft's default backend."""
-    measurements = cast(npt.NDArray[np.uint8], _sample_experimental_sampling(program, shots, seed))
-    detectors = np.empty((shots, 0), dtype=np.uint8)
-    observables = np.empty((shots, 0), dtype=np.uint8)
+    measurements, detectors, observables = cast(
+        tuple[
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+        ],
+        _sample_experimental_sampling(program, shots, seed),
+    )
     return SampleResult(measurements, detectors, observables)
+
+
+def sample_survivors(
+    program: Program,
+    shots: int,
+    seed: int | None = None,
+    *,
+    keep_records: bool = False,
+) -> SampleResult:
+    """Sample survivor counts and optional records from an experimental program."""
+    measurements, detectors, observables, total, passed, logical_errors, observable_ones = cast(
+        tuple[
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            int,
+            int,
+            int,
+            npt.NDArray[np.uint64],
+        ],
+        _sample_survivors_experimental_sampling(program, shots, seed, keep_records),
+    )
+    return SampleResult(
+        measurements,
+        detectors,
+        observables,
+        total,
+        passed,
+        logical_errors,
+        observable_ones,
+    )
 
 
 def record_probabilities(
@@ -80,4 +130,11 @@ def record_probabilities(
     return np.exp(log_probabilities)
 
 
-__all__ = ["MeasurementRecords", "Program", "compile", "record_probabilities", "sample"]
+__all__ = [
+    "MeasurementRecords",
+    "Program",
+    "compile",
+    "record_probabilities",
+    "sample",
+    "sample_survivors",
+]

--- a/tests/python/test_experimental_sampling.py
+++ b/tests/python/test_experimental_sampling.py
@@ -1,7 +1,10 @@
 """Conformance and boundary tests for the explicitly selected sampling backend."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
+import stim
 
 import clifft
 import clifft.experimental as experimental
@@ -39,12 +42,92 @@ def test_seeded_samples_match_legacy_for_curated_circuits(circuit: str) -> None:
 @pytest.mark.parametrize(
     "circuit,operation",
     [
-        ("X_ERROR(0.1) 0\nM 0", "NOISE"),
-        ("H 0\nM 0\nCX rec[-1] 1", "CONDITIONAL_PAULI"),
-        ("R 0", "CONDITIONAL_PAULI"),
-        ("M 0\nDETECTOR rec[-1]", "DETECTOR"),
+        ("EXP_VAL Z0", "EXP_VAL"),
     ],
 )
 def test_unsupported_capabilities_fail_during_compile(circuit: str, operation: str) -> None:
     with pytest.raises(ValueError, match=operation):
         experimental.compile(circuit)
+
+
+def test_noise_readout_feedback_and_syndrome_share_one_symbolic_record() -> None:
+    circuit = """
+        X_ERROR(1) 0
+        M 0
+        READOUT_NOISE(1) rec[-1]
+        CX rec[-1] 1
+        M 1
+        DETECTOR rec[-1] rec[-2]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    """
+    result = experimental.sample(experimental.compile(circuit), shots=32, seed=7)
+
+    np.testing.assert_array_equal(result.measurements, np.zeros((32, 2), dtype=np.uint8))
+    np.testing.assert_array_equal(result.detectors, np.zeros((32, 1), dtype=np.uint8))
+    np.testing.assert_array_equal(result.observables, np.zeros((32, 1), dtype=np.uint8))
+
+
+def test_asymmetric_readout_noise_uses_the_pre_flip_record() -> None:
+    zero = experimental.sample(experimental.compile("M 0\nREADOUT_NOISE(1, 0) rec[-1]"), 16, seed=1)
+    one = experimental.sample(
+        experimental.compile("X 0\nM 0\nREADOUT_NOISE(0, 1) rec[-1]"), 16, seed=1
+    )
+
+    assert np.all(zero.measurements == 1)
+    assert np.all(one.measurements == 0)
+
+
+def test_postselection_survivor_metadata_and_records() -> None:
+    program = experimental.compile(
+        "H 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]",
+        postselection_mask=[1],
+    )
+    with pytest.raises(ValueError, match="sample_survivors"):
+        experimental.sample(program, 10, seed=1)
+
+    result = experimental.sample_survivors(program, 1000, seed=1, keep_records=True)
+    assert result.passed_shots is not None
+    assert result.total_shots is not None
+    assert result.discards is not None
+    assert 0 < result.passed_shots < result.total_shots
+    assert result.discards == result.total_shots - result.passed_shots
+    assert result.logical_errors == 0
+    assert np.all(result.measurements == 0)
+    assert np.all(result.detectors == 0)
+    assert np.all(result.observables == 0)
+
+
+def test_noisy_record_probabilities_remain_explicitly_unsupported() -> None:
+    program = experimental.compile("X_ERROR(0.1) 0\nM 0")
+    with pytest.raises(ValueError, match="presampled symbols"):
+        experimental.record_probabilities(program, ["0"])
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "tests/fixtures/target_qec.stim",
+        "tests/fixtures/cultivation_d5.stim",
+    ],
+)
+def test_representative_qec_fixtures_execute(fixture: str) -> None:
+    program = experimental.compile(Path(fixture).read_text())
+    result = experimental.sample(program, shots=1, seed=3)
+
+    assert result.measurements.shape == (1, program.num_measurements)
+    assert result.detectors.shape == (1, program.num_detectors)
+    assert result.observables.shape == (1, program.num_observables)
+
+
+def test_generated_surface_code_executes_with_reference_normalization() -> None:
+    circuit = stim.Circuit.generated(
+        "surface_code:rotated_memory_x",
+        distance=3,
+        rounds=3,
+        after_clifford_depolarization=0.001,
+    )
+    program = experimental.compile(str(circuit), normalize_syndromes=True)
+    result = experimental.sample(program, shots=2, seed=5)
+
+    assert result.detectors.shape == (2, circuit.num_detectors)
+    assert result.observables.shape == (2, circuit.num_observables)

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -105,14 +105,14 @@ class TestSample:
         assert result.detectors.shape == (50, 0)
         assert result.observables.shape == (50, 0)
 
-    def test_sample_reset_works(self) -> None:
+    def test_sample_reset_works(self, sampling_api: Any) -> None:
         """Reset correctly resets to |0>."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             X 0
             R 0
             M 0
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         # Only one visible measurement (from M 0, after reset)
         # R's internal measurement is hidden, matching Stim behavior
         assert result.measurements.shape == (
@@ -122,23 +122,23 @@ class TestSample:
         # Measurement after reset should always be 0
         assert np.all(result.measurements[:, 0] == 0), "Reset failed"
 
-    def test_sample_mr_visible(self) -> None:
+    def test_sample_mr_visible(self, sampling_api: Any) -> None:
         """MR (measure-and-reset) produces visible measurement unlike R."""
         # R produces 0 visible measurements, MR produces 1
-        prog_r = clifft.compile("R 0")
-        prog_mr = clifft.compile("MR 0")
+        prog_r = sampling_api.compile("R 0")
+        prog_mr = sampling_api.compile("MR 0")
 
         assert prog_r.num_measurements == 0, "R should have 0 visible measurements"
         assert prog_mr.num_measurements == 1, "MR should have 1 visible measurement"
 
         # MR on |0> should always measure 0
-        result = clifft.sample(prog_mr, 100, seed=42)
+        result = sampling_api.sample(prog_mr, 100, seed=42)
         assert result.measurements.shape == (100, 1)
         assert np.all(result.measurements == 0), "MR on |0> should always measure 0"
 
         # MR after X should measure 1
-        prog = clifft.compile("X 0\nMR 0")
-        result = clifft.sample(prog, 100, seed=42)
+        prog = sampling_api.compile("X 0\nMR 0")
+        result = sampling_api.sample(prog, 100, seed=42)
         assert np.all(result.measurements == 1), "MR after X should measure 1"
 
     def test_gap_sampling_sparse_errors(self) -> None:
@@ -520,9 +520,9 @@ class TestNoiseAndQEC:
         assert det.shape == (10, 0)
         assert obs.shape == (10, 0)
 
-    def test_program_detector_observable_counts(self) -> None:
+    def test_program_detector_observable_counts(self, sampling_api: Any) -> None:
         """Program reports correct detector and observable counts."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             H 0
             M 0
             DETECTOR rec[-1]
@@ -532,24 +532,24 @@ class TestNoiseAndQEC:
         assert prog.num_detectors == 1
         assert prog.num_observables == 1
 
-    def test_detector_computes_parity(self) -> None:
+    def test_detector_computes_parity(self, sampling_api: Any) -> None:
         """DETECTOR computes XOR of referenced measurements."""
         # Bell state: M 0 and M 1 always match, so XOR = 0
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             H 0
             CX 0 1
             M 0
             M 1
             DETECTOR rec[-1] rec[-2]
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         # All detectors should be 0 (perfect correlation)
         assert np.all(result.detectors == 0)
 
-    def test_observable_accumulates_xor(self) -> None:
+    def test_observable_accumulates_xor(self, sampling_api: Any) -> None:
         """Multiple OBSERVABLE_INCLUDE to same index XOR together."""
         # Bell state: two identical measurements XOR to 0
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             H 0
             CX 0 1
             M 0
@@ -557,67 +557,67 @@ class TestNoiseAndQEC:
             OBSERVABLE_INCLUDE(0) rec[-1]
             OBSERVABLE_INCLUDE(0) rec[-2]
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         # Observable is XOR of two identical bits = 0
         assert np.all(result.observables == 0)
 
-    def test_observable_tracks_logical_value(self) -> None:
+    def test_observable_tracks_logical_value(self, sampling_api: Any) -> None:
         """Observable correctly tracks logical qubit value."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             H 0
             M 0
             OBSERVABLE_INCLUDE(0) rec[-1]
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         # Observable should equal measurement (single reference)
         assert np.array_equal(result.measurements[:, 0], result.observables[:, 0])
 
-    def test_readout_noise_flips_bits(self) -> None:
+    def test_readout_noise_flips_bits(self, sampling_api: Any) -> None:
         """M(p) readout noise flips measurement results."""
         # 100% readout noise flips |0> -> measured as 1
-        prog = clifft.compile("M(1.0) 0")
-        result = clifft.sample(prog, 100, seed=42)
+        prog = sampling_api.compile("M(1.0) 0")
+        result = sampling_api.sample(prog, 100, seed=42)
         assert np.all(result.measurements == 1)
 
-    def test_readout_noise_probabilistic(self) -> None:
+    def test_readout_noise_probabilistic(self, sampling_api: Any) -> None:
         """M(0.5) readout noise gives ~50% flip rate."""
-        prog = clifft.compile("M(0.5) 0")
-        result = clifft.sample(prog, 1000, seed=42)
+        prog = sampling_api.compile("M(0.5) 0")
+        result = sampling_api.sample(prog, 1000, seed=42)
         flip_rate = float(np.mean(result.measurements))
         # Should be ~50% (measuring |0> with 50% flip = 50% ones)
         tolerance = binomial_tolerance(0.5, 1000)
         assert abs(flip_rate - 0.5) < tolerance
 
-    def test_pauli_noise_x_error(self) -> None:
+    def test_pauli_noise_x_error(self, sampling_api: Any) -> None:
         """X_ERROR(1.0) always flips qubit."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             X_ERROR(1.0) 0
             M 0
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         # X flips |0> to |1>
         assert np.all(result.measurements == 1)
 
-    def test_correlated_error_else_branch(self) -> None:
+    def test_correlated_error_else_branch(self, sampling_api: Any) -> None:
         """ELSE_CORRELATED_ERROR fires when the earlier link does not."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             E(0.0) X0
             ELSE_CORRELATED_ERROR(1.0) X1
             M 0 1
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         assert np.all(result.measurements[:, 0] == 0)
         assert np.all(result.measurements[:, 1] == 1)
 
-    def test_correlated_error_chain_probabilistic(self) -> None:
+    def test_correlated_error_chain_probabilistic(self, sampling_api: Any) -> None:
         """Correlated-error chains convert conditional probabilities correctly."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             E(0.5) X0
             ELSE_CORRELATED_ERROR(0.5) X1
             M 0 1
         """)
         shots = 5000
-        result = clifft.sample(prog, shots, seed=42)
+        result = sampling_api.sample(prog, shots, seed=42)
         q0 = result.measurements[:, 0]
         q1 = result.measurements[:, 1]
 
@@ -627,49 +627,69 @@ class TestNoiseAndQEC:
         assert abs(q1_rate - 0.25) < binomial_tolerance(0.25, shots)
         assert not np.any(q0 & q1)
 
-    def test_pauli_noise_z_error(self) -> None:
+    def test_pauli_noise_z_error(self, sampling_api: Any) -> None:
         """Z_ERROR doesn't affect computational basis measurement."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             Z_ERROR(1.0) 0
             M 0
         """)
-        result = clifft.sample(prog, 100, seed=42)
+        result = sampling_api.sample(prog, 100, seed=42)
         # Z|0> = |0>, so still measure 0
         assert np.all(result.measurements == 0)
 
-    def test_depolarize1_probabilistic(self) -> None:
+    @pytest.mark.parametrize(
+        "circuit,expected",
+        [
+            ("PAULI_CHANNEL_1(1, 0, 0) 0\nM 0", [1]),
+            (
+                "PAULI_CHANNEL_2(0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1\nM 0 1",
+                [1, 0],
+            ),
+            (
+                f"H 0 1 2\nPAULI_CHANNEL_3({', '.join(['0'] * 62 + ['1'])}) 0 1 2\nMX 0 1 2",
+                [1, 1, 1],
+            ),
+        ],
+    )
+    def test_pauli_channels(self, sampling_api: Any, circuit: str, expected: list[int]) -> None:
+        """Explicit one-, two-, and three-qubit Pauli channels execute."""
+        result = sampling_api.sample(sampling_api.compile(circuit), 10, seed=42)
+        expected_rows = np.tile(expected, (10, 1))
+        np.testing.assert_array_equal(result.measurements, expected_rows)
+
+    def test_depolarize1_probabilistic(self, sampling_api: Any) -> None:
         """DEPOLARIZE1 applies X, Y, or Z with equal probability."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             DEPOLARIZE1(1.0) 0
             M 0
         """)
-        result = clifft.sample(prog, 3000, seed=42)
+        result = sampling_api.sample(prog, 3000, seed=42)
         # X and Y flip |0>->|1>, Z doesn't. Expected: 2/3 ones.
         ones_rate = float(np.mean(result.measurements))
         expected = 2.0 / 3.0
         tolerance = binomial_tolerance(expected, 3000)
         assert abs(ones_rate - expected) < tolerance
 
-    def test_noise_detector_interaction(self) -> None:
+    def test_noise_detector_interaction(self, sampling_api: Any) -> None:
         """Noise causes detector to fire."""
         # Two measurements with X_ERROR in between
         # First M gives 0, X_ERROR flips, second M gives 1
         # Detector XORs them: 0 XOR 1 = 1
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             M 0
             X_ERROR(1.0) 0
             M 0
             DETECTOR rec[-1] rec[-2]
         """)
-        result = clifft.sample(prog, 10, seed=0)
+        result = sampling_api.sample(prog, 10, seed=0)
         # First meas = 0, second meas = 1, detector = 1
         assert np.all(result.measurements[:, 0] == 0)
         assert np.all(result.measurements[:, 1] == 1)
         assert np.all(result.detectors[:, 0] == 1)
 
-    def test_sample_shape_with_qec(self) -> None:
+    def test_sample_shape_with_qec(self, sampling_api: Any) -> None:
         """sample() returns correct shapes with detectors/observables."""
-        prog = clifft.compile("""
+        prog = sampling_api.compile("""
             H 0
             M 0
             M 1
@@ -680,7 +700,7 @@ class TestNoiseAndQEC:
             OBSERVABLE_INCLUDE(1) rec[-2]
         """)
         shots = 50
-        result = clifft.sample(prog, shots, seed=0)
+        result = sampling_api.sample(prog, shots, seed=0)
         assert result.measurements.shape == (shots, 2)
         assert result.detectors.shape == (shots, 3)
         assert result.observables.shape == (shots, 2)
@@ -689,37 +709,37 @@ class TestNoiseAndQEC:
 class TestPostselection:
     """Tests for compile() with postselection_mask."""
 
-    def test_compile_with_postselection_mask(self) -> None:
+    def test_compile_with_postselection_mask(self, sampling_api: Any) -> None:
         """Compile with postselection_mask kwarg works via nanobind."""
-        prog = clifft.compile(
+        prog = sampling_api.compile(
             "M 0\nDETECTOR rec[-1]\n",
             postselection_mask=[1],
         )
         assert prog.num_detectors == 1
         assert prog.num_measurements == 1
 
-    def test_has_postselection_flag(self) -> None:
+    def test_has_postselection_flag(self, sampling_api: Any) -> None:
         """has_postselection is True when mask is non-trivial, False otherwise."""
         circuit = "M 0\nDETECTOR rec[-1]\n"
-        prog_no_mask = clifft.compile(circuit)
+        prog_no_mask = sampling_api.compile(circuit)
         assert prog_no_mask.has_postselection is False
 
-        prog_zero_mask = clifft.compile(circuit, postselection_mask=[0])
+        prog_zero_mask = sampling_api.compile(circuit, postselection_mask=[0])
         assert prog_zero_mask.has_postselection is False
 
-        prog_with_mask = clifft.compile(circuit, postselection_mask=[1])
+        prog_with_mask = sampling_api.compile(circuit, postselection_mask=[1])
         assert prog_with_mask.has_postselection is True
 
-    def test_sample_raises_on_postselected_program(self) -> None:
+    def test_sample_raises_on_postselected_program(self, sampling_api: Any) -> None:
         """sample() raises ValueError when program has postselection."""
         circuit = """
             H 0
             M 0
             DETECTOR rec[-1]
         """
-        prog = clifft.compile(circuit, postselection_mask=[1])
+        prog = sampling_api.compile(circuit, postselection_mask=[1])
         with pytest.raises(ValueError, match="sample_survivors"):
-            clifft.sample(prog, 10)
+            sampling_api.sample(prog, 10)
 
     def test_sample_k_raises_on_postselected_program(self) -> None:
         """sample_k() raises ValueError when program has postselection."""
@@ -733,25 +753,40 @@ class TestPostselection:
         with pytest.raises(ValueError, match="sample_k_survivors"):
             clifft.sample_k(prog, 10, k=1)
 
-    def test_sample_ok_without_postselection(self) -> None:
+    def test_sample_ok_without_postselection(self, sampling_api: Any) -> None:
         """sample() works fine when program has no postselection."""
         circuit = "M 0\nDETECTOR rec[-1]\n"
-        prog = clifft.compile(circuit)
-        result = clifft.sample(prog, 10, seed=42)
+        prog = sampling_api.compile(circuit)
+        result = sampling_api.sample(prog, 10, seed=42)
         assert result.detectors.shape == (10, 1)
 
-    def test_empty_mask_is_default(self) -> None:
+    def test_empty_mask_is_default(self, sampling_api: Any) -> None:
         """Empty postselection_mask produces same result as no mask."""
         circuit = "M 0\nDETECTOR rec[-1]\n"
-        prog_default = clifft.compile(circuit)
-        prog_empty = clifft.compile(circuit, postselection_mask=[])
-        assert prog_default.num_instructions == prog_empty.num_instructions
+        prog_default = sampling_api.compile(circuit)
+        prog_empty = sampling_api.compile(circuit, postselection_mask=[])
+        if sampling_api is clifft:
+            assert prog_default.num_instructions == prog_empty.num_instructions
+        else:
+            assert prog_default.num_actions == prog_empty.num_actions
 
 
 class TestSampleSurvivors:
     """Tests for sample_survivors() API."""
 
-    def test_counting_only_fast_path(self) -> None:
+    def test_zero_shots_returns_empty_result(self, sampling_api: Any) -> None:
+        """Zero shots preserves the existing empty-result contract."""
+        program = sampling_api.compile("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
+        result = sampling_api.sample_survivors(program, 0, seed=42)
+
+        assert result.total_shots == 0
+        assert result.passed_shots == 0
+        assert len(result.observable_ones) == 0
+        assert result.measurements.shape == (0, 1)
+        assert result.detectors.shape == (0, 0)
+        assert result.observables.shape == (0, 1)
+
+    def test_counting_only_fast_path(self, sampling_api: Any) -> None:
         """keep_records=False returns survivor metadata with empty arrays."""
         circuit = """
             H 0
@@ -759,8 +794,8 @@ class TestSampleSurvivors:
             DETECTOR rec[-1]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = clifft.compile(circuit, postselection_mask=[1])
-        result = clifft.sample_survivors(prog, 1000, seed=42)
+        prog = sampling_api.compile(circuit, postselection_mask=[1])
+        result = sampling_api.sample_survivors(prog, 1000, seed=42)
 
         assert result.total_shots == 1000
         assert 0 < result.passed_shots < 1000
@@ -773,7 +808,7 @@ class TestSampleSurvivors:
         assert result.detectors.shape == (0, prog.num_detectors)
         assert result.observables.shape == (0, prog.num_observables)
 
-    def test_keep_records_returns_arrays(self) -> None:
+    def test_keep_records_returns_arrays(self, sampling_api: Any) -> None:
         """keep_records=True populates survivor measurement and syndrome arrays."""
         circuit = """
             H 0
@@ -781,8 +816,8 @@ class TestSampleSurvivors:
             DETECTOR rec[-1]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = clifft.compile(circuit, postselection_mask=[1])
-        result = clifft.sample_survivors(prog, 200, seed=42, keep_records=True)
+        prog = sampling_api.compile(circuit, postselection_mask=[1])
+        result = sampling_api.sample_survivors(prog, 200, seed=42, keep_records=True)
 
         passed = result.passed_shots
         assert passed > 0
@@ -794,21 +829,21 @@ class TestSampleSurvivors:
         # All surviving observables should be 0
         assert np.all(result.observables == 0)
 
-    def test_no_postselection_all_pass(self) -> None:
+    def test_no_postselection_all_pass(self, sampling_api: Any) -> None:
         """Without postselection, all shots pass."""
         circuit = """
             H 0
             M 0
             DETECTOR rec[-1]
         """
-        prog = clifft.compile(circuit)  # no mask
-        result = clifft.sample_survivors(prog, 100, seed=42)
+        prog = sampling_api.compile(circuit)  # no mask
+        result = sampling_api.sample_survivors(prog, 100, seed=42)
 
         assert result.total_shots == 100
         assert result.passed_shots == 100
         assert result.discards == 0
 
-    def test_observable_ones_counts_errors(self) -> None:
+    def test_observable_ones_counts_errors(self, sampling_api: Any) -> None:
         """observable_ones correctly counts logical errors in survivors."""
         # No postselection, random observable. ~50% should be 1.
         circuit = """
@@ -816,8 +851,8 @@ class TestSampleSurvivors:
             M 0
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = clifft.compile(circuit)
-        result = clifft.sample_survivors(prog, 10000, seed=42)
+        prog = sampling_api.compile(circuit)
+        result = sampling_api.sample_survivors(prog, 10000, seed=42)
 
         assert result.passed_shots == 10000
         ones = int(result.observable_ones[0])
@@ -852,7 +887,7 @@ class TestSampleSurvivors:
         assert result.discards > 0
         assert len(result.observable_ones) == 1
 
-    def test_keep_records_100_percent_discard(self) -> None:
+    def test_keep_records_100_percent_discard(self, sampling_api: Any) -> None:
         """keep_records=True with all shots discarded returns empty arrays."""
         # Circuit: deterministic meas=1, postselect -> always discards
         circuit = """
@@ -861,8 +896,8 @@ class TestSampleSurvivors:
             DETECTOR rec[-1]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = clifft.compile(circuit, postselection_mask=[1])
-        result = clifft.sample_survivors(prog, 100, seed=42, keep_records=True)
+        prog = sampling_api.compile(circuit, postselection_mask=[1])
+        result = sampling_api.sample_survivors(prog, 100, seed=42, keep_records=True)
 
         assert result.total_shots == 100
         assert result.passed_shots == 0
@@ -871,7 +906,7 @@ class TestSampleSurvivors:
         assert result.detectors.shape == (0, 1)
         assert result.observables.shape == (0, 1)
 
-    def test_logical_errors_multi_observable(self) -> None:
+    def test_logical_errors_multi_observable(self, sampling_api: Any) -> None:
         """logical_errors counts shots, not total observable flips."""
         # Two observables both keyed to same random measurement.
         circuit = """
@@ -880,8 +915,8 @@ class TestSampleSurvivors:
             OBSERVABLE_INCLUDE(0) rec[-1]
             OBSERVABLE_INCLUDE(1) rec[-1]
         """
-        prog = clifft.compile(circuit)
-        result = clifft.sample_survivors(prog, 10000, seed=42)
+        prog = sampling_api.compile(circuit)
+        result = sampling_api.sample_survivors(prog, 10000, seed=42)
 
         assert result.passed_shots == 10000
         # Both observables fire on same shots
@@ -893,7 +928,7 @@ class TestSampleSurvivors:
 
 
 class TestSyndromeNormalization:
-    def test_normalize_syndromes_multiple_observables_xord(self) -> None:
+    def test_normalize_syndromes_multiple_observables_xord(self, sampling_api: Any) -> None:
         """Test normalize_syndromes=True on a circuit where multiple includes XOR together."""
         import numpy as np
 
@@ -917,8 +952,8 @@ class TestSyndromeNormalization:
         """
 
         # 1. Baseline: Without normalization, physical parities match the math above
-        prog_raw = clifft.compile(circuit, normalize_syndromes=False)
-        result_raw = clifft.sample(prog_raw, shots=10, seed=0)
+        prog_raw = sampling_api.compile(circuit, normalize_syndromes=False)
+        result_raw = sampling_api.sample(prog_raw, shots=10, seed=0)
 
         assert np.all(result_raw.detectors[:, 0] == 1)
         assert np.all(result_raw.detectors[:, 1] == 0)
@@ -928,32 +963,32 @@ class TestSyndromeNormalization:
         # 2. Normalized: All output parities must be strictly 0.
         # We also apply a postselection mask on DET 0 (which natively evaluates to 1).
         # Since it is normalized, it becomes 0, meaning shots should SURVIVE.
-        prog_norm = clifft.compile(
+        prog_norm = sampling_api.compile(
             circuit,
             normalize_syndromes=True,
             postselection_mask=[1, 0],
         )
 
-        res = clifft.sample_survivors(prog_norm, shots=10, seed=0, keep_records=True)
+        res = sampling_api.sample_survivors(prog_norm, shots=10, seed=0, keep_records=True)
 
         assert res.passed_shots == 10  # Normalized 1^1=0, so shots survive!
         assert np.all(res.detectors == 0)
         assert np.all(res.observables == 0)
         assert res.logical_errors == 0
 
-    def test_normalize_syndromes_conflict_raises(self) -> None:
+    def test_normalize_syndromes_conflict_raises(self, sampling_api: Any) -> None:
         """Cannot provide explicit expected parities with normalize_syndromes=True."""
         import pytest
 
         circuit = "M 0\nDETECTOR rec[-1]\n"
         with pytest.raises(ValueError):
-            clifft.compile(
+            sampling_api.compile(
                 circuit,
                 normalize_syndromes=True,
                 expected_detectors=[0],
             )
 
-    def test_normalize_syndromes_no_noise_passthrough(self) -> None:
+    def test_normalize_syndromes_no_noise_passthrough(self, sampling_api: Any) -> None:
         """Normalization on a circuit without noise produces all-zero syndromes."""
         import numpy as np
 
@@ -963,13 +998,13 @@ class TestSyndromeNormalization:
             DETECTOR rec[-1]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = clifft.compile(circuit, normalize_syndromes=True)
-        result = clifft.sample(prog, shots=5, seed=0)
+        prog = sampling_api.compile(circuit, normalize_syndromes=True)
+        result = sampling_api.sample(prog, shots=5, seed=0)
 
         assert np.all(result.detectors == 0)
         assert np.all(result.observables == 0)
 
-    def test_normalize_syndromes_with_noise_detects_errors(self) -> None:
+    def test_normalize_syndromes_with_noise_detects_errors(self, sampling_api: Any) -> None:
         """With noise and normalization, errors show up as 1s in syndromes."""
         import numpy as np
 
@@ -979,15 +1014,15 @@ class TestSyndromeNormalization:
             M 0
             DETECTOR rec[-1]
         """
-        prog = clifft.compile(circuit, normalize_syndromes=True)
-        result = clifft.sample(prog, shots=10, seed=0)
+        prog = sampling_api.compile(circuit, normalize_syndromes=True)
+        result = sampling_api.sample(prog, shots=10, seed=0)
 
         # With 100% X error, measurement flips from 0 to 1.
         # Reference (noiseless) detector parity = 0.
         # Noisy parity = 1. Normalized: 1 ^ 0 = 1 (error detected).
         assert np.all(result.detectors[:, 0] == 1)
 
-    def test_explicit_expected_detectors(self) -> None:
+    def test_explicit_expected_detectors(self, sampling_api: Any) -> None:
         """Explicit expected_detectors without normalize_syndromes works."""
         import numpy as np
 
@@ -997,12 +1032,12 @@ class TestSyndromeNormalization:
             DETECTOR rec[-1]
         """
         # Raw detector parity = 1. With expected_detectors=[1], normalized = 0.
-        prog = clifft.compile(circuit, expected_detectors=[1])
-        result = clifft.sample(prog, shots=5, seed=0)
+        prog = sampling_api.compile(circuit, expected_detectors=[1])
+        result = sampling_api.sample(prog, shots=5, seed=0)
 
         assert np.all(result.detectors[:, 0] == 0)
 
-    def test_explicit_expected_observables(self) -> None:
+    def test_explicit_expected_observables(self, sampling_api: Any) -> None:
         """Explicit expected_observables without normalize_syndromes works."""
         import numpy as np
 
@@ -1012,8 +1047,8 @@ class TestSyndromeNormalization:
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
         # Raw obs = 1. With expected_observables=[1], normalized = 0.
-        prog = clifft.compile(circuit, expected_observables=[1])
-        result = clifft.sample(prog, shots=5, seed=0)
+        prog = sampling_api.compile(circuit, expected_observables=[1])
+        result = sampling_api.sample(prog, shots=5, seed=0)
 
         assert np.all(result.observables[:, 0] == 0)
 

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -4,6 +4,8 @@
 #include "clifft/sampling/executor.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/svm/svm.h"
+#include "clifft/util/noise_sampling.h"
+#include "clifft/util/xoshiro.h"
 
 #include <algorithm>
 #include <array>
@@ -32,7 +34,10 @@ using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
 using clifft::sampling::MeasurementBranchKind;
 using clifft::sampling::MeasurementProbabilities;
+using clifft::sampling::NoiseSiteId;
 using clifft::sampling::PlannedAction;
+using clifft::sampling::PresampledNoiseOutcome;
+using clifft::sampling::PresampledNoiseSite;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::record_log_probabilities;
 using clifft::sampling::RecordClassical;
@@ -144,7 +149,148 @@ bool has_arbitrary_angle_active_rotation(const SamplingPlan& plan, double half_t
     });
 }
 
+SamplingPlan categorical_noise_plan() {
+    SamplingPlan plan;
+    plan.num_noise_sites = 4;
+    plan.symbols = {
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{1}},
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{1}},
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{3}},
+    };
+    plan.presampled_noise_sites = {
+        PresampledNoiseSite{NoiseSiteId{0}, {PresampledNoiseOutcome{SymbolId{0}, 0.05}}},
+        PresampledNoiseSite{
+            NoiseSiteId{1},
+            {PresampledNoiseOutcome{SymbolId{1}, 0.1}, PresampledNoiseOutcome{SymbolId{2}, 0.2}}},
+        PresampledNoiseSite{NoiseSiteId{2}, {}},
+        PresampledNoiseSite{NoiseSiteId{3}, {PresampledNoiseOutcome{SymbolId{3}, 0.4}}},
+    };
+    return plan;
+}
+
+std::vector<double> noise_hazards(const SamplingPlan& plan) {
+    std::vector<double> result;
+    result.reserve(plan.presampled_noise_sites.size());
+    double cumulative = 0.0;
+    for (const PresampledNoiseSite& site : plan.presampled_noise_sites) {
+        double probability = 0.0;
+        for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+            probability += outcome.probability;
+        }
+        cumulative += clifft::bernoulli_hazard(probability);
+        result.push_back(cumulative);
+    }
+    return result;
+}
+
+std::vector<uint8_t> sample_reference_noise(const SamplingPlan& plan,
+                                            std::span<const double> hazards,
+                                            clifft::Xoshiro256PlusPlus& rng) {
+    std::vector<uint8_t> result(plan.symbols.size(), 0);
+    uint32_t first_candidate = 0;
+    while (first_candidate < plan.presampled_noise_sites.size()) {
+        const double current_hazard = first_candidate == 0 ? 0.0 : hazards[first_candidate - 1];
+        if (current_hazard >= hazards.back()) {
+            break;
+        }
+        const uint32_t site_index =
+            clifft::sample_next_noise_site(hazards, first_candidate, rng.next_double());
+        if (site_index == clifft::kNoNoiseSite) {
+            break;
+        }
+        const PresampledNoiseSite& site = plan.presampled_noise_sites[site_index];
+        REQUIRE_FALSE(site.outcomes.empty());
+        size_t outcome_index = 0;
+        if (site.outcomes.size() > 1) {
+            double total_probability = 0.0;
+            for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+                total_probability += outcome.probability;
+            }
+            const double channel_draw = rng.next_double() * total_probability;
+            double cumulative = 0.0;
+            for (size_t i = 0; i < site.outcomes.size(); ++i) {
+                cumulative += site.outcomes[i].probability;
+                if (channel_draw < cumulative) {
+                    outcome_index = i;
+                    break;
+                }
+            }
+        }
+        result[static_cast<uint32_t>(site.outcomes[outcome_index].symbol)] = 1;
+        first_candidate = site_index + 1;
+    }
+    return result;
+}
+
 }  // namespace
+
+TEST_CASE("Noise hazard sampler skips silent sites") {
+    const double first = clifft::bernoulli_hazard(0.25);
+    const std::array<double, 3> hazards{
+        first,
+        first,
+        first + clifft::bernoulli_hazard(0.5),
+    };
+
+    REQUIRE(clifft::sample_next_noise_site(hazards, 0, 0.0) == 0);
+    REQUIRE(clifft::sample_next_noise_site(hazards, 1, 0.0) == 2);
+    REQUIRE(clifft::sample_next_noise_site(hazards, 0, 0.3) == 2);
+    REQUIRE(clifft::sample_next_noise_site(hazards, 0, 0.9) == clifft::kNoNoiseSite);
+}
+
+TEST_CASE("Sampling executor skips silent noise sites deterministically") {
+    constexpr uint64_t seed = 0x123456789abcdef0ULL;
+    const SamplingPlan plan = categorical_noise_plan();
+    const std::vector<double> hazards = noise_hazards(plan);
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, seed);
+    clifft::Xoshiro256PlusPlus reference_rng(seed);
+
+    for (uint32_t shot = 0; shot < 128; ++shot) {
+        const std::vector<uint8_t> expected = sample_reference_noise(plan, hazards, reference_rng);
+        executor.run_shot();
+        CAPTURE(shot, expected, executor.symbols());
+        REQUIRE(std::ranges::equal(executor.symbols(), expected));
+    }
+
+    // Alternating supplied and sampled inputs catches stale one bits without
+    // requiring every presampled symbol to be cleared on every shot.
+    const std::array<uint8_t, 4> all_ones{1, 1, 1, 1};
+    executor.run_shot(all_ones);
+    REQUIRE(std::ranges::equal(executor.symbols(), all_ones));
+
+    const std::vector<uint8_t> expected = sample_reference_noise(plan, hazards, reference_rng);
+    executor.run_shot();
+    REQUIRE(std::ranges::equal(executor.symbols(), expected));
+
+    const std::array<uint8_t, 4> all_zeroes{0, 0, 0, 0};
+    executor.run_shot(all_zeroes);
+    REQUIRE(std::ranges::equal(executor.symbols(), all_zeroes));
+}
+
+TEST_CASE("Sampling executor does not draw for empty noise sites") {
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.num_visible_records = 1;
+    plan.num_noise_sites = 1;
+    plan.presampled_noise_sites = {PresampledNoiseSite{NoiseSiteId{0}, {}}};
+    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.actions = {PlannedAction{
+        0, 0,
+        MeasureDormantRandom{0, SymbolId{0}, AffineBool::symbol(SymbolId{0}), RecordSlot{0}}}};
+
+    constexpr uint64_t seed = 1234;
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, seed);
+    clifft::Xoshiro256PlusPlus reference_rng(seed);
+    for (uint32_t shot = 0; shot < 32; ++shot) {
+        const uint8_t expected = static_cast<uint8_t>(reference_rng.next_double() >= 0.5);
+        executor.run_shot();
+        CAPTURE(shot);
+        REQUIRE(executor.visible_records()[0] == expected);
+    }
+}
 
 TEST_CASE("Sampling executor classifies measurement dust without drawing") {
     const auto zero = classify_measurement_branch(MeasurementProbabilities{1.0, 0.0});

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -436,7 +436,55 @@ TEST_CASE("Sampling batch records match legacy seeded execution") {
     REQUIRE(sample_records(executable, 0, uint64_t{5678}).empty());
 }
 
-TEST_CASE("Sampling batch helpers reject presampled symbols") {
+TEST_CASE("Sampling executor presamples mutually exclusive Pauli noise") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        E(0.5) X0
+        ELSE_CORRELATED_ERROR(0.5) X1
+        M 0 1
+    )"));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+
+    const clifft::sampling::SamplingResult result =
+        clifft::sampling::sample(executable, 10000, uint64_t{17});
+    uint32_t q0_ones = 0;
+    uint32_t q1_ones = 0;
+    for (uint32_t shot = 0; shot < 10000; ++shot) {
+        const uint8_t q0 = result.measurements[static_cast<size_t>(shot) * 2];
+        const uint8_t q1 = result.measurements[static_cast<size_t>(shot) * 2 + 1];
+        REQUIRE_FALSE((q0 && q1));
+        q0_ones += q0;
+        q1_ones += q1;
+    }
+    REQUIRE(q0_ones > 4500);
+    REQUIRE(q0_ones < 5500);
+    REQUIRE(q1_ones > 2000);
+    REQUIRE(q1_ones < 3000);
+}
+
+TEST_CASE("Sampling survivor execution normalizes and rejects detectors") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        H 0
+        M 0
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )"));
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection}));
+
+    const clifft::sampling::SamplingSurvivorResult result =
+        clifft::sampling::sample_survivors(executable, 1000, uint64_t{19}, true);
+    REQUIRE(result.total_shots == 1000);
+    REQUIRE(result.passed_shots > 400);
+    REQUIRE(result.passed_shots < 600);
+    REQUIRE(result.logical_errors == 0);
+    REQUIRE(result.measurements.size() == result.passed_shots);
+    REQUIRE(std::ranges::all_of(result.measurements, [](uint8_t value) { return value == 0; }));
+    REQUIRE(std::ranges::all_of(result.detectors, [](uint8_t value) { return value == 0; }));
+    REQUIRE(std::ranges::all_of(result.observables, [](uint8_t value) { return value == 0; }));
+}
+
+TEST_CASE("Sampling batch helpers reject unbound presampled symbols") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
@@ -445,7 +493,7 @@ TEST_CASE("Sampling batch helpers reject presampled symbols") {
     const ExecutablePlan executable(plan);
 
     REQUIRE_THROWS_WITH(sample_records(executable, 0, uint64_t{1234}),
-                        "batch sampling does not yet support plans with presampled symbols");
+                        "batch sampling requires a distribution for every presampled symbol");
     REQUIRE_THROWS_WITH(record_log_probabilities(executable, std::array<uint8_t, 1>{0}, 1),
                         "record probabilities do not yet support plans with presampled symbols");
 }

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -443,9 +443,8 @@ TEST_CASE("Sampling replay checks all records conditional on presampled symbols"
     const ReplayResult mismatching =
         executor.replay_shot(std::array<uint8_t, 2>{0, 1}, std::array<uint8_t, 1>{1});
     REQUIRE_FALSE(mismatching.reachable);
+    // Only the executed prefix is meaningful after an unreachable replay.
     REQUIRE(executor.visible_records()[0] == 1);
-    // The hidden write follows the inconsistent visible record and is skipped.
-    REQUIRE(executor.hidden_records()[0] == 0);
 }
 
 TEST_CASE("Sampling replay applies active measurement dust policy") {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -230,6 +230,13 @@ TEST_CASE("Sampling plan rejects duplicate record writes") {
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
 
+TEST_CASE("Sampling plan requires every declared record slot to be written") {
+    SamplingPlan plan = valid_plan();
+    ++plan.num_hidden_records;
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+}
+
 TEST_CASE("Sampling plan rejects measurement pivots outside Pauli support") {
     const SymbolId branch{0};
     SamplingPlan plan;

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -9,13 +9,18 @@
 
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
+using clifft::sampling::ApplyReadoutNoise;
 using clifft::sampling::DefineSymbol;
+using clifft::sampling::DetectorSlot;
 using clifft::sampling::InstrumentBoundary;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
 using clifft::sampling::NoiseSiteId;
+using clifft::sampling::ObservableSlot;
 using clifft::sampling::PlannedAction;
+using clifft::sampling::PresampledNoiseOutcome;
+using clifft::sampling::PresampledNoiseSite;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RecordSlot;
@@ -24,6 +29,8 @@ using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
 using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
+using clifft::sampling::WriteDetector;
+using clifft::sampling::WriteObservable;
 
 namespace {
 
@@ -44,6 +51,8 @@ SamplingPlan valid_plan() {
         SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
         SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
     };
+    plan.presampled_noise_sites = {
+        PresampledNoiseSite{NoiseSiteId{0}, {PresampledNoiseOutcome{noise, 0.1}}}};
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{0.25, AffineBool::symbol(noise)}},
         PlannedAction{1, 0,
@@ -77,6 +86,24 @@ SamplingPlan valid_dormant_measurement_plan() {
     plan.actions = {
         PlannedAction{0, 0,
                       MeasureDormantRandom{0, branch, AffineBool::symbol(branch), RecordSlot{0}}},
+    };
+    return plan;
+}
+
+SamplingPlan valid_syndrome_plan() {
+    const SymbolId readout{0};
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.num_visible_records = 1;
+    plan.num_detectors = 1;
+    plan.num_observables = 1;
+    plan.has_postselection = true;
+    plan.symbols = {SymbolInfo{SymbolKind::Readout, 1, std::nullopt}};
+    plan.actions = {
+        PlannedAction{0, 0, RecordClassical{AffineBool{}, RecordSlot{0}}},
+        PlannedAction{0, 0, ApplyReadoutNoise{readout, AffineBool{}, RecordSlot{0}, 0.1, 0.2}},
+        PlannedAction{0, 0, WriteDetector{AffineBool::symbol(readout), DetectorSlot{0}, true}},
+        PlannedAction{0, 0, WriteObservable{AffineBool::symbol(readout), ObservableSlot{0}}},
     };
     return plan;
 }
@@ -361,6 +388,51 @@ TEST_CASE("Sampling plan rejects invalid numeric metadata") {
     }
 }
 
+TEST_CASE("Sampling plan validates noise distributions and syndrome actions") {
+    REQUIRE_NOTHROW(valid_syndrome_plan().validate());
+
+    SECTION("a noise symbol cannot name two outcomes") {
+        SamplingPlan plan = valid_plan();
+        plan.presampled_noise_sites[0].outcomes.push_back(PresampledNoiseOutcome{SymbolId{0}, 0.2});
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("noise outcome probabilities cannot exceed one in total") {
+        SamplingPlan plan = valid_plan();
+        const SymbolId second_noise{3};
+        plan.symbols.push_back(SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}});
+        plan.presampled_noise_sites[0].outcomes[0].probability = 0.6;
+        plan.presampled_noise_sites[0].outcomes.push_back(
+            PresampledNoiseOutcome{second_noise, 0.6});
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("readout requires an assigned record") {
+        SamplingPlan plan = valid_syndrome_plan();
+        plan.actions.erase(plan.actions.begin());
+        plan.symbols[0].defining_action = 0;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("readout probabilities are bounded") {
+        SamplingPlan plan = valid_syndrome_plan();
+        std::get<ApplyReadoutNoise>(plan.actions[1].action).prob_zero_to_one = 1.1;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("every declared output is written exactly once") {
+        SamplingPlan plan = valid_syndrome_plan();
+        plan.actions.pop_back();
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("postselection metadata matches detector actions") {
+        SamplingPlan plan = valid_syndrome_plan();
+        plan.has_postselection = false;
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+}
+
 TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
     SamplingPlan plan;
     plan.num_qubits = clifft::kDenseActiveWidthLimit;
@@ -416,5 +488,8 @@ TEST_CASE("Sampling plan predicts only state touching dense passes") {
     REQUIRE(clifft::sampling::predicted_dense_passes(MeasureDormantRandom{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(RecordClassical{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(DefineSymbol{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(ApplyReadoutNoise{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(WriteDetector{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(WriteObservable{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(InstrumentBoundary{}) == 0);
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -4,6 +4,7 @@
 
 #include "test_helpers.h"
 
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
@@ -17,6 +18,7 @@ using clifft::HirModule;
 using clifft::MeasRecordIdx;
 using clifft::NoiseSite;
 using clifft::sampling::AffineBool;
+using clifft::sampling::ApplyReadoutNoise;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
 using clifft::sampling::plan_sampling;
@@ -25,6 +27,9 @@ using clifft::sampling::RecordClassical;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
+using clifft::sampling::SymbolKind;
+using clifft::sampling::WriteDetector;
+using clifft::sampling::WriteObservable;
 using clifft::test::X;
 using clifft::test::Z;
 
@@ -268,12 +273,58 @@ TEST_CASE("Sampling planner preserves sign flipped rotation global factors") {
 }
 
 TEST_CASE("Sampling planner rejects unsupported operations explicitly") {
-    HirModule hir(1, 0);
-    hir.noise_sites.push_back(NoiseSite{});
-    hir.append_noise(clifft::NoiseSiteIdx{0});
+    const HirModule hir = clifft::trace(clifft::parse("EXP_VAL Z0"));
 
     REQUIRE_THROWS_WITH(plan_sampling(hir),
-                        "sampling planner does not support HIR operation NOISE at index 0");
+                        "sampling planner does not support HIR operation EXP_VAL at index 0");
+}
+
+TEST_CASE("Sampling planner eliminates Pauli noise and feedback into record expressions") {
+    const HirModule hir = clifft::trace(clifft::parse(R"(
+        X_ERROR(1) 0
+        M 0
+        CX rec[-1] 1
+        M 1
+    )"));
+
+    const SamplingPlan plan = plan_sampling(hir);
+
+    REQUIRE(plan.presampled_noise_sites.size() == 1);
+    REQUIRE(plan.presampled_noise_sites[0].outcomes.size() == 1);
+    const SymbolId noise = plan.presampled_noise_sites[0].outcomes[0].symbol;
+    REQUIRE(plan.symbols[static_cast<uint32_t>(noise)].kind == SymbolKind::Presampled);
+    REQUIRE(plan.actions.size() == 2);
+    REQUIRE(action_as<RecordClassical>(plan, 0).outcome == AffineBool::symbol(noise));
+    REQUIRE(action_as<RecordClassical>(plan, 1).outcome == AffineBool::symbol(noise));
+}
+
+TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
+    const HirModule hir = clifft::trace(clifft::parse(R"(
+        M 0
+        READOUT_NOISE(0.1, 0.2) rec[-1]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )"));
+    const std::array<uint8_t, 1> postselection{1};
+    const std::array<uint8_t, 1> expected_detectors{1};
+    const std::array<uint8_t, 1> expected_observables{1};
+
+    const SamplingPlan plan =
+        plan_sampling(hir, {postselection, expected_detectors, expected_observables});
+
+    REQUIRE(plan.num_detectors == 1);
+    REQUIRE(plan.num_observables == 1);
+    REQUIRE(plan.has_postselection);
+    REQUIRE(plan.actions.size() == 4);
+    const auto& readout = action_as<ApplyReadoutNoise>(plan, 1);
+    REQUIRE(plan.symbols[static_cast<uint32_t>(readout.flip)].kind == SymbolKind::Readout);
+    REQUIRE(readout.source == AffineBool(false));
+    REQUIRE(readout.prob_zero_to_one == 0.1);
+    REQUIRE(readout.prob_one_to_zero == 0.2);
+    REQUIRE(action_as<WriteDetector>(plan, 2).outcome == (AffineBool::symbol(readout.flip) ^ true));
+    REQUIRE(action_as<WriteDetector>(plan, 2).postselected);
+    REQUIRE(action_as<WriteObservable>(plan, 3).outcome ==
+            (AffineBool::symbol(readout.flip) ^ true));
 }
 
 TEST_CASE("Sampling planner reports the dense active width limit") {


### PR DESCRIPTION
## Summary

- lower Pauli noise, correlated-error chains, feedback, and resets into symbolic affine dependencies while preserving mutually exclusive noise-site distributions
- execute symmetric and asymmetric readout noise, normalized detectors and observables, postselection, and survivor accounting without hot-path allocation
- extend the experimental Python backend and reuse the existing sampling, syndrome-normalization, postselection, and QEC fixture coverage
- keep state-dependent instruments and exact-state probes explicitly unsupported

Closes #265

## Stack

- based on #263, which exposes the experimental Python backend
- #263 is based on #261, which adds forced replay validation

## Validation

- uv run pre-commit run --all-files
- cmake --build build -j4
- ctest --test-dir build -R Sampling --output-on-failure: 60 passed
- uv run pytest tests/python/test_experimental_sampling.py tests/python/test_sample.py -q: 140 passed
