### PR TITLE
test: gate forced ISA check on runtime dispatch

### DIFF
--- a/src/clifft/util/runtime_isa.h
+++ b/src/clifft/util/runtime_isa.h
@@ -5,6 +5,8 @@ namespace clifft::internal {
 // One process-wide selection shared by every architecture-specific kernel.
 // Trap states defer configuration errors until a backend reaches an execution
 // or preparation boundary, avoiding exceptions during static initialization.
+// Builds without runtime dispatch always select Scalar and ignore
+// CLIFFT_FORCE_ISA, matching the portable SVM behavior.
 enum class RuntimeIsa {
     Scalar,
     Avx2,

--- a/tests/python/test_experimental_sampling.py
+++ b/tests/python/test_experimental_sampling.py
@@ -1,6 +1,7 @@
 """Conformance and boundary tests for the explicitly selected sampling backend."""
 
 import os
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -12,7 +13,15 @@ import stim
 import clifft
 import clifft.experimental as experimental
 
+_RUNTIME_DISPATCH_BUILD = platform.machine().lower() in {"amd64", "x86_64"} and not (
+    platform.python_compiler().startswith("MSC")
+)
 
+
+@pytest.mark.skipif(
+    not _RUNTIME_DISPATCH_BUILD,
+    reason="CLIFFT_FORCE_ISA is ignored when runtime dispatch is not compiled",
+)
 def test_unknown_forced_isa_is_rejected_by_symbolic_compile() -> None:
     environment = os.environ.copy()
     environment["CLIFFT_FORCE_ISA"] = "not-an-isa"


### PR DESCRIPTION
## Summary

- restrict the invalid CLIFFT_FORCE_ISA subprocess test to non-MSVC x86-64 builds where runtime-dispatched kernels are compiled
- document that no-dispatch builds preserve the portable SVM behavior by selecting scalar and ignoring the override

## Cause

The test added in #284 assumed every build interprets CLIFFT_FORCE_ISA. Windows MSVC and Apple Silicon intentionally compile without runtime dispatch, so both platforms built successfully and passed every other test but this assertion.

## Validation

- focused experimental-sampling Python suite: 15 passed
- no-dispatch C++ smoke compiled and passed with CLIFFT_FORCE_ISA=not-an-isa
- repository-wide pre-commit hooks passed