### PR TITLE
feat(sampling): add importance sampling parity

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(clifft_core STATIC
     svm/svm_scalar.cc
     svm/svm_state.cc
     util/canonical_phase.cc
+    util/fault_sampling.cc
     util/introspection.cc
     util/page_allocation.cc
     util/xoshiro.cc

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/executor.h"
 
+#include "clifft/util/fault_sampling.h"
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/numeric.h"
 
@@ -169,9 +170,10 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                                                                   index(typed.symbol)});
                 } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
                     has_readout_noise_ = true;
-                    actions_.emplace_back(ExecuteReadoutNoise{
-                        prepare_expression(typed.source), index(typed.flip), index(typed.record),
-                        typed.prob_zero_to_one, typed.prob_one_to_zero});
+                    actions_.emplace_back(
+                        ExecuteReadoutNoise{prepare_expression(typed.source), index(typed.flip),
+                                            index(typed.record), num_readout_noise_sites_++,
+                                            typed.prob_zero_to_one, typed.prob_one_to_zero});
                 } else if constexpr (std::is_same_v<T, WriteDetector>) {
                     actions_.emplace_back(ExecuteDetector{prepare_expression(typed.outcome),
                                                           index(typed.detector),
@@ -225,6 +227,30 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     }
 }
 
+std::vector<double> ExecutablePlan::noise_site_probabilities() const {
+    std::vector<double> probabilities;
+    probabilities.reserve(noise_sites_.size() + num_readout_noise_sites_);
+    for (const PreparedNoiseSite& site : noise_sites_) {
+        probabilities.push_back(site.total_probability);
+    }
+    for (const Action& action : actions_) {
+        const auto* readout = std::get_if<ExecuteReadoutNoise>(&action);
+        if (readout == nullptr) {
+            continue;
+        }
+        if (readout->prob_zero_to_one != readout->prob_one_to_zero) {
+            throw std::invalid_argument(
+                "k-fault conditioning does not support asymmetric readout noise; "
+                "measurement record index " +
+                std::to_string(readout->record) + " has probabilities (" +
+                std::to_string(readout->prob_zero_to_one) + ", " +
+                std::to_string(readout->prob_one_to_zero) + ")");
+        }
+        probabilities.push_back(readout->prob_zero_to_one);
+    }
+    return probabilities;
+}
+
 ExecutablePlan::PreparedExpression ExecutablePlan::prepare_expression(
     const AffineBool& expression) {
     const uint32_t begin = static_cast<uint32_t>(expression_terms_.size());
@@ -268,14 +294,28 @@ void Executor::run_shot() noexcept {
            "automatic execution requires every presampled symbol to have a distribution");
     reset_shot();
     sample_presampled_noise(0, plan_->initial_noise_end_);
-    (void)execute_actions<false, true>({});
+    (void)execute_actions<false, true, false>({});
 }
 
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
     plan_ = root_plan_;
     reset_shot();
     assign_presampled_values(presampled_values);
-    (void)execute_actions<false, false>({});
+    (void)execute_actions<false, false, false>({});
+}
+
+void Executor::run_shot(KFaultSampler& fault_sampler) noexcept {
+    plan_ = root_plan_;
+    assert(fault_sampler.num_sites() ==
+               plan_->noise_sites_.size() + plan_->num_readout_noise_sites_ &&
+           "conditioned sampler must cover every quantum and readout fault site");
+    reset_shot();
+    forced_fault_sites_ = fault_sampler.sample([&]() noexcept { return rng_.next_double(); });
+    forced_fault_cursor_ = 0;
+    assign_forced_quantum_faults();
+    (void)execute_actions<false, false, true>({});
+    forced_fault_sites_ = {};
+    forced_fault_cursor_ = 0;
 }
 
 void Executor::resume(const ExecutablePlan& continuation,
@@ -343,7 +383,7 @@ void Executor::resume(const ExecutablePlan& continuation,
 
     plan_ = &continuation;
     pending_trap_.reset();
-    (void)execute_actions<false, true>({}, offset);
+    (void)execute_actions<false, true, false>({}, offset);
     if (forced_trace_out.has_value() && forced_record_mask_[index(forced_trace_out->record)] != 0) {
         throw std::logic_error("sampling continuation did not consume its forced trace-out record");
     }
@@ -366,7 +406,7 @@ ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
            "forced records must be Boolean");
     reset_shot();
     assign_presampled_values(presampled_values);
-    return execute_actions<true, false>(forced_records);
+    return execute_actions<true, false, false>(forced_records);
 }
 
 void Executor::reset_shot() noexcept {
@@ -412,24 +452,38 @@ void Executor::sample_presampled_noise(uint32_t begin, uint32_t end) noexcept {
         if (site_index == kNoNoiseSite || site_index >= end) {
             return;
         }
-        const ExecutablePlan::PreparedNoiseSite& site = plan_->noise_sites_[site_index];
-        assert(site.outcome_count > 0 && site.total_probability > 0.0 &&
-               "a sampled hazard must identify a nonempty noise site");
-        uint32_t outcome_index = site.outcome_begin;
-        if (site.outcome_count > 1) {
-            const double channel_draw = rng_.next_double() * site.total_probability;
-            while (channel_draw >= plan_->noise_outcomes_[outcome_index].cumulative_probability) {
-                ++outcome_index;
-                assert(outcome_index < site.outcome_begin + site.outcome_count &&
-                       "channel draw must select one prepared outcome");
-            }
-        }
-        const uint32_t symbol = plan_->noise_outcomes_[outcome_index].symbol;
-        assert(symbol < symbols_.size() && symbols_[symbol] == 0 &&
-               "a noise site may define only one fresh symbol per shot");
-        symbols_[symbol] = 1;
-        previous_presampled_ones_.push_back(symbol);
+        activate_noise_site(site_index);
         first_candidate = site_index + 1;
+    }
+}
+
+void Executor::activate_noise_site(uint32_t site_index) noexcept {
+    assert(site_index < plan_->noise_sites_.size() && "noise site must be prepared");
+    const ExecutablePlan::PreparedNoiseSite& site = plan_->noise_sites_[site_index];
+    assert(site.outcome_count > 0 && site.total_probability > 0.0 &&
+           "a firing noise site must contain positive-probability outcomes");
+    uint32_t outcome_index = site.outcome_begin;
+    if (site.outcome_count > 1) {
+        const double channel_draw = rng_.next_double() * site.total_probability;
+        while (channel_draw >= plan_->noise_outcomes_[outcome_index].cumulative_probability) {
+            ++outcome_index;
+            assert(outcome_index < site.outcome_begin + site.outcome_count &&
+                   "channel draw must select one prepared outcome");
+        }
+    }
+    const uint32_t symbol = plan_->noise_outcomes_[outcome_index].symbol;
+    assert(symbol < symbols_.size() && symbols_[symbol] == 0 &&
+           "a noise site may define only one fresh symbol per shot");
+    symbols_[symbol] = 1;
+    previous_presampled_ones_.push_back(symbol);
+}
+
+void Executor::assign_forced_quantum_faults() noexcept {
+    const uint32_t num_quantum_sites = static_cast<uint32_t>(plan_->noise_sites_.size());
+    while (forced_fault_cursor_ < forced_fault_sites_.size() &&
+           forced_fault_sites_[forced_fault_cursor_] < num_quantum_sites) {
+        activate_noise_site(forced_fault_sites_[forced_fault_cursor_]);
+        ++forced_fault_cursor_;
     }
 }
 
@@ -520,7 +574,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteSymbolDefinition& act
     symbols_[action.symbol] = static_cast<uint8_t>(evaluate(action.value));
 }
 
-template <bool ForceRecords>
+template <bool ForceRecords, bool ForceFaults>
 void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
                               std::span<const uint8_t>, ReplayResult& result) noexcept {
     if constexpr (ForceRecords) {
@@ -529,9 +583,22 @@ void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
         const bool source = evaluate(action.source);
         assert(records_[action.record] == static_cast<uint8_t>(source) &&
                "readout source must match the current record value");
-        const double probability = source ? action.prob_one_to_zero : action.prob_zero_to_one;
-        const bool flip =
-            probability >= 1.0 || (probability > 0.0 && rng_.next_double() < probability);
+        bool flip = false;
+        if constexpr (ForceFaults) {
+            const uint32_t fault_site =
+                static_cast<uint32_t>(plan_->noise_sites_.size()) + action.site;
+            assert((forced_fault_cursor_ >= forced_fault_sites_.size() ||
+                    forced_fault_sites_[forced_fault_cursor_] >= fault_site) &&
+                   "conditioned readout sites must be consumed in circuit order");
+            if (forced_fault_cursor_ < forced_fault_sites_.size() &&
+                forced_fault_sites_[forced_fault_cursor_] == fault_site) {
+                flip = true;
+                ++forced_fault_cursor_;
+            }
+        } else {
+            const double probability = source ? action.prob_one_to_zero : action.prob_zero_to_one;
+            flip = probability >= 1.0 || (probability > 0.0 && rng_.next_double() < probability);
+        }
         symbols_[action.flip] = static_cast<uint8_t>(flip);
         records_[action.record] ^= static_cast<uint8_t>(flip);
     }
@@ -672,7 +739,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteBoundary& action,
     }
 }
 
-template <bool ForceRecords, bool SampleNoise>
+template <bool ForceRecords, bool SampleNoise, bool ForceFaults>
 ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                                        uint32_t begin) noexcept {
     ReplayResult result;
@@ -684,6 +751,8 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary>) {
                     execute_action<SampleNoise>(typed, forced_records, result);
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
+                    execute_action<ForceRecords, ForceFaults>(typed, forced_records, result);
                 } else {
                     execute_action<ForceRecords>(typed, forced_records, result);
                 }
@@ -756,20 +825,11 @@ bool Executor::sample_dormant_branch() noexcept {
     return rng_.next_double() >= 0.5;
 }
 
-SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed) {
-    if (plan.has_instruments()) {
-        throw std::invalid_argument(
-            "fixed-plan sampling does not support instrument traps; use the trajectory driver");
-    }
-    if (plan.num_unbound_presampled_symbols() != 0) {
-        throw std::invalid_argument(
-            "batch sampling requires a distribution for every presampled symbol");
-    }
-    if (plan.has_postselection()) {
-        throw std::invalid_argument(
-            "fixed-row sampling does not support postselection; use sample_survivors");
-    }
+namespace {
 
+template <typename RunShot>
+SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
+                                 std::optional<uint64_t> seed, RunShot&& run_shot) {
     auto checked_size = [shots](size_t stride) {
         if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
             throw std::length_error("sampling output size exceeds size_t range");
@@ -788,7 +848,7 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
 
     auto run = [&](Executor& executor) {
         for (uint32_t shot = 0; shot < shots; ++shot) {
-            executor.run_shot();
+            run_shot(executor);
             std::ranges::copy(executor.visible_records(),
                               result.measurements.begin() +
                                   static_cast<size_t>(shot) * plan.num_visible_records());
@@ -814,22 +874,10 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
     return result;
 }
 
-std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
-                                    std::optional<uint64_t> seed) {
-    return sample(plan, shots, seed).measurements;
-}
-
-SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
-                                        std::optional<uint64_t> seed, bool keep_records) {
-    if (plan.has_instruments()) {
-        throw std::invalid_argument(
-            "survivor sampling does not support instrument traps; use the trajectory driver");
-    }
-    if (plan.num_unbound_presampled_symbols() != 0) {
-        throw std::invalid_argument(
-            "survivor sampling requires a distribution for every presampled symbol");
-    }
-
+template <typename RunShot>
+SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_t shots,
+                                             std::optional<uint64_t> seed, bool keep_records,
+                                             RunShot&& run_shot) {
     SamplingSurvivorResult result;
     result.total_shots = shots;
     if (shots == 0) {
@@ -850,7 +898,7 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
     }
     auto run = [&](Executor& executor) {
         for (uint32_t shot = 0; shot < shots; ++shot) {
-            executor.run_shot();
+            run_shot(executor);
             if (executor.discarded()) {
                 continue;
             }
@@ -884,6 +932,91 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
         run(executor);
     }
     return result;
+}
+
+}  // namespace
+
+SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "fixed-plan sampling does not support instrument traps; use the trajectory driver");
+    }
+    if (plan.num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "batch sampling requires a distribution for every presampled symbol");
+    }
+    if (plan.has_postselection()) {
+        throw std::invalid_argument(
+            "fixed-row sampling does not support postselection; use sample_survivors");
+    }
+
+    return sample_fixed_rows(plan, shots, seed,
+                             [](Executor& executor) noexcept { executor.run_shot(); });
+}
+
+std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
+                                    std::optional<uint64_t> seed) {
+    return sample(plan, shots, seed).measurements;
+}
+
+SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
+                                        std::optional<uint64_t> seed, bool keep_records) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "survivor sampling does not support instrument traps; use the trajectory driver");
+    }
+    if (plan.num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "survivor sampling requires a distribution for every presampled symbol");
+    }
+
+    return sample_surviving_rows(plan, shots, seed, keep_records,
+                                 [](Executor& executor) noexcept { executor.run_shot(); });
+}
+
+SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
+                        std::optional<uint64_t> seed) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "forced-fault sampling does not support instrument traps or trajectory drivers");
+    }
+    if (plan.num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "forced-fault sampling requires a distribution for every presampled symbol");
+    }
+    if (plan.has_postselection()) {
+        throw std::invalid_argument(
+            "fixed-row forced-fault sampling does not support postselection; use "
+            "sample_k_survivors");
+    }
+    if (shots == 0) {
+        return sample_fixed_rows(plan, shots, seed,
+                                 [](Executor& executor) noexcept { executor.run_shot(); });
+    }
+    KFaultSampler fault_sampler(plan.noise_site_probabilities(), k);
+    return sample_fixed_rows(
+        plan, shots, seed, [&](Executor& executor) noexcept { executor.run_shot(fault_sampler); });
+}
+
+SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
+                                          std::optional<uint64_t> seed, bool keep_records) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "forced-fault survivor sampling does not support instrument traps or trajectory "
+            "drivers");
+    }
+    if (plan.num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "forced-fault survivor sampling requires a distribution for every presampled symbol");
+    }
+    if (shots == 0) {
+        return sample_surviving_rows(plan, shots, seed, keep_records,
+                                     [](Executor& executor) noexcept { executor.run_shot(); });
+    }
+    KFaultSampler fault_sampler(plan.noise_site_probabilities(), k);
+    return sample_surviving_rows(plan, shots, seed, keep_records, [&](Executor& executor) noexcept {
+        executor.run_shot(fault_sampler);
+    });
 }
 
 std::vector<double> record_log_probabilities(const ExecutablePlan& plan,

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -19,6 +19,10 @@
 #include <variant>
 #include <vector>
 
+namespace clifft {
+class KFaultSampler;
+}
+
 namespace clifft::sampling {
 
 // Zero and one identify the selected Pauli eigenvalue branch before affine
@@ -97,6 +101,7 @@ class ExecutablePlan {
     [[nodiscard]] uint32_t num_unbound_presampled_symbols() const {
         return static_cast<uint32_t>(unbound_presampled_symbols_.size());
     }
+    [[nodiscard]] std::vector<double> noise_site_probabilities() const;
 
   private:
     friend class Executor;
@@ -148,6 +153,7 @@ class ExecutablePlan {
         PreparedExpression source;
         uint32_t flip = 0;
         uint32_t record = 0;
+        uint32_t site = 0;
         double prob_zero_to_one = 0.0;
         double prob_one_to_zero = 0.0;
     };
@@ -217,6 +223,7 @@ class ExecutablePlan {
     bool has_postselection_ = false;
     bool has_readout_noise_ = false;
     bool has_instruments_ = false;
+    uint32_t num_readout_noise_sites_ = 0;
     uint32_t initial_noise_end_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::optional<stim::Tableau<kStimWidth>> final_tableau_;
@@ -257,6 +264,10 @@ class Executor {
     // Use caller-supplied Boolean values for every Presampled symbol in
     // ascending SymbolId order. This path consumes no quantum-noise RNG draws.
     void run_shot(std::span<const uint8_t> presampled_values) noexcept;
+
+    // Draw one exact conditioned set of fault sites, choose a Pauli channel
+    // within each selected quantum site, and force selected readout flips.
+    void run_shot(KFaultSampler& fault_sampler) noexcept;
 
     // Continue a trapped shot in a plan compiled for the selected trajectory.
     // Storage may grow here, before dispatch resumes. A forced record supplies
@@ -304,8 +315,10 @@ class Executor {
     void reset_shot() noexcept;
     void assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept;
     void sample_presampled_noise(uint32_t begin, uint32_t end) noexcept;
+    void activate_noise_site(uint32_t site) noexcept;
+    void assign_forced_quantum_faults() noexcept;
 
-    template <bool ForceRecords, bool SampleNoise>
+    template <bool ForceRecords, bool SampleNoise, bool ForceFaults>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records,
                                                uint32_t begin = 0) noexcept;
     template <bool ForceRecords>
@@ -326,7 +339,7 @@ class Executor {
     template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
+    template <bool ForceRecords, bool ForceFaults>
     void execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <bool ForceRecords>
@@ -362,6 +375,8 @@ class Executor {
     std::vector<uint8_t> forced_record_mask_;
     std::vector<uint8_t> forced_record_values_;
     std::vector<uint32_t> previous_presampled_ones_;
+    std::span<const uint32_t> forced_fault_sites_;
+    uint32_t forced_fault_cursor_ = 0;
     Xoshiro256PlusPlus rng_;
     bool discarded_ = false;
     std::optional<InstrumentTrap> pending_trap_;
@@ -408,5 +423,13 @@ struct SamplingSurvivorResult {
 [[nodiscard]] SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
                                                       std::optional<uint64_t> seed = std::nullopt,
                                                       bool keep_records = false);
+
+[[nodiscard]] SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
+                                      std::optional<uint64_t> seed = std::nullopt);
+
+[[nodiscard]] SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots,
+                                                        uint32_t k,
+                                                        std::optional<uint64_t> seed = std::nullopt,
+                                                        bool keep_records = false);
 
 }  // namespace clifft::sampling

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -2,12 +2,12 @@
 
 #include "clifft/svm/svm_internal.h"
 #include "clifft/svm/svm_math.h"
+#include "clifft/util/fault_sampling.h"
 
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
 #include <limits>
-#include <numeric>
 #include <stdexcept>
 #include <string>
 
@@ -465,142 +465,24 @@ std::vector<double> noise_site_probabilities(const CompiledModule& program) {
 
 namespace {
 
-// Build odds-ratio vector w[i] = p_i / (1 - p_i), clamping p to [0, 1-eps].
-// After computing raw odds ratios, rescale so the mean weight is 1.0.
-// This prevents overflow (p ~ 1 => huge w) and underflow (p ~ 0, large k)
-// without affecting sampling correctness -- the constant factor cancels in
-// the conditional inclusion probability w_i * DP[i+1][j-1] / DP[i][j].
-std::vector<double> build_odds_ratios(const std::vector<double>& probs) {
-    std::vector<double> w(probs.size());
-    for (size_t i = 0; i < probs.size(); ++i) {
-        double p = std::clamp(probs[i], 0.0, 1.0 - 1e-15);
-        w[i] = p / (1.0 - p);
-    }
-    // Normalize to mean 1.0 to keep DP table values in a stable range.
-    double sum_w = std::accumulate(w.begin(), w.end(), 0.0);
-    if (sum_w > 0.0) {
-        double scale = static_cast<double>(w.size()) / sum_w;
-        for (double& weight : w)
-            weight *= scale;
-    }
-    return w;
-}
-
-// Check if all probabilities are exactly equal. Exact equality is safe here
-// because circuit noise probabilities come from floating-point literals that
-// round-trip identically. A tolerance-based check would misfire at extreme
-// noise scales (e.g. p ~ 1e-10 with heterogeneous noise).
-bool all_probs_equal(const std::vector<double>& probs) {
-    if (probs.empty())
-        return true;
-    double p0 = probs[0];
-    for (size_t i = 1; i < probs.size(); ++i) {
-        if (probs[i] != p0)
-            return false;
-    }
-    return true;
-}
-
-// Build flat DP table: dp[i * stride + j] = sum of products of odds ratios
-// over all size-j subsets drawn from suffix [i, N).
-// Returns the flat vector; stride = k + 1.
-std::vector<double> build_dp_table(const std::vector<double>& w, uint32_t k) {
-    uint32_t n = static_cast<uint32_t>(w.size());
-    uint32_t stride = k + 1;
-    std::vector<double> dp(static_cast<size_t>(n + 1) * stride, 0.0);
-
-    // Base case: empty subset
-    for (uint32_t i = 0; i <= n; ++i)
-        dp[static_cast<size_t>(i) * stride + 0] = 1.0;
-
-    // Fill bottom-up
-    for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
-        uint32_t remaining = n - static_cast<uint32_t>(i);
-        uint32_t max_j = std::min(remaining, k);
-        for (uint32_t j = 1; j <= max_j; ++j) {
-            dp[static_cast<size_t>(i) * stride + j] =
-                dp[static_cast<size_t>(i + 1) * stride + j] +
-                w[static_cast<size_t>(i)] * dp[static_cast<size_t>(i + 1) * stride + (j - 1)];
-        }
-    }
-    return dp;
-}
-
-// Sample exactly k indices from [0, N) using the DP table.
-// Appends to noise_indices and readout_indices (pre-cleared by caller).
-void dp_sample_indices(SchrodingerState& state, const std::vector<double>& w,
-                       const std::vector<double>& dp, uint32_t k, uint32_t n_q,
-                       std::vector<uint32_t>& noise_indices,
-                       std::vector<uint32_t>& readout_indices) {
-    uint32_t n = static_cast<uint32_t>(w.size());
-    uint32_t stride = k + 1;
-    uint32_t needed = k;
-
-    for (uint32_t i = 0; i < n && needed > 0; ++i) {
-        double prob_include;
-        uint32_t remaining = n - i;
-        if (needed == remaining) {
-            prob_include = 1.0;  // Must include all remaining
-        } else {
-            double denom = dp[static_cast<size_t>(i) * stride + needed];
-            if (denom > 0.0) {
-                prob_include =
-                    (w[i] * dp[static_cast<size_t>(i + 1) * stride + (needed - 1)]) / denom;
-            } else {
-                prob_include = 0.0;
-            }
-        }
-        if (state.random_double() < prob_include) {
-            if (i < n_q)
-                noise_indices.push_back(i);
-            else
-                readout_indices.push_back(i - n_q);
-            needed--;
-        }
-    }
-}
-
-// Uniform sampling: partial Fisher-Yates on persistent pool.
-void uniform_sample_indices(SchrodingerState& state, std::vector<uint32_t>& pool, uint32_t k,
-                            uint32_t n_q, std::vector<uint32_t>& noise_indices,
-                            std::vector<uint32_t>& readout_indices) {
-    uint32_t n = static_cast<uint32_t>(pool.size());
-    for (uint32_t j = 0; j < k; ++j) {
-        uint32_t remaining = n - j;
-        uint32_t pick = j + static_cast<uint32_t>(state.random_double() * remaining);
-        std::swap(pool[j], pool[pick]);
-    }
-
-    // Sort the first k elements in-place, then partition into noise/readout.
-    // Sorting the selected prefix is safe: the pool is a permutation, and any
-    // permutation is valid input for the next Fisher-Yates run. We sort
-    // in-place rather than copying to a temporary to avoid a heap allocation
-    // per shot (the whole point of the persistent pool is O(k) amortized).
-    std::sort(pool.begin(), pool.begin() + k);
-    for (uint32_t j = 0; j < k; ++j) {
-        uint32_t idx = pool[j];
-        if (idx < n_q)
-            noise_indices.push_back(idx);
-        else
-            readout_indices.push_back(idx - n_q);
-    }
-}
-
 // Prepare forced faults for one shot: fills state.forced_faults with
 // the sampled indices and sets next_noise_idx to the first forced site.
-void prepare_forced_shot(SchrodingerState& state, const std::vector<double>& w,
-                         const std::vector<double>& dp, uint32_t k, uint32_t n_q, bool uniform_mode,
-                         std::vector<uint32_t>& uniform_pool) {
+void prepare_forced_shot(SchrodingerState& state, KFaultSampler& sampler,
+                         uint32_t num_quantum_sites) {
     auto& ff = state.forced_faults;
     ff.noise_indices.clear();
     ff.readout_indices.clear();
     ff.noise_pos = 0;
     ff.readout_pos = 0;
 
-    if (uniform_mode) {
-        uniform_sample_indices(state, uniform_pool, k, n_q, ff.noise_indices, ff.readout_indices);
-    } else {
-        dp_sample_indices(state, w, dp, k, n_q, ff.noise_indices, ff.readout_indices);
+    const std::span<const uint32_t> selected =
+        sampler.sample([&]() noexcept { return state.random_double(); });
+    for (uint32_t site : selected) {
+        if (site < num_quantum_sites) {
+            ff.noise_indices.push_back(site);
+        } else {
+            ff.readout_indices.push_back(site - num_quantum_sites);
+        }
     }
 
     // Set next_noise_idx to the first forced noise site (or sentinel).
@@ -609,32 +491,7 @@ void prepare_forced_shot(SchrodingerState& state, const std::vector<double>& w,
         state.next_noise_idx = ff.noise_indices[0];
         ff.noise_pos = 1;
     } else {
-        state.next_noise_idx = static_cast<uint32_t>(-1);
-    }
-}
-
-// Check that the k-fault stratum has nonzero probability mass.
-// Sites with p==0 can never fire; sites with p==1 always fire.
-// Feasible range: n_certain <= k <= n_total - n_impossible.
-void validate_stratum(const std::vector<double>& probs, uint32_t k) {
-    uint32_t n_total = static_cast<uint32_t>(probs.size());
-    if (k > n_total) {
-        throw std::invalid_argument("k (" + std::to_string(k) + ") exceeds total fault sites (" +
-                                    std::to_string(n_total) + ")");
-    }
-    uint32_t n_certain = 0;     // Sites that always fire (p >= 1.0)
-    uint32_t n_impossible = 0;  // Sites that never fire (p <= 0.0)
-    for (double p : probs) {
-        if (p <= 0.0)
-            n_impossible++;
-        else if (p >= 1.0)
-            n_certain++;
-    }
-    if (k < n_certain || k > n_total - n_impossible) {
-        throw std::invalid_argument("k-fault stratum k=" + std::to_string(k) +
-                                    " has zero probability mass (" + std::to_string(n_certain) +
-                                    " sites have p=1, " + std::to_string(n_impossible) +
-                                    " sites have p=0)");
+        state.next_noise_idx = kNoNoiseSite;
     }
 }
 
@@ -661,18 +518,8 @@ SampleResult sample_k(const CompiledModule& program, uint32_t shots, uint32_t k,
 
     // Build fault site probabilities and precompute DP table.
     auto probs = noise_site_probabilities(program);
-    validate_stratum(probs, k);
-    uint32_t n_total = static_cast<uint32_t>(probs.size());
     uint32_t n_q = static_cast<uint32_t>(program.constant_pool.noise_sites.size());
-
-    bool uniform_mode = all_probs_equal(probs);
-    auto w = uniform_mode ? std::vector<double>{} : build_odds_ratios(probs);
-    auto dp = uniform_mode ? std::vector<double>{} : build_dp_table(w, k);
-    std::vector<uint32_t> uniform_pool;
-    if (uniform_mode) {
-        uniform_pool.resize(n_total);
-        std::iota(uniform_pool.begin(), uniform_pool.end(), 0);
-    }
+    KFaultSampler fault_sampler(probs, k);
 
     SchrodingerState state({.peak_rank = program.peak_rank,
                             .num_measurements = num_total,
@@ -681,12 +528,14 @@ SampleResult sample_k(const CompiledModule& program, uint32_t shots, uint32_t k,
                             .num_observables = num_obs,
                             .num_exp_vals = num_ev,
                             .seed = seed});
+    state.forced_faults.noise_indices.reserve(n_q);
+    state.forced_faults.readout_indices.reserve(probs.size() - n_q);
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
         if (shot > 0)
             state.reset();
 
-        prepare_forced_shot(state, w, dp, k, n_q, uniform_mode, uniform_pool);
+        prepare_forced_shot(state, fault_sampler, n_q);
         execute(program, state);
         throw_on_pending_trap(state);
 
@@ -741,18 +590,8 @@ SurvivorResult sample_k_survivors(const CompiledModule& program, uint32_t shots,
     }
 
     auto probs = noise_site_probabilities(program);
-    validate_stratum(probs, k);
-    uint32_t n_total = static_cast<uint32_t>(probs.size());
     uint32_t n_q = static_cast<uint32_t>(program.constant_pool.noise_sites.size());
-
-    bool uniform_mode = all_probs_equal(probs);
-    auto w = uniform_mode ? std::vector<double>{} : build_odds_ratios(probs);
-    auto dp = uniform_mode ? std::vector<double>{} : build_dp_table(w, k);
-    std::vector<uint32_t> uniform_pool;
-    if (uniform_mode) {
-        uniform_pool.resize(n_total);
-        std::iota(uniform_pool.begin(), uniform_pool.end(), 0);
-    }
+    KFaultSampler fault_sampler(probs, k);
 
     SchrodingerState state({.peak_rank = program.peak_rank,
                             .num_measurements = num_total,
@@ -761,12 +600,14 @@ SurvivorResult sample_k_survivors(const CompiledModule& program, uint32_t shots,
                             .num_observables = num_obs,
                             .num_exp_vals = num_ev,
                             .seed = seed});
+    state.forced_faults.noise_indices.reserve(n_q);
+    state.forced_faults.readout_indices.reserve(probs.size() - n_q);
 
     for (uint32_t shot = 0; shot < shots; ++shot) {
         if (shot > 0)
             state.reset();
 
-        prepare_forced_shot(state, w, dp, k, n_q, uniform_mode, uniform_pool);
+        prepare_forced_shot(state, fault_sampler, n_q);
         execute(program, state);
         throw_on_pending_trap(state);
 

--- a/src/clifft/util/fault_sampling.cc
+++ b/src/clifft/util/fault_sampling.cc
@@ -1,0 +1,91 @@
+#include "clifft/util/fault_sampling.h"
+
+#include "clifft/util/numeric.h"
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+
+namespace clifft {
+
+KFaultSampler::KFaultSampler(std::span<const double> probabilities, uint32_t k) : k_(k) {
+    if (probabilities.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::length_error("fault-site count exceeds uint32 range");
+    }
+    num_sites_ = static_cast<uint32_t>(probabilities.size());
+    if (k > num_sites_) {
+        throw std::invalid_argument("k (" + std::to_string(k) + ") exceeds total fault sites (" +
+                                    std::to_string(num_sites_) + ")");
+    }
+
+    uint32_t impossible_count = 0;
+    for (uint32_t site = 0; site < num_sites_; ++site) {
+        const double probability = probabilities[site];
+        if (!is_probability(probability)) {
+            throw std::invalid_argument("fault-site probability must be finite and in [0, 1]");
+        }
+        if (probability == 0.0) {
+            ++impossible_count;
+        } else if (probability == 1.0) {
+            certain_sites_.push_back(site);
+        } else {
+            uncertain_sites_.push_back(site);
+        }
+    }
+
+    const uint32_t certain_count = static_cast<uint32_t>(certain_sites_.size());
+    if (k < certain_count || k > num_sites_ - impossible_count) {
+        throw std::invalid_argument("k-fault stratum k=" + std::to_string(k) +
+                                    " has zero probability mass (" + std::to_string(certain_count) +
+                                    " sites have p=1, " + std::to_string(impossible_count) +
+                                    " sites have p=0)");
+    }
+    remaining_k_ = k - certain_count;
+    selected_sites_.reserve(k);
+
+    if (remaining_k_ == 0) {
+        return;
+    }
+
+    const double first_probability = probabilities[uncertain_sites_.front()];
+    uniform_mode_ = std::ranges::all_of(
+        uncertain_sites_, [&](uint32_t site) { return probabilities[site] == first_probability; });
+    if (uniform_mode_) {
+        uniform_pool_ = uncertain_sites_;
+        return;
+    }
+
+    odds_ratios_.reserve(uncertain_sites_.size());
+    for (uint32_t site : uncertain_sites_) {
+        const double probability = probabilities[site];
+        odds_ratios_.push_back(probability / (1.0 - probability));
+    }
+    const double sum = std::accumulate(odds_ratios_.begin(), odds_ratios_.end(), 0.0);
+    const double scale = static_cast<double>(odds_ratios_.size()) / sum;
+    for (double& odds : odds_ratios_) {
+        odds *= scale;
+    }
+
+    const size_t rows = uncertain_sites_.size() + 1;
+    const size_t stride = static_cast<size_t>(remaining_k_) + 1;
+    if (rows > std::numeric_limits<size_t>::max() / stride) {
+        throw std::length_error("fault-conditioning table exceeds size_t range");
+    }
+    dp_.assign(rows * stride, 0.0);
+    for (size_t row = 0; row < rows; ++row) {
+        dp_[row * stride] = 1.0;
+    }
+    for (size_t row = uncertain_sites_.size(); row-- > 0;) {
+        const uint32_t remaining = static_cast<uint32_t>(uncertain_sites_.size() - row);
+        const uint32_t max_selected = std::min(remaining, remaining_k_);
+        for (uint32_t selected = 1; selected <= max_selected; ++selected) {
+            dp_[row * stride + selected] =
+                dp_[(row + 1) * stride + selected] +
+                odds_ratios_[row] * dp_[(row + 1) * stride + selected - 1];
+        }
+    }
+}
+
+}  // namespace clifft

--- a/src/clifft/util/fault_sampling.h
+++ b/src/clifft/util/fault_sampling.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace clifft {
+
+// Precomputes and repeatedly samples the exact distribution of independent
+// Bernoulli sites conditioned on exactly k sites firing. Construction owns all
+// allocation and validation; sample() only mutates preallocated buffers.
+class KFaultSampler {
+  public:
+    KFaultSampler(std::span<const double> probabilities, uint32_t k);
+    KFaultSampler(const KFaultSampler&) = delete;
+    KFaultSampler& operator=(const KFaultSampler&) = delete;
+    KFaultSampler(KFaultSampler&&) noexcept = default;
+    KFaultSampler& operator=(KFaultSampler&&) noexcept = default;
+
+    [[nodiscard]] uint32_t num_sites() const noexcept { return num_sites_; }
+    [[nodiscard]] uint32_t k() const noexcept { return k_; }
+
+    template <typename RandomDouble>
+    [[nodiscard]] std::span<const uint32_t> sample(RandomDouble&& random_double) noexcept {
+        selected_sites_.clear();
+        selected_sites_.insert(selected_sites_.end(), certain_sites_.begin(), certain_sites_.end());
+
+        if (uniform_mode_) {
+            const uint32_t count = static_cast<uint32_t>(uniform_pool_.size());
+            for (uint32_t j = 0; j < remaining_k_; ++j) {
+                const uint32_t remaining = count - j;
+                const double draw = random_double();
+                assert(draw >= 0.0 && draw < 1.0 && "fault selection draw must be in [0, 1)");
+                const uint32_t pick = j + static_cast<uint32_t>(draw * remaining);
+                std::swap(uniform_pool_[j], uniform_pool_[pick]);
+            }
+            // Preserve the legacy sampler's persistent-pool evolution as well
+            // as returning sites in circuit order.
+            std::sort(uniform_pool_.begin(), uniform_pool_.begin() + remaining_k_);
+            for (uint32_t j = 0; j < remaining_k_; ++j) {
+                selected_sites_.push_back(uniform_pool_[j]);
+            }
+        } else {
+            const uint32_t count = static_cast<uint32_t>(uncertain_sites_.size());
+            const uint32_t stride = remaining_k_ + 1;
+            uint32_t needed = remaining_k_;
+            for (uint32_t i = 0; i < count && needed > 0; ++i) {
+                double probability = 1.0;
+                const uint32_t remaining = count - i;
+                if (needed != remaining) {
+                    const double denominator = dp_[static_cast<size_t>(i) * stride + needed];
+                    probability = denominator > 0.0
+                                      ? odds_ratios_[i] *
+                                            dp_[static_cast<size_t>(i + 1) * stride + needed - 1] /
+                                            denominator
+                                      : 0.0;
+                }
+                const double draw = random_double();
+                assert(draw >= 0.0 && draw < 1.0 && "fault selection draw must be in [0, 1)");
+                if (draw < probability) {
+                    selected_sites_.push_back(uncertain_sites_[i]);
+                    --needed;
+                }
+            }
+            assert(needed == 0 && "conditioned fault sampler must select the requested stratum");
+        }
+
+        std::sort(selected_sites_.begin(), selected_sites_.end());
+        assert(selected_sites_.size() == k_ && "conditioned fault sampler returned wrong size");
+        return selected_sites_;
+    }
+
+  private:
+    uint32_t num_sites_ = 0;
+    uint32_t k_ = 0;
+    uint32_t remaining_k_ = 0;
+    bool uniform_mode_ = true;
+    std::vector<uint32_t> certain_sites_;
+    std::vector<uint32_t> uncertain_sites_;
+    std::vector<double> odds_ratios_;
+    std::vector<double> dp_;
+    std::vector<uint32_t> uniform_pool_;
+    std::vector<uint32_t> selected_sites_;
+};
+
+}  // namespace clifft

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -923,6 +923,15 @@ NB_MODULE(_clifft_core, m) {
         .def_prop_ro("num_exp_vals", &clifft::sampling::ExecutablePlan::num_exp_vals)
         .def_prop_ro("has_postselection", &clifft::sampling::ExecutablePlan::has_postselection)
         .def_prop_ro("num_actions", &clifft::sampling::ExecutablePlan::num_actions)
+        .def_prop_ro(
+            "noise_site_probabilities",
+            [](const clifft::sampling::ExecutablePlan& p) {
+                auto probabilities = p.noise_site_probabilities();
+                const size_t size = probabilities.size();
+                return vec_to_numpy(std::move(probabilities), {size});
+            },
+            nb::rv_policy::move,
+            "Per-site total fault probabilities: quantum noise sites followed by readout noise.")
         .def("__repr__", [](const clifft::sampling::ExecutablePlan& p) {
             return "ExperimentalSamplingProgram(" + std::to_string(p.num_actions()) + " actions, " +
                    std::to_string(p.num_visible_records()) + " measurements)";
@@ -1006,6 +1015,58 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false,
         "Sample survivor counts and optional records from an experimental program.");
+
+    m.def(
+        "_sample_k_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
+           std::optional<uint64_t> seed) {
+            clifft::sampling::SamplingResult result;
+            {
+                nb::gil_scoped_release release;
+                result = clifft::sampling::sample_k(program, shots, k, seed);
+            }
+            auto measurements = vec_to_numpy(std::move(result.measurements),
+                                             {shots, program.num_visible_records()});
+            auto detectors =
+                vec_to_numpy(std::move(result.detectors), {shots, program.num_detectors()});
+            auto observables =
+                vec_to_numpy(std::move(result.observables), {shots, program.num_observables()});
+            auto exp_vals =
+                vec_to_numpy(std::move(result.exp_vals), {shots, program.num_exp_vals()});
+            return nb::make_tuple(measurements, detectors, observables, exp_vals);
+        },
+        nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
+        "Sample an experimental program with exactly k forced fault sites.");
+
+    m.def(
+        "_sample_k_survivors_experimental_sampling",
+        [](const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
+           std::optional<uint64_t> seed, bool keep_records) {
+            clifft::sampling::SamplingSurvivorResult result;
+            {
+                nb::gil_scoped_release release;
+                result =
+                    clifft::sampling::sample_k_survivors(program, shots, k, seed, keep_records);
+            }
+            const size_t rows = keep_records ? result.passed_shots : 0;
+            auto measurements =
+                vec_to_numpy(std::move(result.measurements), {rows, program.num_visible_records()});
+            auto detectors =
+                vec_to_numpy(std::move(result.detectors), {rows, program.num_detectors()});
+            auto observables =
+                vec_to_numpy(std::move(result.observables), {rows, program.num_observables()});
+            const size_t num_observable_counts = result.observable_ones.size();
+            auto observable_ones =
+                vec_to_numpy(std::move(result.observable_ones), {num_observable_counts});
+            auto exp_vals =
+                vec_to_numpy(std::move(result.exp_vals), {rows, program.num_exp_vals()});
+            return nb::make_tuple(measurements, detectors, observables, result.total_shots,
+                                  result.passed_shots, result.logical_errors, observable_ones,
+                                  exp_vals);
+        },
+        nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
+        nb::arg("keep_records") = false,
+        "Sample experimental survivors with exactly k forced fault sites.");
 
     m.def(
         "_basis_probabilities_experimental_sampling",

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -28,6 +28,8 @@ from clifft._clifft_core import (
     _get_statevector_experimental_sampling,
     _record_probabilities_experimental_sampling,
     _sample_experimental_sampling,
+    _sample_k_experimental_sampling,
+    _sample_k_survivors_experimental_sampling,
     _sample_survivors_experimental_sampling,
     default_hir_pass_manager,
 )
@@ -148,6 +150,72 @@ def sample_survivors(
     )
 
 
+def sample_k(
+    program: Program,
+    shots: int,
+    k: int,
+    seed: int | None = None,
+) -> SampleResult:
+    """Sample with exactly ``k`` forced fault sites per shot."""
+    if program.has_postselection:
+        raise ValueError(
+            "sample_k() cannot represent discarded shots; use sample_k_survivors() instead."
+        )
+    measurements, detectors, observables, exp_vals = cast(
+        tuple[
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.float64],
+        ],
+        _sample_k_experimental_sampling(program, shots, k, seed),
+    )
+    return SampleResult(measurements, detectors, observables, exp_vals=exp_vals)
+
+
+def sample_k_survivors(
+    program: Program,
+    shots: int,
+    k: int,
+    seed: int | None = None,
+    *,
+    keep_records: bool = False,
+) -> SampleResult:
+    """Sample survivors with exactly ``k`` forced fault sites per shot."""
+    (
+        measurements,
+        detectors,
+        observables,
+        total,
+        passed,
+        logical_errors,
+        observable_ones,
+        exp_vals,
+    ) = cast(
+        tuple[
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            npt.NDArray[np.uint8],
+            int,
+            int,
+            int,
+            npt.NDArray[np.uint64],
+            npt.NDArray[np.float64],
+        ],
+        _sample_k_survivors_experimental_sampling(program, shots, k, seed, keep_records),
+    )
+    return SampleResult(
+        measurements,
+        detectors,
+        observables,
+        total,
+        passed,
+        logical_errors,
+        observable_ones,
+        exp_vals,
+    )
+
+
 def record_probabilities(
     program: Program,
     records: MeasurementRecords,
@@ -203,6 +271,8 @@ __all__ = [
     "get_statevector",
     "record_probabilities",
     "sample",
+    "sample_k",
+    "sample_k_survivors",
     "sample_noncomputational",
     "sample_survivors",
 ]

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -23,6 +23,12 @@ def basis_probabilities_api(request: pytest.FixtureRequest) -> Any:
     return cast(Any, request.param)
 
 
+@pytest.fixture(params=[clifft, experimental], ids=["svm", "symbolic-coordinate"])
+def importance_sampling_api(request: pytest.FixtureRequest) -> Any:
+    """Run shared forced-fault tests against both Python APIs."""
+    return cast(Any, request.param)
+
+
 @pytest.fixture(params=["legacy", "experimental"], ids=["legacy", "experimental"])
 def statevector_from_circuit(
     request: pytest.FixtureRequest,

--- a/tests/python/test_importance_sampling.py
+++ b/tests/python/test_importance_sampling.py
@@ -1,5 +1,7 @@
 """Integration tests for importance sampling (forced k-fault) API."""
 
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -7,13 +9,21 @@ import pytest
 import clifft
 
 
-def _compile(stim_text: str) -> clifft.Program:
-    return clifft.compile(
-        stim_text,
-        normalize_syndromes=True,
-        hir_passes=clifft.default_hir_pass_manager(),
-        bytecode_passes=clifft.default_bytecode_pass_manager(),
-    )
+class _ImportanceBackendMixin:
+    sampling_api: Any
+
+    @pytest.fixture(autouse=True)
+    def _select_importance_backend(self, importance_sampling_api: Any) -> None:
+        self.sampling_api = importance_sampling_api
+
+    def compile(self, stim_text: str) -> Any:
+        kwargs: dict[str, Any] = {
+            "normalize_syndromes": True,
+            "hir_passes": clifft.default_hir_pass_manager(),
+        }
+        if self.sampling_api is clifft:
+            kwargs["bytecode_passes"] = clifft.default_bytecode_pass_manager()
+        return self.sampling_api.compile(stim_text, **kwargs)
 
 
 def poisson_binomial_pmf(probs: npt.NDArray[np.float64], max_k: int) -> npt.NDArray[np.float64]:
@@ -27,9 +37,9 @@ def poisson_binomial_pmf(probs: npt.NDArray[np.float64], max_k: int) -> npt.NDAr
     return dp
 
 
-class TestNoiseSiteProbabilities:
+class TestNoiseSiteProbabilities(_ImportanceBackendMixin):
     def test_basic_extraction(self) -> None:
-        prog = _compile(
+        prog = self.compile(
             """
             R 0 1
             DEPOLARIZE1(0.03) 0
@@ -49,15 +59,15 @@ class TestNoiseSiteProbabilities:
         np.testing.assert_allclose(probs[2], 0.005, atol=1e-12)
 
     def test_no_noise(self) -> None:
-        prog = _compile("R 0\nH 0\nM 0")
+        prog = self.compile("R 0\nH 0\nM 0")
         probs = prog.noise_site_probabilities
         assert len(probs) == 0
 
 
-class TestSampleK:
+class TestSampleK(_ImportanceBackendMixin):
     def test_k0_no_errors(self) -> None:
         """With k=0 forced faults, no errors should appear."""
-        prog = _compile(
+        prog = self.compile(
             """
             R 0 1 2
             X_ERROR(0.1) 0 1 2
@@ -67,14 +77,14 @@ class TestSampleK:
             OBSERVABLE_INCLUDE(0) rec[-1]
             """
         )
-        result = clifft.sample_k(prog, shots=1000, k=0, seed=42)
+        result = self.sampling_api.sample_k(prog, shots=1000, k=0, seed=42)
         assert result.measurements.shape == (1000, 3)
         assert np.all(result.observables == 0)
         assert np.all(result.detectors == 0)
 
     def test_k_equals_n_forces_all(self) -> None:
         """k=N should force every noise site to fire."""
-        prog = _compile(
+        prog = self.compile(
             """
             R 0
             X_ERROR(0.5) 0
@@ -85,11 +95,11 @@ class TestSampleK:
         )
         n_sites = len(prog.noise_site_probabilities)
         assert n_sites == 1
-        result = clifft.sample_k(prog, shots=500, k=1, seed=42)
+        result = self.sampling_api.sample_k(prog, shots=500, k=1, seed=42)
         assert np.all(result.observables == 1)
 
     def test_k_exceeds_n_raises(self) -> None:
-        prog = _compile(
+        prog = self.compile(
             """
             R 0
             X_ERROR(0.1) 0
@@ -99,23 +109,23 @@ class TestSampleK:
         )
         n_sites = len(prog.noise_site_probabilities)
         with pytest.raises(ValueError):
-            clifft.sample_k(prog, shots=10, k=n_sites + 1, seed=42)
+            self.sampling_api.sample_k(prog, shots=10, k=n_sites + 1, seed=42)
 
     def test_zero_mass_stratum_raises(self) -> None:
         """k > 0 on a noiseless circuit should raise (zero-mass stratum)."""
-        prog = _compile("R 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
+        prog = self.compile("R 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
         assert len(prog.noise_site_probabilities) == 0
         # k=0 is fine
-        clifft.sample_k(prog, shots=5, k=0, seed=42)
+        self.sampling_api.sample_k(prog, shots=5, k=0, seed=42)
         # k=1 is impossible
         with pytest.raises(ValueError):
-            clifft.sample_k(prog, shots=5, k=1, seed=42)
+            self.sampling_api.sample_k(prog, shots=5, k=1, seed=42)
         with pytest.raises(ValueError):
-            clifft.sample_k_survivors(prog, shots=5, k=1, seed=42)
+            self.sampling_api.sample_k_survivors(prog, shots=5, k=1, seed=42)
 
     def test_exactly_k_faults_per_shot(self) -> None:
         """Verify exactly k measurements flip per shot with X_ERROR."""
-        prog = _compile(
+        prog = self.compile(
             """
             R 0 1 2
             X_ERROR(0.01) 0
@@ -126,12 +136,12 @@ class TestSampleK:
             """
         )
         for k in range(4):
-            result = clifft.sample_k(prog, shots=200, k=k, seed=42 + k)
+            result = self.sampling_api.sample_k(prog, shots=200, k=k, seed=42 + k)
             flips_per_shot = np.sum(result.measurements, axis=1)
             np.testing.assert_array_equal(flips_per_shot, k)
 
     def test_deterministic_with_seed(self) -> None:
-        prog = _compile(
+        prog = self.compile(
             """
             R 0 1
             DEPOLARIZE1(0.05) 0 1
@@ -140,15 +150,15 @@ class TestSampleK:
             OBSERVABLE_INCLUDE(0) rec[-1]
             """
         )
-        r1 = clifft.sample_k(prog, shots=100, k=1, seed=99)
-        r2 = clifft.sample_k(prog, shots=100, k=1, seed=99)
+        r1 = self.sampling_api.sample_k(prog, shots=100, k=1, seed=99)
+        r2 = self.sampling_api.sample_k(prog, shots=100, k=1, seed=99)
         np.testing.assert_array_equal(r1.measurements, r2.measurements)
         np.testing.assert_array_equal(r1.detectors, r2.detectors)
         np.testing.assert_array_equal(r1.observables, r2.observables)
 
     def test_readout_noise_forcing(self) -> None:
         """k=1 with only readout noise should flip every shot."""
-        prog = _compile(
+        prog = self.compile(
             """
             R 0
             M(0.1) 0
@@ -157,13 +167,13 @@ class TestSampleK:
             """
         )
         assert len(prog.noise_site_probabilities) == 1
-        result = clifft.sample_k(prog, shots=500, k=1, seed=42)
+        result = self.sampling_api.sample_k(prog, shots=500, k=1, seed=42)
         assert np.all(result.observables == 1)
 
 
-class TestSampleKSurvivors:
+class TestSampleKSurvivors(_ImportanceBackendMixin):
     def test_k0_no_errors(self) -> None:
-        prog = _compile(
+        prog = self.compile(
             """
             R 0 1 2
             X_ERROR(0.1) 0 1 2
@@ -173,7 +183,7 @@ class TestSampleKSurvivors:
             OBSERVABLE_INCLUDE(0) rec[-1]
             """
         )
-        result = clifft.sample_k_survivors(prog, shots=5000, k=0, seed=42)
+        result = self.sampling_api.sample_k_survivors(prog, shots=5000, k=0, seed=42)
         assert isinstance(result, clifft.SampleResult)
         assert result.total_shots == 5000
         assert result.passed_shots == 5000
@@ -181,7 +191,7 @@ class TestSampleKSurvivors:
         assert result.measurements.shape == (0, prog.num_measurements)
 
     def test_keep_records(self) -> None:
-        prog = _compile(
+        prog = self.compile(
             """
             R 0 1
             X_ERROR(0.1) 0 1
@@ -190,7 +200,9 @@ class TestSampleKSurvivors:
             OBSERVABLE_INCLUDE(0) rec[-1]
             """
         )
-        result = clifft.sample_k_survivors(prog, shots=100, k=1, seed=42, keep_records=True)
+        result = self.sampling_api.sample_k_survivors(
+            prog, shots=100, k=1, seed=42, keep_records=True
+        )
         passed = result.passed_shots
         assert passed > 0
         assert result.measurements.shape == (passed, prog.num_measurements)
@@ -198,12 +210,12 @@ class TestSampleKSurvivors:
         assert result.observables.shape == (passed, prog.num_observables)
 
 
-class TestImportanceSamplingEndToEnd:
+class TestImportanceSamplingEndToEnd(_ImportanceBackendMixin):
     """Integration test: verify the stratified importance sampling workflow."""
 
     def test_single_qubit_k0_vs_k1(self) -> None:
         """Single qubit: k=0 has no error, k=1 always has error."""
-        prog = _compile(
+        prog = self.compile(
             """
             R 0
             X_ERROR(0.1) 0
@@ -215,10 +227,10 @@ class TestImportanceSamplingEndToEnd:
         probs = prog.noise_site_probabilities
         assert len(probs) == 1
 
-        r0 = clifft.sample_k_survivors(prog, shots=1000, k=0, seed=42)
+        r0 = self.sampling_api.sample_k_survivors(prog, shots=1000, k=0, seed=42)
         assert r0.logical_errors == 0
 
-        r1 = clifft.sample_k_survivors(prog, shots=1000, k=1, seed=42)
+        r1 = self.sampling_api.sample_k_survivors(prog, shots=1000, k=1, seed=42)
         assert r1.logical_errors == r1.passed_shots
 
     def test_weighted_error_rate_single_qubit(self) -> None:
@@ -231,7 +243,7 @@ class TestImportanceSamplingEndToEnd:
             DETECTOR rec[-1]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = _compile(circuit_text)
+        prog = self.compile(circuit_text)
         probs = prog.noise_site_probabilities
         max_k = len(probs)
         pmf = poisson_binomial_pmf(probs, max_k)
@@ -243,7 +255,7 @@ class TestImportanceSamplingEndToEnd:
         for k in range(max_k + 1):
             if pmf[k] < 1e-15:
                 continue
-            result = clifft.sample_k_survivors(prog, shots=10000, k=k, seed=42 + k)
+            result = self.sampling_api.sample_k_survivors(prog, shots=10000, k=k, seed=42 + k)
             total = result.total_shots
             if total == 0:
                 continue
@@ -253,7 +265,7 @@ class TestImportanceSamplingEndToEnd:
         p_fail_stratified = weighted_errors / weighted_survival if weighted_survival > 0 else 0.0
 
         # Brute force Monte Carlo estimate
-        mc_result = clifft.sample_survivors(prog, shots=100000, seed=99)
+        mc_result = self.sampling_api.sample_survivors(prog, shots=100000, seed=99)
         p_fail_mc = mc_result.logical_errors / mc_result.passed_shots
 
         # For single qubit with X_ERROR(p), p_L = p exactly.
@@ -272,7 +284,7 @@ class TestImportanceSamplingEndToEnd:
             DETECTOR rec[-1] rec[-2]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-        prog = _compile(circuit_text)
+        prog = self.compile(circuit_text)
         probs = prog.noise_site_probabilities
         max_k = len(probs)
         pmf = poisson_binomial_pmf(probs, max_k)
@@ -283,7 +295,7 @@ class TestImportanceSamplingEndToEnd:
         for k in range(max_k + 1):
             if pmf[k] < 1e-15:
                 continue
-            result = clifft.sample_k_survivors(prog, shots=10000, k=k, seed=42 + k)
+            result = self.sampling_api.sample_k_survivors(prog, shots=10000, k=k, seed=42 + k)
             total = result.total_shots
             if total == 0:
                 continue
@@ -293,7 +305,7 @@ class TestImportanceSamplingEndToEnd:
         p_fail_stratified = weighted_errors / weighted_survival if weighted_survival > 0 else 0.0
 
         # Brute force MC
-        mc_result = clifft.sample_survivors(prog, shots=100000, seed=99)
+        mc_result = self.sampling_api.sample_survivors(prog, shots=100000, seed=99)
         p_fail_mc = mc_result.logical_errors / mc_result.passed_shots
 
         # Observable is rec[-1] = qubit 1. Error whenever qubit 1 flips.

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -4,9 +4,14 @@
 #include "clifft/backend/backend.h"
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/sampling/executor.h"
+#include "clifft/sampling/planner.h"
 #include "clifft/svm/svm.h"
+#include "clifft/util/fault_sampling.h"
+#include "clifft/util/xoshiro.h"
 
 #include <algorithm>
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -27,7 +32,40 @@ clifft::CompiledModule compile_circuit(const std::string& stim_text) {
     return clifft::lower(hir, {}, ref.detectors, ref.observables);
 }
 
+clifft::sampling::ExecutablePlan compile_sampling_circuit(
+    const std::string& stim_text, std::span<const uint8_t> postselection = {}) {
+    auto hir = clifft::trace(clifft::parse(stim_text));
+    auto reference = clifft::compute_reference_syndrome(hir);
+    return clifft::sampling::ExecutablePlan(
+        clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection,
+                                              .expected_detectors = reference.detectors,
+                                              .expected_observables = reference.observables}));
+}
+
 }  // namespace
+
+TEST_CASE("Conditioned fault sampler honors certain and impossible sites") {
+    const std::array<double, 4> probabilities{0.0, 1.0, 0.2, 0.8};
+    clifft::KFaultSampler sampler(probabilities, 2);
+    clifft::Xoshiro256PlusPlus rng(1234);
+    uint32_t low_probability_selections = 0;
+    uint32_t high_probability_selections = 0;
+    for (uint32_t shot = 0; shot < 10000; ++shot) {
+        const std::span<const uint32_t> selected =
+            sampler.sample([&]() noexcept { return rng.next_double(); });
+        REQUIRE(selected.size() == 2);
+        REQUIRE(std::ranges::find(selected, 0) == selected.end());
+        REQUIRE(std::ranges::find(selected, 1) != selected.end());
+        low_probability_selections +=
+            static_cast<uint32_t>(std::ranges::find(selected, 2) != selected.end());
+        high_probability_selections +=
+            static_cast<uint32_t>(std::ranges::find(selected, 3) != selected.end());
+    }
+    CHECK(high_probability_selections > 9000);
+    CHECK(low_probability_selections < 1000);
+    CHECK_THROWS_AS(clifft::KFaultSampler(probabilities, 0), std::invalid_argument);
+    CHECK_THROWS_AS(clifft::KFaultSampler(probabilities, 4), std::invalid_argument);
+}
 
 // =============================================================================
 // noise_site_probabilities
@@ -348,8 +386,8 @@ TEST_CASE("sample_k_survivors - postselection discards some shots") {
         R 0 1
         X_ERROR(0.1) 0 1
         M 0 1
-        DETECTOR rec[-1]
         DETECTOR rec[-2]
+        DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
     )";
     auto circuit = clifft::parse(circuit_text);
@@ -397,5 +435,84 @@ TEST_CASE("k-fault conditioning rejects asymmetric readout noise") {
     CHECK_THROWS_WITH(clifft::noise_site_probabilities(prog),
                       Catch::Matchers::ContainsSubstring("asymmetric"));
     CHECK_THROWS_WITH(clifft::sample_k(prog, 8, 1, 0),
+                      Catch::Matchers::ContainsSubstring("asymmetric"));
+}
+
+TEST_CASE("Symbolic conditioned sampling exposes ordered fault probabilities") {
+    auto program = compile_sampling_circuit(R"(
+        DEPOLARIZE1(0.03) 0
+        X_ERROR(0.01) 1
+        M(0.005) 0
+        M 1
+    )");
+    const std::vector<double> probabilities = program.noise_site_probabilities();
+    REQUIRE(probabilities.size() == 3);
+    CHECK_THAT(probabilities[0], WithinAbs(0.03, 1e-12));
+    CHECK_THAT(probabilities[1], WithinAbs(0.01, 1e-12));
+    CHECK_THAT(probabilities[2], WithinAbs(0.005, 1e-12));
+}
+
+TEST_CASE("Symbolic conditioned sampling forces quantum channels and readout") {
+    auto quantum = compile_sampling_circuit(R"(
+        X_ERROR(0.01) 0
+        X_ERROR(0.05) 1
+        X_ERROR(0.1) 2
+        M 0 1 2
+    )");
+    const clifft::sampling::SamplingResult quantum_result =
+        clifft::sampling::sample_k(quantum, 500, 2, 42);
+    for (uint32_t shot = 0; shot < 500; ++shot) {
+        const auto row = std::span<const uint8_t>(quantum_result.measurements).subspan(shot * 3, 3);
+        CHECK(std::ranges::count(row, uint8_t{1}) == 2);
+    }
+
+    auto readout = compile_sampling_circuit("M(0.1) 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n");
+    const clifft::sampling::SamplingResult readout_result =
+        clifft::sampling::sample_k(readout, 100, 1, 43);
+    CHECK(
+        std::ranges::all_of(readout_result.observables, [](uint8_t value) { return value == 1; }));
+}
+
+TEST_CASE("Symbolic conditioned Pauli channels use conditional probabilities") {
+    auto program = compile_sampling_circuit("DEPOLARIZE1(0.3) 0\nM 0\n");
+    const clifft::sampling::SamplingResult result =
+        clifft::sampling::sample_k(program, 10000, 1, 44);
+    const auto flips = std::ranges::count(result.measurements, uint8_t{1});
+    CHECK(flips > 6200);
+    CHECK(flips < 7100);
+}
+
+TEST_CASE("Symbolic conditioned survivors preserve normalized outputs") {
+    const std::array<uint8_t, 2> postselection{1, 0};
+    auto survivors = compile_sampling_circuit(R"(
+        X_ERROR(0.1) 0 1
+        M 0 1
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        EXP_VAL Z0
+    )",
+                                              postselection);
+    const clifft::sampling::SamplingSurvivorResult result =
+        clifft::sampling::sample_k_survivors(survivors, 1000, 1, 45, true);
+    CHECK(result.total_shots == 1000);
+    CHECK(result.passed_shots > 300);
+    CHECK(result.passed_shots < 700);
+    CHECK(result.logical_errors == result.passed_shots);
+    REQUIRE(result.exp_vals.size() == result.passed_shots);
+    CHECK(std::ranges::all_of(result.exp_vals, [](double value) { return value == 1.0; }));
+
+    auto normalized = compile_sampling_circuit("X 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n");
+    const clifft::sampling::SamplingResult normalized_result =
+        clifft::sampling::sample_k(normalized, 10, 0, 46);
+    CHECK(std::ranges::all_of(normalized_result.observables,
+                              [](uint8_t value) { return value == 0; }));
+}
+
+TEST_CASE("Symbolic conditioned sampling rejects asymmetric readout noise") {
+    auto program = compile_sampling_circuit("M 0\nREADOUT_NOISE(0.1, 0.2) rec[-1]\n");
+    CHECK_THROWS_WITH(program.noise_site_probabilities(),
+                      Catch::Matchers::ContainsSubstring("asymmetric"));
+    CHECK_THROWS_WITH(clifft::sampling::sample_k(program, 8, 1, 0),
                       Catch::Matchers::ContainsSubstring("asymmetric"));
 }


### PR DESCRIPTION
Closes #278.
Tracks #247.

## Summary

- Share exact forced-k fault selection between the legacy SVM and symbolic-coordinate backends, retaining the equal-probability partial Fisher-Yates path and heterogeneous-probability dynamic-programming path.
- Add experimental `sample_k()`, `sample_k_survivors()`, and `noise_site_probabilities` with the existing public result semantics and site ordering.
- Force selected quantum channels and symmetric readout flips without allocation, exceptions, or topology work in hot execution. Ordinary sampling remains compile-time specialized and does not gain a runtime forced-mode branch.
- Run the existing Python importance-sampling corpus against both backends and add focused selector, channel, readout, postselection, observable, and expectation-value coverage.

The default backend is unchanged. Asymmetric readout noise and instrument trajectories remain explicitly outside this conditioning model.

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- C++: 1,233 cases / 406,251 assertions passed
- Python: 1,252 passed
