### PR TITLE
feat(sampling): integrate noncomputational trajectories

### DIFF
--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -9,28 +9,49 @@
 
 namespace clifft {
 
-NonComputationalSample sample_noncomputational(const Circuit& circuit,
-                                               const NonComputationalModel& model, uint32_t shots,
-                                               std::optional<uint64_t> seed,
-                                               std::optional<uint32_t> max_rank) {
+namespace {
+
+SeedRoot make_seed_root(uint32_t shots, std::optional<uint64_t> seed) {
+    if (seed.has_value()) {
+        return seed_root_from_seed(*seed);
+    }
+    SeedRoot root{};
+    if (shots > 0) {
+        const std::array<uint64_t, 4> words = entropy_seed_words();
+        root.w[0] = words[0];
+        root.w[1] = words[1];
+        root.w[2] = words[2];
+        root.w[3] = words[3];
+    }
+    return root;
+}
+
+void validate_noncomputational_entry(const Circuit& circuit) {
     if (circuit.num_exp_vals != 0) {
         throw std::invalid_argument(
             "sample_noncomputational: EXP_VAL probes are not supported in noncomputational "
             "sampling");
     }
+}
 
-    SeedRoot root{};
-    if (seed.has_value()) {
-        root = seed_root_from_seed(*seed);
-    } else if (shots > 0) {
-        const std::array<uint64_t, 4> w = entropy_seed_words();
-        root.w[0] = w[0];
-        root.w[1] = w[1];
-        root.w[2] = w[2];
-        root.w[3] = w[3];
-    }
+}  // namespace
 
-    return run_trajectory_driver(circuit, model, shots, root, max_rank);
+NonComputationalSample sample_noncomputational(const Circuit& circuit,
+                                               const NonComputationalModel& model, uint32_t shots,
+                                               std::optional<uint64_t> seed,
+                                               std::optional<uint32_t> max_rank) {
+    validate_noncomputational_entry(circuit);
+    return run_trajectory_driver(circuit, model, shots, make_seed_root(shots, seed), max_rank);
+}
+
+NonComputationalSample sample_noncomputational_experimental(const Circuit& circuit,
+                                                            const NonComputationalModel& model,
+                                                            uint32_t shots,
+                                                            std::optional<uint64_t> seed,
+                                                            std::optional<uint32_t> max_rank) {
+    validate_noncomputational_entry(circuit);
+    return run_sampling_trajectory_driver(circuit, model, shots, make_seed_root(shots, seed),
+                                          max_rank);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/sample.h
+++ b/src/clifft/noncomp/sample.h
@@ -62,4 +62,10 @@ NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                std::optional<uint64_t> seed = std::nullopt,
                                                std::optional<uint32_t> max_rank = std::nullopt);
 
+// Explicitly selected migration path backed by sampling::Executor. This is
+// intentionally separate from the stable entry point above.
+NonComputationalSample sample_noncomputational_experimental(
+    const Circuit& circuit, const NonComputationalModel& model, uint32_t shots,
+    std::optional<uint64_t> seed = std::nullopt, std::optional<uint32_t> max_rank = std::nullopt);
+
 }  // namespace clifft

--- a/src/clifft/noncomp/seed.h
+++ b/src/clifft/noncomp/seed.h
@@ -1,8 +1,8 @@
 #pragma once
 
-// Derives separate per-shot RNG states for the driver and VM. Keeping these
+// Derives separate per-shot RNG states for the driver and executor. Keeping these
 // streams separate means that adding a driver-side random draw cannot consume
-// from or shift the VM's measurement sequence. Unseeded runs start with 256
+// from or shift the executor's measurement sequence. Unseeded runs start with 256
 // bits of OS entropy; seeded runs expand the user's 64-bit seed
 // deterministically. Within either stream, different shots always receive
 // different 256-bit states. Each state word is mixed differently, so a match
@@ -18,9 +18,9 @@
 namespace clifft {
 
 // Driver-side draws (initial levels, trap destinations, classical
-// consults, herald flags) vs. the in-VM Born measurement randomness.
+// consults, herald flags) vs. the in-executor Born measurement randomness.
 inline constexpr uint64_t kTrajectoryDriverDomain = 0x11;
-inline constexpr uint64_t kTrajectorySvmDomain = 0x12;
+inline constexpr uint64_t kTrajectoryExecutorDomain = 0x12;
 
 struct SeedRoot {
     uint64_t w[4];

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -25,14 +25,20 @@
 #include "clifft/noncomp/transition_instrument.h"
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_registry.h"
+#include "clifft/sampling/executor.h"
+#include "clifft/sampling/planner.h"
 #include "clifft/svm/svm.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/xoshiro.h"
 
 #include <cassert>
 #include <cstdint>
+#include <iterator>
+#include <limits>
 #include <map>
+#include <memory>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -287,6 +293,13 @@ struct CompiledContinuation {
     std::optional<size_t> forced_traceout_slot;
 };
 
+struct SamplingCompiledContinuation {
+    sampling::ExecutablePlan program;
+    std::vector<AnnotationTarget> site_targets;
+    std::vector<QubitStatus> final_status;
+    std::optional<size_t> forced_traceout_slot;
+};
+
 void check_max_rank(const CompiledModule& module, std::optional<uint32_t> max_rank) {
     if (!max_rank.has_value() || module.peak_rank <= *max_rank) {
         return;
@@ -350,6 +363,66 @@ std::vector<uint32_t> record_sequence(const HirModule& hir) {
 }
 #endif
 
+void patch_heralded_measurements(Circuit& circuit,
+                                 std::span<const ClassifiedMeasurement> measurements,
+                                 std::span<const uint8_t> herald_flags) {
+    if (herald_flags.size() != measurements.size()) {
+        throw std::logic_error(
+            "sample_noncomputational: continuation compile received " +
+            std::to_string(herald_flags.size()) + " herald flag(s) for " +
+            std::to_string(measurements.size()) +
+            " classified measurement(s); every classified measurement needs exactly one flag");
+    }
+    for (size_t i = 0; i < herald_flags.size(); ++i) {
+        if (herald_flags[i] == 0) {
+            continue;
+        }
+        assert(measurements[i].noise_node.has_value() &&
+               "classified measurement must have a READOUT_NOISE node to patch for herald");
+        circuit.nodes[*measurements[i].noise_node].args[0] = 0.5;
+    }
+}
+
+struct TracedContinuation {
+    HirModule hir;
+    std::optional<size_t> forced_traceout_slot;
+};
+
+TracedContinuation trace_continuation(Circuit circuit, std::optional<size_t> forced_traceout_node,
+                                      const InstrumentTraceOptions& instrument_options) {
+    std::optional<InstrumentTraceOptions> forced_trace_options;
+    const InstrumentTraceOptions* trace_options = &instrument_options;
+    if (forced_traceout_node.has_value()) {
+        forced_trace_options = instrument_options;
+        forced_trace_options->forced_traceout_node = forced_traceout_node;
+        trace_options = &*forced_trace_options;
+    }
+    HirModule hir = trace(circuit, trace_options);
+    std::optional<size_t> forced_traceout_slot;
+    if (forced_traceout_node.has_value()) {
+        if (!hir.forced_traceout_slot.has_value()) {
+            throw std::logic_error(
+                "sample_noncomputational: trace() did not encounter the forced trace-out reset "
+                "at node " +
+                std::to_string(*forced_traceout_node));
+        }
+        forced_traceout_slot = hir.forced_traceout_slot;
+    }
+
+#ifndef NDEBUG
+    const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
+#endif
+    trajectory_hir_pass_manager().run(hir);
+#ifndef NDEBUG
+    assert(record_sequence(hir) == pre_pass_records &&
+           "a trajectory-pipeline HIR pass reordered or removed a record op");
+#endif
+    return TracedContinuation{
+        .hir = std::move(hir),
+        .forced_traceout_slot = forced_traceout_slot,
+    };
+}
+
 // A trap-form instrument reports a source but leaves the qubit uncollapsed.
 // The rewritten continuation inserts a reset to apply that collapse and
 // prepare the selected destination. Its hidden measurement must reuse the
@@ -381,58 +454,11 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
                                           std::optional<uint32_t> max_rank,
                                           const CompiledModule* executed_prefix_module,
                                           uint32_t prefix_end) {
-    if (herald_flags.size() != rewrite.classified_measurements.size()) {
-        throw std::logic_error(
-            "sample_noncomputational: continuation compile received " +
-            std::to_string(herald_flags.size()) + " herald flag(s) for " +
-            std::to_string(rewrite.classified_measurements.size()) +
-            " classified measurement(s); every classified measurement needs exactly one flag");
-    }
-    std::optional<size_t> forced_traceout_slot;
-    CompiledModule module = [&]() {
-        Circuit patched = std::move(rewrite.circuit);
-        for (size_t i = 0; i < herald_flags.size(); ++i) {
-            if (herald_flags[i] != 0) {
-                const ClassifiedMeasurement& measurement = rewrite.classified_measurements[i];
-                assert(measurement.noise_node.has_value() &&
-                       "classified measurement must have a READOUT_NOISE node to patch for herald");
-                patched.nodes[*measurement.noise_node].args[0] = 0.5;
-            }
-        }
-
-        // When the rewrite names a forced trace-out node, ask trace() to report
-        // the hidden slot it assigns to that reset.
-        std::optional<InstrumentTraceOptions> forced_trace_options;
-        const InstrumentTraceOptions* trace_options = &instrument_options;
-        if (rewrite.forced_traceout_node.has_value()) {
-            forced_trace_options = instrument_options;
-            forced_trace_options->forced_traceout_node = rewrite.forced_traceout_node;
-            trace_options = &*forced_trace_options;
-        }
-        HirModule hir = trace(patched, trace_options);
-
-        if (rewrite.forced_traceout_node.has_value()) {
-            if (!hir.forced_traceout_slot.has_value()) {
-                throw std::logic_error(
-                    "sample_noncomputational: trace() did not encounter the forced "
-                    "trace-out reset at node " +
-                    std::to_string(*rewrite.forced_traceout_node) +
-                    "; the rewrite and trace() must walk the same stream");
-            }
-            forced_traceout_slot = hir.forced_traceout_slot;
-        }
-
-#ifndef NDEBUG
-        const std::vector<uint32_t> pre_pass_records = record_sequence(hir);
-#endif
-        trajectory_hir_pass_manager().run(hir);
-#ifndef NDEBUG
-        assert(record_sequence(hir) == pre_pass_records &&
-               "a trajectory-pipeline HIR pass reordered or removed a record op");
-#endif
-
-        return lower(std::move(hir));
-    }();
+    Circuit patched = std::move(rewrite.circuit);
+    patch_heralded_measurements(patched, rewrite.classified_measurements, herald_flags);
+    TracedContinuation traced =
+        trace_continuation(std::move(patched), rewrite.forced_traceout_node, instrument_options);
+    CompiledModule module = lower(std::move(traced.hir));
     trajectory_bytecode_pass_manager().run(module);
     check_max_rank(module, max_rank);
     if (module.instrument_offsets.size() != rewrite.site_targets.size()) {
@@ -442,8 +468,8 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
                                std::to_string(rewrite.site_targets.size()) +
                                "; the rewriter and trace() must elide zero-fire sites identically");
     }
-    if (forced_traceout_slot.has_value()) {
-        swap_traceout_to_forced(module, *forced_traceout_slot);
+    if (traced.forced_traceout_slot.has_value()) {
+        swap_traceout_to_forced(module, *traced.forced_traceout_slot);
     }
 
     if (executed_prefix_module != nullptr) {
@@ -454,7 +480,59 @@ CompiledContinuation compile_continuation(ContinuationRewrite rewrite,
         .module = std::move(module),
         .site_targets = std::move(rewrite.site_targets),
         .final_status = std::move(rewrite.final_status),
-        .forced_traceout_slot = forced_traceout_slot,
+        .forced_traceout_slot = traced.forced_traceout_slot,
+    };
+}
+
+void prepend_initial_excited_preparations(Circuit& circuit, std::span<const Level> initial_levels,
+                                          std::optional<size_t>& forced_traceout_node) {
+    std::vector<AstNode> preparations;
+    for (uint32_t qubit = 0; qubit < initial_levels.size(); ++qubit) {
+        if (initial_levels[qubit] == Level::E) {
+            preparations.push_back(AstNode{GateType::X, {Target::qubit(qubit)}, {}, 0, {}});
+        }
+    }
+    if (preparations.empty()) {
+        return;
+    }
+    if (forced_traceout_node.has_value()) {
+        *forced_traceout_node += preparations.size();
+    }
+    circuit.nodes.insert(circuit.nodes.begin(), std::make_move_iterator(preparations.begin()),
+                         std::make_move_iterator(preparations.end()));
+}
+
+void check_sampling_max_rank(const sampling::SamplingPlan& plan, std::optional<uint32_t> max_rank) {
+    if (!max_rank.has_value() || plan.max_active_width <= *max_rank) {
+        return;
+    }
+    throw std::invalid_argument("sample_noncomputational: planned active width " +
+                                std::to_string(plan.max_active_width) + " exceeds max_rank " +
+                                std::to_string(*max_rank));
+}
+
+SamplingCompiledContinuation compile_sampling_continuation(
+    ContinuationRewrite rewrite, const std::vector<uint8_t>& herald_flags,
+    const InstrumentTraceOptions& instrument_options, std::optional<uint32_t> max_rank,
+    std::span<const Level> initial_levels) {
+    Circuit patched = std::move(rewrite.circuit);
+    patch_heralded_measurements(patched, rewrite.classified_measurements, herald_flags);
+    prepend_initial_excited_preparations(patched, initial_levels, rewrite.forced_traceout_node);
+    TracedContinuation traced =
+        trace_continuation(std::move(patched), rewrite.forced_traceout_node, instrument_options);
+    sampling::SamplingPlan plan = sampling::plan_sampling(traced.hir);
+    check_sampling_max_rank(plan, max_rank);
+    if (plan.num_instrument_sites != rewrite.site_targets.size()) {
+        throw std::logic_error("sample_noncomputational: sampling plan has " +
+                               std::to_string(plan.num_instrument_sites) +
+                               " instrument site(s) but the rewrite has " +
+                               std::to_string(rewrite.site_targets.size()));
+    }
+    return SamplingCompiledContinuation{
+        .program = sampling::ExecutablePlan(plan),
+        .site_targets = std::move(rewrite.site_targets),
+        .final_status = std::move(rewrite.final_status),
+        .forced_traceout_slot = traced.forced_traceout_slot,
     };
 }
 
@@ -538,6 +616,28 @@ void validate_model_contract(const Circuit& annotated, const NonComputationalMod
     }
 }
 
+Circuit prepare_trajectory_circuit(const Circuit& circuit, const NonComputationalModel& model) {
+    Circuit annotated = expand_transition_hooks(circuit, model);
+    for (uint32_t op_index = 0; op_index < static_cast<uint32_t>(annotated.nodes.size());
+         ++op_index) {
+        const AstNode& node = annotated.nodes[op_index];
+        if (is_noncomputational_annotation(node.gate)) {
+            validate_annotation(node, model, op_index, annotated.num_qubits);
+        }
+        if (is_measurement(node.gate) && node.gate != GateType::MPP && node.targets.size() != 1) {
+            throw std::invalid_argument(
+                "sample_noncomputational: measurement '" + std::string(gate_name(node.gate)) +
+                "' at op " + std::to_string(op_index) + " carries " +
+                std::to_string(node.targets.size()) + " targets; the parser" +
+                " emits one measurement node per target and the rewrite's" +
+                " record accounting relies on that shape; split the node" +
+                " into single-target measurements");
+        }
+    }
+    validate_model_contract(annotated, model);
+    return annotated;
+}
+
 }  // namespace
 
 NonComputationalSample run_trajectory_driver(const Circuit& circuit,
@@ -553,35 +653,7 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
     const MeasurementClassifier* classifier = model.classifier();
     const bool ternary = classifier != nullptr && classifier->has_herald();
 
-    const Circuit annotated = expand_transition_hooks(circuit, model);
-
-    // Validate transition annotations and measurement shapes before sampling so
-    // malformed input fails independently of the path taken by any shot.
-    // Computational transitions can reach trace() unchanged, so they must be
-    // checked here first.
-    for (uint32_t op_index = 0; op_index < static_cast<uint32_t>(annotated.nodes.size());
-         ++op_index) {
-        const AstNode& node = annotated.nodes[op_index];
-        if (is_noncomputational_annotation(node.gate)) {
-            validate_annotation(node, model, op_index, annotated.num_qubits);
-        }
-        // The parser emits one node per target for ordinary measurements, and
-        // the rewrite relies on that shape when assigning record slots. MPP is
-        // intentionally multi-target and still produces one bit. MPAD also
-        // produces one bit per node.
-        if (is_measurement(node.gate) && node.gate != GateType::MPP && node.targets.size() != 1) {
-            throw std::invalid_argument(
-                "sample_noncomputational: measurement '" + std::string(gate_name(node.gate)) +
-                "' at op " + std::to_string(op_index) + " carries " +
-                std::to_string(node.targets.size()) + " targets; the parser" +
-                " emits one measurement node per target and the rewrite's" +
-                " record accounting relies on that shape; split the node" +
-                " into single-target measurements");
-        }
-    }
-
-    // Check model-wide measurement restrictions after annotations resolve.
-    validate_model_contract(annotated, model);
+    const Circuit annotated = prepare_trajectory_circuit(circuit, model);
 
     // Validation is shot-count independent: a zero-shot call checks the
     // circuit/model contract and returns empty results.
@@ -704,7 +776,7 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
             }
         }
         SchrodingerState& state = *state_storage;
-        const auto sw = derive_state(root, shot, kTrajectorySvmDomain);
+        const auto sw = derive_state(root, shot, kTrajectoryExecutorDomain);
         state.reseed_full(sw[0], sw[1], sw[2], sw[3]);
         assert(state.meas_record.size() >= continuation->module.total_meas_slots &&
                "the rebuild block above guarantees meas_record capacity; "
@@ -815,6 +887,190 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                 state.det_record.end());
         result.observables.insert(result.observables.end(), state.obs_record.begin(),
                                   state.obs_record.end());
+        result.final_status.insert(result.final_status.end(), continuation->final_status.begin(),
+                                   continuation->final_status.end());
+        std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
+        for (const auto& [slot, flag] : herald_flags) {
+            shot_heralds[slot] = flag;
+        }
+        result.heralds.insert(result.heralds.end(), shot_heralds.begin(), shot_heralds.end());
+    }
+
+    return result;
+}
+
+NonComputationalSample run_sampling_trajectory_driver(const Circuit& circuit,
+                                                      const NonComputationalModel& model,
+                                                      uint32_t shots, const SeedRoot& root,
+                                                      std::optional<uint32_t> max_rank) {
+    NonComputationalSample result;
+    result.shots = shots;
+    result.num_qubits = circuit.num_qubits;
+    result.num_measurements = circuit.num_measurements;
+    result.num_detectors = circuit.num_detectors;
+    result.num_observables = circuit.num_observables;
+    const MeasurementClassifier* classifier = model.classifier();
+    const bool ternary = classifier != nullptr && classifier->has_herald();
+    const Circuit annotated = prepare_trajectory_circuit(circuit, model);
+    if (shots == 0) {
+        return result;
+    }
+
+    const size_t shot_count = shots;
+    result.measurements.reserve(shot_count * circuit.num_measurements);
+    result.detectors.reserve(shot_count * circuit.num_detectors);
+    result.observables.reserve(shot_count * circuit.num_observables);
+    result.final_status.reserve(shot_count * circuit.num_qubits);
+    result.heralds.reserve(shot_count * circuit.num_measurements);
+
+    const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
+    TrajectoryEvents no_events;
+    no_events.initial_status.assign(circuit.num_qubits, QubitStatus::Computational);
+    std::optional<SamplingCompiledContinuation> all_ground_start;
+    std::optional<sampling::Executor> shared_executor;
+
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const auto driver_words = derive_state(root, shot, kTrajectoryDriverDomain);
+        Xoshiro256PlusPlus driver_rng(0);
+        driver_rng.seed_full(driver_words[0], driver_words[1], driver_words[2], driver_words[3]);
+
+        TrajectoryEvents events;
+        events.initial_status.reserve(circuit.num_qubits);
+        std::vector<Level> initial_levels;
+        initial_levels.reserve(circuit.num_qubits);
+        bool needs_shot_specific_start = false;
+        for (uint32_t qubit = 0; qubit < circuit.num_qubits; ++qubit) {
+            const Level level = draw_initial_level(model, driver_rng);
+            initial_levels.push_back(level);
+            events.initial_status.push_back(status_for(level));
+            // Noncomputational levels change the rewrite. E remains
+            // computational but needs an explicit preparation in this backend.
+            needs_shot_specific_start |= level != Level::G;
+        }
+
+        std::map<uint32_t, uint8_t> herald_flags;
+        auto flags_for = [&](const ContinuationRewrite& rewrite) {
+            std::vector<uint8_t> flags;
+            flags.reserve(rewrite.classified_measurements.size());
+            for (const ClassifiedMeasurement& measurement : rewrite.classified_measurements) {
+                auto [it, inserted] = herald_flags.try_emplace(measurement.slot, 0);
+                if (inserted && ternary) {
+                    const double probability =
+                        classifier->prob(MeasurementClassifier::kHeraldSymbol, measurement.level);
+                    it->second = driver_rng.next_double() < probability ? 1 : 0;
+                }
+                flags.push_back(it->second);
+            }
+            return flags;
+        };
+
+        const bool uses_shared_start = !needs_shot_specific_start;
+        std::optional<SamplingCompiledContinuation> shot_start;
+        const SamplingCompiledContinuation* continuation = nullptr;
+        if (needs_shot_specific_start) {
+            extend_classical_outcomes(annotated, events, model, driver_rng);
+            ContinuationRewrite rewrite = rewrite_continuation(annotated, events, false, model);
+            const std::vector<uint8_t> flags = flags_for(rewrite);
+            shot_start.emplace(compile_sampling_continuation(
+                std::move(rewrite), flags, instrument_options, max_rank, initial_levels));
+            continuation = &*shot_start;
+        } else {
+            if (!all_ground_start.has_value()) {
+                ContinuationRewrite rewrite =
+                    rewrite_continuation(annotated, no_events, false, model);
+                assert(rewrite.classified_measurements.empty() &&
+                       "an all-ground continuation has no classified measurements");
+                all_ground_start.emplace(compile_sampling_continuation(
+                    std::move(rewrite), {}, instrument_options, max_rank, initial_levels));
+            }
+            continuation = &*all_ground_start;
+        }
+
+        std::unique_ptr<SamplingCompiledContinuation> shot_continuation;
+        std::optional<sampling::Executor> shot_executor;
+        sampling::Executor* executor = nullptr;
+        if (uses_shared_start) {
+            if (!shared_executor.has_value()) {
+                shared_executor.emplace(continuation->program);
+            }
+            executor = &*shared_executor;
+        } else {
+            shot_executor.emplace(continuation->program);
+            executor = &*shot_executor;
+        }
+        const auto executor_words = derive_state(root, shot, kTrajectoryExecutorDomain);
+        executor->reseed_full(executor_words[0], executor_words[1], executor_words[2],
+                              executor_words[3]);
+        executor->run_shot();
+
+        while (executor->pending_trap().has_value()) {
+            const sampling::InstrumentTrap trap = *executor->pending_trap();
+            const uint32_t site = sampling::index(trap.site);
+            if (site >= continuation->site_targets.size()) {
+                throw std::logic_error(
+                    "sample_noncomputational: sampling trap site id is out of range");
+            }
+            const auto [op_index, qubit] = continuation->site_targets[site];
+            const AstNode& node = annotated.nodes[op_index];
+            const AnnotationChannel channel = resolve_annotation(node, model, op_index);
+
+            assert(trap.source <= 1 && "the executor reports a computational source as G or E");
+            const Level source = static_cast<Level>(trap.source);
+            Level destination;
+            switch (channel.kind) {
+                case AnnotationChannelKind::Instrument:
+                    if (trap.destination_pending) {
+                        destination = draw_from_column(*channel.instrument, source, driver_rng,
+                                                       [](Level) { return true; });
+                    } else {
+                        destination =
+                            draw_from_column(*channel.instrument, source, driver_rng,
+                                             [](Level level) { return !is_computational(level); });
+                    }
+                    break;
+                case AnnotationChannelKind::Leakage:
+                    destination = source == Level::G ? Level::LeakG : Level::LeakE;
+                    break;
+                case AnnotationChannelKind::Loss:
+                    destination = Level::Lost;
+                    break;
+            }
+
+            events.jumps.push_back({{op_index, qubit}, destination});
+            extend_classical_outcomes(annotated, events, model, driver_rng);
+            const bool force = trap.destination_pending;
+            ContinuationRewrite next_rewrite =
+                rewrite_continuation(annotated, events, force, model);
+            const std::vector<uint8_t> next_flags = flags_for(next_rewrite);
+            auto next = std::make_unique<SamplingCompiledContinuation>(
+                compile_sampling_continuation(std::move(next_rewrite), next_flags,
+                                              instrument_options, max_rank, initial_levels));
+
+            std::optional<sampling::ForcedTraceOut> forced_trace_out;
+            if (force) {
+                if (!next->forced_traceout_slot.has_value() ||
+                    *next->forced_traceout_slot > std::numeric_limits<uint32_t>::max()) {
+                    throw std::logic_error(
+                        "sample_noncomputational: sampling continuation omitted its forced "
+                        "trace-out slot");
+                }
+                forced_trace_out = sampling::ForcedTraceOut{
+                    sampling::RecordSlot{static_cast<uint32_t>(*next->forced_traceout_slot)},
+                    trap.source};
+            }
+            executor->resume(next->program, forced_trace_out);
+            shot_continuation = std::move(next);
+            continuation = shot_continuation.get();
+        }
+
+        const std::span<const uint8_t> measurements = executor->visible_records();
+        result.measurements.insert(result.measurements.end(), measurements.begin(),
+                                   measurements.end());
+        const std::span<const uint8_t> detectors = executor->detectors();
+        result.detectors.insert(result.detectors.end(), detectors.begin(), detectors.end());
+        const std::span<const uint8_t> observables = executor->observables();
+        result.observables.insert(result.observables.end(), observables.begin(), observables.end());
+        executor->return_to_root_plan();
         result.final_status.insert(result.final_status.end(), continuation->final_status.begin(),
                                    continuation->final_status.end());
         std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);

--- a/src/clifft/noncomp/trajectory_driver.h
+++ b/src/clifft/noncomp/trajectory_driver.h
@@ -27,4 +27,11 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                              const SeedRoot& root,
                                              std::optional<uint32_t> max_rank);
 
+// Experimental symbolic-coordinate executor route. The public default remains
+// run_trajectory_driver until feature parity and validation are complete.
+NonComputationalSample run_sampling_trajectory_driver(const Circuit& circuit,
+                                                      const NonComputationalModel& model,
+                                                      uint32_t shots, const SeedRoot& root,
+                                                      std::optional<uint32_t> max_rank);
+
 }  // namespace clifft

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -334,6 +334,12 @@ void Executor::resume(const ExecutablePlan& continuation,
     }
 }
 
+void Executor::return_to_root_plan() noexcept {
+    assert(!pending_trap_.has_value() &&
+           "a trapped shot must resume before releasing its continuation plan");
+    plan_ = root_plan_;
+}
+
 ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
                                    std::span<const uint8_t> presampled_values) noexcept {
     plan_ = root_plan_;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -220,6 +220,12 @@ class Executor {
     // Replace the deterministic seed with OS entropy before executing shots.
     void reseed_from_entropy() { rng_.seed_from_entropy(); }
 
+    // Replace all RNG state words. The trajectory driver uses this to keep
+    // executor draws in a domain separate from its own per-shot decisions.
+    void reseed_full(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) noexcept {
+        rng_.seed_full(s0, s1, s2, s3);
+    }
+
     // Draw plan-bound quantum noise from this executor's RNG before dispatch.
     void run_shot() noexcept;
 
@@ -233,6 +239,10 @@ class Executor {
     // hidden trace-out measurement.
     void resume(const ExecutablePlan& continuation,
                 std::optional<ForcedTraceOut> forced_trace_out = std::nullopt);
+
+    // Drop the borrowed continuation reference after its completed-shot
+    // outputs have been consumed, allowing the caller to destroy that plan.
+    void return_to_root_plan() noexcept;
 
     // Replays the plan while forcing each record to a supplied Boolean value.
     // This reconstructs the corresponding branch state and computes its joint

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -58,6 +58,22 @@ nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> vec,
     return nb::ndarray<nb::numpy, T, nb::c_contig>(data, shape, owner);
 }
 
+nb::tuple noncomp_sample_to_python(clifft::NonComputationalSample r, uint32_t shots) {
+    // These values match Python's QubitStatus enum, including the distinct
+    // leaked substates.
+    std::vector<uint8_t> status(r.final_status.size());
+    for (size_t i = 0; i < r.final_status.size(); ++i) {
+        status[i] = static_cast<uint8_t>(r.final_status[i]);
+    }
+    auto meas = vec_to_numpy(std::move(r.measurements), {shots, r.num_measurements});
+    auto det = vec_to_numpy(std::move(r.detectors), {shots, r.num_detectors});
+    auto obs = vec_to_numpy(std::move(r.observables), {shots, r.num_observables});
+    auto fs = vec_to_numpy(std::move(status), {shots, r.num_qubits});
+    auto her = vec_to_numpy(std::move(r.heralds), {shots, r.num_measurements});
+    return nb::make_tuple(meas, det, obs, fs, her, r.num_qubits, r.num_measurements,
+                          r.num_detectors, r.num_observables);
+}
+
 // Noncomputational (leakage/loss) bindings. Raw spec-builder + sampler entry
 // points; the ergonomic surface (Model, Classifier, sample) lives in the
 // clifft.noncomp Python wrapper. The model is an opaque handle.
@@ -98,25 +114,28 @@ void register_noncomp(nb::module_& m) {
                 nb::gil_scoped_release release;
                 r = clifft::sample_noncomputational(circuit, model, shots, seed, max_rank);
             }
-            // Convert statuses to the uint8 codes exposed by Python. The values
-            // Computational=0, LeakG=1, LeakE=2, Lost=3 match Python's
-            // QubitStatus enum, including the distinct leaked substates.
-            std::vector<uint8_t> status(r.final_status.size());
-            for (size_t i = 0; i < r.final_status.size(); ++i) {
-                status[i] = static_cast<uint8_t>(r.final_status[i]);
-            }
-            auto meas = vec_to_numpy(std::move(r.measurements), {shots, r.num_measurements});
-            auto det = vec_to_numpy(std::move(r.detectors), {shots, r.num_detectors});
-            auto obs = vec_to_numpy(std::move(r.observables), {shots, r.num_observables});
-            auto fs = vec_to_numpy(std::move(status), {shots, r.num_qubits});
-            auto her = vec_to_numpy(std::move(r.heralds), {shots, r.num_measurements});
-            return nb::make_tuple(meas, det, obs, fs, her, r.num_qubits, r.num_measurements,
-                                  r.num_detectors, r.num_observables);
+            return noncomp_sample_to_python(std::move(r), shots);
         },
         nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("max_rank") = nb::none(),
         "Sample a noncomputational model. Returns (measurements, detectors, observables, "
         "final_status, heralds, num_qubits, num_measurements, num_detectors, num_observables).");
+
+    m.def(
+        "_sample_noncomputational_experimental",
+        [](const clifft::Circuit& circuit, const clifft::NonComputationalModel& model,
+           uint32_t shots, std::optional<uint64_t> seed, std::optional<uint32_t> max_rank) {
+            clifft::NonComputationalSample r;
+            {
+                nb::gil_scoped_release release;
+                r = clifft::sample_noncomputational_experimental(circuit, model, shots, seed,
+                                                                 max_rank);
+            }
+            return noncomp_sample_to_python(std::move(r), shots);
+        },
+        nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
+        nb::arg("max_rank") = nb::none(),
+        "Sample a noncomputational model with the experimental symbolic-coordinate backend.");
 }
 
 NB_MODULE(_clifft_core, m) {

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -12,7 +12,7 @@ from typing import TypeAlias, cast
 import numpy as np
 import numpy.typing as npt
 
-from clifft import MeasurementRecords, _records_from_outcomes
+from clifft import Circuit, MeasurementRecords, _records_from_outcomes, noncomp
 from clifft._clifft_core import (
     HirPassManager,
     _compile_experimental_sampling,
@@ -77,6 +77,21 @@ def sample(program: Program, shots: int, seed: int | None = None) -> SampleResul
     return SampleResult(measurements, detectors, observables)
 
 
+def sample_noncomputational(
+    circuit: Circuit | str,
+    model: noncomp.Model,
+    shots: int,
+    seed: int | None = None,
+    max_rank: int | None = None,
+) -> noncomp.NonComputationalSample:
+    """Sample leakage and loss with the experimental symbolic-coordinate backend.
+
+    This has the same inputs and result type as :func:`clifft.noncomp.sample`,
+    but does not change that API's default backend.
+    """
+    return noncomp._sample_experimental(circuit, model, shots, seed, max_rank)
+
+
 def sample_survivors(
     program: Program,
     shots: int,
@@ -136,5 +151,6 @@ __all__ = [
     "compile",
     "record_probabilities",
     "sample",
+    "sample_noncomputational",
     "sample_survivors",
 ]

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
-from typing import Iterator
+from typing import Callable, Iterator
 
 import numpy as np
 import numpy.typing as npt
@@ -326,10 +326,40 @@ def sample(
         ValueError: If a model or circuit contract is violated, an annotation
             is malformed, or a continuation exceeds ``max_rank``.
     """
+    return _sample_with(
+        circuit, model, shots, seed, max_rank, _clifft_core._sample_noncomputational
+    )
+
+
+def _sample_experimental(
+    circuit: Circuit | str,
+    model: Model,
+    shots: int,
+    seed: int | None = None,
+    max_rank: int | None = None,
+) -> NonComputationalSample:
+    return _sample_with(
+        circuit,
+        model,
+        shots,
+        seed,
+        max_rank,
+        _clifft_core._sample_noncomputational_experimental,
+    )
+
+
+def _sample_with(
+    circuit: Circuit | str,
+    model: Model,
+    shots: int,
+    seed: int | None,
+    max_rank: int | None,
+    sampler: Callable,
+) -> NonComputationalSample:
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)
-    meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs = (
-        _clifft_core._sample_noncomputational(circuit, model._handle, shots, seed, max_rank)
+    meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs = sampler(
+        circuit, model._handle, shots, seed, max_rank
     )
     return NonComputationalSample(
         meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -17,6 +17,15 @@ def sampling_api(request: pytest.FixtureRequest) -> Any:
     return cast(Any, request.param)
 
 
+@pytest.fixture(
+    params=[clifft.noncomp.sample, experimental.sample_noncomputational],
+    ids=["svm", "symbolic-coordinate"],
+)
+def noncomp_sampling_api(request: pytest.FixtureRequest) -> Any:
+    """Run supported noncomputational trajectories through both executors."""
+    return cast(Any, request.param)
+
+
 def noncomp_transition_matrix(
     entries: Mapping[tuple[int, int], float],
 ) -> list[list[float]]:

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -252,9 +252,9 @@ def test_classifier_bit_feeds_observable():
     assert (r.observables == 1).all()
 
 
-def test_inverted_classifier_bit_feeds_records_detectors_and_observables():
+def test_inverted_classifier_bit_feeds_records_detectors_and_observables(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [1.0, 0.0]))
-    r = noncomp.sample(
+    r = noncomp_sampling_api(
         "H 0\nS 0\nM !0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n",
         model,
         shots=64,
@@ -275,9 +275,9 @@ def test_lost_measurement_classifier_bit():
     assert (r.measurements == 1).all()
 
 
-def test_measure_reset_on_leaked_preserves_slot_and_resets():
+def test_measure_reset_on_leaked_preserves_slot_and_resets(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
-    r = noncomp.sample("H 0\nS 0\nMR 0\nM 0\n", model, shots=64, seed=12)
+    r = noncomp_sampling_api("H 0\nS 0\nMR 0\nM 0\n", model, shots=64, seed=12)
     assert r.num_measurements == 2
     assert (r.measurements[:, 0] == 1).all()  # MR slot: classifier bit
     assert (r.measurements[:, 1] == 0).all()  # reset, then M reads 0
@@ -489,7 +489,7 @@ def test_policy_knob_strings_validate():
         noncomp.Model(initial_state=ALL_G, damping="bogus")
 
 
-def test_loss_only_exact_damping_stays_at_stabilizer_cost():
+def test_loss_only_exact_damping_stays_at_stabilizer_cost(noncomp_sampling_api):
     """Equal per-source rates (LOSS always qualifies) take the trap-form
     lowering under damping="exact", so a loss-only model compiles at the
     neglect rank -- max_rank=0 passes -- while the physics stays exact:
@@ -497,7 +497,7 @@ def test_loss_only_exact_damping_stays_at_stabilizer_cost():
     circuit = "H 0\nLOSS(0.3) 0\nH 0\nM 0"
     cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
     model = noncomp.Model(classifier=cls)  # damping="exact" default
-    r = noncomp.sample(circuit, model, shots=4000, seed=17, max_rank=0)
+    r = noncomp_sampling_api(circuit, model, shots=4000, seed=17, max_rank=0)
     meas = r.measurements[:, 0]
     lost = r.final_status[:, 0] == noncomp.QubitStatus.LOST
     # Survivors: the H .. H sandwich returns |0> deterministically; a lost
@@ -508,7 +508,7 @@ def test_loss_only_exact_damping_stays_at_stabilizer_cost():
     assert abs(lost.mean() - 0.3) < 4 * (0.3 * 0.7 / 4000) ** 0.5
 
 
-def test_loss_on_many_coherent_qubits_compiles_flat():
+def test_loss_on_many_coherent_qubits_compiles_flat(noncomp_sampling_api):
     """Per-qubit LOSS sites do not accumulate rank under damping="exact"."""
     circuit = (
         "".join(f"H {i}\n" for i in range(5))
@@ -516,11 +516,11 @@ def test_loss_on_many_coherent_qubits_compiles_flat():
         + "".join(f"H {i}\nM {i}\n" for i in range(5))
     )
     cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
-    r = noncomp.sample(circuit, noncomp.Model(classifier=cls), shots=8, seed=3, max_rank=0)
+    r = noncomp_sampling_api(circuit, noncomp.Model(classifier=cls), shots=8, seed=3, max_rank=0)
     assert r.num_measurements == 5
 
 
-def test_max_rank_rejects_over_budget_exact_but_neglect_fits():
+def test_max_rank_rejects_over_budget_exact_but_neglect_fits(noncomp_sampling_api):
     # A source-dependent leak (only out of e) on a coherent dormant qubit is
     # genuinely non-Clifford: damping="exact" expands it into the amplitude
     # array, adding one to the compiled rank per site. Three H-prefixed sites
@@ -543,13 +543,13 @@ def test_max_rank_rejects_over_budget_exact_but_neglect_fits():
         )
 
     with pytest.raises(ValueError, match="max_rank"):
-        noncomp.sample(circuit, model("exact"), shots=4, seed=1, max_rank=2)
+        noncomp_sampling_api(circuit, model("exact"), shots=4, seed=1, max_rank=2)
 
-    r = noncomp.sample(circuit, model("neglect"), shots=4, seed=1, max_rank=2)
+    r = noncomp_sampling_api(circuit, model("neglect"), shots=4, seed=1, max_rank=2)
     assert r.num_measurements == 3
 
 
-def test_max_rank_ignores_the_unreachable_all_computational_module():
+def test_max_rank_ignores_the_unreachable_all_computational_module(noncomp_sampling_api):
     """A model whose initial state has zero computational mass never runs the
     no-event module; its rank must not be able to reject the run."""
     circuit = (
@@ -562,9 +562,9 @@ def test_max_rank_ignores_the_unreachable_all_computational_module():
     # Control: with computational initials the no-event module is real and
     # its rank exceeds the cap -- this is what makes the test discriminating.
     with pytest.raises(ValueError, match="max_rank"):
-        noncomp.sample(circuit, noncomp.Model(classifier=cls), shots=4, seed=3, max_rank=0)
+        noncomp_sampling_api(circuit, noncomp.Model(classifier=cls), shots=4, seed=3, max_rank=0)
     lost = noncomp.Model(initial_state=[0, 0, 0, 0, 1], classifier=cls)
-    r = noncomp.sample(circuit, lost, shots=16, seed=3, max_rank=0)
+    r = noncomp_sampling_api(circuit, lost, shots=16, seed=3, max_rank=0)
     assert (r.final_status == noncomp.QubitStatus.LOST).all()
     # The lost column reads symbol 1 with certainty: a raw readout of the
     # dropped-everything |0> carriers would give 0, so all-1 records verify
@@ -689,7 +689,7 @@ def test_fired_chain_head_on_lost_operand_blocks_else():
     assert np.all(result.measurements[:, 1] == 0)
 
 
-def test_chain_flip_on_parked_carrier_is_destroyed_by_restoring_reset():
+def test_chain_flip_on_parked_carrier_is_destroyed_by_restoring_reset(noncomp_sampling_api):
     """The passthrough is sound because a vacated carrier is unobservable;
     this verifies the restoration leg: a chain flip parked on a lost carrier is
     overwritten by the restoring reset, so the restored qubit reads a clean
@@ -703,7 +703,7 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_restoring_reset():
         classifier=classifier_for(LOST, [1.0, 0.0]),
         reset_restores_lost=True,
     )
-    result = noncomp.sample("S 0\nE(1) X0\nR 0\nM 0", model, shots=16, seed=11)
+    result = noncomp_sampling_api("S 0\nE(1) X0\nR 0\nM 0", model, shots=16, seed=11)
     assert (result.final_status[:, 0] == COMPUTATIONAL).all()
     assert np.all(result.measurements[:, 0] == 0)
 
@@ -789,17 +789,17 @@ def test_capable_model_rejects_mpp():
         noncomp.sample("S 0\nMPP Z0*Z1\n", model, shots=4, seed=5)
 
 
-def test_exp_val_probe_is_rejected():
+def test_exp_val_probe_is_rejected(noncomp_sampling_api):
     with pytest.raises(ValueError, match="EXP_VAL probes are not supported"):
-        noncomp.sample("EXP_VAL Z0\n", noncomp.Model(), shots=1, seed=5)
+        noncomp_sampling_api("EXP_VAL Z0\n", noncomp.Model(), shots=1, seed=5)
 
 
-def test_contract_validated_for_zero_shots():
+def test_contract_validated_for_zero_shots(noncomp_sampling_api):
     """Validation is shot-count independent: shots=0 still rejects a
     leak-capable model that measures without a classifier."""
     model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
     with pytest.raises(ValueError, match="classifier is required"):
-        noncomp.sample("S 0\nM 0", model, shots=0, seed=1)
+        noncomp_sampling_api("S 0\nM 0", model, shots=0, seed=1)
 
 
 def test_malformed_transition_error_names_key():
@@ -825,8 +825,19 @@ def test_sample_type_hints_resolve_at_runtime():
     real module-level name, not a TYPE_CHECKING-only import."""
     from typing import get_type_hints
 
+    from clifft import experimental
+
     hints = get_type_hints(noncomp.sample)
     assert "circuit" in hints
+    experimental_hints = get_type_hints(experimental.sample_noncomputational)
+    assert "circuit" in experimental_hints
+
+
+def test_experimental_noncomp_accepts_a_parsed_circuit():
+    from clifft import experimental
+
+    r = experimental.sample_noncomputational(clifft.parse("M 0"), noncomp.Model(), shots=4, seed=1)
+    assert np.array_equal(r.measurements, np.zeros((4, 1), dtype=np.uint8))
 
 
 def test_qubit_status_values():
@@ -877,7 +888,7 @@ def test_model_repr_contains_keys_and_damping():
     assert "neglect" in r
 
 
-def test_ternary_herald_on_measure_reset():
+def test_ternary_herald_on_measure_reset(noncomp_sampling_api):
     """MR on a leaked qubit heralds the sidecar, resets the qubit, and the
     next M reads 0.
 
@@ -911,7 +922,7 @@ def test_ternary_herald_on_measure_reset():
         transitions={"S": transitions_leak},
         classifier=noncomp.Classifier(clf_matrix),
     )
-    r = noncomp.sample("S 0\nMR 0\nM 0\n", model, shots=HERALD_SHOTS, seed=271)
+    r = noncomp_sampling_api("S 0\nMR 0\nM 0\n", model, shots=HERALD_SHOTS, seed=271)
 
     assert r.num_measurements == 2
 

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -1,8 +1,10 @@
-"""Python-facing tests for the noncomputational (leakage/loss) API.
+"""Python-facing tests for noncomputational leakage and loss.
 
 Covers model construction, end-to-end sampling, classifier/record semantics,
-and record-layout invariants through the clifft.noncomp surface. The model uses
-the built-in five-level set; matrices use the fixed clifft.noncomp.Level order.
+and record-layout invariants. Backend-applicable sampling cases run through both
+the stable SVM route and the experimental symbolic-coordinate route. The model
+uses the built-in five-level set; matrices use the fixed clifft.noncomp.Level
+order.
 """
 
 from __future__ import annotations
@@ -60,11 +62,11 @@ def test_initial_state_out_of_range_probability_raises():
         noncomp.Model(initial_state=[2.0, -1.0, 0.0, 0.0, 0.0])
 
 
-def test_non_gate_key_is_a_named_transition():
+def test_non_gate_key_is_a_named_transition(noncomp_sampling_api):
     """A key that names no gate is a named transition: referenceable from a
     LEVEL_TRANSITION[key] annotation, hooked on nothing."""
     model = noncomp.Model(initial_state=ALL_G, transitions={"my_leak": transition_to(LEAK_G)})
-    r = noncomp.sample("H 0\nS 0\nM 0", model, shots=8, seed=1)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0", model, shots=8, seed=1)
     assert r.final_status.shape == (8, 1)  # no hook fired; plain sampling ran
 
 
@@ -73,25 +75,25 @@ def test_non_hookable_instruction_key_raises():
         noncomp.Model(transitions={"DEPOLARIZE1": transition_to(LEAK_G)})
 
 
-def test_local_annotations_run_end_to_end():
+def test_local_annotations_run_end_to_end(noncomp_sampling_api):
     """Hand-written transition annotations drive the trajectory."""
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"leak": transition_to(LEAK_G)},
         classifier=classifier_for(LEAK_G, [0.0, 1.0]),
     )
-    r = noncomp.sample("H 0\nLEVEL_TRANSITION[leak] 0\nM 0", model, shots=32, seed=2)
+    r = noncomp_sampling_api("H 0\nLEVEL_TRANSITION[leak] 0\nM 0", model, shots=32, seed=2)
     assert np.all(r.measurements[:, 0] == 1)  # leaked slot takes the classifier bit
 
     lossy = noncomp.Model(
         initial_state=ALL_G, transitions={}, classifier=classifier_for(LOST, [1.0, 0.0])
     )
-    s = noncomp.sample("H 0\nLOSS(1) 0\nM 0", lossy, shots=32, seed=3)
+    s = noncomp_sampling_api("H 0\nLOSS(1) 0\nM 0", lossy, shots=32, seed=3)
     assert np.all(s.measurements[:, 0] == 0)  # lost slot fixed by the classifier
 
 
-def test_leakage_preserves_computational_source_level():
-    result = noncomp.sample("X 1\nLEAKAGE(1) 0 1", noncomp.Model(), shots=32, seed=208)
+def test_leakage_preserves_computational_source_level(noncomp_sampling_api):
+    result = noncomp_sampling_api("X 1\nLEAKAGE(1) 0 1", noncomp.Model(), shots=32, seed=208)
     assert (result.final_status[:, 0] == noncomp.QubitStatus.LEAK_G).all()
     assert (result.final_status[:, 1] == noncomp.QubitStatus.LEAK_E).all()
 
@@ -104,38 +106,38 @@ def test_leakage_preserves_computational_source_level():
         ([0, 0, 0, 0, 1], noncomp.QubitStatus.LOST),
     ],
 )
-def test_leakage_leaves_noncomputational_sources_unchanged(initial, expected):
-    result = noncomp.sample(
+def test_leakage_leaves_noncomputational_sources_unchanged(initial, expected, noncomp_sampling_api):
+    result = noncomp_sampling_api(
         "LEAKAGE(1) 0", noncomp.Model(initial_state=initial), shots=16, seed=209
     )
     assert (result.final_status[:, 0] == expected).all()
 
 
-def test_multi_target_leakage_samples_targets_independently():
+def test_multi_target_leakage_samples_targets_independently(noncomp_sampling_api):
     p = 0.3
     shots = 10_000
-    result = noncomp.sample(f"LEAKAGE({p}) 0 1", noncomp.Model(), shots=shots, seed=210)
+    result = noncomp_sampling_api(f"LEAKAGE({p}) 0 1", noncomp.Model(), shots=shots, seed=210)
     leaked = result.final_status != noncomp.QubitStatus.COMPUTATIONAL
     assert abs(float(leaked[:, 0].mean()) - p) < 0.025
     assert abs(float(leaked[:, 1].mean()) - p) < 0.025
     assert abs(float(np.logical_and(leaked[:, 0], leaked[:, 1]).mean()) - p * p) < 0.02
 
 
-def test_sample_accepts_a_parsed_circuit():
+def test_sample_accepts_a_parsed_circuit(noncomp_sampling_api):
     circuit = clifft.parse("LOSS(1) 0\nM 0")
     model = noncomp.Model(classifier=classifier_for(LOST, [1.0, 0.0]))
-    result = noncomp.sample(circuit, model, shots=8, seed=4)
+    result = noncomp_sampling_api(circuit, model, shots=8, seed=4)
     assert (result.final_status == LOST_KIND).all()
     assert (result.measurements == 0).all()
 
 
-def test_gate_hooks_expand_inside_repeat_blocks():
+def test_gate_hooks_expand_inside_repeat_blocks(noncomp_sampling_api):
     circuit = "REPEAT 2 {\nS 0\n}\nM 0"
     model = noncomp.Model(
         transitions={"S": transition_to(LOST)},
         classifier=classifier_for(LOST, [1.0, 0.0]),
     )
-    result = noncomp.sample(circuit, model, shots=8, seed=5)
+    result = noncomp_sampling_api(circuit, model, shots=8, seed=5)
     assert (result.final_status == LOST_KIND).all()
 
 
@@ -162,19 +164,19 @@ def test_whitespace_transition_key_raises():
         noncomp.Model(initial_state=ALL_G, transitions={" padded": t})
 
 
-def test_lossless_matches_plain_record_shape():
+def test_lossless_matches_plain_record_shape(noncomp_sampling_api):
     model = noncomp.Model(initial_state=ALL_G)
-    r = noncomp.sample("H 0\nM 0\n", model, shots=512, seed=2)
+    r = noncomp_sampling_api("H 0\nM 0\n", model, shots=512, seed=2)
     assert r.measurements.shape == (512, 1)
     assert r.num_measurements == 1
     ones = int(r.measurements.sum())
     assert 200 < ones < 312  # H then M is ~50/50
 
 
-def test_initial_one_population_prep_is_deterministic():
+def test_initial_one_population_prep_is_deterministic(noncomp_sampling_api):
     # initial all-e is computational |1>: X-prep makes M read 1 every shot.
     model = noncomp.Model(initial_state=ALL_E)
-    r = noncomp.sample("M 0\n", model, shots=64, seed=3)
+    r = noncomp_sampling_api("M 0\n", model, shots=64, seed=3)
     assert (r.measurements == 1).all()
 
 
@@ -185,7 +187,9 @@ def test_initial_one_population_prep_is_deterministic():
         (LOST, noncomp.QubitStatus.LOST, 0.5, 32),
     ],
 )
-def test_initial_noncomputational_population_sampling(level, status, probability, seed):
+def test_initial_noncomputational_population_sampling(
+    level, status, probability, seed, noncomp_sampling_api
+):
     initial = [0.0] * 5
     initial[noncomp.Level.G] = 1.0 - probability
     initial[level] = probability
@@ -194,18 +198,18 @@ def test_initial_noncomputational_population_sampling(level, status, probability
         classifier=classifier_for(level, [0.0, 1.0]),
     )
 
-    r = noncomp.sample("M 0\n", model, shots=8000, seed=seed)
+    r = noncomp_sampling_api("M 0\n", model, shots=8000, seed=seed)
     assert abs(float((r.final_status[:, 0] == status).mean()) - probability) < 0.04
     assert abs(float(r.measurements[:, 0].mean()) - probability) < 0.04
 
 
-def test_state_independent_loss_changes_final_status():
+def test_state_independent_loss_changes_final_status(noncomp_sampling_api):
     model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
-    r = noncomp.sample("H 0\nS 0\n", model, shots=16, seed=4)
+    r = noncomp_sampling_api("H 0\nS 0\n", model, shots=16, seed=4)
     assert (r.final_status == LOST_KIND).all()
 
 
-def test_known_source_dependent_transition_accepted():
+def test_known_source_dependent_transition_accepted(noncomp_sampling_api):
     # Source-dependent (g->leak_g, e->leak_e). At S entry the qubit sits
     # in |g> -- no scrambling yet -- so the fire collapses onto g and the
     # destination is fixed to leak_g.
@@ -213,41 +217,43 @@ def test_known_source_dependent_transition_accepted():
     t[LEAK_G][0] = 1.0
     t[LEAK_E][1] = 1.0
     model = noncomp.Model(initial_state=ALL_G, transitions={"S": t})
-    r = noncomp.sample("S 0\n", model, shots=8, seed=5)
+    r = noncomp_sampling_api("S 0\n", model, shots=8, seed=5)
     assert (r.final_status == noncomp.QubitStatus.LEAK_G).all()
 
 
-def test_reset_reload_policy_changes_lost_site():
+def test_reset_reload_policy_changes_lost_site(noncomp_sampling_api):
     # A reset on a lost qubit drops by default (the site stays lost); with
     # reset_restores_lost it reloads the qubit to a computational state.
     circuit = "H 0\nS 0\nR 0\n"
     dropped = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
-    r = noncomp.sample(circuit, dropped, shots=8, seed=7)
+    r = noncomp_sampling_api(circuit, dropped, shots=8, seed=7)
     assert (r.final_status == LOST_KIND).all()  # reset dropped; the site stays lost
 
     restore = noncomp.Model(
         initial_state=ALL_G, transitions={"S": transition_to(LOST)}, reset_restores_lost=True
     )
-    r = noncomp.sample(circuit, restore, shots=8, seed=7)
+    r = noncomp_sampling_api(circuit, restore, shots=8, seed=7)
     assert (r.final_status == COMPUTATIONAL).all()
 
 
-def test_leaked_classifier_bit_in_measurements():
+def test_leaked_classifier_bit_in_measurements(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
-    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=64, seed=8)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=64, seed=8)
     assert (r.measurements == 1).all()
 
 
-def test_classifier_bit_feeds_detector():
+def test_classifier_bit_feeds_detector(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
-    r = noncomp.sample("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n", model, shots=64, seed=9)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0\nDETECTOR rec[-1]\n", model, shots=64, seed=9)
     assert r.num_detectors == 1
     assert (r.detectors == 1).all()
 
 
-def test_classifier_bit_feeds_observable():
+def test_classifier_bit_feeds_observable(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [0.0, 1.0]))
-    r = noncomp.sample("H 0\nS 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n", model, shots=64, seed=10)
+    r = noncomp_sampling_api(
+        "H 0\nS 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n", model, shots=64, seed=10
+    )
     assert r.num_observables == 1
     assert (r.observables == 1).all()
 
@@ -265,13 +271,13 @@ def test_inverted_classifier_bit_feeds_records_detectors_and_observables(noncomp
     assert (r.observables[:, 0] == 1).all()
 
 
-def test_lost_measurement_classifier_bit():
+def test_lost_measurement_classifier_bit(noncomp_sampling_api):
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
         classifier=classifier_for(LOST, [0.0, 1.0]),
     )
-    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=64, seed=11)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=64, seed=11)
     assert (r.measurements == 1).all()
 
 
@@ -283,18 +289,18 @@ def test_measure_reset_on_leaked_preserves_slot_and_resets(noncomp_sampling_api)
     assert (r.measurements[:, 1] == 0).all()  # reset, then M reads 0
 
 
-def test_inverted_measure_reset_classifier_preserves_slot_and_resets():
+def test_inverted_measure_reset_classifier_preserves_slot_and_resets(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [1.0, 0.0]))
-    r = noncomp.sample("H 0\nS 0\nMR !0\nM 0\n", model, shots=64, seed=102)
+    r = noncomp_sampling_api("H 0\nS 0\nMR !0\nM 0\n", model, shots=64, seed=102)
     assert r.num_measurements == 2
     assert (r.measurements[:, 0] == 1).all()
     assert (r.measurements[:, 1] == 0).all()
 
 
-def test_missing_classifier_on_leaked_measurement_raises():
+def test_missing_classifier_on_leaked_measurement_raises(noncomp_sampling_api):
     model = leak_model(classifier=None)
     with pytest.raises(ValueError, match="classifier"):
-        noncomp.sample("H 0\nS 0\nM 0\n", model, shots=8, seed=13)
+        noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=8, seed=13)
 
 
 def test_substochastic_classifier_column_rejects_at_construction():
@@ -324,14 +330,14 @@ def test_classifier_stores_matrix():
     assert len(c.matrix[0]) == 5
 
 
-def test_ternary_herald_rides_the_sidecar():
+def test_ternary_herald_rides_the_sidecar(noncomp_sampling_api):
     """A lost qubit's measurement heralds; the visible record stays binary."""
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
         classifier=classifier_for(LOST, [0.0, 0.0, 1.0]),
     )
-    r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=4000, seed=21)
+    r = noncomp_sampling_api("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=4000, seed=21)
     assert r.heralds.shape == (4000, 2)
     assert np.all(r.heralds[:, 0] == 1)  # the lost qubit's slot heralds
     assert np.all(r.heralds[:, 1] == 0)  # the survivor's does not
@@ -343,28 +349,28 @@ def test_ternary_herald_rides_the_sidecar():
     assert np.array_equal(sym[:, 1], r.measurements[:, 1])
 
 
-def test_two_symbol_classifier_heralds_nothing():
+def test_two_symbol_classifier_heralds_nothing(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [0.5, 0.5]))
-    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=64, seed=22)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=64, seed=22)
     assert r.heralds.shape == (64, 1)
     assert not r.heralds.any()
     assert np.array_equal(r.symbols(), r.measurements)
 
 
-def test_herald_deterministic_in_seed():
+def test_herald_deterministic_in_seed(noncomp_sampling_api):
     model = noncomp.Model(
         initial_state=ALL_G,
         transitions={"S": transition_to(LOST)},
         classifier=classifier_for(LOST, [0.2, 0.1, 0.7]),
     )
-    a = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
-    b = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
+    a = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
+    b = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=128, seed=23)
     assert np.array_equal(a.heralds, b.heralds)
     assert np.array_equal(a.measurements, b.measurements)
     assert abs(a.heralds[:, 0].mean() - 0.7) < 0.15
 
 
-def test_ternary_herald_feeds_detector_and_observable():
+def test_ternary_herald_feeds_detector_and_observable(noncomp_sampling_api):
     """Heralded slots keep a binary record drawn uniformly; anything consuming
     the record (detectors, observables) must see that same patched bit, and
     the herald rides only in the sidecar."""
@@ -378,7 +384,7 @@ def test_ternary_herald_feeds_detector_and_observable():
         classifier=classifier_for(LOST, [0.2, 0.1, 0.7]),
     )
     circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n"
-    r = noncomp.sample(circuit, model, shots=4000, seed=24)
+    r = noncomp_sampling_api(circuit, model, shots=4000, seed=24)
 
     # Detector and observable both read the classifier-substituted measurement bit.
     assert np.array_equal(r.detectors[:, 0], r.measurements[:, 0])
@@ -403,9 +409,9 @@ def test_ternary_herald_feeds_detector_and_observable():
     assert np.array_equal(sym[~heralded, 0], meas[~heralded])
 
 
-def test_hidden_trace_out_does_not_shift_visible_count():
+def test_hidden_trace_out_does_not_shift_visible_count(noncomp_sampling_api):
     plain = noncomp.Model(initial_state=ALL_G)
-    rp = noncomp.sample("H 0\nCX 0 1\nM 0\nM 1\n", plain, shots=8, seed=16)
+    rp = noncomp_sampling_api("H 0\nCX 0 1\nM 0\nM 1\n", plain, shots=8, seed=16)
     assert rp.num_measurements == 2
 
     # Losing q0 inserts a hidden trace-out R, but the visible record is unchanged.
@@ -414,13 +420,13 @@ def test_hidden_trace_out_does_not_shift_visible_count():
         transitions={"S": transition_to(LOST)},
         classifier=classifier_for(LOST, [1.0, 0.0]),
     )
-    r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", lossy, shots=8, seed=17)
+    r = noncomp_sampling_api("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", lossy, shots=8, seed=17)
     assert r.num_measurements == 2
 
 
-def test_zero_shots_reports_widths_and_empty_arrays():
+def test_zero_shots_reports_widths_and_empty_arrays(noncomp_sampling_api):
     model = noncomp.Model(initial_state=ALL_G)
-    r = noncomp.sample("H 0\nM 0\nDETECTOR rec[-1]\n", model, shots=0, seed=1)
+    r = noncomp_sampling_api("H 0\nM 0\nDETECTOR rec[-1]\n", model, shots=0, seed=1)
     assert r.shots == 0
     assert r.num_measurements == 1
     assert r.num_detectors == 1
@@ -428,35 +434,35 @@ def test_zero_shots_reports_widths_and_empty_arrays():
     assert r.detectors.shape == (0, 1)
 
 
-def test_final_status_shape_is_shots_by_qubits():
+def test_final_status_shape_is_shots_by_qubits(noncomp_sampling_api):
     model = noncomp.Model(initial_state=ALL_G)
-    r = noncomp.sample("H 0\nCX 0 1\nM 0\nM 1\n", model, shots=32, seed=18)
+    r = noncomp_sampling_api("H 0\nCX 0 1\nM 0\nM 1\n", model, shots=32, seed=18)
     assert r.final_status.shape == (32, 2)
 
 
-def test_deterministic_in_seed():
+def test_deterministic_in_seed(noncomp_sampling_api):
     model = leak_model(classifier_for(LEAK_G, [0.5, 0.5]))
     circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\n"
-    a = noncomp.sample(circuit, model, shots=128, seed=42)
-    b = noncomp.sample(circuit, model, shots=128, seed=42)
+    a = noncomp_sampling_api(circuit, model, shots=128, seed=42)
+    b = noncomp_sampling_api(circuit, model, shots=128, seed=42)
     assert np.array_equal(a.measurements, b.measurements)
     assert np.array_equal(a.detectors, b.detectors)
     assert np.array_equal(a.final_status, b.final_status)
 
 
-def test_different_seeds_differ():
+def test_different_seeds_differ(noncomp_sampling_api):
     # The companion to the determinism check: a different seed must actually
     # change the draws, so a fixed-sequence regression cannot masquerade as
     # "deterministic". 128 coin-flip measurements collide with probability
     # 2**-128.
     model = leak_model(classifier_for(LEAK_G, [0.5, 0.5]))
     circuit = "H 0\nS 0\nM 0\nDETECTOR rec[-1]\n"
-    a = noncomp.sample(circuit, model, shots=128, seed=42)
-    b = noncomp.sample(circuit, model, shots=128, seed=43)
+    a = noncomp_sampling_api(circuit, model, shots=128, seed=42)
+    b = noncomp_sampling_api(circuit, model, shots=128, seed=43)
     assert not np.array_equal(a.measurements, b.measurements)
 
 
-def test_deterministic_in_seed_with_noncomputational_initials():
+def test_deterministic_in_seed_with_noncomputational_initials(noncomp_sampling_api):
     """Shots that start leaked or lost select their own starting modules
     rather than the shared main line; the streams must still be fully
     seed-determined under both dampings, and a different seed must differ."""
@@ -470,14 +476,14 @@ def test_deterministic_in_seed_with_noncomputational_initials():
             classifier=classifier_for(LEAK_E, [0.0, 1.0]),
             damping=damping,
         )
-        a = noncomp.sample(circuit, model, shots=64, seed=29)
-        b = noncomp.sample(circuit, model, shots=64, seed=29)
+        a = noncomp_sampling_api(circuit, model, shots=64, seed=29)
+        b = noncomp_sampling_api(circuit, model, shots=64, seed=29)
         assert np.array_equal(a.measurements, b.measurements)
         assert np.array_equal(a.final_status, b.final_status)
         assert np.array_equal(a.heralds, b.heralds)
         # Vacuity guard: the noncomputational-initial path really ran.
         assert (a.final_status != noncomp.QubitStatus.COMPUTATIONAL).any()
-        c = noncomp.sample(circuit, model, shots=64, seed=30)
+        c = noncomp_sampling_api(circuit, model, shots=64, seed=30)
         assert not np.array_equal(a.measurements, c.measurements) or not np.array_equal(
             a.final_status, c.final_status
         )
@@ -572,7 +578,7 @@ def test_max_rank_ignores_the_unreachable_all_computational_module(noncomp_sampl
     assert (r.measurements == 1).all()
 
 
-def test_a_multi_round_circuit_runs_through_loss():
+def test_a_multi_round_circuit_runs_through_loss(noncomp_sampling_api):
     """A lost data qubit drops its syndrome CXs (identity on the ancilla).
 
     Dropping an operation with no representable effect on a vacated site is
@@ -583,13 +589,13 @@ def test_a_multi_round_circuit_runs_through_loss():
     classifier = classifier_for(LOST, [0.0, 1.0])
 
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
-    r = noncomp.sample(circuit, model, shots=16, seed=2)
+    r = noncomp_sampling_api(circuit, model, shots=16, seed=2)
     assert r.num_measurements == 3
     assert np.array_equal(r.measurements, np.tile([0, 0, 1], (16, 1)))
     assert np.all(r.final_status[:, 0] == LOST_KIND)
 
 
-def test_mx_measurement_of_a_lost_qubit_classifies():
+def test_mx_measurement_of_a_lost_qubit_classifies(noncomp_sampling_api):
     """An X-basis measurement of a lost qubit reads the classifier bit.
 
     On a vacated carrier the readout basis is incidental; MX classifies
@@ -598,17 +604,17 @@ def test_mx_measurement_of_a_lost_qubit_classifies():
     transitions = {"S": transition_to(LOST)}
     classifier = classifier_for(LOST, [0.0, 1.0])
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
-    r = noncomp.sample(circuit, model, shots=8, seed=2)
+    r = noncomp_sampling_api(circuit, model, shots=8, seed=2)
     assert r.num_measurements == 1
     assert (r.measurements[:, 0] == 1).all()
     assert (r.final_status[:, 0] == LOST_KIND).all()
 
 
-def test_zero_fire_loss_before_firing_loss_samples_cleanly():
+def test_zero_fire_loss_before_firing_loss_samples_cleanly(noncomp_sampling_api):
     """A zero-rate LOSS elided by trace() must not shift later site ids."""
     classifier = noncomp.Classifier([[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]])
     model = noncomp.Model(initial_state=ALL_G, classifier=classifier)
-    r = noncomp.sample("LOSS(0) 0\nLOSS(0.5) 0\nM 0\n", model, shots=64, seed=90)
+    r = noncomp_sampling_api("LOSS(0) 0\nLOSS(0.5) 0\nM 0\n", model, shots=64, seed=90)
     assert r.shots == 64
     # Every shot ends Lost or Computational (no assertion failures).
     assert r.final_status.shape == (64, 1)
@@ -620,20 +626,20 @@ def test_zero_fire_loss_before_firing_loss_samples_cleanly():
             assert r.final_status[i, 0] == COMPUTATIONAL
 
 
-def test_seepage_only_before_firing_site_samples_cleanly():
+def test_seepage_only_before_firing_site_samples_cleanly(noncomp_sampling_api):
     """A transition elided on computational sources must not shift later site ids."""
     seep = _zeros(5, 5)
     seep[LEAK_E][LEAK_E] = 1.0  # leak_e -> leak_e, only noncomp columns
 
     classifier = noncomp.Classifier([[1.0, 0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 1.0, 1.0]])
     model = noncomp.Model(initial_state=ALL_G, transitions={"seep": seep}, classifier=classifier)
-    r = noncomp.sample("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0\n", model, shots=32, seed=91)
+    r = noncomp_sampling_api("LEVEL_TRANSITION[seep] 0\nLOSS(1) 0\nM 0\n", model, shots=32, seed=91)
     assert r.shots == 32
     assert (r.final_status == LOST_KIND).all()
     assert (r.measurements[:, 0] == 1).all()
 
 
-def test_computational_readout_confusion_misreports_the_record():
+def test_computational_readout_confusion_misreports_the_record(noncomp_sampling_api):
     """The classifier's computational columns act as asymmetric readout
     confusion on Z measurements: the qubit collapses to its true state but
     the record bit is misreported at the column's off-diagonal rate."""
@@ -646,11 +652,11 @@ def test_computational_readout_confusion_misreports_the_record():
         m[0][lvl] = 1.0
     model = noncomp.Model(initial_state=ALL_G, transitions={}, classifier=noncomp.Classifier(m))
 
-    zero = noncomp.sample("M 0", model, shots=4000, seed=11)
+    zero = noncomp_sampling_api("M 0", model, shots=4000, seed=11)
     ones = int(zero.measurements[:, 0].sum())
     assert 1020 <= ones <= 1380  # expected 1200; ~6 sigma band
 
-    one = noncomp.sample("X 0\nM 0", model, shots=4000, seed=12)
+    one = noncomp_sampling_api("X 0\nM 0", model, shots=4000, seed=12)
     zeros = int((1 - one.measurements[:, 0]).sum())
     assert 650 <= zeros <= 950  # expected 800; ~6 sigma band
 
@@ -665,26 +671,26 @@ def _lose_model() -> noncomp.Model:
     )
 
 
-def test_correlated_chain_on_lost_qubit_does_not_crash():
+def test_correlated_chain_on_lost_qubit_does_not_crash(noncomp_sampling_api):
     """A correlated-error chain whose head operand is lost must pass through
     the noncomp layers without an exception. Dropping the head would orphan
     the ELSE and produce a dangling-chain error at trace time."""
     model = _lose_model()
     circuit = "S 0\nE(0.5) X0 X1\nELSE_CORRELATED_ERROR(0.5) X1\nM 0 1\n"
-    result = noncomp.sample(circuit, model, shots=32, seed=83)
+    result = noncomp_sampling_api(circuit, model, shots=32, seed=83)
     # The loss really happened, and the lost column reads 0 every shot.
     assert (result.final_status[:, 0] == LOST_KIND).all()
     assert np.all(result.measurements[:, 0] == 0)
 
 
-def test_fired_chain_head_on_lost_operand_blocks_else():
+def test_fired_chain_head_on_lost_operand_blocks_else(noncomp_sampling_api):
     """Conditioning check: E(1) fires (the head always fires, operating on the
     vacated q0 carrier), so the ELSE must not fire. q1 records must all be 0
     because the ELSE's X1 was never applied; a dropped head would promote the
     ELSE to fire unconditionally and flip q1."""
     model = _lose_model()
     circuit = "S 0\nE(1) X0\nELSE_CORRELATED_ERROR(1) X1\nM 0 1\n"
-    result = noncomp.sample(circuit, model, shots=32, seed=89)
+    result = noncomp_sampling_api(circuit, model, shots=32, seed=89)
     assert (result.final_status[:, 0] == LOST_KIND).all()
     assert np.all(result.measurements[:, 1] == 0)
 
@@ -708,7 +714,7 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_restoring_reset(noncomp_sa
     assert np.all(result.measurements[:, 0] == 0)
 
 
-def test_chain_flip_on_parked_carrier_is_destroyed_by_recapture():
+def test_chain_flip_on_parked_carrier_is_destroyed_by_recapture(noncomp_sampling_api):
     """The recapture leg of the same contract: a chain flip parked on a
     leaked carrier neither disturbs the classified record (first M reads the
     leak_g column, proving the leak happened) nor survives the recapture,
@@ -721,13 +727,13 @@ def test_chain_flip_on_parked_carrier_is_destroyed_by_recapture():
         classifier=classifier_for(LEAK_G, [1.0, 0.0]),
     )
     circuit = "S 0\nE(1) X0\nM 0\nLEVEL_TRANSITION[seep] 0\nM 0\n"
-    result = noncomp.sample(circuit, model, shots=16, seed=13)
+    result = noncomp_sampling_api(circuit, model, shots=16, seed=13)
     assert np.all(result.measurements[:, 0] == 0)  # classified while leaked
     assert np.all(result.measurements[:, 1] == 1)  # recaptured to e
     assert (result.final_status[:, 0] == COMPUTATIONAL).all()
 
 
-def test_mx_classified_deterministic():
+def test_mx_classified_deterministic(noncomp_sampling_api):
     """MX on a certainly-lost qubit reads the classifier's lost column.
 
     The lost column [0.0, 1.0] is deterministic 1."""
@@ -735,58 +741,58 @@ def test_mx_classified_deterministic():
     transitions = {"S": transition_to(LOST)}
     classifier = classifier_for(LOST, [0.0, 1.0])
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
-    r = noncomp.sample(circuit, model, shots=8, seed=201)
+    r = noncomp_sampling_api(circuit, model, shots=8, seed=201)
     assert r.num_measurements == 1
     assert (r.measurements[:, 0] == 1).all()
     assert (r.final_status[:, 0] == LOST_KIND).all()
 
 
-def test_mx_inverted_complements_classifier_bit():
+def test_mx_inverted_complements_classifier_bit(noncomp_sampling_api):
     """MX !0 on a certainly-lost qubit produces the complement of the classifier bit."""
     circuit = "S 0\nMX !0\n"
     transitions = {"S": transition_to(LOST)}
     classifier = classifier_for(LOST, [0.0, 1.0])  # lost column: always 1 without inversion
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
-    r = noncomp.sample(circuit, model, shots=8, seed=203)
+    r = noncomp_sampling_api(circuit, model, shots=8, seed=203)
     assert (r.measurements[:, 0] == 0).all()  # inverted: 1 -> 0
 
 
-def test_mry_classifies_and_restores_a_leaked_site():
+def test_mry_classifies_and_restores_a_leaked_site(noncomp_sampling_api):
     model = noncomp.Model(
         transitions={"S": transition_to(LEAK_G)},
         classifier=classifier_for(LEAK_G, [0.0, 1.0]),
     )
-    result = noncomp.sample("S 0\nMRY 0", model, shots=8, seed=204)
+    result = noncomp_sampling_api("S 0\nMRY 0", model, shots=8, seed=204)
     assert (result.measurements == 1).all()
     assert (result.final_status == COMPUTATIONAL).all()
 
 
-def test_capable_model_with_measurement_requires_classifier():
+def test_capable_model_with_measurement_requires_classifier(noncomp_sampling_api):
     """A model that can lose qubits requires a classifier when the circuit measures."""
     transitions = {"S": transition_to(LOST)}
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions)
     # The circuit uses the "S" hook so the annotated circuit has a
     # LEVEL_TRANSITION node that fires into the noncomp category.
     with pytest.raises(ValueError, match="classifier is required"):
-        noncomp.sample("H 0\nS 0\nM 0\n", model, shots=4, seed=4)
+        noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=4, seed=4)
 
 
-def test_mpad_does_not_require_classifier():
+def test_mpad_does_not_require_classifier(noncomp_sampling_api):
     """MPAD writes classical literals and never reads a noncomputational carrier."""
     model = noncomp.Model(initial_state=ALL_G, transitions={"S": transition_to(LOST)})
-    result = noncomp.sample("S 0\nMPAD 0 1\n", model, shots=4, seed=4)
+    result = noncomp_sampling_api("S 0\nMPAD 0 1\n", model, shots=4, seed=4)
 
     assert (result.measurements == [0, 1]).all()
     assert (result.final_status[:, 0] == LOST_KIND).all()
 
 
-def test_capable_model_rejects_mpp():
+def test_capable_model_rejects_mpp(noncomp_sampling_api):
     """MPP is not supported when the model can leak or lose qubits."""
     transitions = {"S": transition_to(LOST)}
     classifier = classifier_for(LOST, [0.5, 0.5])
     model = noncomp.Model(initial_state=ALL_G, transitions=transitions, classifier=classifier)
     with pytest.raises(ValueError, match="not supported"):
-        noncomp.sample("S 0\nMPP Z0*Z1\n", model, shots=4, seed=5)
+        noncomp_sampling_api("S 0\nMPP Z0*Z1\n", model, shots=4, seed=5)
 
 
 def test_exp_val_probe_is_rejected(noncomp_sampling_api):
@@ -858,7 +864,7 @@ def test_qubit_status_not_level_collision_guard():
     assert int(noncomp.QubitStatus.LEAK_G) != int(noncomp.Level.LEAK_G)
 
 
-def test_fine_grained_leak_e_status():
+def test_fine_grained_leak_e_status(noncomp_sampling_api):
     """A certain leak into leak_e yields final_status == QubitStatus.LEAK_E."""
     t = _zeros(5, 5)
     t[noncomp.Level.LEAK_E][noncomp.Level.G] = 1.0
@@ -868,12 +874,12 @@ def test_fine_grained_leak_e_status():
         transitions={"S": t},
         classifier=classifier_for(noncomp.Level.LEAK_E, [0.0, 1.0]),
     )
-    r = noncomp.sample("S 0\n", model, shots=8, seed=77)
+    r = noncomp_sampling_api("S 0\n", model, shots=8, seed=77)
     assert (r.final_status == noncomp.QubitStatus.LEAK_E).all()
 
 
-def test_model_default_initial_state_reads_zero():
-    r = noncomp.sample("M 0", noncomp.Model(), shots=4, seed=1)
+def test_model_default_initial_state_reads_zero(noncomp_sampling_api):
+    r = noncomp_sampling_api("M 0", noncomp.Model(), shots=4, seed=1)
     assert np.all(r.measurements == 0)
 
 
@@ -941,13 +947,13 @@ def test_ternary_herald_on_measure_reset(noncomp_sampling_api):
     assert np.all(r.final_status[:, 0] == COMPUTATIONAL), "final status was not COMPUTATIONAL"
 
 
-def test_seed_none_smoke():
+def test_seed_none_smoke(noncomp_sampling_api):
     """sample() with no seed runs and returns the correct shapes.
 
     The entropy-default path (seed=None) is never exercised by the
     determinism or different-seed checks.  A shape-only smoke test is
     sufficient: correctness is covered by the seeded suite."""
-    r = noncomp.sample("H 0\nM 0", noncomp.Model(), shots=8)
+    r = noncomp_sampling_api("H 0\nM 0", noncomp.Model(), shots=8)
     assert r.shots == 8
     assert r.num_measurements == 1
     assert r.measurements.shape == (8, 1)

--- a/tests/python/test_noncomp_oracle.py
+++ b/tests/python/test_noncomp_oracle.py
@@ -1,9 +1,9 @@
-"""Cross-check clifft.noncomp sampling against an independent reference.
+"""Cross-check both noncomputational executors against an independent reference.
 
 The reference (``utils_noncomp_oracle``) is a tiny numpy density-matrix
 simulator built from first principles, plus explicit closed-form probabilities
 for the classical events (initial level, transitions, classifier). It is
-independent of clifft's sampler/rewriter/SVM. We first self-check the reference
+independent of Clifft's rewriter and executors. We first self-check the reference
 against clifft's own simulator on lossless circuits, then use it to validate the
 supported noncomputational subset within shot noise.
 
@@ -65,10 +65,10 @@ def test_oracle_partial_trace_of_bell_is_maximally_mixed():
 # Supported noncomputational behavior against the reference.
 
 
-def test_lossless_matches_clifft_distribution():
+def test_lossless_matches_clifft_distribution(noncomp_sampling_api):
     text = "H 0\nCX 0 1\nM 0\nM 1\n"
     model = noncomp.Model(initial_state=[1.0, 0.0, 0.0, 0.0, 0.0])
-    nc = noncomp.sample(text, model, shots=SHOTS, seed=1)
+    nc = noncomp_sampling_api(text, model, shots=SHOTS, seed=1)
     plain = np.asarray(clifft.sample(clifft.compile(text), SHOTS, 1).measurements)
     nc_m = np.asarray(nc.measurements)
     for q in range(2):
@@ -77,27 +77,27 @@ def test_lossless_matches_clifft_distribution():
     assert (nc_m[:, 0] == nc_m[:, 1]).mean() > 0.99
 
 
-def test_initial_population_sampling():
+def test_initial_population_sampling(noncomp_sampling_api):
     # 70% g (-> 0), 30% e (-> 1 via X-prep); expected P(record=1) = 0.3.
     model = noncomp.Model(initial_state=[0.7, 0.3, 0.0, 0.0, 0.0])
-    r = noncomp.sample("M 0\n", model, shots=SHOTS, seed=2)
+    r = noncomp_sampling_api("M 0\n", model, shots=SHOTS, seed=2)
     assert abs(_p1(r, 0) - 0.3) < BAND
 
 
-def test_transition_probability_on_known_source():
+def test_transition_probability_on_known_source(noncomp_sampling_api):
     # On known g, S jumps to leak_g with prob 0.4 (deficit 0.6 stays g).
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
         transitions={"S": noncomp_transition_matrix({(Level.LEAK_G, Level.G): 0.4})},
     )
-    r = noncomp.sample("S 0\n", model, shots=SHOTS, seed=3)
+    r = noncomp_sampling_api("S 0\n", model, shots=SHOTS, seed=3)
     leaked = np.isin(
         np.asarray(r.final_status), (noncomp.QubitStatus.LEAK_G, noncomp.QubitStatus.LEAK_E)
     ).mean()
     assert abs(leaked - 0.4) < BAND
 
 
-def test_inline_leakage_matches_exact_enumerator():
+def test_inline_leakage_matches_exact_enumerator(noncomp_sampling_api):
     """Source-preserving leakage agrees on entangled records and statuses."""
     import utils_noncomp_enumerator as en
 
@@ -112,7 +112,7 @@ def test_inline_leakage_matches_exact_enumerator():
     )
     assert reference.dropped_mass < 1e-12
 
-    result = noncomp.sample(
+    result = noncomp_sampling_api(
         circuit,
         noncomp.Model(classifier=noncomp.Classifier(classifier_matrix)),
         shots=SHOTS,
@@ -132,7 +132,7 @@ def test_inline_leakage_matches_exact_enumerator():
             assert abs(observed - expected) < BAND
 
 
-def test_inline_leakage_measure_reset_reprepares_parked_factor():
+def test_inline_leakage_measure_reset_reprepares_parked_factor(noncomp_sampling_api):
     """MR restores a leaked carrier at zero in both reference and sampler."""
     import utils_noncomp_enumerator as en
 
@@ -146,7 +146,7 @@ def test_inline_leakage_measure_reset_reprepares_parked_factor():
     )
     assert reference.record_probs == {(1, 0): 1.0}
 
-    result = noncomp.sample(
+    result = noncomp_sampling_api(
         circuit,
         noncomp.Model(classifier=noncomp.Classifier(classifier_matrix)),
         shots=32,
@@ -156,7 +156,7 @@ def test_inline_leakage_measure_reset_reprepares_parked_factor():
 
 
 @pytest.mark.parametrize("col,expected", [([0.0, 1.0], 1.0), ([1.0, 0.0], 0.0), ([0.5, 0.5], 0.5)])
-def test_classifier_replacement_distribution(col, expected):
+def test_classifier_replacement_distribution(col, expected, noncomp_sampling_api):
     # Always leak to leak_g, then the classifier's column sets the record bit.
     model = noncomp.Model(
         initial_state=[1.0, 0.0, 0.0, 0.0, 0.0],
@@ -167,11 +167,11 @@ def test_classifier_replacement_distribution(col, expected):
         },
         classifier=_classifier(Level.LEAK_G, col),
     )
-    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=4)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=4)
     assert abs(_p1(r, 0) - expected) < BAND
 
 
-def test_partial_relaxation_matches_analytic_mixture():
+def test_partial_relaxation_matches_analytic_mixture(noncomp_sampling_api):
     # With probability p the S transition collapses the H-prepared |+> to g;
     # otherwise the carrier stays coherent. P(M=1) = (1 - p) * P(1 | H|0>).
     p = 0.3
@@ -181,13 +181,13 @@ def test_partial_relaxation_matches_analytic_mixture():
             "S": noncomp_transition_matrix({(Level.G, Level.G): p, (Level.G, Level.E): p})
         },
     )
-    r = noncomp.sample("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=6)
+    r = noncomp_sampling_api("H 0\nS 0\nM 0\n", model, shots=SHOTS, seed=6)
     h = oracle.apply_1q(oracle.zero_state(1), "H", 0, 1)
     expected = (1 - p) * oracle.prob_one(h, 0, 1)
     assert abs(_p1(r, 0) - expected) < BAND
 
 
-def test_survivor_marginal_equals_partial_trace():
+def test_survivor_marginal_equals_partial_trace(noncomp_sampling_api):
     # Bell pair, lose qubit 0. The survivor's record marginal must equal the
     # reference partial trace (0.5), and the lost record follows the classifier.
     model = noncomp.Model(
@@ -197,7 +197,7 @@ def test_survivor_marginal_equals_partial_trace():
         },
         classifier=_classifier(Level.LOST, [0.5, 0.5]),
     )
-    r = noncomp.sample("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=SHOTS, seed=5)
+    r = noncomp_sampling_api("H 0\nCX 0 1\nS 0\nM 0\nM 1\n", model, shots=SHOTS, seed=5)
 
     bell = oracle.apply_cx(oracle.apply_1q(oracle.zero_state(2), "H", 0, 2), 0, 1, 2)
     expected_survivor = oracle.marginal_one_after_trace_out(bell, lost=0, survivor=1, n=2)
@@ -249,7 +249,7 @@ def test_set_collapsed_qubit_reprepares_destination():
 # Two-site exact-damping composition against the enumerator.
 
 
-def test_two_site_exact_damping_composition_matches_enumerator():
+def test_two_site_exact_damping_composition_matches_enumerator(noncomp_sampling_api):
     """Two LEVEL_TRANSITION[leak] sites in a row with p=0.5 from e, exact damping.
 
     Circuit: H 0 / LEVEL_TRANSITION[leak] 0 / LEVEL_TRANSITION[leak] 0 / H 0 / M 0.
@@ -285,7 +285,7 @@ def test_two_site_exact_damping_composition_matches_enumerator():
         classifier=_classifier(Level.LEAK_E, [0.0, 1.0]),
         damping="exact",
     )
-    r = noncomp.sample(circuit_text, model, shots=SHOTS, seed=31)
+    r = noncomp_sampling_api(circuit_text, model, shots=SHOTS, seed=31)
 
     empirical = en.empirical_record_probs(np.asarray(r.measurements))
     tvd = en.tvd(reference.record_probs, empirical)

--- a/tests/python/test_noncomp_trajectory_probes.py
+++ b/tests/python/test_noncomp_trajectory_probes.py
@@ -37,20 +37,22 @@ def _model(transitions: dict, damping: str = "exact") -> noncomp.Model:
     )
 
 
-def test_gate_determined_source_fires_exactly_zero():
+def test_gate_determined_source_fires_exactly_zero(noncomp_sampling_api):
     """H then H returns the qubit to |g> by algebra; a leak that fires only
     from e must then never fire -- the fire draw conditions on the live
     state, where <P_e> is exactly 0. The certain rate (p = 1) makes any
     ahead-of-time source guess loud: a uniform draw would leak half the
     shots."""
     model = _model({"leak": noncomp_transition_matrix({(Level.LEAK_E, Level.E): 1.0})})
-    r = noncomp.sample("H 0\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0\n", model, shots=SHOTS, seed=11)
+    r = noncomp_sampling_api(
+        "H 0\nH 0\nLEVEL_TRANSITION[leak] 0\nM 0\n", model, shots=SHOTS, seed=11
+    )
     status = np.asarray(r.final_status)
     assert (status == noncomp.QubitStatus.COMPUTATIONAL).all()
     assert (np.asarray(r.measurements) == 0).all()  # H H |0> measures 0
 
 
-def test_bell_joint_correlation_has_tvd_zero():
+def test_bell_joint_correlation_has_tvd_zero(noncomp_sampling_api):
     """Source-dependent certain destinations on a Bell half: the collapse
     that picks the source is the same collapse the partner's measurement
     sees, so the classified record and the partner agree on every shot.
@@ -63,7 +65,7 @@ def test_bell_joint_correlation_has_tvd_zero():
             )
         }
     )
-    r = noncomp.sample(
+    r = noncomp_sampling_api(
         "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n", model, shots=SHOTS, seed=12
     )
     m = np.asarray(r.measurements)
@@ -75,7 +77,7 @@ def test_bell_joint_correlation_has_tvd_zero():
     assert abs(m[:, 0].mean() - 0.5) < binomial_tolerance(0.5, SHOTS)
 
 
-def test_damping_boundary_probe_separates_exact_from_neglect():
+def test_damping_boundary_probe_separates_exact_from_neglect(noncomp_sampling_api):
     """|+> through one leak-from-e site, then an X-basis readout (H, M).
 
     The no-fire branch's back-action is the whole difference between the
@@ -106,8 +108,10 @@ def test_damping_boundary_probe_separates_exact_from_neglect():
         tol_exact + tol_neglect
     ), "probe lost its discriminating power; adjust p or SHOTS"
 
-    r_exact = noncomp.sample(text, _model(transitions, damping="exact"), shots=SHOTS, seed=13)
-    r_neglect = noncomp.sample(text, _model(transitions, damping="neglect"), shots=SHOTS, seed=14)
+    r_exact = noncomp_sampling_api(text, _model(transitions, damping="exact"), shots=SHOTS, seed=13)
+    r_neglect = noncomp_sampling_api(
+        text, _model(transitions, damping="neglect"), shots=SHOTS, seed=14
+    )
     p1_exact = float(np.asarray(r_exact.measurements)[:, 0].mean())
     p1_neglect = float(np.asarray(r_neglect.measurements)[:, 0].mean())
 
@@ -115,7 +119,7 @@ def test_damping_boundary_probe_separates_exact_from_neglect():
     assert abs(p1_neglect - expected_neglect) < tol_neglect
 
 
-def test_damping_null_source_independent_rates_make_neglect_exact():
+def test_damping_null_source_independent_rates_make_neglect_exact(noncomp_sampling_api):
     """Null counterpart of the boundary probe, which checks the direction the
     modes separate at source-DEPENDENT rates: when a transition's
     computational columns are EQUAL (fire 0.3 from g and from e, both to
@@ -142,7 +146,7 @@ def test_damping_null_source_independent_rates_make_neglect_exact():
             classifier=classifier,
             damping=damping,
         )
-        r = noncomp.sample(text, model, shots=shots, seed=11)
+        r = noncomp_sampling_api(text, model, shots=shots, seed=11)
         meas = np.asarray(r.measurements)[:, 0]
         status = np.asarray(r.final_status)[:, 0]
 
@@ -160,7 +164,7 @@ def test_damping_null_source_independent_rates_make_neglect_exact():
     assert abs(means["exact"] - means["neglect"]) < 8 * sigma
 
 
-def test_entangled_two_site_chain_matches_hand_derived_distribution():
+def test_entangled_two_site_chain_matches_hand_derived_distribution(noncomp_sampling_api):
     """GHZ across three qubits with two sequential leak sites; exact joint distribution.
 
     State after H 0 / CX 0 1 / CX 0 2: (|000> + |111>) / sqrt(2).
@@ -189,7 +193,7 @@ def test_entangled_two_site_chain_matches_hand_derived_distribution():
         "LEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
         "M 0\nM 1\nM 2\n"
     )
-    r = noncomp.sample(circuit, model, shots=SHOTS, seed=16)
+    r = noncomp_sampling_api(circuit, model, shots=SHOTS, seed=16)
     m = np.asarray(r.measurements)
 
     expected = {
@@ -230,7 +234,7 @@ def test_entangled_two_site_chain_matches_hand_derived_distribution():
     assert abs(float(both_leaked) - 0.405) < binomial_tolerance(0.405, SHOTS)
 
 
-def test_neglect_bell_correlation_probe():
+def test_neglect_bell_correlation_probe(noncomp_sampling_api):
     """Neglect-mode forced trace-out keeps the source-determined partner correlation.
 
     Model: source-dependent "leak" (e->leak_e p=1, g stays), identity
@@ -254,7 +258,7 @@ def test_neglect_bell_correlation_probe():
     model = _model(transitions, damping="neglect")
     text = "H 0\nCX 0 1\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n"
 
-    r = noncomp.sample(text, model, shots=PROBE_SHOTS, seed=15)
+    r = noncomp_sampling_api(text, model, shots=PROBE_SHOTS, seed=15)
     m = np.asarray(r.measurements)
 
     # Per-shot correlation: m0 and m1 must agree on every shot.

--- a/tests/python/test_noncomp_trajectory_tvd.py
+++ b/tests/python/test_noncomp_trajectory_tvd.py
@@ -3,12 +3,14 @@
 The enumerator (``utils_noncomp_enumerator``) computes the exact joint
 distribution of the visible record from first principles; the tests here
 first self-check it against hand-derived closed forms, then compare
-clifft's trajectory sampling to it on a distance-3 repetition-code round
+both trajectory executors to it on a distance-3 repetition-code round
 at cold-atom-magnitude rates, by total variation distance with a
 shot-noise band calibrated from the reference distribution itself.
 """
 
 from __future__ import annotations
+
+from collections.abc import Callable
 
 import numpy as np
 import utils_noncomp_enumerator as en
@@ -153,7 +155,9 @@ def _status_kind_fractions(noncomp_probs: dict[int, float]) -> tuple[float, floa
     return leaked, lost
 
 
-def _run_and_compare(seed: int) -> None:
+def _run_and_compare(
+    seed: int, sample_noncomp: Callable[..., noncomp.NonComputationalSample]
+) -> None:
     reference = en.enumerate_exact(
         REP_CODE_ROUND,
         initial=INITIAL,
@@ -163,7 +167,7 @@ def _run_and_compare(seed: int) -> None:
     )
     assert reference.dropped_mass < 1e-6
 
-    r = noncomp.sample(REP_CODE_ROUND, _model(INITIAL, TRANSITIONS), shots=SHOTS, seed=seed)
+    r = sample_noncomp(REP_CODE_ROUND, _model(INITIAL, TRANSITIONS), shots=SHOTS, seed=seed)
     empirical = en.empirical_record_probs(np.asarray(r.measurements))
 
     band = _shot_noise_band(reference.record_probs, SHOTS) + reference.dropped_mass
@@ -183,5 +187,5 @@ def _run_and_compare(seed: int) -> None:
         assert abs(got_lost - want_lost) < binomial_tolerance(max(want_lost, 1e-4), SHOTS)
 
 
-def test_rep_code_round_tvd_reaches_shot_noise():
-    _run_and_compare(seed=21)
+def test_rep_code_round_tvd_reaches_shot_noise(noncomp_sampling_api):
+    _run_and_compare(seed=21, sample_noncomp=noncomp_sampling_api)

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -274,9 +274,9 @@ TEST_CASE("trajectory: same seed reproduces identical runs") {
     }
 }
 
-TEST_CASE("trajectory: the driver and SVM seed streams are domain-separated") {
+TEST_CASE("trajectory: the driver and executor seed streams are domain-separated") {
     // The host draws (initial levels, trap destinations, classifier consults)
-    // and the in-VM Born draws run on independent streams; handing the same
+    // and the in-executor Born draws run on independent streams; handing the same
     // per-shot state to both would correlate them. Guard the documented domain
     // split at its source: for every shot, the same (root, shot) with
     // different domains yields unrelated states.
@@ -284,14 +284,15 @@ TEST_CASE("trajectory: the driver and SVM seed streams are domain-separated") {
         const SeedRoot root = seed_root_from_seed(seed);
         for (uint64_t shot = 0; shot < 16; ++shot) {
             const std::array<uint64_t, 4> host = derive_state(root, shot, kTrajectoryDriverDomain);
-            const std::array<uint64_t, 4> svm = derive_state(root, shot, kTrajectorySvmDomain);
-            REQUIRE(host != svm);
+            const std::array<uint64_t, 4> executor =
+                derive_state(root, shot, kTrajectoryExecutorDomain);
+            REQUIRE(host != executor);
         }
     }
 }
 
 TEST_CASE("trajectory: a cross-domain word alias does not expand to a full-state collision") {
-    // Shots 1302581290 (driver) and 4231854694 (SVM) alias on derived word 0
+    // Shots 1302581290 (driver) and 4231854694 (executor) alias on derived word 0
     // for every root: the root and the word-0 tag terms cancel in the
     // comparison. They probe the word index folded into the domain tag --
     // without it, the alias would repeat in all four words and the two
@@ -300,9 +301,10 @@ TEST_CASE("trajectory: a cross-domain word alias does not expand to a full-state
         const SeedRoot root = seed_root_from_seed(seed);
         const std::array<uint64_t, 4> driver =
             derive_state(root, 1302581290ULL, kTrajectoryDriverDomain);
-        const std::array<uint64_t, 4> svm = derive_state(root, 4231854694ULL, kTrajectorySvmDomain);
-        REQUIRE(driver[0] == svm[0]);
-        REQUIRE(driver != svm);
+        const std::array<uint64_t, 4> executor =
+            derive_state(root, 4231854694ULL, kTrajectoryExecutorDomain);
+        REQUIRE(driver[0] == executor[0]);
+        REQUIRE(driver != executor);
     }
 }
 


### PR DESCRIPTION
## Summary

- connect the existing leakage/loss rewriter and trajectory lifecycle to the symbolic-coordinate sampling executor, including initial levels, chained traps, forced trace-out records, heralds, and continuation storage growth
- expose `clifft.experimental.sample_noncomputational(...)` with the same inputs and result type as `clifft.noncomp.sample(...)`, while leaving the SVM route as the stable default
- share trajectory validation, herald patching, and HIR preparation across both drivers
- run every backend-applicable Python noncomputational sampling test through both executors, including the independent density-matrix oracle, exact enumerator, closed-form trajectory probes, and repetition-code TVD comparison

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `./build/tests/clifft_tests '~Bench:*'` — 1,215 cases / 372,932 assertions
- `uv run pytest tests/python -q` — 1,074 passed

EXP_VAL and exact-query integration remain separate follow-up sequencing decisions.

Closes #269