### PR TITLE
perf(sampling): preserve uniform fixed-k probabilities

### DIFF
--- a/src/clifft/backend/backend.cc
+++ b/src/clifft/backend/backend.cc
@@ -4,6 +4,7 @@
 #include "clifft/util/canonical_phase.h"
 #include "clifft/util/mask_view.h"
 #include "clifft/util/noise_sampling.h"
+#include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <bit>
@@ -892,6 +893,7 @@ CompiledModule lower_impl(const HirModule& hir,
                 const auto& hir_site = hir.noise_sites[site_idx];
 
                 NoiseSite mapped_site;
+                mapped_site.total_probability = hir_site.total_probability;
                 for (const auto& ch : hir_site.channels) {
                     auto in_view = source_noise_channel_masks.at(ch.mask);
                     auto out_handle =
@@ -906,6 +908,12 @@ CompiledModule lower_impl(const HirModule& hir,
                 double prob_sum = 0.0;
                 for (const auto& ch : mapped_site.channels) {
                     prob_sum += ch.prob;
+                }
+                if (!is_probability(mapped_site.total_probability) ||
+                    ((mapped_site.total_probability == 0.0) != (prob_sum == 0.0)) ||
+                    std::abs(mapped_site.total_probability - prob_sum) > 1e-12) {
+                    throw std::invalid_argument(
+                        "noise site total probability disagrees with its channels");
                 }
 
                 uint32_t cp_idx = static_cast<uint32_t>(ctx.constant_pool.noise_sites.size());

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -176,10 +176,25 @@ NoiseChannel rewind_pauli_targets(HirModule& hir, const stim::TableauSimulator<k
     return NoiseChannel{h, prob};
 }
 
-void append_noise_site(HirModule& hir, NoiseSite site) {
+void append_noise_site(HirModule& hir, NoiseSite site, double total_probability) {
+    site.total_probability = total_probability;
     NoiseSiteIdx idx{static_cast<uint32_t>(hir.noise_sites.size())};
     hir.noise_sites.push_back(std::move(site));
     hir.append_noise(idx);
+}
+
+double sum_noise_probabilities(const NoiseSite& site) {
+    double total_probability = 0.0;
+    for (const NoiseChannel& channel : site.channels) {
+        total_probability += channel.prob;
+    }
+    return total_probability;
+}
+
+double represented_depolarizing_probability(double probability, double outcome_count) {
+    // A channel probability rounded to zero cannot be selected by either
+    // executor, so fixed-k conditioning must also treat the site as impossible.
+    return probability / outcome_count == 0.0 ? 0.0 : probability;
 }
 
 NoiseSite make_single_qubit_noise_site(HirModule& hir,
@@ -901,7 +916,11 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                 for (const auto& target : node.targets) {
                     NoiseSite site =
                         make_single_qubit_noise_site(hir, sim, node.gate, target.value(), prob);
-                    append_noise_site(hir, std::move(site));
+                    const double total_probability =
+                        node.gate == GateType::DEPOLARIZE1
+                            ? represented_depolarizing_probability(prob, 3.0)
+                            : prob;
+                    append_noise_site(hir, std::move(site), total_probability);
                 }
                 break;
             }
@@ -921,7 +940,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                                 rewind_pauli_terms(hir, sim, {{qubit, p + 1}}, prob));
                         }
                     }
-                    append_noise_site(hir, std::move(site));
+                    const double total_probability = sum_noise_probabilities(site);
+                    append_noise_site(hir, std::move(site), total_probability);
                 }
                 break;
             }
@@ -947,7 +967,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                             ++arg_idx;
                         }
                     }
-                    append_noise_site(hir, std::move(site));
+                    const double total_probability = sum_noise_probabilities(site);
+                    append_noise_site(hir, std::move(site), total_probability);
                 }
                 break;
             }
@@ -976,7 +997,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                             }
                         }
                     }
-                    append_noise_site(hir, std::move(site));
+                    const double total_probability = sum_noise_probabilities(site);
+                    append_noise_site(hir, std::move(site), total_probability);
                 }
                 break;
             }
@@ -1006,7 +1028,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     }
                     chain_end = next;
                 }
-                append_noise_site(hir, std::move(site));
+                const double total_probability = sum_noise_probabilities(site);
+                append_noise_site(hir, std::move(site), total_probability);
                 node_index = chain_end;
                 break;
             }
@@ -1021,7 +1044,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
                     NoiseSite site = make_depolarize2_noise_site(hir, sim, q1, q2, prob);
-                    append_noise_site(hir, std::move(site));
+                    append_noise_site(hir, std::move(site),
+                                      represented_depolarizing_probability(prob, 15.0));
                 }
                 break;
             }
@@ -1033,7 +1057,8 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     uint32_t q2 = node.targets[i + 1].value();
                     uint32_t q3 = node.targets[i + 2].value();
                     NoiseSite site = make_depolarize3_noise_site(hir, sim, q1, q2, q3, prob);
-                    append_noise_site(hir, std::move(site));
+                    append_noise_site(hir, std::move(site),
+                                      represented_depolarizing_probability(prob, 63.0));
                 }
                 break;
             }

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -61,10 +61,10 @@ enum class ExpValIdx : uint32_t {};
 // Noise Channel Structures
 // =============================================================================
 //
-// A NoiseSite is a list of NoiseChannels; each channel has a Pauli mask
-// (handle into the surrounding arena -- HirModule::noise_channel_masks for
-// HIR-side sites, ConstantPool::noise_channel_masks for compiled sites)
-// and a firing probability. Channel signs are unused (E and -E act
+// A NoiseSite is a mutually exclusive Pauli-noise distribution. Its total
+// probability is retained separately from the channel probabilities so
+// fixed-k conditioning does not have to reconstruct a source gate parameter
+// through rounded channel sums. Channel signs are unused (E and -E act
 // identically as stochastic Pauli errors).
 
 struct NoiseChannel {
@@ -75,6 +75,7 @@ struct NoiseChannel {
 };
 
 struct NoiseSite {
+    double total_probability = 0.0;
     std::vector<NoiseChannel> channels;
 
     [[nodiscard]] bool operator==(const NoiseSite&) const = default;

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -127,25 +127,13 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     for (const PresampledNoiseSite& site : plan.presampled_noise_sites) {
         const uint32_t begin = static_cast<uint32_t>(noise_outcomes_.size());
         double cumulative_probability = 0.0;
-        const double first_probability =
-            site.outcomes.empty() ? 0.0 : site.outcomes.front().probability;
-        bool homogeneous = true;
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
-            homogeneous &= outcome.probability == first_probability;
             cumulative_probability += outcome.probability;
             noise_outcomes_.push_back({index(outcome.symbol), cumulative_probability});
             bound_presampled[index(outcome.symbol)] = true;
         }
-        double conditioned_probability = cumulative_probability;
-        if (homogeneous) {
-            // Reconstruct the source gate's total with one multiplication.
-            // Repeated accumulation can differ by one bit between a
-            // single-channel site and an equivalent depolarizing site,
-            // needlessly disabling uniform fixed-k sampling.
-            conditioned_probability = first_probability * static_cast<double>(site.outcomes.size());
-        }
-        noise_sites_.push_back({begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin,
-                                conditioned_probability});
+        noise_sites_.push_back(
+            {begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin, site.total_probability});
         cumulative_hazard += bernoulli_hazard(cumulative_probability);
         noise_hazards_.push_back(cumulative_hazard);
     }

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -127,13 +127,25 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     for (const PresampledNoiseSite& site : plan.presampled_noise_sites) {
         const uint32_t begin = static_cast<uint32_t>(noise_outcomes_.size());
         double cumulative_probability = 0.0;
+        const double first_probability =
+            site.outcomes.empty() ? 0.0 : site.outcomes.front().probability;
+        bool homogeneous = true;
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+            homogeneous &= outcome.probability == first_probability;
             cumulative_probability += outcome.probability;
             noise_outcomes_.push_back({index(outcome.symbol), cumulative_probability});
             bound_presampled[index(outcome.symbol)] = true;
         }
-        noise_sites_.push_back(
-            {begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin, cumulative_probability});
+        double conditioned_probability = cumulative_probability;
+        if (homogeneous) {
+            // Reconstruct the source gate's total with one multiplication.
+            // Repeated accumulation can differ by one bit between a
+            // single-channel site and an equivalent depolarizing site,
+            // needlessly disabling uniform fixed-k sampling.
+            conditioned_probability = first_probability * static_cast<double>(site.outcomes.size());
+        }
+        noise_sites_.push_back({begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin,
+                                conditioned_probability});
         cumulative_hazard += bernoulli_hazard(cumulative_probability);
         noise_hazards_.push_back(cumulative_hazard);
     }
@@ -289,7 +301,7 @@ std::vector<double> ExecutablePlan::noise_site_probabilities() const {
     std::vector<double> probabilities;
     probabilities.reserve(noise_sites_.size() + num_readout_noise_sites_);
     for (const PreparedNoiseSite& site : noise_sites_) {
-        probabilities.push_back(site.total_probability);
+        probabilities.push_back(site.conditioned_probability);
     }
     for (const Action& action : actions_) {
         const auto* readout = std::get_if<ExecuteReadoutNoise>(&action);

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -160,7 +160,9 @@ class ExecutablePlan {
     struct PreparedNoiseSite {
         uint32_t outcome_begin = 0;
         uint32_t outcome_count = 0;
-        double total_probability = 0.0;
+        // Stable total exposed to fixed-k conditioning. Ordinary execution
+        // retains the final cumulative outcome as its channel-draw bound.
+        double conditioned_probability = 0.0;
     };
 
     using Action =

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -160,7 +160,7 @@ class ExecutablePlan {
     struct PreparedNoiseSite {
         uint32_t outcome_begin = 0;
         uint32_t outcome_count = 0;
-        // Stable total exposed to fixed-k conditioning. Ordinary execution
+        // Exact HIR total exposed to fixed-k conditioning. Ordinary execution
         // retains the final cumulative outcome as its channel-draw bound.
         double conditioned_probability = 0.0;
     };

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -268,11 +268,17 @@ void Executor::sample_presampled_noise(uint32_t begin, uint32_t end) noexcept {
 void Executor::activate_noise_site(uint32_t site_index) noexcept {
     assert(site_index < plan_->noise_sites_.size() && "noise site must be prepared");
     const ExecutablePlan::PreparedNoiseSite& site = plan_->noise_sites_[site_index];
-    assert(site.outcome_count > 0 && site.total_probability > 0.0 &&
+    assert(site.outcome_count > 0 &&
+           "a firing noise site must contain positive-probability outcomes");
+    const uint32_t outcome_end = site.outcome_begin + site.outcome_count;
+    assert(outcome_end <= plan_->noise_outcomes_.size() &&
+           plan_->noise_outcomes_[outcome_end - 1].cumulative_probability > 0.0 &&
            "a firing noise site must contain positive-probability outcomes");
     uint32_t outcome_index = site.outcome_begin;
     if (site.outcome_count > 1) {
-        const double channel_draw = rng_.next_double() * site.total_probability;
+        const double execution_probability =
+            plan_->noise_outcomes_[outcome_end - 1].cumulative_probability;
+        const double channel_draw = rng_.next_double() * execution_probability;
         while (channel_draw >= plan_->noise_outcomes_[outcome_index].cumulative_probability) {
             ++outcome_index;
             assert(outcome_index < site.outcome_begin + site.outcome_count &&

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -3,6 +3,7 @@
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <sstream>
@@ -412,6 +413,10 @@ void SamplingPlan::validate() const {
         if (index(site.site) != site_index) {
             invalid_plan("presampled noise sites are not in stable id order");
         }
+        if (!is_probability(site.total_probability)) {
+            invalid_plan("noise site " + std::to_string(site_index) +
+                         " has an invalid total probability");
+        }
         double total_probability = 0.0;
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
             const uint32_t symbol_index = index(outcome.symbol);
@@ -435,6 +440,11 @@ void SamplingPlan::validate() const {
         if (!is_finite_robust(total_probability) || total_probability > 1.0 + 1e-12) {
             invalid_plan("noise site " + std::to_string(site_index) +
                          " outcome probabilities exceed one");
+        }
+        if (((site.total_probability == 0.0) != (total_probability == 0.0)) ||
+            std::abs(total_probability - site.total_probability) > 1e-12) {
+            invalid_plan("noise site " + std::to_string(site_index) +
+                         " total probability disagrees with its outcomes");
         }
     }
 
@@ -743,7 +753,8 @@ std::string SamplingPlan::inspect() const {
         out << '\n';
     }
     for (const PresampledNoiseSite& site : presampled_noise_sites) {
-        out << "  noise_site " << index(site.site) << " outcomes=" << site.outcomes.size();
+        out << "  noise_site " << index(site.site) << " probability=" << site.total_probability
+            << " outcomes=" << site.outcomes.size();
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
             out << " s" << index(outcome.symbol) << ':' << outcome.probability;
         }

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -278,6 +278,9 @@ struct PresampledNoiseOutcome {
 
 struct PresampledNoiseSite {
     NoiseSiteId site{};
+    // Exact semantic probability copied from the HIR noise site. Execution
+    // still uses the ordered outcome probabilities for channel selection.
+    double total_probability = 0.0;
     std::vector<PresampledNoiseOutcome> outcomes;
 };
 

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -240,6 +240,8 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
     plan.presampled_noise_sites.resize(hir.noise_sites.size());
     for (uint32_t site = 0; site < hir.noise_sites.size(); ++site) {
         plan.presampled_noise_sites[site].site = NoiseSiteId{site};
+        plan.presampled_noise_sites[site].total_probability =
+            hir.noise_sites[site].total_probability;
     }
     std::vector<bool> seen_noise_sites(hir.noise_sites.size(), false);
     plan.instrument_distributions.reserve(hir.instrument_sites.size());

--- a/src/clifft/svm/svm.cc
+++ b/src/clifft/svm/svm.cc
@@ -351,10 +351,7 @@ std::vector<double> noise_site_probabilities(const CompiledModule& program) {
     std::vector<double> probs;
     probs.reserve(pool.noise_sites.size() + pool.readout_noise.size());
     for (const auto& site : pool.noise_sites) {
-        double p = 0.0;
-        for (const auto& ch : site.channels)
-            p += ch.prob;
-        probs.push_back(p);
+        probs.push_back(site.total_probability);
     }
     for (const auto& entry : pool.readout_noise) {
         // k-fault conditioning requires one fixed probability per site. An

--- a/src/clifft/svm/svm.h
+++ b/src/clifft/svm/svm.h
@@ -354,7 +354,7 @@ SurvivorResult sample_k_survivors(const CompiledModule& program, uint32_t shots,
 
 /// Return per-site total fault probabilities for importance sampling.
 /// The returned vector has length N_q + N_r: first the quantum noise sites
-/// (sum of channel probs), then the readout noise entries.
+/// (using their preserved semantic totals), then the readout noise entries.
 std::vector<double> noise_site_probabilities(const CompiledModule& program);
 
 /// Return exact |<x|psi>|^2 computational-basis probabilities for unitary

--- a/tests/test_backend.cc
+++ b/tests/test_backend.cc
@@ -769,10 +769,13 @@ TEST_CASE("Backend: Gap sampling hazard array accumulation") {
 
     HirModule hir(3, /*pauli_capacity=*/16, /*noise_channel_capacity=*/3);
     NoiseSite site1;
+    site1.total_probability = 0.5;
     site1.channels.push_back({clifft::test::claim_noise_channel_mask(hir, 1, 0), 0.5});
     NoiseSite site2;
+    site2.total_probability = 0.75;
     site2.channels.push_back({clifft::test::claim_noise_channel_mask(hir, 2, 0), 0.75});
     NoiseSite site3;
+    site3.total_probability = 1.0;
     site3.channels.push_back({clifft::test::claim_noise_channel_mask(hir, 4, 0), 1.0});
 
     hir.noise_sites.push_back(std::move(site1));
@@ -1544,6 +1547,7 @@ TEST_CASE("Lower: queued virtual gates affect later noise masks") {
     HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/1);
 
     NoiseSite site;
+    site.total_probability = 0.25;
     site.channels.push_back({clifft::test::claim_noise_channel_mask(hir, X(0), 0), 0.25});
     hir.noise_sites.push_back(site);
 
@@ -1566,6 +1570,7 @@ TEST_CASE("Lower: consuming overload maps noise masks in place") {
     HirModule hir(1, /*pauli_capacity=*/16, /*noise_channel_capacity=*/2);
 
     NoiseSite site;
+    site.total_probability = 0.75;
     const auto x_handle = clifft::test::claim_noise_channel_mask(hir, X(0), 0);
     const auto z_handle = clifft::test::claim_noise_channel_mask(hir, 0, Z(0));
     // Reverse handle order so preserving the HIR handles distinguishes the
@@ -1609,6 +1614,7 @@ TEST_CASE("Lower: consuming overload compacts overallocated noise arena") {
 TEST_CASE("Lower: consuming overload rejects out of bounds noise handles") {
     HirModule hir(1, /*pauli_capacity=*/0, /*noise_channel_capacity=*/1);
     NoiseSite site;
+    site.total_probability = 0.25;
     site.channels.push_back({PauliMaskHandle{1}, 0.25});
     hir.noise_sites.push_back(site);
     hir.append_noise(NoiseSiteIdx{0});
@@ -1620,6 +1626,7 @@ TEST_CASE("Lower: consuming overload rejects duplicate noise handles") {
     HirModule hir(1, /*pauli_capacity=*/0, /*noise_channel_capacity=*/1);
     const auto handle = clifft::test::claim_noise_channel_mask(hir, X(0), 0);
     NoiseSite site;
+    site.total_probability = 0.3;
     site.channels.push_back({handle, 0.1});
     site.channels.push_back({handle, 0.2});
     hir.noise_sites.push_back(site);

--- a/tests/test_continuation_prefix.cc
+++ b/tests/test_continuation_prefix.cc
@@ -33,8 +33,8 @@ CompiledModule module_with_prefix_constants() {
     pool.noise_channel_masks.mut_at(PauliMaskHandle{0}).x().bit_set(0, true);
     pool.noise_channel_masks.mut_at(PauliMaskHandle{1}).z().bit_set(1, true);
     pool.noise_sites = {
-        NoiseSite{{NoiseChannel{PauliMaskHandle{0}, 0.125}}},
-        NoiseSite{{NoiseChannel{PauliMaskHandle{1}, 0.25}}},
+        NoiseSite{0.125, {NoiseChannel{PauliMaskHandle{0}, 0.125}}},
+        NoiseSite{0.25, {NoiseChannel{PauliMaskHandle{1}, 0.25}}},
     };
     pool.noise_hazards = {0.13353139262452263, 0.42121346507630353};
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1135,6 +1135,7 @@ TEST_CASE("Frontend: DEPOLARIZE2 produces 15 channels", "[frontend][noise]") {
 
     const auto& site = hir.noise_sites[0];
     REQUIRE(site.channels.size() == 15);
+    CHECK(site.total_probability == 0.15);
 
     // Each channel should have probability p/15 = 0.01
     for (const auto& ch : site.channels) {
@@ -1151,6 +1152,7 @@ TEST_CASE("Frontend: DEPOLARIZE3 produces 63 channels", "[frontend][noise]") {
     REQUIRE(hir.noise_sites.size() == 1);
     const auto& site = hir.noise_sites[0];
     REQUIRE(site.channels.size() == 63);
+    CHECK(site.total_probability == 0.63);
 
     for (const auto& ch : site.channels) {
         CHECK(ch.prob == Catch::Approx(0.01));
@@ -1607,6 +1609,7 @@ TEST_CASE("Frontend: PAULI_CHANNEL_1 emits noise with correct channel count", "[
     CHECK(hir.ops[0].op_type() == OpType::NOISE);
     REQUIRE(hir.noise_sites.size() == 1);
     CHECK(hir.noise_sites[0].channels.size() == 3);
+    CHECK(hir.noise_sites[0].total_probability == Catch::Approx(0.6));
     CHECK(hir.noise_sites[0].channels[0].prob == Catch::Approx(0.1));
     CHECK(hir.noise_sites[0].channels[1].prob == Catch::Approx(0.2));
     CHECK(hir.noise_sites[0].channels[2].prob == Catch::Approx(0.3));

--- a/tests/test_hir.cc
+++ b/tests/test_hir.cc
@@ -208,6 +208,7 @@ TEST_CASE("HirModule with noise sites", "[hir]") {
     HirModule hir(2, /*num_pauli_masks=*/0, /*num_noise_channels=*/1);
 
     NoiseSite site;
+    site.total_probability = 0.1;
     auto h = clifft::test::claim_noise_channel_mask(hir, X(0), 0);
     site.channels.push_back({h, 0.1});
     hir.noise_sites.push_back(std::move(site));

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -455,13 +455,15 @@ TEST_CASE("Symbolic conditioned sampling exposes ordered fault probabilities") {
 TEST_CASE("Symbolic conditioned sampling preserves homogeneous site totals") {
     auto program = compile_sampling_circuit(R"(
         DEPOLARIZE2(0.001) 0 1
-        X_ERROR(0.001) 2
-        M 0 1 2
+        DEPOLARIZE1(0.001) 2
+        X_ERROR(0.001) 3
+        M 0 1 2 3
     )");
     const std::vector<double> probabilities = program.noise_site_probabilities();
-    REQUIRE(probabilities.size() == 2);
+    REQUIRE(probabilities.size() == 3);
     CHECK(probabilities[0] == 0.001);
     CHECK(probabilities[0] == probabilities[1]);
+    CHECK(probabilities[0] == probabilities[2]);
 }
 
 TEST_CASE("Symbolic conditioned sampling forces quantum channels and readout") {

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -452,18 +452,22 @@ TEST_CASE("Symbolic conditioned sampling exposes ordered fault probabilities") {
     CHECK_THAT(probabilities[2], WithinAbs(0.005, 1e-12));
 }
 
-TEST_CASE("Symbolic conditioned sampling preserves homogeneous site totals") {
-    auto program = compile_sampling_circuit(R"(
-        DEPOLARIZE2(0.001) 0 1
-        DEPOLARIZE1(0.001) 2
-        X_ERROR(0.001) 3
+TEST_CASE("Conditioned sampling preserves source noise site totals") {
+    const std::string circuit = R"(
+        DEPOLARIZE2(0.000015) 0 1
+        DEPOLARIZE1(0.000015) 2
+        X_ERROR(0.000015) 3
         M 0 1 2 3
-    )");
-    const std::vector<double> probabilities = program.noise_site_probabilities();
-    REQUIRE(probabilities.size() == 3);
-    CHECK(probabilities[0] == 0.001);
-    CHECK(probabilities[0] == probabilities[1]);
-    CHECK(probabilities[0] == probabilities[2]);
+    )";
+    const auto check_probabilities = [](const std::vector<double>& probabilities) {
+        REQUIRE(probabilities.size() == 3);
+        CHECK(probabilities[0] == 0.000015);
+        CHECK(probabilities[0] == probabilities[1]);
+        CHECK(probabilities[0] == probabilities[2]);
+    };
+
+    check_probabilities(clifft::noise_site_probabilities(compile_circuit(circuit)));
+    check_probabilities(compile_sampling_circuit(circuit).noise_site_probabilities());
 }
 
 TEST_CASE("Symbolic conditioned sampling forces quantum channels and readout") {

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -452,6 +452,18 @@ TEST_CASE("Symbolic conditioned sampling exposes ordered fault probabilities") {
     CHECK_THAT(probabilities[2], WithinAbs(0.005, 1e-12));
 }
 
+TEST_CASE("Symbolic conditioned sampling preserves homogeneous site totals") {
+    auto program = compile_sampling_circuit(R"(
+        DEPOLARIZE2(0.001) 0 1
+        X_ERROR(0.001) 2
+        M 0 1 2
+    )");
+    const std::vector<double> probabilities = program.noise_site_probabilities();
+    REQUIRE(probabilities.size() == 2);
+    CHECK(probabilities[0] == 0.001);
+    CHECK(probabilities[0] == probabilities[1]);
+}
+
 TEST_CASE("Symbolic conditioned sampling forces quantum channels and readout") {
     auto quantum = compile_sampling_circuit(R"(
         X_ERROR(0.01) 0

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -219,12 +219,13 @@ SamplingPlan categorical_noise_plan() {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{3}},
     };
     plan.presampled_noise_sites = {
-        PresampledNoiseSite{NoiseSiteId{0}, {PresampledNoiseOutcome{SymbolId{0}, 0.05}}},
+        PresampledNoiseSite{NoiseSiteId{0}, 0.05, {PresampledNoiseOutcome{SymbolId{0}, 0.05}}},
         PresampledNoiseSite{
             NoiseSiteId{1},
+            0.3,
             {PresampledNoiseOutcome{SymbolId{1}, 0.1}, PresampledNoiseOutcome{SymbolId{2}, 0.2}}},
-        PresampledNoiseSite{NoiseSiteId{2}, {}},
-        PresampledNoiseSite{NoiseSiteId{3}, {PresampledNoiseOutcome{SymbolId{3}, 0.4}}},
+        PresampledNoiseSite{NoiseSiteId{2}, 0.0, {}},
+        PresampledNoiseSite{NoiseSiteId{3}, 0.4, {PresampledNoiseOutcome{SymbolId{3}, 0.4}}},
     };
     return plan;
 }
@@ -334,7 +335,7 @@ TEST_CASE("Sampling executor does not draw for empty noise sites") {
     plan.num_qubits = 1;
     plan.num_visible_records = 1;
     plan.num_noise_sites = 1;
-    plan.presampled_noise_sites = {PresampledNoiseSite{NoiseSiteId{0}, {}}};
+    plan.presampled_noise_sites = {PresampledNoiseSite{NoiseSiteId{0}, 0.0, {}}};
     plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
     plan.actions = {PlannedAction{
         0, 0,

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -59,7 +59,7 @@ SamplingPlan valid_plan() {
         SymbolInfo{SymbolKind::Instrument, 4, std::nullopt},
     };
     plan.presampled_noise_sites = {
-        PresampledNoiseSite{NoiseSiteId{0}, {PresampledNoiseOutcome{noise, 0.1}}}};
+        PresampledNoiseSite{NoiseSiteId{0}, 0.1, {PresampledNoiseOutcome{noise, 0.1}}}};
     plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {0.0, 0.0}, {}}};
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{0.25, AffineBool::symbol(noise)}},
@@ -151,6 +151,13 @@ TEST_CASE("Sampling plan validates symbolic and active state invariants") {
     REQUIRE(text.find("outcome=s0 ^ s1 record=0") != std::string::npos);
     REQUIRE(text.find("5 active_width=0->0 dense_passes=0 instrument_boundary site=0 ") !=
             std::string::npos);
+}
+
+TEST_CASE("Sampling plan rejects inconsistent noise site totals") {
+    SamplingPlan plan = valid_plan();
+    plan.presampled_noise_sites[0].total_probability = 0.2;
+
+    REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
 
 TEST_CASE("Sampling plan rejects symbolic use before assignment") {


### PR DESCRIPTION
## Summary

- preserve each semantic noise-site total from the frontend through HIR, legacy lowering, and symbolic sampling plans
- use those exact totals for fixed-k conditioning, making uniform-site detection independent of channel-sum rounding and compiler reduction order
- retain the existing cumulative channel arithmetic for ordinary hazards and within-site selection, preserving ordinary RNG schedules and output semantics
- validate preserved totals against represented outcomes during both lowering paths

This is scoped to sample_k(), sample_k_survivors(), and the noise_site_probabilities() values they consume. It adds no selector, sidecar, schedule, hot-loop allocation, or ordinary-sampling dispatch. NoiseSite and the temporary PresampledNoiseSite each grow by eight bytes per quantum noise site; the symbolic executable descriptor and action tape do not grow.

## Motivation

KFaultSampler uses an O(k) Fisher-Yates path when all site probabilities are exactly equal. Reconstructing a depolarizing total by summing rounded p/3, p/15, or p/63 channel probabilities can differ from a single-channel p by one ulp, silently selecting the O(N*k) weighted path.

The earlier prototype reconstructed homogeneous totals with multiplication. That fixed the benchmark values but was still best-effort: for example, both (0.000015 / 3) * 3 and (0.000015 / 15) * 15 differ from the original double. This revision carries the original semantic total instead, for both backends.

## Measurements

Release build with debug symbols and frame pointers, one thread, CPU-pinned:

| Case | Symbolic main | This PR | Change |
| --- | ---: | ---: | ---: |
| surface d7 r7, k=8, 100k shots | ~0.870 s | ~0.151 s | 5.8x faster |
| cultivation d5, k=4, 20k shots | ~0.291 s | ~0.10 s | ~3x faster |

Surface d7 r7 fixed-k measured approximately 0.151 s symbolic versus 0.168 s legacy after exact-total propagation.

Paired ordinary surface guards remained neutral and bit-stable:

- sample_survivors(), 500k shots: identical checksums for both legacy and symbolic; this PR was slightly faster in the measured blocks
- raw sample(), 200k shots: identical checksums for both legacy and symbolic; this PR was slightly faster in the measured blocks

No ordinary-path speedup is claimed.

## Verification

- full Debug suite: 1,269/1,269 tests passed
- focused fixed-k tests: 6,028 assertions in 12 cases passed
- noise-filtered suite: 10,852 assertions in 82 cases passed
- continuation-prefix, symbolic continuation, and trap/resume suites passed
- adversarial /3 and /15 source-total regression passes for both legacy and symbolic backends
- pre-commit checks passed

Relates to #280.