### PR TITLE
perf(sampling): make symbolic planning forward

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(clifft_core STATIC
     backend/backend.cc
     sampling/plan.cc
     sampling/planner.cc
+    sampling/planner_frame.cc
     sampling/direct_rotation_dispatch.cc
     sampling/executable_plan.cc
     sampling/executor.cc

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -259,6 +259,27 @@ bool AffineBool::is_canonical() const {
 
 AffineBool& AffineBool::operator^=(const AffineBool& other) {
     constant_ ^= other.constant_;
+    if (other.terms_.empty()) {
+        return *this;
+    }
+    if (other.terms_.size() == 1) {
+        const SymbolId term = other.terms_.front();
+        if (terms_.empty() || index(terms_.back()) < index(term)) {
+            // Forward planning usually introduces symbols in ascending order.
+            // Preserve vector capacity instead of rebuilding the full parity.
+            terms_.push_back(term);
+            return *this;
+        }
+        auto position = std::lower_bound(
+            terms_.begin(), terms_.end(), term,
+            [](SymbolId left, SymbolId right) { return index(left) < index(right); });
+        if (position != terms_.end() && *position == term) {
+            terms_.erase(position);
+        } else {
+            terms_.insert(position, term);
+        }
+        return *this;
+    }
     terms_ = xor_terms(terms_, other.terms_);
     return *this;
 }

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -7,11 +7,16 @@
 #include "stim.h"
 
 #include <algorithm>
+#include <bit>
+#include <cassert>
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <numbers>
+#include <numeric>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -78,8 +83,8 @@ struct PendingReadoutNoise {
 };
 
 struct PendingInstrument {
-    // Source observable and computational destination correction, expressed
-    // in the coordinate basis that future planner transformations update.
+    // Source observable and computational destination correction stay in the
+    // initial HIR coordinates used by the cumulative symbolic Pauli frame.
     Pauli body;
     Pauli destination_flip;
     // Maps the source observable's eigenspaces to physical G and E; earlier
@@ -87,7 +92,7 @@ struct PendingInstrument {
     AffineBool sign;
     // Indexes both the plan-owned distribution and its continuation boundary.
     InstrumentSiteId site{};
-    // Reserved in HIR order so a rewritten suffix cannot renumber the prefix.
+    // Reserved in HIR order so coordinate evolution cannot renumber the prefix.
     SymbolId destination_flip_symbol{};
     // Continuations retain only noise and symbols preceding this HIR site.
     uint32_t next_noise_site = 0;
@@ -160,6 +165,171 @@ Pauli positive_body_xor(const Pauli& left, const Pauli& right) {
 
 bool anticommutes(const Pauli& left, const Pauli& right) {
     return !left.ref().commutes(right.ref());
+}
+
+std::vector<size_t> identity_indices(size_t size) {
+    std::vector<size_t> result(size);
+    std::iota(result.begin(), result.end(), size_t{0});
+    return result;
+}
+
+class CoordinateFrame {
+  public:
+    explicit CoordinateFrame(uint32_t num_qubits)
+        : current_to_initial_(num_qubits),
+          initial_to_current_(num_qubits),
+          indices_(identity_indices(num_qubits)) {}
+
+    [[nodiscard]] Pauli to_current(const Pauli& initial) const {
+        return initial_to_current_.scatter_eval(initial.ref(), indices_);
+    }
+
+    [[nodiscard]] Pauli to_initial(const Pauli& current) const {
+        return current_to_initial_.scatter_eval(current.ref(), indices_);
+    }
+
+    void change_basis(const Tableau& new_basis_in_old_coordinates) {
+        current_to_initial_ = new_basis_in_old_coordinates.then(current_to_initial_);
+        initial_to_current_ = current_to_initial_.inverse();
+    }
+
+  private:
+    // These two tableaus are maintained together so ordinary operations never
+    // pay for an inverse. The forward map is also needed when a sampled branch
+    // adds a Pauli correction expressed in the newly selected coordinates.
+    Tableau current_to_initial_;
+    Tableau initial_to_current_;
+    std::vector<size_t> indices_;
+};
+
+class SymbolicPauliFrame {
+  public:
+    SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols)
+        : num_qubits_(num_qubits),
+          num_symbols_(num_symbols),
+          words_per_row_((static_cast<size_t>(num_symbols) + 63) / 64),
+          x_constants_(num_qubits, 0),
+          z_constants_(num_qubits, 0),
+          scratch_(words_per_row_, 0) {
+        if (num_qubits != 0 && words_per_row_ > std::numeric_limits<size_t>::max() / num_qubits) {
+            throw std::length_error("sampling symbolic Pauli frame is too large");
+        }
+        const size_t storage_words = static_cast<size_t>(num_qubits) * words_per_row_;
+        x_terms_.assign(storage_words, 0);
+        z_terms_.assign(storage_words, 0);
+    }
+
+    void apply(const Pauli& correction, const AffineBool& condition) {
+        assert(correction.num_qubits == num_qubits_ &&
+               "symbolic Pauli correction width must match the planner frame");
+        for (uint32_t q = 0; q < num_qubits_; ++q) {
+            if (correction.xs[q]) {
+                xor_condition(x_row(q), x_constants_[q], condition);
+            }
+            if (correction.zs[q]) {
+                xor_condition(z_row(q), z_constants_[q], condition);
+            }
+        }
+    }
+
+    [[nodiscard]] AffineBool sign_for(const Pauli& observable) {
+        assert(observable.num_qubits == num_qubits_ &&
+               "symbolic Pauli observable width must match the planner frame");
+        std::ranges::fill(scratch_, uint64_t{0});
+        bool constant = false;
+        for (uint32_t q = 0; q < num_qubits_; ++q) {
+            if (observable.xs[q]) {
+                xor_row(scratch_, z_row(q));
+                constant ^= z_constants_[q] != 0;
+            }
+            if (observable.zs[q]) {
+                xor_row(scratch_, x_row(q));
+                constant ^= x_constants_[q] != 0;
+            }
+        }
+
+        size_t term_count = 0;
+        for (uint64_t word : scratch_) {
+            term_count += std::popcount(word);
+        }
+        std::vector<SymbolId> terms;
+        terms.reserve(term_count);
+        for (size_t w = 0; w < scratch_.size(); ++w) {
+            uint64_t word = scratch_[w];
+            while (word != 0) {
+                const uint32_t bit = std::countr_zero(word);
+                const size_t symbol = 64 * w + bit;
+                assert(symbol < num_symbols_ &&
+                       "symbolic Pauli frame contains an out-of-range term");
+                terms.push_back(SymbolId{static_cast<uint32_t>(symbol)});
+                word &= word - 1;
+            }
+        }
+        return AffineBool(constant, std::move(terms));
+    }
+
+  private:
+    [[nodiscard]] std::span<uint64_t> x_row(uint32_t q) {
+        return std::span<uint64_t>{x_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                     words_per_row_);
+    }
+    [[nodiscard]] std::span<const uint64_t> x_row(uint32_t q) const {
+        return std::span<const uint64_t>{x_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                           words_per_row_);
+    }
+    [[nodiscard]] std::span<uint64_t> z_row(uint32_t q) {
+        return std::span<uint64_t>{z_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                     words_per_row_);
+    }
+    [[nodiscard]] std::span<const uint64_t> z_row(uint32_t q) const {
+        return std::span<const uint64_t>{z_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                           words_per_row_);
+    }
+
+    static void xor_row(std::span<uint64_t> destination, std::span<const uint64_t> source) {
+        assert(destination.size() == source.size());
+        for (size_t w = 0; w < destination.size(); ++w) {
+            destination[w] ^= source[w];
+        }
+    }
+
+    void xor_condition(std::span<uint64_t> row, uint8_t& constant,
+                       const AffineBool& condition) const {
+        constant ^= static_cast<uint8_t>(condition.constant());
+        for (SymbolId term : condition.terms()) {
+            const uint32_t symbol = index(term);
+            if (symbol >= num_symbols_) {
+                throw std::logic_error(
+                    "sampling symbolic Pauli condition contains an out-of-range symbol");
+            }
+            row[symbol / 64] ^= uint64_t{1} << (symbol % 64);
+        }
+    }
+
+    uint32_t num_qubits_;
+    uint32_t num_symbols_;
+    size_t words_per_row_;
+    std::vector<uint64_t> x_terms_;
+    std::vector<uint64_t> z_terms_;
+    std::vector<uint8_t> x_constants_;
+    std::vector<uint8_t> z_constants_;
+    std::vector<uint64_t> scratch_;
+};
+
+struct ResolvedPauli {
+    Pauli body;
+    AffineBool sign;
+};
+
+ResolvedPauli resolve_pauli(const Pauli& initial_body, const AffineBool& initial_sign,
+                            const CoordinateFrame& coordinates,
+                            SymbolicPauliFrame& symbolic_frame) {
+    AffineBool sign = initial_sign;
+    sign ^= symbolic_frame.sign_for(initial_body);
+    Pauli body = coordinates.to_current(initial_body);
+    sign ^= static_cast<bool>(body.sign);
+    body.sign = false;
+    return ResolvedPauli{std::move(body), std::move(sign)};
 }
 
 std::optional<uint32_t> first_x_at_or_above(const Pauli& pauli, uint32_t begin) {
@@ -288,8 +458,8 @@ Tableau active_measurement_frame(const Pauli& measured, uint32_t active_width, u
     const Pauli pivot_z = single_z(n, pivot);
 
     // Moving the measured Pauli to the last active Z generator gives the
-    // direct measurement kernel one coordinate to remove. Future operations
-    // are rewritten into the remaining packed coordinates below.
+    // direct measurement kernel one coordinate to remove. The cumulative
+    // frame maps later operations into the remaining packed coordinates.
     frame.zs[active_width - 1] = measured;
     frame.xs[active_width - 1] = diagonal ? pivot_x : pivot_z;
 
@@ -321,111 +491,6 @@ Tableau active_measurement_frame(const Pauli& measured, uint32_t active_width, u
         throw std::logic_error("sampling planner produced an invalid active measurement frame");
     }
     return frame;
-}
-
-template <typename Function>
-void visit_pending_pauli(PendingOperation& operation, Function&& function) {
-    std::visit(
-        [&](auto& typed) {
-            using T = std::decay_t<decltype(typed)>;
-            if constexpr (std::is_same_v<T, PendingRotation> ||
-                          std::is_same_v<T, PendingMeasurement> ||
-                          std::is_same_v<T, PendingExpectation>) {
-                function(typed.body, &typed.sign);
-            } else if constexpr (std::is_same_v<T, PendingInstrument>) {
-                function(typed.body, &typed.sign);
-                function(typed.destination_flip, nullptr);
-            } else if constexpr (std::is_same_v<T, PendingConditionalPauli>) {
-                function(typed.body, nullptr);
-            } else if constexpr (std::is_same_v<T, PendingNoise>) {
-                for (PendingNoiseChannel& channel : typed.channels) {
-                    function(channel.body, nullptr);
-                }
-            } else if constexpr (std::is_same_v<T, PendingReadoutNoise> ||
-                                 std::is_same_v<T, PendingDetector> ||
-                                 std::is_same_v<T, PendingObservable>) {
-                // Purely classical operations have no coordinate body.
-            } else {
-                static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
-            }
-        },
-        operation);
-}
-
-void transform_future_operations(std::vector<PendingOperation>& pending, size_t begin,
-                                 const Tableau& new_basis_in_old_coordinates) {
-    // Planning owns coordinate evolution. Runtime actions therefore receive
-    // already-transformed Paulis and never need to discover dependencies or
-    // perform tableau evolution in the dispatch loop.
-    const Tableau old_to_new = new_basis_in_old_coordinates.inverse();
-    for (size_t i = begin; i < pending.size(); ++i) {
-        visit_pending_pauli(pending[i], [&](Pauli& body, AffineBool* sign) {
-            Pauli transformed = old_to_new(body);
-            if (sign != nullptr) {
-                *sign ^= static_cast<bool>(transformed.sign);
-            }
-            transformed.sign = false;
-            body = std::move(transformed);
-        });
-    }
-}
-
-void propagate_conditional_pauli(std::vector<PendingOperation>& pending, size_t begin,
-                                 const Pauli& correction, const AffineBool& condition) {
-    for (size_t i = begin; i < pending.size(); ++i) {
-        std::visit(
-            [&](auto& typed) {
-                using T = std::decay_t<decltype(typed)>;
-                if constexpr (std::is_same_v<T, PendingRotation> ||
-                              std::is_same_v<T, PendingMeasurement> ||
-                              std::is_same_v<T, PendingExpectation> ||
-                              std::is_same_v<T, PendingInstrument>) {
-                    if (anticommutes(correction, typed.body)) {
-                        typed.sign ^= condition;
-                    }
-                } else if constexpr (std::is_same_v<T, PendingConditionalPauli> ||
-                                     std::is_same_v<T, PendingNoise> ||
-                                     std::is_same_v<T, PendingReadoutNoise> ||
-                                     std::is_same_v<T, PendingDetector> ||
-                                     std::is_same_v<T, PendingObservable>) {
-                    // Pauli-frame phases do not affect later Pauli corrections or
-                    // classical record consumers.
-                } else {
-                    static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
-                }
-            },
-            pending[i]);
-    }
-}
-
-void propagate_branch(std::vector<PendingOperation>& pending, size_t begin,
-                      uint32_t branch_coordinate, SymbolId branch) {
-    // The sampled minus eigenspace differs by X on the replaced Z coordinate.
-    // Anticommuting future Paulis therefore acquire this branch in their sign.
-    for (size_t i = begin; i < pending.size(); ++i) {
-        std::visit(
-            [&](auto& typed) {
-                using T = std::decay_t<decltype(typed)>;
-                if constexpr (std::is_same_v<T, PendingRotation> ||
-                              std::is_same_v<T, PendingMeasurement> ||
-                              std::is_same_v<T, PendingExpectation> ||
-                              std::is_same_v<T, PendingInstrument>) {
-                    if (typed.body.zs[branch_coordinate]) {
-                        typed.sign ^= AffineBool::symbol(branch);
-                    }
-                } else if constexpr (std::is_same_v<T, PendingConditionalPauli> ||
-                                     std::is_same_v<T, PendingNoise> ||
-                                     std::is_same_v<T, PendingReadoutNoise> ||
-                                     std::is_same_v<T, PendingDetector> ||
-                                     std::is_same_v<T, PendingObservable>) {
-                    // A branch Pauli can only add an irrelevant sign to another
-                    // Pauli-frame correction.
-                } else {
-                    static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
-                }
-            },
-            pending[i]);
-    }
 }
 
 SymbolId reserve_symbol(SamplingPlan& plan) {
@@ -646,14 +711,16 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
     return pending;
 }
 
-void process_rotation(std::vector<PendingOperation>& pending, size_t index,
-                      const PendingRotation& rotation, SamplingPlan& plan, uint32_t& active_width) {
-    const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(rotation.body, active_width);
+void process_rotation(const PendingRotation& rotation, SamplingPlan& plan, uint32_t& active_width,
+                      CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame) {
+    ResolvedPauli resolved =
+        resolve_pauli(rotation.body, rotation.sign, coordinates, symbolic_frame);
+    const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (!dormant_pivot.has_value()) {
         plan.actions.push_back(
             PlannedAction{active_width, active_width,
-                          RotateActivePauli{active_projection(rotation.body, active_width),
-                                            rotation.half_turns, rotation.sign}});
+                          RotateActivePauli{active_projection(resolved.body, active_width),
+                                            rotation.half_turns, std::move(resolved.sign)}});
         return;
     }
 
@@ -663,64 +730,69 @@ void process_rotation(std::vector<PendingOperation>& pending, size_t index,
             ", but the dense-state limit is " + std::to_string(kDenseActiveWidthLimit));
     }
 
-    const Tableau frame = dormant_promotion_frame(rotation.body, active_width, *dormant_pivot);
-    transform_future_operations(pending, index + 1, frame);
+    const Tableau frame = dormant_promotion_frame(resolved.body, active_width, *dormant_pivot);
+    coordinates.change_basis(frame);
     compose_final_tableau(plan, frame);
     plan.actions.push_back(
         PlannedAction{active_width, active_width + 1,
-                      PromoteDormantRotation{rotation.half_turns, rotation.sign}});
+                      PromoteDormantRotation{rotation.half_turns, std::move(resolved.sign)}});
     ++active_width;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
 }
 
-AffineBool process_measurement(std::vector<PendingOperation>& pending, size_t index,
-                               const PendingMeasurement& measurement, SamplingPlan& plan,
-                               uint32_t& active_width) {
-    const std::optional<uint32_t> dormant_pivot =
-        first_x_at_or_above(measurement.body, active_width);
+AffineBool process_measurement(const PendingMeasurement& measurement, SamplingPlan& plan,
+                               uint32_t& active_width, CoordinateFrame& coordinates,
+                               SymbolicPauliFrame& symbolic_frame) {
+    ResolvedPauli resolved =
+        resolve_pauli(measurement.body, measurement.sign, coordinates, symbolic_frame);
+    const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (dormant_pivot.has_value()) {
-        const Tableau frame = dormant_measurement_frame(measurement.body, *dormant_pivot);
-        transform_future_operations(pending, index + 1, frame);
+        const Tableau frame = dormant_measurement_frame(resolved.body, *dormant_pivot);
+        coordinates.change_basis(frame);
 
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
         const SymbolId branch = measurement.branch;
         define_symbol(plan, branch, SymbolKind::Branch, action_index);
-        propagate_branch(pending, index + 1, *dormant_pivot, branch);
-        const AffineBool outcome = measurement.sign ^ AffineBool::symbol(branch);
+        Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, *dormant_pivot));
+        correction.sign = false;
+        symbolic_frame.apply(correction, AffineBool::symbol(branch));
+        const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
         plan.actions.push_back(PlannedAction{
             active_width, active_width,
             MeasureDormantRandom{*dormant_pivot, branch, outcome, measurement.record}});
         return outcome;
     }
 
-    const ActivePauli active = active_projection(measurement.body, active_width);
+    const ActivePauli active = active_projection(resolved.body, active_width);
     if (active.is_identity()) {
-        plan.actions.push_back(PlannedAction{
-            active_width, active_width, RecordClassical{measurement.sign, measurement.record}});
-        return measurement.sign;
+        plan.actions.push_back(PlannedAction{active_width, active_width,
+                                             RecordClassical{resolved.sign, measurement.record}});
+        return resolved.sign;
     }
 
-    std::optional<uint32_t> pivot = first_x_below(measurement.body, active_width);
+    std::optional<uint32_t> pivot = first_x_below(resolved.body, active_width);
     if (!pivot.has_value()) {
-        pivot = first_z_below(measurement.body, active_width);
+        pivot = first_z_below(resolved.body, active_width);
     }
     if (!pivot.has_value()) {
         throw std::logic_error("sampling planner could not select an active measurement pivot");
     }
 
-    Pauli active_body(measurement.body.num_qubits);
+    Pauli active_body(resolved.body.num_qubits);
     for (uint32_t q = 0; q < active_width; ++q) {
-        active_body.xs[q] = measurement.body.xs[q];
-        active_body.zs[q] = measurement.body.zs[q];
+        active_body.xs[q] = resolved.body.xs[q];
+        active_body.zs[q] = resolved.body.zs[q];
     }
     const Tableau frame = active_measurement_frame(active_body, active_width, *pivot);
-    transform_future_operations(pending, index + 1, frame);
+    coordinates.change_basis(frame);
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     const SymbolId branch = measurement.branch;
     define_symbol(plan, branch, SymbolKind::Branch, action_index);
-    propagate_branch(pending, index + 1, active_width - 1, branch);
-    const AffineBool outcome = measurement.sign ^ AffineBool::symbol(branch);
+    Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, active_width - 1));
+    correction.sign = false;
+    symbolic_frame.apply(correction, AffineBool::symbol(branch));
+    const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
     plan.actions.push_back(
         PlannedAction{active_width, active_width - 1,
                       MeasureActivePauli{active, *pivot, branch, outcome, measurement.record}});
@@ -728,18 +800,18 @@ AffineBool process_measurement(std::vector<PendingOperation>& pending, size_t in
     return outcome;
 }
 
-void process_instrument(std::vector<PendingOperation>& pending, size_t operation_index,
-                        const PendingInstrument& instrument, SamplingPlan& plan,
-                        uint32_t& active_width) {
+void process_instrument(const PendingInstrument& instrument, SamplingPlan& plan,
+                        uint32_t& active_width, CoordinateFrame& coordinates,
+                        SymbolicPauliFrame& symbolic_frame) {
     const InstrumentDistribution& distribution =
         plan.instrument_distributions.at(index(instrument.site));
-    const std::optional<uint32_t> dormant_pivot =
-        first_x_at_or_above(instrument.body, active_width);
+    ResolvedPauli resolved =
+        resolve_pauli(instrument.body, instrument.sign, coordinates, symbolic_frame);
+    const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
 
     InstrumentMode mode = InstrumentMode::Classical;
     ActivePauli source;
-    AffineBool sign = instrument.sign;
-    Pauli destination_flip = instrument.destination_flip;
+    AffineBool sign = std::move(resolved.sign);
     uint32_t active_after = active_width;
 
     if (dormant_pivot.has_value()) {
@@ -755,23 +827,20 @@ void process_instrument(std::vector<PendingOperation>& pending, size_t operation
                                           ", but the dense-state limit is " +
                                           std::to_string(kDenseActiveWidthLimit));
             }
-            // Apply one coordinate change consistently to the source,
-            // destination correction, and every later operation.
             const Tableau frame =
-                dormant_promotion_frame(instrument.body, active_width, *dormant_pivot);
+                dormant_promotion_frame(resolved.body, active_width, *dormant_pivot);
             const Tableau old_to_new = frame.inverse();
-            Pauli transformed_source = old_to_new(instrument.body);
+            const std::vector<size_t> indices = identity_indices(old_to_new.num_qubits);
+            Pauli transformed_source = old_to_new.scatter_eval(resolved.body.ref(), indices);
             sign ^= static_cast<bool>(transformed_source.sign);
             transformed_source.sign = false;
-            destination_flip = old_to_new(destination_flip);
-            destination_flip.sign = false;
-            transform_future_operations(pending, operation_index + 1, frame);
+            coordinates.change_basis(frame);
             ++active_after;
             mode = InstrumentMode::Activate;
             source = active_projection(transformed_source, active_after);
         }
     } else {
-        source = active_projection(instrument.body, active_width);
+        source = active_projection(resolved.body, active_width);
         // An identity projection means the source is already determined by
         // the symbolic sign; otherwise its active Pauli needs coefficient work.
         mode = source.is_identity() ? InstrumentMode::Classical : InstrumentMode::Active;
@@ -791,9 +860,7 @@ void process_instrument(std::vector<PendingOperation>& pending, size_t operation
                       ApplyInstrument{instrument.site, mode, source, sign, destination_symbol}});
 
     if (destination_symbol.has_value()) {
-        // Compile the possible runtime flip into signs of future operations.
-        propagate_conditional_pauli(pending, operation_index + 1, destination_flip,
-                                    AffineBool::symbol(*destination_symbol));
+        symbolic_frame.apply(instrument.destination_flip, AffineBool::symbol(*destination_symbol));
     }
     active_width = active_after;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
@@ -819,6 +886,11 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     plan.global_weight = hir.global_weight;
 
     std::vector<PendingOperation> pending = queue_supported_operations(hir, plan, options);
+    if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::length_error("sampling planner symbol count exceeds uint32 range");
+    }
+    CoordinateFrame coordinates(hir.num_qubits);
+    SymbolicPauliFrame symbolic_frame(hir.num_qubits, static_cast<uint32_t>(plan.symbols.size()));
     std::vector<std::optional<AffineBool>> record_values(static_cast<size_t>(hir.num_measurements) +
                                                          hir.num_hidden_measurements);
     std::vector<AffineBool> observable_values(hir.num_observables);
@@ -858,18 +930,16 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
             [&](const auto& operation) {
                 using T = std::decay_t<decltype(operation)>;
                 if constexpr (std::is_same_v<T, PendingRotation>) {
-                    process_rotation(pending, i, operation, plan, active_width);
+                    process_rotation(operation, plan, active_width, coordinates, symbolic_frame);
                 } else if constexpr (std::is_same_v<T, PendingMeasurement>) {
-                    const AffineBool outcome =
-                        process_measurement(pending, i, operation, plan, active_width);
+                    const AffineBool outcome = process_measurement(operation, plan, active_width,
+                                                                   coordinates, symbolic_frame);
                     assign_record(operation.record, outcome, i);
                 } else if constexpr (std::is_same_v<T, PendingConditionalPauli>) {
-                    propagate_conditional_pauli(pending, i + 1, operation.body,
-                                                require_record(operation.controller, i));
+                    symbolic_frame.apply(operation.body, require_record(operation.controller, i));
                 } else if constexpr (std::is_same_v<T, PendingNoise>) {
                     for (const PendingNoiseChannel& channel : operation.channels) {
-                        propagate_conditional_pauli(pending, i + 1, channel.body,
-                                                    AffineBool::symbol(channel.symbol));
+                        symbolic_frame.apply(channel.body, AffineBool::symbol(channel.symbol));
                     }
                 } else if constexpr (std::is_same_v<T, PendingReadoutNoise>) {
                     const AffineBool source = require_record(operation.record, i);
@@ -885,17 +955,19 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                                           operation.prob_zero_to_one, operation.prob_one_to_zero}});
                     record_values[index(operation.record)] = source ^ AffineBool::symbol(flip);
                 } else if constexpr (std::is_same_v<T, PendingExpectation>) {
+                    ResolvedPauli resolved =
+                        resolve_pauli(operation.body, operation.sign, coordinates, symbolic_frame);
                     const bool is_zero =
-                        first_x_at_or_above(operation.body, active_width).has_value();
+                        first_x_at_or_above(resolved.body, active_width).has_value();
                     plan.actions.push_back(PlannedAction{
                         active_width, active_width,
                         WriteExpectationValue{
                             is_zero ? std::nullopt
-                                    : std::optional<ActivePauli>{active_projection(operation.body,
+                                    : std::optional<ActivePauli>{active_projection(resolved.body,
                                                                                    active_width)},
-                            is_zero ? AffineBool{} : operation.sign, operation.exp_val}});
+                            is_zero ? AffineBool{} : std::move(resolved.sign), operation.exp_val}});
                 } else if constexpr (std::is_same_v<T, PendingInstrument>) {
-                    process_instrument(pending, i, operation, plan, active_width);
+                    process_instrument(operation, plan, active_width, coordinates, symbolic_frame);
                 } else if constexpr (std::is_same_v<T, PendingDetector>) {
                     AffineBool outcome = record_parity(operation.records, i);
                     outcome ^= operation.expected;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -202,6 +202,8 @@ class CoordinateFrame {
     std::vector<size_t> indices_;
 };
 
+// This planner-only frame uses O(num_qubits * num_symbols / 64) words and is
+// discarded before executable lowering or hot execution.
 class SymbolicPauliFrame {
   public:
     SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols)
@@ -829,15 +831,12 @@ void process_instrument(const PendingInstrument& instrument, SamplingPlan& plan,
             }
             const Tableau frame =
                 dormant_promotion_frame(resolved.body, active_width, *dormant_pivot);
-            const Tableau old_to_new = frame.inverse();
-            const std::vector<size_t> indices = identity_indices(old_to_new.num_qubits);
-            Pauli transformed_source = old_to_new.scatter_eval(resolved.body.ref(), indices);
-            sign ^= static_cast<bool>(transformed_source.sign);
-            transformed_source.sign = false;
             coordinates.change_basis(frame);
             ++active_after;
             mode = InstrumentMode::Activate;
-            source = active_projection(transformed_source, active_after);
+            // The promotion frame installs this observable as the next X
+            // generator, so rediscovering it through a local inverse is wasteful.
+            source.x = uint64_t{1} << active_width;
         }
     } else {
         source = active_projection(resolved.body, active_width);
@@ -885,7 +884,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     plan.num_exp_vals = hir.num_exp_vals;
     plan.global_weight = hir.global_weight;
 
-    std::vector<PendingOperation> pending = queue_supported_operations(hir, plan, options);
+    const std::vector<PendingOperation> pending = queue_supported_operations(hir, plan, options);
     if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
         throw std::length_error("sampling planner symbol count exceeds uint32 range");
     }

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/planner.h"
 
+#include "clifft/sampling/planner_frame.h"
 #include "clifft/util/hir_introspection.h"
 #include "clifft/util/numeric.h"
 #include "clifft/util/stim_mask.h"
@@ -7,14 +8,11 @@
 #include "stim.h"
 
 #include <algorithm>
-#include <bit>
-#include <cassert>
 #include <cmath>
 #include <complex>
 #include <cstdint>
 #include <limits>
 #include <numbers>
-#include <numeric>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -28,8 +26,13 @@ namespace clifft::sampling {
 
 namespace {
 
-using Pauli = stim::PauliString<kStimWidth>;
-using Tableau = stim::Tableau<kStimWidth>;
+using Pauli = internal::PlannerPauli;
+using Tableau = internal::PlannerTableau;
+using internal::active_measurement_frame;
+using internal::CoordinateFrame;
+using internal::dormant_measurement_frame;
+using internal::dormant_promotion_frame;
+using internal::SymbolicPauliFrame;
 
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
@@ -146,178 +149,6 @@ Pauli single_x(uint32_t num_qubits, uint32_t q) {
     return result;
 }
 
-Pauli single_z(uint32_t num_qubits, uint32_t q) {
-    Pauli result(num_qubits);
-    result.zs[q] = true;
-    return result;
-}
-
-Pauli positive_body_xor(const Pauli& left, const Pauli& right) {
-    // Callers only combine canonical generator rows whose nonidentity supports
-    // are disjoint. Overlapping supports could contribute a phase that this
-    // body-only helper intentionally does not compute.
-    Pauli result(left);
-    result.xs ^= right.xs;
-    result.zs ^= right.zs;
-    result.sign = false;
-    return result;
-}
-
-bool anticommutes(const Pauli& left, const Pauli& right) {
-    return !left.ref().commutes(right.ref());
-}
-
-std::vector<size_t> identity_indices(size_t size) {
-    std::vector<size_t> result(size);
-    std::iota(result.begin(), result.end(), size_t{0});
-    return result;
-}
-
-class CoordinateFrame {
-  public:
-    explicit CoordinateFrame(uint32_t num_qubits)
-        : current_to_initial_(num_qubits),
-          initial_to_current_(num_qubits),
-          indices_(identity_indices(num_qubits)) {}
-
-    [[nodiscard]] Pauli to_current(const Pauli& initial) const {
-        return initial_to_current_.scatter_eval(initial.ref(), indices_);
-    }
-
-    [[nodiscard]] Pauli to_initial(const Pauli& current) const {
-        return current_to_initial_.scatter_eval(current.ref(), indices_);
-    }
-
-    void change_basis(const Tableau& new_basis_in_old_coordinates) {
-        current_to_initial_ = new_basis_in_old_coordinates.then(current_to_initial_);
-        initial_to_current_ = current_to_initial_.inverse();
-    }
-
-  private:
-    // These two tableaus are maintained together so ordinary operations never
-    // pay for an inverse. The forward map is also needed when a sampled branch
-    // adds a Pauli correction expressed in the newly selected coordinates.
-    Tableau current_to_initial_;
-    Tableau initial_to_current_;
-    std::vector<size_t> indices_;
-};
-
-// This planner-only frame uses O(num_qubits * num_symbols / 64) words and is
-// discarded before executable lowering or hot execution.
-class SymbolicPauliFrame {
-  public:
-    SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols)
-        : num_qubits_(num_qubits),
-          num_symbols_(num_symbols),
-          words_per_row_((static_cast<size_t>(num_symbols) + 63) / 64),
-          x_constants_(num_qubits, 0),
-          z_constants_(num_qubits, 0),
-          scratch_(words_per_row_, 0) {
-        if (num_qubits != 0 && words_per_row_ > std::numeric_limits<size_t>::max() / num_qubits) {
-            throw std::length_error("sampling symbolic Pauli frame is too large");
-        }
-        const size_t storage_words = static_cast<size_t>(num_qubits) * words_per_row_;
-        x_terms_.assign(storage_words, 0);
-        z_terms_.assign(storage_words, 0);
-    }
-
-    void apply(const Pauli& correction, const AffineBool& condition) {
-        assert(correction.num_qubits == num_qubits_ &&
-               "symbolic Pauli correction width must match the planner frame");
-        for (uint32_t q = 0; q < num_qubits_; ++q) {
-            if (correction.xs[q]) {
-                xor_condition(x_row(q), x_constants_[q], condition);
-            }
-            if (correction.zs[q]) {
-                xor_condition(z_row(q), z_constants_[q], condition);
-            }
-        }
-    }
-
-    [[nodiscard]] AffineBool sign_for(const Pauli& observable) {
-        assert(observable.num_qubits == num_qubits_ &&
-               "symbolic Pauli observable width must match the planner frame");
-        std::ranges::fill(scratch_, uint64_t{0});
-        bool constant = false;
-        for (uint32_t q = 0; q < num_qubits_; ++q) {
-            if (observable.xs[q]) {
-                xor_row(scratch_, z_row(q));
-                constant ^= z_constants_[q] != 0;
-            }
-            if (observable.zs[q]) {
-                xor_row(scratch_, x_row(q));
-                constant ^= x_constants_[q] != 0;
-            }
-        }
-
-        size_t term_count = 0;
-        for (uint64_t word : scratch_) {
-            term_count += std::popcount(word);
-        }
-        std::vector<SymbolId> terms;
-        terms.reserve(term_count);
-        for (size_t w = 0; w < scratch_.size(); ++w) {
-            uint64_t word = scratch_[w];
-            while (word != 0) {
-                const uint32_t bit = std::countr_zero(word);
-                const size_t symbol = 64 * w + bit;
-                assert(symbol < num_symbols_ &&
-                       "symbolic Pauli frame contains an out-of-range term");
-                terms.push_back(SymbolId{static_cast<uint32_t>(symbol)});
-                word &= word - 1;
-            }
-        }
-        return AffineBool(constant, std::move(terms));
-    }
-
-  private:
-    [[nodiscard]] std::span<uint64_t> x_row(uint32_t q) {
-        return std::span<uint64_t>{x_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
-                                                     words_per_row_);
-    }
-    [[nodiscard]] std::span<const uint64_t> x_row(uint32_t q) const {
-        return std::span<const uint64_t>{x_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
-                                                           words_per_row_);
-    }
-    [[nodiscard]] std::span<uint64_t> z_row(uint32_t q) {
-        return std::span<uint64_t>{z_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
-                                                     words_per_row_);
-    }
-    [[nodiscard]] std::span<const uint64_t> z_row(uint32_t q) const {
-        return std::span<const uint64_t>{z_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
-                                                           words_per_row_);
-    }
-
-    static void xor_row(std::span<uint64_t> destination, std::span<const uint64_t> source) {
-        assert(destination.size() == source.size());
-        for (size_t w = 0; w < destination.size(); ++w) {
-            destination[w] ^= source[w];
-        }
-    }
-
-    void xor_condition(std::span<uint64_t> row, uint8_t& constant,
-                       const AffineBool& condition) const {
-        constant ^= static_cast<uint8_t>(condition.constant());
-        for (SymbolId term : condition.terms()) {
-            const uint32_t symbol = index(term);
-            if (symbol >= num_symbols_) {
-                throw std::logic_error(
-                    "sampling symbolic Pauli condition contains an out-of-range symbol");
-            }
-            row[symbol / 64] ^= uint64_t{1} << (symbol % 64);
-        }
-    }
-
-    uint32_t num_qubits_;
-    uint32_t num_symbols_;
-    size_t words_per_row_;
-    std::vector<uint64_t> x_terms_;
-    std::vector<uint64_t> z_terms_;
-    std::vector<uint8_t> x_constants_;
-    std::vector<uint8_t> z_constants_;
-    std::vector<uint64_t> scratch_;
-};
-
 struct ResolvedPauli {
     Pauli body;
     AffineBool sign;
@@ -368,131 +199,6 @@ ActivePauli active_projection(const Pauli& pauli, uint32_t active_width) {
         result.z |= static_cast<uint64_t>(pauli.zs[q]) << q;
     }
     return result;
-}
-
-Tableau dormant_promotion_frame(const Pauli& promoted, uint32_t active_width,
-                                uint32_t dormant_pivot) {
-    const uint32_t n = static_cast<uint32_t>(promoted.num_qubits);
-    Tableau frame(n);
-    const Pauli old_stabilizer = single_z(n, dormant_pivot);
-
-    // The rows express the new coordinate generators in the old basis. Making
-    // the promoted Pauli the next X generator turns its rotation into a
-    // single-coordinate expansion; the stabilizer products keep every other
-    // generator in a canonical symplectic pair.
-    for (uint32_t q = 0; q < active_width; ++q) {
-        Pauli x = single_x(n, q);
-        Pauli z = single_z(n, q);
-        if (anticommutes(x, promoted)) {
-            x = positive_body_xor(x, old_stabilizer);
-        }
-        if (anticommutes(z, promoted)) {
-            z = positive_body_xor(z, old_stabilizer);
-        }
-        frame.xs[q] = x;
-        frame.zs[q] = z;
-    }
-
-    frame.xs[active_width] = promoted;
-    frame.zs[active_width] = old_stabilizer;
-
-    uint32_t new_q = active_width + 1;
-    for (uint32_t old_q = active_width; old_q < n; ++old_q) {
-        if (old_q == dormant_pivot) {
-            continue;
-        }
-        Pauli x = single_x(n, old_q);
-        Pauli z = single_z(n, old_q);
-        if (anticommutes(x, promoted)) {
-            x = positive_body_xor(x, old_stabilizer);
-        }
-        if (anticommutes(z, promoted)) {
-            z = positive_body_xor(z, old_stabilizer);
-        }
-        frame.xs[new_q] = x;
-        frame.zs[new_q] = z;
-        ++new_q;
-    }
-
-    if (!frame.satisfies_invariants()) {
-        throw std::logic_error("sampling planner produced an invalid promotion frame");
-    }
-    return frame;
-}
-
-Tableau dormant_measurement_frame(const Pauli& measured, uint32_t dormant_pivot) {
-    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
-    Tableau frame(n);
-    const Pauli old_stabilizer = single_z(n, dormant_pivot);
-
-    // Replacing one dormant Z generator with the measured Pauli represents the
-    // collapsed eigenspace without changing the dense coefficient state.
-    for (uint32_t q = 0; q < n; ++q) {
-        if (q == dormant_pivot) {
-            continue;
-        }
-        Pauli x = single_x(n, q);
-        Pauli z = single_z(n, q);
-        if (anticommutes(x, measured)) {
-            x = positive_body_xor(x, old_stabilizer);
-        }
-        if (anticommutes(z, measured)) {
-            z = positive_body_xor(z, old_stabilizer);
-        }
-        frame.xs[q] = x;
-        frame.zs[q] = z;
-    }
-
-    frame.xs[dormant_pivot] = old_stabilizer;
-    frame.zs[dormant_pivot] = measured;
-
-    if (!frame.satisfies_invariants()) {
-        throw std::logic_error("sampling planner produced an invalid dormant measurement frame");
-    }
-    return frame;
-}
-
-Tableau active_measurement_frame(const Pauli& measured, uint32_t active_width, uint32_t pivot) {
-    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
-    Tableau frame(n);
-    const bool diagonal = !first_x_below(measured, active_width).has_value();
-    const Pauli pivot_x = single_x(n, pivot);
-    const Pauli pivot_z = single_z(n, pivot);
-
-    // Moving the measured Pauli to the last active Z generator gives the
-    // direct measurement kernel one coordinate to remove. The cumulative
-    // frame maps later operations into the remaining packed coordinates.
-    frame.zs[active_width - 1] = measured;
-    frame.xs[active_width - 1] = diagonal ? pivot_x : pivot_z;
-
-    uint32_t new_q = 0;
-    for (uint32_t old_q = 0; old_q < active_width; ++old_q) {
-        if (old_q == pivot) {
-            continue;
-        }
-        Pauli x = single_x(n, old_q);
-        Pauli z = single_z(n, old_q);
-        if (diagonal) {
-            if (measured.zs[old_q]) {
-                x = positive_body_xor(x, pivot_x);
-            }
-        } else {
-            if (measured.xs[old_q]) {
-                z = positive_body_xor(z, pivot_z);
-            }
-            if (measured.zs[old_q]) {
-                x = positive_body_xor(x, pivot_z);
-            }
-        }
-        frame.xs[new_q] = x;
-        frame.zs[new_q] = z;
-        ++new_q;
-    }
-
-    if (!frame.satisfies_invariants()) {
-        throw std::logic_error("sampling planner produced an invalid active measurement frame");
-    }
-    return frame;
 }
 
 SymbolId reserve_symbol(SamplingPlan& plan) {

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -54,8 +54,7 @@ bool has_x_below(const PlannerPauli& pauli, uint32_t end) {
 }
 
 size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
-    static_cast<void>(
-        SymbolicPauliFrame::estimated_workspace_bytes(num_qubits, num_symbols));
+    static_cast<void>(SymbolicPauliFrame::estimated_workspace_bytes(num_qubits, num_symbols));
     return (static_cast<size_t>(num_symbols) + 63) / 64;
 }
 
@@ -79,8 +78,7 @@ void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordi
     initial_to_current_ = current_to_initial_.inverse();
 }
 
-size_t SymbolicPauliFrame::estimated_workspace_bytes(uint32_t num_qubits,
-                                                     uint32_t num_symbols) {
+size_t SymbolicPauliFrame::estimated_workspace_bytes(uint32_t num_qubits, uint32_t num_symbols) {
     const size_t words_per_row = (static_cast<size_t>(num_symbols) + 63) / 64;
     constexpr size_t kMax = std::numeric_limits<size_t>::max();
     const size_t qubits = num_qubits;
@@ -151,8 +149,7 @@ AffineBool SymbolicPauliFrame::sign_for(const PlannerPauli& observable) {
         while (word != 0) {
             const uint32_t bit = std::countr_zero(word);
             const size_t symbol = 64 * w + bit;
-            assert(symbol < num_symbols_ &&
-                   "symbolic Pauli frame contains an out-of-range term");
+            assert(symbol < num_symbols_ && "symbolic Pauli frame contains an out-of-range term");
             terms.push_back(SymbolId{static_cast<uint32_t>(symbol)});
             word &= word - 1;
         }

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -1,0 +1,330 @@
+#include "clifft/sampling/planner_frame.h"
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+
+namespace clifft::sampling::internal {
+
+namespace {
+
+std::vector<size_t> identity_indices(size_t size) {
+    std::vector<size_t> result(size);
+    std::iota(result.begin(), result.end(), size_t{0});
+    return result;
+}
+
+PlannerPauli single_x(uint32_t num_qubits, uint32_t q) {
+    PlannerPauli result(num_qubits);
+    result.xs[q] = true;
+    return result;
+}
+
+PlannerPauli single_z(uint32_t num_qubits, uint32_t q) {
+    PlannerPauli result(num_qubits);
+    result.zs[q] = true;
+    return result;
+}
+
+PlannerPauli positive_body_xor(const PlannerPauli& left, const PlannerPauli& right) {
+    // Callers only combine canonical generator rows whose nonidentity supports
+    // are disjoint. Overlapping supports could contribute a phase that this
+    // body-only helper intentionally does not compute.
+    PlannerPauli result(left);
+    result.xs ^= right.xs;
+    result.zs ^= right.zs;
+    result.sign = false;
+    return result;
+}
+
+bool anticommutes(const PlannerPauli& left, const PlannerPauli& right) {
+    return !left.ref().commutes(right.ref());
+}
+
+bool has_x_below(const PlannerPauli& pauli, uint32_t end) {
+    for (uint32_t q = 0; q < end; ++q) {
+        if (pauli.xs[q]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
+    static_cast<void>(
+        SymbolicPauliFrame::estimated_workspace_bytes(num_qubits, num_symbols));
+    return (static_cast<size_t>(num_symbols) + 63) / 64;
+}
+
+}  // namespace
+
+CoordinateFrame::CoordinateFrame(uint32_t num_qubits)
+    : current_to_initial_(num_qubits),
+      initial_to_current_(num_qubits),
+      indices_(identity_indices(num_qubits)) {}
+
+PlannerPauli CoordinateFrame::to_current(const PlannerPauli& initial) const {
+    return initial_to_current_.scatter_eval(initial.ref(), indices_);
+}
+
+PlannerPauli CoordinateFrame::to_initial(const PlannerPauli& current) const {
+    return current_to_initial_.scatter_eval(current.ref(), indices_);
+}
+
+void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordinates) {
+    current_to_initial_ = new_basis_in_old_coordinates.then(current_to_initial_);
+    initial_to_current_ = current_to_initial_.inverse();
+}
+
+size_t SymbolicPauliFrame::estimated_workspace_bytes(uint32_t num_qubits,
+                                                     uint32_t num_symbols) {
+    const size_t words_per_row = (static_cast<size_t>(num_symbols) + 63) / 64;
+    constexpr size_t kMax = std::numeric_limits<size_t>::max();
+    const size_t qubits = num_qubits;
+    if (qubits > (kMax - 1) / 2) {
+        throw std::length_error("sampling symbolic Pauli frame is too large");
+    }
+    const size_t packed_rows = 2 * qubits + 1;
+    if (words_per_row != 0 && packed_rows > kMax / words_per_row) {
+        throw std::length_error("sampling symbolic Pauli frame is too large");
+    }
+    const size_t packed_words = packed_rows * words_per_row;
+    const size_t constant_bytes = 2 * qubits * sizeof(uint8_t);
+    if (packed_words > (kMax - constant_bytes) / sizeof(uint64_t)) {
+        throw std::length_error("sampling symbolic Pauli frame is too large");
+    }
+    return packed_words * sizeof(uint64_t) + constant_bytes;
+}
+
+SymbolicPauliFrame::SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols)
+    : num_qubits_(num_qubits),
+      num_symbols_(num_symbols),
+      words_per_row_(validated_words_per_row(num_qubits, num_symbols)),
+      x_constants_(num_qubits, 0),
+      z_constants_(num_qubits, 0),
+      scratch_(words_per_row_, 0) {
+    const size_t storage_words = static_cast<size_t>(num_qubits) * words_per_row_;
+    x_terms_.assign(storage_words, 0);
+    z_terms_.assign(storage_words, 0);
+}
+
+void SymbolicPauliFrame::apply(const PlannerPauli& correction, const AffineBool& condition) {
+    assert(correction.num_qubits == num_qubits_ &&
+           "symbolic Pauli correction width must match the planner frame");
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        if (correction.xs[q]) {
+            xor_condition(x_row(q), x_constants_[q], condition);
+        }
+        if (correction.zs[q]) {
+            xor_condition(z_row(q), z_constants_[q], condition);
+        }
+    }
+}
+
+AffineBool SymbolicPauliFrame::sign_for(const PlannerPauli& observable) {
+    assert(observable.num_qubits == num_qubits_ &&
+           "symbolic Pauli observable width must match the planner frame");
+    std::ranges::fill(scratch_, uint64_t{0});
+    bool constant = false;
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        if (observable.xs[q]) {
+            xor_row(scratch_, z_row(q));
+            constant ^= z_constants_[q] != 0;
+        }
+        if (observable.zs[q]) {
+            xor_row(scratch_, x_row(q));
+            constant ^= x_constants_[q] != 0;
+        }
+    }
+
+    size_t term_count = 0;
+    for (uint64_t word : scratch_) {
+        term_count += std::popcount(word);
+    }
+    std::vector<SymbolId> terms;
+    terms.reserve(term_count);
+    for (size_t w = 0; w < scratch_.size(); ++w) {
+        uint64_t word = scratch_[w];
+        while (word != 0) {
+            const uint32_t bit = std::countr_zero(word);
+            const size_t symbol = 64 * w + bit;
+            assert(symbol < num_symbols_ &&
+                   "symbolic Pauli frame contains an out-of-range term");
+            terms.push_back(SymbolId{static_cast<uint32_t>(symbol)});
+            word &= word - 1;
+        }
+    }
+    return AffineBool(constant, std::move(terms));
+}
+
+std::span<uint64_t> SymbolicPauliFrame::x_row(uint32_t q) {
+    return std::span<uint64_t>{x_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                 words_per_row_);
+}
+
+std::span<const uint64_t> SymbolicPauliFrame::x_row(uint32_t q) const {
+    return std::span<const uint64_t>{x_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                       words_per_row_);
+}
+
+std::span<uint64_t> SymbolicPauliFrame::z_row(uint32_t q) {
+    return std::span<uint64_t>{z_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                 words_per_row_);
+}
+
+std::span<const uint64_t> SymbolicPauliFrame::z_row(uint32_t q) const {
+    return std::span<const uint64_t>{z_terms_}.subspan(static_cast<size_t>(q) * words_per_row_,
+                                                       words_per_row_);
+}
+
+void SymbolicPauliFrame::xor_row(std::span<uint64_t> destination,
+                                 std::span<const uint64_t> source) {
+    assert(destination.size() == source.size());
+    for (size_t w = 0; w < destination.size(); ++w) {
+        destination[w] ^= source[w];
+    }
+}
+
+void SymbolicPauliFrame::xor_condition(std::span<uint64_t> row, uint8_t& constant,
+                                       const AffineBool& condition) const {
+    constant ^= static_cast<uint8_t>(condition.constant());
+    for (SymbolId term : condition.terms()) {
+        const uint32_t symbol = index(term);
+        if (symbol >= num_symbols_) {
+            throw std::logic_error(
+                "sampling symbolic Pauli condition contains an out-of-range symbol");
+        }
+        row[symbol / 64] ^= uint64_t{1} << (symbol % 64);
+    }
+}
+
+PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted, uint32_t active_width,
+                                       uint32_t dormant_pivot) {
+    const uint32_t n = static_cast<uint32_t>(promoted.num_qubits);
+    PlannerTableau frame(n);
+    const PlannerPauli old_stabilizer = single_z(n, dormant_pivot);
+
+    // The rows express the new coordinate generators in the old basis. Making
+    // the promoted Pauli the next X generator turns its rotation into a
+    // single-coordinate expansion; the stabilizer products keep every other
+    // generator in a canonical symplectic pair.
+    for (uint32_t q = 0; q < active_width; ++q) {
+        PlannerPauli x = single_x(n, q);
+        PlannerPauli z = single_z(n, q);
+        if (anticommutes(x, promoted)) {
+            x = positive_body_xor(x, old_stabilizer);
+        }
+        if (anticommutes(z, promoted)) {
+            z = positive_body_xor(z, old_stabilizer);
+        }
+        frame.xs[q] = x;
+        frame.zs[q] = z;
+    }
+
+    frame.xs[active_width] = promoted;
+    frame.zs[active_width] = old_stabilizer;
+
+    uint32_t new_q = active_width + 1;
+    for (uint32_t old_q = active_width; old_q < n; ++old_q) {
+        if (old_q == dormant_pivot) {
+            continue;
+        }
+        PlannerPauli x = single_x(n, old_q);
+        PlannerPauli z = single_z(n, old_q);
+        if (anticommutes(x, promoted)) {
+            x = positive_body_xor(x, old_stabilizer);
+        }
+        if (anticommutes(z, promoted)) {
+            z = positive_body_xor(z, old_stabilizer);
+        }
+        frame.xs[new_q] = x;
+        frame.zs[new_q] = z;
+        ++new_q;
+    }
+
+    if (!frame.satisfies_invariants()) {
+        throw std::logic_error("sampling planner produced an invalid promotion frame");
+    }
+    return frame;
+}
+
+PlannerTableau dormant_measurement_frame(const PlannerPauli& measured, uint32_t dormant_pivot) {
+    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
+    PlannerTableau frame(n);
+    const PlannerPauli old_stabilizer = single_z(n, dormant_pivot);
+
+    // Replacing one dormant Z generator with the measured Pauli represents the
+    // collapsed eigenspace without changing the dense coefficient state.
+    for (uint32_t q = 0; q < n; ++q) {
+        if (q == dormant_pivot) {
+            continue;
+        }
+        PlannerPauli x = single_x(n, q);
+        PlannerPauli z = single_z(n, q);
+        if (anticommutes(x, measured)) {
+            x = positive_body_xor(x, old_stabilizer);
+        }
+        if (anticommutes(z, measured)) {
+            z = positive_body_xor(z, old_stabilizer);
+        }
+        frame.xs[q] = x;
+        frame.zs[q] = z;
+    }
+
+    frame.xs[dormant_pivot] = old_stabilizer;
+    frame.zs[dormant_pivot] = measured;
+
+    if (!frame.satisfies_invariants()) {
+        throw std::logic_error("sampling planner produced an invalid dormant measurement frame");
+    }
+    return frame;
+}
+
+PlannerTableau active_measurement_frame(const PlannerPauli& measured, uint32_t active_width,
+                                        uint32_t pivot) {
+    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
+    PlannerTableau frame(n);
+    const bool diagonal = !has_x_below(measured, active_width);
+    const PlannerPauli pivot_x = single_x(n, pivot);
+    const PlannerPauli pivot_z = single_z(n, pivot);
+
+    // Moving the measured Pauli to the last active Z generator gives the
+    // direct measurement kernel one coordinate to remove. The cumulative
+    // frame maps later operations into the remaining packed coordinates.
+    frame.zs[active_width - 1] = measured;
+    frame.xs[active_width - 1] = diagonal ? pivot_x : pivot_z;
+
+    uint32_t new_q = 0;
+    for (uint32_t old_q = 0; old_q < active_width; ++old_q) {
+        if (old_q == pivot) {
+            continue;
+        }
+        PlannerPauli x = single_x(n, old_q);
+        PlannerPauli z = single_z(n, old_q);
+        if (diagonal) {
+            if (measured.zs[old_q]) {
+                x = positive_body_xor(x, pivot_x);
+            }
+        } else {
+            if (measured.xs[old_q]) {
+                z = positive_body_xor(z, pivot_z);
+            }
+            if (measured.zs[old_q]) {
+                x = positive_body_xor(x, pivot_z);
+            }
+        }
+        frame.xs[new_q] = x;
+        frame.zs[new_q] = z;
+        ++new_q;
+    }
+
+    if (!frame.satisfies_invariants()) {
+        throw std::logic_error("sampling planner produced an invalid active measurement frame");
+    }
+    return frame;
+}
+
+}  // namespace clifft::sampling::internal

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -72,11 +72,10 @@ class SymbolicPauliFrame {
 // Each tableau maps newly selected planner coordinates into the previous
 // coordinate basis.
 [[nodiscard]] PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted,
-                                                      uint32_t active_width,
-                                                      uint32_t dormant_pivot);
+                                                     uint32_t active_width, uint32_t dormant_pivot);
 [[nodiscard]] PlannerTableau dormant_measurement_frame(const PlannerPauli& measured,
-                                                        uint32_t dormant_pivot);
+                                                       uint32_t dormant_pivot);
 [[nodiscard]] PlannerTableau active_measurement_frame(const PlannerPauli& measured,
-                                                       uint32_t active_width, uint32_t pivot);
+                                                      uint32_t active_width, uint32_t pivot);
 
 }  // namespace clifft::sampling::internal

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "clifft/sampling/plan.h"
+
+#include "stim.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace clifft::sampling::internal {
+
+using PlannerPauli = stim::PauliString<kStimWidth>;
+using PlannerTableau = stim::Tableau<kStimWidth>;
+
+// Tracks the cumulative relationship between physical HIR coordinates and the
+// packed stabilizer coordinates selected while planning.
+class CoordinateFrame {
+  public:
+    explicit CoordinateFrame(uint32_t num_qubits);
+
+    [[nodiscard]] PlannerPauli to_current(const PlannerPauli& initial) const;
+    [[nodiscard]] PlannerPauli to_initial(const PlannerPauli& current) const;
+
+    void change_basis(const PlannerTableau& new_basis_in_old_coordinates);
+
+  private:
+    // These two tableaus are maintained together so ordinary operations never
+    // pay for an inverse. The forward map is also needed when a sampled branch
+    // adds a Pauli correction expressed in the newly selected coordinates.
+    PlannerTableau current_to_initial_;
+    PlannerTableau initial_to_current_;
+    std::vector<size_t> indices_;
+};
+
+// Tracks how sampled Boolean symbols contribute Pauli corrections in the
+// initial physical coordinates. It uses O(num_qubits * num_symbols / 64) words
+// and is discarded before executable lowering or hot execution.
+class SymbolicPauliFrame {
+  public:
+    SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols);
+
+    void apply(const PlannerPauli& correction, const AffineBool& condition);
+    [[nodiscard]] AffineBool sign_for(const PlannerPauli& observable);
+
+    // Reports the packed row and scratch storage owned by the frame, excluding
+    // allocator and vector object overhead.
+    [[nodiscard]] static size_t estimated_workspace_bytes(uint32_t num_qubits,
+                                                          uint32_t num_symbols);
+
+  private:
+    [[nodiscard]] std::span<uint64_t> x_row(uint32_t q);
+    [[nodiscard]] std::span<const uint64_t> x_row(uint32_t q) const;
+    [[nodiscard]] std::span<uint64_t> z_row(uint32_t q);
+    [[nodiscard]] std::span<const uint64_t> z_row(uint32_t q) const;
+
+    static void xor_row(std::span<uint64_t> destination, std::span<const uint64_t> source);
+    void xor_condition(std::span<uint64_t> row, uint8_t& constant,
+                       const AffineBool& condition) const;
+
+    uint32_t num_qubits_;
+    uint32_t num_symbols_;
+    size_t words_per_row_;
+    std::vector<uint64_t> x_terms_;
+    std::vector<uint64_t> z_terms_;
+    std::vector<uint8_t> x_constants_;
+    std::vector<uint8_t> z_constants_;
+    std::vector<uint64_t> scratch_;
+};
+
+// Each tableau maps newly selected planner coordinates into the previous
+// coordinate basis.
+[[nodiscard]] PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted,
+                                                      uint32_t active_width,
+                                                      uint32_t dormant_pivot);
+[[nodiscard]] PlannerTableau dormant_measurement_frame(const PlannerPauli& measured,
+                                                        uint32_t dormant_pivot);
+[[nodiscard]] PlannerTableau active_measurement_frame(const PlannerPauli& measured,
+                                                       uint32_t active_width, uint32_t pivot);
+
+}  // namespace clifft::sampling::internal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(clifft_tests
     test_backend.cc
     test_sampling_plan.cc
     test_sampling_planner.cc
+    test_sampling_planner_frame.cc
     test_sampling_executor.cc
     test_fused_rotation.cc
     test_sampling_kernels.cc

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -132,6 +132,12 @@ TEST_CASE("Sampling plan affine expressions are canonical") {
     REQUIRE((expression ^ expression) == AffineBool(false));
     REQUIRE((true ^ expression).constant());
     REQUIRE((true ^ expression).terms() == std::vector<SymbolId>{s0});
+
+    AffineBool inserted(false, {s0, s2});
+    inserted ^= AffineBool::symbol(s1);
+    REQUIRE(inserted.terms() == std::vector<SymbolId>{s0, s1, s2});
+    inserted ^= AffineBool::symbol(s2);
+    REQUIRE(inserted.terms() == std::vector<SymbolId>{s0, s1});
 }
 
 TEST_CASE("Sampling plan validates symbolic and active state invariants") {

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -397,6 +397,41 @@ TEST_CASE("Sampling planner eliminates Pauli noise and feedback into record expr
     REQUIRE(action_as<RecordClassical>(plan, 1).outcome == AffineBool::symbol(noise));
 }
 
+TEST_CASE("Sampling planner carries symbolic frame across coordinate changes") {
+    const SamplingPlan plan = plan_sampling(clifft::trace(clifft::parse(R"(
+        H 0
+        T 0
+        X_ERROR(1) 1
+        MPP X0*Z1
+        CX rec[-1] 2
+        H 2
+        T 2
+        MPP Y0*X2
+        M 0 1 2
+    )")));
+
+    REQUIRE(plan.actions.size() == 7);
+    REQUIRE(plan.symbols.size() == 6);
+    const SymbolId noise = plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    const auto& first_measurement = action_as<MeasureActivePauli>(plan, 1);
+    REQUIRE(first_measurement.outcome ==
+            (AffineBool::symbol(noise) ^ AffineBool::symbol(first_measurement.branch)));
+
+    const auto& mixed_measurement = action_as<MeasureDormantRandom>(plan, 3);
+    REQUIRE(mixed_measurement.outcome ==
+            (AffineBool::symbol(noise) ^ AffineBool::symbol(mixed_measurement.branch) ^ true));
+
+    const auto& first_final_measurement = action_as<MeasureDormantRandom>(plan, 4);
+    REQUIRE(first_final_measurement.outcome ==
+            (AffineBool::symbol(mixed_measurement.branch) ^
+             AffineBool::symbol(first_final_measurement.branch)));
+    REQUIRE(action_as<RecordClassical>(plan, 5).outcome == AffineBool::symbol(noise));
+
+    const auto& last_measurement = action_as<MeasureActivePauli>(plan, 6);
+    REQUIRE(last_measurement.outcome == (AffineBool::symbol(first_final_measurement.branch) ^
+                                         AffineBool::symbol(last_measurement.branch)));
+}
+
 TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
     const HirModule hir = clifft::trace(clifft::parse(R"(
         M 0

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -202,9 +202,18 @@ TEST_CASE("Sampling planner fixes instrument source handling before execution") 
     REQUIRE(instrument(classical).mode == InstrumentMode::Classical);
     REQUIRE(std::holds_alternative<InstrumentBoundary>(classical.actions.back().action));
 
-    const SamplingPlan activated = plan_for("H 0\nLEVEL_TRANSITION[jump] 0", false);
-    REQUIRE(instrument(activated).mode == InstrumentMode::Activate);
-    REQUIRE(activated.max_active_width == 1);
+    const SamplingPlan activated = plan_for("H 0\nT 0\nH 1\nLEVEL_TRANSITION[jump] 1\nM 1", false);
+    const ApplyInstrument& activated_instrument = instrument(activated);
+    REQUIRE(activated_instrument.mode == InstrumentMode::Activate);
+    REQUIRE(activated_instrument.source.x == 2);
+    REQUIRE(activated_instrument.source.z == 0);
+    REQUIRE(activated_instrument.sign == AffineBool(false));
+    REQUIRE(activated_instrument.destination_flip.has_value());
+    REQUIRE(activated.max_active_width == 2);
+    const auto& after_activation = action_as<MeasureActivePauli>(activated, 3);
+    REQUIRE(after_activation.outcome ==
+            (AffineBool::symbol(*activated_instrument.destination_flip) ^
+             AffineBool::symbol(after_activation.branch)));
 
     const SamplingPlan active = plan_for("H 0\nT 0\nLEVEL_TRANSITION[jump] 0", false);
     REQUIRE(instrument(active).mode == InstrumentMode::Active);

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -1,0 +1,110 @@
+#include "clifft/sampling/planner_frame.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+using clifft::sampling::AffineBool;
+using clifft::sampling::SymbolId;
+using clifft::sampling::internal::active_measurement_frame;
+using clifft::sampling::internal::CoordinateFrame;
+using clifft::sampling::internal::dormant_measurement_frame;
+using clifft::sampling::internal::dormant_promotion_frame;
+using clifft::sampling::internal::PlannerPauli;
+using clifft::sampling::internal::PlannerTableau;
+using clifft::sampling::internal::SymbolicPauliFrame;
+
+TEST_CASE("Planner coordinate frame round trips composed basis changes") {
+    CoordinateFrame coordinates(3);
+    PlannerTableau first(3);
+    first.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
+    PlannerTableau second(3);
+    second.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(), {0, 1});
+
+    PlannerPauli initial(3);
+    initial.xs[0] = true;
+    initial.zs[1] = true;
+    initial.sign = true;
+
+    coordinates.change_basis(first);
+    const PlannerPauli after_first = coordinates.to_current(initial);
+    REQUIRE(after_first.xs[0] == false);
+    REQUIRE(after_first.zs[0] == true);
+    REQUIRE(after_first.zs[1] == true);
+    REQUIRE(coordinates.to_initial(after_first) == initial);
+
+    coordinates.change_basis(second);
+    const PlannerPauli after_second = coordinates.to_current(initial);
+    REQUIRE(coordinates.to_initial(after_second) == initial);
+}
+
+TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
+    SymbolicPauliFrame frame(2, 130);
+    const AffineBool wide_condition(
+        true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});
+
+    PlannerPauli x_correction(2);
+    x_correction.xs[0] = true;
+    frame.apply(x_correction, wide_condition);
+
+    PlannerPauli z_observable(2);
+    z_observable.zs[0] = true;
+    REQUIRE(frame.sign_for(z_observable) == wide_condition);
+
+    PlannerPauli z_correction(2);
+    z_correction.zs[0] = true;
+    frame.apply(z_correction, AffineBool::symbol(SymbolId{1}));
+
+    PlannerPauli y_observable(2);
+    y_observable.xs[0] = true;
+    y_observable.zs[0] = true;
+    REQUIRE(frame.sign_for(y_observable) ==
+            (wide_condition ^ AffineBool::symbol(SymbolId{1})));
+
+    frame.apply(x_correction, wide_condition);
+    REQUIRE(frame.sign_for(z_observable) == AffineBool(false));
+    REQUIRE(SymbolicPauliFrame::estimated_workspace_bytes(2, 130) == 124);
+}
+
+TEST_CASE("Planner symbolic frame rejects unknown symbols") {
+    SymbolicPauliFrame frame(1, 1);
+    PlannerPauli correction(1);
+    correction.xs[0] = true;
+
+    REQUIRE_THROWS_AS(frame.apply(correction, AffineBool::symbol(SymbolId{1})), std::logic_error);
+}
+
+TEST_CASE("Planner promotion frame localizes the promoted observable") {
+    PlannerPauli promoted(3);
+    promoted.zs[0] = true;
+    promoted.xs[2] = true;
+
+    const PlannerTableau frame = dormant_promotion_frame(promoted, 1, 2);
+    REQUIRE(frame.satisfies_invariants());
+    REQUIRE(frame.xs[1] == promoted);
+
+    const PlannerTableau old_to_new = frame.inverse();
+    const PlannerPauli localized =
+        old_to_new.scatter_eval(promoted.ref(), std::vector<size_t>{0, 1, 2});
+    PlannerPauli expected(3);
+    expected.xs[1] = true;
+    REQUIRE(localized == expected);
+}
+
+TEST_CASE("Planner measurement frames install the selected observables") {
+    PlannerPauli dormant(3);
+    dormant.zs[0] = true;
+    dormant.xs[2] = true;
+    const PlannerTableau dormant_frame = dormant_measurement_frame(dormant, 2);
+    REQUIRE(dormant_frame.satisfies_invariants());
+    REQUIRE(dormant_frame.zs[2] == dormant);
+
+    PlannerPauli active(3);
+    active.xs[0] = true;
+    active.zs[1] = true;
+    const PlannerTableau active_frame = active_measurement_frame(active, 2, 0);
+    REQUIRE(active_frame.satisfies_invariants());
+    REQUIRE(active_frame.zs[1] == active);
+}

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -1,7 +1,6 @@
 #include "clifft/sampling/planner_frame.h"
 
 #include <catch2/catch_test_macros.hpp>
-
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
@@ -42,8 +41,7 @@ TEST_CASE("Planner coordinate frame round trips composed basis changes") {
 
 TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
     SymbolicPauliFrame frame(2, 130);
-    const AffineBool wide_condition(
-        true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});
+    const AffineBool wide_condition(true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});
 
     PlannerPauli x_correction(2);
     x_correction.xs[0] = true;
@@ -60,8 +58,7 @@ TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
     PlannerPauli y_observable(2);
     y_observable.xs[0] = true;
     y_observable.zs[0] = true;
-    REQUIRE(frame.sign_for(y_observable) ==
-            (wide_condition ^ AffineBool::symbol(SymbolId{1})));
+    REQUIRE(frame.sign_for(y_observable) == (wide_condition ^ AffineBool::symbol(SymbolId{1})));
 
     frame.apply(x_correction, wide_condition);
     REQUIRE(frame.sign_for(z_observable) == AffineBool(false));

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -5,9 +5,10 @@ sampling profilers:
 
 - `profile_svm` compiles a circuit once and runs many shots, so the SVM hot
   loops accumulate enough samples for meaningful analysis.
-- `profile_compile` loops parse → trace → lower → bytecode passes many
-  times with no shots, so a `perf record` run captures the compile path
-  rather than the sampling loop. Useful for workflows that recompile
+- `profile_compile` loops the selected production compile path many times with
+  no shots, so a sampling profiler captures compilation rather than execution.
+  It can measure either the legacy lower/bytecode path or the symbolic
+  planner/executable-plan path. This is useful for workflows that recompile
   often (e.g. stratified loss-topology sampling).
 - `profile_probability` compiles a unitary circuit and calls
   `clifft::basis_probabilities()` over a batch of bitstrings, so a `perf record`
@@ -58,6 +59,7 @@ CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim CLIFFT_SHOTS=10 ./buil
 | `CLIFFT_T_GATES` | 0 | Number of T-gates to append |
 | `CLIFFT_SHOTS` | 100000 | Number of shots to sample (`profile_svm`) |
 | `CLIFFT_COMPILE_ITERATIONS` | 20 | Number of compile iterations (`profile_compile`) |
+| `CLIFFT_COMPILE_BACKEND` | `legacy` | Compile path for `profile_compile`: `legacy` or `symbolic` |
 | `CLIFFT_QUERIES` | 100 | Number of bitstring queries (`profile_probability`) |
 | `CLIFFT_POSTSELECT_ALL` | *(unset)* | If set, all detectors become postselects |
 
@@ -76,6 +78,12 @@ timings match what `clifft.compile()` would actually pay.
 ```bash
 # Per-stage timings only
 CLIFFT_COMPILE_ITERATIONS=20 \
+  CLIFFT_CIRCUIT_FILE=tests/fixtures/target_qec.stim \
+  ./build/profile_compile
+
+# Split symbolic compilation into planner and executable preparation timings
+CLIFFT_COMPILE_BACKEND=symbolic \
+  CLIFFT_COMPILE_ITERATIONS=20 \
   CLIFFT_CIRCUIT_FILE=tests/fixtures/target_qec.stim \
   ./build/profile_compile
 

--- a/tools/profile/profile_compile.cpp
+++ b/tools/profile/profile_compile.cpp
@@ -14,6 +14,7 @@
 #include "clifft/optimizer/pass_factory.h"
 #include "clifft/sampling/executable_plan.h"
 #include "clifft/sampling/planner.h"
+#include "clifft/sampling/planner_frame.h"
 #include "clifft/svm/svm.h"
 
 #include <algorithm>
@@ -249,12 +250,9 @@ int main() {
                 planned_actions = plan.actions.size();
                 planned_symbols = plan.symbols.size();
                 max_active_width = plan.max_active_width;
-                const size_t symbol_words = (planned_symbols + 63) / 64;
-                // Mirrors the current planner-only SymbolicPauliFrame layout:
-                // packed X/Z rows, one scratch row, and X/Z constant bytes.
                 estimated_symbolic_frame_bytes =
-                    (2 * static_cast<size_t>(total_qubits) + 1) * symbol_words * sizeof(uint64_t) +
-                    2 * static_cast<size_t>(total_qubits) * sizeof(uint8_t);
+                    clifft::sampling::internal::SymbolicPauliFrame::estimated_workspace_bytes(
+                        total_qubits, static_cast<uint32_t>(planned_symbols));
             }
 
             t0 = std::chrono::high_resolution_clock::now();

--- a/tools/profile/profile_compile.cpp
+++ b/tools/profile/profile_compile.cpp
@@ -1,9 +1,8 @@
 // Clifft compilation profiler
 //
 // Sibling to profile_svm.cpp, but biased toward compilation rather than
-// sampling. Loops parse -> trace -> HirPassManager -> lower ->
-// BytecodePassManager many times so a `perf record` run captures the
-// compile path instead of the sample loop.
+// sampling. Loops the selected production compilation path many times so a
+// sampling profiler captures compilation instead of execution.
 //
 // See tools/profile/README.md for build instructions.
 
@@ -13,6 +12,8 @@
 #include "clifft/optimizer/bytecode_pass.h"
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_factory.h"
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/planner.h"
 #include "clifft/svm/svm.h"
 
 #include <algorithm>
@@ -24,6 +25,7 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
@@ -33,6 +35,8 @@ constexpr int kDefaultNumQubits = 50;
 constexpr int kDefaultCliffordDepth = 5000;
 constexpr int kDefaultTGates = 0;
 constexpr uint64_t kSeed = 42;
+
+enum class CompileBackend { Legacy, Symbolic };
 
 std::string generate_circuit(int num_qubits, int clifford_depth, int t_gates, uint64_t seed) {
     std::mt19937_64 rng(seed);
@@ -73,6 +77,22 @@ bool get_env_bool(const char* name) {
     return val != nullptr && std::string(val) != "0" && std::string(val) != "";
 }
 
+CompileBackend get_compile_backend() {
+    const char* value = std::getenv("CLIFFT_COMPILE_BACKEND");
+    if (value == nullptr || std::string_view(value) == "legacy") {
+        return CompileBackend::Legacy;
+    }
+    if (std::string_view(value) == "symbolic") {
+        return CompileBackend::Symbolic;
+    }
+    std::cerr << "Error: CLIFFT_COMPILE_BACKEND must be legacy or symbolic\n";
+    std::exit(1);
+}
+
+const char* backend_name(CompileBackend backend) {
+    return backend == CompileBackend::Legacy ? "legacy" : "symbolic";
+}
+
 std::string read_file(const std::string& path) {
     std::ifstream f(path);
     if (!f.is_open()) {
@@ -89,10 +109,12 @@ struct StageTimings {
     double trace_ms = 0.0;  // includes HirPassManager
     double lower_ms = 0.0;
     double bpm_ms = 0.0;
+    double plan_ms = 0.0;
+    double prepare_ms = 0.0;
 };
 
 double total_ms(const StageTimings& t) {
-    return t.parse_ms + t.trace_ms + t.lower_ms + t.bpm_ms;
+    return t.parse_ms + t.trace_ms + t.lower_ms + t.bpm_ms + t.plan_ms + t.prepare_ms;
 }
 
 void summarize(const std::string& label, std::vector<double> samples) {
@@ -122,6 +144,7 @@ int main() {
     int t_gates = get_env_int("CLIFFT_T_GATES", kDefaultTGates);
     const char* circuit_file = std::getenv("CLIFFT_CIRCUIT_FILE");
     bool postselect_all = get_env_bool("CLIFFT_POSTSELECT_ALL");
+    const CompileBackend backend = get_compile_backend();
 
     std::cout << "Clifft Compile Profiler\n";
     std::cout << "================\n";
@@ -142,10 +165,12 @@ int main() {
         std::cout << " (generated)\n";
         circuit_text = generate_circuit(num_qubits, clifford_depth, t_gates, kSeed);
     }
+    std::cout << "Backend:        " << backend_name(backend) << "\n";
     std::cout << "Iterations:     " << iterations << "\n";
     std::cout << "Postselect all: " << (postselect_all ? "yes" : "no") << "\n";
     std::cout << "(Set CLIFFT_COMPILE_ITERATIONS, CLIFFT_CIRCUIT_FILE, CLIFFT_NUM_QUBITS, "
-                 "CLIFFT_CLIFFORD_DEPTH, CLIFFT_T_GATES, CLIFFT_POSTSELECT_ALL)\n\n";
+                 "CLIFFT_CLIFFORD_DEPTH, CLIFFT_T_GATES, CLIFFT_POSTSELECT_ALL, "
+                 "CLIFFT_COMPILE_BACKEND)\n\n";
 
     std::vector<StageTimings> samples;
     samples.reserve(iterations);
@@ -154,7 +179,12 @@ int main() {
     size_t bytecode_size_pre = 0;
     size_t bytecode_size_post = 0;
     uint32_t peak_rank = 0;
+    uint32_t max_active_width = 0;
     uint32_t total_qubits = 0;
+    size_t planned_actions = 0;
+    size_t executable_actions = 0;
+    size_t planned_symbols = 0;
+    size_t symbolic_frame_bytes = 0;
 
     auto outer_start = std::chrono::high_resolution_clock::now();
 
@@ -189,25 +219,49 @@ int main() {
             postselection_mask.assign(num_det, 1);
         }
 
-        // Backend lower()
-        t0 = std::chrono::high_resolution_clock::now();
-        clifft::CompiledModule program = clifft::lower(hir, postselection_mask);
-        t1 = std::chrono::high_resolution_clock::now();
-        t.lower_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-        if (iter == 0) {
-            bytecode_size_pre = program.bytecode.size();
-            peak_rank = program.peak_rank;
-            total_qubits = program.num_qubits;
-        }
+        total_qubits = hir.num_qubits;
+        if (backend == CompileBackend::Legacy) {
+            // Backend lower()
+            t0 = std::chrono::high_resolution_clock::now();
+            clifft::CompiledModule program = clifft::lower(hir, postselection_mask);
+            t1 = std::chrono::high_resolution_clock::now();
+            t.lower_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            if (iter == 0) {
+                bytecode_size_pre = program.bytecode.size();
+                peak_rank = program.peak_rank;
+            }
 
-        // Bytecode pass manager (production default set).
-        t0 = std::chrono::high_resolution_clock::now();
-        auto bpm = clifft::default_bytecode_pass_manager();
-        bpm.run(program);
-        t1 = std::chrono::high_resolution_clock::now();
-        t.bpm_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-        if (iter == 0)
-            bytecode_size_post = program.bytecode.size();
+            // Bytecode pass manager (production default set).
+            t0 = std::chrono::high_resolution_clock::now();
+            auto bpm = clifft::default_bytecode_pass_manager();
+            bpm.run(program);
+            t1 = std::chrono::high_resolution_clock::now();
+            t.bpm_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            if (iter == 0)
+                bytecode_size_post = program.bytecode.size();
+        } else {
+            t0 = std::chrono::high_resolution_clock::now();
+            clifft::sampling::SamplingPlan plan =
+                clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection_mask});
+            t1 = std::chrono::high_resolution_clock::now();
+            t.plan_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            if (iter == 0) {
+                planned_actions = plan.actions.size();
+                planned_symbols = plan.symbols.size();
+                max_active_width = plan.max_active_width;
+                const size_t symbol_words = (planned_symbols + 63) / 64;
+                symbolic_frame_bytes =
+                    (2 * static_cast<size_t>(total_qubits) + 1) * symbol_words * sizeof(uint64_t) +
+                    2 * static_cast<size_t>(total_qubits) * sizeof(uint8_t);
+            }
+
+            t0 = std::chrono::high_resolution_clock::now();
+            clifft::sampling::ExecutablePlan program(plan);
+            t1 = std::chrono::high_resolution_clock::now();
+            t.prepare_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            if (iter == 0)
+                executable_actions = program.num_actions();
+        }
 
         samples.push_back(t);
 
@@ -217,32 +271,52 @@ int main() {
             std::cout << "First-iteration timings (warmup):\n";
             std::cout << "  parse:  " << t.parse_ms << " ms\n";
             std::cout << "  trace:  " << t.trace_ms << " ms\n";
-            std::cout << "  lower:  " << t.lower_ms << " ms\n";
-            std::cout << "  bpm:    " << t.bpm_ms << " ms\n";
+            if (backend == CompileBackend::Legacy) {
+                std::cout << "  lower:  " << t.lower_ms << " ms\n";
+                std::cout << "  bpm:    " << t.bpm_ms << " ms\n";
+            } else {
+                std::cout << "  plan:   " << t.plan_ms << " ms\n";
+                std::cout << "  prepare: " << t.prepare_ms << " ms\n";
+            }
             std::cout << "  total:  " << total_ms(t) << " ms\n";
-            std::cout << "Module: " << total_qubits << " qubits, peak_rank " << peak_rank << ", "
-                      << parsed_ops << " parsed ops, " << bytecode_size_pre << " -> "
-                      << bytecode_size_post << " bytecode instructions\n\n";
+            std::cout << "Module: " << total_qubits << " qubits, ";
+            if (backend == CompileBackend::Legacy) {
+                std::cout << "peak_rank " << peak_rank << ", " << parsed_ops << " parsed ops, "
+                          << bytecode_size_pre << " -> " << bytecode_size_post
+                          << " bytecode instructions\n\n";
+            } else {
+                std::cout << "max_active_width " << max_active_width << ", " << parsed_ops
+                          << " parsed ops, " << planned_actions << " -> " << executable_actions
+                          << " actions, " << planned_symbols << " symbols, " << symbolic_frame_bytes
+                          << " symbolic-frame workspace bytes\n\n";
+            }
         }
     }
 
     auto outer_end = std::chrono::high_resolution_clock::now();
     double outer_ms = std::chrono::duration<double, std::milli>(outer_end - outer_start).count();
 
-    std::vector<double> parse_v, trace_v, lower_v, bpm_v, total_v;
+    std::vector<double> parse_v, trace_v, lower_v, bpm_v, plan_v, prepare_v, total_v;
     for (const auto& s : samples) {
         parse_v.push_back(s.parse_ms);
         trace_v.push_back(s.trace_ms);
         lower_v.push_back(s.lower_ms);
         bpm_v.push_back(s.bpm_ms);
+        plan_v.push_back(s.plan_ms);
+        prepare_v.push_back(s.prepare_ms);
         total_v.push_back(total_ms(s));
     }
 
     std::cout << "Per-stage distribution across " << iterations << " iterations:\n";
     summarize("parse  ", parse_v);
     summarize("trace  ", trace_v);
-    summarize("lower  ", lower_v);
-    summarize("bpm    ", bpm_v);
+    if (backend == CompileBackend::Legacy) {
+        summarize("lower  ", lower_v);
+        summarize("bpm    ", bpm_v);
+    } else {
+        summarize("plan   ", plan_v);
+        summarize("prepare", prepare_v);
+    }
     summarize("total  ", total_v);
 
     double mean_total = 0;

--- a/tools/profile/profile_compile.cpp
+++ b/tools/profile/profile_compile.cpp
@@ -184,7 +184,7 @@ int main() {
     size_t planned_actions = 0;
     size_t executable_actions = 0;
     size_t planned_symbols = 0;
-    size_t symbolic_frame_bytes = 0;
+    size_t estimated_symbolic_frame_bytes = 0;
 
     auto outer_start = std::chrono::high_resolution_clock::now();
 
@@ -250,7 +250,9 @@ int main() {
                 planned_symbols = plan.symbols.size();
                 max_active_width = plan.max_active_width;
                 const size_t symbol_words = (planned_symbols + 63) / 64;
-                symbolic_frame_bytes =
+                // Mirrors the current planner-only SymbolicPauliFrame layout:
+                // packed X/Z rows, one scratch row, and X/Z constant bytes.
+                estimated_symbolic_frame_bytes =
                     (2 * static_cast<size_t>(total_qubits) + 1) * symbol_words * sizeof(uint64_t) +
                     2 * static_cast<size_t>(total_qubits) * sizeof(uint8_t);
             }
@@ -287,8 +289,9 @@ int main() {
             } else {
                 std::cout << "max_active_width " << max_active_width << ", " << parsed_ops
                           << " parsed ops, " << planned_actions << " -> " << executable_actions
-                          << " actions, " << planned_symbols << " symbols, " << symbolic_frame_bytes
-                          << " symbolic-frame workspace bytes\n\n";
+                          << " actions, " << planned_symbols << " symbols, "
+                          << estimated_symbolic_frame_bytes
+                          << " estimated symbolic-frame workspace bytes\n\n";
             }
         }
     }


### PR DESCRIPTION
## Summary

- replace eager pending-suffix coordinate rewrites with a cumulative coordinate frame that localizes each Pauli when planning reaches it
- accumulate noise, feedback, measurement branches, and instrument destination flips in a packed forward symbolic Pauli frame
- preserve the semantic `SamplingPlan` / `AffineBool` boundary and the existing flat symbol-major executable dependency tape
- add symbolic planning and executable-preparation stages to the native compile profiler

The symbolic frame follows the same broad `p_x` / `p_z` idea as the legacy virtual frame and the symbolic Clifford-Pauli-frame separation described by [SymFT](https://arxiv.org/abs/2607.28600). Runtime topology planning, the legacy instruction ABI, and hot execution are unchanged.

## Planner-stage results

RelWithDebInfo on Apple Silicon; medians compare the same fixtures before and after this branch:

| Fixture | Before | After | Speedup | Frame workspace |
| --- | ---: | ---: | ---: | ---: |
| target QEC | 2.94 ms | 0.65 ms | 4.5x | 7,684 B |
| cultivation d5 | 159.1 ms | 12.24 ms | 13.0x | 172,804 B |
| QV-20 seed 42 | 10.13 ms | 2.23 ms | 4.5x | 368 B |

The remaining cultivation planner profile is dominated by cumulative tableau composition/inversion. Executable preparation and semantic affine-expression ownership are not the current planner bottleneck.

## Batching disposition

This PR does not implement batching. It keeps batching straightforward by leaving `SamplingPlan` lane-independent; `ExecutablePlan` continues to lower affine expressions into its scalar symbol-major dependency tape, while a future batch executor can lower the same semantic expressions into a bit-sliced lane layout.

## Validation

- `ctest --test-dir build-debug --output-on-failure -j4 -E "^Bench:"`: 1,253/1,253 passed
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`: passed
- focused planner and canonical affine-expression regressions
- symbolic compile-profiler smoke checks for both symbolic and legacy backends

Refs #247. Supports the planner and continuation-compile track in #280.
