### PR TITLE
perf: evaluate symbolic expressions incrementally

### DIFF
--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -100,7 +100,42 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     if (num_expression_terms > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable expression storage exceeds uint32 range");
     }
-    expression_terms_.reserve(num_expression_terms);
+    std::vector<uint32_t> expression_terms;
+    expression_terms.reserve(num_expression_terms);
+    std::vector<uint32_t> expression_term_begins;
+    expression_term_begins.reserve(plan.actions.size());
+    expression_register_constants_.reserve(plan.actions.size());
+
+    auto prepare_expression = [&](const AffineBool& expression) {
+        if (expression_register_constants_.size() >= std::numeric_limits<uint32_t>::max()) {
+            throw std::length_error("sampling executable expression count exceeds uint32 range");
+        }
+        const uint32_t register_id = static_cast<uint32_t>(expression_register_constants_.size());
+        expression_term_begins.push_back(static_cast<uint32_t>(expression_terms.size()));
+        expression_register_constants_.push_back(static_cast<uint8_t>(expression.constant()));
+        for (SymbolId term : expression.terms()) {
+            expression_terms.push_back(index(term));
+        }
+        return PreparedExpression{register_id};
+    };
+    auto prepare_measurement_correction = [&](const AffineBool& outcome, uint32_t branch) {
+        if (expression_register_constants_.size() >= std::numeric_limits<uint32_t>::max()) {
+            throw std::length_error("sampling executable expression count exceeds uint32 range");
+        }
+        const uint32_t register_id = static_cast<uint32_t>(expression_register_constants_.size());
+        const uint32_t begin = static_cast<uint32_t>(expression_terms.size());
+        expression_term_begins.push_back(begin);
+        expression_register_constants_.push_back(static_cast<uint8_t>(outcome.constant()));
+        for (SymbolId term : outcome.terms()) {
+            if (index(term) != branch) {
+                expression_terms.push_back(index(term));
+            }
+        }
+        assert(expression_terms.size() == static_cast<size_t>(begin) + outcome.terms().size() - 1 &&
+               "validated measurement outcome must contain its branch exactly once");
+        return PreparedExpression{register_id};
+    };
+
     actions_.reserve(plan.actions.size());
     instrument_resume_offsets_.assign(plan.num_instrument_sites,
                                       std::numeric_limits<uint32_t>::max());
@@ -225,6 +260,27 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
             },
             planned.action);
     }
+
+    expression_dependency_offsets_.assign(static_cast<size_t>(num_symbols_) + 1, 0);
+    for (uint32_t symbol : expression_terms) {
+        ++expression_dependency_offsets_[static_cast<size_t>(symbol) + 1];
+    }
+    for (size_t i = 1; i < expression_dependency_offsets_.size(); ++i) {
+        expression_dependency_offsets_[i] += expression_dependency_offsets_[i - 1];
+    }
+    expression_dependency_targets_.resize(expression_terms.size());
+    std::vector<uint32_t> next_dependency = expression_dependency_offsets_;
+    for (size_t expression = 0; expression < expression_term_begins.size(); ++expression) {
+        const uint32_t register_id = static_cast<uint32_t>(expression);
+        const uint32_t begin = expression_term_begins[expression];
+        const uint32_t end = expression + 1 < expression_term_begins.size()
+                                 ? expression_term_begins[expression + 1]
+                                 : static_cast<uint32_t>(expression_terms.size());
+        for (uint32_t i = begin; i < end; ++i) {
+            const uint32_t symbol = expression_terms[i];
+            expression_dependency_targets_[next_dependency[symbol]++] = register_id;
+        }
+    }
 }
 
 std::vector<double> ExecutablePlan::noise_site_probabilities() const {
@@ -251,33 +307,12 @@ std::vector<double> ExecutablePlan::noise_site_probabilities() const {
     return probabilities;
 }
 
-ExecutablePlan::PreparedExpression ExecutablePlan::prepare_expression(
-    const AffineBool& expression) {
-    const uint32_t begin = static_cast<uint32_t>(expression_terms_.size());
-    for (SymbolId term : expression.terms()) {
-        expression_terms_.push_back(index(term));
-    }
-    return {begin, static_cast<uint32_t>(expression.terms().size()), expression.constant()};
-}
-
-ExecutablePlan::PreparedExpression ExecutablePlan::prepare_measurement_correction(
-    const AffineBool& outcome, uint32_t branch) {
-    const uint32_t begin = static_cast<uint32_t>(expression_terms_.size());
-    for (SymbolId term : outcome.terms()) {
-        if (index(term) != branch) {
-            expression_terms_.push_back(index(term));
-        }
-    }
-    assert(expression_terms_.size() == static_cast<size_t>(begin) + outcome.terms().size() - 1 &&
-           "validated measurement outcome must contain its branch exactly once");
-    return {begin, static_cast<uint32_t>(outcome.terms().size() - 1), outcome.constant()};
-}
-
 Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
     : root_plan_(&plan),
       plan_(&plan),
       state_(plan.max_active_width_, plan.initial_active_width_, plan.global_weight_),
       symbols_(plan.num_symbols_, 0),
+      expression_registers_(plan.expression_register_constants_),
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
       detectors_(plan.num_detectors_, 0),
       observables_(plan.num_observables_, 0),
@@ -365,6 +400,10 @@ void Executor::resume(const ExecutablePlan& continuation,
     state_.ensure_capacity(continuation.max_active_width_);
     symbols_.resize(std::max(symbols_.size(), static_cast<size_t>(continuation.num_symbols_)), 0);
     std::fill(symbols_.begin() + boundary->symbol_prefix_size, symbols_.end(), uint8_t{0});
+    expression_registers_.resize(
+        std::max(expression_registers_.size(), continuation.expression_register_constants_.size()),
+        0);
+    initialize_expression_registers(continuation, boundary->symbol_prefix_size);
     const size_t record_count =
         static_cast<size_t>(continuation.num_visible_records_) + continuation.num_hidden_records_;
     records_.resize(std::max(records_.size(), record_count), 0);
@@ -398,9 +437,8 @@ void Executor::return_to_root_plan() noexcept {
 ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
                                    std::span<const uint8_t> presampled_values) noexcept {
     plan_ = root_plan_;
-    const size_t root_record_count =
-        static_cast<size_t>(plan_->num_visible_records_) + plan_->num_hidden_records_;
-    assert(forced_records.size() == root_record_count &&
+    assert(forced_records.size() ==
+               static_cast<size_t>(plan_->num_visible_records_) + plan_->num_hidden_records_ &&
            "one forced value is required for every plan record");
     assert(std::ranges::all_of(forced_records, [](uint8_t value) { return value <= 1; }) &&
            "forced records must be Boolean");
@@ -419,9 +457,45 @@ void Executor::reset_shot() noexcept {
         symbols_[symbol] = 0;
     }
     previous_presampled_ones_.clear();
+    initialize_expression_registers(*plan_, 0);
     std::ranges::fill(forced_record_mask_, uint8_t{0});
     discarded_ = false;
     pending_trap_.reset();
+}
+
+void Executor::initialize_expression_registers(const ExecutablePlan& plan,
+                                               uint32_t symbol_prefix_size) noexcept {
+    assert(expression_registers_.size() >= plan.expression_register_constants_.size() &&
+           "expression register storage must cover the active plan");
+    assert(symbol_prefix_size <= plan.num_symbols_ &&
+           "expression reconstruction prefix must belong to the active plan");
+    std::ranges::copy(plan.expression_register_constants_, expression_registers_.begin());
+    for (uint32_t symbol = 0; symbol < symbol_prefix_size; ++symbol) {
+        if (symbols_[symbol] != 0) {
+            propagate_true_symbol(plan, symbol);
+        }
+    }
+}
+
+void Executor::propagate_true_symbol(const ExecutablePlan& plan, uint32_t symbol) noexcept {
+    assert(static_cast<size_t>(symbol) + 1 < plan.expression_dependency_offsets_.size() &&
+           "assigned symbol must have an expression dependency range");
+    const uint32_t begin = plan.expression_dependency_offsets_[symbol];
+    const uint32_t end = plan.expression_dependency_offsets_[symbol + 1];
+    for (uint32_t i = begin; i < end; ++i) {
+        const uint32_t register_id = plan.expression_dependency_targets_[i];
+        assert(register_id < expression_registers_.size() &&
+               "expression dependency must refer to a preallocated register");
+        expression_registers_[register_id] ^= uint8_t{1};
+    }
+}
+
+void Executor::assign_symbol(uint32_t symbol, bool value) noexcept {
+    assert(symbol < symbols_.size() && "assigned symbol must belong to the active plan");
+    symbols_[symbol] = static_cast<uint8_t>(value);
+    if (value) {
+        propagate_true_symbol(*plan_, symbol);
+    }
 }
 
 void Executor::assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept {
@@ -430,7 +504,7 @@ void Executor::assign_presampled_values(std::span<const uint8_t> presampled_valu
     for (size_t i = 0; i < presampled_values.size(); ++i) {
         assert(presampled_values[i] <= 1 && "presampled symbols must be Boolean");
         const uint32_t symbol = plan_->presampled_symbols_[i];
-        symbols_[symbol] = presampled_values[i];
+        assign_symbol(symbol, presampled_values[i] != 0);
         if (presampled_values[i] != 0) {
             previous_presampled_ones_.push_back(symbol);
         }
@@ -474,7 +548,7 @@ void Executor::activate_noise_site(uint32_t site_index) noexcept {
     const uint32_t symbol = plan_->noise_outcomes_[outcome_index].symbol;
     assert(symbol < symbols_.size() && symbols_[symbol] == 0 &&
            "a noise site may define only one fresh symbol per shot");
-    symbols_[symbol] = 1;
+    assign_symbol(symbol, true);
     previous_presampled_ones_.push_back(symbol);
 }
 
@@ -526,7 +600,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
             branch = sample_active_branch(probabilities);
         }
     }
-    symbols_[action.branch] = static_cast<uint8_t>(branch);
+    assign_symbol(action.branch, branch);
     collapse_measurement(state_, action.measurement, branch, probabilities.for_branch(branch));
     records_[action.record] = static_cast<uint8_t>(branch ^ correction);
 }
@@ -548,7 +622,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& a
             branch = sample_dormant_branch();
         }
     }
-    symbols_[action.branch] = static_cast<uint8_t>(branch);
+    assign_symbol(action.branch, branch);
     records_[action.record] = static_cast<uint8_t>(branch ^ correction);
 }
 
@@ -571,7 +645,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& acti
 template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    symbols_[action.symbol] = static_cast<uint8_t>(evaluate(action.value));
+    assign_symbol(action.symbol, evaluate(action.value));
 }
 
 template <bool ForceRecords, bool ForceFaults>
@@ -599,7 +673,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
             const double probability = source ? action.prob_one_to_zero : action.prob_zero_to_one;
             flip = probability >= 1.0 || (probability > 0.0 && rng_.next_double() < probability);
         }
-        symbols_[action.flip] = static_cast<uint8_t>(flip);
+        assign_symbol(action.flip, flip);
         records_[action.record] ^= static_cast<uint8_t>(flip);
     }
 }
@@ -645,7 +719,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
            "instrument action must reference a prepared distribution");
     const InstrumentDistribution& distribution = plan_->instrument_distributions_[action.site];
     if (action.destination_flip.has_value()) {
-        symbols_[*action.destination_flip] = 0;
+        assign_symbol(*action.destination_flip, false);
     }
 
     auto trap = [&](uint8_t source, bool destination_pending) {
@@ -667,7 +741,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
         } else if (destination != source) {
             assert(action.destination_flip.has_value() &&
                    "in-line instrument requires a destination-flip symbol");
-            symbols_[*action.destination_flip] = 1;
+            assign_symbol(*action.destination_flip, true);
         }
     };
 
@@ -774,17 +848,10 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
 }
 
 bool Executor::evaluate(ExecutablePlan::PreparedExpression expression) const noexcept {
-    assert(static_cast<uint64_t>(expression.term_begin) + expression.term_count <=
-               plan_->expression_terms_.size() &&
-           "prepared affine expression must stay inside term storage");
-    bool value = expression.constant;
-    for (uint32_t i = 0; i < expression.term_count; ++i) {
-        const uint32_t symbol = plan_->expression_terms_[expression.term_begin + i];
-        assert(symbol < symbols_.size() && symbols_[symbol] <= 1 &&
-               "prepared affine term must refer to a Boolean symbol");
-        value ^= symbols_[symbol] != 0;
-    }
-    return value;
+    assert(expression.register_id < plan_->expression_register_constants_.size() &&
+           expression.register_id < expression_registers_.size() &&
+           "prepared affine expression must refer to the active register file");
+    return expression_registers_[expression.register_id] != 0;
 }
 
 bool Executor::sample_active_branch(MeasurementProbabilities probabilities) noexcept {

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -100,6 +100,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     if (num_expression_terms > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable expression storage exceeds uint32 range");
     }
+    // Retain action-order terms only long enough to build the reverse dependency map.
     std::vector<uint32_t> expression_terms;
     expression_terms.reserve(num_expression_terms);
     std::vector<uint32_t> expression_term_begins;
@@ -261,6 +262,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
             planned.action);
     }
 
+    // Transpose expression-major terms into the symbol-major dependency tape.
     expression_dependency_offsets_.assign(static_cast<size_t>(num_symbols_) + 1, 0);
     for (uint32_t symbol : expression_terms) {
         ++expression_dependency_offsets_[static_cast<size_t>(symbol) + 1];

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -491,6 +491,11 @@ void Executor::propagate_true_symbol(const ExecutablePlan& plan, uint32_t symbol
 }
 
 void Executor::assign_symbol(uint32_t symbol, bool value) noexcept {
+    // Expression registers begin at their constant values and receive each
+    // symbol's contribution exactly once when that symbol is assigned true.
+    // False is the unpropagated baseline, so assigning false updates symbols_
+    // without modifying registers. symbols_ remains authoritative because resume
+    // reconstructs continuation registers by replaying the live true prefix.
     assert(symbol < symbols_.size() && "assigned symbol must belong to the active plan");
     symbols_[symbol] = static_cast<uint8_t>(value);
     if (value) {

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -1,10 +1,10 @@
 #pragma once
 
 // Executes a backend-neutral SamplingPlan on the CPU without runtime topology
-// work. ExecutablePlan prepares direct-Pauli kernel descriptors and packed
-// affine expressions once; Executor then evaluates per-shot symbols, evolves
-// the active-coordinate coefficient state, samples measurements, and writes
-// records using only preallocated storage.
+// work. ExecutablePlan prepares direct-Pauli kernel descriptors and affine
+// expression registers once; Executor then evaluates per-shot symbols,
+// evolves the active-coordinate coefficient state, samples measurements, and
+// writes records using only preallocated storage.
 
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
@@ -69,8 +69,8 @@ class ExecutablePlan;
     MeasurementProbabilities probabilities) noexcept;
 
 // Owns the CPU lowering of one validated SamplingPlan. Direct-Pauli kernel
-// descriptors and affine-expression term ranges are prepared once here so a
-// shot only reads fixed storage.
+// descriptors and affine-expression register dependencies are prepared once
+// here so a shot only reads fixed storage.
 class ExecutablePlan {
   public:
     explicit ExecutablePlan(const SamplingPlan& plan);
@@ -107,9 +107,7 @@ class ExecutablePlan {
     friend class Executor;
 
     struct PreparedExpression {
-        uint32_t term_begin = 0;
-        uint32_t term_count = 0;
-        bool constant = false;
+        uint32_t register_id = 0;
     };
 
     struct ExecuteRotation {
@@ -208,9 +206,6 @@ class ExecutablePlan {
                      ExecuteReadoutNoise, ExecuteDetector, ExecuteObservable, ExecuteExpectation,
                      ExecuteInstrument, ExecuteBoundary>;
 
-    PreparedExpression prepare_expression(const AffineBool& expression);
-    PreparedExpression prepare_measurement_correction(const AffineBool& outcome, uint32_t branch);
-
     uint32_t num_qubits_ = 0;
     uint32_t initial_active_width_ = 0;
     uint32_t max_active_width_ = 0;
@@ -227,7 +222,9 @@ class ExecutablePlan {
     uint32_t initial_noise_end_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::optional<stim::Tableau<kStimWidth>> final_tableau_;
-    std::vector<uint32_t> expression_terms_;
+    std::vector<uint8_t> expression_register_constants_;
+    std::vector<uint32_t> expression_dependency_offsets_;
+    std::vector<uint32_t> expression_dependency_targets_;
     // Maps each dense presampled input position to its plan-local SymbolId.
     // The constructor records those ids in ascending order.
     std::vector<uint32_t> presampled_symbols_;
@@ -317,6 +314,10 @@ class Executor {
     void sample_presampled_noise(uint32_t begin, uint32_t end) noexcept;
     void activate_noise_site(uint32_t site) noexcept;
     void assign_forced_quantum_faults() noexcept;
+    void assign_symbol(uint32_t symbol, bool value) noexcept;
+    void propagate_true_symbol(const ExecutablePlan& plan, uint32_t symbol) noexcept;
+    void initialize_expression_registers(const ExecutablePlan& plan,
+                                         uint32_t symbol_prefix_size) noexcept;
 
     template <bool ForceRecords, bool SampleNoise, bool ForceFaults>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records,
@@ -368,6 +369,7 @@ class Executor {
     const ExecutablePlan* plan_;
     State state_;
     std::vector<uint8_t> symbols_;
+    std::vector<uint8_t> expression_registers_;
     std::vector<uint8_t> records_;
     std::vector<uint8_t> detectors_;
     std::vector<uint8_t> observables_;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -222,6 +222,9 @@ class ExecutablePlan {
     uint32_t initial_noise_end_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::optional<stim::Tableau<kStimWidth>> final_tableau_;
+    // Constants are indexed by PreparedExpression::register_id. The dependency
+    // vectors form CSR: targets[offsets[symbol]..offsets[symbol + 1]) lists the
+    // expression registers toggled when that symbol is true.
     std::vector<uint8_t> expression_register_constants_;
     std::vector<uint32_t> expression_dependency_offsets_;
     std::vector<uint32_t> expression_dependency_targets_;

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -846,6 +846,16 @@ def test_experimental_noncomp_accepts_a_parsed_circuit():
     assert np.array_equal(r.measurements, np.zeros((4, 1), dtype=np.uint8))
 
 
+def test_experimental_noncomp_preserves_true_prefix_expressions_across_continuations():
+    from clifft import experimental
+
+    model = noncomp.Model(classifier=classifier_for(LEAK_G, [1.0, 0.0]))
+    result = experimental.sample_noncomputational(
+        "X_ERROR(1) 0\nLEAKAGE(1) 1\nM 0", model, shots=8, seed=280
+    )
+    assert np.array_equal(result.measurements, np.ones((8, 1), dtype=np.uint8))
+
+
 def test_qubit_status_values():
     """QubitStatus integer values differ from Level values for the shared names."""
     assert int(noncomp.QubitStatus.COMPUTATIONAL) == 0

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -567,6 +567,46 @@ TEST_CASE("Sampling replay checks all records conditional on presampled symbols"
     REQUIRE(executor.visible_records()[0] == 1);
 }
 
+TEST_CASE("Sampling expression registers reset true symbols between shots") {
+    SamplingPlan plan;
+    plan.num_visible_records = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.actions = {
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
+    };
+
+    const ExecutablePlan executable(plan);
+    Executor executor(executable);
+    executor.run_shot(std::array<uint8_t, 1>{1});
+    REQUIRE(executor.visible_records()[0] == 1);
+    executor.run_shot(std::array<uint8_t, 1>{0});
+    REQUIRE(executor.visible_records()[0] == 0);
+    executor.run_shot(std::array<uint8_t, 1>{1});
+    REQUIRE(executor.visible_records()[0] == 1);
+}
+
+TEST_CASE("Sampling expression registers preserve noisy postselection") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        X_ERROR(0.5) 0
+        M 0
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )"));
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection,
+                                              .expected_detectors = {},
+                                              .expected_observables = {}}));
+
+    const clifft::sampling::SamplingSurvivorResult result =
+        clifft::sampling::sample_survivors(executable, 2000, uint64_t{280}, true);
+    REQUIRE(result.passed_shots > 900);
+    REQUIRE(result.passed_shots < 1100);
+    REQUIRE(std::ranges::all_of(result.measurements, [](uint8_t value) { return value == 0; }));
+    REQUIRE(std::ranges::all_of(result.detectors, [](uint8_t value) { return value == 0; }));
+    REQUIRE(std::ranges::all_of(result.observables, [](uint8_t value) { return value == 0; }));
+}
+
 TEST_CASE("Sampling replay applies active measurement dust policy") {
     const ExecutablePlan dusty(active_then_dormant_plan(1e-10));
     Executor survivor(dusty);
@@ -828,6 +868,24 @@ TEST_CASE("Sampling executor defers suffix noise until an instrument continuatio
     executor.resume(executable);
     REQUIRE_FALSE(executor.pending_trap().has_value());
     REQUIRE(executor.symbols()[index(suffix_noise)] == 1);
+}
+
+TEST_CASE("Sampling continuation reconstructs expressions from true prefix symbols") {
+    clifft::InstrumentTraceOptions options;
+    const clifft::HirModule hir =
+        clifft::trace(clifft::parse("X_ERROR(1) 0\nLEAKAGE(1) 1\nM 0"), &options);
+    const SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+    const SymbolId prefix_noise = plan.presampled_noise_sites[0].outcomes[0].symbol;
+    const ExecutablePlan executable(plan);
+    Executor executor(executable, 9);
+
+    executor.run_shot();
+    REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.symbols()[index(prefix_noise)] == 1);
+
+    executor.resume(executable);
+    REQUIRE_FALSE(executor.pending_trap().has_value());
+    REQUIRE(executor.visible_records()[0] == 1);
 }
 
 TEST_CASE("Sampling continuation consumes a forced hidden source record") {


### PR DESCRIPTION
## Summary

- lower every prepared affine expression to a Boolean register plus a symbol-to-register dependency tape
- update each dependent register only when a symbol is assigned true, making expression reads O(1)
- reconstruct continuation registers from constants and the live true-symbol prefix at the trap boundary
- remove the retained per-expression term lists from `ExecutablePlan`

This is the focused scalar execution optimization selected by the measurements in #280. It does not add packed-shot execution, prototype modes, public instrumentation, or a general graph-optimization framework.

## Release acceptance

Three balanced paired blocks were run from fresh processes on one pinned CPU, using matched circuit/output semantics and paired seeds. `symbolic/legacy` below 1 means symbolic is faster. The baseline is the pre-change run already posted on #280.

| Case | Baseline symbolic/legacy | This PR symbolic/legacy | This PR legacy ms | This PR symbolic ms |
|---|---:|---:|---:|---:|
| surface d7 r7 aggregate | 10.683x | 0.669x | 612.6 | 412.0 |
| surface d7 r7 forced k0 | not previously run | 0.468x | 1526.0 | 717.9 |
| cultivation d3 aggregate | 10.118x | 0.897x | 650.0 | 582.9 |
| cultivation d3 forced k0 | 12.541x | 0.972x | 547.0 | 531.8 |
| distillation aggregate | 0.454x | 0.176x | 2127.8 | 374.5 |
| coherent d3 r3 aggregate | 1.592x | 1.640x | 833.2 | 1389.6 |
| regime k12/L512 | 1.268x | 1.129x | 936.0 | 1057.9 |
| low-leak noncomputational | 9.850x | 9.687x | 405.3 | 3956.5 |

The surface A/A paired B/A control had median 0.998 (range 0.947-1.028); k12/L512 had median 1.007 (range 0.968-1.014). Discard and conditional logical statistics agree within their reported uncertainty. Checksums were used only to prove that outputs were consumed; cross-backend checksum equality was not required because RNG schedules differ.

The result closes the 10-12x surface/cultivation expression-evaluation gap without packed counts. It intentionally leaves the independently measured coherent-kernel gap, noncomputational continuation/suffix-rewrite gap, and compile-time gap for separate work.

## Profile

A Release-optimized, symbolized, frame-pointer build profiled surface d7 r7 after the change. The old per-use affine term scan is absent. Flat cycle shares for the replacement path were:

- direct expression-register lookup: 6.74%
- true-symbol dependency propagation: 4.74%
- expression-register reset: 0.95%
- symbol assignment helper: 0.89%

The larger remaining self-costs are normal shot dispatch/action execution and presampled-noise handling, rather than affine term traversal.

## Correctness

Added focused coverage for:

- resetting true-symbol effects across shots
- noisy postselection and normalized outputs
- continuation reconstruction from true prefix symbols
- the experimental noncomputational Python path across a trap

Existing suites cover forced-k sampling, replay, EXP_VAL, detector/observable normalization, continuation register growth, and the legacy/analytic oracles.

Validation:

- `ctest --test-dir build-production --output-on-failure` - 1,243 passed
- `uv run pytest tests/python/ -q` - 1,253 passed
- `uv run pre-commit run --all-files` - passed

Refs #280
