### PR TITLE
feat(sampling): add basis probability queries

### DIFF
--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -2,6 +2,7 @@
 // inverse Clifford tableau and the per-bitstring amplitude lookup are the
 // implementation of the algorithm derived in docs/theory/basis_probabilities.md.
 
+#include "clifft/sampling/executor.h"
 #include "clifft/svm/svm.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/mask_view.h"
@@ -259,9 +260,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
 }
 
 [[nodiscard]] StabilizerAmplitudeStructure make_stabilizer_amplitude_structure(
-    const CompiledModule& program, const stim::Tableau<kStimWidth>& inv_tableau,
-    uint32_t active_k) {
-    const uint32_t n = program.num_qubits;
+    uint32_t n, const stim::Tableau<kStimWidth>& inv_tableau, uint32_t active_k) {
     std::vector<StabilizerRow> rows;
     std::vector<BasisMask> sign_masks;
     rows.reserve(n);
@@ -478,35 +477,17 @@ void assert_probability_program_is_supported(const CompiledModule& program) {
     }
 }
 
-}  // namespace
+template <typename CoefficientAt>
+std::vector<double> basis_probabilities_from_factored_state(
+    uint32_t n, uint32_t active_width, uint64_t active_size,
+    const stim::Tableau<kStimWidth>& final_tableau, std::complex<double> scale, MaskView state_px,
+    uint64_t active_z_mask, CoefficientAt coefficient_at, std::span<const uint64_t> basis_masks,
+    size_t num_basis_masks, size_t words_per_basis_mask) {
+    // The factored state is scale * U_C * P * (|phi>_A x |0>_D). The inverse
+    // tableau lets the batch query evaluator reuse stabilizers of
+    // U_C^dagger |x> for every requested physical bitstring x.
+    stim::Tableau<kStimWidth> inv_tableau = final_tableau.inverse(false);
 
-std::vector<double> basis_probabilities(const CompiledModule& program,
-                                        std::span<const uint64_t> basis_masks,
-                                        size_t num_basis_masks, size_t words_per_basis_mask) {
-    assert_probability_program_is_supported(program);
-    if (!program.constant_pool.final_tableau.has_value()) {
-        throw std::invalid_argument(
-            "basis_probabilities() requires final Clifford tableau metadata; compile programs "
-            "through "
-            "clifft.compile() or preserve ConstantPool::final_tableau.");
-    }
-    assert_arena_widths_match(program.num_qubits, program.constant_pool);
-
-    SchrodingerState state({.peak_rank = program.peak_rank,
-                            .num_measurements = program.total_meas_slots,
-                            .num_qubits = program.num_qubits,
-                            .num_detectors = program.num_detectors,
-                            .num_observables = program.num_observables,
-                            .num_exp_vals = program.num_exp_vals,
-                            .seed = uint64_t{0}});
-    execute(program, state);
-
-    // The VM gives the factored final state gamma * U_C * P *
-    // (|phi>_A x |0>_D). The inverse tableau lets the batch query evaluator use
-    // stabilizers of U_C^\dagger |x> for each requested physical bitstring x.
-    stim::Tableau<kStimWidth> inv_tableau = program.constant_pool.final_tableau->inverse(false);
-
-    const uint32_t n = program.num_qubits;
     const size_t expected_words = basis_word_count(n);
     if (words_per_basis_mask != expected_words) {
         throw std::invalid_argument(
@@ -516,15 +497,7 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
         throw std::invalid_argument("probability basis mask buffer has inconsistent shape");
     }
 
-    const uint64_t active_size = state.v_size();
-    const std::complex<double> scale = state.gamma() * program.constant_pool.global_weight;
-    const auto structure =
-        make_stabilizer_amplitude_structure(program, inv_tableau, state.active_k);
-    const auto state_px = MaskView{std::span<const uint64_t>(state.p_x)};
-    // validate_peak_rank() caps active_k below 60, so active bits fit in word 0
-    // and this shift never reaches 64.
-    const uint64_t active_z_mask =
-        state.active_k == 0 ? 0 : (state.p_z[0] & ((uint64_t{1} << state.active_k) - uint64_t{1}));
+    const auto structure = make_stabilizer_amplitude_structure(n, inv_tableau, active_width);
     BasisMask virtual_basis_storage(expected_words);
     BasisMask residual_storage(expected_words);
     BasisMask current_storage(expected_words);
@@ -535,7 +508,7 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
     // Active bits live in [0, active_k). validate_peak_rank() caps active_k
     // below 60, so the mask fits in one word and the shift never reaches 64.
     const uint64_t active_mask =
-        state.active_k == 0 ? uint64_t{0} : (uint64_t{1} << state.active_k) - uint64_t{1};
+        active_width == 0 ? uint64_t{0} : (uint64_t{1} << active_width) - uint64_t{1};
 
     std::vector<double> out;
     out.reserve(num_basis_masks);
@@ -576,7 +549,7 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
                 // Dormant |0> axes do not contribute a Z-frame sign.
                 const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
                 double sign = sign_bit ? -1.0 : 1.0;
-                amp += state.v()[active_index] * sign * coeff;
+                amp += coefficient_at(active_index) * sign * coeff;
             }
         } else {
             // Fast path: every dormant column is a pivot, so dormant
@@ -610,7 +583,7 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
             // Debug invariant: every dormant bit of `current` now matches
             // state_px. Checked only in debug builds.
             assert([&]() {
-                for (uint32_t q = state.active_k; q < n; ++q) {
+                for (uint32_t q = active_width; q < n; ++q) {
                     const bool c = (current.words[q / 64] >> (q % 64)) & 1U;
                     const bool t = (state_px.words[q / 64] >> (q % 64)) & 1U;
                     if (c != t) {
@@ -640,11 +613,11 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
                 // active_index = active bits of (current XOR state_px). All
                 // active bits fit in word 0 (active_k < 63).
                 const uint64_t active_index =
-                    state.active_k == 0 ? uint64_t{0}
-                                        : ((current.words[0] ^ state_px.words[0]) & active_mask);
+                    active_width == 0 ? uint64_t{0}
+                                      : ((current.words[0] ^ state_px.words[0]) & active_mask);
                 const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
                 const double sign = sign_bit ? -1.0 : 1.0;
-                total += state.v()[active_index] * sign * amp;
+                total += coefficient_at(active_index) * sign * amp;
             }
             amp = total;
         }
@@ -652,5 +625,69 @@ std::vector<double> basis_probabilities(const CompiledModule& program,
     }
     return out;
 }
+
+}  // namespace
+
+std::vector<double> basis_probabilities(const CompiledModule& program,
+                                        std::span<const uint64_t> basis_masks,
+                                        size_t num_basis_masks, size_t words_per_basis_mask) {
+    assert_probability_program_is_supported(program);
+    if (!program.constant_pool.final_tableau.has_value()) {
+        throw std::invalid_argument(
+            "basis_probabilities() requires final Clifford tableau metadata; compile programs "
+            "through clifft.compile() or preserve ConstantPool::final_tableau.");
+    }
+    assert_arena_widths_match(program.num_qubits, program.constant_pool);
+
+    SchrodingerState state({.peak_rank = program.peak_rank,
+                            .num_measurements = program.total_meas_slots,
+                            .num_qubits = program.num_qubits,
+                            .num_detectors = program.num_detectors,
+                            .num_observables = program.num_observables,
+                            .num_exp_vals = program.num_exp_vals,
+                            .seed = uint64_t{0}});
+    execute(program, state);
+
+    const auto state_px = MaskView{std::span<const uint64_t>(state.p_x)};
+    // validate_peak_rank() caps active_k below 60, so active bits fit in word
+    // zero and this shift never reaches 64.
+    const uint64_t active_z_mask =
+        state.active_k == 0 ? 0 : (state.p_z[0] & ((uint64_t{1} << state.active_k) - uint64_t{1}));
+    return basis_probabilities_from_factored_state(
+        program.num_qubits, state.active_k, state.v_size(), *program.constant_pool.final_tableau,
+        state.gamma() * program.constant_pool.global_weight, state_px, active_z_mask,
+        [&](uint64_t active_index) { return state.v()[active_index]; }, basis_masks,
+        num_basis_masks, words_per_basis_mask);
+}
+
+namespace sampling {
+
+std::vector<double> basis_probabilities(const ExecutablePlan& plan,
+                                        std::span<const uint64_t> basis_masks,
+                                        size_t num_basis_masks, size_t words_per_basis_mask) {
+    if (!plan.final_tableau_.has_value()) {
+        throw std::invalid_argument(
+            "basis_probabilities() requires pure-state evolution: measurements, feedback, "
+            "noise, readout noise, transition instruments, detectors, postselection, and "
+            "observables are not supported. EXP_VAL probes are allowed but their outputs are "
+            "ignored. Use DropNonUnitaryPass only if you intentionally want to query the "
+            "unitary skeleton of a mixed circuit.");
+    }
+
+    Executor executor(plan);
+    executor.run_shot();
+    const State& state = executor.state();
+    BasisMask zero_frame = zero_basis_mask(plan.num_qubits_);
+    return basis_probabilities_from_factored_state(
+        plan.num_qubits_, state.active_width(), state.size(), *plan.final_tableau_,
+        state.global_scalar(), basis_mask_view(zero_frame), 0,
+        [&](uint64_t active_index) {
+            return std::complex<double>{state.real_data()[active_index],
+                                        state.imag_data()[active_index]};
+        },
+        basis_masks, num_basis_masks, words_per_basis_mask);
+}
+
+}  // namespace sampling
 
 }  // namespace clifft

--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -665,7 +665,8 @@ namespace sampling {
 std::vector<double> basis_probabilities(const ExecutablePlan& plan,
                                         std::span<const uint64_t> basis_masks,
                                         size_t num_basis_masks, size_t words_per_basis_mask) {
-    if (!plan.final_tableau_.has_value()) {
+    const stim::Tableau<kStimWidth>* final_tableau = plan.final_state_tableau();
+    if (final_tableau == nullptr) {
         throw std::invalid_argument(
             "basis_probabilities() requires pure-state evolution: measurements, feedback, "
             "noise, readout noise, transition instruments, detectors, postselection, and "
@@ -677,9 +678,9 @@ std::vector<double> basis_probabilities(const ExecutablePlan& plan,
     Executor executor(plan);
     executor.run_shot();
     const State& state = executor.state();
-    BasisMask zero_frame = zero_basis_mask(plan.num_qubits_);
+    BasisMask zero_frame = zero_basis_mask(plan.num_qubits());
     return basis_probabilities_from_factored_state(
-        plan.num_qubits_, state.active_width(), state.size(), *plan.final_tableau_,
+        plan.num_qubits(), state.active_width(), state.size(), *final_tableau,
         state.global_scalar(), basis_mask_view(zero_frame), 0,
         [&](uint64_t active_index) {
             return std::complex<double>{state.real_data()[active_index],

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -54,6 +54,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       num_exp_vals_(plan.num_exp_vals),
       has_postselection_(plan.has_postselection),
       global_weight_(plan.global_weight),
+      final_tableau_(plan.final_tableau),
       instrument_distributions_(plan.instrument_distributions) {
     plan.validate();
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -52,6 +52,13 @@ struct ForcedTraceOut {
     uint8_t source = 0;
 };
 
+class ExecutablePlan;
+
+[[nodiscard]] std::vector<double> basis_probabilities(const ExecutablePlan& plan,
+                                                      std::span<const uint64_t> basis_masks,
+                                                      size_t num_basis_masks,
+                                                      size_t words_per_basis_mask);
+
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept;
 
@@ -71,6 +78,7 @@ class ExecutablePlan {
     [[nodiscard]] bool has_postselection() const { return has_postselection_; }
     [[nodiscard]] bool has_readout_noise() const { return has_readout_noise_; }
     [[nodiscard]] bool has_instruments() const { return has_instruments_; }
+    [[nodiscard]] bool supports_basis_probabilities() const { return final_tableau_.has_value(); }
     [[nodiscard]] uint32_t num_instrument_sites() const {
         return static_cast<uint32_t>(instrument_distributions_.size());
     }
@@ -85,6 +93,10 @@ class ExecutablePlan {
 
   private:
     friend class Executor;
+    friend std::vector<double> basis_probabilities(const ExecutablePlan& plan,
+                                                   std::span<const uint64_t> basis_masks,
+                                                   size_t num_basis_masks,
+                                                   size_t words_per_basis_mask);
 
     struct PreparedExpression {
         uint32_t term_begin = 0;
@@ -204,6 +216,7 @@ class ExecutablePlan {
     bool has_instruments_ = false;
     uint32_t initial_noise_end_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
+    std::optional<stim::Tableau<kStimWidth>> final_tableau_;
     std::vector<uint32_t> expression_terms_;
     // Maps each dense presampled input position to its plan-local SymbolId.
     // The constructor records those ids in ascending order.

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -79,6 +79,11 @@ class ExecutablePlan {
     [[nodiscard]] bool has_readout_noise() const { return has_readout_noise_; }
     [[nodiscard]] bool has_instruments() const { return has_instruments_; }
     [[nodiscard]] bool supports_basis_probabilities() const { return final_tableau_.has_value(); }
+    // Exact final-state queries need the coordinate-to-physical map, but
+    // ordinary execution must not depend on or mutate it.
+    [[nodiscard]] const stim::Tableau<kStimWidth>* final_state_tableau() const noexcept {
+        return final_tableau_ ? &*final_tableau_ : nullptr;
+    }
     [[nodiscard]] uint32_t num_instrument_sites() const {
         return static_cast<uint32_t>(instrument_distributions_.size());
     }
@@ -93,10 +98,6 @@ class ExecutablePlan {
 
   private:
     friend class Executor;
-    friend std::vector<double> basis_probabilities(const ExecutablePlan& plan,
-                                                   std::span<const uint64_t> basis_masks,
-                                                   size_t num_basis_masks,
-                                                   size_t words_per_basis_mask);
 
     struct PreparedExpression {
         uint32_t term_begin = 0;

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -348,6 +348,9 @@ void SamplingPlan::validate() const {
     if (!is_finite_robust(global_weight.real()) || !is_finite_robust(global_weight.imag())) {
         invalid_plan("global weight is not finite");
     }
+    if (final_tableau.has_value() && final_tableau->num_qubits != num_qubits) {
+        invalid_plan("final tableau width does not match the qubit count");
+    }
 
     if (presampled_noise_sites.size() != num_noise_sites) {
         invalid_plan("presampled noise-site table does not match declared count");
@@ -514,6 +517,12 @@ void SamplingPlan::validate() const {
         }
 
         const std::optional<SymbolId> definition = defined_symbol(planned.action);
+        if (final_tableau.has_value() &&
+            !std::holds_alternative<RotateActivePauli>(planned.action) &&
+            !std::holds_alternative<PromoteDormantRotation>(planned.action) &&
+            !std::holds_alternative<WriteExpectationValue>(planned.action)) {
+            invalid_plan("final tableau is retained for a nonunitary action stream");
+        }
         std::visit(
             [&](const auto& typed) {
                 using T = std::decay_t<decltype(typed)>;
@@ -697,8 +706,8 @@ std::string SamplingPlan::inspect() const {
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
         << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
         << " observables=" << num_observables << " exp_vals=" << num_exp_vals
-        << " postselection=" << has_postselection << " dust_epsilon=" << kMeasurementDustEpsilon
-        << '\n';
+        << " postselection=" << has_postselection << " basis_queries=" << final_tableau.has_value()
+        << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
     out << "global_weight=" << global_weight.real() << ',' << global_weight.imag() << '\n';
     out << "symbols=" << symbols.size() << '\n';
     for (uint32_t i = 0; i < symbols.size(); ++i) {

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -15,6 +15,7 @@
 // Clifford--Pauli Frames and Stabilizer Coordinates, arXiv:2607.28600.
 
 #include "clifft/util/numeric.h"
+#include "clifft/util/stim_mask.h"
 
 #include <array>
 #include <complex>
@@ -307,6 +308,11 @@ struct SamplingPlan {
     uint32_t num_exp_vals = 0;
     bool has_postselection = false;
     std::complex<double> global_weight = {1.0, 0.0};
+
+    // Present only for pure-state plans eligible for computational-basis
+    // queries. It maps the final stabilizer coordinates used by the action
+    // stream into physical qubits and is never read by ordinary dispatch.
+    std::optional<stim::Tableau<kStimWidth>> final_tableau;
 
     std::vector<SymbolInfo> symbols;
     std::vector<PresampledNoiseSite> presampled_noise_sites;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -29,6 +29,14 @@ using Tableau = stim::Tableau<kStimWidth>;
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
 
+void compose_final_tableau(SamplingPlan& plan, const Tableau& new_basis_in_old_coordinates) {
+    if (plan.final_tableau.has_value()) {
+        // A.then(B) represents B * A. The frame maps new coordinates into
+        // the old basis, so prepend it on the right of the physical map.
+        plan.final_tableau = new_basis_in_old_coordinates.then(*plan.final_tableau);
+    }
+}
+
 struct PendingRotation {
     Pauli body;
     double half_turns = 0.0;
@@ -479,6 +487,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
     uint32_t detector_index = 0;
     uint32_t next_noise_site = 0;
     uint32_t next_instrument_site = 0;
+    bool basis_queries_supported = true;
 
     for (size_t i = 0; i < hir.ops.size(); ++i) {
         const HeisenbergOp& op = hir.ops[i];
@@ -499,16 +508,19 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::MEASURE:
+                basis_queries_supported = false;
                 pending.emplace_back(PendingMeasurement{
                     pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
                     RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}, reserve_symbol(plan)});
                 break;
             case OpType::CONDITIONAL_PAULI:
+                basis_queries_supported = false;
                 pending.emplace_back(PendingConditionalPauli{
                     pauli_from_hir(hir, op),
                     RecordSlot{static_cast<uint32_t>(op.controlling_meas())}});
                 break;
             case OpType::NOISE: {
+                basis_queries_supported = false;
                 const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
                 if (site_index >= hir.noise_sites.size()) {
                     throw std::invalid_argument("sampling planner noise site is out of range");
@@ -543,6 +555,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::READOUT_NOISE: {
+                basis_queries_supported = false;
                 const uint32_t entry_index = static_cast<uint32_t>(op.readout_noise_idx());
                 if (entry_index >= hir.readout_noise.size()) {
                     throw std::invalid_argument("sampling planner readout entry is out of range");
@@ -554,6 +567,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::INSTRUMENT: {
+                basis_queries_supported = false;
                 const uint32_t site_index = static_cast<uint32_t>(op.instrument_site_idx());
                 if (site_index >= hir.instrument_sites.size() ||
                     site_index != next_instrument_site) {
@@ -574,6 +588,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::DETECTOR: {
+                basis_queries_supported = false;
                 const uint32_t targets_index = static_cast<uint32_t>(op.detector_idx());
                 if (targets_index >= hir.detector_targets.size() ||
                     detector_index >= hir.num_detectors) {
@@ -587,6 +602,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::OBSERVABLE: {
+                basis_queries_supported = false;
                 const uint32_t targets_index = op.observable_target_list_idx();
                 const uint32_t observable_index = static_cast<uint32_t>(op.observable_idx());
                 if (targets_index >= hir.observable_targets.size() ||
@@ -624,6 +640,9 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
         throw std::invalid_argument(
             "sampling planner instrument-site table is inconsistent with HIR");
     }
+    if (basis_queries_supported) {
+        plan.final_tableau = hir.final_tableau;
+    }
     return pending;
 }
 
@@ -646,6 +665,7 @@ void process_rotation(std::vector<PendingOperation>& pending, size_t index,
 
     const Tableau frame = dormant_promotion_frame(rotation.body, active_width, *dormant_pivot);
     transform_future_operations(pending, index + 1, frame);
+    compose_final_tableau(plan, frame);
     plan.actions.push_back(
         PlannedAction{active_width, active_width + 1,
                       PromoteDormantRotation{rotation.half_turns, rotation.sign}});

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1008,6 +1008,23 @@ NB_MODULE(_clifft_core, m) {
         "Sample survivor counts and optional records from an experimental program.");
 
     m.def(
+        "_basis_probabilities_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program,
+           nb::ndarray<nb::numpy, const uint64_t, nb::shape<-1, -1>, nb::c_contig> basis_masks) {
+            std::vector<double> probabilities;
+            {
+                nb::gil_scoped_release release;
+                probabilities = clifft::sampling::basis_probabilities(
+                    program, std::span<const uint64_t>(basis_masks.data(), basis_masks.size()),
+                    basis_masks.shape(0), basis_masks.shape(1));
+            }
+            const size_t size = probabilities.size();
+            return vec_to_numpy(std::move(probabilities), {size});
+        },
+        nb::arg("program"), nb::arg("basis_masks"),
+        "Return experimental scalar sampling computational-basis probabilities.");
+
+    m.def(
         "_record_probabilities_experimental_sampling",
         [](const clifft::sampling::ExecutablePlan& program,
            nb::ndarray<nb::numpy, const uint8_t, nb::shape<-1, -1>, nb::c_contig> records) {

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -12,9 +12,17 @@ from typing import TypeAlias, cast
 import numpy as np
 import numpy.typing as npt
 
-from clifft import Circuit, MeasurementRecords, _records_from_outcomes, noncomp
+from clifft import (
+    BasisBitstrings,
+    Circuit,
+    MeasurementRecords,
+    _basis_masks_from_bitstrings,
+    _records_from_outcomes,
+    noncomp,
+)
 from clifft._clifft_core import (
     HirPassManager,
+    _basis_probabilities_experimental_sampling,
     _compile_experimental_sampling,
     _ExperimentalSamplingProgram,
     _record_probabilities_experimental_sampling,
@@ -46,7 +54,7 @@ def compile(
     """Compile Stim text for the experimental scalar sampling backend.
 
     The default HIR optimization pipeline matches :func:`clifft.compile`;
-    pass ``None`` to skip it. Exact final-state queries remain unsupported.
+    pass ``None`` to skip it. Dense statevector expansion remains unsupported.
     """
     if isinstance(hir_passes, _DefaultPasses):
         hir_passes = default_hir_pass_manager()
@@ -161,9 +169,30 @@ def record_probabilities(
     return np.exp(log_probabilities)
 
 
+def basis_probabilities(
+    program: Program,
+    bitstrings: BasisBitstrings,
+    *,
+    bit_order: str = "big",
+    return_log: bool = False,
+) -> npt.NDArray[np.float64]:
+    """Return exact Born probabilities from an experimental pure-state program."""
+    probabilities = cast(
+        npt.NDArray[np.float64],
+        _basis_probabilities_experimental_sampling(
+            program, _basis_masks_from_bitstrings(program, bitstrings, bit_order)
+        ),
+    )
+    if return_log:
+        with np.errstate(divide="ignore"):
+            return np.log(probabilities)
+    return probabilities
+
+
 __all__ = [
     "MeasurementRecords",
     "Program",
+    "basis_probabilities",
     "compile",
     "record_probabilities",
     "sample",

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -17,6 +17,12 @@ def sampling_api(request: pytest.FixtureRequest) -> Any:
     return cast(Any, request.param)
 
 
+@pytest.fixture(params=[clifft, experimental], ids=["legacy", "experimental"])
+def basis_probabilities_api(request: pytest.FixtureRequest) -> Any:
+    """Run shared exact basis-query tests against both Python APIs."""
+    return cast(Any, request.param)
+
+
 @pytest.fixture(
     params=[clifft.noncomp.sample, experimental.sample_noncomputational],
     ids=["svm", "symbolic-coordinate"],

--- a/tests/python/test_basis_probabilities.py
+++ b/tests/python/test_basis_probabilities.py
@@ -12,91 +12,108 @@ from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
 import clifft
 
 
-def test_program_num_qubits_property() -> None:
-    prog = clifft.compile("H 0\nCX 0 2")
+def test_program_num_qubits_property(basis_probabilities_api: Any) -> None:
+    prog = basis_probabilities_api.compile("H 0\nCX 0 2")
 
     assert prog.num_qubits == 3
 
 
-def test_bell_state_basis_probabilities() -> None:
-    prog = clifft.compile("H 0\nCX 0 1")
+def test_bell_state_basis_probabilities(basis_probabilities_api: Any) -> None:
+    prog = basis_probabilities_api.compile("H 0\nCX 0 1")
 
-    probs = clifft.basis_probabilities(prog, ["00", "01", "10", "11"])
+    probs = basis_probabilities_api.basis_probabilities(prog, ["00", "01", "10", "11"])
 
     np.testing.assert_allclose(probs, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
     assert probs.dtype == np.float64
     assert probs.shape == (4,)
 
 
-def test_bit_order_big_maps_first_position_to_qubit_zero() -> None:
-    prog_x0 = clifft.compile("X 0\nH 1\nH 1")
-    prog_x1 = clifft.compile("X 1")
-
-    np.testing.assert_allclose(clifft.basis_probabilities(prog_x0, ["10", "01"]), [1.0, 0.0])
-    np.testing.assert_allclose(clifft.basis_probabilities(prog_x1, ["10", "01"]), [0.0, 1.0])
-
-
-def test_bit_order_little_maps_last_position_to_qubit_zero() -> None:
-    prog_x0 = clifft.compile("X 0\nH 1\nH 1")
-    prog_x1 = clifft.compile("X 1")
+def test_bit_order_big_maps_first_position_to_qubit_zero(basis_probabilities_api: Any) -> None:
+    prog_x0 = basis_probabilities_api.compile("X 0\nH 1\nH 1")
+    prog_x1 = basis_probabilities_api.compile("X 1")
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog_x0, ["01", "10"], bit_order="little"), [1.0, 0.0]
+        basis_probabilities_api.basis_probabilities(prog_x0, ["10", "01"]), [1.0, 0.0]
     )
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog_x1, ["01", "10"], bit_order="little"), [0.0, 1.0]
+        basis_probabilities_api.basis_probabilities(prog_x1, ["10", "01"]), [0.0, 1.0]
+    )
+
+
+def test_bit_order_little_maps_last_position_to_qubit_zero(
+    basis_probabilities_api: Any,
+) -> None:
+    prog_x0 = basis_probabilities_api.compile("X 0\nH 1\nH 1")
+    prog_x1 = basis_probabilities_api.compile("X 1")
+
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog_x0, ["01", "10"], bit_order="little"),
+        [1.0, 0.0],
+    )
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog_x1, ["01", "10"], bit_order="little"),
+        [0.0, 1.0],
     )
 
 
 @pytest.mark.parametrize("dtype", [np.bool_, np.uint8])
-def test_array_input_matches_string_input(dtype: np.dtype) -> None:
-    prog = clifft.compile("X 0\nH 1\nH 1")
+def test_array_input_matches_string_input(dtype: np.dtype, basis_probabilities_api: Any) -> None:
+    prog = basis_probabilities_api.compile("X 0\nH 1\nH 1")
     bits = np.array([[1, 0], [0, 1]], dtype=dtype)
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bits),
-        clifft.basis_probabilities(prog, ["10", "01"]),
+        basis_probabilities_api.basis_probabilities(prog, bits),
+        basis_probabilities_api.basis_probabilities(prog, ["10", "01"]),
     )
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bits, bit_order="little"),
-        clifft.basis_probabilities(prog, ["10", "01"], bit_order="little"),
+        basis_probabilities_api.basis_probabilities(prog, bits, bit_order="little"),
+        basis_probabilities_api.basis_probabilities(prog, ["10", "01"], bit_order="little"),
     )
 
 
-def test_probabilities_supports_high_qubit_string_bitstrings() -> None:
-    prog = clifft.compile("H 70")
+def test_probabilities_supports_high_qubit_string_bitstrings(
+    basis_probabilities_api: Any,
+) -> None:
+    prog = basis_probabilities_api.compile("H 70")
     zero = "0" * 71
     one_q70_big = ("0" * 70) + "1"
     one_q70_little = "1" + ("0" * 70)
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, [zero, one_q70_big]),
+        basis_probabilities_api.basis_probabilities(prog, [zero, one_q70_big]),
         [0.5, 0.5],
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, [zero, one_q70_little], bit_order="little"),
+        basis_probabilities_api.basis_probabilities(
+            prog, [zero, one_q70_little], bit_order="little"
+        ),
         [0.5, 0.5],
         atol=1e-12,
     )
 
 
 @pytest.mark.parametrize("dtype", [np.bool_, np.uint8])
-def test_probabilities_supports_high_qubit_array_bitstrings(dtype: np.dtype) -> None:
-    prog = clifft.compile("X 70")
+def test_probabilities_supports_high_qubit_array_bitstrings(
+    dtype: np.dtype, basis_probabilities_api: Any
+) -> None:
+    prog = basis_probabilities_api.compile("X 70")
     bits = np.zeros((2, 71), dtype=dtype)
     bits[1, 70] = 1
     little_bits = np.zeros((2, 71), dtype=dtype)
     little_bits[1, 0] = 1
 
-    np.testing.assert_allclose(clifft.basis_probabilities(prog, bits), [0.0, 1.0])
+    np.testing.assert_allclose(basis_probabilities_api.basis_probabilities(prog, bits), [0.0, 1.0])
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, little_bits, bit_order="little"), [0.0, 1.0]
+        basis_probabilities_api.basis_probabilities(prog, little_bits, bit_order="little"),
+        [0.0, 1.0],
     )
 
 
-def test_probabilities_supports_multiword_array_bitstrings() -> None:
-    prog = clifft.compile("H 199\nH 199")
+def test_probabilities_supports_multiword_array_bitstrings(
+    basis_probabilities_api: Any,
+) -> None:
+    prog = basis_probabilities_api.compile("H 199\nH 199")
     bits = np.zeros((3, 200), dtype=np.uint8)
     bits[1, 0] = 1
     bits[2, 199] = 1
@@ -104,34 +121,36 @@ def test_probabilities_supports_multiword_array_bitstrings() -> None:
     little_bits[1, 199] = 1
     little_bits[2, 0] = 1
 
-    np.testing.assert_allclose(clifft.basis_probabilities(prog, bits), [1.0, 0.0, 0.0])
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, little_bits, bit_order="little"),
+        basis_probabilities_api.basis_probabilities(prog, bits), [1.0, 0.0, 0.0]
+    )
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog, little_bits, bit_order="little"),
         [1.0, 0.0, 0.0],
     )
 
 
-def test_probability_input_validation() -> None:
-    prog = clifft.compile("H 0\nCX 0 1")
+def test_probability_input_validation(basis_probabilities_api: Any) -> None:
+    prog = basis_probabilities_api.compile("H 0\nCX 0 1")
 
     with pytest.raises(ValueError, match="length 1, expected 2"):
-        clifft.basis_probabilities(prog, ["0"])
+        basis_probabilities_api.basis_probabilities(prog, ["0"])
     with pytest.raises(ValueError, match="expected only '0' and '1'"):
-        clifft.basis_probabilities(prog, ["0x"])
+        basis_probabilities_api.basis_probabilities(prog, ["0x"])
     with pytest.raises(ValueError, match="bit_order"):
-        clifft.basis_probabilities(prog, ["00"], bit_order="middle")
+        basis_probabilities_api.basis_probabilities(prog, ["00"], bit_order="middle")
     with pytest.raises(TypeError, match="strings or a 2D"):
         invalid_sequence: Any = [[0, 0]]
-        clifft.basis_probabilities(prog, invalid_sequence)
+        basis_probabilities_api.basis_probabilities(prog, invalid_sequence)
     with pytest.raises(ValueError, match="array must be 2D"):
-        clifft.basis_probabilities(prog, np.array([0, 1], dtype=np.uint8))
+        basis_probabilities_api.basis_probabilities(prog, np.array([0, 1], dtype=np.uint8))
     with pytest.raises(ValueError, match="3 columns, expected 2"):
-        clifft.basis_probabilities(prog, np.array([[0, 1, 0]], dtype=np.uint8))
+        basis_probabilities_api.basis_probabilities(prog, np.array([[0, 1, 0]], dtype=np.uint8))
     with pytest.raises(TypeError, match="dtype must be bool or uint8"):
         invalid_dtype: Any = np.array([[0, 1]], dtype=np.int64)
-        clifft.basis_probabilities(prog, invalid_dtype)
+        basis_probabilities_api.basis_probabilities(prog, invalid_dtype)
     with pytest.raises(ValueError, match="contain only 0 and 1"):
-        clifft.basis_probabilities(prog, np.array([[0, 2]], dtype=np.uint8))
+        basis_probabilities_api.basis_probabilities(prog, np.array([[0, 2]], dtype=np.uint8))
 
 
 @pytest.mark.parametrize(
@@ -146,28 +165,32 @@ def test_probability_input_validation() -> None:
         ("M 0\nCX rec[-1] 1", {}),
     ],
 )
-def test_probabilities_rejects_non_unitary_programs(circuit: str, kwargs: dict[str, Any]) -> None:
-    prog = clifft.compile(circuit, **kwargs)
+def test_probabilities_rejects_non_unitary_programs(
+    circuit: str, kwargs: dict[str, Any], basis_probabilities_api: Any
+) -> None:
+    prog = basis_probabilities_api.compile(circuit, **kwargs)
 
     with pytest.raises(ValueError, match="requires pure-state evolution"):
-        clifft.basis_probabilities(prog, ["0" * prog.num_qubits])
+        basis_probabilities_api.basis_probabilities(prog, ["0" * prog.num_qubits])
 
 
-def test_probabilities_allows_exp_val_probes() -> None:
-    with_probe = clifft.compile("H 0\nEXP_VAL X0")
-    without_probe = clifft.compile("H 0")
+def test_probabilities_allows_exp_val_probes(basis_probabilities_api: Any) -> None:
+    with_probe = basis_probabilities_api.compile("H 0\nEXP_VAL X0")
+    without_probe = basis_probabilities_api.compile("H 0")
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(with_probe, ["0", "1"]),
-        clifft.basis_probabilities(without_probe, ["0", "1"]),
+        basis_probabilities_api.basis_probabilities(with_probe, ["0", "1"]),
+        basis_probabilities_api.basis_probabilities(without_probe, ["0", "1"]),
         atol=1e-12,
     )
 
 
-def test_drop_non_unitary_pass_enables_querying_unitary_skeleton() -> None:
+def test_drop_non_unitary_pass_enables_querying_unitary_skeleton(
+    basis_probabilities_api: Any,
+) -> None:
     passes = clifft.HirPassManager()
     passes.add(clifft.DropNonUnitaryPass())
-    prog = clifft.compile(
+    prog = basis_probabilities_api.compile(
         """
         H 0
         M 0
@@ -183,10 +206,16 @@ def test_drop_non_unitary_pass_enables_querying_unitary_skeleton() -> None:
     assert prog.num_detectors == 0
     assert prog.num_observables == 0
     assert prog.num_exp_vals == 0
-    np.testing.assert_allclose(clifft.basis_probabilities(prog, ["0", "1"]), [0.5, 0.5], atol=1e-12)
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog, ["0", "1"]),
+        [0.5, 0.5],
+        atol=1e-12,
+    )
 
 
-def test_probabilities_match_dense_statevector_for_small_circuit() -> None:
+def test_probabilities_match_dense_statevector_for_small_circuit(
+    basis_probabilities_api: Any,
+) -> None:
     circuit = """
     H 0
     CX 0 1
@@ -194,20 +223,27 @@ def test_probabilities_match_dense_statevector_for_small_circuit() -> None:
     H 2
     CX 2 0
     """
-    prog = clifft.compile(circuit)
+    prog = basis_probabilities_api.compile(circuit)
+    legacy_prog = clifft.compile(circuit)
 
-    state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)
-    clifft.execute(prog, state)
-    expected = np.abs(clifft.get_statevector(prog, state)) ** 2
+    state = clifft.State(
+        peak_rank=legacy_prog.peak_rank, num_measurements=legacy_prog.num_measurements
+    )
+    clifft.execute(legacy_prog, state)
+    expected = np.abs(clifft.get_statevector(legacy_prog, state)) ** 2
     bitstrings = [format(i, f"0{prog.num_qubits}b")[::-1] for i in range(1 << prog.num_qubits)]
 
-    np.testing.assert_allclose(clifft.basis_probabilities(prog, bitstrings), expected, atol=1e-12)
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog, bitstrings), expected, atol=1e-12
+    )
 
 
 @pytest.mark.parametrize("num_qubits,seed", [(2, 101), (3, 202), (4, 303)])
-def test_probabilities_match_qiskit_for_random_small_circuits(num_qubits: int, seed: int) -> None:
+def test_probabilities_match_qiskit_for_random_small_circuits(
+    num_qubits: int, seed: int, basis_probabilities_api: Any
+) -> None:
     circuit = random_dense_clifford_t_circuit(num_qubits, depth=18, seed=seed)
-    prog = clifft.compile(circuit)
+    prog = basis_probabilities_api.compile(circuit)
     qiskit_sv = qiskit_statevector(stim_to_qiskit_noiseless(circuit))
     bitstrings = (
         (
@@ -218,71 +254,85 @@ def test_probabilities_match_qiskit_for_random_small_circuits(num_qubits: int, s
     ).astype(np.uint8)
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bitstrings),
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
         np.abs(qiskit_sv) ** 2,
         atol=1e-12,
     )
 
 
-def test_probabilities_supports_active_rank_beyond_dense_statevector_limit() -> None:
+def test_probabilities_supports_active_rank_beyond_dense_statevector_limit(
+    basis_probabilities_api: Any,
+) -> None:
     circuit = "\n".join(f"H {q}\nT {q}" for q in range(12))
-    prog = clifft.compile(circuit)
+    prog = basis_probabilities_api.compile(circuit)
+    legacy_prog = clifft.compile(circuit)
 
     assert prog.num_qubits == 12
-    assert prog.peak_rank > 10
+    assert legacy_prog.peak_rank > 10
     with pytest.raises(RuntimeError, match="Statevector expansion limited"):
-        state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)
-        clifft.execute(prog, state)
-        clifft.get_statevector(prog, state)
+        state = clifft.State(
+            peak_rank=legacy_prog.peak_rank, num_measurements=legacy_prog.num_measurements
+        )
+        clifft.execute(legacy_prog, state)
+        clifft.get_statevector(legacy_prog, state)
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, ["0" * 12, "1" * 12]),
+        basis_probabilities_api.basis_probabilities(prog, ["0" * 12, "1" * 12]),
         [2**-12, 2**-12],
         atol=1e-15,
     )
 
 
-def test_probabilities_match_formula_for_continuous_z_rotation() -> None:
+def test_probabilities_match_formula_for_continuous_z_rotation(
+    basis_probabilities_api: Any,
+) -> None:
     # H R_Z(alpha) H |0> -> cos(pi*alpha/2) |0> - i sin(pi*alpha/2) |1>.
     # Exercises the OP_ARRAY_ROT / PHASE_ROTATION path the random Clifford+T
     # circuits never touch.
     alpha = 0.123
-    prog = clifft.compile(f"H 0\nR_Z({alpha}) 0\nH 0")
+    prog = basis_probabilities_api.compile(f"H 0\nR_Z({alpha}) 0\nH 0")
     half_angle = math.pi * alpha / 2.0
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, ["0", "1"]),
+        basis_probabilities_api.basis_probabilities(prog, ["0", "1"]),
         [math.cos(half_angle) ** 2, math.sin(half_angle) ** 2],
         atol=1e-12,
     )
 
 
-def test_probabilities_sum_to_one_at_high_active_rank() -> None:
+def test_probabilities_sum_to_one_at_high_active_rank(basis_probabilities_api: Any) -> None:
     # Unitarity invariant on a circuit whose peak_rank exceeds the
     # statevector-expansion limit, so this catches normalization regressions
     # that the small-circuit statevector cross-check cannot.
-    prog = clifft.compile("\n".join(f"H {q}\nT {q}" for q in range(12)))
-    assert prog.peak_rank > 10
+    circuit = "\n".join(f"H {q}\nT {q}" for q in range(12))
+    prog = basis_probabilities_api.compile(circuit)
+    assert clifft.compile(circuit).peak_rank > 10
     n = prog.num_qubits
     bitstrings = [format(i, f"0{n}b") for i in range(1 << n)]
-    np.testing.assert_allclose(clifft.basis_probabilities(prog, bitstrings).sum(), 1.0, atol=1e-10)
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog, bitstrings).sum(), 1.0, atol=1e-10
+    )
 
 
-def test_probabilities_handles_empty_and_singleton_inputs() -> None:
-    prog = clifft.compile("H 0")
+def test_probabilities_handles_empty_and_singleton_inputs(
+    basis_probabilities_api: Any,
+) -> None:
+    prog = basis_probabilities_api.compile("H 0")
 
-    empty_list = clifft.basis_probabilities(prog, [])
+    empty_list = basis_probabilities_api.basis_probabilities(prog, [])
     assert empty_list.shape == (0,)
     assert empty_list.dtype == np.float64
 
-    empty_arr = clifft.basis_probabilities(prog, np.zeros((0, 1), dtype=np.uint8))
+    empty_arr = basis_probabilities_api.basis_probabilities(prog, np.zeros((0, 1), dtype=np.uint8))
     assert empty_arr.shape == (0,)
 
-    single = clifft.basis_probabilities(prog, "0")
+    single = basis_probabilities_api.basis_probabilities(prog, "0")
     assert single.shape == (1,)
     np.testing.assert_allclose(single, [0.5], atol=1e-12)
 
 
-def test_probabilities_match_statevector_for_fused_unitaries() -> None:
+def test_probabilities_match_statevector_for_fused_unitaries(
+    basis_probabilities_api: Any,
+) -> None:
     # Construct a circuit that triggers both single-axis (OP_ARRAY_U2) and
     # tile (OP_ARRAY_U4) fusion so the supported-opcode listing for those
     # paths is actually exercised end-to-end.
@@ -291,17 +341,22 @@ def test_probabilities_match_statevector_for_fused_unitaries() -> None:
         "H 1\nT 1\nS 1\nH 1\nT 1\nS 1\nH 1\nT 1\nS 1\n"
         "CX 0 1\nH 0\nT 0\nS 0"
     )
-    prog = clifft.compile(src)
-    opcodes = {instr.opcode for instr in prog}
+    prog = basis_probabilities_api.compile(src)
+    legacy_prog = clifft.compile(src)
+    opcodes = {instr.opcode for instr in legacy_prog}
     assert clifft.Opcode.OP_ARRAY_U2 in opcodes, "test circuit no longer triggers U2 fusion"
     assert clifft.Opcode.OP_ARRAY_U4 in opcodes, "test circuit no longer triggers U4 fusion"
 
-    state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)
-    clifft.execute(prog, state)
-    expected = np.abs(clifft.get_statevector(prog, state)) ** 2
+    state = clifft.State(
+        peak_rank=legacy_prog.peak_rank, num_measurements=legacy_prog.num_measurements
+    )
+    clifft.execute(legacy_prog, state)
+    expected = np.abs(clifft.get_statevector(legacy_prog, state)) ** 2
     n = prog.num_qubits
     bitstrings = [format(i, f"0{n}b")[::-1] for i in range(1 << n)]
-    np.testing.assert_allclose(clifft.basis_probabilities(prog, bitstrings), expected, atol=1e-12)
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog, bitstrings), expected, atol=1e-12
+    )
 
 
 def _all_bitstrings(num_qubits: int) -> list[str]:
@@ -318,21 +373,27 @@ def _statevector_probs(prog: clifft.Program) -> npt.NDArray[np.float64]:
     return cast(npt.NDArray[np.float64], np.abs(clifft.get_statevector(prog, state)) ** 2)
 
 
-def test_probabilities_pure_clifford_zero_active_rank() -> None:
+def test_probabilities_pure_clifford_zero_active_rank(basis_probabilities_api: Any) -> None:
     # Pure Clifford circuit: peak_rank == 0, so the Gray code walk degenerates
     # to a single iteration (r_A = 0). The H-on-every-qubit prefix makes the
     # inverse tableau's Z-block fully X-rotated, so every dormant column is a
     # pivot and the fast path engages.
-    prog = clifft.compile("H 0\nH 1\nH 2\nCX 0 1\nCX 1 2\nS 0")
-    assert prog.peak_rank == 0
+    circuit = "H 0\nH 1\nH 2\nCX 0 1\nCX 1 2\nS 0"
+    prog = basis_probabilities_api.compile(circuit)
+    legacy_prog = clifft.compile(circuit)
+    assert legacy_prog.peak_rank == 0
 
     bitstrings = _all_bitstrings(prog.num_qubits)
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
+        _statevector_probs(legacy_prog),
+        atol=1e-12,
     )
 
 
-def test_probabilities_full_rank_clifford_t_matches_statevector() -> None:
+def test_probabilities_full_rank_clifford_t_matches_statevector(
+    basis_probabilities_api: Any,
+) -> None:
     # Every qubit is touched by Clifford+T, so the inverse tableau has full
     # X-rank and every dormant column is a pivot. Exercises the Gray code
     # fast path.
@@ -348,50 +409,67 @@ def test_probabilities_full_rank_clifford_t_matches_statevector() -> None:
         lines.append(f"T {q}")
     for q in range(n):
         lines.append(f"H {q}")
-    prog = clifft.compile("\n".join(lines))
+    circuit = "\n".join(lines)
+    prog = basis_probabilities_api.compile(circuit)
+    legacy_prog = clifft.compile(circuit)
 
     bitstrings = _all_bitstrings(n)
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
+        _statevector_probs(legacy_prog),
+        atol=1e-12,
     )
 
 
-def test_probabilities_rank_deficient_fallback_matches_statevector() -> None:
+def test_probabilities_rank_deficient_fallback_matches_statevector(
+    basis_probabilities_api: Any,
+) -> None:
     # Untouched qubits leave the inverse tableau's Z-row at Z_q, which has no
     # X support. With an active subspace formed by T-gates on other qubits,
     # the X-rank restricted to dormant columns drops below (n - active_k),
     # which forces the can_use_gray_code = false fallback in basis_probabilities().
     # If the fallback regresses we will see a mismatch here.
-    prog = clifft.compile("H 0\nT 0\nH 0\nH 2")
+    circuit = "H 0\nT 0\nH 0\nH 2"
+    prog = basis_probabilities_api.compile(circuit)
+    legacy_prog = clifft.compile(circuit)
     assert prog.num_qubits == 3
     bitstrings = _all_bitstrings(3)
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
+        _statevector_probs(legacy_prog),
+        atol=1e-12,
     )
 
 
 @pytest.mark.parametrize("seed", [0, 1, 7, 42, 1234])
-def test_probabilities_random_clifford_t_matches_statevector(seed: int) -> None:
+def test_probabilities_random_clifford_t_matches_statevector(
+    seed: int, basis_probabilities_api: Any
+) -> None:
     # Spot-check both paths against ground truth across several seeds. The
     # random circuit generator typically yields full-rank tableaus, so this
     # primarily exercises the Gray code path, but the assertion catches any
     # bug in either branch.
     circuit = random_dense_clifford_t_circuit(num_qubits=5, depth=20, seed=seed)
-    prog = clifft.compile(circuit)
+    prog = basis_probabilities_api.compile(circuit)
+    legacy_prog = clifft.compile(circuit)
     bitstrings = _all_bitstrings(prog.num_qubits)
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bitstrings), _statevector_probs(prog), atol=1e-12
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
+        _statevector_probs(legacy_prog),
+        atol=1e-12,
     )
 
 
-def test_probabilities_fast_path_multiword_dormant_block() -> None:
+def test_probabilities_fast_path_multiword_dormant_block(
+    basis_probabilities_api: Any,
+) -> None:
     # H on every qubit gives a uniform superposition (probability 2^-n for
     # each basis state) and an inverse tableau with full X-rank, so the
     # fast path engages. Pushing past 64 qubits forces the dormant-bit
     # match and the running basis to cross word boundaries, which the
     # other regression tests (all n <= 64) do not exercise.
     n = 70
-    prog = clifft.compile("\n".join(f"H {q}" for q in range(n)))
+    prog = basis_probabilities_api.compile("\n".join(f"H {q}" for q in range(n)))
     assert prog.num_qubits == n
 
     zero = "0" * n
@@ -401,22 +479,24 @@ def test_probabilities_fast_path_multiword_dormant_block() -> None:
     bitstrings = [zero, one_q0, one_q63, one_q69]
 
     np.testing.assert_allclose(
-        clifft.basis_probabilities(prog, bitstrings),
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
         [2.0**-n] * len(bitstrings),
         atol=1e-15,
     )
 
 
-def test_basis_probabilities_return_log() -> None:
-    prog = clifft.compile("H 0\nCX 0 1")
-    log_probs = clifft.basis_probabilities(prog, ["00", "01", "10", "11"], return_log=True)
+def test_basis_probabilities_return_log(basis_probabilities_api: Any) -> None:
+    prog = basis_probabilities_api.compile("H 0\nCX 0 1")
+    log_probs = basis_probabilities_api.basis_probabilities(
+        prog, ["00", "01", "10", "11"], return_log=True
+    )
     assert np.isclose(log_probs[0], np.log(0.5))
     assert log_probs[1] == -np.inf
     assert log_probs[2] == -np.inf
     assert np.isclose(log_probs[3], np.log(0.5))
 
 
-def test_basis_probabilities_return_log_default_false() -> None:
-    prog = clifft.compile("H 0")
-    probs = clifft.basis_probabilities(prog, ["0"])
+def test_basis_probabilities_return_log_default_false(basis_probabilities_api: Any) -> None:
+    prog = basis_probabilities_api.compile("H 0")
+    probs = basis_probabilities_api.basis_probabilities(prog, ["0"])
     np.testing.assert_allclose(probs, [0.5], atol=1e-12)

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -115,6 +115,22 @@ void require_matches_legacy(std::string_view circuit_text, uint32_t shots, uint6
     }
 }
 
+void require_basis_probabilities_match_legacy(std::string_view circuit_text,
+                                              std::span<const uint64_t> basis_masks,
+                                              size_t num_basis_masks, size_t words_per_basis_mask) {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(circuit_text));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    const std::vector<double> actual = clifft::sampling::basis_probabilities(
+        executable, basis_masks, num_basis_masks, words_per_basis_mask);
+    const std::vector<double> expected = clifft::basis_probabilities(
+        clifft::lower(hir), basis_masks, num_basis_masks, words_per_basis_mask);
+    REQUIRE(actual.size() == expected.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+        CAPTURE(circuit_text, i);
+        REQUIRE_THAT(actual[i], Catch::Matchers::WithinAbs(expected[i], 1e-12));
+    }
+}
+
 void require_replay_matches_legacy(std::string_view circuit_text,
                                    std::span<const uint8_t> forced_records, size_t num_records) {
     const clifft::HirModule hir = clifft::trace(clifft::parse(circuit_text));
@@ -448,6 +464,32 @@ TEST_CASE("Sampling replay evaluates record-dependent expectations") {
         REQUIRE_THAT(replay.log_probability, Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
         REQUIRE(executor.exp_vals()[0] == (forced_record == 0 ? 1.0 : -1.0));
     }
+}
+
+TEST_CASE("Sampling basis probabilities match legacy exact queries") {
+    constexpr std::array<uint64_t, 4> kTwoQubitBasis{0, 1, 2, 3};
+    require_basis_probabilities_match_legacy("H 0\nCX 0 1\n", kTwoQubitBasis, 4, 1);
+    require_basis_probabilities_match_legacy("H 0\nT 0\nH 1\nT 1\nCX 0 1\n", kTwoQubitBasis, 4, 1);
+    require_basis_probabilities_match_legacy("H 0\nT 0\nCX 0 1\nR_Z(0.123) 1\nH 0\n",
+                                             kTwoQubitBasis, 4, 1);
+
+    constexpr std::array<uint64_t, 4> kHighQubitBasis{0, 0, 0, uint64_t{1} << 6};
+    require_basis_probabilities_match_legacy("H 70\n", kHighQubitBasis, 2, 2);
+}
+
+TEST_CASE("Sampling basis probabilities reject nonunitary plans") {
+    const ExecutablePlan measured(plan_from("M 0\n"));
+    REQUIRE_FALSE(measured.supports_basis_probabilities());
+    REQUIRE_THROWS_AS(
+        clifft::sampling::basis_probabilities(measured, std::array<uint64_t, 1>{0}, 1, 1),
+        std::invalid_argument);
+
+    const ExecutablePlan with_probe(plan_from("H 0\nEXP_VAL X0\n"));
+    REQUIRE(with_probe.supports_basis_probabilities());
+    const std::vector<double> probabilities =
+        clifft::sampling::basis_probabilities(with_probe, std::array<uint64_t, 2>{0, 1}, 2, 1);
+    REQUIRE_THAT(probabilities[0], Catch::Matchers::WithinAbs(0.5, 1e-12));
+    REQUIRE_THAT(probabilities[1], Catch::Matchers::WithinAbs(0.5, 1e-12));
 }
 
 TEST_CASE("Sampling replay checks all records conditional on presampled symbols") {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -522,6 +522,24 @@ TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
     }
 }
 
+TEST_CASE("Sampling plan validates exact-query metadata") {
+    SamplingPlan unitary = valid_rotation_plan();
+    unitary.final_tableau = stim::Tableau<clifft::kStimWidth>(1);
+    REQUIRE_NOTHROW(unitary.validate());
+    REQUIRE(unitary.inspect().find("basis_queries=1") != std::string::npos);
+
+    SECTION("tableau width") {
+        unitary.final_tableau = stim::Tableau<clifft::kStimWidth>(2);
+        REQUIRE_THROWS_AS(unitary.validate(), std::invalid_argument);
+    }
+
+    SECTION("nonunitary action stream") {
+        SamplingPlan measured = valid_dormant_measurement_plan();
+        measured.final_tableau = stim::Tableau<clifft::kStimWidth>(1);
+        REQUIRE_THROWS_AS(measured.validate(), std::invalid_argument);
+    }
+}
+
 TEST_CASE("Sampling plan predicts only state touching dense passes") {
     SamplingPlan plan = valid_rotation_plan();
     REQUIRE_NOTHROW(plan.validate());

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -347,6 +347,7 @@ TEST_CASE("Sampling planner classifies active and dormant expectation probes") {
 
     REQUIRE(plan.num_exp_vals == 3);
     REQUIRE(plan.actions.size() == 4);
+    REQUIRE(plan.final_tableau.has_value());
     const auto& active = action_as<WriteExpectationValue>(plan, 1);
     REQUIRE(active.active_projection.has_value());
     REQUIRE_FALSE(active.active_projection->is_identity());
@@ -362,6 +363,7 @@ TEST_CASE("Sampling planner classifies active and dormant expectation probes") {
 TEST_CASE("Sampling planner propagates stochastic signs into expectation probes") {
     const SamplingPlan noise =
         plan_sampling(clifft::trace(clifft::parse("X_ERROR(1) 0\nEXP_VAL Z0")));
+    REQUIRE_FALSE(noise.final_tableau.has_value());
     const auto& noise_probe = action_as<WriteExpectationValue>(noise, 0);
     REQUIRE(noise_probe.active_projection.has_value());
     REQUIRE(noise_probe.active_projection->is_identity());


### PR DESCRIPTION
Closes #274.

## Summary

- retain the final coordinate-to-physical tableau only for pure-state plans eligible for exact basis queries
- share the existing exact basis-probability evaluator between the legacy interleaved state and symbolic split coefficients
- expose clifft.experimental.basis_probabilities with the same query inputs and results as the public API
- run the existing basis-probability Python oracle suite against both backends, plus focused planner, validation, multiword-mask, and executor differentials

## Sampling-path impact

This adds no sampling actions and changes no ordinary executor dispatch or kernel. The final tableau is composed during planning and retained only for eligible unitary plans; noisy, measured, feedback, detector, and instrument plans do not carry it. Executor state is evaluated only when the exact query is explicitly requested.

Dense statevector expansion remains deferred to a separate slice.

## Validation

- pre-commit: all hooks passed
- C++: 1,225 cases / 375,688 assertions passed
- Python: 1,145 tests passed
- focused basis-probability Python suite: 80 tests passed