### PR TITLE
feat(sampling): add expectation value probes

### DIFF
--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -51,6 +51,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       num_hidden_records_(plan.num_hidden_records),
       num_detectors_(plan.num_detectors),
       num_observables_(plan.num_observables),
+      num_exp_vals_(plan.num_exp_vals),
       has_postselection_(plan.has_postselection),
       global_weight_(plan.global_weight),
       instrument_distributions_(plan.instrument_distributions) {
@@ -82,6 +83,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, WriteDetector> ||
                                      std::is_same_v<T, WriteObservable>) {
                     num_expression_terms += typed.outcome.terms().size();
+                } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                    num_expression_terms += typed.sign.terms().size();
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     num_expression_terms += typed.sign.terms().size();
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
@@ -175,6 +178,13 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     actions_.emplace_back(ExecuteObservable{prepare_expression(typed.outcome),
                                                             index(typed.observable)});
+                } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                    std::optional<PreparedPauli> pauli;
+                    if (typed.pauli.has_value()) {
+                        pauli = prepare_pauli(*typed.pauli, planned.active_before);
+                    }
+                    actions_.emplace_back(ExecuteExpectation{
+                        std::move(pauli), prepare_expression(typed.sign), index(typed.exp_val)});
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     has_instruments_ = true;
                     std::optional<PreparedMeasurement> measurement;
@@ -242,6 +252,7 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
       detectors_(plan.num_detectors_, 0),
       observables_(plan.num_observables_, 0),
+      exp_vals_(plan.num_exp_vals_, 0.0),
       forced_record_mask_(records_.size(), 0),
       forced_record_values_(records_.size(), 0),
       rng_(seed) {
@@ -298,7 +309,8 @@ void Executor::resume(const ExecutablePlan& continuation,
     if (continuation.num_qubits_ != plan_->num_qubits_ ||
         continuation.num_visible_records_ != plan_->num_visible_records_ ||
         continuation.num_detectors_ != plan_->num_detectors_ ||
-        continuation.num_observables_ != plan_->num_observables_) {
+        continuation.num_observables_ != plan_->num_observables_ ||
+        continuation.num_exp_vals_ != plan_->num_exp_vals_) {
         throw std::invalid_argument(
             "sampling continuation changes externally visible plan dimensions");
     }
@@ -537,6 +549,18 @@ void Executor::execute_action(const ExecutablePlan::ExecuteObservable& action,
 }
 
 template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    assert(action.exp_val < exp_vals_.size() && "expectation slot must be preallocated");
+    if (!action.pauli.has_value()) {
+        exp_vals_[action.exp_val] = 0.0;
+        return;
+    }
+    const double value = expectation_value(state_, *action.pauli);
+    exp_vals_[action.exp_val] = evaluate(action.sign) ? -value : value;
+}
+
+template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
                               std::span<const uint8_t>, ReplayResult& result) noexcept {
     if constexpr (ForceRecords) {
@@ -751,6 +775,7 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
     result.measurements.resize(checked_size(plan.num_visible_records()));
     result.detectors.resize(checked_size(plan.num_detectors()));
     result.observables.resize(checked_size(plan.num_observables()));
+    result.exp_vals.resize(checked_size(plan.num_exp_vals()));
     if (shots == 0) {
         return result;
     }
@@ -767,6 +792,9 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
             std::ranges::copy(
                 executor.observables(),
                 result.observables.begin() + static_cast<size_t>(shot) * plan.num_observables());
+            std::ranges::copy(
+                executor.exp_vals(),
+                result.exp_vals.begin() + static_cast<size_t>(shot) * plan.num_exp_vals());
         }
     };
     if (seed.has_value()) {
@@ -812,6 +840,7 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
         result.measurements.reserve(checked_reserve(plan.num_visible_records()));
         result.detectors.reserve(checked_reserve(plan.num_detectors()));
         result.observables.reserve(checked_reserve(plan.num_observables()));
+        result.exp_vals.reserve(checked_reserve(plan.num_exp_vals()));
     }
     auto run = [&](Executor& executor) {
         for (uint32_t shot = 0; shot < shots; ++shot) {
@@ -835,6 +864,8 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
                                         executor.detectors().end());
                 result.observables.insert(result.observables.end(), executor.observables().begin(),
                                           executor.observables().end());
+                result.exp_vals.insert(result.exp_vals.end(), executor.exp_vals().begin(),
+                                       executor.exp_vals().end());
             }
         }
     };

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -179,12 +179,14 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                     actions_.emplace_back(ExecuteObservable{prepare_expression(typed.outcome),
                                                             index(typed.observable)});
                 } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
-                    std::optional<PreparedPauli> pauli;
-                    if (typed.pauli.has_value()) {
-                        pauli = prepare_pauli(*typed.pauli, planned.active_before);
+                    std::optional<PreparedPauli> active_projection;
+                    if (typed.active_projection.has_value()) {
+                        active_projection =
+                            prepare_pauli(*typed.active_projection, planned.active_before);
                     }
-                    actions_.emplace_back(ExecuteExpectation{
-                        std::move(pauli), prepare_expression(typed.sign), index(typed.exp_val)});
+                    actions_.emplace_back(ExecuteExpectation{std::move(active_projection),
+                                                             prepare_expression(typed.sign),
+                                                             index(typed.exp_val)});
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     has_instruments_ = true;
                     std::optional<PreparedMeasurement> measurement;
@@ -552,11 +554,14 @@ template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.exp_val < exp_vals_.size() && "expectation slot must be preallocated");
-    if (!action.pauli.has_value()) {
+    if (!action.active_projection.has_value()) {
+        // Outputs are overwritten instead of cleared at each shot. This store
+        // also prevents stale values when a continuation changes the planner's
+        // classification of the same probe from active to exact zero.
         exp_vals_[action.exp_val] = 0.0;
         return;
     }
-    const double value = expectation_value(state_, *action.pauli);
+    const double value = expectation_value(state_, *action.active_projection);
     exp_vals_[action.exp_val] = evaluate(action.sign) ? -value : value;
 }
 

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -67,6 +67,7 @@ class ExecutablePlan {
     [[nodiscard]] uint32_t num_hidden_records() const { return num_hidden_records_; }
     [[nodiscard]] uint32_t num_detectors() const { return num_detectors_; }
     [[nodiscard]] uint32_t num_observables() const { return num_observables_; }
+    [[nodiscard]] uint32_t num_exp_vals() const { return num_exp_vals_; }
     [[nodiscard]] bool has_postselection() const { return has_postselection_; }
     [[nodiscard]] bool has_readout_noise() const { return has_readout_noise_; }
     [[nodiscard]] bool has_instruments() const { return has_instruments_; }
@@ -147,6 +148,12 @@ class ExecutablePlan {
         uint32_t observable = 0;
     };
 
+    struct ExecuteExpectation {
+        std::optional<PreparedPauli> pauli;
+        PreparedExpression sign;
+        uint32_t exp_val = 0;
+    };
+
     struct ExecuteInstrument {
         InstrumentMode mode = InstrumentMode::Classical;
         PreparedExpression sign;
@@ -174,10 +181,11 @@ class ExecutablePlan {
         double total_probability = 0.0;
     };
 
-    using Action = std::variant<ExecuteRotation, ExecutePromotion, ExecuteActiveMeasurement,
-                                ExecuteDormantMeasurement, ExecuteClassicalRecord,
-                                ExecuteSymbolDefinition, ExecuteReadoutNoise, ExecuteDetector,
-                                ExecuteObservable, ExecuteInstrument, ExecuteBoundary>;
+    using Action =
+        std::variant<ExecuteRotation, ExecutePromotion, ExecuteActiveMeasurement,
+                     ExecuteDormantMeasurement, ExecuteClassicalRecord, ExecuteSymbolDefinition,
+                     ExecuteReadoutNoise, ExecuteDetector, ExecuteObservable, ExecuteExpectation,
+                     ExecuteInstrument, ExecuteBoundary>;
 
     PreparedExpression prepare_expression(const AffineBool& expression);
     PreparedExpression prepare_measurement_correction(const AffineBool& outcome, uint32_t branch);
@@ -189,6 +197,7 @@ class ExecutablePlan {
     uint32_t num_hidden_records_ = 0;
     uint32_t num_detectors_ = 0;
     uint32_t num_observables_ = 0;
+    uint32_t num_exp_vals_ = 0;
     uint32_t num_symbols_ = 0;
     bool has_postselection_ = false;
     bool has_readout_noise_ = false;
@@ -267,6 +276,7 @@ class Executor {
     }
     [[nodiscard]] std::span<const uint8_t> detectors() const { return detectors_; }
     [[nodiscard]] std::span<const uint8_t> observables() const { return observables_; }
+    [[nodiscard]] std::span<const double> exp_vals() const { return exp_vals_; }
     [[nodiscard]] bool discarded() const { return discarded_; }
     [[nodiscard]] std::optional<InstrumentTrap> pending_trap() const { return pending_trap_; }
     [[nodiscard]] const State& state() const { return state_; }
@@ -310,6 +320,9 @@ class Executor {
     void execute_action(const ExecutablePlan::ExecuteObservable& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteExpectation& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteInstrument& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <bool SampleNoise>
@@ -329,6 +342,7 @@ class Executor {
     std::vector<uint8_t> records_;
     std::vector<uint8_t> detectors_;
     std::vector<uint8_t> observables_;
+    std::vector<double> exp_vals_;
     std::vector<uint8_t> forced_record_mask_;
     std::vector<uint8_t> forced_record_values_;
     std::vector<uint32_t> previous_presampled_ones_;
@@ -358,6 +372,7 @@ struct SamplingResult {
     std::vector<uint8_t> measurements;
     std::vector<uint8_t> detectors;
     std::vector<uint8_t> observables;
+    std::vector<double> exp_vals;
 };
 
 struct SamplingSurvivorResult {
@@ -368,6 +383,7 @@ struct SamplingSurvivorResult {
     std::vector<uint8_t> measurements;
     std::vector<uint8_t> detectors;
     std::vector<uint8_t> observables;
+    std::vector<double> exp_vals;
 };
 
 [[nodiscard]] SamplingResult sample(const ExecutablePlan& plan, uint32_t shots,

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -149,7 +149,7 @@ class ExecutablePlan {
     };
 
     struct ExecuteExpectation {
-        std::optional<PreparedPauli> pauli;
+        std::optional<PreparedPauli> active_projection;
         PreparedExpression sign;
         uint32_t exp_val = 0;
     };

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -115,6 +115,28 @@ PreparedMeasurement prepare_measurement(ActivePauli pauli, uint32_t active_width
                                prepared.z & ~pivot_bit};
 }
 
+double expectation_value(const State& state, const PreparedPauli& pauli) noexcept {
+    assert_descriptor_width(state, pauli);
+    if (pauli.is_identity()) {
+        return 1.0;
+    }
+    const uint64_t size = state.size();
+    double result = 0.0;
+    if (pauli.is_diagonal()) {
+        for (uint64_t basis = 0; basis < size; ++basis) {
+            const double eigenvalue = (std::popcount(basis & pauli.z) & 1U) != 0 ? -1.0 : 1.0;
+            result += eigenvalue * std::norm(load(state, basis));
+        }
+        return result;
+    }
+
+    for (uint64_t basis = 0; basis < size; ++basis) {
+        result += std::real(std::conj(load(state, basis ^ pauli.x)) * phase_at(pauli, basis) *
+                            load(state, basis));
+    }
+    return result;
+}
+
 void apply_rotation(State& state, const PreparedRotation& rotation, bool sign) noexcept {
     assert_descriptor_width(state, rotation.pauli);
     const double sine = sign ? -rotation.sine : rotation.sine;

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -55,6 +55,10 @@ struct MeasurementProbabilities {
 [[nodiscard]] PreparedMeasurement prepare_measurement(ActivePauli pauli, uint32_t active_width,
                                                       uint32_t pivot);
 
+// Computes <P> on normalized active-coordinate coefficients. The common
+// global scalar cancels and the state is not mutated.
+[[nodiscard]] double expectation_value(const State& state, const PreparedPauli& pauli) noexcept;
+
 // Runtime signs have already been evaluated from the plan expression. A true
 // sign negates the Pauli, equivalently negating the prepared sine.
 void apply_rotation(State& state, const PreparedRotation& rotation, bool sign) noexcept;

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -165,6 +165,7 @@ std::optional<SymbolId> defined_symbol(const SamplingAction& action) {
                                  std::is_same_v<T, RecordClassical> ||
                                  std::is_same_v<T, WriteDetector> ||
                                  std::is_same_v<T, WriteObservable> ||
+                                 std::is_same_v<T, WriteExpectationValue> ||
                                  std::is_same_v<T, InstrumentBoundary>) {
                 return std::nullopt;
             } else {
@@ -309,6 +310,8 @@ uint32_t predicted_dense_passes(const SamplingAction& action) {
                         return 2;
                 }
                 return 0;
+            } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                return typed.pauli.has_value() && !typed.pauli->is_identity() ? 1 : 0;
             } else if constexpr (std::is_same_v<T, MeasureDormantRandom> ||
                                  std::is_same_v<T, RecordClassical> ||
                                  std::is_same_v<T, DefineSymbol> ||
@@ -484,6 +487,7 @@ void SamplingPlan::validate() const {
     std::unordered_set<uint32_t> written_records;
     std::unordered_set<uint32_t> written_detectors;
     std::unordered_set<uint32_t> written_observables;
+    std::unordered_set<uint32_t> written_exp_vals;
     bool observed_postselection = false;
     uint32_t observed_instruments = 0;
     uint32_t observed_instrument_boundaries = 0;
@@ -582,6 +586,18 @@ void SamplingPlan::validate() const {
                         invalid_plan("observable write has invalid width or slot");
                     }
                     validate_expression(*this, typed.outcome, action_index, definition, false);
+                } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                    if (planned.active_after != planned.active_before ||
+                        index(typed.exp_val) >= num_exp_vals ||
+                        !written_exp_vals.insert(index(typed.exp_val)).second) {
+                        invalid_plan("expectation write has invalid width or slot");
+                    }
+                    if (typed.pauli.has_value()) {
+                        validate_pauli(*typed.pauli, planned.active_before, action_index);
+                    } else if (typed.sign != AffineBool{}) {
+                        invalid_plan("zero expectation write has an irrelevant symbolic sign");
+                    }
+                    validate_expression(*this, typed.sign, action_index, definition, false);
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     if (index(typed.site) != observed_instruments ||
                         index(typed.site) >= num_instrument_sites) {
@@ -654,8 +670,9 @@ void SamplingPlan::validate() const {
         invalid_plan("declared record count does not match the action stream");
     }
     if (written_detectors.size() != num_detectors ||
-        written_observables.size() != num_observables) {
-        invalid_plan("declared detector or observable count does not match the action stream");
+        written_observables.size() != num_observables || written_exp_vals.size() != num_exp_vals) {
+        invalid_plan(
+            "declared detector, observable, or expectation count does not match the action stream");
     }
     if (observed_postselection != has_postselection) {
         invalid_plan("declared postselection flag does not match detector actions");
@@ -675,8 +692,9 @@ std::string SamplingPlan::inspect() const {
         << " max_width=" << max_active_width << " visible_records=" << num_visible_records
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
         << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
-        << " observables=" << num_observables << " postselection=" << has_postselection
-        << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
+        << " observables=" << num_observables << " exp_vals=" << num_exp_vals
+        << " postselection=" << has_postselection << " dust_epsilon=" << kMeasurementDustEpsilon
+        << '\n';
     out << "global_weight=" << global_weight.real() << ',' << global_weight.imag() << '\n';
     out << "symbols=" << symbols.size() << '\n';
     for (uint32_t i = 0; i < symbols.size(); ++i) {
@@ -739,6 +757,15 @@ std::string SamplingPlan::inspect() const {
                 } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     out << "write_observable outcome=" << format_expression(typed.outcome)
                         << " observable=" << index(typed.observable);
+                } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                    out << "write_expectation ";
+                    if (typed.pauli.has_value()) {
+                        out << format_pauli(*typed.pauli)
+                            << " sign=" << format_expression(typed.sign);
+                    } else {
+                        out << "zero";
+                    }
+                    out << " exp_val=" << index(typed.exp_val);
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     out << "apply_instrument site=" << index(typed.site)
                         << " mode=" << instrument_mode_name(typed.mode) << ' '

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -311,7 +311,10 @@ uint32_t predicted_dense_passes(const SamplingAction& action) {
                 }
                 return 0;
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
-                return typed.pauli.has_value() && !typed.pauli->is_identity() ? 1 : 0;
+                return typed.active_projection.has_value() &&
+                               !typed.active_projection->is_identity()
+                           ? 1
+                           : 0;
             } else if constexpr (std::is_same_v<T, MeasureDormantRandom> ||
                                  std::is_same_v<T, RecordClassical> ||
                                  std::is_same_v<T, DefineSymbol> ||
@@ -592,8 +595,9 @@ void SamplingPlan::validate() const {
                         !written_exp_vals.insert(index(typed.exp_val)).second) {
                         invalid_plan("expectation write has invalid width or slot");
                     }
-                    if (typed.pauli.has_value()) {
-                        validate_pauli(*typed.pauli, planned.active_before, action_index);
+                    if (typed.active_projection.has_value()) {
+                        validate_pauli(*typed.active_projection, planned.active_before,
+                                       action_index);
                     } else if (typed.sign != AffineBool{}) {
                         invalid_plan("zero expectation write has an irrelevant symbolic sign");
                     }
@@ -759,8 +763,8 @@ std::string SamplingPlan::inspect() const {
                         << " observable=" << index(typed.observable);
                 } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                     out << "write_expectation ";
-                    if (typed.pauli.has_value()) {
-                        out << format_pauli(*typed.pauli)
+                    if (typed.active_projection.has_value()) {
+                        out << format_pauli(*typed.active_projection)
                             << " sign=" << format_expression(typed.sign);
                     } else {
                         out << "zero";

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -199,11 +199,11 @@ struct WriteObservable {
     ObservableSlot observable{};
 };
 
-// Writes a non-destructive Pauli expectation probe. An absent active Pauli
-// means the transformed operator has X or Y support on a dormant |0>
-// coordinate, so its expectation is exactly zero without coefficient work.
+// Writes a non-destructive Pauli expectation probe. The planner retains only
+// the coefficient-kernel input, not the full transformed observable: an absent
+// active projection means dormant X or Y support proved the result is zero.
 struct WriteExpectationValue {
-    std::optional<ActivePauli> pauli;
+    std::optional<ActivePauli> active_projection;
     AffineBool sign;
     ExpValSlot exp_val{};
 };

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -36,6 +36,7 @@ enum class NoiseSiteId : uint32_t {};
 enum class InstrumentSiteId : uint32_t {};
 enum class DetectorSlot : uint32_t {};
 enum class ObservableSlot : uint32_t {};
+enum class ExpValSlot : uint32_t {};
 
 // Keep the IDs non-interchangeable while giving every sampling layer one
 // explicit operation for indexing their plan-owned storage.
@@ -55,6 +56,9 @@ enum class ObservableSlot : uint32_t {};
     return static_cast<uint32_t>(slot);
 }
 [[nodiscard]] constexpr uint32_t index(ObservableSlot slot) noexcept {
+    return static_cast<uint32_t>(slot);
+}
+[[nodiscard]] constexpr uint32_t index(ExpValSlot slot) noexcept {
     return static_cast<uint32_t>(slot);
 }
 
@@ -195,6 +199,15 @@ struct WriteObservable {
     ObservableSlot observable{};
 };
 
+// Writes a non-destructive Pauli expectation probe. An absent active Pauli
+// means the transformed operator has X or Y support on a dormant |0>
+// coordinate, so its expectation is exactly zero without coefficient work.
+struct WriteExpectationValue {
+    std::optional<ActivePauli> pauli;
+    AffineBool sign;
+    ExpValSlot exp_val{};
+};
+
 // Instruments share one semantic action because their execution forms differ
 // only in how the source observable enters the dense state. The planner fixes
 // that choice; runtime never performs localization or topology discovery.
@@ -229,10 +242,10 @@ struct InstrumentBoundary {
     uint32_t symbol_prefix_size = 0;
 };
 
-using SamplingAction =
-    std::variant<RotateActivePauli, PromoteDormantRotation, MeasureActivePauli,
-                 MeasureDormantRandom, RecordClassical, DefineSymbol, ApplyReadoutNoise,
-                 WriteDetector, WriteObservable, ApplyInstrument, InstrumentBoundary>;
+using SamplingAction = std::variant<RotateActivePauli, PromoteDormantRotation, MeasureActivePauli,
+                                    MeasureDormantRandom, RecordClassical, DefineSymbol,
+                                    ApplyReadoutNoise, WriteDetector, WriteObservable,
+                                    WriteExpectationValue, ApplyInstrument, InstrumentBoundary>;
 
 struct PlannedAction {
     uint32_t active_before = 0;
@@ -291,6 +304,7 @@ struct SamplingPlan {
     uint32_t num_instrument_sites = 0;
     uint32_t num_detectors = 0;
     uint32_t num_observables = 0;
+    uint32_t num_exp_vals = 0;
     bool has_postselection = false;
     std::complex<double> global_weight = {1.0, 0.0};
 

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -42,6 +42,12 @@ struct PendingMeasurement {
     SymbolId branch{};
 };
 
+struct PendingExpectation {
+    Pauli body;
+    AffineBool sign;
+    ExpValSlot exp_val{};
+};
+
 struct PendingConditionalPauli {
     Pauli body;
     RecordSlot controller{};
@@ -93,9 +99,9 @@ struct PendingObservable {
     ObservableSlot observable{};
 };
 
-using PendingOperation =
-    std::variant<PendingRotation, PendingMeasurement, PendingConditionalPauli, PendingNoise,
-                 PendingReadoutNoise, PendingInstrument, PendingDetector, PendingObservable>;
+using PendingOperation = std::variant<PendingRotation, PendingMeasurement, PendingExpectation,
+                                      PendingConditionalPauli, PendingNoise, PendingReadoutNoise,
+                                      PendingInstrument, PendingDetector, PendingObservable>;
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
@@ -315,7 +321,8 @@ void visit_pending_pauli(PendingOperation& operation, Function&& function) {
         [&](auto& typed) {
             using T = std::decay_t<decltype(typed)>;
             if constexpr (std::is_same_v<T, PendingRotation> ||
-                          std::is_same_v<T, PendingMeasurement>) {
+                          std::is_same_v<T, PendingMeasurement> ||
+                          std::is_same_v<T, PendingExpectation>) {
                 function(typed.body, &typed.sign);
             } else if constexpr (std::is_same_v<T, PendingInstrument>) {
                 function(typed.body, &typed.sign);
@@ -363,6 +370,7 @@ void propagate_conditional_pauli(std::vector<PendingOperation>& pending, size_t 
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, PendingRotation> ||
                               std::is_same_v<T, PendingMeasurement> ||
+                              std::is_same_v<T, PendingExpectation> ||
                               std::is_same_v<T, PendingInstrument>) {
                     if (anticommutes(correction, typed.body)) {
                         typed.sign ^= condition;
@@ -392,6 +400,7 @@ void propagate_branch(std::vector<PendingOperation>& pending, size_t begin,
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, PendingRotation> ||
                               std::is_same_v<T, PendingMeasurement> ||
+                              std::is_same_v<T, PendingExpectation> ||
                               std::is_same_v<T, PendingInstrument>) {
                     if (typed.body.zs[branch_coordinate]) {
                         typed.sign ^= AffineBool::symbol(branch);
@@ -589,7 +598,16 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                                       ObservableSlot{observable_index}});
                 break;
             }
-            case OpType::EXP_VAL:
+            case OpType::EXP_VAL: {
+                const uint32_t exp_val_index = static_cast<uint32_t>(op.exp_val_idx());
+                if (exp_val_index >= hir.num_exp_vals) {
+                    throw std::invalid_argument(
+                        "sampling planner expectation slot is out of range");
+                }
+                pending.emplace_back(PendingExpectation{
+                    pauli_from_hir(hir, op), AffineBool(hir.sign(op)), ExpValSlot{exp_val_index}});
+                break;
+            }
             case OpType::NUM_OP_TYPES:
                 throw std::invalid_argument("sampling planner does not support HIR operation " +
                                             op_type_to_str(op.op_type()) + " at index " +
@@ -777,6 +795,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     plan.num_instrument_sites = static_cast<uint32_t>(hir.instrument_sites.size());
     plan.num_detectors = hir.num_detectors;
     plan.num_observables = hir.num_observables;
+    plan.num_exp_vals = hir.num_exp_vals;
     plan.global_weight = hir.global_weight;
 
     std::vector<PendingOperation> pending = queue_supported_operations(hir, plan, options);
@@ -845,6 +864,16 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                         ApplyReadoutNoise{flip, source, operation.record,
                                           operation.prob_zero_to_one, operation.prob_one_to_zero}});
                     record_values[index(operation.record)] = source ^ AffineBool::symbol(flip);
+                } else if constexpr (std::is_same_v<T, PendingExpectation>) {
+                    const bool is_zero =
+                        first_x_at_or_above(operation.body, active_width).has_value();
+                    plan.actions.push_back(PlannedAction{
+                        active_width, active_width,
+                        WriteExpectationValue{
+                            is_zero ? std::nullopt
+                                    : std::optional<ActivePauli>{active_projection(operation.body,
+                                                                                   active_width)},
+                            is_zero ? AffineBool{} : operation.sign, operation.exp_val}});
                 } else if constexpr (std::is_same_v<T, PendingInstrument>) {
                     process_instrument(pending, i, operation, plan, active_width);
                 } else if constexpr (std::is_same_v<T, PendingDetector>) {

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -920,6 +920,7 @@ NB_MODULE(_clifft_core, m) {
                      &clifft::sampling::ExecutablePlan::num_hidden_records)
         .def_prop_ro("num_detectors", &clifft::sampling::ExecutablePlan::num_detectors)
         .def_prop_ro("num_observables", &clifft::sampling::ExecutablePlan::num_observables)
+        .def_prop_ro("num_exp_vals", &clifft::sampling::ExecutablePlan::num_exp_vals)
         .def_prop_ro("has_postselection", &clifft::sampling::ExecutablePlan::has_postselection)
         .def_prop_ro("num_actions", &clifft::sampling::ExecutablePlan::num_actions)
         .def("__repr__", [](const clifft::sampling::ExecutablePlan& p) {
@@ -970,7 +971,9 @@ NB_MODULE(_clifft_core, m) {
                 vec_to_numpy(std::move(result.detectors), {shots, program.num_detectors()});
             auto observables =
                 vec_to_numpy(std::move(result.observables), {shots, program.num_observables()});
-            return nb::make_tuple(measurements, detectors, observables);
+            auto exp_vals =
+                vec_to_numpy(std::move(result.exp_vals), {shots, program.num_exp_vals()});
+            return nb::make_tuple(measurements, detectors, observables, exp_vals);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         "Sample an experimental scalar sampling program.");
@@ -994,8 +997,11 @@ NB_MODULE(_clifft_core, m) {
             const size_t num_observable_counts = result.observable_ones.size();
             auto observable_ones =
                 vec_to_numpy(std::move(result.observable_ones), {num_observable_counts});
+            auto exp_vals =
+                vec_to_numpy(std::move(result.exp_vals), {rows, program.num_exp_vals()});
             return nb::make_tuple(measurements, detectors, observables, result.total_shots,
-                                  result.passed_shots, result.logical_errors, observable_ones);
+                                  result.passed_shots, result.logical_errors, observable_ones,
+                                  exp_vals);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false,

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -46,8 +46,7 @@ def compile(
     """Compile Stim text for the experimental scalar sampling backend.
 
     The default HIR optimization pipeline matches :func:`clifft.compile`;
-    pass ``None`` to skip it. State-dependent instruments and exact-state
-    probes remain unsupported.
+    pass ``None`` to skip it. Exact final-state queries remain unsupported.
     """
     if isinstance(hir_passes, _DefaultPasses):
         hir_passes = default_hir_pass_manager()
@@ -66,15 +65,21 @@ def compile(
 
 def sample(program: Program, shots: int, seed: int | None = None) -> SampleResult:
     """Sample a prepared experimental program without changing Clifft's default backend."""
-    measurements, detectors, observables = cast(
+    measurements, detectors, observables, exp_vals = cast(
         tuple[
             npt.NDArray[np.uint8],
             npt.NDArray[np.uint8],
             npt.NDArray[np.uint8],
+            npt.NDArray[np.float64],
         ],
         _sample_experimental_sampling(program, shots, seed),
     )
-    return SampleResult(measurements, detectors, observables)
+    return SampleResult(
+        measurements,
+        detectors,
+        observables,
+        exp_vals=exp_vals,
+    )
 
 
 def sample_noncomputational(
@@ -100,7 +105,16 @@ def sample_survivors(
     keep_records: bool = False,
 ) -> SampleResult:
     """Sample survivor counts and optional records from an experimental program."""
-    measurements, detectors, observables, total, passed, logical_errors, observable_ones = cast(
+    (
+        measurements,
+        detectors,
+        observables,
+        total,
+        passed,
+        logical_errors,
+        observable_ones,
+        exp_vals,
+    ) = cast(
         tuple[
             npt.NDArray[np.uint8],
             npt.NDArray[np.uint8],
@@ -109,6 +123,7 @@ def sample_survivors(
             int,
             int,
             npt.NDArray[np.uint64],
+            npt.NDArray[np.float64],
         ],
         _sample_survivors_experimental_sampling(program, shots, seed, keep_records),
     )
@@ -120,6 +135,7 @@ def sample_survivors(
         passed,
         logical_errors,
         observable_ones,
+        exp_vals,
     )
 
 

--- a/tests/python/test_exp_value.py
+++ b/tests/python/test_exp_value.py
@@ -9,6 +9,8 @@ Tests cover:
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 from conftest import random_clifford_t_circuit
@@ -75,62 +77,75 @@ def random_pauli_product(num_qubits: int, rng: np.random.Generator) -> str:
 class TestExactOracle:
     """Compare EXP_VAL results to numpy statevector Pauli expectations."""
 
-    def test_single_qubit_x_on_plus(self) -> None:
+    def test_single_qubit_x_on_plus(self, sampling_api: Any) -> None:
         """<X> on |+> = +1."""
         circuit = "H 0"
         sv = clifft_statevector(circuit)
         expected = pauli_expectation(sv, "X0", 1)
 
-        result = clifft.sample(clifft.compile(f"{circuit}\nEXP_VAL X0"), 1, seed=0)
+        result = sampling_api.sample(sampling_api.compile(f"{circuit}\nEXP_VAL X0"), 1, seed=0)
         np.testing.assert_allclose(result.exp_vals[0, 0], expected, atol=1e-12)
 
-    def test_single_qubit_z_on_plus(self) -> None:
+    def test_single_qubit_z_on_plus(self, sampling_api: Any) -> None:
         """<Z> on |+> = 0."""
         circuit = "H 0"
         sv = clifft_statevector(circuit)
         expected = pauli_expectation(sv, "Z0", 1)
 
-        result = clifft.sample(clifft.compile(f"{circuit}\nEXP_VAL Z0"), 1, seed=0)
+        result = sampling_api.sample(sampling_api.compile(f"{circuit}\nEXP_VAL Z0"), 1, seed=0)
         np.testing.assert_allclose(result.exp_vals[0, 0], expected, atol=1e-12)
 
-    def test_bell_zz(self) -> None:
+    def test_bell_zz(self, sampling_api: Any) -> None:
         """<Z0*Z1> on Bell state = +1."""
         circuit = "H 0\nCX 0 1"
         sv = clifft_statevector(circuit)
         expected = pauli_expectation(sv, "Z0*Z1", 2)
 
-        result = clifft.sample(clifft.compile(f"{circuit}\nEXP_VAL Z0*Z1"), 1, seed=0)
+        result = sampling_api.sample(sampling_api.compile(f"{circuit}\nEXP_VAL Z0*Z1"), 1, seed=0)
         np.testing.assert_allclose(result.exp_vals[0, 0], expected, atol=1e-12)
 
-    def test_bell_xx(self) -> None:
+    def test_bell_xx(self, sampling_api: Any) -> None:
         """<X0*X1> on Bell state = +1."""
         circuit = "H 0\nCX 0 1"
         sv = clifft_statevector(circuit)
         expected = pauli_expectation(sv, "X0*X1", 2)
 
-        result = clifft.sample(clifft.compile(f"{circuit}\nEXP_VAL X0*X1"), 1, seed=0)
+        result = sampling_api.sample(sampling_api.compile(f"{circuit}\nEXP_VAL X0*X1"), 1, seed=0)
         np.testing.assert_allclose(result.exp_vals[0, 0], expected, atol=1e-12)
 
-    def test_t_gate_expectation(self) -> None:
+    def test_t_gate_expectation(self, sampling_api: Any) -> None:
         """<X> after H-T on |0> = cos(pi/4) = 1/sqrt(2)."""
         circuit = "H 0\nT 0"
         sv = clifft_statevector(circuit)
         expected = pauli_expectation(sv, "X0", 1)
 
-        result = clifft.sample(clifft.compile(f"{circuit}\nEXP_VAL X0"), 1, seed=0)
+        result = sampling_api.sample(sampling_api.compile(f"{circuit}\nEXP_VAL X0"), 1, seed=0)
         np.testing.assert_allclose(result.exp_vals[0, 0], expected, atol=1e-10)
 
-    def test_multi_qubit_product(self) -> None:
+    def test_multi_qubit_product(self, sampling_api: Any) -> None:
         """<X0*Y1*Z2> on a 3-qubit state matches numpy oracle."""
         circuit = "H 0\nCX 0 1\nS 1\nH 2"
         sv = clifft_statevector(circuit)
         expected = pauli_expectation(sv, "X0*Y1*Z2", 3)
 
-        result = clifft.sample(clifft.compile(f"{circuit}\nEXP_VAL X0*Y1*Z2"), 1, seed=0)
+        result = sampling_api.sample(
+            sampling_api.compile(f"{circuit}\nEXP_VAL X0*Y1*Z2"), 1, seed=0
+        )
         np.testing.assert_allclose(result.exp_vals[0, 0], expected, atol=1e-10)
 
+    def test_high_dormant_support_with_active_factor(self, sampling_api: Any) -> None:
+        """Dormant masks beyond one word retain X/Y-zero and Z-identity semantics."""
+        program = sampling_api.compile("H 0\nT 0\nEXP_VAL X0*Z128 X0*X128 Z128")
+        result = sampling_api.sample(program, 1, seed=0)
+
+        np.testing.assert_allclose(
+            result.exp_vals[0],
+            [1.0 / np.sqrt(2.0), 0.0, 1.0],
+            atol=1e-10,
+        )
+
     @pytest.mark.parametrize("seed", range(8))
-    def test_random_clifford_t_oracle(self, seed: int) -> None:
+    def test_random_clifford_t_oracle(self, seed: int, sampling_api: Any) -> None:
         """Random Clifford+T circuit with random Pauli product matches oracle."""
         rng = np.random.default_rng(seed + 1000)
         num_qubits = int(rng.integers(3, 6))
@@ -142,8 +157,8 @@ class TestExactOracle:
         pauli = random_pauli_product(num_qubits, rng)
         expected = pauli_expectation(sv, pauli, num_qubits)
 
-        prog = clifft.compile(f"{circuit}\nEXP_VAL {pauli}")
-        result = clifft.sample(prog, 1, seed=0)
+        prog = sampling_api.compile(f"{circuit}\nEXP_VAL {pauli}")
+        result = sampling_api.sample(prog, 1, seed=0)
         np.testing.assert_allclose(
             result.exp_vals[0, 0],
             expected,
@@ -170,18 +185,18 @@ class TestStatisticalEquivalence:
             ("H 0\nCX 0 1\nT 0", "X0"),
         ],
     )
-    def test_exp_val_matches_mpp_mean(self, circuit: str, pauli: str) -> None:
+    def test_exp_val_matches_mpp_mean(self, circuit: str, pauli: str, sampling_api: Any) -> None:
         """mean(exp_vals) ≈ mean(1 - 2*mpp_bits) over many shots."""
         shots = 5000
 
         # EXP_VAL path
-        ev_prog = clifft.compile(f"{circuit}\nEXP_VAL {pauli}")
-        ev_result = clifft.sample(ev_prog, shots, seed=42)
+        ev_prog = sampling_api.compile(f"{circuit}\nEXP_VAL {pauli}")
+        ev_result = sampling_api.sample(ev_prog, shots, seed=42)
         ev_mean = float(np.mean(ev_result.exp_vals[:, 0]))
 
         # MPP path (destructive measurement of same Pauli)
-        mpp_prog = clifft.compile(f"{circuit}\nMPP {pauli}")
-        mpp_result = clifft.sample(mpp_prog, shots, seed=42)
+        mpp_prog = sampling_api.compile(f"{circuit}\nMPP {pauli}")
+        mpp_result = sampling_api.sample(mpp_prog, shots, seed=42)
         mpp_mean = float(np.mean(1.0 - 2.0 * mpp_result.measurements[:, -1].astype(np.float64)))
 
         # For deterministic states, both should be exact
@@ -203,50 +218,50 @@ class TestStatisticalEquivalence:
 class TestPauliFrameInteraction:
     """Verify EXP_VAL correctly reads the Pauli frame."""
 
-    def test_z_error_flips_x_expectation(self) -> None:
+    def test_z_error_flips_x_expectation(self, sampling_api: Any) -> None:
         """Z_ERROR(1.0) anti-commutes with X, flipping <X> from +1 to -1."""
-        prog = clifft.compile("H 0\nZ_ERROR(1.0) 0\nEXP_VAL X0")
-        result = clifft.sample(prog, 10, seed=0)
+        prog = sampling_api.compile("H 0\nZ_ERROR(1.0) 0\nEXP_VAL X0")
+        result = sampling_api.sample(prog, 10, seed=0)
         np.testing.assert_allclose(result.exp_vals[:, 0], -1.0, atol=1e-12)
 
-    def test_x_error_flips_z_expectation(self) -> None:
+    def test_x_error_flips_z_expectation(self, sampling_api: Any) -> None:
         """X_ERROR(1.0) anti-commutes with Z, flipping <Z> from +1 to -1."""
-        prog = clifft.compile("X_ERROR(1.0) 0\nEXP_VAL Z0")
-        result = clifft.sample(prog, 10, seed=0)
+        prog = sampling_api.compile("X_ERROR(1.0) 0\nEXP_VAL Z0")
+        result = sampling_api.sample(prog, 10, seed=0)
         np.testing.assert_allclose(result.exp_vals[:, 0], -1.0, atol=1e-12)
 
-    def test_z_error_commutes_with_z(self) -> None:
+    def test_z_error_commutes_with_z(self, sampling_api: Any) -> None:
         """Z_ERROR(1.0) commutes with Z, so <Z> on |0> stays +1."""
-        prog = clifft.compile("Z_ERROR(1.0) 0\nEXP_VAL Z0")
-        result = clifft.sample(prog, 10, seed=0)
+        prog = sampling_api.compile("Z_ERROR(1.0) 0\nEXP_VAL Z0")
+        result = sampling_api.sample(prog, 10, seed=0)
         np.testing.assert_allclose(result.exp_vals[:, 0], 1.0, atol=1e-12)
 
-    def test_measurement_feedback_cx(self) -> None:
+    def test_measurement_feedback_cx(self, sampling_api: Any) -> None:
         """EXP_VAL reads post-measurement Pauli frame via CX feedback.
 
         Circuit: H 0 / M 0 / CX rec[-1] 1 / EXP_VAL Z1
         Per shot: exp[0] == 1 - 2*meas[0]
         """
-        prog = clifft.compile("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1")
-        result = clifft.sample(prog, 100, seed=42)
+        prog = sampling_api.compile("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1")
+        result = sampling_api.sample(prog, 100, seed=42)
         expected = 1.0 - 2.0 * result.measurements[:, 0].astype(np.float64)
         np.testing.assert_allclose(result.exp_vals[:, 0], expected, atol=1e-12)
 
-    def test_measurement_feedback_cz(self) -> None:
+    def test_measurement_feedback_cz(self, sampling_api: Any) -> None:
         """EXP_VAL reads post-measurement Pauli frame via CZ feedback.
 
         Circuit: H 1 / H 0 / M 0 / CZ rec[-1] 1 / EXP_VAL X1
         Per shot: exp[0] == 1 - 2*meas[0]
         """
-        prog = clifft.compile("H 1\nH 0\nM 0\nCZ rec[-1] 1\nEXP_VAL X1")
-        result = clifft.sample(prog, 100, seed=42)
+        prog = sampling_api.compile("H 1\nH 0\nM 0\nCZ rec[-1] 1\nEXP_VAL X1")
+        result = sampling_api.sample(prog, 100, seed=42)
         expected = 1.0 - 2.0 * result.measurements[:, 0].astype(np.float64)
         np.testing.assert_allclose(result.exp_vals[:, 0], expected, atol=1e-12)
 
-    def test_depolarize_reduces_expectation(self) -> None:
+    def test_depolarize_reduces_expectation(self, sampling_api: Any) -> None:
         """DEPOLARIZE1(1.0) on |0> applies X/Y/Z uniformly, <Z> averages to -1/3."""
-        prog = clifft.compile("DEPOLARIZE1(1.0) 0\nEXP_VAL Z0")
-        result = clifft.sample(prog, 10000, seed=0)
+        prog = sampling_api.compile("DEPOLARIZE1(1.0) 0\nEXP_VAL Z0")
+        result = sampling_api.sample(prog, 10000, seed=0)
         mean_z = float(np.mean(result.exp_vals[:, 0]))
         # DEPOLARIZE1(1.0) applies one of {X, Y, Z} with equal probability.
         # X|0>=|1>: <Z>=-1, Y|0>=i|1>: <Z>=-1, Z|0>=|0>: <Z>=+1.
@@ -264,15 +279,15 @@ class TestPauliFrameInteraction:
 class TestNoExpValRegression:
     """Circuits without EXP_VAL should behave identically to before."""
 
-    def test_exp_vals_shape_empty(self) -> None:
+    def test_exp_vals_shape_empty(self, sampling_api: Any) -> None:
         """exp_vals has shape (shots, 0) when no EXP_VAL in circuit."""
-        prog = clifft.compile("H 0\nM 0")
-        result = clifft.sample(prog, 10, seed=0)
+        prog = sampling_api.compile("H 0\nM 0")
+        result = sampling_api.sample(prog, 10, seed=0)
         assert result.exp_vals.shape == (10, 0)
 
-    def test_num_exp_vals_zero(self) -> None:
+    def test_num_exp_vals_zero(self, sampling_api: Any) -> None:
         """Program reports num_exp_vals == 0."""
-        prog = clifft.compile("H 0\nM 0")
+        prog = sampling_api.compile("H 0\nM 0")
         assert prog.num_exp_vals == 0
 
     def test_no_exp_val_opcode_in_bytecode(self) -> None:
@@ -282,16 +297,16 @@ class TestNoExpValRegression:
             d = inst.as_dict()
             assert d["opcode"] != "OP_EXP_VAL"
 
-    def test_measurements_unchanged(self) -> None:
+    def test_measurements_unchanged(self, sampling_api: Any) -> None:
         """Measurement outcomes match with and without EXP_VAL in circuit."""
         base_circuit = "H 0\nM 0"
         shots = 200
 
-        prog_no_ev = clifft.compile(base_circuit)
-        result_no_ev = clifft.sample(prog_no_ev, shots, seed=42)
+        prog_no_ev = sampling_api.compile(base_circuit)
+        result_no_ev = sampling_api.sample(prog_no_ev, shots, seed=42)
 
-        prog_with_ev = clifft.compile("H 0\nEXP_VAL Z0\nM 0")
-        result_with_ev = clifft.sample(prog_with_ev, shots, seed=42)
+        prog_with_ev = sampling_api.compile("H 0\nEXP_VAL Z0\nM 0")
+        result_with_ev = sampling_api.sample(prog_with_ev, shots, seed=42)
 
         np.testing.assert_array_equal(
             result_no_ev.measurements,
@@ -299,18 +314,18 @@ class TestNoExpValRegression:
             err_msg="EXP_VAL changed measurement outcomes",
         )
 
-    def test_detectors_observables_unchanged(self) -> None:
+    def test_detectors_observables_unchanged(self, sampling_api: Any) -> None:
         """Detector and observable records are unaffected by EXP_VAL."""
         base = "H 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]"
         shots = 100
 
-        prog_no_ev = clifft.compile(base)
-        result_no_ev = clifft.sample(prog_no_ev, shots, seed=42)
+        prog_no_ev = sampling_api.compile(base)
+        result_no_ev = sampling_api.sample(prog_no_ev, shots, seed=42)
 
-        prog_with_ev = clifft.compile(
+        prog_with_ev = sampling_api.compile(
             "H 0\nEXP_VAL X0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]"
         )
-        result_with_ev = clifft.sample(prog_with_ev, shots, seed=42)
+        result_with_ev = sampling_api.sample(prog_with_ev, shots, seed=42)
 
         np.testing.assert_array_equal(result_no_ev.detectors, result_with_ev.detectors)
         np.testing.assert_array_equal(result_no_ev.observables, result_with_ev.observables)

--- a/tests/python/test_experimental_sampling.py
+++ b/tests/python/test_experimental_sampling.py
@@ -39,15 +39,12 @@ def test_seeded_samples_match_legacy_for_curated_circuits(circuit: str) -> None:
     np.testing.assert_array_equal(actual, legacy)
 
 
-@pytest.mark.parametrize(
-    "circuit,operation",
-    [
-        ("EXP_VAL Z0", "EXP_VAL"),
-    ],
-)
-def test_unsupported_capabilities_fail_during_compile(circuit: str, operation: str) -> None:
-    with pytest.raises(ValueError, match=operation):
-        experimental.compile(circuit)
+def test_expectation_probes_are_available_without_changing_the_default_backend() -> None:
+    program = experimental.compile("EXP_VAL X0 Z0")
+    result = experimental.sample(program, 3, seed=1)
+
+    assert program.num_exp_vals == 2
+    np.testing.assert_allclose(result.exp_vals, [[0.0, 1.0]] * 3, atol=1e-12)
 
 
 def test_noise_readout_feedback_and_syndrome_share_one_symbolic_record() -> None:
@@ -79,7 +76,7 @@ def test_asymmetric_readout_noise_uses_the_pre_flip_record() -> None:
 
 def test_postselection_survivor_metadata_and_records() -> None:
     program = experimental.compile(
-        "H 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]",
+        "H 0\nEXP_VAL X0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]",
         postselection_mask=[1],
     )
     with pytest.raises(ValueError, match="sample_survivors"):
@@ -95,6 +92,7 @@ def test_postselection_survivor_metadata_and_records() -> None:
     assert np.all(result.measurements == 0)
     assert np.all(result.detectors == 0)
     assert np.all(result.observables == 0)
+    np.testing.assert_allclose(result.exp_vals, 1.0, atol=1e-12)
 
 
 def test_noisy_record_probabilities_remain_explicitly_unsupported() -> None:

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -89,6 +89,7 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
     clifft::SchrodingerState legacy({.peak_rank = legacy_program.peak_rank,
                                      .num_measurements = legacy_program.total_meas_slots,
                                      .num_qubits = legacy_program.num_qubits,
+                                     .num_exp_vals = legacy_program.num_exp_vals,
                                      .seed = seed});
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
@@ -103,6 +104,11 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
         REQUIRE(std::ranges::equal(
             executor.visible_records(),
             std::span<const uint8_t>(legacy.meas_record).first(legacy_program.num_measurements)));
+        REQUIRE(executor.exp_vals().size() == legacy.exp_vals.size());
+        for (size_t i = 0; i < legacy.exp_vals.size(); ++i) {
+            REQUIRE_THAT(executor.exp_vals()[i],
+                         Catch::Matchers::WithinAbs(legacy.exp_vals[i], 1e-12));
+        }
     }
 }
 
@@ -786,6 +792,48 @@ TEST_CASE("Sampling batch records match legacy seeded execution") {
     const clifft::SampleResult expected = clifft::sample(clifft::lower(hir), 64, uint64_t{5678});
     REQUIRE(actual == expected.measurements);
     REQUIRE(sample_records(executable, 0, uint64_t{5678}).empty());
+}
+
+TEST_CASE("Sampling executor expectation probes match legacy execution") {
+    require_matches_legacy("EXP_VAL X0\nEXP_VAL Z0", 1, 1234);
+    require_matches_legacy("H 0\nT 0\nEXP_VAL X0\nEXP_VAL Y0\nEXP_VAL Z0", 1, 2345);
+    require_matches_legacy("H 0\nH 1\nT 0\nT 1\nCX 0 1\nEXP_VAL Y0*Z1", 1, 3456);
+    require_matches_legacy("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1", 64, 4567);
+    require_matches_legacy("X_ERROR(1) 0\nEXP_VAL Z0", 1, 5678);
+}
+
+TEST_CASE("Sampling batch and survivor results carry expectation columns") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        H 0
+        T 0
+        EXP_VAL X0
+        H 1
+        M 1
+        DETECTOR rec[-1]
+    )"));
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection}));
+
+    const clifft::sampling::SamplingSurvivorResult survivors =
+        clifft::sampling::sample_survivors(executable, 1000, uint64_t{17}, true);
+    REQUIRE(survivors.passed_shots > 400);
+    REQUIRE(survivors.passed_shots < 600);
+    REQUIRE(survivors.exp_vals.size() == survivors.passed_shots);
+    for (double value : survivors.exp_vals) {
+        REQUIRE_THAT(value, Catch::Matchers::WithinAbs(1.0 / std::sqrt(2.0), 1e-12));
+    }
+
+    const ExecutablePlan fixed(clifft::sampling::plan_sampling(
+        clifft::trace(clifft::parse("H 0\nT 0\nEXP_VAL X0\nEXP_VAL Z0"))));
+    const clifft::sampling::SamplingResult result =
+        clifft::sampling::sample(fixed, 3, uint64_t{17});
+    REQUIRE(result.exp_vals.size() == 6);
+    for (uint32_t shot = 0; shot < 3; ++shot) {
+        REQUIRE_THAT(result.exp_vals[2 * shot],
+                     Catch::Matchers::WithinAbs(1.0 / std::sqrt(2.0), 1e-12));
+        REQUIRE_THAT(result.exp_vals[2 * shot + 1], Catch::Matchers::WithinAbs(0.0, 1e-12));
+    }
 }
 
 TEST_CASE("Sampling executor presamples mutually exclusive Pauli noise") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -25,12 +25,14 @@
 #include <variant>
 #include <vector>
 
+using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::ApplyInstrument;
 using clifft::sampling::classify_measurement_branch;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
+using clifft::sampling::ExpValSlot;
 using clifft::sampling::ForcedTraceOut;
 using clifft::sampling::index;
 using clifft::sampling::InstrumentBoundary;
@@ -56,6 +58,7 @@ using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
 using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
+using clifft::sampling::WriteExpectationValue;
 
 namespace {
 
@@ -760,6 +763,40 @@ TEST_CASE("Sampling continuation consumes a forced hidden source record") {
     REQUIRE(executor.pending_trap().has_value());
     REQUIRE(executor.hidden_records().empty());
     REQUIRE(executor.symbols().size() == root_plan.symbols.size());
+}
+
+TEST_CASE("Sampling continuation overwrites an expectation with exact zero") {
+    SamplingPlan root_plan;
+    root_plan.num_qubits = 1;
+    root_plan.num_exp_vals = 1;
+    root_plan.num_instrument_sites = 1;
+    root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
+    root_plan.instrument_distributions = {
+        InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    root_plan.actions = {
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{
+                InstrumentSiteId{0}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
+        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{0}}},
+    };
+    SamplingPlan continuation_plan = root_plan;
+    continuation_plan.actions.back() =
+        PlannedAction{0, 0, WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{0}}};
+    const ExecutablePlan root(root_plan);
+    const ExecutablePlan continuation(continuation_plan);
+    Executor executor(root, 13);
+
+    executor.run_shot();
+    REQUIRE(executor.pending_trap().has_value());
+    executor.resume(root);
+    REQUIRE(executor.exp_vals()[0] == 1.0);
+
+    executor.run_shot();
+    REQUIRE(executor.pending_trap().has_value());
+    executor.resume(continuation);
+    REQUIRE(executor.exp_vals()[0] == 0.0);
 }
 
 TEST_CASE("Sampling executor matches legacy records for supported circuits") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -437,6 +437,19 @@ TEST_CASE("Sampling replay inverts affine records and preserves branch dependenc
     }
 }
 
+TEST_CASE("Sampling replay evaluates record-dependent expectations") {
+    const ExecutablePlan executable(plan_from("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1\n"));
+    Executor executor(executable);
+
+    for (uint8_t forced_record : {uint8_t{0}, uint8_t{1}}) {
+        const ReplayResult replay = executor.replay_shot(std::array{forced_record});
+        CAPTURE(forced_record);
+        REQUIRE(replay.reachable);
+        REQUIRE_THAT(replay.log_probability, Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
+        REQUIRE(executor.exp_vals()[0] == (forced_record == 0 ? 1.0 : -1.0));
+    }
+}
+
 TEST_CASE("Sampling replay checks all records conditional on presampled symbols") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
@@ -768,35 +781,41 @@ TEST_CASE("Sampling continuation consumes a forced hidden source record") {
 TEST_CASE("Sampling continuation overwrites an expectation with exact zero") {
     SamplingPlan root_plan;
     root_plan.num_qubits = 1;
-    root_plan.num_exp_vals = 1;
+    root_plan.num_exp_vals = 2;
     root_plan.num_instrument_sites = 1;
     root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
     root_plan.instrument_distributions = {
         InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
     root_plan.actions = {
+        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{0}}},
         PlannedAction{
             0, 0,
             ApplyInstrument{
                 InstrumentSiteId{0}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}},
         PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
-        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{0}}},
+        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{1}}},
     };
     SamplingPlan continuation_plan = root_plan;
     continuation_plan.actions.back() =
-        PlannedAction{0, 0, WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{0}}};
+        PlannedAction{0, 0, WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{1}}};
     const ExecutablePlan root(root_plan);
     const ExecutablePlan continuation(continuation_plan);
     Executor executor(root, 13);
 
     executor.run_shot();
     REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.exp_vals()[0] == 1.0);
     executor.resume(root);
     REQUIRE(executor.exp_vals()[0] == 1.0);
+    REQUIRE(executor.exp_vals()[1] == 1.0);
 
     executor.run_shot();
     REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.exp_vals()[0] == 1.0);
+    REQUIRE(executor.exp_vals()[1] == 1.0);
     executor.resume(continuation);
-    REQUIRE(executor.exp_vals()[0] == 0.0);
+    REQUIRE(executor.exp_vals()[0] == 1.0);
+    REQUIRE(executor.exp_vals()[1] == 0.0);
 }
 
 TEST_CASE("Sampling executor matches legacy records for supported circuits") {

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -21,9 +21,11 @@ using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
 using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
+using clifft::sampling::expectation_value;
 using clifft::sampling::measurement_probabilities;
 using clifft::sampling::MeasurementProbabilities;
 using clifft::sampling::prepare_measurement;
+using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::PreparedMeasurement;
@@ -315,6 +317,31 @@ TEST_CASE("Sampling kernels rotations match the existing dense matrix oracle") {
                         REQUIRE(state.active_width() == active_width);
                     }
                 }
+            }
+        }
+    }
+}
+
+TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {
+    for (uint32_t active_width = 0; active_width <= 4; ++active_width) {
+        const uint64_t mask_limit = uint64_t{1} << active_width;
+        const std::vector<std::complex<double>> input = deterministic_state(active_width);
+        for (uint64_t x = 0; x < mask_limit; ++x) {
+            for (uint64_t z = 0; z < mask_limit; ++z) {
+                CAPTURE(active_width, x, z);
+                State state(active_width, active_width, {0.3, 0.4});
+                load_state(state, input);
+
+                const std::vector<std::complex<double>> applied =
+                    dense_matvec(dense_axis_rotation(x, z, false, 1.0, active_width), input);
+                std::complex<double> expected{0.0, 0.0};
+                for (size_t i = 0; i < input.size(); ++i) {
+                    expected += std::conj(input[i]) * applied[i];
+                }
+
+                REQUIRE_THAT(expectation_value(state, prepare_pauli({x, z}, active_width)),
+                             Catch::Matchers::WithinAbs(expected.real(), kTolerance));
+                REQUIRE_THAT(expected.imag(), Catch::Matchers::WithinAbs(0.0, kTolerance));
             }
         }
     }

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -13,6 +13,7 @@ using clifft::sampling::ApplyInstrument;
 using clifft::sampling::ApplyReadoutNoise;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::DetectorSlot;
+using clifft::sampling::ExpValSlot;
 using clifft::sampling::InstrumentBoundary;
 using clifft::sampling::InstrumentDistribution;
 using clifft::sampling::InstrumentMode;
@@ -33,6 +34,7 @@ using clifft::sampling::SymbolId;
 using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
 using clifft::sampling::WriteDetector;
+using clifft::sampling::WriteExpectationValue;
 using clifft::sampling::WriteObservable;
 
 namespace {
@@ -493,6 +495,33 @@ TEST_CASE("Sampling plan distinguishes dormant branch labels from records") {
     REQUIRE(plan.inspect().find("branch=s0 outcome=1 ^ s0 record=0") != std::string::npos);
 }
 
+TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.initial_active_width = 1;
+    plan.max_active_width = 1;
+    plan.num_exp_vals = 2;
+    plan.actions = {
+        PlannedAction{1, 1,
+                      WriteExpectationValue{ActivePauli{1, 1}, AffineBool(true), ExpValSlot{0}}},
+        PlannedAction{1, 1, WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{1}}},
+    };
+
+    REQUIRE_NOTHROW(plan.validate());
+    const std::string text = plan.inspect();
+    REQUIRE(text.find("dense_passes=1 write_expectation") != std::string::npos);
+    REQUIRE(text.find("dense_passes=0 write_expectation zero exp_val=1") != std::string::npos);
+
+    SECTION("duplicate slot") {
+        std::get<WriteExpectationValue>(plan.actions[1].action).exp_val = ExpValSlot{0};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+    SECTION("zero probe carries irrelevant sign") {
+        std::get<WriteExpectationValue>(plan.actions[1].action).sign = AffineBool(true);
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+}
+
 TEST_CASE("Sampling plan predicts only state touching dense passes") {
     SamplingPlan plan = valid_rotation_plan();
     REQUIRE_NOTHROW(plan.validate());
@@ -508,5 +537,11 @@ TEST_CASE("Sampling plan predicts only state touching dense passes") {
     REQUIRE(clifft::sampling::predicted_dense_passes(ApplyReadoutNoise{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(WriteDetector{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(WriteObservable{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(
+                WriteExpectationValue{ActivePauli{1, 0}, AffineBool{}, ExpValSlot{0}}) == 1);
+    REQUIRE(clifft::sampling::predicted_dense_passes(
+                WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{0}}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(
+                WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{0}}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(InstrumentBoundary{}) == 0);
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -34,6 +34,7 @@ using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
 using clifft::sampling::SymbolKind;
 using clifft::sampling::WriteDetector;
+using clifft::sampling::WriteExpectationValue;
 using clifft::sampling::WriteObservable;
 using clifft::test::X;
 using clifft::test::Z;
@@ -335,11 +336,44 @@ TEST_CASE("Sampling planner preserves sign flipped rotation global factors") {
     }
 }
 
-TEST_CASE("Sampling planner rejects unsupported operations explicitly") {
-    const HirModule hir = clifft::trace(clifft::parse("EXP_VAL Z0"));
+TEST_CASE("Sampling planner classifies active and dormant expectation probes") {
+    const SamplingPlan plan = plan_sampling(clifft::trace(clifft::parse(R"(
+        H 0
+        T 0
+        EXP_VAL X0
+        EXP_VAL X1
+        EXP_VAL Z1
+    )")));
 
-    REQUIRE_THROWS_WITH(plan_sampling(hir),
-                        "sampling planner does not support HIR operation EXP_VAL at index 0");
+    REQUIRE(plan.num_exp_vals == 3);
+    REQUIRE(plan.actions.size() == 4);
+    const auto& active = action_as<WriteExpectationValue>(plan, 1);
+    REQUIRE(active.pauli.has_value());
+    REQUIRE_FALSE(active.pauli->is_identity());
+    REQUIRE(active.exp_val == clifft::sampling::ExpValSlot{0});
+    const auto& dormant_x = action_as<WriteExpectationValue>(plan, 2);
+    REQUIRE_FALSE(dormant_x.pauli.has_value());
+    REQUIRE(dormant_x.sign == AffineBool{});
+    const auto& dormant_z = action_as<WriteExpectationValue>(plan, 3);
+    REQUIRE(dormant_z.pauli.has_value());
+    REQUIRE(dormant_z.pauli->is_identity());
+}
+
+TEST_CASE("Sampling planner propagates stochastic signs into expectation probes") {
+    const SamplingPlan noise =
+        plan_sampling(clifft::trace(clifft::parse("X_ERROR(1) 0\nEXP_VAL Z0")));
+    const auto& noise_probe = action_as<WriteExpectationValue>(noise, 0);
+    REQUIRE(noise_probe.pauli.has_value());
+    REQUIRE(noise_probe.pauli->is_identity());
+    REQUIRE(noise_probe.sign == AffineBool::symbol(SymbolId{0}));
+
+    const SamplingPlan feedback =
+        plan_sampling(clifft::trace(clifft::parse("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1")));
+    const auto& measurement = action_as<MeasureDormantRandom>(feedback, 0);
+    const auto& feedback_probe = action_as<WriteExpectationValue>(feedback, 1);
+    REQUIRE(feedback_probe.pauli.has_value());
+    REQUIRE(feedback_probe.pauli->is_identity());
+    REQUIRE(feedback_probe.sign == AffineBool::symbol(measurement.branch));
 }
 
 TEST_CASE("Sampling planner eliminates Pauli noise and feedback into record expressions") {

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -348,31 +348,31 @@ TEST_CASE("Sampling planner classifies active and dormant expectation probes") {
     REQUIRE(plan.num_exp_vals == 3);
     REQUIRE(plan.actions.size() == 4);
     const auto& active = action_as<WriteExpectationValue>(plan, 1);
-    REQUIRE(active.pauli.has_value());
-    REQUIRE_FALSE(active.pauli->is_identity());
+    REQUIRE(active.active_projection.has_value());
+    REQUIRE_FALSE(active.active_projection->is_identity());
     REQUIRE(active.exp_val == clifft::sampling::ExpValSlot{0});
     const auto& dormant_x = action_as<WriteExpectationValue>(plan, 2);
-    REQUIRE_FALSE(dormant_x.pauli.has_value());
+    REQUIRE_FALSE(dormant_x.active_projection.has_value());
     REQUIRE(dormant_x.sign == AffineBool{});
     const auto& dormant_z = action_as<WriteExpectationValue>(plan, 3);
-    REQUIRE(dormant_z.pauli.has_value());
-    REQUIRE(dormant_z.pauli->is_identity());
+    REQUIRE(dormant_z.active_projection.has_value());
+    REQUIRE(dormant_z.active_projection->is_identity());
 }
 
 TEST_CASE("Sampling planner propagates stochastic signs into expectation probes") {
     const SamplingPlan noise =
         plan_sampling(clifft::trace(clifft::parse("X_ERROR(1) 0\nEXP_VAL Z0")));
     const auto& noise_probe = action_as<WriteExpectationValue>(noise, 0);
-    REQUIRE(noise_probe.pauli.has_value());
-    REQUIRE(noise_probe.pauli->is_identity());
+    REQUIRE(noise_probe.active_projection.has_value());
+    REQUIRE(noise_probe.active_projection->is_identity());
     REQUIRE(noise_probe.sign == AffineBool::symbol(SymbolId{0}));
 
     const SamplingPlan feedback =
         plan_sampling(clifft::trace(clifft::parse("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1")));
     const auto& measurement = action_as<MeasureDormantRandom>(feedback, 0);
     const auto& feedback_probe = action_as<WriteExpectationValue>(feedback, 1);
-    REQUIRE(feedback_probe.pauli.has_value());
-    REQUIRE(feedback_probe.pauli->is_identity());
+    REQUIRE(feedback_probe.active_projection.has_value());
+    REQUIRE(feedback_probe.active_projection->is_identity());
     REQUIRE(feedback_probe.sign == AffineBool::symbol(measurement.branch));
 }
 


### PR DESCRIPTION
## Summary

- lower `EXP_VAL` probes through planner coordinate rewrites and symbolic Pauli-frame sign propagation
- evaluate prepared active-coordinate Paulis without state mutation, RNG consumption, allocation, or exceptions in hot dispatch
- classify dormant X/Y probes and active identity probes so they require no dense coefficient pass
- return preallocated `exp_vals` columns from experimental fixed-row and survivor sampling
- run the existing NumPy, MPP, noise, feedback, and non-disturbance oracle suite against both backends

## Scope

This completes in-stream expectation-probe parity. `record_probabilities()` already supports the experimental backend. Final-state `basis_probabilities()` and `get_statevector()` remain the next exact-query increment because they require a retained and composed physical-coordinate frame rather than the circuit-position Pauli used by `EXP_VAL`.

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- C++ non-benchmark suite: 1,222 cases / 375,657 assertions
- focused C++ sampling suite: 82 cases / 166,768 assertions
- Python suite: 1,105 tests
- focused EXP_VAL and experimental API suite, including a 129-qubit dormant-mask regression
- continuation persistence and forced-replay expectation regressions

Closes #272