### PR TITLE
feat(sampling): add pure-state statevector queries

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(clifft_core STATIC
     api/basis_probabilities.cc
     api/record_probabilities.cc
     api/reference_syndrome.cc
+    api/statevector.cc
     svm/svm.cc
     svm/svm_forced_kernels.cc
     svm/svm_instrument_kernels.cc

--- a/src/clifft/api/statevector.cc
+++ b/src/clifft/api/statevector.cc
@@ -1,0 +1,115 @@
+#include "clifft/sampling/executor.h"
+#include "clifft/svm/svm.h"
+#include "clifft/svm/svm_math.h"
+
+#include <bit>
+#include <cassert>
+#include <complex>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace clifft {
+namespace {
+
+constexpr uint32_t kMaxStatevectorQubits = 10;
+
+void validate_statevector_size(uint32_t num_qubits) {
+    if (num_qubits > kMaxStatevectorQubits) {
+        throw std::runtime_error(
+            "Statevector expansion limited to 10 qubits (dense U_C matrix is 4^n)");
+    }
+}
+
+template <typename CoefficientAt>
+std::vector<std::complex<double>> expand_factored_state(
+    uint32_t num_qubits, uint32_t active_width, uint64_t active_size, uint64_t pauli_x,
+    uint64_t pauli_z, const stim::Tableau<kStimWidth>* final_tableau, std::complex<double> scale,
+    CoefficientAt coefficient_at) {
+    validate_statevector_size(num_qubits);
+    const uint64_t dimension = uint64_t{1} << num_qubits;
+    assert(active_width <= num_qubits && "active width exceeds physical qubit count");
+    assert(active_size == (uint64_t{1} << active_width) &&
+           "active coefficient count does not match active width");
+
+    // Active coordinates occupy the low bits and dormant coordinates are
+    // |0>. Apply the virtual Pauli frame while embedding so the dense
+    // expansion needs only the framed and physical arrays.
+    std::vector<std::complex<double>> framed(dimension, {0.0, 0.0});
+    for (uint64_t index = 0; index < active_size; ++index) {
+        const uint64_t target = index ^ pauli_x;
+        const double sign = (std::popcount(index & pauli_z) & 1U) != 0 ? -1.0 : 1.0;
+        framed[target] = coefficient_at(index) * sign;
+    }
+
+    std::vector<std::complex<double>> physical;
+    if (final_tableau == nullptr) {
+        physical = std::move(framed);
+    } else {
+        physical.assign(dimension, {0.0, 0.0});
+        const auto unitary = final_tableau->to_flat_unitary_matrix(true);
+        for (uint64_t row = 0; row < dimension; ++row) {
+            std::complex<double> amplitude{0.0, 0.0};
+            for (uint64_t col = 0; col < dimension; ++col) {
+                const auto factor = unitary[row * dimension + col];
+                amplitude += std::complex<double>{factor.real(), factor.imag()} * framed[col];
+            }
+            physical[row] = amplitude;
+        }
+    }
+
+    for (std::complex<double>& amplitude : physical) {
+        amplitude *= scale;
+    }
+    return physical;
+}
+
+}  // namespace
+
+std::vector<std::complex<double>> get_statevector(const CompiledModule& program,
+                                                  const SchrodingerState& state) {
+    validate_statevector_size(program.num_qubits);
+    uint64_t pauli_x = 0;
+    uint64_t pauli_z = 0;
+    for (uint32_t q = 0; q < program.num_qubits; ++q) {
+        if (bit_get(state.p_x, q)) {
+            pauli_x |= uint64_t{1} << q;
+        }
+        if (bit_get(state.p_z, q)) {
+            pauli_z |= uint64_t{1} << q;
+        }
+    }
+    const stim::Tableau<kStimWidth>* final_tableau =
+        program.constant_pool.final_tableau ? &*program.constant_pool.final_tableau : nullptr;
+    return expand_factored_state(program.num_qubits, state.active_k, state.v_size(), pauli_x,
+                                 pauli_z, final_tableau,
+                                 state.gamma() * program.constant_pool.global_weight,
+                                 [&](uint64_t index) { return state.v()[index]; });
+}
+
+namespace sampling {
+
+std::vector<std::complex<double>> get_statevector(const ExecutablePlan& plan) {
+    const stim::Tableau<kStimWidth>* final_tableau = plan.final_state_tableau();
+    if (final_tableau == nullptr) {
+        throw std::invalid_argument(
+            "get_statevector() requires pure-state unitary evolution: measurements, feedback, "
+            "noise, readout noise, transition instruments, detectors, postselection, and "
+            "observables are not supported. EXP_VAL probes are allowed but their outputs are "
+            "ignored. Use DropNonUnitaryPass only if you intentionally want to inspect the "
+            "unitary skeleton of a mixed circuit.");
+    }
+
+    Executor executor(plan);
+    executor.run_shot();
+    const State& state = executor.state();
+    return expand_factored_state(plan.num_qubits(), state.active_width(), state.size(), 0, 0,
+                                 final_tableau, state.global_scalar(), [&](uint64_t index) {
+                                     return std::complex<double>{state.real_data()[index],
+                                                                 state.imag_data()[index]};
+                                 });
+}
+
+}  // namespace sampling
+}  // namespace clifft

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -59,6 +59,8 @@ class ExecutablePlan;
                                                       size_t num_basis_masks,
                                                       size_t words_per_basis_mask);
 
+[[nodiscard]] std::vector<std::complex<double>> get_statevector(const ExecutablePlan& plan);
+
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept;
 
@@ -78,7 +80,7 @@ class ExecutablePlan {
     [[nodiscard]] bool has_postselection() const { return has_postselection_; }
     [[nodiscard]] bool has_readout_noise() const { return has_readout_noise_; }
     [[nodiscard]] bool has_instruments() const { return has_instruments_; }
-    [[nodiscard]] bool supports_basis_probabilities() const { return final_tableau_.has_value(); }
+    [[nodiscard]] bool supports_final_state_queries() const { return final_tableau_.has_value(); }
     // Exact final-state queries need the coordinate-to-physical map, but
     // ordinary execution must not depend on or mutate it.
     [[nodiscard]] const stim::Tableau<kStimWidth>* final_state_tableau() const noexcept {

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -706,7 +706,8 @@ std::string SamplingPlan::inspect() const {
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
         << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
         << " observables=" << num_observables << " exp_vals=" << num_exp_vals
-        << " postselection=" << has_postselection << " basis_queries=" << final_tableau.has_value()
+        << " postselection=" << has_postselection
+        << " final_state_queries=" << final_tableau.has_value()
         << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
     out << "global_weight=" << global_weight.real() << ',' << global_weight.imag() << '\n';
     out << "symbols=" << symbols.size() << '\n';

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -309,7 +309,7 @@ struct SamplingPlan {
     bool has_postselection = false;
     std::complex<double> global_weight = {1.0, 0.0};
 
-    // Present only for pure-state plans eligible for computational-basis
+    // Present only for pure-state plans eligible for exact final-state
     // queries. It maps the final stabilizer coordinates used by the action
     // stream into physical qubits and is never read by ordinary dispatch.
     std::optional<stim::Tableau<kStimWidth>> final_tableau;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -487,7 +487,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
     uint32_t detector_index = 0;
     uint32_t next_noise_site = 0;
     uint32_t next_instrument_site = 0;
-    bool basis_queries_supported = true;
+    bool final_state_queries_supported = true;
 
     for (size_t i = 0; i < hir.ops.size(); ++i) {
         const HeisenbergOp& op = hir.ops[i];
@@ -508,19 +508,19 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::MEASURE:
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 pending.emplace_back(PendingMeasurement{
                     pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
                     RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}, reserve_symbol(plan)});
                 break;
             case OpType::CONDITIONAL_PAULI:
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 pending.emplace_back(PendingConditionalPauli{
                     pauli_from_hir(hir, op),
                     RecordSlot{static_cast<uint32_t>(op.controlling_meas())}});
                 break;
             case OpType::NOISE: {
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
                 if (site_index >= hir.noise_sites.size()) {
                     throw std::invalid_argument("sampling planner noise site is out of range");
@@ -555,7 +555,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::READOUT_NOISE: {
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 const uint32_t entry_index = static_cast<uint32_t>(op.readout_noise_idx());
                 if (entry_index >= hir.readout_noise.size()) {
                     throw std::invalid_argument("sampling planner readout entry is out of range");
@@ -567,7 +567,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::INSTRUMENT: {
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 const uint32_t site_index = static_cast<uint32_t>(op.instrument_site_idx());
                 if (site_index >= hir.instrument_sites.size() ||
                     site_index != next_instrument_site) {
@@ -588,7 +588,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::DETECTOR: {
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 const uint32_t targets_index = static_cast<uint32_t>(op.detector_idx());
                 if (targets_index >= hir.detector_targets.size() ||
                     detector_index >= hir.num_detectors) {
@@ -602,7 +602,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
                 break;
             }
             case OpType::OBSERVABLE: {
-                basis_queries_supported = false;
+                final_state_queries_supported = false;
                 const uint32_t targets_index = op.observable_target_list_idx();
                 const uint32_t observable_index = static_cast<uint32_t>(op.observable_idx());
                 if (targets_index >= hir.observable_targets.size() ||
@@ -640,7 +640,7 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
         throw std::invalid_argument(
             "sampling planner instrument-site table is inconsistent with HIR");
     }
-    if (basis_queries_supported) {
+    if (final_state_queries_supported) {
         plan.final_tableau = hir.final_tableau;
     }
     return pending;

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -4,7 +4,6 @@
 #include "clifft/svm/svm_math.h"
 
 #include <algorithm>
-#include <bit>
 #include <cctype>
 #include <cstdlib>
 #include <limits>
@@ -805,87 +804,6 @@ SurvivorResult sample_k_survivors(const CompiledModule& program, uint32_t shots,
     }
 
     return result;
-}
-
-// =============================================================================
-// Statevector Expansion
-// =============================================================================
-//
-// Expands the factored state |psi> = gamma * U_C * P * (|phi>_A (x) |0>_D)
-// into a dense 2^n statevector. Used as a validation oracle for small circuits.
-//
-// The active statevector |phi>_A lives on virtual axes 0..k-1 (contiguous
-// lowest bits). Dormant qubits occupy axes k..n-1 and are strictly |0>.
-// The Clifford frame U_C (final_tableau) rotates from the virtual basis
-// to the physical laboratory basis.
-
-std::vector<std::complex<double>> get_statevector(const CompiledModule& program,
-                                                  const SchrodingerState& state) {
-    uint32_t n = program.num_qubits;
-    if (n > 10) {
-        throw std::runtime_error(
-            "Statevector expansion limited to 10 qubits (dense U_C matrix is 4^n)");
-    }
-    uint64_t dim = 1ULL << n;
-
-    // Step 1: Embed |phi>_A into dense 2^n virtual-basis state.
-    // Active axes are strictly 0..k-1, so the 2^k active amplitudes align
-    // perfectly with the first 2^k entries of the dense array.
-    assert(state.active_k <= n && "More active qubits than physical qubits");
-    uint64_t active_size = state.v_size();
-    assert(active_size <= dim && "Active array exceeds statevector dimension");
-    std::vector<std::complex<double>> dense(dim, {0.0, 0.0});
-    for (uint64_t i = 0; i < active_size; ++i) {
-        dense[i] = state.v()[i];
-    }
-
-    // Step 2: Apply Pauli frame P = X^{p_x} Z^{p_z}.
-    // P|i> = (-1)^popcount(i & p_z) * |i XOR p_x>
-    // Extract p_x and p_z as uint64_t masks (portable: reconstruct from bits).
-    uint64_t px_mask = 0;
-    uint64_t pz_mask = 0;
-    for (uint32_t q = 0; q < n; ++q) {
-        if (bit_get(state.p_x, q)) {
-            px_mask |= (uint64_t{1} << q);
-        }
-        if (bit_get(state.p_z, q)) {
-            pz_mask |= (uint64_t{1} << q);
-        }
-    }
-
-    std::vector<std::complex<double>> framed(dim, {0.0, 0.0});
-    for (uint64_t i = 0; i < dim; ++i) {
-        uint64_t target = i ^ px_mask;
-        double sign = (std::popcount(i & pz_mask) % 2 == 1) ? -1.0 : 1.0;
-        framed[target] += dense[i] * sign;
-    }
-
-    // Step 3: Apply U_C (final_tableau) via dense matrix multiplication.
-    // to_flat_unitary_matrix(true) returns row-major complex<float> in
-    // little-endian qubit order. If no tableau, treat as identity.
-    std::vector<std::complex<double>> physical(dim, {0.0, 0.0});
-    if (program.constant_pool.final_tableau.has_value()) {
-        auto flat_uc = program.constant_pool.final_tableau->to_flat_unitary_matrix(true);
-        // flat_uc is dim x dim row-major: flat_uc[row * dim + col]
-        for (uint64_t row = 0; row < dim; ++row) {
-            std::complex<double> sum{0.0, 0.0};
-            for (uint64_t col = 0; col < dim; ++col) {
-                auto u = flat_uc[row * dim + col];
-                sum += std::complex<double>(u.real(), u.imag()) * framed[col];
-            }
-            physical[row] = sum;
-        }
-    } else {
-        physical = framed;
-    }
-
-    // Step 4: Scale by gamma * global_weight.
-    std::complex<double> scale = state.gamma() * program.constant_pool.global_weight;
-    for (uint64_t i = 0; i < dim; ++i) {
-        physical[i] *= scale;
-    }
-
-    return physical;
 }
 
 }  // namespace clifft

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1025,6 +1025,20 @@ NB_MODULE(_clifft_core, m) {
         "Return experimental scalar sampling computational-basis probabilities.");
 
     m.def(
+        "_get_statevector_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program) {
+            std::vector<std::complex<double>> statevector;
+            {
+                nb::gil_scoped_release release;
+                statevector = clifft::sampling::get_statevector(program);
+            }
+            const size_t size = statevector.size();
+            return vec_to_numpy(std::move(statevector), {size});
+        },
+        nb::arg("program"),
+        "Expand an experimental pure-state sampling program into a dense statevector.");
+
+    m.def(
         "_record_probabilities_experimental_sampling",
         [](const clifft::sampling::ExecutablePlan& program,
            nb::ndarray<nb::numpy, const uint8_t, nb::shape<-1, -1>, nb::c_contig> records) {

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -25,6 +25,7 @@ from clifft._clifft_core import (
     _basis_probabilities_experimental_sampling,
     _compile_experimental_sampling,
     _ExperimentalSamplingProgram,
+    _get_statevector_experimental_sampling,
     _record_probabilities_experimental_sampling,
     _sample_experimental_sampling,
     _sample_survivors_experimental_sampling,
@@ -54,7 +55,7 @@ def compile(
     """Compile Stim text for the experimental scalar sampling backend.
 
     The default HIR optimization pipeline matches :func:`clifft.compile`;
-    pass ``None`` to skip it. Dense statevector expansion remains unsupported.
+    pass ``None`` to skip it.
     """
     if isinstance(hir_passes, _DefaultPasses):
         hir_passes = default_hir_pass_manager()
@@ -189,11 +190,17 @@ def basis_probabilities(
     return probabilities
 
 
+def get_statevector(program: Program) -> npt.NDArray[np.complex128]:
+    """Return the dense final statevector of an experimental pure-state program."""
+    return cast(npt.NDArray[np.complex128], _get_statevector_experimental_sampling(program))
+
+
 __all__ = [
     "MeasurementRecords",
     "Program",
     "basis_probabilities",
     "compile",
+    "get_statevector",
     "record_probabilities",
     "sample",
     "sample_noncomputational",

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,6 +1,6 @@
 """Shared test fixtures and utilities for Clifft Python tests."""
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, cast
 
 import numpy as np
@@ -21,6 +21,33 @@ def sampling_api(request: pytest.FixtureRequest) -> Any:
 def basis_probabilities_api(request: pytest.FixtureRequest) -> Any:
     """Run shared exact basis-query tests against both Python APIs."""
     return cast(Any, request.param)
+
+
+@pytest.fixture(params=["legacy", "experimental"], ids=["legacy", "experimental"])
+def statevector_from_circuit(
+    request: pytest.FixtureRequest,
+) -> Callable[[str], npt.NDArray[np.complex128]]:
+    """Compile and expand a pure-state circuit through either backend."""
+    if request.param == "experimental":
+
+        def experimental_statevector(stim_text: str) -> npt.NDArray[np.complex128]:
+            return cast(
+                npt.NDArray[np.complex128],
+                experimental.get_statevector(experimental.compile(stim_text)),
+            )
+
+        return experimental_statevector
+
+    def legacy_statevector(stim_text: str) -> npt.NDArray[np.complex128]:
+        program = clifft.compile(stim_text)
+        state = clifft.State(
+            peak_rank=program.peak_rank,
+            num_measurements=program.num_measurements,
+        )
+        clifft.execute(program, state)
+        return cast(npt.NDArray[np.complex128], clifft.get_statevector(program, state))
+
+    return legacy_statevector
 
 
 @pytest.fixture(

--- a/tests/python/test_experimental_statevector.py
+++ b/tests/python/test_experimental_statevector.py
@@ -1,0 +1,90 @@
+"""Focused contracts for experimental symbolic-coordinate statevectors."""
+
+from typing import Any, cast
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+import clifft
+import clifft.experimental as experimental
+
+
+def _legacy_statevector(stim_text: str) -> npt.NDArray[np.complex128]:
+    program = clifft.compile(stim_text)
+    state = clifft.State(
+        peak_rank=program.peak_rank,
+        num_measurements=program.num_measurements,
+    )
+    clifft.execute(program, state)
+    return cast(npt.NDArray[np.complex128], clifft.get_statevector(program, state))
+
+
+@pytest.mark.parametrize(
+    "circuit",
+    [
+        "H 0\nT 0\nT 0\nH 0",
+        "H 0\nT_DAG 0\nT_DAG 0\nH 0",
+        "Y 0\nH 0\nT 0\nT 0\nT 0\nT 0",
+        "H 0\nCX 0 1\nT 1\nT 1\nCX 0 1\nH 0",
+        "H 0\nT 0\nT 0\nT 0\nH 0\nT 0",
+    ],
+)
+def test_statevector_matches_legacy_componentwise(circuit: str) -> None:
+    actual = experimental.get_statevector(experimental.compile(circuit))
+    np.testing.assert_allclose(actual, _legacy_statevector(circuit), atol=1e-6, rtol=0)
+
+
+def test_statevector_preserves_exact_global_phase() -> None:
+    program = experimental.compile("H 0\nT 0\nT 0\nH 0")
+    np.testing.assert_allclose(
+        experimental.get_statevector(program),
+        np.array([0.5 + 0.5j, 0.5 - 0.5j]),
+        atol=1e-6,
+        rtol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "circuit,kwargs",
+    [
+        ("M 0", {}),
+        ("M(0.1) 0", {}),
+        ("X_ERROR(0.1) 0", {}),
+        ("M 0\nDETECTOR rec[-1]", {}),
+        ("M 0\nDETECTOR rec[-1]", {"postselection_mask": [1]}),
+        ("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]", {}),
+        ("M 0\nCX rec[-1] 1", {}),
+    ],
+)
+def test_statevector_rejects_nonunitary_programs(circuit: str, kwargs: dict[str, Any]) -> None:
+    program = experimental.compile(circuit, **kwargs)
+    with pytest.raises(ValueError, match="requires pure-state unitary evolution"):
+        experimental.get_statevector(program)
+
+
+def test_statevector_allows_expectation_probes() -> None:
+    with_probe = experimental.compile("H 0\nEXP_VAL X0")
+    without_probe = experimental.compile("H 0")
+    np.testing.assert_allclose(
+        experimental.get_statevector(with_probe),
+        experimental.get_statevector(without_probe),
+        atol=1e-12,
+        rtol=0,
+    )
+
+
+def test_drop_non_unitary_pass_enables_unitary_skeleton() -> None:
+    passes = clifft.HirPassManager()
+    passes.add(clifft.DropNonUnitaryPass())
+    program = experimental.compile("H 0\nM 0\nX_ERROR(0.1) 0", hir_passes=passes)
+    expected = 1.0 / np.sqrt(2.0)
+    np.testing.assert_allclose(
+        experimental.get_statevector(program), [expected, expected], atol=1e-6, rtol=0
+    )
+
+
+def test_statevector_keeps_existing_dense_limit() -> None:
+    program = experimental.compile("H 10")
+    with pytest.raises(RuntimeError, match="limited to 10 qubits"):
+        experimental.get_statevector(program)

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -5,7 +5,10 @@ validate statevector equivalence up to global phase. Componentwise
 global-phase checks live in the peephole/canonical-phase suites.
 """
 
+from collections.abc import Callable
+
 import numpy as np
+import numpy.typing as npt
 import pytest
 from conftest import (
     assert_statevectors_equiv,
@@ -14,25 +17,26 @@ from conftest import (
 )
 from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
 
-import clifft
+
+class _StatevectorBackendMixin:
+    """Run each independent oracle through both final-state implementations."""
+
+    statevector: Callable[[str], npt.NDArray[np.complex128]]
+
+    @pytest.fixture(autouse=True)
+    def _select_statevector_backend(
+        self, statevector_from_circuit: Callable[[str], npt.NDArray[np.complex128]]
+    ) -> None:
+        self.statevector = statevector_from_circuit
 
 
-def _clifft_statevector(circuit_str: str) -> np.ndarray:
-    """Compile and execute circuit in Clifft, return dense statevector."""
-    prog = clifft.compile(circuit_str)
-    state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)
-    clifft.execute(prog, state)
-    sv: np.ndarray = clifft.get_statevector(prog, state)
-    return sv
-
-
-class TestQiskitStatevectorOracle:
+class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
     """Validate Clifft statevectors against Qiskit-Aer."""
 
     def test_single_h(self) -> None:
         """H|0> = |+> matches Qiskit."""
         circuit = "H 0"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -40,7 +44,7 @@ class TestQiskitStatevectorOracle:
     def test_single_t(self) -> None:
         """H-T circuit matches Qiskit."""
         circuit = "H 0\nT 0"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -48,7 +52,7 @@ class TestQiskitStatevectorOracle:
     def test_t_dagger(self) -> None:
         """H-T_DAG circuit matches Qiskit."""
         circuit = "H 0\nT_DAG 0"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -56,7 +60,7 @@ class TestQiskitStatevectorOracle:
     def test_bell_plus_t(self) -> None:
         """Bell state + T gate matches Qiskit."""
         circuit = "H 0\nCX 0 1\nT 0"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -64,7 +68,7 @@ class TestQiskitStatevectorOracle:
     def test_two_t_equals_s(self) -> None:
         """T*T = S identity matches Qiskit."""
         circuit = "H 0\nT 0\nT 0"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -72,7 +76,7 @@ class TestQiskitStatevectorOracle:
     def test_four_t_equals_z(self) -> None:
         """T^4 = Z identity matches Qiskit."""
         circuit = "H 0\nT 0\nT 0\nT 0\nT 0"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -82,7 +86,7 @@ class TestQiskitStatevectorOracle:
     def test_random_clifford_t_small(self, num_qubits: int, seed: int) -> None:
         """Random Clifford+T circuits up to 5 qubits match Qiskit."""
         circuit = random_clifford_t_circuit(num_qubits, depth=15, seed=seed)
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv, msg=f"{num_qubits}q seed={seed}\n{circuit}")
@@ -92,7 +96,7 @@ class TestQiskitStatevectorOracle:
         """Random Clifford+T circuits at 6 qubits match Qiskit."""
         for num_qubits in [6]:
             circuit = random_clifford_t_circuit(num_qubits, depth=20, seed=seed)
-            clifft_sv = _clifft_statevector(circuit)
+            clifft_sv = self.statevector(circuit)
             qc = stim_to_qiskit_noiseless(circuit)
             qiskit_sv = qiskit_statevector(qc)
             assert_statevectors_equiv(
@@ -115,7 +119,7 @@ class TestQiskitStatevectorOracle:
                 "T 0",
             ]
         )
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -123,7 +127,7 @@ class TestQiskitStatevectorOracle:
     def test_ch_gate(self) -> None:
         """CH parser rewrite matches Qiskit."""
         circuit = "H 0\nCH 0 1"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -131,7 +135,7 @@ class TestQiskitStatevectorOracle:
     def test_ccz_gate(self) -> None:
         """CCZ parser rewrite matches Qiskit."""
         circuit = "H 0\nH 1\nH 2\nCCZ 0 1 2"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -139,7 +143,7 @@ class TestQiskitStatevectorOracle:
     def test_ccx_gate(self) -> None:
         """CCX parser rewrite matches Qiskit."""
         circuit = "H 0\nH 1\nCCX 0 1 2"
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
@@ -151,13 +155,13 @@ class TestQiskitStatevectorOracle:
             lines.append(f"T {i % 2}")
             lines.append("CX 0 1")
         circuit = "\n".join(lines)
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
 
-class TestDenseCliffordTFuzzer:
+class TestDenseCliffordTFuzzer(_StatevectorBackendMixin):
     """Validate Clifft against Qiskit-Aer with dense entanglement circuits.
 
     Uses higher 2-qubit gate probability (50%) and all three 2-qubit gates
@@ -169,7 +173,7 @@ class TestDenseCliffordTFuzzer:
     def test_dense_entanglement_small(self, num_qubits: int, seed: int) -> None:
         """Dense Clifford+T circuits at 3-5 qubits match Qiskit."""
         circuit = random_dense_clifford_t_circuit(num_qubits, depth=30, seed=seed)
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(
@@ -180,7 +184,7 @@ class TestDenseCliffordTFuzzer:
     def test_dense_entanglement_medium(self, seed: int) -> None:
         """Dense Clifford+T at 6 qubits match Qiskit."""
         circuit = random_dense_clifford_t_circuit(6, depth=40, seed=seed)
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv, msg=f"dense 6q seed={seed}")
@@ -189,13 +193,13 @@ class TestDenseCliffordTFuzzer:
     def test_deep_phase_accumulation(self, seed: int) -> None:
         """Deep circuits (depth=100) stress T-gate phase arithmetic."""
         circuit = random_dense_clifford_t_circuit(4, depth=100, seed=seed, two_qubit_prob=0.3)
-        clifft_sv = _clifft_statevector(circuit)
+        clifft_sv = self.statevector(circuit)
         qc = stim_to_qiskit_noiseless(circuit)
         qiskit_sv = qiskit_statevector(qc)
         assert_statevectors_equiv(clifft_sv, qiskit_sv, msg=f"deep 4q seed={seed}")
 
 
-class TestArbitraryRotations:
+class TestArbitraryRotations(_StatevectorBackendMixin):
     """Validate continuous rotation gates against Qiskit Aer."""
 
     def _check_amplitudes(self, stim_text: str, atol: float = 1e-6) -> None:
@@ -207,18 +211,7 @@ class TestArbitraryRotations:
         this single global scalar and then enforce strict equality across
         all relative amplitudes.
         """
-        import clifft
-
-        prog = clifft.compile(
-            stim_text,
-            hir_passes=clifft.default_hir_pass_manager(),
-            bytecode_passes=clifft.default_bytecode_pass_manager(),
-        )
-        state = clifft.State(
-            peak_rank=prog.peak_rank, num_measurements=prog.num_measurements, seed=42
-        )
-        clifft.execute(prog, state)
-        clifft_sv = np.array(clifft.get_statevector(prog, state))
+        clifft_sv = self.statevector(stim_text)
 
         qc = stim_to_qiskit_noiseless(stim_text)
         qiskit_sv = qiskit_statevector(qc)

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -334,18 +334,14 @@ class TestStatevector:
 class TestCliffordValidation:
     """Validate pure-Clifford statevectors against Stim."""
 
-    def test_random_clifford_single_qubit(self) -> None:
+    def test_random_clifford_single_qubit(self, statevector_from_circuit: Any) -> None:
         """Random 1-qubit Clifford circuits match Stim."""
         import stim
 
         for seed in range(10):
             circuit_str = random_clifford_circuit(1, 5, seed)
 
-            # Clifft statevector
-            prog = clifft.compile(circuit_str)
-            state = clifft.State(peak_rank=prog.peak_rank, num_measurements=prog.num_measurements)
-            clifft.execute(prog, state)
-            clifft_sv = clifft.get_statevector(prog, state)
+            clifft_sv = statevector_from_circuit(circuit_str)
 
             # Stim statevector
             stim_circuit = stim.Circuit(circuit_str)
@@ -355,7 +351,7 @@ class TestCliffordValidation:
 
             assert_statevectors_equiv(clifft_sv, stim_sv, msg=f"circuit:\n{circuit_str}")
 
-    def test_random_clifford_multi_qubit(self) -> None:
+    def test_random_clifford_multi_qubit(self, statevector_from_circuit: Any) -> None:
         """Random 2-4 qubit Clifford circuits match Stim."""
         import stim
 
@@ -363,13 +359,7 @@ class TestCliffordValidation:
             for seed in range(5):
                 circuit_str = random_clifford_circuit(num_qubits, 10, seed)
 
-                # Clifft statevector
-                prog = clifft.compile(circuit_str)
-                state = clifft.State(
-                    peak_rank=prog.peak_rank, num_measurements=prog.num_measurements
-                )
-                clifft.execute(prog, state)
-                clifft_sv = clifft.get_statevector(prog, state)
+                clifft_sv = statevector_from_circuit(circuit_str)
 
                 # Stim statevector
                 stim_circuit = stim.Circuit(circuit_str)

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -131,6 +131,29 @@ void require_basis_probabilities_match_legacy(std::string_view circuit_text,
     }
 }
 
+void require_statevector_matches_legacy(std::string_view circuit_text) {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(circuit_text));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    const std::vector<std::complex<double>> actual = clifft::sampling::get_statevector(executable);
+
+    const clifft::CompiledModule legacy_program = clifft::lower(hir);
+    clifft::SchrodingerState legacy({.peak_rank = legacy_program.peak_rank,
+                                     .num_measurements = legacy_program.total_meas_slots,
+                                     .num_qubits = legacy_program.num_qubits,
+                                     .num_exp_vals = legacy_program.num_exp_vals,
+                                     .seed = 0});
+    clifft::execute(legacy_program, legacy);
+    const std::vector<std::complex<double>> expected =
+        clifft::get_statevector(legacy_program, legacy);
+
+    REQUIRE(actual.size() == expected.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+        CAPTURE(circuit_text, i);
+        REQUIRE_THAT(actual[i].real(), Catch::Matchers::WithinAbs(expected[i].real(), 1e-6));
+        REQUIRE_THAT(actual[i].imag(), Catch::Matchers::WithinAbs(expected[i].imag(), 1e-6));
+    }
+}
+
 void require_replay_matches_legacy(std::string_view circuit_text,
                                    std::span<const uint8_t> forced_records, size_t num_records) {
     const clifft::HirModule hir = clifft::trace(clifft::parse(circuit_text));
@@ -479,17 +502,43 @@ TEST_CASE("Sampling basis probabilities match legacy exact queries") {
 
 TEST_CASE("Sampling basis probabilities reject nonunitary plans") {
     const ExecutablePlan measured(plan_from("M 0\n"));
-    REQUIRE_FALSE(measured.supports_basis_probabilities());
+    REQUIRE_FALSE(measured.supports_final_state_queries());
     REQUIRE_THROWS_AS(
         clifft::sampling::basis_probabilities(measured, std::array<uint64_t, 1>{0}, 1, 1),
         std::invalid_argument);
 
     const ExecutablePlan with_probe(plan_from("H 0\nEXP_VAL X0\n"));
-    REQUIRE(with_probe.supports_basis_probabilities());
+    REQUIRE(with_probe.supports_final_state_queries());
     const std::vector<double> probabilities =
         clifft::sampling::basis_probabilities(with_probe, std::array<uint64_t, 2>{0, 1}, 2, 1);
     REQUIRE_THAT(probabilities[0], Catch::Matchers::WithinAbs(0.5, 1e-12));
     REQUIRE_THAT(probabilities[1], Catch::Matchers::WithinAbs(0.5, 1e-12));
+}
+
+TEST_CASE("Sampling statevectors match legacy exact queries componentwise") {
+    require_statevector_matches_legacy("H 0\n");
+    require_statevector_matches_legacy("H 0\nT 0\n");
+    require_statevector_matches_legacy("Y 0\nH 0\nT 0\nT 0\nT 0\n");
+    require_statevector_matches_legacy("H 0\nT_DAG 0\nH 1\nCX 0 1\nR_Z(0.123) 1\nH 0\n");
+    require_statevector_matches_legacy(
+        "H 0\nH 1\nR_XX(0.25) 0 1\nR_YY(-0.375) 0 1\nR_PAULI(0.2) X0*Y1\n");
+    require_statevector_matches_legacy("H 0\nT 0\nT 0\nH 0\nT 0\n");
+}
+
+TEST_CASE("Sampling statevectors reject nonunitary and oversized plans") {
+    const ExecutablePlan measured(plan_from("H 0\nM 0\n"));
+    REQUIRE_THROWS_AS(clifft::sampling::get_statevector(measured), std::invalid_argument);
+
+    const ExecutablePlan oversized(plan_from("H 10\n"));
+    REQUIRE_THROWS_AS(clifft::sampling::get_statevector(oversized), std::runtime_error);
+
+    const ExecutablePlan with_probe(plan_from("H 0\nEXP_VAL X0\n"));
+    const std::vector<std::complex<double>> statevector =
+        clifft::sampling::get_statevector(with_probe);
+    REQUIRE(statevector.size() == 2);
+    const double expected = 1.0 / std::numbers::sqrt2;
+    REQUIRE_THAT(statevector[0].real(), Catch::Matchers::WithinAbs(expected, 1e-6));
+    REQUIRE_THAT(statevector[1].real(), Catch::Matchers::WithinAbs(expected, 1e-6));
 }
 
 TEST_CASE("Sampling replay checks all records conditional on presampled symbols") {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -526,7 +526,7 @@ TEST_CASE("Sampling plan validates exact-query metadata") {
     SamplingPlan unitary = valid_rotation_plan();
     unitary.final_tableau = stim::Tableau<clifft::kStimWidth>(1);
     REQUIRE_NOTHROW(unitary.validate());
-    REQUIRE(unitary.inspect().find("basis_queries=1") != std::string::npos);
+    REQUIRE(unitary.inspect().find("final_state_queries=1") != std::string::npos);
 
     SECTION("tableau width") {
         unitary.final_tableau = stim::Tableau<clifft::kStimWidth>(2);


### PR DESCRIPTION
Closes #276.

## Summary

- moves dense factored-state expansion into a shared exact-query implementation used by both the legacy SVM and symbolic-coordinate backends
- exposes `clifft.experimental.get_statevector(program)` for pure-unitary experimental programs
- generalizes final-tableau metadata from basis-probability-specific terminology to exact final-state queries
- deliberately rejects measurement, feedback, noise, readout noise, instruments, detectors, postselection, and observables; `EXP_VAL` remains allowed
- preserves the existing 10-qubit dense-expansion limit and exact componentwise global phase

This does not change the public default or the ordinary sampling dispatch path. Dropping legacy post-measurement/noisy statevector behavior is an intentional part of the eventual backend switch; callers may explicitly apply `DropNonUnitaryPass` when they want a circuit unitary skeleton.

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `build/tests/clifft_tests '~[bench]' -r compact` — 1,227 cases / 375,731 assertions
- `uv run --frozen --only-group dev pytest -q tests/python` — 1,238 passed
- all 75 existing Qiskit-Aer statevector cases and the existing Stim Clifford checks now run against both backends
- focused componentwise legacy parity, exact global-phase, nonunitary rejection, `EXP_VAL`, `DropNonUnitaryPass`, and dense-limit tests