### PR TITLE
perf: vectorize fused symbolic rotations

### DIFF
--- a/.github/scripts/wheel_smoke.sh
+++ b/.github/scripts/wheel_smoke.sh
@@ -57,12 +57,12 @@ script='from pathlib import Path
 import clifft
 from clifft import experimental
 print(f"version={clifft.__version__}  baseline={clifft.CPU_BASELINE}  backend={clifft.svm_backend()}", flush=True)
-prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-ps = clifft.record_probabilities(prog, ["00", "11"])
-assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
 symbolic = experimental.compile(Path("tests/fixtures/qv10.stim").read_text())
 result = experimental.sample(symbolic, shots=1, seed=280)
 assert result.measurements.shape[0] == 1, result.measurements.shape
+prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+ps = clifft.record_probabilities(prog, ["00", "11"])
+assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
 print("smoke ok", flush=True)
 '
 

--- a/.github/scripts/wheel_smoke.sh
+++ b/.github/scripts/wheel_smoke.sh
@@ -53,11 +53,16 @@ if ! command -v qemu-x86_64 >/dev/null 2>&1; then
     exit 2
 fi
 
-script='import clifft
+script='from pathlib import Path
+import clifft
+from clifft import experimental
 print(f"version={clifft.__version__}  baseline={clifft.CPU_BASELINE}  backend={clifft.svm_backend()}", flush=True)
 prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
 ps = clifft.record_probabilities(prog, ["00", "11"])
 assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
+symbolic = experimental.compile(Path("tests/fixtures/qv10.stim").read_text())
+result = experimental.sample(symbolic, shots=1, seed=280)
+assert result.measurements.shape[0] == 1, result.measurements.shape
 print("smoke ok", flush=True)
 '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Check uv lockfile
         run: uv lock --check
 
+      - name: Check runtime ISA without dispatch
+        run: |
+          c++ -std=c++20 -Isrc \
+            src/clifft/util/runtime_isa.cc \
+            tools/ci/check_runtime_isa_no_dispatch.cc \
+            -o /tmp/clifft-runtime-isa-no-dispatch
+          /tmp/clifft-runtime-isa-no-dispatch
+
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(clifft_core STATIC
     util/fault_sampling.cc
     util/introspection.cc
     util/page_allocation.cc
+    util/runtime_isa.cc
     util/xoshiro.cc
     noncomp/transition_instrument.cc
     noncomp/transition_hooks.cc

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -53,11 +53,18 @@ add_library(clifft_core STATIC
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)") AND NOT MSVC)
-    target_sources(clifft_core PRIVATE svm/svm_avx2.cc svm/svm_avx512.cc)
+    target_sources(clifft_core PRIVATE
+        sampling/kernels_avx512.cc
+        svm/svm_avx2.cc
+        svm/svm_avx512.cc
+    )
     set_source_files_properties(svm/svm_avx2.cc
         PROPERTIES COMPILE_OPTIONS "-mavx2;-mbmi2;-mfma"
     )
     set_source_files_properties(svm/svm_avx512.cc
+        PROPERTIES COMPILE_OPTIONS "-mavx2;-mbmi2;-mfma;-mavx512f;-mavx512dq"
+    )
+    set_source_files_properties(sampling/kernels_avx512.cc
         PROPERTIES COMPILE_OPTIONS "-mavx2;-mbmi2;-mfma;-mavx512f;-mavx512dq"
     )
     target_compile_definitions(clifft_core PRIVATE CLIFFT_ENABLE_RUNTIME_DISPATCH)

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -1,9 +1,9 @@
 #include "clifft/sampling/executor.h"
 
-#include "clifft/svm/svm.h"
 #include "clifft/util/fault_sampling.h"
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/numeric.h"
+#include "clifft/util/runtime_isa.h"
 
 #include <algorithm>
 #include <bit>
@@ -13,7 +13,6 @@
 #include <numbers>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <type_traits>
 
 namespace clifft::sampling {
@@ -60,8 +59,10 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       final_tableau_(plan.final_tableau),
       instrument_distributions_(plan.instrument_distributions) {
     plan.validate();
+    const internal::RuntimeIsa runtime_isa = internal::runtime_isa();
+    internal::validate_runtime_isa(runtime_isa);
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    const bool prepare_avx512_sidecars = std::string_view(clifft::svm_backend()) == "avx512";
+    const bool prepare_avx512_sidecars = runtime_isa == internal::RuntimeIsa::Avx512;
 #endif
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable symbol count exceeds uint32 range");

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/executor.h"
 
+#include "clifft/svm/svm.h"
 #include "clifft/util/fault_sampling.h"
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/numeric.h"
@@ -12,6 +13,7 @@
 #include <numbers>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 namespace clifft::sampling {
@@ -58,6 +60,9 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       final_tableau_(plan.final_tableau),
       instrument_distributions_(plan.instrument_distributions) {
     plan.validate();
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    const bool prepare_avx512_sidecars = std::string_view(clifft::svm_backend()) == "avx512";
+#endif
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable symbol count exceeds uint32 range");
     }
@@ -269,6 +274,13 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
         if (run.rotation.has_value()) {
             const uint32_t fused_index = static_cast<uint32_t>(fused_rotations_.size());
             fused_rotations_.push_back(std::move(*run.rotation));
+            FusedRotationSidecar sidecar;
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+            if (prepare_avx512_sidecars) {
+                sidecar = prepare_fused_rotation_avx512_sidecar(fused_rotations_.back());
+            }
+#endif
+            fused_rotation_sidecars_.push_back(std::move(sidecar));
             actions_.emplace_back(ExecuteFusedRotation{fused_index});
             planned_index += run.action_count;
             continue;
@@ -597,7 +609,16 @@ void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->fused_rotations_.size() &&
            "fused rotation action must reference a prepared descriptor");
-    apply_fused_rotation(state_, plan_->fused_rotations_[action.rotation_index]);
+    assert(action.rotation_index < plan_->fused_rotation_sidecars_.size() &&
+           "fused rotation action must reference a prepared sidecar slot");
+    const PreparedFusedRotation& rotation = plan_->fused_rotations_[action.rotation_index];
+    const FusedRotationSidecar& sidecar =
+        plan_->fused_rotation_sidecars_[action.rotation_index];
+    if (sidecar) {
+        sidecar.kernel(state_, rotation, sidecar.storage.get());
+    } else {
+        apply_fused_rotation(state_, rotation);
+    }
 }
 
 template <bool ForceRecords>

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -273,15 +273,14 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
         FusedRotationRun run = prepare_fused_rotation_run(
             std::span<const PlannedAction>(plan.actions).subspan(planned_index));
         if (run.rotation.has_value()) {
-            const uint32_t fused_index = static_cast<uint32_t>(fused_rotations_.size());
-            fused_rotations_.push_back(std::move(*run.rotation));
-            FusedRotationSidecar sidecar;
+            FusedRotationEntry entry{.rotation = std::move(*run.rotation), .sidecar = {}};
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
             if (prepare_avx512_sidecars) {
-                sidecar = prepare_fused_rotation_avx512_sidecar(fused_rotations_.back());
+                entry.sidecar = prepare_fused_rotation_avx512_sidecar(entry.rotation);
             }
 #endif
-            fused_rotation_sidecars_.push_back(std::move(sidecar));
+            const uint32_t fused_index = static_cast<uint32_t>(fused_rotation_entries_.size());
+            fused_rotation_entries_.push_back(std::move(entry));
             actions_.emplace_back(ExecuteFusedRotation{fused_index});
             planned_index += run.action_count;
             continue;
@@ -608,17 +607,14 @@ void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
 template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    assert(action.rotation_index < plan_->fused_rotations_.size() &&
-           "fused rotation action must reference a prepared descriptor");
-    assert(action.rotation_index < plan_->fused_rotation_sidecars_.size() &&
-           "fused rotation action must reference a prepared sidecar slot");
-    const PreparedFusedRotation& rotation = plan_->fused_rotations_[action.rotation_index];
-    const FusedRotationSidecar& sidecar =
-        plan_->fused_rotation_sidecars_[action.rotation_index];
-    if (sidecar) {
-        sidecar.kernel(state_, rotation, sidecar.storage.get());
+    assert(action.rotation_index < plan_->fused_rotation_entries_.size() &&
+           "fused rotation action must reference a prepared entry");
+    const ExecutablePlan::FusedRotationEntry& entry =
+        plan_->fused_rotation_entries_[action.rotation_index];
+    if (entry.sidecar) {
+        entry.sidecar.kernel(state_, entry.rotation, entry.sidecar.storage.get());
     } else {
-        apply_fused_rotation(state_, rotation);
+        apply_fused_rotation(state_, entry.rotation);
     }
 }
 

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -122,7 +122,9 @@ class ExecutablePlan {
     };
 
     struct FusedRotationEntry {
+        // The architecture-neutral descriptor always supports scalar execution.
         PreparedFusedRotation rotation;
+        // The resolved ISA may attach prepared storage and a specialized kernel.
         FusedRotationSidecar sidecar;
     };
 

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -7,6 +7,7 @@
 // writes records using only preallocated storage.
 
 #include "clifft/sampling/fused_rotation.h"
+#include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
 #include "clifft/sampling/state.h"
@@ -243,6 +244,7 @@ class ExecutablePlan {
     std::vector<InstrumentDistribution> instrument_distributions_;
     std::vector<uint32_t> instrument_resume_offsets_;
     std::vector<PreparedFusedRotation> fused_rotations_;
+    std::vector<FusedRotationSidecar> fused_rotation_sidecars_;
     std::vector<Action> actions_;
 };
 

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -121,6 +121,11 @@ class ExecutablePlan {
         uint32_t rotation_index = 0;
     };
 
+    struct FusedRotationEntry {
+        PreparedFusedRotation rotation;
+        FusedRotationSidecar sidecar;
+    };
+
     struct ExecutePromotion {
         PreparedPromotion promotion;
         PreparedExpression sign;
@@ -243,8 +248,7 @@ class ExecutablePlan {
     std::vector<double> noise_hazards_;
     std::vector<InstrumentDistribution> instrument_distributions_;
     std::vector<uint32_t> instrument_resume_offsets_;
-    std::vector<PreparedFusedRotation> fused_rotations_;
-    std::vector<FusedRotationSidecar> fused_rotation_sidecars_;
+    std::vector<FusedRotationEntry> fused_rotation_entries_;
     std::vector<Action> actions_;
 };
 

--- a/src/clifft/sampling/fused_rotation.cc
+++ b/src/clifft/sampling/fused_rotation.cc
@@ -221,12 +221,7 @@ void apply_fused_rotation_orbits(State& state, const PreparedFusedRotation& rota
             representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
         }
 
-        size_t selector = 0;
-        for (size_t bit = 0; bit < rotation.selector_masks.size(); ++bit) {
-            selector |= static_cast<size_t>(
-                            std::popcount(representative & rotation.selector_masks[bit]) & 1U)
-                        << bit;
-        }
+        const size_t selector = selector_index(representative, rotation.selector_masks);
         const std::complex<double>* const matrix =
             rotation.matrices.data() + selector * matrix_size;
 

--- a/src/clifft/sampling/fused_rotation_simd.h
+++ b/src/clifft/sampling/fused_rotation_simd.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "clifft/sampling/fused_rotation.h"
+
+#include <memory>
+
+namespace clifft::sampling {
+
+using FusedRotationKernel = void (*)(State&, const PreparedFusedRotation&, const void*) noexcept;
+
+// Type-erases an optional host-specific descriptor. The scalar descriptor
+// remains portable, and common code never names or embeds SIMD vector types.
+struct FusedRotationSidecar {
+    std::shared_ptr<const void> storage;
+    FusedRotationKernel kernel = nullptr;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return storage != nullptr && kernel != nullptr;
+    }
+};
+
+// This function is linked only on x86-64 runtime-dispatch builds and must be
+// called only after the dispatcher has selected the AVX-512 implementation.
+[[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(
+    const PreparedFusedRotation& rotation);
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/indexing.h
+++ b/src/clifft/sampling/indexing.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <bit>
+#include <cstddef>
 #include <cstdint>
+#include <span>
 
 namespace clifft::sampling {
 
@@ -9,6 +12,16 @@ namespace clifft::sampling {
 inline uint64_t insert_zero_bit(uint64_t packed, uint32_t pivot) noexcept {
     const uint64_t lower_mask = (uint64_t{1} << pivot) - 1;
     return (packed & lower_mask) | ((packed & ~lower_mask) << 1);
+}
+
+// Packs the parities selected by masks into an index, with masks[i]
+// contributing bit i.
+inline size_t selector_index(uint64_t representative, std::span<const uint64_t> masks) noexcept {
+    size_t selector = 0;
+    for (size_t bit = 0; bit < masks.size(); ++bit) {
+        selector |= static_cast<size_t>(std::popcount(representative & masks[bit]) & 1U) << bit;
+    }
+    return selector;
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -1,0 +1,160 @@
+// AVX-512F+AVX-512DQ fused-rotation kernel. This translation unit is compiled
+// with the same explicit AVX2/BMI2/FMA/AVX-512 flags as the SVM AVX-512 path.
+
+#include "clifft/sampling/fused_rotation_simd.h"
+
+#include <array>
+#include <bit>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <immintrin.h>
+#include <memory>
+#include <vector>
+
+namespace clifft::sampling {
+
+namespace {
+
+constexpr size_t kLanes = 8;
+constexpr size_t kDimension = 4;
+constexpr size_t kMatrixSize = kDimension * kDimension;
+
+struct alignas(64) LanePermutation {
+    std::array<uint64_t, kLanes> indices{};
+};
+
+struct alignas(64) LaneWeights {
+    std::array<double, kLanes> real{};
+    std::array<double, kLanes> imag{};
+};
+
+struct FusedRotationAvx512Sidecar {
+    std::array<LanePermutation, kDimension> permutations;
+    std::vector<LaneWeights> weights;
+};
+
+uint64_t insert_zero_bit(uint64_t packed, uint32_t pivot) noexcept {
+    const uint64_t lower_mask = (uint64_t{1} << pivot) - 1;
+    return (packed & lower_mask) | ((packed & ~lower_mask) << 1);
+}
+
+size_t selector_at(uint64_t representative, const PreparedFusedRotation& rotation) noexcept {
+    size_t selector = 0;
+    for (size_t bit = 0; bit < rotation.selector_masks.size(); ++bit) {
+        selector |=
+            static_cast<size_t>(std::popcount(representative & rotation.selector_masks[bit]) & 1U)
+            << bit;
+    }
+    return selector;
+}
+
+void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rotation,
+                                 const void* opaque_sidecar) noexcept {
+    const auto& sidecar = *static_cast<const FusedRotationAvx512Sidecar*>(opaque_sidecar);
+    assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 3 &&
+           "AVX-512 fused rotation requires a high-pivot rank-two orbit");
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+
+    const uint64_t orbit_count = state.size() / kDimension;
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+
+    for (uint64_t packed = 0; packed < orbit_count; packed += kLanes) {
+        uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
+        representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+        const LaneWeights* const matrix =
+            sidecar.weights.data() + selector_at(representative, rotation) * kMatrixSize;
+
+        std::array<__m512d, kDimension> input_real;
+        std::array<__m512d, kDimension> input_imag;
+        for (size_t column = 0; column < kDimension; ++column) {
+            uint64_t index = representative;
+            if ((column & 1U) != 0) {
+                index ^= rotation.orbit_masks[0];
+            }
+            if ((column & 2U) != 0) {
+                index ^= rotation.orbit_masks[1];
+            }
+            const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+            const __m512i permutation =
+                _mm512_load_si512(sidecar.permutations[column].indices.data());
+            input_real[column] =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(real + physical_base));
+            input_imag[column] =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(imag + physical_base));
+        }
+
+        for (size_t row = 0; row < kDimension; ++row) {
+            __m512d output_real = _mm512_setzero_pd();
+            __m512d output_imag = _mm512_setzero_pd();
+            for (size_t column = 0; column < kDimension; ++column) {
+                const LaneWeights& weight = matrix[row * kDimension + column];
+                const __m512d weight_real = _mm512_load_pd(weight.real.data());
+                const __m512d weight_imag = _mm512_load_pd(weight.imag.data());
+                output_real = _mm512_fmadd_pd(weight_real, input_real[column], output_real);
+                output_real = _mm512_fnmadd_pd(weight_imag, input_imag[column], output_real);
+                output_imag = _mm512_fmadd_pd(weight_real, input_imag[column], output_imag);
+                output_imag = _mm512_fmadd_pd(weight_imag, input_real[column], output_imag);
+            }
+
+            uint64_t index = representative;
+            if ((row & 1U) != 0) {
+                index ^= rotation.orbit_masks[0];
+            }
+            if ((row & 2U) != 0) {
+                index ^= rotation.orbit_masks[1];
+            }
+            const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+            const __m512i permutation = _mm512_load_si512(sidecar.permutations[row].indices.data());
+            _mm512_store_pd(real + physical_base, _mm512_permutexvar_pd(permutation, output_real));
+            _mm512_store_pd(imag + physical_base, _mm512_permutexvar_pd(permutation, output_imag));
+        }
+    }
+}
+
+}  // namespace
+
+FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRotation& rotation) {
+    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 3) {
+        return {};
+    }
+
+    auto sidecar = std::make_shared<FusedRotationAvx512Sidecar>();
+    for (size_t member = 0; member < kDimension; ++member) {
+        uint64_t mask = 0;
+        if ((member & 1U) != 0) {
+            mask ^= rotation.orbit_masks[0];
+        }
+        if ((member & 2U) != 0) {
+            mask ^= rotation.orbit_masks[1];
+        }
+        const uint64_t lane_xor = mask & (kLanes - 1);
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            sidecar->permutations[member].indices[lane] = lane ^ lane_xor;
+        }
+    }
+
+    const size_t num_variants = size_t{1} << rotation.selector_masks.size();
+    assert(rotation.matrices.size() == num_variants * kMatrixSize &&
+           "fused rotation matrix table must cover every selector value");
+    sidecar->weights.resize(num_variants * kMatrixSize);
+    for (size_t base_selector = 0; base_selector < num_variants; ++base_selector) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            const size_t selector = base_selector ^ selector_at(lane, rotation);
+            for (size_t element = 0; element < kMatrixSize; ++element) {
+                const std::complex<double> weight =
+                    rotation.matrices[selector * kMatrixSize + element];
+                LaneWeights& expanded = sidecar->weights[base_selector * kMatrixSize + element];
+                expanded.real[lane] = weight.real();
+                expanded.imag[lane] = weight.imag();
+            }
+        }
+    }
+
+    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx512};
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -2,9 +2,9 @@
 // with the same explicit AVX2/BMI2/FMA/AVX-512 flags as the SVM AVX-512 path.
 
 #include "clifft/sampling/fused_rotation_simd.h"
+#include "clifft/sampling/indexing.h"
 
 #include <array>
-#include <bit>
 #include <cassert>
 #include <complex>
 #include <cstddef>
@@ -35,21 +35,6 @@ struct FusedRotationAvx512Sidecar {
     std::vector<LaneWeights> weights;
 };
 
-uint64_t insert_zero_bit(uint64_t packed, uint32_t pivot) noexcept {
-    const uint64_t lower_mask = (uint64_t{1} << pivot) - 1;
-    return (packed & lower_mask) | ((packed & ~lower_mask) << 1);
-}
-
-size_t selector_at(uint64_t representative, const PreparedFusedRotation& rotation) noexcept {
-    size_t selector = 0;
-    for (size_t bit = 0; bit < rotation.selector_masks.size(); ++bit) {
-        selector |=
-            static_cast<size_t>(std::popcount(representative & rotation.selector_masks[bit]) & 1U)
-            << bit;
-    }
-    return selector;
-}
-
 void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rotation,
                                  const void* opaque_sidecar) noexcept {
     const auto& sidecar = *static_cast<const FusedRotationAvx512Sidecar*>(opaque_sidecar);
@@ -66,7 +51,8 @@ void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rota
         uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
         representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
         const LaneWeights* const matrix =
-            sidecar.weights.data() + selector_at(representative, rotation) * kMatrixSize;
+            sidecar.weights.data() +
+            selector_index(representative, rotation.selector_masks) * kMatrixSize;
 
         std::array<__m512d, kDimension> input_real;
         std::array<__m512d, kDimension> input_imag;
@@ -143,7 +129,7 @@ FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRo
     sidecar->weights.resize(num_variants * kMatrixSize);
     for (size_t base_selector = 0; base_selector < num_variants; ++base_selector) {
         for (size_t lane = 0; lane < kLanes; ++lane) {
-            const size_t selector = base_selector ^ selector_at(lane, rotation);
+            const size_t selector = base_selector ^ selector_index(lane, rotation.selector_masks);
             for (size_t element = 0; element < kMatrixSize; ++element) {
                 const std::complex<double> weight =
                     rotation.matrices[selector * kMatrixSize + element];

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -3,10 +3,8 @@
 #include "clifft/svm/svm_internal.h"
 #include "clifft/svm/svm_math.h"
 #include "clifft/util/fault_sampling.h"
+#include "clifft/util/runtime_isa.h"
 
-#include <algorithm>
-#include <cctype>
-#include <cstdlib>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -37,111 +35,40 @@ void execute_internal(const CompiledModule& program, SchrodingerState& state, si
 using DispatchFn = void (*)(const CompiledModule&, SchrodingerState&, size_t);
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-
-// Each per-ISA kernel TU is compiled with a specific set of -m flags
-// (see src/clifft/CMakeLists.txt). The runtime dispatcher must match
-// that exact set or risk emitting an instruction the host CPU cannot
-// execute. The helpers below are the one place where each kernel's
-// compile-time feature requirements are declared, so the auto-detect
-// path and the CLIFFT_FORCE_ISA override path stay in sync.
-
-static bool host_supports_avx2_kernel() {
-#if (defined(__GNUC__) || defined(__clang__)) && \
-    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
-    // svm_avx2.cc is compiled with -mavx2 -mbmi2 -mfma. All three must
-    // be present at runtime, not just avx2+bmi2 -- a CPU with AVX2+BMI2
-    // but no FMA (Excavator-gen AMD, some VIA Eden-X4) will SIGILL on
-    // an FMA instruction otherwise.
-    return __builtin_cpu_supports("avx2") && __builtin_cpu_supports("bmi2") &&
-           __builtin_cpu_supports("fma");
-#else
-    return false;
-#endif
-}
-
-static bool host_supports_avx512_kernel() {
-#if (defined(__GNUC__) || defined(__clang__)) && \
-    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
-    // svm_avx512.cc is compiled with -mavx2 -mbmi2 -mfma -mavx512f
-    // -mavx512dq, so all five features must be present at runtime.
-    return host_supports_avx2_kernel() && __builtin_cpu_supports("avx512f") &&
-           __builtin_cpu_supports("avx512dq");
-#else
-    return false;
-#endif
-}
-
 // Trap functions installed when the user explicitly requests an ISA via
 // CLIFFT_FORCE_ISA that the host CPU cannot actually execute. We install
 // these at static-initialization time and let the throw fire on the
 // first execute() call -- throwing during static init would terminate
 // the entire process (no Python catch is in scope yet) and turn a clear
 // runtime error into a hard crash at import.
-[[noreturn]] static void trap_force_isa_avx2(const CompiledModule&, SchrodingerState&, size_t) {
-    throw std::runtime_error(
-        "CLIFFT_FORCE_ISA=avx2 requested but host CPU lacks one or more required "
-        "features (avx2, bmi2, fma). Unset CLIFFT_FORCE_ISA to use the auto-detected "
-        "fallback, or set it to 'scalar' explicitly.");
+static void trap_force_isa_avx2(const CompiledModule&, SchrodingerState&, size_t) {
+    internal::validate_runtime_isa(internal::RuntimeIsa::TrapAvx2);
 }
 
-[[noreturn]] static void trap_force_isa_avx512(const CompiledModule&, SchrodingerState&, size_t) {
-    throw std::runtime_error(
-        "CLIFFT_FORCE_ISA=avx512 requested but host CPU lacks one or more required "
-        "features (avx2, bmi2, fma, avx512f, avx512dq). Unset CLIFFT_FORCE_ISA to use "
-        "the auto-detected fallback, or set it to 'avx2' or 'scalar' explicitly.");
+static void trap_force_isa_avx512(const CompiledModule&, SchrodingerState&, size_t) {
+    internal::validate_runtime_isa(internal::RuntimeIsa::TrapAvx512);
 }
 
-[[noreturn]] static void trap_force_isa_unknown(const CompiledModule&, SchrodingerState&, size_t) {
-    throw std::runtime_error(
-        "CLIFFT_FORCE_ISA is set to an unrecognized value. Accepted values are "
-        "'avx512', 'avx2', 'scalar' (case-insensitive). Unset CLIFFT_FORCE_ISA to "
-        "use the auto-detected fallback.");
+static void trap_force_isa_unknown(const CompiledModule&, SchrodingerState&, size_t) {
+    internal::validate_runtime_isa(internal::RuntimeIsa::TrapUnknown);
 }
 
-// Lowercase a copy of the env var and strip surrounding whitespace so the
-// parser stays case-insensitive without mutating the host environment.
-static std::string normalize_force_isa(const char* env) {
-    std::string s(env);
-    auto not_space = [](unsigned char c) { return !std::isspace(c); };
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
-    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
-    return s;
-}
-
-static DispatchFn resolve_dispatcher() {
-    // Allow environment override for testing.
-    if (const char* env = std::getenv("CLIFFT_FORCE_ISA")) {
-        std::string name = normalize_force_isa(env);
-        if (name == "avx512") {
-            return host_supports_avx512_kernel() ? avx512::execute_internal : trap_force_isa_avx512;
-        }
-        if (name == "avx2") {
-            return host_supports_avx2_kernel() ? avx2::execute_internal : trap_force_isa_avx2;
-        }
-        if (name == "scalar") {
+static DispatchFn resolve_dispatcher(internal::RuntimeIsa isa) {
+    switch (isa) {
+        case internal::RuntimeIsa::Scalar:
             return scalar::execute_internal;
-        }
-        // An empty CLIFFT_FORCE_ISA (e.g. `CLIFFT_FORCE_ISA= python ...`)
-        // falls back to auto-detect rather than reporting an error: bash
-        // sets the var to empty when written that way, and the previous
-        // dispatcher treated empty as scalar. Allow it to behave like
-        // "unset" so callers don't have to special-case shell quirks.
-        if (name.empty()) {
-            // Fall through to auto-detect below.
-        } else {
+        case internal::RuntimeIsa::Avx2:
+            return avx2::execute_internal;
+        case internal::RuntimeIsa::Avx512:
+            return avx512::execute_internal;
+        case internal::RuntimeIsa::TrapAvx2:
+            return trap_force_isa_avx2;
+        case internal::RuntimeIsa::TrapAvx512:
+            return trap_force_isa_avx512;
+        case internal::RuntimeIsa::TrapUnknown:
             return trap_force_isa_unknown;
-        }
     }
-
-    // Auto-detect: walk down to the highest kernel the host can run.
-    if (host_supports_avx512_kernel()) {
-        return avx512::execute_internal;
-    }
-    if (host_supports_avx2_kernel()) {
-        return avx2::execute_internal;
-    }
-    return scalar::execute_internal;
+    return trap_force_isa_unknown;
 }
 
 #endif  // CLIFFT_ENABLE_RUNTIME_DISPATCH
@@ -152,7 +79,7 @@ static DispatchFn resolve_dispatcher() {
 
 // Resolved once on first use; shared by execute() and svm_backend().
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-static DispatchFn resolved_fn = resolve_dispatcher();
+static DispatchFn resolved_fn = resolve_dispatcher(internal::runtime_isa());
 #endif
 
 void execute(const CompiledModule& program, SchrodingerState& state) {
@@ -235,24 +162,7 @@ void resume(const CompiledModule& program, SchrodingerState& state, uint32_t off
 }
 
 const char* svm_backend() {
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    if (resolved_fn == avx512::execute_internal)
-        return "avx512";
-    if (resolved_fn == avx2::execute_internal)
-        return "avx2";
-    // Trap states surface a CLIFFT_FORCE_ISA misconfig: the user asked
-    // for an ISA the host can't run, or set the variable to a value the
-    // dispatcher doesn't recognize. Reporting these distinctly (rather
-    // than masquerading as "scalar") lets tests and tooling notice the
-    // misconfig before execute() actually throws.
-    if (resolved_fn == trap_force_isa_avx512)
-        return "trap:avx512";
-    if (resolved_fn == trap_force_isa_avx2)
-        return "trap:avx2";
-    if (resolved_fn == trap_force_isa_unknown)
-        return "trap:unknown";
-#endif
-    return "scalar";
+    return internal::runtime_isa_name(internal::runtime_isa());
 }
 
 // Plain sampling cannot return a partial shot. Instrument programs that stop

--- a/src/clifft/util/runtime_isa.cc
+++ b/src/clifft/util/runtime_isa.cc
@@ -1,0 +1,126 @@
+#include "clifft/util/runtime_isa.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace clifft::internal {
+
+namespace {
+
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+
+bool host_supports_avx2_kernel() {
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
+    // Every AVX2 kernel TU uses -mavx2 -mbmi2 -mfma, so all three
+    // features are required even when a particular kernel uses fewer.
+    return __builtin_cpu_supports("avx2") && __builtin_cpu_supports("bmi2") &&
+           __builtin_cpu_supports("fma");
+#else
+    return false;
+#endif
+}
+
+bool host_supports_avx512_kernel() {
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    (defined(__x86_64__) || defined(__i386__) || defined(_M_X64))
+    // Every AVX-512 kernel TU additionally uses -mavx512f -mavx512dq.
+    return host_supports_avx2_kernel() && __builtin_cpu_supports("avx512f") &&
+           __builtin_cpu_supports("avx512dq");
+#else
+    return false;
+#endif
+}
+
+std::string normalize_force_isa(const char* environment_value) {
+    std::string name(environment_value);
+    const auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    name.erase(name.begin(), std::find_if(name.begin(), name.end(), not_space));
+    name.erase(std::find_if(name.rbegin(), name.rend(), not_space).base(), name.end());
+    std::transform(name.begin(), name.end(), name.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return name;
+}
+
+RuntimeIsa resolve_runtime_isa() {
+    if (const char* environment_value = std::getenv("CLIFFT_FORCE_ISA")) {
+        const std::string name = normalize_force_isa(environment_value);
+        if (name == "avx512") {
+            return host_supports_avx512_kernel() ? RuntimeIsa::Avx512 : RuntimeIsa::TrapAvx512;
+        }
+        if (name == "avx2") {
+            return host_supports_avx2_kernel() ? RuntimeIsa::Avx2 : RuntimeIsa::TrapAvx2;
+        }
+        if (name == "scalar") {
+            return RuntimeIsa::Scalar;
+        }
+        // Treat an empty override as auto-detect so shell callers do not need
+        // to distinguish an unset variable from CLIFFT_FORCE_ISA=.
+        if (!name.empty()) {
+            return RuntimeIsa::TrapUnknown;
+        }
+    }
+
+    if (host_supports_avx512_kernel()) {
+        return RuntimeIsa::Avx512;
+    }
+    if (host_supports_avx2_kernel()) {
+        return RuntimeIsa::Avx2;
+    }
+#endif
+    return RuntimeIsa::Scalar;
+}
+
+}  // namespace
+
+RuntimeIsa runtime_isa() {
+    static const RuntimeIsa selected = resolve_runtime_isa();
+    return selected;
+}
+
+const char* runtime_isa_name(RuntimeIsa isa) noexcept {
+    switch (isa) {
+        case RuntimeIsa::Scalar:
+            return "scalar";
+        case RuntimeIsa::Avx2:
+            return "avx2";
+        case RuntimeIsa::Avx512:
+            return "avx512";
+        case RuntimeIsa::TrapAvx2:
+            return "trap:avx2";
+        case RuntimeIsa::TrapAvx512:
+            return "trap:avx512";
+        case RuntimeIsa::TrapUnknown:
+            return "trap:unknown";
+    }
+    return "trap:unknown";
+}
+
+void validate_runtime_isa(RuntimeIsa isa) {
+    switch (isa) {
+        case RuntimeIsa::Scalar:
+        case RuntimeIsa::Avx2:
+        case RuntimeIsa::Avx512:
+            return;
+        case RuntimeIsa::TrapAvx2:
+            throw std::runtime_error(
+                "CLIFFT_FORCE_ISA=avx2 requested but host CPU lacks one or more required "
+                "features (avx2, bmi2, fma). Unset CLIFFT_FORCE_ISA to use the auto-detected "
+                "fallback, or set it to 'scalar' explicitly.");
+        case RuntimeIsa::TrapAvx512:
+            throw std::runtime_error(
+                "CLIFFT_FORCE_ISA=avx512 requested but host CPU lacks one or more required "
+                "features (avx2, bmi2, fma, avx512f, avx512dq). Unset CLIFFT_FORCE_ISA to use "
+                "the auto-detected fallback, or set it to 'avx2' or 'scalar' explicitly.");
+        case RuntimeIsa::TrapUnknown:
+            throw std::runtime_error(
+                "CLIFFT_FORCE_ISA is set to an unrecognized value. Accepted values are "
+                "'avx512', 'avx2', 'scalar' (case-insensitive). Unset CLIFFT_FORCE_ISA to "
+                "use the auto-detected fallback.");
+    }
+}
+
+}  // namespace clifft::internal

--- a/src/clifft/util/runtime_isa.cc
+++ b/src/clifft/util/runtime_isa.cc
@@ -70,9 +70,16 @@ RuntimeIsa resolve_runtime_isa() {
     if (host_supports_avx2_kernel()) {
         return RuntimeIsa::Avx2;
     }
-#endif
     return RuntimeIsa::Scalar;
 }
+
+#else
+
+RuntimeIsa resolve_runtime_isa() {
+    return RuntimeIsa::Scalar;
+}
+
+#endif
 
 }  // namespace
 

--- a/src/clifft/util/runtime_isa.h
+++ b/src/clifft/util/runtime_isa.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace clifft::internal {
+
+// One process-wide selection shared by every architecture-specific kernel.
+// Trap states defer configuration errors until a backend reaches an execution
+// or preparation boundary, avoiding exceptions during static initialization.
+enum class RuntimeIsa {
+    Scalar,
+    Avx2,
+    Avx512,
+    TrapAvx2,
+    TrapAvx512,
+    TrapUnknown,
+};
+
+[[nodiscard]] RuntimeIsa runtime_isa();
+[[nodiscard]] const char* runtime_isa_name(RuntimeIsa isa) noexcept;
+
+// Returns for executable selections and throws the established
+// CLIFFT_FORCE_ISA error for trap selections.
+void validate_runtime_isa(RuntimeIsa isa);
+
+}  // namespace clifft::internal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(clifft_tests
     test_basis_probabilities.cc
     test_record_probabilities.cc
     test_exp_value.cc
+    test_runtime_isa.cc
     test_openmp.cc
     test_fuzz.cc
     test_noncomp_value_types.cc

--- a/tests/python/test_experimental_sampling.py
+++ b/tests/python/test_experimental_sampling.py
@@ -1,5 +1,8 @@
 """Conformance and boundary tests for the explicitly selected sampling backend."""
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -8,6 +11,26 @@ import stim
 
 import clifft
 import clifft.experimental as experimental
+
+
+def test_unknown_forced_isa_is_rejected_by_symbolic_compile() -> None:
+    environment = os.environ.copy()
+    environment["CLIFFT_FORCE_ISA"] = "not-an-isa"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from clifft import experimental; experimental.compile('M 0')",
+        ],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "CLIFFT_FORCE_ISA" in completed.stderr
+    assert "unrecognized value" in completed.stderr
 
 
 def test_program_is_separate_from_legacy_bytecode() -> None:

--- a/tests/test_runtime_isa.cc
+++ b/tests/test_runtime_isa.cc
@@ -1,0 +1,40 @@
+#include "clifft/svm/svm.h"
+#include "clifft/util/runtime_isa.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <string_view>
+
+using Catch::Matchers::ContainsSubstring;
+using clifft::internal::runtime_isa;
+using clifft::internal::runtime_isa_name;
+using clifft::internal::RuntimeIsa;
+using clifft::internal::validate_runtime_isa;
+
+TEST_CASE("Runtime ISA names are stable") {
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Scalar)) == "scalar");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Avx2)) == "avx2");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Avx512)) == "avx512");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapAvx2)) == "trap:avx2");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapAvx512)) == "trap:avx512");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapUnknown)) == "trap:unknown");
+}
+
+TEST_CASE("Runtime ISA selection is shared with SVM introspection") {
+    REQUIRE(std::string_view(clifft::svm_backend()) == runtime_isa_name(runtime_isa()));
+}
+
+TEST_CASE("Runtime ISA validates executable selections") {
+    REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Scalar));
+    REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Avx2));
+    REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Avx512));
+}
+
+TEST_CASE("Runtime ISA reports forced selection errors") {
+    REQUIRE_THROWS_WITH(validate_runtime_isa(RuntimeIsa::TrapAvx2),
+                        ContainsSubstring("CLIFFT_FORCE_ISA=avx2 requested"));
+    REQUIRE_THROWS_WITH(validate_runtime_isa(RuntimeIsa::TrapAvx512),
+                        ContainsSubstring("CLIFFT_FORCE_ISA=avx512 requested"));
+    REQUIRE_THROWS_WITH(validate_runtime_isa(RuntimeIsa::TrapUnknown),
+                        ContainsSubstring("unrecognized value"));
+}

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -521,6 +521,15 @@ TEST_CASE("Sampling executor fuses constant rotation orbits") {
     };
     require_matches_scalar(5, max_selectors);
 
+    const std::array<RotateActivePauli, 5> rank_two_high_pivots = {
+        RotateActivePauli{{0b001011, 0b100101}, 0.25, AffineBool(false)},
+        RotateActivePauli{{0b101101, 0b011010}, -0.3, AffineBool(true)},
+        RotateActivePauli{{0b100110, 0b110001}, 0.4, AffineBool(false)},
+        RotateActivePauli{{0b001011, 0b001111}, 0.1, AffineBool(false)},
+        RotateActivePauli{{0b101101, 0b101100}, -0.2, AffineBool(true)},
+    };
+    require_matches_scalar(6, rank_two_high_pivots);
+
     SamplingPlan wide_selector_plan;
     wide_selector_plan.num_qubits = 6;
     wide_selector_plan.initial_active_width = 6;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1070,6 +1070,81 @@ TEST_CASE("Sampling continuation overwrites an expectation with exact zero") {
     REQUIRE(executor.exp_vals()[1] == 0.0);
 }
 
+TEST_CASE("Sampling continuation preserves fused rotation prefixes") {
+    constexpr uint32_t kActiveWidth = 6;
+    const std::array<RotateActivePauli, 3> prefix_rotations = {
+        RotateActivePauli{{0b001011, 0b100101}, 0.25, AffineBool(false)},
+        RotateActivePauli{{0b101101, 0b011010}, -0.3, AffineBool(true)},
+        RotateActivePauli{{0b100110, 0b110001}, 0.4, AffineBool(false)},
+    };
+    const std::array<RotateActivePauli, 3> continuation_rotations = {
+        RotateActivePauli{{0b001011, 0b001111}, 0.1, AffineBool(false)},
+        RotateActivePauli{{0b101101, 0b101100}, -0.2, AffineBool(true)},
+        RotateActivePauli{{0b100110, 0b010011}, 0.35, AffineBool(false)},
+    };
+
+    SamplingPlan root_plan;
+    root_plan.num_qubits = kActiveWidth + 1;
+    root_plan.initial_active_width = kActiveWidth;
+    root_plan.max_active_width = kActiveWidth;
+    root_plan.num_instrument_sites = 1;
+    root_plan.instrument_distributions = {
+        InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    for (const RotateActivePauli& rotation : prefix_rotations) {
+        root_plan.actions.push_back(PlannedAction{kActiveWidth, kActiveWidth, rotation});
+    }
+    root_plan.actions.push_back(PlannedAction{
+        kActiveWidth, kActiveWidth,
+        ApplyInstrument{
+            InstrumentSiteId{0}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}});
+    root_plan.actions.push_back(
+        PlannedAction{kActiveWidth, kActiveWidth, InstrumentBoundary{InstrumentSiteId{0}, 0, 0}});
+
+    SamplingPlan continuation_plan = root_plan;
+    for (const RotateActivePauli& rotation : continuation_rotations) {
+        continuation_plan.actions.push_back(PlannedAction{kActiveWidth, kActiveWidth, rotation});
+    }
+
+    const ExecutablePlan root(root_plan);
+    const ExecutablePlan continuation(continuation_plan);
+    REQUIRE(root.num_actions() == 3);
+    REQUIRE(continuation.num_actions() == 4);
+
+    State expected(kActiveWidth, kActiveWidth);
+    for (const RotateActivePauli& rotation : prefix_rotations) {
+        apply_rotation(expected,
+                       prepare_rotation(rotation.pauli, kActiveWidth, rotation.half_turns),
+                       rotation.sign.constant());
+    }
+
+    Executor executor(root, 17);
+    executor.run_shot();
+    REQUIRE(executor.pending_trap().has_value());
+    REQUIRE(executor.pending_trap()->destination_pending);
+    for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+        CAPTURE(basis);
+        REQUIRE_THAT(executor.state().real_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.real_data()[basis], 1e-12));
+        REQUIRE_THAT(executor.state().imag_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.imag_data()[basis], 1e-12));
+    }
+
+    for (const RotateActivePauli& rotation : continuation_rotations) {
+        apply_rotation(expected,
+                       prepare_rotation(rotation.pauli, kActiveWidth, rotation.half_turns),
+                       rotation.sign.constant());
+    }
+    executor.resume(continuation);
+    REQUIRE_FALSE(executor.pending_trap().has_value());
+    for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+        CAPTURE(basis);
+        REQUIRE_THAT(executor.state().real_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.real_data()[basis], 1e-12));
+        REQUIRE_THAT(executor.state().imag_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.imag_data()[basis], 1e-12));
+    }
+}
+
 TEST_CASE("Sampling executor matches legacy records for supported circuits") {
     require_matches_legacy("M 0\n", 32, 1234);
     require_matches_legacy("H 0\nM 0\nM 0\n", 64, 2345);

--- a/tools/ci/check_runtime_isa_no_dispatch.cc
+++ b/tools/ci/check_runtime_isa_no_dispatch.cc
@@ -1,0 +1,18 @@
+#include "clifft/util/runtime_isa.h"
+
+#include <string_view>
+
+int main() {
+    using clifft::internal::runtime_isa;
+    using clifft::internal::runtime_isa_name;
+    using clifft::internal::RuntimeIsa;
+    using clifft::internal::validate_runtime_isa;
+
+    const RuntimeIsa selected = runtime_isa();
+    if (selected != RuntimeIsa::Scalar ||
+        std::string_view(runtime_isa_name(selected)) != "scalar") {
+        return 1;
+    }
+    validate_runtime_isa(selected);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add an AVX-512 specialization for rank-two fused symbolic rotations with `pivot_lo >= 3`
- keep scalar fused execution as the fallback and correctness oracle
- prepare optional eight-lane weight sidecars only when the process-wide runtime selector chooses AVX-512
- move CPU feature detection and `CLIFFT_FORCE_ISA` handling into a shared internal utility used by both the legacy SVM and symbolic executor
- exercise symbolic sampling before legacy execution in wheel/QEMU smoke tests so fallback paths cannot accidentally rely on SVM initialization

This is stacked on #283. The scalar descriptor remains ISA-neutral; SIMD types and intrinsics stay in the separately compiled AVX-512 translation unit.

## Measured result

Single-threaded Release-with-symbols profiles on the issue #280 QV controls:

| Case | Scalar fusion | AVX-512 | Speedup | Legacy | Symbolic / legacy |
| --- | ---: | ---: | ---: | ---: | ---: |
| QV-10 | 1.523 s | 0.663 s | 2.30x | 0.499 s | 1.33x |
| QV-20 | 0.815 s | 0.183 s | 4.46x | 0.249 s | 0.73x |

The high-pivot specialization covers about 88% of fused QV-10 coefficient visits and effectively all QV-20 fused work. Post-change profiles attribute 32.2% of QV-10 runtime and 85.2% of QV-20 runtime to the packed U4 kernel. QV-10 remains behind legacy because 33.7% of runtime is unfused direct rotation and 22.8% is low-pivot/ineligible scalar fusion; those shapes are intentionally deferred.

Prepared AVX-512 sidecars add about 1.14 MiB for QV-10 and 7.69 MiB for QV-20. Scalar, AVX2, ARM, and WASM plans do not pay this cost. Each scalar descriptor and optional sidecar now live in one private entry, making their correspondence structural. The review changes were performance-neutral or better in balanced checks: both QV-10 and QV-20 medians were about 4% lower than the pre-review AVX binary.

## Portability

- non-dispatch builds have an explicit scalar runtime-ISA resolver
- PR CI compiles and runs that path without `CLIFFT_ENABLE_RUNTIME_DISPATCH`
- the no-dispatch smoke passes with both GCC and Clang locally
- the symbolic executor has no dependency on `svm_backend()` or SVM initialization
- SIMD types remain absent from common headers

## Validation

- 1,247 non-benchmark C++ tests in Debug and `x86-64-v2` Release builds
- 1,254 Python tests
- targeted symbolic executor tests under auto, forced scalar, and forced AVX2 selection
- QEMU Haswell and Nehalem symbolic execution, selecting AVX2 and scalar fallbacks respectively
- forced unsupported AVX-512/AVX2 requests under QEMU fail with a clean `CLIFFT_FORCE_ISA` exception rather than `SIGILL`
- object disassembly confirms no ZMM instructions in executor, scalar fusion, or shared-selector objects and packed ZMM instructions in the AVX-512 kernel object
- pre-commit hooks

## Deferred follow-ups

- low-pivot fused U4
- remaining direct rotation shapes
- AVX2 symbolic kernels
- OpenMP

These are separate kernel/parallelization decisions and are not included in this stack.

Refs #280
