### PR TITLE
perf: vectorize direct symbolic rotations

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(clifft_core STATIC
     backend/backend.cc
     sampling/plan.cc
     sampling/planner.cc
+    sampling/direct_rotation_dispatch.cc
     sampling/executable_plan.cc
     sampling/executor.cc
     sampling/fused_rotation.cc

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -7,28 +7,60 @@
 
 namespace clifft::sampling {
 
+namespace {
+
+DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotation) noexcept {
+    if (rotation.pauli.is_identity()) {
+        return DirectRotationKernel::Scalar;
+    }
+    if (rotation.pauli.is_diagonal()) {
+        return rotation.pauli.active_width >= 3 ? DirectRotationKernel::Diagonal
+                                                : DirectRotationKernel::Scalar;
+    }
+    const uint64_t pairing_bit = rotation.pauli.pair_selector;
+    // Pivot four has a distinct stride-16 access pattern that regressed against
+    // scalar at every measured width, so it remains on the fallback until a
+    // kernel designed for that shape is available.
+    return pairing_bit >= (uint64_t{1} << 3) && pairing_bit != (uint64_t{1} << 4)
+               ? DirectRotationKernel::HighPivot
+               : DirectRotationKernel::Scalar;
+}
+
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+
+// The selected ISA is process-wide, while each action stores only a shape. A
+// predicted branch and direct call are cheaper here than the SVM's function
+// pointer pattern, which amortizes one indirect call over an entire program.
+const internal::RuntimeIsa kResolvedDirectRotationIsa = internal::runtime_isa();
+
+#endif
+
+}  // namespace
+
 DirectRotationKernel resolve_direct_rotation_kernel(const PreparedRotation& rotation,
                                                     internal::RuntimeIsa runtime_isa) noexcept {
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    return select_direct_rotation_kernel(rotation, runtime_isa == internal::RuntimeIsa::Avx512);
-#else
-    (void)runtime_isa;
-    return select_direct_rotation_kernel(rotation, false);
-#endif
+    if (runtime_isa == internal::RuntimeIsa::Avx512) {
+        return select_direct_rotation_avx512(rotation);
+    }
+    return DirectRotationKernel::Scalar;
 }
 
 void apply_direct_rotation(State& state, const PreparedRotation& rotation,
                            DirectRotationKernel kernel, bool sign) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
     if (kernel != DirectRotationKernel::Scalar) {
+        assert(kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx512 &&
+               "vector direct rotation shape requires the selected AVX-512 implementation");
         apply_direct_rotation_avx512(state, rotation, kernel, sign);
         return;
     }
+    apply_rotation(state, rotation, sign);
 #else
     assert(kernel == DirectRotationKernel::Scalar &&
            "portable direct rotation dispatch requires the scalar kernel");
-#endif
+    static_cast<void>(kernel);
     apply_rotation(state, rotation, sign);
+#endif
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -1,0 +1,34 @@
+#include "clifft/sampling/direct_rotation_dispatch.h"
+
+#include "clifft/sampling/direct_rotation_simd.h"
+#include "clifft/util/runtime_isa.h"
+
+#include <cassert>
+
+namespace clifft::sampling {
+
+DirectRotationKernel resolve_direct_rotation_kernel(const PreparedRotation& rotation,
+                                                    internal::RuntimeIsa runtime_isa) noexcept {
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    return select_direct_rotation_kernel(rotation, runtime_isa == internal::RuntimeIsa::Avx512);
+#else
+    (void)runtime_isa;
+    return select_direct_rotation_kernel(rotation, false);
+#endif
+}
+
+void apply_direct_rotation(State& state, const PreparedRotation& rotation,
+                           DirectRotationKernel kernel, bool sign) noexcept {
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    if (kernel != DirectRotationKernel::Scalar) {
+        apply_direct_rotation_avx512(state, rotation, kernel, sign);
+        return;
+    }
+#else
+    assert(kernel == DirectRotationKernel::Scalar &&
+           "portable direct rotation dispatch requires the scalar kernel");
+#endif
+    apply_rotation(state, rotation, sign);
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/direct_rotation_dispatch.h
+++ b/src/clifft/sampling/direct_rotation_dispatch.h
@@ -4,11 +4,14 @@
 
 #include <cstdint>
 
+namespace clifft::internal {
+enum class RuntimeIsa;
+}
+
 namespace clifft::sampling {
 
-// The selector fits in ExecuteRotation's existing tail padding. Architecture-
-// specific data stays in its translation unit instead of expanding every
-// direct-rotation descriptor.
+// This selector occupies ExecuteRotation's existing tail padding. It carries
+// no architecture-specific data and does not expand the action descriptor.
 enum class DirectRotationKernel : uint8_t {
     Scalar,
     Avx512Diagonal,
@@ -17,6 +20,8 @@ enum class DirectRotationKernel : uint8_t {
 
 static_assert(sizeof(DirectRotationKernel) == 1);
 
+// Exposed separately from host ISA resolution so portable tests can verify the
+// structural eligibility boundaries even on machines without AVX-512.
 [[nodiscard]] inline DirectRotationKernel select_direct_rotation_kernel(
     const PreparedRotation& rotation, bool use_avx512) noexcept {
     if (!use_avx512 || rotation.pauli.is_identity()) {
@@ -27,16 +32,20 @@ static_assert(sizeof(DirectRotationKernel) == 1);
                                                 : DirectRotationKernel::Scalar;
     }
     const uint64_t pairing_bit = rotation.pauli.pair_selector;
-    // Pivot-four sweeps regress relative to scalar at every measured active
-    // width, unlike both the pivot-three boundary and pivots five and above.
+    // On the current Zen 4 performance host, pivot-four sweeps regress at every
+    // measured active width, unlike both the pivot-three boundary and pivots
+    // five and above.
     return pairing_bit >= (uint64_t{1} << 3) && pairing_bit != (uint64_t{1} << 4)
                ? DirectRotationKernel::Avx512HighPivot
                : DirectRotationKernel::Scalar;
 }
 
-// This function is linked only on x86-64 runtime-dispatch builds and must be
-// called only after the dispatcher has selected AVX-512.
-void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
-                                  DirectRotationKernel kernel, bool sign) noexcept;
+[[nodiscard]] DirectRotationKernel resolve_direct_rotation_kernel(
+    const PreparedRotation& rotation, internal::RuntimeIsa runtime_isa) noexcept;
+
+// Keeps ISA selection out of the executor while retaining the scalar kernel as
+// the portable fallback and correctness implementation.
+void apply_direct_rotation(State& state, const PreparedRotation& rotation,
+                           DirectRotationKernel kernel, bool sign) noexcept;
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/direct_rotation_dispatch.h
+++ b/src/clifft/sampling/direct_rotation_dispatch.h
@@ -14,31 +14,11 @@ namespace clifft::sampling {
 // no architecture-specific data and does not expand the action descriptor.
 enum class DirectRotationKernel : uint8_t {
     Scalar,
-    Avx512Diagonal,
-    Avx512HighPivot,
+    Diagonal,
+    HighPivot,
 };
 
 static_assert(sizeof(DirectRotationKernel) == 1);
-
-// Exposed separately from host ISA resolution so portable tests can verify the
-// structural eligibility boundaries even on machines without AVX-512.
-[[nodiscard]] inline DirectRotationKernel select_direct_rotation_kernel(
-    const PreparedRotation& rotation, bool use_avx512) noexcept {
-    if (!use_avx512 || rotation.pauli.is_identity()) {
-        return DirectRotationKernel::Scalar;
-    }
-    if (rotation.pauli.is_diagonal()) {
-        return rotation.pauli.active_width >= 3 ? DirectRotationKernel::Avx512Diagonal
-                                                : DirectRotationKernel::Scalar;
-    }
-    const uint64_t pairing_bit = rotation.pauli.pair_selector;
-    // On the current Zen 4 performance host, pivot-four sweeps regress at every
-    // measured active width, unlike both the pivot-three boundary and pivots
-    // five and above.
-    return pairing_bit >= (uint64_t{1} << 3) && pairing_bit != (uint64_t{1} << 4)
-               ? DirectRotationKernel::Avx512HighPivot
-               : DirectRotationKernel::Scalar;
-}
 
 [[nodiscard]] DirectRotationKernel resolve_direct_rotation_kernel(
     const PreparedRotation& rotation, internal::RuntimeIsa runtime_isa) noexcept;

--- a/src/clifft/sampling/direct_rotation_simd.h
+++ b/src/clifft/sampling/direct_rotation_simd.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "clifft/sampling/direct_rotation_dispatch.h"
+
+namespace clifft::sampling {
+
+// This function is linked only on x86-64 runtime-dispatch builds and must be
+// called only after the dispatcher has selected AVX-512.
+void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
+                                  DirectRotationKernel kernel, bool sign) noexcept;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -37,11 +37,6 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     plan.validate();
     const internal::RuntimeIsa runtime_isa = internal::runtime_isa();
     internal::validate_runtime_isa(runtime_isa);
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    const bool use_avx512_kernels = runtime_isa == internal::RuntimeIsa::Avx512;
-#else
-    const bool use_avx512_kernels = false;
-#endif
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable symbol count exceeds uint32 range");
     }
@@ -170,7 +165,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                     PreparedRotation rotation =
                         prepare_rotation(typed.pauli, planned.active_before, typed.half_turns);
                     const DirectRotationKernel kernel =
-                        select_direct_rotation_kernel(rotation, use_avx512_kernels);
+                        resolve_direct_rotation_kernel(rotation, runtime_isa);
                     actions_.emplace_back(ExecuteRotation{std::move(rotation),
                                                           prepare_expression(typed.sign), kernel});
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -37,6 +37,11 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     plan.validate();
     const internal::RuntimeIsa runtime_isa = internal::runtime_isa();
     internal::validate_runtime_isa(runtime_isa);
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    const bool use_avx512_kernels = runtime_isa == internal::RuntimeIsa::Avx512;
+#else
+    const bool use_avx512_kernels = false;
+#endif
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling executable symbol count exceeds uint32 range");
     }
@@ -162,9 +167,12 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
             [&](const auto& typed) {
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, RotateActivePauli>) {
-                    actions_.emplace_back(ExecuteRotation{
-                        prepare_rotation(typed.pauli, planned.active_before, typed.half_turns),
-                        prepare_expression(typed.sign)});
+                    PreparedRotation rotation =
+                        prepare_rotation(typed.pauli, planned.active_before, typed.half_turns);
+                    const DirectRotationKernel kernel =
+                        select_direct_rotation_kernel(rotation, use_avx512_kernels);
+                    actions_.emplace_back(ExecuteRotation{std::move(rotation),
+                                                          prepare_expression(typed.sign), kernel});
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
                     actions_.emplace_back(ExecutePromotion{prepare_promotion(typed.half_turns),
                                                            prepare_expression(typed.sign)});

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "clifft/sampling/direct_rotation_dispatch.h"
 #include "clifft/sampling/fused_rotation_dispatch.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
-#include "clifft/sampling/rotation_simd.h"
 
 #include <complex>
 #include <cstddef>
@@ -61,8 +61,15 @@ class ExecutablePlan {
     struct ExecuteRotation {
         PreparedRotation rotation;
         PreparedExpression sign;
-        DirectRotationKernel kernel = DirectRotationKernel::Scalar;
+        DirectRotationKernel kernel;
+
+        void apply(State& state, bool sign_value) const noexcept {
+            apply_direct_rotation(state, rotation, kernel, sign_value);
+        }
     };
+
+    static_assert(sizeof(ExecuteRotation) == 72,
+                  "direct rotation dispatch must not expand its action descriptor");
 
     struct ExecuteFusedRotation {
         uint32_t rotation_index = 0;

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -59,8 +59,11 @@ class ExecutablePlan {
     };
 
     struct ExecuteRotation {
+        // Geometry and trigonometric weights shared by every implementation.
         PreparedRotation rotation;
+        // Register containing the branch-dependent Pauli sign for this shot.
         PreparedExpression sign;
+        // Host-selected shape tag stored in the descriptor's tail padding.
         DirectRotationKernel kernel;
 
         void apply(State& state, bool sign_value) const noexcept {

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -3,6 +3,7 @@
 #include "clifft/sampling/fused_rotation_dispatch.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
+#include "clifft/sampling/rotation_simd.h"
 
 #include <complex>
 #include <cstddef>
@@ -60,6 +61,7 @@ class ExecutablePlan {
     struct ExecuteRotation {
         PreparedRotation rotation;
         PreparedExpression sign;
+        DirectRotationKernel kernel = DirectRotationKernel::Scalar;
     };
 
     struct ExecuteFusedRotation {

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -298,7 +298,14 @@ void Executor::assign_forced_quantum_faults() noexcept {
 template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    apply_rotation(state_, action.rotation, evaluate(action.sign));
+    const bool sign = evaluate(action.sign);
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    if (action.kernel != DirectRotationKernel::Scalar) {
+        apply_direct_rotation_avx512(state_, action.rotation, action.kernel, sign);
+        return;
+    }
+#endif
+    apply_rotation(state_, action.rotation, sign);
 }
 
 template <bool ForceRecords>

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -298,14 +298,7 @@ void Executor::assign_forced_quantum_faults() noexcept {
 template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    const bool sign = evaluate(action.sign);
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    if (action.kernel != DirectRotationKernel::Scalar) {
-        apply_direct_rotation_avx512(state_, action.rotation, action.kernel, sign);
-        return;
-    }
-#endif
-    apply_rotation(state_, action.rotation, sign);
+    action.apply(state_, evaluate(action.sign));
 }
 
 template <bool ForceRecords>

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -1,10 +1,12 @@
-// AVX-512F+AVX-512DQ fused-rotation kernel. This translation unit is compiled
+// AVX-512F+AVX-512DQ sampling kernels. This translation unit is compiled
 // with the same explicit AVX2/BMI2/FMA/AVX-512 flags as the SVM AVX-512 path.
 
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
+#include "clifft/sampling/rotation_simd.h"
 
 #include <array>
+#include <bit>
 #include <cassert>
 #include <complex>
 #include <cstddef>
@@ -21,6 +23,32 @@ constexpr size_t kLanes = 8;
 constexpr size_t kDimension = 4;
 constexpr size_t kMatrixSize = kDimension * kDimension;
 
+using LaneIndices = std::array<uint64_t, kLanes>;
+using LaneSigns = std::array<double, kLanes>;
+
+constexpr std::array<LaneIndices, kLanes> make_lane_permutations() {
+    std::array<LaneIndices, kLanes> result{};
+    for (size_t lane_xor = 0; lane_xor < kLanes; ++lane_xor) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            result[lane_xor][lane] = lane ^ lane_xor;
+        }
+    }
+    return result;
+}
+
+constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
+    std::array<LaneSigns, kLanes> result{};
+    for (size_t z = 0; z < kLanes; ++z) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            result[z][lane] = (std::popcount(z & lane) & 1U) != 0 ? -1.0 : 1.0;
+        }
+    }
+    return result;
+}
+
+alignas(64) constexpr auto kLanePermutations = make_lane_permutations();
+alignas(64) constexpr auto kLaneParitySigns = make_lane_parity_signs();
+
 struct alignas(64) LanePermutation {
     std::array<uint64_t, kLanes> indices{};
 };
@@ -34,6 +62,96 @@ struct FusedRotationAvx512Sidecar {
     std::array<LanePermutation, kDimension> permutations;
     std::vector<LaneWeights> weights;
 };
+
+__m512d signed_sine_lanes(uint64_t basis, uint64_t z, double sine) noexcept {
+    const bool high_parity = (std::popcount(basis & z) & 1U) != 0;
+    const double block_sine = high_parity ? -sine : sine;
+    const __m512d lane_signs = _mm512_load_pd(kLaneParitySigns[z & (kLanes - 1)].data());
+    return _mm512_mul_pd(_mm512_set1_pd(block_sine), lane_signs);
+}
+
+void apply_diagonal_rotation_avx512(State& state, const PreparedRotation& rotation,
+                                    double sine) noexcept {
+    assert(rotation.pauli.is_diagonal() && !rotation.pauli.is_identity() &&
+           rotation.pauli.active_width >= 3 &&
+           "AVX-512 diagonal rotation requires at least one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const __m512d cosine = _mm512_set1_pd(rotation.cosine);
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m512d input_real = _mm512_load_pd(real + basis);
+        const __m512d input_imag = _mm512_load_pd(imag + basis);
+        const __m512d signed_sine = signed_sine_lanes(basis, rotation.pauli.z, sine);
+        const __m512d output_real =
+            _mm512_fmadd_pd(signed_sine, input_imag, _mm512_mul_pd(cosine, input_real));
+        const __m512d output_imag =
+            _mm512_fnmadd_pd(signed_sine, input_real, _mm512_mul_pd(cosine, input_imag));
+        _mm512_store_pd(real + basis, output_real);
+        _mm512_store_pd(imag + basis, output_imag);
+    }
+}
+
+template <bool RealPhase>
+void apply_nondiagonal_rotation_avx512(State& state, const PreparedRotation& rotation,
+                                       double sine) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector >= kLanes &&
+           "AVX-512 non-diagonal rotation requires a high pairing pivot");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = rotation.pauli.pair_selector;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const __m512d cosine = _mm512_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+
+    for (uint64_t block = 0; block < state.size(); block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; offset += kLanes) {
+            const uint64_t left = block + offset;
+            const uint64_t right_base = (left ^ rotation.pauli.x) & ~(uint64_t{kLanes - 1});
+            const __m512d left_real = _mm512_load_pd(real + left);
+            const __m512d left_imag = _mm512_load_pd(imag + left);
+            const __m512d right_real =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(real + right_base));
+            const __m512d right_imag =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(imag + right_base));
+            const __m512d left_sine = signed_sine_lanes(left, rotation.pauli.z, even_left_sine);
+
+            __m512d output_left_real;
+            __m512d output_left_imag;
+            __m512d output_right_real;
+            __m512d output_right_imag;
+            if constexpr (RealPhase) {
+                output_left_real =
+                    _mm512_fmadd_pd(left_sine, right_imag, _mm512_mul_pd(cosine, left_real));
+                output_left_imag =
+                    _mm512_fnmadd_pd(left_sine, right_real, _mm512_mul_pd(cosine, left_imag));
+                output_right_real =
+                    _mm512_fmadd_pd(left_sine, left_imag, _mm512_mul_pd(cosine, right_real));
+                output_right_imag =
+                    _mm512_fnmadd_pd(left_sine, left_real, _mm512_mul_pd(cosine, right_imag));
+            } else {
+                output_left_real =
+                    _mm512_fnmadd_pd(left_sine, right_real, _mm512_mul_pd(cosine, left_real));
+                output_left_imag =
+                    _mm512_fnmadd_pd(left_sine, right_imag, _mm512_mul_pd(cosine, left_imag));
+                output_right_real =
+                    _mm512_fmadd_pd(left_sine, left_real, _mm512_mul_pd(cosine, right_real));
+                output_right_imag =
+                    _mm512_fmadd_pd(left_sine, left_imag, _mm512_mul_pd(cosine, right_imag));
+            }
+
+            _mm512_store_pd(real + left, output_left_real);
+            _mm512_store_pd(imag + left, output_left_imag);
+            _mm512_store_pd(real + right_base,
+                            _mm512_permutexvar_pd(permutation, output_right_real));
+            _mm512_store_pd(imag + right_base,
+                            _mm512_permutexvar_pd(permutation, output_right_imag));
+        }
+    }
+}
 
 void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rotation,
                                  const void* opaque_sidecar) noexcept {
@@ -102,6 +220,29 @@ void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rota
 }
 
 }  // namespace
+
+void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
+                                  DirectRotationKernel kernel, bool sign) noexcept {
+    assert(state.active_width() == rotation.pauli.active_width &&
+           "AVX-512 rotation width must match the active state");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+    switch (kernel) {
+        case DirectRotationKernel::Avx512Diagonal:
+            apply_diagonal_rotation_avx512(state, rotation, sine);
+            return;
+        case DirectRotationKernel::Avx512HighPivot:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_nondiagonal_rotation_avx512<true>(state, rotation, sine);
+            } else {
+                apply_nondiagonal_rotation_avx512<false>(state, rotation, sine);
+            }
+            return;
+        case DirectRotationKernel::Scalar:
+            assert(false && "scalar rotations must not enter the AVX-512 kernel");
+            return;
+    }
+    assert(false && "unknown direct rotation kernel");
+}
 
 FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRotation& rotation) {
     if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 3) {

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -1,9 +1,9 @@
 // AVX-512F+AVX-512DQ sampling kernels. This translation unit is compiled
 // with the same explicit AVX2/BMI2/FMA/AVX-512 flags as the SVM AVX-512 path.
 
+#include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
-#include "clifft/sampling/rotation_simd.h"
 
 #include <array>
 #include <bit>

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -63,6 +63,8 @@ struct FusedRotationAvx512Sidecar {
     std::vector<LaneWeights> weights;
 };
 
+// Each vector block shares the parity from basis bits above the lanes. The
+// lookup supplies the remaining per-lane signs without scalar branching.
 __m512d signed_sine_lanes(uint64_t basis, uint64_t z, double sine) noexcept {
     const bool high_parity = (std::popcount(basis & z) & 1U) != 0;
     const double block_sine = high_parity ? -sine : sine;
@@ -70,6 +72,8 @@ __m512d signed_sine_lanes(uint64_t basis, uint64_t z, double sine) noexcept {
     return _mm512_mul_pd(_mm512_set1_pd(block_sine), lane_signs);
 }
 
+// A diagonal Pauli never moves coefficients, so eight amplitudes can be
+// updated in place with only lane-dependent parity signs.
 void apply_diagonal_rotation_avx512(State& state, const PreparedRotation& rotation,
                                     double sine) noexcept {
     assert(rotation.pauli.is_diagonal() && !rotation.pauli.is_identity() &&
@@ -91,6 +95,9 @@ void apply_diagonal_rotation_avx512(State& state, const PreparedRotation& rotati
     }
 }
 
+// A pivot at or above the lane bits pairs two aligned vector blocks. XORing the
+// full X mask finds the partner block, while one fixed permutation accounts
+// for X bits within each block.
 template <bool RealPhase>
 void apply_nondiagonal_rotation_avx512(State& state, const PreparedRotation& rotation,
                                        double sine) noexcept {
@@ -153,6 +160,9 @@ void apply_nondiagonal_rotation_avx512(State& state, const PreparedRotation& rot
     }
 }
 
+// Fused matrices vary with representative parity. The sidecar expands those
+// choices by lane so the hot loop can traverse eight independent orbits without
+// gathers or selector branches.
 void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rotation,
                                  const void* opaque_sidecar) noexcept {
     const auto& sidecar = *static_cast<const FusedRotationAvx512Sidecar*>(opaque_sidecar);
@@ -227,10 +237,12 @@ void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation
            "AVX-512 rotation width must match the active state");
     const double sine = sign ? -rotation.sine : rotation.sine;
     switch (kernel) {
-        case DirectRotationKernel::Avx512Diagonal:
+        case DirectRotationKernel::Diagonal:
             apply_diagonal_rotation_avx512(state, rotation, sine);
             return;
-        case DirectRotationKernel::Avx512HighPivot:
+        case DirectRotationKernel::HighPivot:
+            // Prepared Paulis have phases in {+1, -1, +i, -i}; specializing
+            // the real and imaginary cases avoids generic complex arithmetic.
             if (rotation.pauli.even_phase.real() != 0.0) {
                 apply_nondiagonal_rotation_avx512<true>(state, rotation, sine);
             } else {
@@ -244,6 +256,8 @@ void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation
     assert(false && "unknown direct rotation kernel");
 }
 
+// Host-specific preparation transposes selector matrices into lane-major
+// weights once, keeping both allocation and selector expansion out of shots.
 FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRotation& rotation) {
     if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 3) {
         return {};

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -19,6 +19,9 @@ namespace clifft::sampling {
 
 namespace {
 
+// State stores amplitudes in separate real and imaginary arrays. A SIMD lane
+// is one basis index in either array, so matching lanes from a real vector and
+// an imaginary vector represent eight consecutive complex amplitudes.
 constexpr size_t kLanes = 8;
 constexpr size_t kDimension = 4;
 constexpr size_t kMatrixSize = kDimension * kDimension;

--- a/src/clifft/sampling/rotation_simd.h
+++ b/src/clifft/sampling/rotation_simd.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "clifft/sampling/kernels.h"
+
+#include <cstdint>
+
+namespace clifft::sampling {
+
+// The selector fits in ExecuteRotation's existing tail padding. Architecture-
+// specific data stays in its translation unit instead of expanding every
+// direct-rotation descriptor.
+enum class DirectRotationKernel : uint8_t {
+    Scalar,
+    Avx512Diagonal,
+    Avx512HighPivot,
+};
+
+static_assert(sizeof(DirectRotationKernel) == 1);
+
+[[nodiscard]] inline DirectRotationKernel select_direct_rotation_kernel(
+    const PreparedRotation& rotation, bool use_avx512) noexcept {
+    if (!use_avx512 || rotation.pauli.is_identity()) {
+        return DirectRotationKernel::Scalar;
+    }
+    if (rotation.pauli.is_diagonal()) {
+        return rotation.pauli.active_width >= 3 ? DirectRotationKernel::Avx512Diagonal
+                                                : DirectRotationKernel::Scalar;
+    }
+    const uint64_t pairing_bit = rotation.pauli.pair_selector;
+    // Pivot-four sweeps regress relative to scalar at every measured active
+    // width, unlike both the pivot-three boundary and pivots five and above.
+    return pairing_bit >= (uint64_t{1} << 3) && pairing_bit != (uint64_t{1} << 4)
+               ? DirectRotationKernel::Avx512HighPivot
+               : DirectRotationKernel::Scalar;
+}
+
+// This function is linked only on x86-64 runtime-dispatch builds and must be
+// called only after the dispatcher has selected AVX-512.
+void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
+                                  DirectRotationKernel kernel, bool sign) noexcept;
+
+}  // namespace clifft::sampling

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -119,3 +119,46 @@ TEST_CASE("Fused rotation falls back for a rank three run") {
     };
     require_matches_scalar(rotation_plan(3, rotations), 0, 3);
 }
+
+TEST_CASE("Direct rotation SIMD matches scalar across eligible shapes") {
+    const std::array rotations = {
+        RotateActivePauli{{0, 0}, 0.125, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0, 0b101011}, -0.3, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b001011, 0b000011}, 0.2, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b011001, 0b010101}, -0.4, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b000101, 0b000110}, 0.35, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b001111, 0b001001}, -0.15, AffineBool::symbol(SymbolId{0})},
+    };
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    require_matches_scalar(plan, 0, rotations.size());
+    require_matches_scalar(plan, 1, rotations.size());
+}
+
+TEST_CASE("Direct rotation SIMD matches scalar for every lane permutation") {
+    std::array<RotateActivePauli, 16> rotations;
+    for (uint64_t lane_xor = 0; lane_xor < 8; ++lane_xor) {
+        const uint64_t x = 0b100000 | lane_xor;
+        rotations[2 * lane_xor] =
+            RotateActivePauli{{x, (~x) & 0b111111}, 0.2, AffineBool::symbol(SymbolId{0})};
+        rotations[2 * lane_xor + 1] =
+            RotateActivePauli{{x, x & (~x + 1)}, -0.3, AffineBool::symbol(SymbolId{0})};
+    }
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    require_matches_scalar(plan, 0, rotations.size());
+    require_matches_scalar(plan, 1, rotations.size());
+}
+
+TEST_CASE("Direct rotation SIMD matches scalar at vector boundaries") {
+    const std::array diagonal = {
+        RotateActivePauli{{0, 0b111}, 0.3, AffineBool::symbol(SymbolId{0})},
+    };
+    require_matches_scalar(rotation_plan(3, diagonal), 0, diagonal.size());
+    require_matches_scalar(rotation_plan(3, diagonal), 1, diagonal.size());
+
+    const std::array paired = {
+        RotateActivePauli{{0b1101, 0b0011}, -0.25, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b1011, 0b0101}, 0.4, AffineBool::symbol(SymbolId{0})},
+    };
+    require_matches_scalar(rotation_plan(4, paired), 0, paired.size());
+    require_matches_scalar(rotation_plan(4, paired), 1, paired.size());
+}

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -148,6 +148,18 @@ TEST_CASE("Direct rotation SIMD matches scalar for every lane permutation") {
     require_matches_scalar(plan, 1, rotations.size());
 }
 
+TEST_CASE("Direct rotation SIMD matches scalar with intermediate high bits") {
+    const std::array rotations = {
+        RotateActivePauli{{0b101010, 0b001110}, 0.2, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b111000, 0b100101}, -0.3, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b110011, 0b010001}, 0.4, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0, 0b101000}, -0.25, AffineBool::symbol(SymbolId{0})},
+    };
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    require_matches_scalar(plan, 0, rotations.size());
+    require_matches_scalar(plan, 1, rotations.size());
+}
+
 TEST_CASE("Direct rotation SIMD matches scalar at vector boundaries") {
     const std::array diagonal = {
         RotateActivePauli{{0, 0b111}, 0.3, AffineBool::symbol(SymbolId{0})},

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -1,5 +1,5 @@
+#include "clifft/sampling/direct_rotation_dispatch.h"
 #include "clifft/sampling/kernels.h"
-#include "clifft/sampling/rotation_simd.h"
 
 #include "test_helpers.h"
 

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/direct_rotation_dispatch.h"
 #include "clifft/sampling/kernels.h"
+#include "clifft/util/runtime_isa.h"
 
 #include "test_helpers.h"
 
@@ -15,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+using clifft::internal::RuntimeIsa;
 using clifft::sampling::activate_zero_coordinate;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::apply_instrument_no_fire;
@@ -31,7 +33,7 @@ using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::PreparedMeasurement;
-using clifft::sampling::select_direct_rotation_kernel;
+using clifft::sampling::resolve_direct_rotation_kernel;
 using clifft::sampling::State;
 using clifft::test::check_complex;
 using clifft::test::dense_axis_rotation;
@@ -326,19 +328,20 @@ TEST_CASE("Sampling kernels rotations match the existing dense matrix oracle") {
 }
 
 TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
-    const auto select = [](ActivePauli pauli, uint32_t active_width, bool use_avx512 = true) {
-        return select_direct_rotation_kernel(prepare_rotation(pauli, active_width, 0.3),
-                                             use_avx512);
+    const auto select = [](ActivePauli pauli, uint32_t active_width,
+                           RuntimeIsa runtime_isa = RuntimeIsa::Avx512) {
+        return resolve_direct_rotation_kernel(prepare_rotation(pauli, active_width, 0.3),
+                                              runtime_isa);
     };
 
     REQUIRE(select({0, 0}, 4) == DirectRotationKernel::Scalar);
     REQUIRE(select({0, 0b11}, 2) == DirectRotationKernel::Scalar);
-    REQUIRE(select({0, 0b101}, 3) == DirectRotationKernel::Avx512Diagonal);
+    REQUIRE(select({0, 0b101}, 3) == DirectRotationKernel::Diagonal);
     REQUIRE(select({0b100, 0b011}, 3) == DirectRotationKernel::Scalar);
-    REQUIRE(select({0b1000, 0b0111}, 4) == DirectRotationKernel::Avx512HighPivot);
+    REQUIRE(select({0b1000, 0b0111}, 4) == DirectRotationKernel::HighPivot);
     REQUIRE(select({0b10000, 0b01111}, 5) == DirectRotationKernel::Scalar);
-    REQUIRE(select({0b100000, 0b011111}, 6) == DirectRotationKernel::Avx512HighPivot);
-    REQUIRE(select({0b1000, 0b0111}, 4, false) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b100000, 0b011111}, 6) == DirectRotationKernel::HighPivot);
+    REQUIRE(select({0b1000, 0b0111}, 4, RuntimeIsa::Avx2) == DirectRotationKernel::Scalar);
 }
 
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -1,4 +1,5 @@
 #include "clifft/sampling/kernels.h"
+#include "clifft/sampling/rotation_simd.h"
 
 #include "test_helpers.h"
 
@@ -21,6 +22,7 @@ using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
 using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
+using clifft::sampling::DirectRotationKernel;
 using clifft::sampling::expectation_value;
 using clifft::sampling::measurement_probabilities;
 using clifft::sampling::MeasurementProbabilities;
@@ -29,6 +31,7 @@ using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::PreparedMeasurement;
+using clifft::sampling::select_direct_rotation_kernel;
 using clifft::sampling::State;
 using clifft::test::check_complex;
 using clifft::test::dense_axis_rotation;
@@ -320,6 +323,22 @@ TEST_CASE("Sampling kernels rotations match the existing dense matrix oracle") {
             }
         }
     }
+}
+
+TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
+    const auto select = [](ActivePauli pauli, uint32_t active_width, bool use_avx512 = true) {
+        return select_direct_rotation_kernel(prepare_rotation(pauli, active_width, 0.3),
+                                             use_avx512);
+    };
+
+    REQUIRE(select({0, 0}, 4) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0, 0b11}, 2) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0, 0b101}, 3) == DirectRotationKernel::Avx512Diagonal);
+    REQUIRE(select({0b100, 0b011}, 3) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b1000, 0b0111}, 4) == DirectRotationKernel::Avx512HighPivot);
+    REQUIRE(select({0b10000, 0b01111}, 5) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b100000, 0b011111}, 6) == DirectRotationKernel::Avx512HighPivot);
+    REQUIRE(select({0b1000, 0b0111}, 4, false) == DirectRotationKernel::Scalar);
 }
 
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {


### PR DESCRIPTION
## Summary

- add separately compiled AVX-512 kernels for direct diagonal and non-diagonal symbolic-coordinate rotations
- select a one-byte kernel during `SamplingPlan` to `ExecutablePlan` lowering, without growing `ExecuteRotation` (72 bytes) or the action variant (112 bytes)
- evaluate dynamic signs once per action and retain scalar handling for identity/global phase, short diagonal states, low pivots, and the measured-unprofitable pivot-four shape
- keep ISA-specific types and data out of common descriptors; lane permutations and parity signs are shared static tables, with no per-action sidecar

The initial eligibility boundary was checked with a Release microbenchmark. Width-three diagonal and pivot-three paired rotations were profitable (about 1.24x and 1.26x respectively), as were pivots five and above. Pivot-four rotations were 8-18% slower than scalar across tested active widths, so they deliberately remain on the scalar path.

## Performance

Same Release build, one thread pinned on an AMD EPYC 9554P, runtime ISA `avx512`. Ratios below are symbolic / legacy, so lower is better.

| Case | Before | This PR |
|---|---:|---:|
| QV-10 seed 42, 5,000 shots | 1.346x | 1.02x |
| QV-10 seed 44, 5,000 shots | 1.597x | 1.12x |
| QV-10 seed 51, 5,000 shots | 0.814x | 0.77x |
| QV-20 seed 47, 3 shots | 0.708x | 0.73x |
| QV-20 seed 49, 3 shots | 0.883x | 0.83x |
| coherent d3 r3, 300,000 shots | 1.133x | 0.92x |
| k12/L512, 20,000 shots | 0.769x | 0.59x |

Surface d7 r7, cultivation d3, and distillation aggregate screens showed no material regression; cultivation also improved. One-shot QV-20 remains a setup guard and passed for both selected seeds.

The refreshed QV-10 seed-44 profile is now 37.1% scalar fused rotation, 34.9% AVX-512 fused U4, 12.2% direct AVX-512 rotation, 1.8% scalar direct rotation, and 9.8% measurement probability/collapse. That makes low-pivot fused U4/U2 the next independent kernel target; this PR intentionally does not broaden into it.

## Correctness and portability

- scalar-oracle checks for both dynamic-sign values, real and imaginary Pauli phase classes, every within-vector lane permutation, and identity/global phase
- explicit diagonal width-two/three and pairing pivot-two/three/four/five boundaries
- complete Release C++ suite under automatic, forced scalar, and forced AVX2 dispatch
- `x86-64-v2` build-flag audit and focused tests under automatic, forced scalar, and forced AVX2 dispatch
- QEMU execution on Haswell/forced-AVX2 and Nehalem/forced-scalar CPUs
- no-runtime-dispatch compile check for the generic executor path
- generated assembly contains packed `zmm`, `vpermpd`, and FMA operations
- pre-commit suite

Refs #280.
