### PR TITLE
feat(sampling): execute transition instruments

### DIFF
--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -265,7 +265,7 @@ void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
 }
 
 void Executor::resume(const ExecutablePlan& continuation,
-                      std::optional<std::pair<RecordSlot, uint8_t>> forced_record) {
+                      std::optional<ForcedTraceOut> forced_trace_out) {
     if (!pending_trap_.has_value()) {
         throw std::invalid_argument("sampling executor resume requires a pending instrument trap");
     }
@@ -317,19 +317,19 @@ void Executor::resume(const ExecutablePlan& continuation,
     forced_record_values_.resize(records_.size(), 0);
     previous_presampled_ones_.reserve(continuation.presampled_symbols_.size());
 
-    if (forced_record.has_value()) {
-        if (forced_record->second > 1 || index(forced_record->first) >= record_count) {
+    if (forced_trace_out.has_value()) {
+        if (forced_trace_out->source > 1 || index(forced_trace_out->record) >= record_count) {
             throw std::invalid_argument("sampling continuation forced record is out of range");
         }
-        const uint32_t record = index(forced_record->first);
+        const uint32_t record = index(forced_trace_out->record);
         forced_record_mask_[record] = 1;
-        forced_record_values_[record] = forced_record->second;
+        forced_record_values_[record] = forced_trace_out->source;
     }
 
     plan_ = &continuation;
     pending_trap_.reset();
     (void)execute_actions<false, true>({}, offset);
-    if (forced_record.has_value() && forced_record_mask_[index(forced_record->first)] != 0) {
+    if (forced_trace_out.has_value() && forced_record_mask_[index(forced_trace_out->record)] != 0) {
         throw std::logic_error("sampling continuation did not consume its forced trace-out record");
     }
 }

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -4,6 +4,7 @@
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cmath>
 #include <limits>
@@ -51,7 +52,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       num_detectors_(plan.num_detectors),
       num_observables_(plan.num_observables),
       has_postselection_(plan.has_postselection),
-      global_weight_(plan.global_weight) {
+      global_weight_(plan.global_weight),
+      instrument_distributions_(plan.instrument_distributions) {
     plan.validate();
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable symbol count exceeds uint32 range");
@@ -80,8 +82,10 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, WriteDetector> ||
                                      std::is_same_v<T, WriteObservable>) {
                     num_expression_terms += typed.outcome.terms().size();
+                } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                    num_expression_terms += typed.sign.terms().size();
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
-                    // Rejected below after all structural validation has run.
+                    // Boundaries have no affine payload.
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
                 }
@@ -93,6 +97,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     }
     expression_terms_.reserve(num_expression_terms);
     actions_.reserve(plan.actions.size());
+    instrument_resume_offsets_.assign(plan.num_instrument_sites,
+                                      std::numeric_limits<uint32_t>::max());
     presampled_symbols_.reserve(plan.symbols.size());
     std::vector<bool> bound_presampled(plan.symbols.size(), false);
     noise_sites_.reserve(plan.presampled_noise_sites.size());
@@ -120,6 +126,17 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
         }
     }
 
+    std::vector<uint32_t> boundary_noise_starts;
+    boundary_noise_starts.reserve(plan.num_instrument_sites);
+    for (const PlannedAction& planned : plan.actions) {
+        if (const auto* boundary = std::get_if<InstrumentBoundary>(&planned.action)) {
+            boundary_noise_starts.push_back(boundary->next_noise_site);
+        }
+    }
+    initial_noise_end_ =
+        boundary_noise_starts.empty() ? plan.num_noise_sites : boundary_noise_starts.front();
+
+    size_t boundary_index = 0;
     for (const PlannedAction& planned : plan.actions) {
         std::visit(
             [&](const auto& typed) {
@@ -158,10 +175,35 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     actions_.emplace_back(ExecuteObservable{prepare_expression(typed.outcome),
                                                             index(typed.observable)});
+                } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                    has_instruments_ = true;
+                    std::optional<PreparedMeasurement> measurement;
+                    if (typed.mode == InstrumentMode::Active ||
+                        typed.mode == InstrumentMode::Activate) {
+                        const uint32_t width = typed.mode == InstrumentMode::Activate
+                                                   ? planned.active_after
+                                                   : planned.active_before;
+                        const uint64_t support =
+                            typed.source.x != 0 ? typed.source.x : typed.source.z;
+                        const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
+                        measurement = prepare_measurement(typed.source, width, pivot);
+                    }
+                    actions_.emplace_back(ExecuteInstrument{
+                        typed.mode, prepare_expression(typed.sign), std::move(measurement),
+                        index(typed.site),
+                        typed.destination_flip.has_value()
+                            ? std::optional<uint32_t>{index(*typed.destination_flip)}
+                            : std::nullopt});
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
-                    throw std::invalid_argument(
-                        "sampling executable does not yet support instrument boundary site " +
-                        std::to_string(index(typed.site)));
+                    const uint32_t noise_end = boundary_index + 1 < boundary_noise_starts.size()
+                                                   ? boundary_noise_starts[boundary_index + 1]
+                                                   : plan.num_noise_sites;
+                    instrument_resume_offsets_[index(typed.site)] =
+                        static_cast<uint32_t>(actions_.size());
+                    actions_.emplace_back(ExecuteBoundary{index(typed.site), planned.active_before,
+                                                          boundary_noise_starts[boundary_index],
+                                                          noise_end, typed.symbol_prefix_size});
+                    ++boundary_index;
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
                 }
@@ -193,39 +235,117 @@ ExecutablePlan::PreparedExpression ExecutablePlan::prepare_measurement_correctio
 }
 
 Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
-    : plan_(plan),
+    : root_plan_(&plan),
+      plan_(&plan),
       state_(plan.max_active_width_, plan.initial_active_width_, plan.global_weight_),
       symbols_(plan.num_symbols_, 0),
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
       detectors_(plan.num_detectors_, 0),
       observables_(plan.num_observables_, 0),
+      forced_record_mask_(records_.size(), 0),
+      forced_record_values_(records_.size(), 0),
       rng_(seed) {
     previous_presampled_ones_.reserve(plan.presampled_symbols_.size());
 }
 
 void Executor::run_shot() noexcept {
-    assert(plan_.unbound_presampled_symbols_.empty() &&
+    plan_ = root_plan_;
+    assert(plan_->unbound_presampled_symbols_.empty() &&
            "automatic execution requires every presampled symbol to have a distribution");
     reset_shot();
-    sample_presampled_noise();
-    (void)execute_actions<false>({});
+    sample_presampled_noise(0, plan_->initial_noise_end_);
+    (void)execute_actions<false, true>({});
 }
 
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
+    plan_ = root_plan_;
     reset_shot();
     assign_presampled_values(presampled_values);
-    (void)execute_actions<false>({});
+    (void)execute_actions<false, false>({});
+}
+
+void Executor::resume(const ExecutablePlan& continuation,
+                      std::optional<std::pair<RecordSlot, uint8_t>> forced_record) {
+    if (!pending_trap_.has_value()) {
+        throw std::invalid_argument("sampling executor resume requires a pending instrument trap");
+    }
+    const uint32_t site = index(pending_trap_->site);
+    if (site >= continuation.instrument_resume_offsets_.size() ||
+        site >= plan_->instrument_resume_offsets_.size()) {
+        throw std::invalid_argument("sampling continuation omits the trapped instrument site");
+    }
+    const uint32_t offset = continuation.instrument_resume_offsets_[site];
+    if (offset >= continuation.actions_.size()) {
+        throw std::invalid_argument(
+            "sampling continuation has no resume boundary for the trapped site");
+    }
+    const auto* boundary =
+        std::get_if<ExecutablePlan::ExecuteBoundary>(&continuation.actions_[offset]);
+    const uint32_t old_offset = plan_->instrument_resume_offsets_[site];
+    const auto* old_boundary =
+        old_offset < plan_->actions_.size()
+            ? std::get_if<ExecutablePlan::ExecuteBoundary>(&plan_->actions_[old_offset])
+            : nullptr;
+    if (boundary == nullptr || old_boundary == nullptr || boundary->site != site ||
+        boundary->active_width != state_.active_width()) {
+        throw std::invalid_argument(
+            "sampling continuation boundary is incompatible with the live active state");
+    }
+    if (boundary->symbol_prefix_size != old_boundary->symbol_prefix_size) {
+        throw std::invalid_argument(
+            "sampling continuation changes symbol identities before the trapped site");
+    }
+    if (continuation.num_qubits_ != plan_->num_qubits_ ||
+        continuation.num_visible_records_ != plan_->num_visible_records_ ||
+        continuation.num_detectors_ != plan_->num_detectors_ ||
+        continuation.num_observables_ != plan_->num_observables_) {
+        throw std::invalid_argument(
+            "sampling continuation changes externally visible plan dimensions");
+    }
+    if (!continuation.unbound_presampled_symbols_.empty()) {
+        throw std::invalid_argument(
+            "sampling continuation requires distributions for every presampled symbol");
+    }
+
+    state_.ensure_capacity(continuation.max_active_width_);
+    symbols_.resize(std::max(symbols_.size(), static_cast<size_t>(continuation.num_symbols_)), 0);
+    std::fill(symbols_.begin() + boundary->symbol_prefix_size, symbols_.end(), uint8_t{0});
+    const size_t record_count =
+        static_cast<size_t>(continuation.num_visible_records_) + continuation.num_hidden_records_;
+    records_.resize(std::max(records_.size(), record_count), 0);
+    forced_record_mask_.resize(records_.size(), 0);
+    forced_record_values_.resize(records_.size(), 0);
+    previous_presampled_ones_.reserve(continuation.presampled_symbols_.size());
+
+    if (forced_record.has_value()) {
+        if (forced_record->second > 1 || index(forced_record->first) >= record_count) {
+            throw std::invalid_argument("sampling continuation forced record is out of range");
+        }
+        const uint32_t record = index(forced_record->first);
+        forced_record_mask_[record] = 1;
+        forced_record_values_[record] = forced_record->second;
+    }
+
+    plan_ = &continuation;
+    pending_trap_.reset();
+    (void)execute_actions<false, true>({}, offset);
+    if (forced_record.has_value() && forced_record_mask_[index(forced_record->first)] != 0) {
+        throw std::logic_error("sampling continuation did not consume its forced trace-out record");
+    }
 }
 
 ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
                                    std::span<const uint8_t> presampled_values) noexcept {
-    assert(forced_records.size() == records_.size() &&
+    plan_ = root_plan_;
+    const size_t root_record_count =
+        static_cast<size_t>(plan_->num_visible_records_) + plan_->num_hidden_records_;
+    assert(forced_records.size() == root_record_count &&
            "one forced value is required for every plan record");
     assert(std::ranges::all_of(forced_records, [](uint8_t value) { return value <= 1; }) &&
            "forced records must be Boolean");
     reset_shot();
     assign_presampled_values(presampled_values);
-    return execute_actions<true>(forced_records);
+    return execute_actions<true, false>(forced_records);
 }
 
 void Executor::reset_shot() noexcept {
@@ -238,15 +358,17 @@ void Executor::reset_shot() noexcept {
         symbols_[symbol] = 0;
     }
     previous_presampled_ones_.clear();
+    std::ranges::fill(forced_record_mask_, uint8_t{0});
     discarded_ = false;
+    pending_trap_.reset();
 }
 
 void Executor::assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept {
-    assert(presampled_values.size() == plan_.presampled_symbols_.size() &&
+    assert(presampled_values.size() == plan_->presampled_symbols_.size() &&
            "one value is required for every presampled symbol");
     for (size_t i = 0; i < presampled_values.size(); ++i) {
         assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
-        const uint32_t symbol = plan_.presampled_symbols_[i];
+        const uint32_t symbol = plan_->presampled_symbols_[i];
         symbols_[symbol] = presampled_values[i];
         if (presampled_values[i] != 0) {
             previous_presampled_ones_.push_back(symbol);
@@ -254,32 +376,34 @@ void Executor::assign_presampled_values(std::span<const uint8_t> presampled_valu
     }
 }
 
-void Executor::sample_presampled_noise() noexcept {
-    uint32_t first_candidate = 0;
-    while (first_candidate < plan_.noise_sites_.size()) {
+void Executor::sample_presampled_noise(uint32_t begin, uint32_t end) noexcept {
+    assert(begin <= end && end <= plan_->noise_sites_.size() &&
+           "noise segment must stay inside prepared sites");
+    uint32_t first_candidate = begin;
+    while (first_candidate < end) {
         const double current_hazard =
-            first_candidate == 0 ? 0.0 : plan_.noise_hazards_[first_candidate - 1];
-        if (current_hazard >= plan_.noise_hazards_.back()) {
+            first_candidate == 0 ? 0.0 : plan_->noise_hazards_[first_candidate - 1];
+        if (current_hazard >= plan_->noise_hazards_[end - 1]) {
             return;
         }
         const uint32_t site_index =
-            sample_next_noise_site(plan_.noise_hazards_, first_candidate, rng_.next_double());
-        if (site_index == kNoNoiseSite) {
+            sample_next_noise_site(plan_->noise_hazards_, first_candidate, rng_.next_double());
+        if (site_index == kNoNoiseSite || site_index >= end) {
             return;
         }
-        const ExecutablePlan::PreparedNoiseSite& site = plan_.noise_sites_[site_index];
+        const ExecutablePlan::PreparedNoiseSite& site = plan_->noise_sites_[site_index];
         assert(site.outcome_count > 0 && site.total_probability > 0.0 &&
                "a sampled hazard must identify a nonempty noise site");
         uint32_t outcome_index = site.outcome_begin;
         if (site.outcome_count > 1) {
             const double channel_draw = rng_.next_double() * site.total_probability;
-            while (channel_draw >= plan_.noise_outcomes_[outcome_index].cumulative_probability) {
+            while (channel_draw >= plan_->noise_outcomes_[outcome_index].cumulative_probability) {
                 ++outcome_index;
                 assert(outcome_index < site.outcome_begin + site.outcome_count &&
                        "channel draw must select one prepared outcome");
             }
         }
-        const uint32_t symbol = plan_.noise_outcomes_[outcome_index].symbol;
+        const uint32_t symbol = plan_->noise_outcomes_[outcome_index].symbol;
         assert(symbol < symbols_.size() && symbols_[symbol] == 0 &&
                "a noise site may define only one fresh symbol per shot");
         symbols_[symbol] = 1;
@@ -317,7 +441,15 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
         }
         result.log_probability += *log_increment;
     } else {
-        branch = sample_active_branch(probabilities);
+        if (forced_record_mask_[action.record] != 0) {
+            branch = (forced_record_values_[action.record] != 0) ^ correction;
+            const std::optional<double> forced = force_active_branch(probabilities, branch);
+            assert(forced.has_value() &&
+                   "forced continuation measurement branch must be reachable");
+            forced_record_mask_[action.record] = 0;
+        } else {
+            branch = sample_active_branch(probabilities);
+        }
     }
     symbols_[action.branch] = static_cast<uint8_t>(branch);
     collapse_measurement(state_, action.measurement, branch, probabilities.for_branch(branch));
@@ -334,7 +466,12 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& a
         branch = (forced_records[action.record] != 0) ^ correction;
         result.log_probability += kLogHalf;
     } else {
-        branch = sample_dormant_branch();
+        if (forced_record_mask_[action.record] != 0) {
+            branch = (forced_record_values_[action.record] != 0) ^ correction;
+            forced_record_mask_[action.record] = 0;
+        } else {
+            branch = sample_dormant_branch();
+        }
     }
     symbols_[action.branch] = static_cast<uint8_t>(branch);
     records_[action.record] = static_cast<uint8_t>(branch ^ correction);
@@ -349,6 +486,10 @@ void Executor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& acti
         if (records_[action.record] != forced_records[action.record]) {
             result.reachable = false;
         }
+    } else if (forced_record_mask_[action.record] != 0) {
+        assert(records_[action.record] == forced_record_values_[action.record] &&
+               "forced continuation classical record must match its deterministic value");
+        forced_record_mask_[action.record] = 0;
     }
 }
 
@@ -390,12 +531,126 @@ void Executor::execute_action(const ExecutablePlan::ExecuteObservable& action,
 }
 
 template <bool ForceRecords>
-ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) noexcept {
+void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
+                              std::span<const uint8_t>, ReplayResult& result) noexcept {
+    if constexpr (ForceRecords) {
+        result.reachable = false;
+        return;
+    }
+
+    assert(action.site < plan_->instrument_distributions_.size() &&
+           "instrument action must reference a prepared distribution");
+    const InstrumentDistribution& distribution = plan_->instrument_distributions_[action.site];
+    if (action.destination_flip.has_value()) {
+        symbols_[*action.destination_flip] = 0;
+    }
+
+    auto trap = [&](uint8_t source, bool destination_pending) {
+        pending_trap_ = InstrumentTrap{InstrumentSiteId{action.site}, source, destination_pending};
+    };
+    auto finish_fire = [&](uint8_t source) {
+        assert(distribution.p_fire[source] > 0.0 &&
+               "a fired instrument source must have positive mass");
+        const double draw = rng_.next_double() * distribution.p_fire[source];
+        int destination = -1;
+        if (draw < distribution.p_computational_dest[source][0]) {
+            destination = 0;
+        } else if (draw < distribution.p_computational_dest[source][0] +
+                              distribution.p_computational_dest[source][1]) {
+            destination = 1;
+        }
+        if (destination < 0) {
+            trap(source, false);
+        } else if (destination != source) {
+            assert(action.destination_flip.has_value() &&
+                   "in-line instrument requires a destination-flip symbol");
+            symbols_[*action.destination_flip] = 1;
+        }
+    };
+
+    if (action.mode == InstrumentMode::Classical) {
+        const uint8_t source = static_cast<uint8_t>(evaluate(action.sign));
+        if (rng_.next_double() < distribution.p_fire[source]) {
+            finish_fire(source);
+        }
+        return;
+    }
+
+    if (action.mode == InstrumentMode::DormantTrap) {
+        const double mass = distribution.p_fire[0] + distribution.p_fire[1];
+        if (rng_.next_double() * 2.0 >= mass) {
+            return;
+        }
+        const uint8_t source =
+            rng_.next_double() * mass < distribution.p_fire[0] ? uint8_t{0} : uint8_t{1};
+        trap(source, true);
+        return;
+    }
+
+    assert(action.measurement.has_value() &&
+           "active instrument requires a prepared source measurement");
+    if (action.mode == InstrumentMode::Activate) {
+        activate_zero_coordinate(state_);
+    }
+    const bool sign = evaluate(action.sign);
+    const MeasurementProbabilities eigen_populations =
+        measurement_probabilities(state_, *action.measurement);
+    const double total = eigen_populations.total();
+    const double epsilon = kMeasurementDustEpsilon * total;
+    const double physical_zero = eigen_populations.for_branch(sign);
+    const double physical_one = eigen_populations.for_branch(!sign);
+    const double fire_zero =
+        physical_zero <= epsilon ? 0.0 : distribution.p_fire[0] * physical_zero;
+    const double fire_one = physical_one <= epsilon ? 0.0 : distribution.p_fire[1] * physical_one;
+    const double draw = rng_.next_double() * total;
+    std::optional<uint8_t> fired_source;
+    if (draw < fire_zero) {
+        fired_source = 0;
+    } else if (draw < fire_zero + fire_one) {
+        fired_source = 1;
+    }
+
+    if (!fired_source.has_value()) {
+        const double factor_zero = std::sqrt(1.0 - distribution.p_fire[static_cast<uint8_t>(sign)]);
+        const double factor_one = std::sqrt(1.0 - distribution.p_fire[static_cast<uint8_t>(!sign)]);
+        const double no_fire_probability = factor_zero * factor_zero * eigen_populations.zero +
+                                           factor_one * factor_one * eigen_populations.one;
+        assert(no_fire_probability > 0.0 &&
+               "a selected no-fire branch must have positive probability");
+        apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
+                                 no_fire_probability);
+        return;
+    }
+
+    const bool eigen_branch = (*fired_source != 0) ^ sign;
+    collapse_instrument_source(state_, action.measurement->pauli, eigen_branch,
+                               eigen_populations.for_branch(eigen_branch));
+    finish_fire(*fired_source);
+}
+
+template <bool SampleNoise>
+void Executor::execute_action(const ExecutablePlan::ExecuteBoundary& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    if constexpr (SampleNoise) {
+        sample_presampled_noise(action.noise_begin, action.noise_end);
+    }
+}
+
+template <bool ForceRecords, bool SampleNoise>
+ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
+                                       uint32_t begin) noexcept {
     ReplayResult result;
-    for (const ExecutablePlan::Action& action : plan_.actions_) {
+    assert(begin <= plan_->actions_.size() && "execution offset must be inside the action stream");
+    for (size_t action_index = begin; action_index < plan_->actions_.size(); ++action_index) {
+        const ExecutablePlan::Action& action = plan_->actions_[action_index];
         std::visit(
             [&](const auto& typed) noexcept {
-                execute_action<ForceRecords>(typed, forced_records, result);
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary>) {
+                    execute_action<SampleNoise>(typed, forced_records, result);
+                } else {
+                    execute_action<ForceRecords>(typed, forced_records, result);
+                }
             },
             action);
         if constexpr (ForceRecords) {
@@ -406,17 +661,20 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records) 
         if (discarded_) {
             return result;
         }
+        if (pending_trap_.has_value()) {
+            return result;
+        }
     }
     return result;
 }
 
 bool Executor::evaluate(ExecutablePlan::PreparedExpression expression) const noexcept {
     assert(static_cast<uint64_t>(expression.term_begin) + expression.term_count <=
-               plan_.expression_terms_.size() &&
+               plan_->expression_terms_.size() &&
            "prepared affine expression must stay inside term storage");
     bool value = expression.constant;
     for (uint32_t i = 0; i < expression.term_count; ++i) {
-        const uint32_t symbol = plan_.expression_terms_[expression.term_begin + i];
+        const uint32_t symbol = plan_->expression_terms_[expression.term_begin + i];
         assert(symbol < symbols_.size() && symbols_[symbol] <= 1 &&
                "prepared affine term must refer to a Boolean symbol");
         value ^= symbols_[symbol] != 0;
@@ -463,6 +721,10 @@ bool Executor::sample_dormant_branch() noexcept {
 }
 
 SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "fixed-plan sampling does not support instrument traps; use the trajectory driver");
+    }
     if (plan.num_unbound_presampled_symbols() != 0) {
         throw std::invalid_argument(
             "batch sampling requires a distribution for every presampled symbol");
@@ -519,6 +781,10 @@ std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
 
 SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
                                         std::optional<uint64_t> seed, bool keep_records) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "survivor sampling does not support instrument traps; use the trajectory driver");
+    }
     if (plan.num_unbound_presampled_symbols() != 0) {
         throw std::invalid_argument(
             "survivor sampling requires a distribution for every presampled symbol");
@@ -580,6 +846,9 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
 std::vector<double> record_log_probabilities(const ExecutablePlan& plan,
                                              std::span<const uint8_t> forced_records,
                                              size_t num_records) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument("record probabilities do not yet support instruments");
+    }
     if (plan.num_presampled_symbols() != 0) {
         throw std::invalid_argument(
             "record probabilities do not yet support plans with presampled symbols");

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <optional>
 #include <span>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -46,6 +45,11 @@ struct InstrumentTrap {
     InstrumentSiteId site{};
     uint8_t source = 0;
     bool destination_pending = false;
+};
+
+struct ForcedTraceOut {
+    RecordSlot record{};
+    uint8_t source = 0;
 };
 
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
@@ -228,7 +232,7 @@ class Executor {
     // the source chosen by a trap-only dormant instrument to the continuation's
     // hidden trace-out measurement.
     void resume(const ExecutablePlan& continuation,
-                std::optional<std::pair<RecordSlot, uint8_t>> forced_record = std::nullopt);
+                std::optional<ForcedTraceOut> forced_trace_out = std::nullopt);
 
     // Replays the plan while forcing each record to a supplied Boolean value.
     // This reconstructs the corresponding branch state and computes its joint

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <optional>
 #include <span>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -41,6 +42,12 @@ struct ReplayResult {
     double log_probability = 0.0;
 };
 
+struct InstrumentTrap {
+    InstrumentSiteId site{};
+    uint8_t source = 0;
+    bool destination_pending = false;
+};
+
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept;
 
@@ -58,6 +65,10 @@ class ExecutablePlan {
     [[nodiscard]] uint32_t num_observables() const { return num_observables_; }
     [[nodiscard]] bool has_postselection() const { return has_postselection_; }
     [[nodiscard]] bool has_readout_noise() const { return has_readout_noise_; }
+    [[nodiscard]] bool has_instruments() const { return has_instruments_; }
+    [[nodiscard]] uint32_t num_instrument_sites() const {
+        return static_cast<uint32_t>(instrument_distributions_.size());
+    }
     [[nodiscard]] uint32_t num_symbols() const { return num_symbols_; }
     [[nodiscard]] uint32_t num_presampled_symbols() const {
         return static_cast<uint32_t>(presampled_symbols_.size());
@@ -132,6 +143,22 @@ class ExecutablePlan {
         uint32_t observable = 0;
     };
 
+    struct ExecuteInstrument {
+        InstrumentMode mode = InstrumentMode::Classical;
+        PreparedExpression sign;
+        std::optional<PreparedMeasurement> measurement;
+        uint32_t site = 0;
+        std::optional<uint32_t> destination_flip;
+    };
+
+    struct ExecuteBoundary {
+        uint32_t site = 0;
+        uint32_t active_width = 0;
+        uint32_t noise_begin = 0;
+        uint32_t noise_end = 0;
+        uint32_t symbol_prefix_size = 0;
+    };
+
     struct PreparedNoiseOutcome {
         uint32_t symbol = 0;
         double cumulative_probability = 0.0;
@@ -143,10 +170,10 @@ class ExecutablePlan {
         double total_probability = 0.0;
     };
 
-    using Action =
-        std::variant<ExecuteRotation, ExecutePromotion, ExecuteActiveMeasurement,
-                     ExecuteDormantMeasurement, ExecuteClassicalRecord, ExecuteSymbolDefinition,
-                     ExecuteReadoutNoise, ExecuteDetector, ExecuteObservable>;
+    using Action = std::variant<ExecuteRotation, ExecutePromotion, ExecuteActiveMeasurement,
+                                ExecuteDormantMeasurement, ExecuteClassicalRecord,
+                                ExecuteSymbolDefinition, ExecuteReadoutNoise, ExecuteDetector,
+                                ExecuteObservable, ExecuteInstrument, ExecuteBoundary>;
 
     PreparedExpression prepare_expression(const AffineBool& expression);
     PreparedExpression prepare_measurement_correction(const AffineBool& outcome, uint32_t branch);
@@ -161,6 +188,8 @@ class ExecutablePlan {
     uint32_t num_symbols_ = 0;
     bool has_postselection_ = false;
     bool has_readout_noise_ = false;
+    bool has_instruments_ = false;
+    uint32_t initial_noise_end_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::vector<uint32_t> expression_terms_;
     // Maps each dense presampled input position to its plan-local SymbolId.
@@ -170,6 +199,8 @@ class ExecutablePlan {
     std::vector<PreparedNoiseOutcome> noise_outcomes_;
     std::vector<PreparedNoiseSite> noise_sites_;
     std::vector<double> noise_hazards_;
+    std::vector<InstrumentDistribution> instrument_distributions_;
+    std::vector<uint32_t> instrument_resume_offsets_;
     std::vector<Action> actions_;
 };
 
@@ -192,6 +223,13 @@ class Executor {
     // ascending SymbolId order. This path consumes no quantum-noise RNG draws.
     void run_shot(std::span<const uint8_t> presampled_values) noexcept;
 
+    // Continue a trapped shot in a plan compiled for the selected trajectory.
+    // Storage may grow here, before dispatch resumes. A forced record supplies
+    // the source chosen by a trap-only dormant instrument to the continuation's
+    // hidden trace-out measurement.
+    void resume(const ExecutablePlan& continuation,
+                std::optional<std::pair<RecordSlot, uint8_t>> forced_record = std::nullopt);
+
     // Replays the plan while forcing each record to a supplied Boolean value.
     // This reconstructs the corresponding branch state and computes its joint
     // log probability, enabling differential validation and exact record
@@ -204,15 +242,19 @@ class Executor {
         std::span<const uint8_t> presampled_values = {}) noexcept;
 
     [[nodiscard]] std::span<const uint8_t> visible_records() const {
-        return std::span<const uint8_t>(records_).first(plan_.num_visible_records_);
+        return std::span<const uint8_t>(records_).first(plan_->num_visible_records_);
     }
     [[nodiscard]] std::span<const uint8_t> hidden_records() const {
-        return std::span<const uint8_t>(records_).subspan(plan_.num_visible_records_);
+        return std::span<const uint8_t>(records_).subspan(plan_->num_visible_records_,
+                                                          plan_->num_hidden_records_);
     }
-    [[nodiscard]] std::span<const uint8_t> symbols() const { return symbols_; }
+    [[nodiscard]] std::span<const uint8_t> symbols() const {
+        return std::span<const uint8_t>(symbols_).first(plan_->num_symbols_);
+    }
     [[nodiscard]] std::span<const uint8_t> detectors() const { return detectors_; }
     [[nodiscard]] std::span<const uint8_t> observables() const { return observables_; }
     [[nodiscard]] bool discarded() const { return discarded_; }
+    [[nodiscard]] std::optional<InstrumentTrap> pending_trap() const { return pending_trap_; }
     [[nodiscard]] const State& state() const { return state_; }
     // Counts positive branch probability mass classified as numerical dust.
     // This telemetry accumulates across shots.
@@ -221,10 +263,11 @@ class Executor {
   private:
     void reset_shot() noexcept;
     void assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept;
-    void sample_presampled_noise() noexcept;
+    void sample_presampled_noise(uint32_t begin, uint32_t end) noexcept;
 
-    template <bool ForceRecords>
-    [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records) noexcept;
+    template <bool ForceRecords, bool SampleNoise>
+    [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records,
+                                               uint32_t begin = 0) noexcept;
     template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
@@ -252,6 +295,12 @@ class Executor {
     template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteObservable& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteInstrument& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool SampleNoise>
+    void execute_action(const ExecutablePlan::ExecuteBoundary& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
 
     [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
     [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
@@ -259,15 +308,19 @@ class Executor {
                                                             bool branch) noexcept;
     [[nodiscard]] bool sample_dormant_branch() noexcept;
 
-    const ExecutablePlan& plan_;
+    const ExecutablePlan* root_plan_;
+    const ExecutablePlan* plan_;
     State state_;
     std::vector<uint8_t> symbols_;
     std::vector<uint8_t> records_;
     std::vector<uint8_t> detectors_;
     std::vector<uint8_t> observables_;
+    std::vector<uint8_t> forced_record_mask_;
+    std::vector<uint8_t> forced_record_values_;
     std::vector<uint32_t> previous_presampled_ones_;
     Xoshiro256PlusPlus rng_;
     bool discarded_ = false;
+    std::optional<InstrumentTrap> pending_trap_;
     uint64_t dust_clamps_ = 0;
 };
 

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -2,6 +2,7 @@
 
 #include "clifft/util/numeric.h"
 
+#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <cmath>
@@ -223,6 +224,94 @@ void collapse_measurement(State& state, const PreparedMeasurement& measurement, 
         }
     }
     state.set_active_width(state.active_width() - 1);
+}
+
+void activate_zero_coordinate(State& state) noexcept {
+    assert(state.active_width() < state.max_active_width() &&
+           "instrument activation must fit the sampling state allocation");
+    const uint64_t old_size = state.size();
+    std::fill_n(state.real_data() + old_size, static_cast<size_t>(old_size), 0.0);
+    std::fill_n(state.imag_data() + old_size, static_cast<size_t>(old_size), 0.0);
+    state.set_active_width(state.active_width() + 1);
+}
+
+void apply_instrument_no_fire(State& state, const PreparedPauli& source, double factor_zero,
+                              double factor_one, double no_fire_probability) noexcept {
+    assert_descriptor_width(state, source);
+    assert(!source.is_identity() && "state-dependent instrument source must be nonidentity");
+    assert(factor_zero >= 0.0 && factor_zero <= 1.0 && factor_one >= 0.0 && factor_one <= 1.0 &&
+           no_fire_probability > 0.0 && is_finite_robust(no_fire_probability) &&
+           "instrument no-fire filter requires valid factors and probability");
+    const double inv_norm = 1.0 / std::sqrt(no_fire_probability);
+    double* real = state.real_data();
+    double* imag = state.imag_data();
+    const uint64_t size = state.size();
+    if (source.is_diagonal()) {
+        for (uint64_t basis = 0; basis < size; ++basis) {
+            const bool branch = (std::popcount(basis & source.z) & 1U) != 0;
+            const double factor = (branch ? factor_one : factor_zero) * inv_norm;
+            real[basis] *= factor;
+            imag[basis] *= factor;
+        }
+        return;
+    }
+
+    const double identity_factor = 0.5 * (factor_zero + factor_one);
+    const double pauli_factor = 0.5 * (factor_zero - factor_one);
+    for (uint64_t left = 0; left < size; ++left) {
+        if ((left & source.pair_selector) != 0) {
+            continue;
+        }
+        const uint64_t right = left ^ source.x;
+        const std::complex<double> left_value{real[left], imag[left]};
+        const std::complex<double> right_value{real[right], imag[right]};
+        const std::complex<double> left_result =
+            identity_factor * left_value + pauli_factor * phase_at(source, right) * right_value;
+        const std::complex<double> right_result =
+            identity_factor * right_value + pauli_factor * phase_at(source, left) * left_value;
+        store(state, left, inv_norm * left_result);
+        store(state, right, inv_norm * right_result);
+    }
+}
+
+void collapse_instrument_source(State& state, const PreparedPauli& source, bool branch,
+                                double branch_probability) noexcept {
+    assert_descriptor_width(state, source);
+    assert(!source.is_identity() && "state-dependent instrument source must be nonidentity");
+    assert(branch_probability > 0.0 && is_finite_robust(branch_probability) &&
+           "instrument collapse requires a positive finite probability");
+    const double inv_norm = 1.0 / std::sqrt(branch_probability);
+    double* real = state.real_data();
+    double* imag = state.imag_data();
+    const uint64_t size = state.size();
+    if (source.is_diagonal()) {
+        for (uint64_t basis = 0; basis < size; ++basis) {
+            const bool basis_branch = (std::popcount(basis & source.z) & 1U) != 0;
+            if (basis_branch == branch) {
+                real[basis] *= inv_norm;
+                imag[basis] *= inv_norm;
+            } else {
+                real[basis] = 0.0;
+                imag[basis] = 0.0;
+            }
+        }
+        return;
+    }
+
+    const double eigenvalue = branch ? -1.0 : 1.0;
+    const double scale = 0.5 * inv_norm;
+    for (uint64_t left = 0; left < size; ++left) {
+        if ((left & source.pair_selector) != 0) {
+            continue;
+        }
+        const uint64_t right = left ^ source.x;
+        const std::complex<double> left_value{real[left], imag[left]};
+        const std::complex<double> right_value{real[right], imag[right]};
+        store(state, left,
+              scale * (left_value + eigenvalue * phase_at(source, right) * right_value));
+        store(state, right,
+              scale * (right_value + eigenvalue * phase_at(source, left) * left_value));
+    }
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -70,4 +70,15 @@ void apply_promotion(State& state, const PreparedPromotion& promotion, bool sign
 void collapse_measurement(State& state, const PreparedMeasurement& measurement, bool branch,
                           double branch_probability) noexcept;
 
+// Instrument back-action preserves active coordinates. An activating site adds
+// one |0> coordinate first; its prepared source Pauli already uses that wider
+// layout. The population reduction is shared with measurement preparation,
+// while filter and collapse keep the full coefficient array instead of
+// compacting a coordinate.
+void activate_zero_coordinate(State& state) noexcept;
+void apply_instrument_no_fire(State& state, const PreparedPauli& source, double factor_zero,
+                              double factor_one, double no_fire_probability) noexcept;
+void collapse_instrument_source(State& state, const PreparedPauli& source, bool branch,
+                                double branch_probability) noexcept;
+
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -81,6 +81,8 @@ std::string format_expression(const AffineBool& expression) {
 
 std::string_view symbol_kind_name(SymbolKind kind) {
     switch (kind) {
+        case SymbolKind::Unused:
+            return "unused";
         case SymbolKind::Presampled:
             return "presampled";
         case SymbolKind::Derived:
@@ -89,6 +91,22 @@ std::string_view symbol_kind_name(SymbolKind kind) {
             return "branch";
         case SymbolKind::Readout:
             return "readout";
+        case SymbolKind::Instrument:
+            return "instrument";
+    }
+    return "unknown";
+}
+
+std::string_view instrument_mode_name(InstrumentMode mode) {
+    switch (mode) {
+        case InstrumentMode::Classical:
+            return "classical";
+        case InstrumentMode::Active:
+            return "active";
+        case InstrumentMode::Activate:
+            return "activate";
+        case InstrumentMode::DormantTrap:
+            return "dormant_trap";
     }
     return "unknown";
 }
@@ -140,6 +158,8 @@ std::optional<SymbolId> defined_symbol(const SamplingAction& action) {
                 return typed.symbol;
             } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
                 return typed.flip;
+            } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                return typed.destination_flip;
             } else if constexpr (std::is_same_v<T, RotateActivePauli> ||
                                  std::is_same_v<T, PromoteDormantRotation> ||
                                  std::is_same_v<T, RecordClassical> ||
@@ -278,6 +298,17 @@ uint32_t predicted_dense_passes(const SamplingAction& action) {
                 // Sampling requires one reduction before the branch is known,
                 // then a second traversal to collapse and compact that branch.
                 return 2;
+            } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                switch (typed.mode) {
+                    case InstrumentMode::Classical:
+                    case InstrumentMode::DormantTrap:
+                        return 0;
+                    case InstrumentMode::Active:
+                    case InstrumentMode::Activate:
+                        // One population reduction followed by a filter or collapse pass.
+                        return 2;
+                }
+                return 0;
             } else if constexpr (std::is_same_v<T, MeasureDormantRandom> ||
                                  std::is_same_v<T, RecordClassical> ||
                                  std::is_same_v<T, DefineSymbol> ||
@@ -314,6 +345,35 @@ void SamplingPlan::validate() const {
 
     if (presampled_noise_sites.size() != num_noise_sites) {
         invalid_plan("presampled noise-site table does not match declared count");
+    }
+    if (instrument_distributions.size() != num_instrument_sites) {
+        invalid_plan("instrument distribution table does not match declared count");
+    }
+
+    for (uint32_t site_index = 0; site_index < instrument_distributions.size(); ++site_index) {
+        const InstrumentDistribution& distribution = instrument_distributions[site_index];
+        if (index(distribution.site) != site_index) {
+            invalid_plan("instrument distributions are not in stable id order");
+        }
+        for (uint8_t source = 0; source < 2; ++source) {
+            if (!is_probability(distribution.p_fire[source])) {
+                invalid_plan("instrument site " + std::to_string(site_index) +
+                             " has an invalid fire probability");
+            }
+            double computational = 0.0;
+            for (uint8_t destination = 0; destination < 2; ++destination) {
+                const double probability = distribution.p_computational_dest[source][destination];
+                if (!is_probability(probability)) {
+                    invalid_plan("instrument site " + std::to_string(site_index) +
+                                 " has an invalid destination probability");
+                }
+                computational += probability;
+            }
+            if (computational > distribution.p_fire[source] + 1e-12) {
+                invalid_plan("instrument site " + std::to_string(site_index) +
+                             " computational destinations exceed its fire probability");
+            }
+        }
     }
 
     std::vector<bool> bound_noise_symbols(symbols.size(), false);
@@ -372,6 +432,14 @@ void SamplingPlan::validate() const {
             invalid_plan("symbol s" + std::to_string(symbol_index) +
                          " has an invalid noise-site identity");
         }
+        if (info.kind == SymbolKind::Unused) {
+            if (info.defining_action.has_value() || info.noise_site.has_value() ||
+                actual_definitions[symbol_index].has_value()) {
+                invalid_plan("unused symbol s" + std::to_string(symbol_index) +
+                             " must not have a definition or noise identity");
+            }
+            continue;
+        }
         if (info.kind == SymbolKind::Presampled) {
             if (info.defining_action.has_value() || actual_definitions[symbol_index].has_value()) {
                 invalid_plan("presampled symbol s" + std::to_string(symbol_index) +
@@ -404,6 +472,11 @@ void SamplingPlan::validate() const {
             invalid_plan("readout symbol s" + std::to_string(symbol_index) +
                          " must be defined by ApplyReadoutNoise");
         }
+        if (info.kind == SymbolKind::Instrument &&
+            !std::holds_alternative<ApplyInstrument>(action)) {
+            invalid_plan("instrument symbol s" + std::to_string(symbol_index) +
+                         " must be defined by ApplyInstrument");
+        }
     }
 
     uint32_t active_width = initial_active_width;
@@ -412,6 +485,10 @@ void SamplingPlan::validate() const {
     std::unordered_set<uint32_t> written_detectors;
     std::unordered_set<uint32_t> written_observables;
     bool observed_postselection = false;
+    uint32_t observed_instruments = 0;
+    uint32_t observed_instrument_boundaries = 0;
+    uint32_t previous_noise_boundary = 0;
+    uint32_t previous_symbol_boundary = 0;
     written_records.reserve(std::min<size_t>(
         actions.size(), static_cast<uint64_t>(num_visible_records) + num_hidden_records));
     for (uint32_t action_index = 0; action_index < actions.size(); ++action_index) {
@@ -505,11 +582,62 @@ void SamplingPlan::validate() const {
                         invalid_plan("observable write has invalid width or slot");
                     }
                     validate_expression(*this, typed.outcome, action_index, definition, false);
+                } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                    if (index(typed.site) != observed_instruments ||
+                        index(typed.site) >= num_instrument_sites) {
+                        invalid_plan("instrument action has an invalid or out-of-order site id");
+                    }
+                    const bool width_unchanged = planned.active_after == planned.active_before;
+                    switch (typed.mode) {
+                        case InstrumentMode::Classical:
+                            if (!width_unchanged || !typed.source.is_identity()) {
+                                invalid_plan("classical instrument has invalid width or source");
+                            }
+                            break;
+                        case InstrumentMode::Active:
+                            if (!width_unchanged || typed.source.is_identity()) {
+                                invalid_plan("active instrument has invalid width or source");
+                            }
+                            validate_pauli(typed.source, planned.active_before, action_index);
+                            break;
+                        case InstrumentMode::Activate:
+                            if (planned.active_after != planned.active_before + 1 ||
+                                typed.source.is_identity()) {
+                                invalid_plan("activating instrument has invalid width or source");
+                            }
+                            validate_pauli(typed.source, planned.active_after, action_index);
+                            break;
+                        case InstrumentMode::DormantTrap:
+                            if (!width_unchanged || !typed.source.is_identity() ||
+                                typed.destination_flip.has_value() || typed.sign != AffineBool{}) {
+                                invalid_plan("dormant trap instrument has incompatible fields");
+                            }
+                            break;
+                    }
+                    if (typed.mode != InstrumentMode::DormantTrap &&
+                        !typed.destination_flip.has_value()) {
+                        invalid_plan("in-line instrument omits its destination-flip symbol");
+                    }
+                    validate_expression(*this, typed.sign, action_index, definition, false);
+                    ++observed_instruments;
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     if (planned.active_after != planned.active_before ||
-                        index(typed.site) >= num_instrument_sites) {
+                        index(typed.site) >= num_instrument_sites ||
+                        typed.next_noise_site > num_noise_sites ||
+                        typed.next_noise_site < previous_noise_boundary || action_index == 0 ||
+                        index(typed.site) != observed_instrument_boundaries ||
+                        typed.symbol_prefix_size > symbols.size() ||
+                        typed.symbol_prefix_size < previous_symbol_boundary) {
                         invalid_plan("instrument boundary has an invalid width or site id");
                     }
+                    const auto* instrument =
+                        std::get_if<ApplyInstrument>(&actions[action_index - 1].action);
+                    if (instrument == nullptr || instrument->site != typed.site) {
+                        invalid_plan("instrument boundary must immediately follow its action");
+                    }
+                    previous_noise_boundary = typed.next_noise_site;
+                    previous_symbol_boundary = typed.symbol_prefix_size;
+                    ++observed_instrument_boundaries;
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
                 }
@@ -531,6 +659,10 @@ void SamplingPlan::validate() const {
     }
     if (observed_postselection != has_postselection) {
         invalid_plan("declared postselection flag does not match detector actions");
+    }
+    if (observed_instruments != num_instrument_sites ||
+        observed_instrument_boundaries != num_instrument_sites) {
+        invalid_plan("declared instrument count does not match the action stream");
     }
 }
 
@@ -607,8 +739,17 @@ std::string SamplingPlan::inspect() const {
                 } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     out << "write_observable outcome=" << format_expression(typed.outcome)
                         << " observable=" << index(typed.observable);
+                } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                    out << "apply_instrument site=" << index(typed.site)
+                        << " mode=" << instrument_mode_name(typed.mode) << ' '
+                        << format_pauli(typed.source) << " sign=" << format_expression(typed.sign);
+                    if (typed.destination_flip.has_value()) {
+                        out << " flip=s" << index(*typed.destination_flip);
+                    }
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
-                    out << "instrument_boundary site=" << index(typed.site);
+                    out << "instrument_boundary site=" << index(typed.site)
+                        << " next_noise_site=" << typed.next_noise_site
+                        << " symbol_prefix_size=" << typed.symbol_prefix_size;
                 } else {
                     static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
                 }

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -16,6 +16,7 @@
 
 #include "clifft/util/numeric.h"
 
+#include <array>
 #include <complex>
 #include <cstdint>
 #include <limits>
@@ -58,10 +59,12 @@ enum class ObservableSlot : uint32_t {};
 }
 
 enum class SymbolKind : uint8_t {
+    Unused,      // Stable operation-order slot that this compiled plan does not need.
     Presampled,  // Available before the action stream, such as sampled noise.
     Derived,     // Computed as a parity of previously available symbols.
     Branch,      // Sampled while applying a measurement action.
     Readout,     // Sampled from a record-dependent readout channel.
+    Instrument,  // Records an in-line computational instrument destination flip.
 };
 
 // A parity expression over plan symbols, optionally XORed with true. For
@@ -192,19 +195,44 @@ struct WriteObservable {
     ObservableSlot observable{};
 };
 
+// Instruments share one semantic action because their execution forms differ
+// only in how the source observable enters the dense state. The planner fixes
+// that choice; runtime never performs localization or topology discovery.
+enum class InstrumentMode : uint8_t {
+    Classical,    // The source is the Boolean sign; no coefficient work is needed.
+    Active,       // The source Pauli is already supported on active coordinates.
+    Activate,     // Add one |0> coordinate before applying the source Pauli.
+    DormantTrap,  // Sample a dormant-random source and let a continuation collapse it.
+};
+
+struct ApplyInstrument {
+    InstrumentSiteId site{};
+    InstrumentMode mode = InstrumentMode::Classical;
+    // Identity for Classical and DormantTrap. Activate uses the post-activation
+    // width, while Active uses the unchanged width.
+    ActivePauli source;
+    AffineBool sign;
+    // Present when a computational destination can continue in-line. The
+    // symbol is true exactly when that destination differs from its source.
+    std::optional<SymbolId> destination_flip;
+};
+
 // Divides ahead-of-time execution segments. A continuation must preserve the
 // live coefficients, active-coordinate meaning and order, active width,
 // symbol and record values, and RNG position established here. It need not
-// reproduce an arbitrary prior plan prefix byte-for-byte. The marker does not
-// itself change the active state; any transition belongs to a following action.
+// reproduce an arbitrary prior plan prefix byte-for-byte. The instrument
+// action precedes this marker, so a trap resumes at the marker and samples only
+// the replacement suffix's presampled-noise segment.
 struct InstrumentBoundary {
     InstrumentSiteId site{};
+    uint32_t next_noise_site = 0;
+    uint32_t symbol_prefix_size = 0;
 };
 
 using SamplingAction =
     std::variant<RotateActivePauli, PromoteDormantRotation, MeasureActivePauli,
                  MeasureDormantRandom, RecordClassical, DefineSymbol, ApplyReadoutNoise,
-                 WriteDetector, WriteObservable, InstrumentBoundary>;
+                 WriteDetector, WriteObservable, ApplyInstrument, InstrumentBoundary>;
 
 struct PlannedAction {
     uint32_t active_before = 0;
@@ -215,15 +243,15 @@ struct PlannedAction {
 // SamplingPlan::validate enforces the legal field combinations and verifies
 // that definition metadata agrees with the referenced action.
 struct SymbolInfo {
-    SymbolKind kind = SymbolKind::Presampled;
+    SymbolKind kind = SymbolKind::Unused;
 
-    // This is nullopt for Presampled. For Branch and Derived it identifies the
-    // unique action that assigns the symbol.
+    // For action-defined kinds, this identifies the unique assigning action.
+    // Presampled and Unused symbols use nullopt.
     std::optional<uint32_t> defining_action;
 
     // For a Presampled noise symbol, this identifies its stable HIR noise site.
-    // Nullopt means the presampled event has no noise-site identity. Branch and
-    // Derived symbols must always use nullopt.
+    // Nullopt means the presampled event has no noise-site identity. All other
+    // symbol kinds must use nullopt.
     std::optional<NoiseSiteId> noise_site;
 };
 
@@ -237,6 +265,15 @@ struct PresampledNoiseOutcome {
 struct PresampledNoiseSite {
     NoiseSiteId site{};
     std::vector<PresampledNoiseOutcome> outcomes;
+};
+
+// Plan-owned copy of one HIR instrument distribution. Source and destination
+// indices use 0 for g and 1 for e. Computational entries are unconditional;
+// their row sum is at most p_fire[source].
+struct InstrumentDistribution {
+    InstrumentSiteId site{};
+    std::array<double, 2> p_fire{};
+    std::array<std::array<double, 2>, 2> p_computational_dest{};
 };
 
 struct SamplingPlan {
@@ -259,6 +296,7 @@ struct SamplingPlan {
 
     std::vector<SymbolInfo> symbols;
     std::vector<PresampledNoiseSite> presampled_noise_sites;
+    std::vector<InstrumentDistribution> instrument_distributions;
     std::vector<PlannedAction> actions;
 
     // Throws std::invalid_argument when the plan is structurally inconsistent.

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -208,8 +208,8 @@ enum class InstrumentMode : uint8_t {
 struct ApplyInstrument {
     InstrumentSiteId site{};
     InstrumentMode mode = InstrumentMode::Classical;
-    // Identity for Classical and DormantTrap. Activate uses the post-activation
-    // width, while Active uses the unchanged width.
+    // The source is identity for Classical and DormantTrap. Activate uses the
+    // post-activation width, while Active uses the unchanged width.
     ActivePauli source;
     AffineBool sign;
     // Present when a computational destination can continue in-line. The
@@ -245,8 +245,8 @@ struct PlannedAction {
 struct SymbolInfo {
     SymbolKind kind = SymbolKind::Unused;
 
-    // For action-defined kinds, this identifies the unique assigning action.
-    // Presampled and Unused symbols use nullopt.
+    // Index of the action that assigns this symbol. Required for Derived,
+    // Branch, Readout, and Instrument; absent for Presampled and Unused.
     std::optional<uint32_t> defining_action;
 
     // For a Presampled noise symbol, this identifies its stable HIR noise site.

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -39,6 +39,7 @@ struct PendingMeasurement {
     Pauli body;
     AffineBool sign;
     RecordSlot record{};
+    SymbolId branch{};
 };
 
 struct PendingConditionalPauli {
@@ -59,6 +60,18 @@ struct PendingReadoutNoise {
     RecordSlot record{};
     double prob_zero_to_one = 0.0;
     double prob_one_to_zero = 0.0;
+    SymbolId flip{};
+};
+
+struct PendingInstrument {
+    Pauli body;
+    Pauli destination_flip;
+    AffineBool sign;
+    InstrumentSiteId site{};
+    SymbolId flip{};
+    uint32_t next_noise_site = 0;
+    uint32_t symbol_prefix_size = 0;
+    bool neglect_damping = false;
 };
 
 struct PendingDetector {
@@ -75,7 +88,7 @@ struct PendingObservable {
 
 using PendingOperation =
     std::variant<PendingRotation, PendingMeasurement, PendingConditionalPauli, PendingNoise,
-                 PendingReadoutNoise, PendingDetector, PendingObservable>;
+                 PendingReadoutNoise, PendingInstrument, PendingDetector, PendingObservable>;
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
@@ -89,6 +102,15 @@ Pauli noise_pauli_from_hir(const HirModule& hir, PauliMaskHandle handle) {
     const PauliMaskView mask = hir.noise_channel_masks.at(handle);
     mask_view_to_stim(mask.x(), hir.num_qubits, result.xs);
     mask_view_to_stim(mask.z(), hir.num_qubits, result.zs);
+    return result;
+}
+
+Pauli pauli_from_mask(const HirModule& hir, PauliMaskHandle handle) {
+    Pauli result(hir.num_qubits);
+    const PauliMaskView mask = hir.pauli_masks.at(handle);
+    mask_view_to_stim(mask.x(), hir.num_qubits, result.xs);
+    mask_view_to_stim(mask.z(), hir.num_qubits, result.zs);
+    result.sign = false;
     return result;
 }
 
@@ -288,6 +310,9 @@ void visit_pending_pauli(PendingOperation& operation, Function&& function) {
             if constexpr (std::is_same_v<T, PendingRotation> ||
                           std::is_same_v<T, PendingMeasurement>) {
                 function(typed.body, &typed.sign);
+            } else if constexpr (std::is_same_v<T, PendingInstrument>) {
+                function(typed.body, &typed.sign);
+                function(typed.destination_flip, nullptr);
             } else if constexpr (std::is_same_v<T, PendingConditionalPauli>) {
                 function(typed.body, nullptr);
             } else if constexpr (std::is_same_v<T, PendingNoise>) {
@@ -330,7 +355,8 @@ void propagate_conditional_pauli(std::vector<PendingOperation>& pending, size_t 
             [&](auto& typed) {
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, PendingRotation> ||
-                              std::is_same_v<T, PendingMeasurement>) {
+                              std::is_same_v<T, PendingMeasurement> ||
+                              std::is_same_v<T, PendingInstrument>) {
                     if (anticommutes(correction, typed.body)) {
                         typed.sign ^= condition;
                     }
@@ -358,7 +384,8 @@ void propagate_branch(std::vector<PendingOperation>& pending, size_t begin,
             [&](auto& typed) {
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, PendingRotation> ||
-                              std::is_same_v<T, PendingMeasurement>) {
+                              std::is_same_v<T, PendingMeasurement> ||
+                              std::is_same_v<T, PendingInstrument>) {
                     if (typed.body.zs[branch_coordinate]) {
                         typed.sign ^= AffineBool::symbol(branch);
                     }
@@ -377,10 +404,19 @@ void propagate_branch(std::vector<PendingOperation>& pending, size_t begin,
     }
 }
 
-SymbolId append_branch(SamplingPlan& plan, uint32_t defining_action) {
-    const SymbolId branch{static_cast<uint32_t>(plan.symbols.size())};
-    plan.symbols.push_back(SymbolInfo{SymbolKind::Branch, defining_action, std::nullopt});
-    return branch;
+SymbolId reserve_symbol(SamplingPlan& plan) {
+    const SymbolId symbol{static_cast<uint32_t>(plan.symbols.size())};
+    plan.symbols.emplace_back();
+    return symbol;
+}
+
+void define_symbol(SamplingPlan& plan, SymbolId symbol, SymbolKind kind, uint32_t action) {
+    SymbolInfo& info = plan.symbols.at(index(symbol));
+    if (info.kind != SymbolKind::Unused || info.defining_action.has_value() ||
+        info.noise_site.has_value()) {
+        throw std::logic_error("sampling planner attempted to redefine a reserved symbol");
+    }
+    info = SymbolInfo{kind, action, std::nullopt};
 }
 
 void multiply_phase(std::complex<double>& weight, double angle) {
@@ -409,8 +445,24 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
         plan.presampled_noise_sites[site].site = NoiseSiteId{site};
     }
     std::vector<bool> seen_noise_sites(hir.noise_sites.size(), false);
+    plan.instrument_distributions.reserve(hir.instrument_sites.size());
+    for (uint32_t site = 0; site < hir.instrument_sites.size(); ++site) {
+        const InstrumentProbabilities& probabilities = hir.instrument_sites[site].probabilities;
+        InstrumentDistribution distribution;
+        distribution.site = InstrumentSiteId{site};
+        for (uint8_t source = 0; source < 2; ++source) {
+            distribution.p_fire[source] = probabilities.p_fire[source];
+            for (uint8_t destination = 0; destination < 2; ++destination) {
+                distribution.p_computational_dest[source][destination] =
+                    probabilities.p_computational_dest[source][destination];
+            }
+        }
+        plan.instrument_distributions.push_back(distribution);
+    }
 
     uint32_t detector_index = 0;
+    uint32_t next_noise_site = 0;
+    uint32_t next_instrument_site = 0;
 
     for (size_t i = 0; i < hir.ops.size(); ++i) {
         const HeisenbergOp& op = hir.ops[i];
@@ -431,9 +483,9 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::MEASURE:
-                pending.emplace_back(
-                    PendingMeasurement{pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
-                                       RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}});
+                pending.emplace_back(PendingMeasurement{
+                    pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
+                    RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}, reserve_symbol(plan)});
                 break;
             case OpType::CONDITIONAL_PAULI:
                 pending.emplace_back(PendingConditionalPauli{
@@ -449,6 +501,11 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                     throw std::invalid_argument(
                         "sampling planner encountered a duplicate noise site");
                 }
+                if (site_index != next_noise_site) {
+                    throw std::invalid_argument(
+                        "sampling planner noise sites are not in circuit order");
+                }
+                ++next_noise_site;
                 seen_noise_sites[site_index] = true;
                 const NoiseSite& hir_site = hir.noise_sites[site_index];
                 PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];
@@ -475,8 +532,29 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                     throw std::invalid_argument("sampling planner readout entry is out of range");
                 }
                 const ReadoutNoiseEntry& entry = hir.readout_noise[entry_index];
-                pending.emplace_back(PendingReadoutNoise{
-                    RecordSlot{entry.meas_idx}, entry.prob_zero_to_one, entry.prob_one_to_zero});
+                pending.emplace_back(
+                    PendingReadoutNoise{RecordSlot{entry.meas_idx}, entry.prob_zero_to_one,
+                                        entry.prob_one_to_zero, reserve_symbol(plan)});
+                break;
+            }
+            case OpType::INSTRUMENT: {
+                const uint32_t site_index = static_cast<uint32_t>(op.instrument_site_idx());
+                if (site_index >= hir.instrument_sites.size() ||
+                    site_index != next_instrument_site) {
+                    throw std::invalid_argument(
+                        "sampling planner instrument site is out of range or circuit order");
+                }
+                const InstrumentSite& site = hir.instrument_sites[site_index];
+                if (site.destination_flip_mask == kNoMask) {
+                    throw std::invalid_argument(
+                        "sampling planner instrument omits its destination flip");
+                }
+                const SymbolId flip = reserve_symbol(plan);
+                pending.emplace_back(PendingInstrument{
+                    pauli_from_hir(hir, op), pauli_from_mask(hir, site.destination_flip_mask),
+                    AffineBool(hir.sign(op)), InstrumentSiteId{site_index}, flip, next_noise_site,
+                    static_cast<uint32_t>(plan.symbols.size()), hir.neglect_instrument_damping});
+                ++next_instrument_site;
                 break;
             }
             case OpType::DETECTOR: {
@@ -505,7 +583,6 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::EXP_VAL:
-            case OpType::INSTRUMENT:
             case OpType::NUM_OP_TYPES:
                 throw std::invalid_argument("sampling planner does not support HIR operation " +
                                             op_type_to_str(op.op_type()) + " at index " +
@@ -517,6 +594,10 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
     }
     if (!std::ranges::all_of(seen_noise_sites, [](bool seen) { return seen; })) {
         throw std::invalid_argument("sampling planner noise-site table is inconsistent with HIR");
+    }
+    if (next_instrument_site != hir.instrument_sites.size()) {
+        throw std::invalid_argument(
+            "sampling planner instrument-site table is inconsistent with HIR");
     }
     return pending;
 }
@@ -557,7 +638,8 @@ AffineBool process_measurement(std::vector<PendingOperation>& pending, size_t in
         transform_future_operations(pending, index + 1, frame);
 
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-        const SymbolId branch = append_branch(plan, action_index);
+        const SymbolId branch = measurement.branch;
+        define_symbol(plan, branch, SymbolKind::Branch, action_index);
         propagate_branch(pending, index + 1, *dormant_pivot, branch);
         const AffineBool outcome = measurement.sign ^ AffineBool::symbol(branch);
         plan.actions.push_back(PlannedAction{
@@ -590,7 +672,8 @@ AffineBool process_measurement(std::vector<PendingOperation>& pending, size_t in
     transform_future_operations(pending, index + 1, frame);
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-    const SymbolId branch = append_branch(plan, action_index);
+    const SymbolId branch = measurement.branch;
+    define_symbol(plan, branch, SymbolKind::Branch, action_index);
     propagate_branch(pending, index + 1, active_width - 1, branch);
     const AffineBool outcome = measurement.sign ^ AffineBool::symbol(branch);
     plan.actions.push_back(
@@ -598,6 +681,71 @@ AffineBool process_measurement(std::vector<PendingOperation>& pending, size_t in
                       MeasureActivePauli{active, *pivot, branch, outcome, measurement.record}});
     --active_width;
     return outcome;
+}
+
+void process_instrument(std::vector<PendingOperation>& pending, size_t operation_index,
+                        const PendingInstrument& instrument, SamplingPlan& plan,
+                        uint32_t& active_width) {
+    const InstrumentDistribution& distribution =
+        plan.instrument_distributions.at(index(instrument.site));
+    const std::optional<uint32_t> dormant_pivot =
+        first_x_at_or_above(instrument.body, active_width);
+
+    InstrumentMode mode = InstrumentMode::Classical;
+    ActivePauli source;
+    AffineBool sign = instrument.sign;
+    Pauli destination_flip = instrument.destination_flip;
+    uint32_t active_after = active_width;
+
+    if (dormant_pivot.has_value()) {
+        if (instrument.neglect_damping || distribution.p_fire[0] == distribution.p_fire[1]) {
+            mode = InstrumentMode::DormantTrap;
+            sign = AffineBool{};
+        } else {
+            if (active_width + 1 >= kDenseActiveWidthLimit) {
+                throw std::overflow_error("sampling planner active width would reach " +
+                                          std::to_string(active_width + 1) +
+                                          ", but the dense-state limit is " +
+                                          std::to_string(kDenseActiveWidthLimit));
+            }
+            const Tableau frame =
+                dormant_promotion_frame(instrument.body, active_width, *dormant_pivot);
+            const Tableau old_to_new = frame.inverse();
+            Pauli transformed_source = old_to_new(instrument.body);
+            sign ^= static_cast<bool>(transformed_source.sign);
+            transformed_source.sign = false;
+            destination_flip = old_to_new(destination_flip);
+            destination_flip.sign = false;
+            transform_future_operations(pending, operation_index + 1, frame);
+            ++active_after;
+            mode = InstrumentMode::Activate;
+            source = active_projection(transformed_source, active_after);
+        }
+    } else {
+        source = active_projection(instrument.body, active_width);
+        mode = source.is_identity() ? InstrumentMode::Classical : InstrumentMode::Active;
+    }
+
+    const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
+    std::optional<SymbolId> destination_symbol;
+    if (mode != InstrumentMode::DormantTrap) {
+        destination_symbol = instrument.flip;
+        define_symbol(plan, instrument.flip, SymbolKind::Instrument, action_index);
+    }
+    plan.actions.push_back(
+        PlannedAction{active_width, active_after,
+                      ApplyInstrument{instrument.site, mode, source, sign, destination_symbol}});
+
+    if (destination_symbol.has_value()) {
+        propagate_conditional_pauli(pending, operation_index + 1, destination_flip,
+                                    AffineBool::symbol(*destination_symbol));
+    }
+    active_width = active_after;
+    plan.max_active_width = std::max(plan.max_active_width, active_width);
+    plan.actions.push_back(
+        PlannedAction{active_width, active_width,
+                      InstrumentBoundary{instrument.site, instrument.next_noise_site,
+                                         instrument.symbol_prefix_size}});
 }
 
 }  // namespace
@@ -672,14 +820,15 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                         return;
                     }
                     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-                    const SymbolId flip{static_cast<uint32_t>(plan.symbols.size())};
-                    plan.symbols.push_back(
-                        SymbolInfo{SymbolKind::Readout, action_index, std::nullopt});
+                    const SymbolId flip = operation.flip;
+                    define_symbol(plan, flip, SymbolKind::Readout, action_index);
                     plan.actions.push_back(PlannedAction{
                         active_width, active_width,
                         ApplyReadoutNoise{flip, source, operation.record,
                                           operation.prob_zero_to_one, operation.prob_one_to_zero}});
                     record_values[index(operation.record)] = source ^ AffineBool::symbol(flip);
+                } else if constexpr (std::is_same_v<T, PendingInstrument>) {
+                    process_instrument(pending, i, operation, plan, active_width);
                 } else if constexpr (std::is_same_v<T, PendingDetector>) {
                     AffineBool outcome = record_parity(operation.records, i);
                     outcome ^= operation.expected;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -64,11 +64,18 @@ struct PendingReadoutNoise {
 };
 
 struct PendingInstrument {
+    // Source observable and computational destination correction, expressed
+    // in the coordinate basis that future planner transformations update.
     Pauli body;
     Pauli destination_flip;
+    // Maps the source observable's eigenspaces to physical G and E; earlier
+    // stochastic outcomes can make this mapping symbolic.
     AffineBool sign;
+    // Indexes both the plan-owned distribution and its continuation boundary.
     InstrumentSiteId site{};
-    SymbolId flip{};
+    // Reserved in HIR order so a rewritten suffix cannot renumber the prefix.
+    SymbolId destination_flip_symbol{};
+    // Continuations retain only noise and symbols preceding this HIR site.
     uint32_t next_noise_site = 0;
     uint32_t symbol_prefix_size = 0;
     bool neglect_damping = false;
@@ -698,6 +705,8 @@ void process_instrument(std::vector<PendingOperation>& pending, size_t operation
     uint32_t active_after = active_width;
 
     if (dormant_pivot.has_value()) {
+        // Equal no-fire factors normalize away. Otherwise exact damping needs
+        // the dormant-coherent source represented in the dense state.
         if (instrument.neglect_damping || distribution.p_fire[0] == distribution.p_fire[1]) {
             mode = InstrumentMode::DormantTrap;
             sign = AffineBool{};
@@ -708,6 +717,8 @@ void process_instrument(std::vector<PendingOperation>& pending, size_t operation
                                           ", but the dense-state limit is " +
                                           std::to_string(kDenseActiveWidthLimit));
             }
+            // Apply one coordinate change consistently to the source,
+            // destination correction, and every later operation.
             const Tableau frame =
                 dormant_promotion_frame(instrument.body, active_width, *dormant_pivot);
             const Tableau old_to_new = frame.inverse();
@@ -723,25 +734,32 @@ void process_instrument(std::vector<PendingOperation>& pending, size_t operation
         }
     } else {
         source = active_projection(instrument.body, active_width);
+        // An identity projection means the source is already determined by
+        // the symbolic sign; otherwise its active Pauli needs coefficient work.
         mode = source.is_identity() ? InstrumentMode::Classical : InstrumentMode::Active;
     }
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     std::optional<SymbolId> destination_symbol;
     if (mode != InstrumentMode::DormantTrap) {
-        destination_symbol = instrument.flip;
-        define_symbol(plan, instrument.flip, SymbolKind::Instrument, action_index);
+        // Only an in-line computational destination needs the reserved flip;
+        // a trapped continuation resolves its destination instead.
+        destination_symbol = instrument.destination_flip_symbol;
+        define_symbol(plan, instrument.destination_flip_symbol, SymbolKind::Instrument,
+                      action_index);
     }
     plan.actions.push_back(
         PlannedAction{active_width, active_after,
                       ApplyInstrument{instrument.site, mode, source, sign, destination_symbol}});
 
     if (destination_symbol.has_value()) {
+        // Compile the possible runtime flip into signs of future operations.
         propagate_conditional_pauli(pending, operation_index + 1, destination_flip,
                                     AffineBool::symbol(*destination_symbol));
     }
     active_width = active_after;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
+    // A trapped shot resumes here so it cannot execute the instrument twice.
     plan.actions.push_back(
         PlannedAction{active_width, active_width,
                       InstrumentBoundary{instrument.site, instrument.next_noise_site,

--- a/src/clifft/sampling/planner.h
+++ b/src/clifft/sampling/planner.h
@@ -17,8 +17,8 @@ struct SamplingPlanOptions {
     std::span<const uint8_t> expected_observables;
 };
 
-// State-dependent instruments and exact-state probes remain outside this
-// sampling-only plan.
+// Exact-state probes remain outside this sampling-only plan. Instruments lower
+// to explicit state actions and continuation boundaries.
 [[nodiscard]] SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options = {});
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/state.cc
+++ b/src/clifft/sampling/state.cc
@@ -109,6 +109,9 @@ void State::ensure_capacity(uint32_t max_active_width) {
         throw std::length_error("sampling state allocation exceeds addressable memory");
     }
 
+    // The old block must remain live until both coefficient arrays are copied.
+    // This transient old-plus-new peak preserves the shot if allocation fails;
+    // portable aligned allocation has no in-place growth operation.
     PageAlignedAllocation allocation(static_cast<size_t>(allocated_doubles) * sizeof(double));
     double* const new_real = static_cast<double*>(allocation.data());
     double* const new_imag = new_real + new_coefficient_stride;

--- a/src/clifft/sampling/state.cc
+++ b/src/clifft/sampling/state.cc
@@ -91,6 +91,41 @@ void State::reset() noexcept {
     real_[0] = 1.0;
 }
 
+void State::ensure_capacity(uint32_t max_active_width) {
+    if (max_active_width <= max_active_width_) {
+        return;
+    }
+    if (max_active_width >= kDenseActiveWidthLimit) {
+        throw std::invalid_argument("sampling state maximum active width must be below " +
+                                    std::to_string(kDenseActiveWidthLimit));
+    }
+
+    const uint64_t new_capacity = uint64_t{1} << max_active_width;
+    const uint64_t new_coefficient_stride = round_array_stride(new_capacity);
+    const uint64_t new_scratch_capacity = std::max(uint64_t{1}, new_capacity >> 1);
+    const uint64_t new_scratch_stride = round_array_stride(new_scratch_capacity);
+    const uint64_t allocated_doubles = 2 * new_coefficient_stride + 2 * new_scratch_stride;
+    if (allocated_doubles > std::numeric_limits<size_t>::max() / sizeof(double)) {
+        throw std::length_error("sampling state allocation exceeds addressable memory");
+    }
+
+    PageAlignedAllocation allocation(static_cast<size_t>(allocated_doubles) * sizeof(double));
+    double* const new_real = static_cast<double*>(allocation.data());
+    double* const new_imag = new_real + new_coefficient_stride;
+    std::copy_n(real_, static_cast<size_t>(size()), new_real);
+    std::copy_n(imag_, static_cast<size_t>(size()), new_imag);
+
+    allocation_ = std::move(allocation);
+    real_ = new_real;
+    imag_ = new_imag;
+    scratch_real_ = imag_ + new_coefficient_stride;
+    scratch_imag_ = scratch_real_ + new_scratch_stride;
+    capacity_ = new_capacity;
+    coefficient_stride_ = new_coefficient_stride;
+    scratch_stride_ = new_scratch_stride;
+    max_active_width_ = max_active_width;
+}
+
 void State::set_global_scalar(std::complex<double> value) {
     validate_scalar(value);
     global_scalar_ = value;

--- a/src/clifft/sampling/state.h
+++ b/src/clifft/sampling/state.h
@@ -32,6 +32,12 @@ class State {
     // The allocation and all array addresses remain unchanged.
     void reset() noexcept;
 
+    // A continuation boundary may require a wider dense state than the plan
+    // that began the shot. Grow without changing live coefficients or the
+    // initial configuration used by the next reset; ordinary dispatch never
+    // calls this function.
+    void ensure_capacity(uint32_t max_active_width);
+
     [[nodiscard]] uint32_t active_width() const { return active_width_; }
     [[nodiscard]] uint32_t initial_active_width() const { return initial_active_width_; }
     [[nodiscard]] uint32_t max_active_width() const { return max_active_width_; }

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -7,6 +7,8 @@
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/xoshiro.h"
 
+#include "instrument_test_helpers.h"
+
 #include <algorithm>
 #include <array>
 #include <bit>
@@ -24,12 +26,15 @@
 #include <vector>
 
 using clifft::sampling::AffineBool;
+using clifft::sampling::ApplyInstrument;
 using clifft::sampling::classify_measurement_branch;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
 using clifft::sampling::index;
 using clifft::sampling::InstrumentBoundary;
+using clifft::sampling::InstrumentDistribution;
+using clifft::sampling::InstrumentMode;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
@@ -541,13 +546,132 @@ TEST_CASE("Sampling executor retains exact identity rotation scalars") {
                  Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
 }
 
-TEST_CASE("Sampling executor rejects instrument boundaries before dispatch") {
-    SamplingPlan plan;
-    plan.num_instrument_sites = 1;
-    plan.actions = {PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}}}};
+TEST_CASE("Sampling executor prepares instrument boundaries before dispatch") {
+    const clifft::InstrumentTraceOptions options = clifft::test::source_dependent_jump_options();
+    const clifft::HirModule hir =
+        clifft::trace(clifft::parse("LEVEL_TRANSITION[jump] 0"), &options);
 
-    REQUIRE_THROWS_WITH(ExecutablePlan(plan),
-                        "sampling executable does not yet support instrument boundary site 0");
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+
+    REQUIRE(executable.has_instruments());
+    REQUIRE(executable.num_instrument_sites() == 1);
+}
+
+TEST_CASE("Sampling executor applies computational instrument destinations in line") {
+    clifft::InstrumentTraceOptions options;
+    clifft::InstrumentProbabilities reset;
+    reset.p_fire[1] = 1.0;
+    reset.p_computational_dest[1][0] = 1.0;
+    options.transitions.emplace("reset", reset);
+
+    for (std::string_view circuit : {
+             "X 0\nLEVEL_TRANSITION[reset] 0\nM 0",
+             "H 0\nLEVEL_TRANSITION[reset] 0\nM 0",
+             "H 0\nT 0\nLEVEL_TRANSITION[reset] 0\nM 0",
+         }) {
+        const clifft::HirModule hir = clifft::trace(clifft::parse(circuit), &options);
+        const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+        Executor executor(executable, 17);
+
+        for (uint32_t shot = 0; shot < 20; ++shot) {
+            executor.run_shot();
+            CAPTURE(circuit, shot);
+            REQUIRE_FALSE(executor.pending_trap().has_value());
+            REQUIRE(executor.visible_records().size() == 1);
+            REQUIRE(executor.visible_records()[0] == 0);
+        }
+    }
+}
+
+TEST_CASE("Sampling executor propagates an entangled destination flip") {
+    clifft::InstrumentTraceOptions options;
+    clifft::InstrumentProbabilities reset;
+    reset.p_fire[0] = 1.0;
+    reset.p_fire[1] = 1.0;
+    reset.p_computational_dest[0][0] = 1.0;
+    reset.p_computational_dest[1][0] = 1.0;
+    options.transitions.emplace("reset", reset);
+    const clifft::HirModule hir = clifft::trace(
+        clifft::parse("H 0\nH 1\nCZ 0 1\nT 1\nLEVEL_TRANSITION[reset] 1\nM 1"), &options);
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    Executor executor(executable, 29);
+
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        executor.run_shot();
+        REQUIRE_FALSE(executor.pending_trap().has_value());
+        REQUIRE(executor.visible_records()[0] == 0);
+    }
+}
+
+TEST_CASE("Sampling executor stops at noncomputational destinations") {
+    clifft::InstrumentTraceOptions options;
+    const clifft::HirModule hir = clifft::trace(clifft::parse("LOSS(1) 0\nM 0"), &options);
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    Executor executor(executable, 3);
+
+    executor.run_shot();
+
+    REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.pending_trap()->site == InstrumentSiteId{0});
+    REQUIRE(executor.pending_trap()->source == 0);
+    REQUIRE_FALSE(executor.pending_trap()->destination_pending);
+}
+
+TEST_CASE("Sampling executor defers suffix noise until an instrument continuation") {
+    clifft::InstrumentTraceOptions options;
+    const clifft::HirModule hir =
+        clifft::trace(clifft::parse("X_ERROR(1) 0\nLEAKAGE(1) 0\nX_ERROR(1) 0\nM 0"), &options);
+    const SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+    const SymbolId suffix_noise = plan.presampled_noise_sites[1].outcomes[0].symbol;
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, 9);
+
+    executor.run_shot();
+    REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.symbols()[index(suffix_noise)] == 0);
+
+    executor.resume(executable);
+    REQUIRE_FALSE(executor.pending_trap().has_value());
+    REQUIRE(executor.symbols()[index(suffix_noise)] == 1);
+}
+
+TEST_CASE("Sampling continuation consumes a forced hidden source record") {
+    SamplingPlan root_plan;
+    root_plan.num_qubits = 1;
+    root_plan.num_instrument_sites = 1;
+    root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
+    root_plan.instrument_distributions = {
+        InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    root_plan.actions = {
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{
+                InstrumentSiteId{0}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
+    };
+    SamplingPlan continuation_plan = root_plan;
+    continuation_plan.num_hidden_records = 1;
+    continuation_plan.symbols.push_back(SymbolInfo{SymbolKind::Branch, 2, std::nullopt});
+    continuation_plan.actions.push_back(PlannedAction{
+        0, 0,
+        MeasureDormantRandom{0, SymbolId{1}, AffineBool::symbol(SymbolId{1}), RecordSlot{0}}});
+    const ExecutablePlan root(root_plan);
+    const ExecutablePlan continuation(continuation_plan);
+    Executor executor(root, 11);
+
+    executor.run_shot();
+    const auto trap = executor.pending_trap();
+    REQUIRE(trap.has_value());
+    REQUIRE(trap->destination_pending);
+
+    executor.resume(continuation, std::pair{RecordSlot{0}, trap->source});
+    REQUIRE_FALSE(executor.pending_trap().has_value());
+    REQUIRE(executor.hidden_records()[0] == trap->source);
+
+    executor.run_shot();
+    REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.hidden_records().empty());
+    REQUIRE(executor.symbols().size() == root_plan.symbols.size());
 }
 
 TEST_CASE("Sampling executor matches legacy records for supported circuits") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -31,6 +31,7 @@ using clifft::sampling::classify_measurement_branch;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
+using clifft::sampling::ForcedTraceOut;
 using clifft::sampling::index;
 using clifft::sampling::InstrumentBoundary;
 using clifft::sampling::InstrumentDistribution;
@@ -664,7 +665,7 @@ TEST_CASE("Sampling continuation consumes a forced hidden source record") {
     REQUIRE(trap.has_value());
     REQUIRE(trap->destination_pending);
 
-    executor.resume(continuation, std::pair{RecordSlot{0}, trap->source});
+    executor.resume(continuation, ForcedTraceOut{RecordSlot{0}, trap->source});
     REQUIRE_FALSE(executor.pending_trap().has_value());
     REQUIRE(executor.hidden_records()[0] == trap->source);
 

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -604,6 +604,87 @@ TEST_CASE("Sampling executor propagates an entangled destination flip") {
     }
 }
 
+TEST_CASE("Sampling executor composes sequential computational instruments") {
+    clifft::InstrumentTraceOptions options;
+    clifft::InstrumentProbabilities reset_to_e;
+    reset_to_e.p_fire[0] = 1.0;
+    reset_to_e.p_fire[1] = 1.0;
+    reset_to_e.p_computational_dest[0][1] = 1.0;
+    reset_to_e.p_computational_dest[1][1] = 1.0;
+    options.transitions.emplace("reset_e", reset_to_e);
+
+    clifft::InstrumentProbabilities pump_g;
+    pump_g.p_fire[0] = 1.0;
+    pump_g.p_computational_dest[0][1] = 1.0;
+    options.transitions.emplace("pump_g", pump_g);
+
+    // The first site prepares E. The second can fire only from G, so its
+    // destination symbol proves that the first site's update reached the next
+    // instrument rather than merely producing the expected final record.
+    const clifft::HirModule hir =
+        clifft::trace(clifft::parse("H 0\nT 0\nLEVEL_TRANSITION[reset_e] 0\n"
+                                    "LEVEL_TRANSITION[pump_g] 0\nM 0"),
+                      &options);
+    const SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+    std::optional<SymbolId> second_flip;
+    uint32_t instrument_count = 0;
+    for (const PlannedAction& action : plan.actions) {
+        if (const auto* instrument = std::get_if<ApplyInstrument>(&action.action)) {
+            if (instrument_count == 1) {
+                second_flip = instrument->destination_flip;
+            }
+            ++instrument_count;
+        }
+    }
+    REQUIRE(instrument_count == 2);
+    REQUIRE(second_flip.has_value());
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, 31);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        executor.run_shot();
+        CAPTURE(shot);
+        REQUIRE_FALSE(executor.pending_trap().has_value());
+        REQUIRE(executor.symbols()[index(*second_flip)] == 0);
+        REQUIRE(executor.visible_records()[0] == 1);
+    }
+}
+
+TEST_CASE("Sampling executor maps a signed active source to physical levels") {
+    clifft::InstrumentTraceOptions options;
+    clifft::InstrumentProbabilities reset_to_g;
+    reset_to_g.p_fire[0] = 1.0;
+    reset_to_g.p_fire[1] = 1.0;
+    reset_to_g.p_computational_dest[0][0] = 1.0;
+    reset_to_g.p_computational_dest[1][0] = 1.0;
+    options.transitions.emplace("reset_g", reset_to_g);
+
+    // This conjugation produces a constant sign while retaining active source
+    // support, exercising physical G/E relabeling in both collapse and flip.
+    const clifft::HirModule hir = clifft::trace(
+        clifft::parse("X 0\nH 0\nT 0\nH 0\nLEVEL_TRANSITION[reset_g] 0\nM 0"), &options);
+    const SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+    const ApplyInstrument* planned = nullptr;
+    for (const PlannedAction& action : plan.actions) {
+        if (const auto* instrument = std::get_if<ApplyInstrument>(&action.action)) {
+            planned = instrument;
+            break;
+        }
+    }
+    REQUIRE(planned != nullptr);
+    REQUIRE(planned->mode == InstrumentMode::Active);
+    REQUIRE(planned->sign == AffineBool(true));
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, 37);
+    for (uint32_t shot = 0; shot < 20; ++shot) {
+        executor.run_shot();
+        CAPTURE(shot);
+        REQUIRE_FALSE(executor.pending_trap().has_value());
+        REQUIRE(executor.visible_records()[0] == 0);
+    }
+}
+
 TEST_CASE("Sampling executor stops at noncomputational destinations") {
     clifft::InstrumentTraceOptions options;
     const clifft::HirModule hir = clifft::trace(clifft::parse("LOSS(1) 0\nM 0"), &options);

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -14,9 +14,12 @@
 #include <utility>
 #include <vector>
 
+using clifft::sampling::activate_zero_coordinate;
 using clifft::sampling::ActivePauli;
+using clifft::sampling::apply_instrument_no_fire;
 using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
+using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
 using clifft::sampling::measurement_probabilities;
 using clifft::sampling::MeasurementProbabilities;
@@ -257,6 +260,31 @@ TEST_CASE("Sampling kernel state owns stable aligned storage") {
     REQUIRE(assigned.imag_data() == imag);
 }
 
+TEST_CASE("Sampling state grows only at a continuation boundary and preserves live data") {
+    const std::complex<double> scalar{0.6, 0.8};
+    State state(1, 1, scalar);
+    const std::vector<std::complex<double>> input = deterministic_state(1);
+    load_state(state, input);
+
+    state.ensure_capacity(3);
+
+    REQUIRE(state.active_width() == 1);
+    REQUIRE(state.initial_active_width() == 1);
+    REQUIRE(state.max_active_width() == 3);
+    REQUIRE(state.capacity() == 8);
+    REQUIRE(state.global_scalar() == scalar);
+    require_vectors_close(coefficients(state), input);
+    REQUIRE(reinterpret_cast<uintptr_t>(state.real_data()) %
+                clifft::PageAlignedAllocation::kBaseAlignment ==
+            0);
+
+    state.reset();
+    REQUIRE(state.active_width() == 1);
+    REQUIRE(state.global_scalar() == scalar);
+    REQUIRE(state.real_data()[0] == 1.0);
+    REQUIRE(state.real_data()[1] == 0.0);
+}
+
 TEST_CASE("Sampling kernels rotations match the existing dense matrix oracle") {
     static constexpr double kAngles[] = {-0.75, -0.25, 0.0, 0.3};
     for (uint32_t active_width = 0; active_width <= 4; ++active_width) {
@@ -385,6 +413,79 @@ TEST_CASE("Sampling kernels measurements match dense projectors for every small 
                 }
             }
         }
+    }
+}
+
+TEST_CASE("Sampling instrument kernels match dense projectors without compacting") {
+    constexpr double kFactorZero = 0.8;
+    constexpr double kFactorOne = 0.3;
+    for (uint32_t active_width = 1; active_width <= 3; ++active_width) {
+        const uint64_t limit = uint64_t{1} << active_width;
+        const std::vector<std::complex<double>> input = deterministic_state(active_width);
+        for (uint64_t x = 0; x < limit; ++x) {
+            for (uint64_t z = 0; z < limit; ++z) {
+                if (x == 0 && z == 0) {
+                    continue;
+                }
+                CAPTURE(active_width, x, z);
+                const uint64_t support = x != 0 ? x : z;
+                const PreparedMeasurement measurement = prepare_measurement(
+                    {x, z}, active_width, static_cast<uint32_t>(std::countr_zero(support)));
+                const ProjectedBranch projected_zero =
+                    dense_project(input, x, z, false, active_width);
+                const ProjectedBranch projected_one =
+                    dense_project(input, x, z, true, active_width);
+
+                const double no_fire_probability =
+                    kFactorZero * kFactorZero * projected_zero.probability +
+                    kFactorOne * kFactorOne * projected_one.probability;
+                std::vector<std::complex<double>> filtered(input.size());
+                for (size_t i = 0; i < filtered.size(); ++i) {
+                    filtered[i] = (kFactorZero * std::sqrt(projected_zero.probability) *
+                                       projected_zero.normalized[i] +
+                                   kFactorOne * std::sqrt(projected_one.probability) *
+                                       projected_one.normalized[i]) /
+                                  std::sqrt(no_fire_probability);
+                }
+
+                State no_fire(active_width, active_width);
+                load_state(no_fire, input);
+                apply_instrument_no_fire(no_fire, measurement.pauli, kFactorZero, kFactorOne,
+                                         no_fire_probability);
+                require_vectors_close(coefficients(no_fire), filtered);
+                REQUIRE(no_fire.active_width() == active_width);
+
+                for (bool branch : {false, true}) {
+                    const ProjectedBranch& projected = branch ? projected_one : projected_zero;
+                    State collapsed(active_width, active_width);
+                    load_state(collapsed, input);
+                    collapse_instrument_source(collapsed, measurement.pauli, branch,
+                                               projected.probability);
+                    require_vectors_close(coefficients(collapsed), projected.normalized);
+                    REQUIRE(collapsed.active_width() == active_width);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Sampling instrument activation adds a clean coordinate in existing storage") {
+    State state(3, 2);
+    const std::vector<std::complex<double>> input = deterministic_state(2);
+    load_state(state, input);
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+
+    activate_zero_coordinate(state);
+
+    REQUIRE(state.active_width() == 3);
+    REQUIRE(state.real_data() == real);
+    REQUIRE(state.imag_data() == imag);
+    for (uint64_t i = 0; i < input.size(); ++i) {
+        REQUIRE(state.real_data()[i] == input[i].real());
+        REQUIRE(state.imag_data()[i] == input[i].imag());
+        REQUIRE(state.real_data()[input.size() + i] == 0.0);
+        REQUIRE(state.imag_data()[input.size() + i] == 0.0);
     }
 }
 

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -9,10 +9,13 @@
 
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
+using clifft::sampling::ApplyInstrument;
 using clifft::sampling::ApplyReadoutNoise;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::DetectorSlot;
 using clifft::sampling::InstrumentBoundary;
+using clifft::sampling::InstrumentDistribution;
+using clifft::sampling::InstrumentMode;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
@@ -38,6 +41,7 @@ SamplingPlan valid_plan() {
     const SymbolId noise{0};
     const SymbolId branch{1};
     const SymbolId derived{2};
+    const SymbolId instrument_flip{3};
 
     SamplingPlan plan;
     plan.num_qubits = 2;
@@ -50,9 +54,11 @@ SamplingPlan valid_plan() {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
         SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
         SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
+        SymbolInfo{SymbolKind::Instrument, 4, std::nullopt},
     };
     plan.presampled_noise_sites = {
         PresampledNoiseSite{NoiseSiteId{0}, {PresampledNoiseOutcome{noise, 0.1}}}};
+    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {0.0, 0.0}, {}}};
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{0.25, AffineBool::symbol(noise)}},
         PlannedAction{1, 0,
@@ -61,7 +67,11 @@ SamplingPlan valid_plan() {
                                          RecordSlot{0}}},
         PlannedAction{0, 0, DefineSymbol{derived, AffineBool::symbol(branch) ^ true}},
         PlannedAction{0, 0, RecordClassical{AffineBool::symbol(derived), RecordSlot{1}}},
-        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}}},
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{
+                InstrumentSiteId{0}, InstrumentMode::Classical, {}, AffineBool{}, instrument_flip}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 1, 4}},
     };
     return plan;
 }
@@ -131,7 +141,7 @@ TEST_CASE("Sampling plan validates symbolic and active state invariants") {
     REQUIRE(text.find("s0 kind=presampled noise_site=0") != std::string::npos);
     REQUIRE(text.find("1 active_width=1->0 dense_passes=2 measure_active") != std::string::npos);
     REQUIRE(text.find("outcome=s0 ^ s1 record=0") != std::string::npos);
-    REQUIRE(text.find("4 active_width=0->0 dense_passes=0 instrument_boundary site=0") !=
+    REQUIRE(text.find("5 active_width=0->0 dense_passes=0 instrument_boundary site=0 ") !=
             std::string::npos);
 }
 
@@ -170,7 +180,7 @@ TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
 
     SECTION("action defines an out-of-range symbol") {
         SamplingPlan plan = valid_plan();
-        std::get<DefineSymbol>(plan.actions[2].action).symbol = SymbolId{3};
+        std::get<DefineSymbol>(plan.actions[2].action).symbol = SymbolId{4};
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
@@ -195,7 +205,7 @@ TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
     SECTION("expression references an out-of-range symbol") {
         SamplingPlan plan = valid_plan();
         std::get<PromoteDormantRotation>(plan.actions[0].action).sign =
-            AffineBool::symbol(SymbolId{3});
+            AffineBool::symbol(SymbolId{4});
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
@@ -337,7 +347,7 @@ TEST_CASE("Sampling plan rejects invalid dimensions and action contracts") {
 
     SECTION("instrument boundary changes width") {
         SamplingPlan plan = valid_plan();
-        plan.actions[4].active_after = 1;
+        plan.actions[5].active_after = 1;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
@@ -361,7 +371,7 @@ TEST_CASE("Sampling plan rejects invalid dimensions and action contracts") {
 
     SECTION("instrument site is out of range") {
         SamplingPlan plan = valid_plan();
-        std::get<InstrumentBoundary>(plan.actions[4].action).site = InstrumentSiteId{1};
+        std::get<InstrumentBoundary>(plan.actions[5].action).site = InstrumentSiteId{1};
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -2,6 +2,7 @@
 #include "clifft/frontend/frontend.h"
 #include "clifft/sampling/planner.h"
 
+#include "instrument_test_helpers.h"
 #include "test_helpers.h"
 
 #include <array>
@@ -12,13 +13,17 @@
 #include <numbers>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <variant>
 
 using clifft::HirModule;
 using clifft::MeasRecordIdx;
 using clifft::NoiseSite;
 using clifft::sampling::AffineBool;
+using clifft::sampling::ApplyInstrument;
 using clifft::sampling::ApplyReadoutNoise;
+using clifft::sampling::InstrumentBoundary;
+using clifft::sampling::InstrumentMode;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
 using clifft::sampling::plan_sampling;
@@ -120,7 +125,8 @@ TEST_CASE("Sampling planner records repeat dormant measurements consistently") {
     const SamplingPlan plan = plan_sampling(hir);
 
     REQUIRE(plan.actions.size() == 2);
-    REQUIRE(plan.symbols.size() == 1);
+    REQUIRE(plan.symbols.size() == 2);
+    REQUIRE(plan.symbols[1].kind == SymbolKind::Unused);
     const auto& first = action_as<MeasureDormantRandom>(plan, 0);
     REQUIRE(first.branch == SymbolId{0});
     REQUIRE(first.outcome == AffineBool::symbol(SymbolId{0}));
@@ -174,6 +180,63 @@ TEST_CASE("Sampling planner accepts traced rotation and measurement HIR") {
     REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[0].action));
     REQUIRE(std::holds_alternative<MeasureActivePauli>(plan.actions[1].action));
     REQUIRE(plan.symbols.size() == 1);
+}
+
+TEST_CASE("Sampling planner fixes instrument source handling before execution") {
+    auto plan_for = [](std::string_view circuit, bool neglect) {
+        const clifft::InstrumentTraceOptions options =
+            clifft::test::source_dependent_jump_options(neglect);
+        return plan_sampling(clifft::trace(clifft::parse(circuit), &options));
+    };
+    auto instrument = [](const SamplingPlan& plan) -> const ApplyInstrument& {
+        for (const auto& action : plan.actions) {
+            if (const auto* result = std::get_if<ApplyInstrument>(&action.action)) {
+                return *result;
+            }
+        }
+        throw std::logic_error("test plan omitted its instrument action");
+    };
+
+    const SamplingPlan classical = plan_for("LEVEL_TRANSITION[jump] 0", false);
+    REQUIRE(instrument(classical).mode == InstrumentMode::Classical);
+    REQUIRE(std::holds_alternative<InstrumentBoundary>(classical.actions.back().action));
+
+    const SamplingPlan activated = plan_for("H 0\nLEVEL_TRANSITION[jump] 0", false);
+    REQUIRE(instrument(activated).mode == InstrumentMode::Activate);
+    REQUIRE(activated.max_active_width == 1);
+
+    const SamplingPlan active = plan_for("H 0\nT 0\nLEVEL_TRANSITION[jump] 0", false);
+    REQUIRE(instrument(active).mode == InstrumentMode::Active);
+
+    const SamplingPlan neglected = plan_for("H 0\nLEVEL_TRANSITION[jump] 0", true);
+    REQUIRE(instrument(neglected).mode == InstrumentMode::DormantTrap);
+    REQUIRE(neglected.max_active_width == 0);
+}
+
+TEST_CASE("Sampling planner keeps prefix symbols stable across continuation suffixes") {
+    const clifft::InstrumentTraceOptions options = clifft::test::source_dependent_jump_options();
+    const auto make = [&](std::string_view suffix) {
+        const std::string circuit = "H 0\nM 0\nLEVEL_TRANSITION[jump] 0\n" + std::string(suffix);
+        return plan_sampling(clifft::trace(clifft::parse(circuit), &options));
+    };
+    const SamplingPlan short_plan = make("");
+    const SamplingPlan longer_plan = make("X_ERROR(0.1) 0");
+
+    const auto& short_measurement = action_as<MeasureDormantRandom>(short_plan, 0);
+    const auto& longer_measurement = action_as<MeasureDormantRandom>(longer_plan, 0);
+    REQUIRE(short_measurement.branch == longer_measurement.branch);
+
+    const auto find_instrument = [](const SamplingPlan& plan) -> const ApplyInstrument& {
+        for (const auto& action : plan.actions) {
+            if (const auto* instrument = std::get_if<ApplyInstrument>(&action.action)) {
+                return *instrument;
+            }
+        }
+        throw std::logic_error("test plan omitted its instrument action");
+    };
+    REQUIRE(find_instrument(short_plan).destination_flip ==
+            find_instrument(longer_plan).destination_flip);
+    REQUIRE(longer_plan.symbols.size() == short_plan.symbols.size() + 1);
 }
 
 TEST_CASE("Sampling planner collapses active measurements and propagates branches") {


### PR DESCRIPTION
Part of #269.

This adds the internal sampling-plan and executor support needed for transition instruments:

- plan classical, active, activating, and dormant-trap source handling without runtime topology work
- apply exact no-fire filtering and source collapse for direct active Paulis, while propagating computational destination changes symbolically
- stop on noncomputational outcomes and resume replacement plans at validated instrument boundaries
- preserve stable symbol prefixes and defer suffix noise sampling until the matching continuation is known
- allow coefficient and side storage to grow only at an explicit continuation boundary, including forced hidden trace-out records
- restore the original executable automatically before the next shot after a continuation

The existing fixed-plan batch entry points continue to reject instrument plans. Issue #269 remains open for the stacked public experimental trajectory driver that will connect the noncomputational rewriter to these continuation APIs.

Validation:

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `ctest --test-dir build --output-on-failure` (1,219 tests, including benchmarks)
- post-format `ctest --test-dir build -E '^Bench:' --output-on-failure -j 8` (1,213 tests)
