### PR TITLE
refactor(sampling): centralize plan ID conversions

### DIFF
--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -21,26 +21,6 @@ inline constexpr bool kAlwaysFalse = false;
 
 constexpr double kLogHalf = -std::numbers::ln2;
 
-uint32_t index(SymbolId id) {
-    return static_cast<uint32_t>(id);
-}
-
-uint32_t index(RecordSlot slot) {
-    return static_cast<uint32_t>(slot);
-}
-
-uint32_t index(InstrumentSiteId site) {
-    return static_cast<uint32_t>(site);
-}
-
-uint32_t index(DetectorSlot slot) {
-    return static_cast<uint32_t>(slot);
-}
-
-uint32_t index(ObservableSlot slot) {
-    return static_cast<uint32_t>(slot);
-}
-
 }  // namespace
 
 MeasurementBranchClassification classify_measurement_branch(

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -19,30 +19,6 @@ namespace {
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
 
-uint32_t index(SymbolId id) {
-    return static_cast<uint32_t>(id);
-}
-
-uint32_t index(RecordSlot slot) {
-    return static_cast<uint32_t>(slot);
-}
-
-uint32_t index(NoiseSiteId site) {
-    return static_cast<uint32_t>(site);
-}
-
-uint32_t index(InstrumentSiteId site) {
-    return static_cast<uint32_t>(site);
-}
-
-uint32_t index(DetectorSlot slot) {
-    return static_cast<uint32_t>(slot);
-}
-
-uint32_t index(ObservableSlot slot) {
-    return static_cast<uint32_t>(slot);
-}
-
 std::vector<SymbolId> xor_terms(const std::vector<SymbolId>& left,
                                 const std::vector<SymbolId>& right) {
     // Canonical inputs are sorted and unique, so XOR is their symmetric

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -36,6 +36,27 @@ enum class InstrumentSiteId : uint32_t {};
 enum class DetectorSlot : uint32_t {};
 enum class ObservableSlot : uint32_t {};
 
+// Keep the IDs non-interchangeable while giving every sampling layer one
+// explicit operation for indexing their plan-owned storage.
+[[nodiscard]] constexpr uint32_t index(SymbolId id) noexcept {
+    return static_cast<uint32_t>(id);
+}
+[[nodiscard]] constexpr uint32_t index(RecordSlot slot) noexcept {
+    return static_cast<uint32_t>(slot);
+}
+[[nodiscard]] constexpr uint32_t index(NoiseSiteId site) noexcept {
+    return static_cast<uint32_t>(site);
+}
+[[nodiscard]] constexpr uint32_t index(InstrumentSiteId site) noexcept {
+    return static_cast<uint32_t>(site);
+}
+[[nodiscard]] constexpr uint32_t index(DetectorSlot slot) noexcept {
+    return static_cast<uint32_t>(slot);
+}
+[[nodiscard]] constexpr uint32_t index(ObservableSlot slot) noexcept {
+    return static_cast<uint32_t>(slot);
+}
+
 enum class SymbolKind : uint8_t {
     Presampled,  // Available before the action stream, such as sampled noise.
     Derived,     // Computed as a parity of previously available symbols.

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -619,7 +619,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     std::vector<AffineBool> observable_values(hir.num_observables);
 
     auto require_record = [&](RecordSlot record, size_t operation_index) -> const AffineBool& {
-        const uint32_t record_index = static_cast<uint32_t>(record);
+        const uint32_t record_index = index(record);
         if (record_index >= record_values.size() || !record_values[record_index].has_value()) {
             throw std::invalid_argument("sampling planner operation " +
                                         std::to_string(operation_index) + " reads record " +
@@ -629,7 +629,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     };
 
     auto assign_record = [&](RecordSlot record, AffineBool value, size_t operation_index) {
-        const uint32_t record_index = static_cast<uint32_t>(record);
+        const uint32_t record_index = index(record);
         if (record_index >= record_values.size()) {
             throw std::invalid_argument("sampling planner operation " +
                                         std::to_string(operation_index) + " writes record " +
@@ -679,8 +679,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                         active_width, active_width,
                         ApplyReadoutNoise{flip, source, operation.record,
                                           operation.prob_zero_to_one, operation.prob_one_to_zero}});
-                    record_values[static_cast<uint32_t>(operation.record)] =
-                        source ^ AffineBool::symbol(flip);
+                    record_values[index(operation.record)] = source ^ AffineBool::symbol(flip);
                 } else if constexpr (std::is_same_v<T, PendingDetector>) {
                     AffineBool outcome = record_parity(operation.records, i);
                     outcome ^= operation.expected;
@@ -689,7 +688,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                         WriteDetector{outcome, operation.detector, operation.postselected}});
                     plan.has_postselection |= operation.postselected;
                 } else if constexpr (std::is_same_v<T, PendingObservable>) {
-                    observable_values[static_cast<uint32_t>(operation.observable)] ^=
+                    observable_values[index(operation.observable)] ^=
                         record_parity(operation.records, i);
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -28,6 +28,7 @@ using clifft::sampling::classify_measurement_branch;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
+using clifft::sampling::index;
 using clifft::sampling::InstrumentBoundary;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
@@ -217,7 +218,7 @@ std::vector<uint8_t> sample_reference_noise(const SamplingPlan& plan,
                 }
             }
         }
-        result[static_cast<uint32_t>(site.outcomes[outcome_index].symbol)] = 1;
+        result[index(site.outcomes[outcome_index].symbol)] = 1;
         first_candidate = site_index + 1;
     }
     return result;


### PR DESCRIPTION
## Summary

- place the shared `index()` overloads beside the strong sampling ID types
- use the shared conversion in planner bookkeeping and test noise sampling
- remove the duplicated translation-unit helpers without changing plan or executor semantics

This deliberately leaves action variants, symbol metadata, active-width annotations, `DefineSymbol`, and instrument contracts unchanged.

## Validation

- `cmake --build build -j 4`
- `./build/tests/clifft_tests "Sampling*"` — 63 test cases, 159344 assertions
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Closes #267