### PR TITLE
perf: vectorize lane-paired symbolic rotations

### DIFF
--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -18,6 +18,10 @@ DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotat
                                                 : DirectRotationKernel::Scalar;
     }
     const uint64_t pairing_bit = rotation.pauli.pair_selector;
+    if (pairing_bit < (uint64_t{1} << 3)) {
+        return rotation.pauli.active_width >= 3 ? DirectRotationKernel::LanePaired
+                                                : DirectRotationKernel::Scalar;
+    }
     // Pivot four has a distinct stride-16 access pattern that regressed against
     // scalar at every measured width, so it remains on the fallback until a
     // kernel designed for that shape is available.

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -9,25 +9,31 @@ namespace clifft::sampling {
 
 namespace {
 
+// One full vector block: the dense state must span the vector lanes before a
+// whole-block kernel is profitable or even addressable.
+constexpr uint32_t kMinVectorActiveWidth = 3;
+static_assert(uint64_t{1} << kMinVectorActiveWidth == kAvx512DoubleLanes);
+
+// Stride-16 pairing regressed against scalar at every measured active width,
+// so this pivot stays on the fallback until a kernel designed for it exists.
+constexpr uint64_t kPivotFourSelector = uint64_t{1} << 4;
+
 DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotation) noexcept {
     if (rotation.pauli.is_identity()) {
         return DirectRotationKernel::Scalar;
     }
     if (rotation.pauli.is_diagonal()) {
-        return rotation.pauli.active_width >= 3 ? DirectRotationKernel::Diagonal
-                                                : DirectRotationKernel::Scalar;
+        return rotation.pauli.active_width >= kMinVectorActiveWidth ? DirectRotationKernel::Diagonal
+                                                                    : DirectRotationKernel::Scalar;
     }
     const uint64_t pairing_bit = rotation.pauli.pair_selector;
-    if (pairing_bit < (uint64_t{1} << 3)) {
-        return rotation.pauli.active_width >= 3 ? DirectRotationKernel::LanePaired
-                                                : DirectRotationKernel::Scalar;
+    if (pairing_bit < kAvx512DoubleLanes) {
+        return rotation.pauli.active_width >= kMinVectorActiveWidth
+                   ? DirectRotationKernel::LanePaired
+                   : DirectRotationKernel::Scalar;
     }
-    // Pivot four has a distinct stride-16 access pattern that regressed against
-    // scalar at every measured width, so it remains on the fallback until a
-    // kernel designed for that shape is available.
-    return pairing_bit >= (uint64_t{1} << 3) && pairing_bit != (uint64_t{1} << 4)
-               ? DirectRotationKernel::HighPivot
-               : DirectRotationKernel::Scalar;
+    return pairing_bit != kPivotFourSelector ? DirectRotationKernel::HighPivot
+                                             : DirectRotationKernel::Scalar;
 }
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)

--- a/src/clifft/sampling/direct_rotation_dispatch.h
+++ b/src/clifft/sampling/direct_rotation_dispatch.h
@@ -16,6 +16,7 @@ enum class DirectRotationKernel : uint8_t {
     Scalar,
     Diagonal,
     HighPivot,
+    LanePaired,
 };
 
 static_assert(sizeof(DirectRotationKernel) == 1);

--- a/src/clifft/sampling/direct_rotation_simd.h
+++ b/src/clifft/sampling/direct_rotation_simd.h
@@ -2,7 +2,13 @@
 
 #include "clifft/sampling/direct_rotation_dispatch.h"
 
+#include <cstdint>
+
 namespace clifft::sampling {
+
+// Lane count of one 512-bit double vector. Both the portable kernel selector
+// and the AVX-512 translation unit measure shape eligibility against it.
+inline constexpr uint64_t kAvx512DoubleLanes = 8;
 
 // This function is linked only on x86-64 runtime-dispatch builds and must be
 // called only after the dispatcher has selected AVX-512.

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -22,7 +22,7 @@ namespace {
 // State stores amplitudes in separate real and imaginary arrays. A SIMD lane
 // is one basis index in either array, so matching lanes from a real vector and
 // an imaginary vector represent eight consecutive complex amplitudes.
-constexpr size_t kLanes = 8;
+constexpr size_t kLanes = kAvx512DoubleLanes;
 constexpr size_t kDimension = 4;
 constexpr size_t kMatrixSize = kDimension * kDimension;
 

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -98,6 +98,51 @@ void apply_diagonal_rotation_avx512(State& state, const PreparedRotation& rotati
     }
 }
 
+// A low pairing pivot keeps both members of every coefficient pair in one
+// vector. Computing all lanes from the original block avoids scalar pair
+// enumeration. Hermiticity determines the partner phase from the current lane,
+// avoiding another permutation or a gather.
+template <bool RealPhase>
+void apply_lane_paired_rotation_avx512(State& state, const PreparedRotation& rotation,
+                                       double sine) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector < kLanes &&
+           rotation.pauli.active_width >= 3 &&
+           "AVX-512 lane-paired rotation requires one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const __m512d cosine = _mm512_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m512d input_real = _mm512_load_pd(real + basis);
+        const __m512d input_imag = _mm512_load_pd(imag + basis);
+        const __m512d partner_real = _mm512_permutexvar_pd(permutation, input_real);
+        const __m512d partner_imag = _mm512_permutexvar_pd(permutation, input_imag);
+        const __m512d basis_sine = signed_sine_lanes(basis, rotation.pauli.z, sine * base_phase);
+        const __m512d partner_sine =
+            RealPhase ? basis_sine : _mm512_sub_pd(_mm512_setzero_pd(), basis_sine);
+
+        __m512d output_real;
+        __m512d output_imag;
+        if constexpr (RealPhase) {
+            output_real =
+                _mm512_fmadd_pd(partner_sine, partner_imag, _mm512_mul_pd(cosine, input_real));
+            output_imag =
+                _mm512_fnmadd_pd(partner_sine, partner_real, _mm512_mul_pd(cosine, input_imag));
+        } else {
+            output_real =
+                _mm512_fmadd_pd(partner_sine, partner_real, _mm512_mul_pd(cosine, input_real));
+            output_imag =
+                _mm512_fmadd_pd(partner_sine, partner_imag, _mm512_mul_pd(cosine, input_imag));
+        }
+        _mm512_store_pd(real + basis, output_real);
+        _mm512_store_pd(imag + basis, output_imag);
+    }
+}
+
 // A pivot at or above the lane bits pairs two aligned vector blocks. XORing the
 // full X mask finds the partner block, while one fixed permutation accounts
 // for X bits within each block.
@@ -250,6 +295,13 @@ void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation
                 apply_nondiagonal_rotation_avx512<true>(state, rotation, sine);
             } else {
                 apply_nondiagonal_rotation_avx512<false>(state, rotation, sine);
+            }
+            return;
+        case DirectRotationKernel::LanePaired:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_lane_paired_rotation_avx512<true>(state, rotation, sine);
+            } else {
+                apply_lane_paired_rotation_avx512<false>(state, rotation, sine);
             }
             return;
         case DirectRotationKernel::Scalar:

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -161,6 +161,17 @@ TEST_CASE("Direct rotation SIMD matches scalar for every lane-paired mask") {
     require_matches_scalar(plan, 1, rotations.size());
 }
 
+TEST_CASE("Direct rotation SIMD matches scalar for imaginary lane pairs with high Z") {
+    const std::array rotations = {
+        RotateActivePauli{{0b001, 0b111001}, 0.2, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b110, 0b101010}, -0.3, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b101, 0b011100}, 0.45, AffineBool::symbol(SymbolId{0})},
+    };
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    require_matches_scalar(plan, 0, rotations.size());
+    require_matches_scalar(plan, 1, rotations.size());
+}
+
 TEST_CASE("Direct rotation SIMD matches scalar with intermediate high bits") {
     const std::array rotations = {
         RotateActivePauli{{0b101010, 0b001110}, 0.2, AffineBool::symbol(SymbolId{0})},

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -148,6 +148,19 @@ TEST_CASE("Direct rotation SIMD matches scalar for every lane permutation") {
     require_matches_scalar(plan, 1, rotations.size());
 }
 
+TEST_CASE("Direct rotation SIMD matches scalar for every lane-paired mask") {
+    std::array<RotateActivePauli, 14> rotations;
+    for (uint64_t x = 1; x < 8; ++x) {
+        rotations[2 * (x - 1)] =
+            RotateActivePauli{{x, (~x) & 0b111111}, 0.2, AffineBool::symbol(SymbolId{0})};
+        rotations[2 * (x - 1) + 1] =
+            RotateActivePauli{{x, x & (~x + 1)}, -0.3, AffineBool::symbol(SymbolId{0})};
+    }
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    require_matches_scalar(plan, 0, rotations.size());
+    require_matches_scalar(plan, 1, rotations.size());
+}
+
 TEST_CASE("Direct rotation SIMD matches scalar with intermediate high bits") {
     const std::array rotations = {
         RotateActivePauli{{0b101010, 0b001110}, 0.2, AffineBool::symbol(SymbolId{0})},
@@ -166,6 +179,14 @@ TEST_CASE("Direct rotation SIMD matches scalar at vector boundaries") {
     };
     require_matches_scalar(rotation_plan(3, diagonal), 0, diagonal.size());
     require_matches_scalar(rotation_plan(3, diagonal), 1, diagonal.size());
+
+    const std::array lane_paired = {
+        RotateActivePauli{{0b001, 0b110}, 0.2, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b010, 0b101}, -0.3, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b111, 0b011}, 0.4, AffineBool::symbol(SymbolId{0})},
+    };
+    require_matches_scalar(rotation_plan(3, lane_paired), 0, lane_paired.size());
+    require_matches_scalar(rotation_plan(3, lane_paired), 1, lane_paired.size());
 
     const std::array paired = {
         RotateActivePauli{{0b1101, 0b0011}, -0.25, AffineBool::symbol(SymbolId{0})},

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -337,7 +337,10 @@ TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0, 0}, 4) == DirectRotationKernel::Scalar);
     REQUIRE(select({0, 0b11}, 2) == DirectRotationKernel::Scalar);
     REQUIRE(select({0, 0b101}, 3) == DirectRotationKernel::Diagonal);
-    REQUIRE(select({0b100, 0b011}, 3) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b10, 0b01}, 2) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b001, 0b110}, 3) == DirectRotationKernel::LanePaired);
+    REQUIRE(select({0b010, 0b101}, 3) == DirectRotationKernel::LanePaired);
+    REQUIRE(select({0b100, 0b011}, 3) == DirectRotationKernel::LanePaired);
     REQUIRE(select({0b1000, 0b0111}, 4) == DirectRotationKernel::HighPivot);
     REQUIRE(select({0b10000, 0b01111}, 5) == DirectRotationKernel::Scalar);
     REQUIRE(select({0b100000, 0b011111}, 6) == DirectRotationKernel::HighPivot);


### PR DESCRIPTION
## Summary

- add an AVX-512 direct-rotation kernel for pairing pivots 0 through 2, where both members of every coefficient pair fit in one eight-lane vector
- derive partner amplitudes with an in-register XOR permutation and use the existing lane parity tables without adding a per-action sidecar
- retain the compact one-byte kernel selector and scalar fallback for AVX2, scalar-only, narrow-width, identity, and pivot-4 shapes
- compare every low-lane X mask against the scalar oracle for both signs and both real/imaginary phase cases, including imaginary-class shapes whose Z mask extends above the vector lanes
- name the selector's lane-count, width-floor, and pivot-four constants in the shared SIMD header so the portable selector and the AVX-512 translation unit cannot drift

## Evidence

On the issue #280 Release-with-symbols build, one thread pinned to CPU 3 on the AMD EPYC 9554P:

- coherent d5 r1 symbolic median: 11.25 s on merged main, 8.16 s here (1.38x faster); the established legacy median is 6.51 s
- coherent d3 r3: approximately 1.16x faster in the stable paired blocks
- k12/L512: approximately 1.20x faster
- QV-10 and QV-20 guards: neutral to slightly faster, depending on circuit seed
- surface, cultivation, and distillation guards: neutral

The isolated kernel is 1.34x faster than scalar at width 3 and 2.3x-3.8x faster from widths 4 through 12. Generated assembly contains packed `zmm`, `vpermpd`, and FMA operations.

The post-change coherent d5 r1 profile is 48.5% vector direct rotation, 21.6% scalar pivot-4 rotation, and 25.5% measurement probability/collapse. Two pivot-4 prototypes regressed end-to-end and are intentionally excluded.

## Tests

- `ctest --test-dir /tmp/clifft-issue280-fusion-build --output-on-failure -E '^Bench:'`
- `ctest --test-dir /tmp/clifft-issue280-fusion-build --output-on-failure -R '^Bench:'`
- direct-rotation differential tests under native AVX-512, `CLIFFT_FORCE_ISA=avx2`, and `CLIFFT_FORCE_ISA=scalar` (1,311 assertions each)
- scalar-only runtime ISA compile check
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

