### PR TITLE
perf: specialize symbolic Pauli rotations

### DIFF
--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -56,7 +56,7 @@ void apply_nondiagonal_rotation(State& state, const PreparedRotation& rotation,
             const double right_imag = imag[right];
             const bool odd_phase = (std::popcount(left & rotation.pauli.z) & 1U) != 0;
             const double left_sine = odd_phase ? -even_left_sine : even_left_sine;
-            const double right_sine = rotation.pauli.partner_phase_negated ? -left_sine : left_sine;
+            const double right_sine = RealPhase ? left_sine : -left_sine;
 
             if constexpr (RealPhase) {
                 real[left] = rotation.cosine * left_real + right_sine * right_imag;
@@ -117,7 +117,6 @@ PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width) {
         {1.0, 0.0}, {0.0, 1.0}, {-1.0, 0.0}, {0.0, -1.0}};
     const uint32_t overlap = std::popcount(pauli.x & pauli.z);
     return PreparedPauli{.active_width = active_width,
-                         .partner_phase_negated = (overlap & 1U) != 0,
                          .x = pauli.x,
                          .z = pauli.z,
                          .pair_selector = std::bit_floor(pauli.x),

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -34,6 +34,45 @@ std::complex<double> phase_at(const PreparedPauli& pauli, uint64_t basis) {
     return (std::popcount(basis & pauli.z) & 1U) != 0 ? -pauli.even_phase : pauli.even_phase;
 }
 
+template <bool RealPhase>
+void apply_nondiagonal_rotation(State& state, const PreparedRotation& rotation,
+                                double sine) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t size = state.size();
+    const uint64_t pair_stride = rotation.pauli.pair_selector;
+    const uint64_t pair_period = pair_stride << 1;
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+
+    for (uint64_t block = 0; block < size; block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; ++offset) {
+            const uint64_t left = block + offset;
+            const uint64_t right = left ^ rotation.pauli.x;
+            const double left_real = real[left];
+            const double left_imag = imag[left];
+            const double right_real = real[right];
+            const double right_imag = imag[right];
+            const bool odd_phase = (std::popcount(left & rotation.pauli.z) & 1U) != 0;
+            const double left_sine = odd_phase ? -even_left_sine : even_left_sine;
+            const double right_sine = rotation.pauli.partner_phase_negated ? -left_sine : left_sine;
+
+            if constexpr (RealPhase) {
+                real[left] = rotation.cosine * left_real + right_sine * right_imag;
+                imag[left] = rotation.cosine * left_imag - right_sine * right_real;
+                real[right] = rotation.cosine * right_real + left_sine * left_imag;
+                imag[right] = rotation.cosine * right_imag - left_sine * left_real;
+            } else {
+                real[left] = rotation.cosine * left_real + right_sine * right_real;
+                imag[left] = rotation.cosine * left_imag + right_sine * right_imag;
+                real[right] = rotation.cosine * right_real + left_sine * left_real;
+                imag[right] = rotation.cosine * right_imag + left_sine * left_imag;
+            }
+        }
+    }
+}
+
 uint64_t insert_zero_bit(uint64_t packed, uint32_t pivot) {
     const uint64_t lower_mask = (uint64_t{1} << pivot) - 1;
     return (packed & lower_mask) | ((packed & ~lower_mask) << 1);
@@ -77,8 +116,12 @@ PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width) {
     static constexpr std::complex<double> kIPowers[4] = {
         {1.0, 0.0}, {0.0, 1.0}, {-1.0, 0.0}, {0.0, -1.0}};
     const uint32_t overlap = std::popcount(pauli.x & pauli.z);
-    return PreparedPauli{active_width, pauli.x, pauli.z, std::bit_floor(pauli.x),
-                         kIPowers[overlap & 3U]};
+    return PreparedPauli{.active_width = active_width,
+                         .partner_phase_negated = (overlap & 1U) != 0,
+                         .x = pauli.x,
+                         .z = pauli.z,
+                         .pair_selector = std::bit_floor(pauli.x),
+                         .even_phase = kIPowers[overlap & 3U]};
 }
 
 PreparedRotation prepare_rotation(ActivePauli pauli, uint32_t active_width, double half_turns) {
@@ -161,18 +204,10 @@ void apply_rotation(State& state, const PreparedRotation& rotation, bool sign) n
         return;
     }
 
-    const std::complex<double> minus_i_sine{0.0, -sine};
-    for (uint64_t left = 0; left < size; ++left) {
-        if ((left & rotation.pauli.pair_selector) != 0) {
-            continue;
-        }
-        const uint64_t right = left ^ rotation.pauli.x;
-        const std::complex<double> left_value{real[left], imag[left]};
-        const std::complex<double> right_value{real[right], imag[right]};
-        const std::complex<double> left_phase = phase_at(rotation.pauli, left);
-        const std::complex<double> right_phase = phase_at(rotation.pauli, right);
-        store(state, left, rotation.cosine * left_value + minus_i_sine * right_phase * right_value);
-        store(state, right, rotation.cosine * right_value + minus_i_sine * left_phase * left_value);
+    if (rotation.pauli.even_phase.real() != 0.0) {
+        apply_nondiagonal_rotation<true>(state, rotation, sine);
+    } else {
+        apply_nondiagonal_rotation<false>(state, rotation, sine);
     }
 }
 

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -13,8 +13,6 @@ namespace clifft::sampling {
 // the State's storage.
 struct PreparedPauli {
     uint32_t active_width = 0;
-    // Pairs differ by x, so their phases differ by (-1)^popcount(x & z).
-    bool partner_phase_negated = false;
     uint64_t x = 0;
     uint64_t z = 0;
     uint64_t pair_selector = 0;

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -13,6 +13,8 @@ namespace clifft::sampling {
 // the State's storage.
 struct PreparedPauli {
     uint32_t active_width = 0;
+    // Pairs differ by x, so their phases differ by (-1)^popcount(x & z).
+    bool partner_phase_negated = false;
     uint64_t x = 0;
     uint64_t z = 0;
     uint64_t pair_selector = 0;

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -582,8 +582,13 @@ TEST_CASE("Sampling kernels compose across collapse and promotion") {
     REQUIRE(state.global_scalar() == scalar);
 }
 
-TEST_CASE("Sampling kernel preparation rejects malformed inputs") {
+TEST_CASE("Sampling kernel preparation precomputes non-diagonal pair metadata") {
     REQUIRE(prepare_rotation({0b101, 0}, 3, 0.25).pauli.pair_selector == 0b100);
+    REQUIRE(prepare_rotation({0b101, 0b001}, 3, 0.25).pauli.partner_phase_negated);
+    REQUIRE_FALSE(prepare_rotation({0b101, 0b101}, 3, 0.25).pauli.partner_phase_negated);
+}
+
+TEST_CASE("Sampling kernel preparation rejects malformed inputs") {
     REQUIRE_THROWS_AS(State(clifft::kDenseActiveWidthLimit), std::invalid_argument);
     REQUIRE_THROWS_AS(State(1, 2), std::invalid_argument);
     REQUIRE_THROWS_AS(State(1, 0, {clifft::test::opaque_nan(), 0.0}), std::invalid_argument);

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -582,10 +582,8 @@ TEST_CASE("Sampling kernels compose across collapse and promotion") {
     REQUIRE(state.global_scalar() == scalar);
 }
 
-TEST_CASE("Sampling kernel preparation precomputes non-diagonal pair metadata") {
+TEST_CASE("Sampling kernel preparation precomputes non-diagonal pairing metadata") {
     REQUIRE(prepare_rotation({0b101, 0}, 3, 0.25).pauli.pair_selector == 0b100);
-    REQUIRE(prepare_rotation({0b101, 0b001}, 3, 0.25).pauli.partner_phase_negated);
-    REQUIRE_FALSE(prepare_rotation({0b101, 0b101}, 3, 0.25).pauli.partner_phase_negated);
 }
 
 TEST_CASE("Sampling kernel preparation rejects malformed inputs") {


### PR DESCRIPTION
## Summary

- enumerate non-diagonal Pauli coefficient pairs directly instead of scanning and skipping half of the state
- precompute the one-bit phase relationship between paired coefficients
- specialize the scalar butterfly into explicit real and imaginary arithmetic for real and imaginary Pauli phases
- keep diagonal rotation, fusion, SIMD, measurement, and packed-shot behavior unchanged

Part of #280.

## Measurement

The descriptor-driven microbenchmark used the actual non-diagonal rotation streams from coherent d3 r3 and k12/L512. Individual speedups versus the current scalar kernel were:

| Variant | coherent d3 r3 | k12/L512 |
|---|---:|---:|
| direct pair enumeration | 1.06x | 1.07x |
| derive partner phase | 1.01x | 0.99x |
| explicit arithmetic | 1.19x | 1.29x |
| all three combined | 1.63x | 1.71x |

Three balanced blocks with six fresh processes per backend gave:

| Case | main symbolic/legacy | PR symbolic/legacy | PR legacy ms | PR symbolic ms |
|---|---:|---:|---:|---:|
| coherent d3 r3 aggregate | 1.640x | 1.189x | 824.2 | 970.2 |
| regime k12/L512 | 1.129x | 0.776x | 918.7 | 713.0 |
| surface d7 r7 aggregate | 0.669x | 0.774x | 542.5 | 414.8 |
| cultivation d3 aggregate | 0.897x | 0.860x | 609.2 | 526.1 |
| distillation aggregate | 0.176x | 0.195x | 1945.4 | 382.6 |

The surface and distillation symbolic absolute times remain stable; ratio movement there is dominated by legacy timing variation. Outcome statistics agree within uncertainty.

QV-10 raw was not in the earlier acceptance subset, so it received a clean main A/B. Symbolic time fell from 6.07 seconds to 4.42 seconds per 10,000 shots, a 1.37x speedup. The remaining 8.64x legacy gap is therefore pre-existing, not a regression from this change.

On coherent d3 r3, versus the merged-main profile, symbolic cycles fell 29.1%, instructions 34.6%, and branches 57.3%. Rotation self share fell from 68.99% to 53.73%; its estimated absolute cycle cost fell about 1.81x. The confirming call graph had zero lost samples. Measurement probability is now 13.59%, executor work 10.17%, and collapse 6.55%.

## Validation

- exhaustive dense rotation oracle: 91,264 assertions
- C++: 1,244/1,244 passed
- Python: 1,253/1,253 passed
- repository pre-commit: passed
