### PR TITLE
perf(sampling): vectorize lane-paired active measurements

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(clifft_core STATIC
     sampling/plan.cc
     sampling/planner.cc
     sampling/planner_frame.cc
+    sampling/active_measurement_dispatch.cc
     sampling/direct_rotation_dispatch.cc
     sampling/executable_plan.cc
     sampling/executor.cc

--- a/src/clifft/sampling/active_measurement_dispatch.cc
+++ b/src/clifft/sampling/active_measurement_dispatch.cc
@@ -1,0 +1,81 @@
+#include "clifft/sampling/active_measurement_dispatch.h"
+
+#include "clifft/sampling/active_measurement_simd.h"
+#include "clifft/sampling/direct_rotation_simd.h"
+#include "clifft/util/runtime_isa.h"
+
+#include <cassert>
+
+namespace clifft::sampling {
+
+namespace {
+
+constexpr uint32_t kMinVectorActiveWidth = 3;
+static_assert(uint64_t{1} << kMinVectorActiveWidth == kAvx512DoubleLanes);
+
+// A single vector block regressed against the scalar probability-plus-collapse
+// pair on this host; two blocks amortize the vector setup.
+constexpr uint32_t kMinProfitableActiveWidth = 4;
+
+ActiveMeasurementKernel select_active_measurement_avx512(
+    const PreparedMeasurement& measurement) noexcept {
+    if (measurement.pauli.is_diagonal() || measurement.pauli.x >= kAvx512DoubleLanes ||
+        measurement.pivot >= kMinVectorActiveWidth ||
+        measurement.pauli.active_width < kMinProfitableActiveWidth) {
+        return ActiveMeasurementKernel::Scalar;
+    }
+    return ActiveMeasurementKernel::LanePaired;
+}
+
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+
+const internal::RuntimeIsa kResolvedActiveMeasurementIsa = internal::runtime_isa();
+
+#endif
+
+}  // namespace
+
+ActiveMeasurementKernel resolve_active_measurement_kernel(
+    const PreparedMeasurement& measurement, internal::RuntimeIsa runtime_isa) noexcept {
+    if (runtime_isa == internal::RuntimeIsa::Avx512) {
+        return select_active_measurement_avx512(measurement);
+    }
+    return ActiveMeasurementKernel::Scalar;
+}
+
+MeasurementProbabilities active_measurement_probabilities(const State& state,
+                                                          const PreparedMeasurement& measurement,
+                                                          ActiveMeasurementKernel kernel) noexcept {
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    if (kernel == ActiveMeasurementKernel::LanePaired) {
+        assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
+               "vector active measurement requires the selected AVX-512 implementation");
+        return active_measurement_probabilities_avx512(state, measurement);
+    }
+#else
+    assert(kernel == ActiveMeasurementKernel::Scalar &&
+           "portable active measurement dispatch requires the scalar kernel");
+    static_cast<void>(kernel);
+#endif
+    return measurement_probabilities(state, measurement);
+}
+
+void collapse_active_measurement(State& state, const PreparedMeasurement& measurement,
+                                 ActiveMeasurementKernel kernel, bool branch,
+                                 double branch_probability) noexcept {
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    if (kernel == ActiveMeasurementKernel::LanePaired) {
+        assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
+               "vector active measurement requires the selected AVX-512 implementation");
+        collapse_active_measurement_avx512(state, measurement, branch, branch_probability);
+        return;
+    }
+#else
+    assert(kernel == ActiveMeasurementKernel::Scalar &&
+           "portable active measurement dispatch requires the scalar kernel");
+    static_cast<void>(kernel);
+#endif
+    collapse_measurement(state, measurement, branch, branch_probability);
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/active_measurement_dispatch.cc
+++ b/src/clifft/sampling/active_measurement_dispatch.cc
@@ -10,8 +10,8 @@ namespace clifft::sampling {
 
 namespace {
 
-constexpr uint32_t kMinVectorActiveWidth = 3;
-static_assert(uint64_t{1} << kMinVectorActiveWidth == kAvx512DoubleLanes);
+constexpr uint32_t kVectorLaneIndexBits = 3;
+static_assert(uint64_t{1} << kVectorLaneIndexBits == kAvx512DoubleLanes);
 
 // A single vector block regressed against the scalar probability-plus-collapse
 // pair on this host; two blocks amortize the vector setup.
@@ -20,7 +20,7 @@ constexpr uint32_t kMinProfitableActiveWidth = 4;
 ActiveMeasurementKernel select_active_measurement_avx512(
     const PreparedMeasurement& measurement) noexcept {
     if (measurement.pauli.is_diagonal() || measurement.pauli.x >= kAvx512DoubleLanes ||
-        measurement.pivot >= kMinVectorActiveWidth ||
+        measurement.pivot >= kVectorLaneIndexBits ||
         measurement.pauli.active_width < kMinProfitableActiveWidth) {
         return ActiveMeasurementKernel::Scalar;
     }

--- a/src/clifft/sampling/active_measurement_dispatch.h
+++ b/src/clifft/sampling/active_measurement_dispatch.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "clifft/sampling/kernels.h"
+
+#include <cstdint>
+
+namespace clifft::internal {
+enum class RuntimeIsa;
+}
+
+namespace clifft::sampling {
+
+// Architecture-neutral selection stored in an executable measurement action.
+enum class ActiveMeasurementKernel : uint8_t {
+    Scalar,
+    LanePaired,
+};
+
+static_assert(sizeof(ActiveMeasurementKernel) == 1);
+
+[[nodiscard]] ActiveMeasurementKernel resolve_active_measurement_kernel(
+    const PreparedMeasurement& measurement, internal::RuntimeIsa runtime_isa) noexcept;
+
+[[nodiscard]] MeasurementProbabilities active_measurement_probabilities(
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept;
+void collapse_active_measurement(State& state, const PreparedMeasurement& measurement,
+                                 ActiveMeasurementKernel kernel, bool branch,
+                                 double branch_probability) noexcept;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/active_measurement_simd.h
+++ b/src/clifft/sampling/active_measurement_simd.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "clifft/sampling/active_measurement_dispatch.h"
+
+namespace clifft::sampling {
+
+// Linked only on x86-64 runtime-dispatch builds and called only after AVX-512
+// has been selected for this process and measurement shape.
+[[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx512(
+    const State& state, const PreparedMeasurement& measurement) noexcept;
+void collapse_active_measurement_avx512(State& state, const PreparedMeasurement& measurement,
+                                        bool branch, double branch_probability) noexcept;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -172,10 +172,14 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                     actions_.emplace_back(ExecutePromotion{prepare_promotion(typed.half_turns),
                                                            prepare_expression(typed.sign)});
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
+                    PreparedMeasurement measurement =
+                        prepare_measurement(typed.pauli, planned.active_before, typed.active_pivot);
+                    const ActiveMeasurementKernel kernel =
+                        resolve_active_measurement_kernel(measurement, runtime_isa);
                     actions_.emplace_back(ExecuteActiveMeasurement{
-                        prepare_measurement(typed.pauli, planned.active_before, typed.active_pivot),
+                        std::move(measurement),
                         prepare_measurement_correction(typed.outcome, index(typed.branch)),
-                        index(typed.branch), index(typed.record)});
+                        index(typed.branch), index(typed.record), kernel});
                 } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
                     actions_.emplace_back(ExecuteDormantMeasurement{
                         prepare_measurement_correction(typed.outcome, index(typed.branch)),

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "clifft/sampling/active_measurement_dispatch.h"
 #include "clifft/sampling/direct_rotation_dispatch.h"
 #include "clifft/sampling/fused_rotation_dispatch.h"
 #include "clifft/sampling/kernels.h"
@@ -92,7 +93,28 @@ class ExecutablePlan {
         PreparedExpression correction;
         uint32_t branch = 0;
         uint32_t record = 0;
+        ActiveMeasurementKernel kernel = ActiveMeasurementKernel::Scalar;
+
+        [[nodiscard]] MeasurementProbabilities probabilities(const State& state) const noexcept {
+            if (kernel == ActiveMeasurementKernel::Scalar) {
+                return measurement_probabilities(state, measurement);
+            }
+            return active_measurement_probabilities(state, measurement, kernel);
+        }
+
+        void collapse(State& state, bool selected_branch,
+                      double branch_probability) const noexcept {
+            if (kernel == ActiveMeasurementKernel::Scalar) {
+                collapse_measurement(state, measurement, selected_branch, branch_probability);
+                return;
+            }
+            collapse_active_measurement(state, measurement, kernel, selected_branch,
+                                        branch_probability);
+        }
     };
+
+    static_assert(sizeof(ExecuteActiveMeasurement) == 88,
+                  "active measurement dispatch must not expand its action descriptor");
 
     struct ExecuteDormantMeasurement {
         PreparedExpression correction;

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -325,8 +325,7 @@ template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
                               std::span<const uint8_t> forced_records,
                               ReplayResult& result) noexcept {
-    const MeasurementProbabilities probabilities =
-        measurement_probabilities(state_, action.measurement);
+    const MeasurementProbabilities probabilities = action.probabilities(state_);
     const bool correction = evaluate(action.correction);
     bool branch = false;
     if constexpr (ForceRecords) {
@@ -349,7 +348,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
         }
     }
     assign_symbol(action.branch, branch);
-    collapse_measurement(state_, action.measurement, branch, probabilities.for_branch(branch));
+    action.collapse(state_, branch, probabilities.for_branch(branch));
     records_[action.record] = static_cast<uint8_t>(branch ^ correction);
 }
 

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -29,10 +29,11 @@ constexpr size_t kDimension = 4;
 constexpr size_t kMatrixSize = kDimension * kDimension;
 constexpr double kInvSqrt2 = 0.707106781186547524400844362104849039;
 
-// Lanes whose measurement pivot is zero are the unique representatives of
-// the four Pauli pairs in a vector block. Fixed permutations place those lanes
-// in the low half for an ordinary four-double store; hardware compress-stores
-// were substantially slower on the performance host.
+// Measuring a Pauli P pairs |b> with |b xor x>. Lanes whose measurement pivot
+// is zero enumerate the four pairs in a vector block exactly once: pivot zero,
+// for example, selects |0>, |2>, |4>, and |6>. Fixed permutations place those
+// representatives in the low half for an ordinary four-double store; hardware
+// compress-stores were substantially slower on the performance host.
 constexpr std::array<__mmask8, 3> kMeasurementSourceMasks = {0x55, 0x33, 0x0f};
 
 using LaneIndices = std::array<uint64_t, kLanes>;
@@ -305,6 +306,10 @@ MeasurementProbabilities active_measurement_probabilities_avx512_impl(
     __m512d zero_sum = _mm512_setzero_pd();
     __m512d one_sum = _mm512_setzero_pd();
 
+    // For eigenvalue e in {+1, -1}, one compacted branch amplitude is
+    //   (psi[b] + e * conj(phase(P, b)) * psi[b xor x]) / sqrt(2).
+    // Build both eigenvalue branches together, then count only the pivot-zero
+    // representative of each pair when accumulating their squared norms.
     for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
         const __m512d input_real = _mm512_load_pd(real + basis);
         const __m512d input_imag = _mm512_load_pd(imag + basis);
@@ -316,6 +321,8 @@ MeasurementProbabilities active_measurement_probabilities_avx512_impl(
         __m512d zero_imag;
         __m512d one_real;
         __m512d one_imag;
+        // Prepared Pauli phases are in {+1, -1, +i, -i}. Splitting real and
+        // imaginary phase classes turns the complex multiply into FMAs.
         if constexpr (RealPhase) {
             zero_real = _mm512_fmadd_pd(coefficient, partner_real, input_real);
             zero_imag = _mm512_fmadd_pd(coefficient, partner_imag, input_imag);
@@ -352,8 +359,10 @@ void collapse_active_measurement_avx512_impl(State& state, const PreparedMeasure
                                                             : -measurement.pauli.even_phase.imag());
     const __m512d scale = _mm512_set1_pd(kInvSqrt2 / std::sqrt(branch_probability));
 
-    // Each input block is loaded in full before its compacted output is
-    // written. Forward traversal therefore cannot overwrite a future source.
+    // Apply the selected (I + eP) branch and normalize it. Removing the pivot
+    // maps each eight-amplitude block to four consecutive output amplitudes;
+    // each input block is in registers before that compacted output is written,
+    // so forward traversal cannot overwrite a future source.
     for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
         const __m512d input_real = _mm512_load_pd(real + basis);
         const __m512d input_imag = _mm512_load_pd(imag + basis);

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -1,6 +1,7 @@
 // AVX-512F+AVX-512DQ sampling kernels. This translation unit is compiled
 // with the same explicit AVX2/BMI2/FMA/AVX-512 flags as the SVM AVX-512 path.
 
+#include "clifft/sampling/active_measurement_simd.h"
 #include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
@@ -8,6 +9,7 @@
 #include <array>
 #include <bit>
 #include <cassert>
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
@@ -25,9 +27,22 @@ namespace {
 constexpr size_t kLanes = kAvx512DoubleLanes;
 constexpr size_t kDimension = 4;
 constexpr size_t kMatrixSize = kDimension * kDimension;
+constexpr double kInvSqrt2 = 0.707106781186547524400844362104849039;
+
+// Lanes whose measurement pivot is zero are the unique representatives of
+// the four Pauli pairs in a vector block. Fixed permutations place those lanes
+// in the low half for an ordinary four-double store; hardware compress-stores
+// were substantially slower on the performance host.
+constexpr std::array<__mmask8, 3> kMeasurementSourceMasks = {0x55, 0x33, 0x0f};
 
 using LaneIndices = std::array<uint64_t, kLanes>;
 using LaneSigns = std::array<double, kLanes>;
+
+alignas(64) constexpr std::array<LaneIndices, 3> kMeasurementCompactionPermutations = {{
+    {0, 2, 4, 6, 0, 0, 0, 0},
+    {0, 1, 4, 5, 0, 0, 0, 0},
+    {0, 1, 2, 3, 0, 0, 0, 0},
+}};
 
 constexpr std::array<LaneIndices, kLanes> make_lane_permutations() {
     std::array<LaneIndices, kLanes> result{};
@@ -277,7 +292,125 @@ void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rota
     }
 }
 
+template <bool RealPhase>
+MeasurementProbabilities active_measurement_probabilities_avx512_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    const uint64_t lane_xor = measurement.pauli.x;
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const __mmask8 source_mask = kMeasurementSourceMasks[measurement.pivot];
+    const double base_coefficient =
+        RealPhase ? measurement.pauli.even_phase.real() : -measurement.pauli.even_phase.imag();
+    __m512d zero_sum = _mm512_setzero_pd();
+    __m512d one_sum = _mm512_setzero_pd();
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m512d input_real = _mm512_load_pd(real + basis);
+        const __m512d input_imag = _mm512_load_pd(imag + basis);
+        const __m512d partner_real = _mm512_permutexvar_pd(permutation, input_real);
+        const __m512d partner_imag = _mm512_permutexvar_pd(permutation, input_imag);
+        const __m512d coefficient = signed_sine_lanes(basis, measurement.pauli.z, base_coefficient);
+
+        __m512d zero_real;
+        __m512d zero_imag;
+        __m512d one_real;
+        __m512d one_imag;
+        if constexpr (RealPhase) {
+            zero_real = _mm512_fmadd_pd(coefficient, partner_real, input_real);
+            zero_imag = _mm512_fmadd_pd(coefficient, partner_imag, input_imag);
+            one_real = _mm512_fnmadd_pd(coefficient, partner_real, input_real);
+            one_imag = _mm512_fnmadd_pd(coefficient, partner_imag, input_imag);
+        } else {
+            zero_real = _mm512_fnmadd_pd(coefficient, partner_imag, input_real);
+            zero_imag = _mm512_fmadd_pd(coefficient, partner_real, input_imag);
+            one_real = _mm512_fmadd_pd(coefficient, partner_imag, input_real);
+            one_imag = _mm512_fnmadd_pd(coefficient, partner_real, input_imag);
+        }
+        const __m512d zero_norm =
+            _mm512_fmadd_pd(zero_real, zero_real, _mm512_mul_pd(zero_imag, zero_imag));
+        const __m512d one_norm =
+            _mm512_fmadd_pd(one_real, one_real, _mm512_mul_pd(one_imag, one_imag));
+        zero_sum = _mm512_mask_add_pd(zero_sum, source_mask, zero_sum, zero_norm);
+        one_sum = _mm512_mask_add_pd(one_sum, source_mask, one_sum, one_norm);
+    }
+    return MeasurementProbabilities{0.5 * _mm512_reduce_add_pd(zero_sum),
+                                    0.5 * _mm512_reduce_add_pd(one_sum)};
+}
+
+template <bool RealPhase>
+void collapse_active_measurement_avx512_impl(State& state, const PreparedMeasurement& measurement,
+                                             bool branch, double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t lane_xor = measurement.pauli.x;
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const __m512i compaction =
+        _mm512_load_si512(kMeasurementCompactionPermutations[measurement.pivot].data());
+    const double eigenvalue = branch ? -1.0 : 1.0;
+    const double base_coefficient = eigenvalue * (RealPhase ? measurement.pauli.even_phase.real()
+                                                            : -measurement.pauli.even_phase.imag());
+    const __m512d scale = _mm512_set1_pd(kInvSqrt2 / std::sqrt(branch_probability));
+
+    // Each input block is loaded in full before its compacted output is
+    // written. Forward traversal therefore cannot overwrite a future source.
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m512d input_real = _mm512_load_pd(real + basis);
+        const __m512d input_imag = _mm512_load_pd(imag + basis);
+        const __m512d partner_real = _mm512_permutexvar_pd(permutation, input_real);
+        const __m512d partner_imag = _mm512_permutexvar_pd(permutation, input_imag);
+        const __m512d coefficient = signed_sine_lanes(basis, measurement.pauli.z, base_coefficient);
+
+        __m512d output_real;
+        __m512d output_imag;
+        if constexpr (RealPhase) {
+            output_real = _mm512_fmadd_pd(coefficient, partner_real, input_real);
+            output_imag = _mm512_fmadd_pd(coefficient, partner_imag, input_imag);
+        } else {
+            output_real = _mm512_fnmadd_pd(coefficient, partner_imag, input_real);
+            output_imag = _mm512_fmadd_pd(coefficient, partner_real, input_imag);
+        }
+        output_real = _mm512_mul_pd(scale, output_real);
+        output_imag = _mm512_mul_pd(scale, output_imag);
+        const __m256d compact_real =
+            _mm512_castpd512_pd256(_mm512_permutexvar_pd(compaction, output_real));
+        const __m256d compact_imag =
+            _mm512_castpd512_pd256(_mm512_permutexvar_pd(compaction, output_imag));
+        _mm256_storeu_pd(real + basis / 2, compact_real);
+        _mm256_storeu_pd(imag + basis / 2, compact_imag);
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 }  // namespace
+
+MeasurementProbabilities active_measurement_probabilities_avx512(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    assert(state.active_width() == measurement.pauli.active_width &&
+           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
+           measurement.pivot < 3 && measurement.pauli.active_width >= 3 &&
+           "AVX-512 active measurement requires a low-lane Pauli pairing");
+    if (measurement.pauli.even_phase.real() != 0.0) {
+        return active_measurement_probabilities_avx512_impl<true>(state, measurement);
+    }
+    return active_measurement_probabilities_avx512_impl<false>(state, measurement);
+}
+
+void collapse_active_measurement_avx512(State& state, const PreparedMeasurement& measurement,
+                                        bool branch, double branch_probability) noexcept {
+    assert(state.active_width() == measurement.pauli.active_width &&
+           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
+           measurement.pivot < 3 && measurement.pauli.active_width >= 3 &&
+           std::isfinite(branch_probability) && branch_probability > 0.0 &&
+           "AVX-512 active measurement requires a positive-probability low-lane pairing");
+    if (measurement.pauli.even_phase.real() != 0.0) {
+        collapse_active_measurement_avx512_impl<true>(state, measurement, branch,
+                                                      branch_probability);
+    } else {
+        collapse_active_measurement_avx512_impl<false>(state, measurement, branch,
+                                                       branch_probability);
+    }
+}
 
 void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
                                   DirectRotationKernel kernel, bool sign) noexcept {

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -1,3 +1,4 @@
+#include "clifft/sampling/active_measurement_dispatch.h"
 #include "clifft/sampling/direct_rotation_dispatch.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/util/runtime_isa.h"
@@ -18,10 +19,13 @@
 
 using clifft::internal::RuntimeIsa;
 using clifft::sampling::activate_zero_coordinate;
+using clifft::sampling::active_measurement_probabilities;
+using clifft::sampling::ActiveMeasurementKernel;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::apply_instrument_no_fire;
 using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
+using clifft::sampling::collapse_active_measurement;
 using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
 using clifft::sampling::DirectRotationKernel;
@@ -33,6 +37,7 @@ using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::PreparedMeasurement;
+using clifft::sampling::resolve_active_measurement_kernel;
 using clifft::sampling::resolve_direct_rotation_kernel;
 using clifft::sampling::State;
 using clifft::test::check_complex;
@@ -347,6 +352,22 @@ TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b1000, 0b0111}, 4, RuntimeIsa::Avx2) == DirectRotationKernel::Scalar);
 }
 
+TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
+    const auto select = [](ActivePauli pauli, uint32_t active_width, uint32_t pivot,
+                           RuntimeIsa runtime_isa = RuntimeIsa::Avx512) {
+        return resolve_active_measurement_kernel(prepare_measurement(pauli, active_width, pivot),
+                                                 runtime_isa);
+    };
+
+    REQUIRE(select({0, 0b101}, 3, 0) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b01, 0b10}, 2, 0) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b001, 0b110}, 3, 0) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b001, 0b1110}, 4, 0) == ActiveMeasurementKernel::LanePaired);
+    REQUIRE(select({0b111, 0b101000}, 6, 2) == ActiveMeasurementKernel::LanePaired);
+    REQUIRE(select({0b1000, 0b0111}, 4, 3) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b111, 0b101000}, 6, 2, RuntimeIsa::Avx2) == ActiveMeasurementKernel::Scalar);
+}
+
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {
     for (uint32_t active_width = 0; active_width <= 4; ++active_width) {
         const uint64_t mask_limit = uint64_t{1} << active_width;
@@ -461,6 +482,63 @@ TEST_CASE("Sampling kernels measurements match dense projectors for every small 
                         REQUIRE(state.scratch_imag_data() == scratch_imag);
                         REQUIRE(state.active_width() == active_width - 1);
                         REQUIRE(state.global_scalar() == scalar);
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
+    if (clifft::internal::runtime_isa() != RuntimeIsa::Avx512) {
+        return;
+    }
+
+    for (uint32_t active_width = 3; active_width <= 6; ++active_width) {
+        const uint64_t z_limit = uint64_t{1} << active_width;
+        const std::vector<std::complex<double>> input = deterministic_state(active_width);
+        for (uint64_t x = 1; x < 8; ++x) {
+            for (uint64_t z = 0; z < z_limit; ++z) {
+                for (uint32_t pivot : valid_measurement_pivots(x, z, active_width)) {
+                    if (pivot >= 3 || (x & (uint64_t{1} << pivot)) == 0) {
+                        continue;
+                    }
+                    CAPTURE(active_width, x, z, pivot);
+                    const PreparedMeasurement measurement =
+                        prepare_measurement({x, z}, active_width, pivot);
+                    const ActiveMeasurementKernel selected =
+                        resolve_active_measurement_kernel(measurement, RuntimeIsa::Avx512);
+                    REQUIRE(selected == (active_width >= 4 ? ActiveMeasurementKernel::LanePaired
+                                                           : ActiveMeasurementKernel::Scalar));
+
+                    State scalar_probability_state(active_width, active_width);
+                    load_state(scalar_probability_state, input);
+                    const MeasurementProbabilities expected =
+                        measurement_probabilities(scalar_probability_state, measurement);
+
+                    State vector_probability_state(active_width, active_width);
+                    load_state(vector_probability_state, input);
+                    const MeasurementProbabilities actual = active_measurement_probabilities(
+                        vector_probability_state, measurement, ActiveMeasurementKernel::LanePaired);
+                    REQUIRE_THAT(actual.zero,
+                                 Catch::Matchers::WithinAbs(expected.zero, kTolerance));
+                    REQUIRE_THAT(actual.one, Catch::Matchers::WithinAbs(expected.one, kTolerance));
+
+                    for (bool branch : {false, true}) {
+                        State scalar_state(active_width, active_width);
+                        load_state(scalar_state, input);
+                        collapse_measurement(scalar_state, measurement, branch,
+                                             expected.for_branch(branch));
+
+                        State vector_state(active_width, active_width);
+                        load_state(vector_state, input);
+                        collapse_active_measurement(vector_state, measurement,
+                                                    ActiveMeasurementKernel::LanePaired, branch,
+                                                    actual.for_branch(branch));
+
+                        require_vectors_close(coefficients(vector_state),
+                                              coefficients(scalar_state));
+                        REQUIRE(vector_state.active_width() == active_width - 1);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- add an AVX-512 probability and collapse kernel for active measurements whose Pauli pairing stays within an eight-double lane block
- select the kernel once while lowering the executable plan, storing the one-byte selector in existing action padding
- compact the selected branch in place using fixed permutations and four-double stores, with the existing scalar implementation as the correctness and portability fallback
- retain scalar execution for diagonal, high-pivot, AVX2/scalar, and one-vector-block width-3 shapes

No allocation, exception, runtime topology planning, architecture-specific descriptor data, or action-size growth is introduced.

## Performance

Paired medians from the same pinned Release build and benchmark harness on the AVX-512 performance host:

| Workload | main symbolic | this PR | change |
| --- | ---: | ---: | ---: |
| coherent d5 r1, 20k shots | 1.645 s | 1.373 s | 16.5% faster |
| coherent d3 r3, 100k shots | 0.236 s | 0.219 s | 7.1% faster |
| k12/L512, 20k shots | 0.463 s | 0.283 s | 39.0% faster |
| noncomputational d17 r5, 500 shots | 1.330 s | 1.054 s | 20.8% faster |

For coherent d5 r1, symbolic is now within about 5% of legacy on this host. Coherent d3 r3 and k12/L512 remain faster than legacy. Noncomputational execution remains about 5.2x slower than legacy because its dominant high-pivot instrument activation path is unchanged by this PR.

QV measurements are diagonal and therefore structurally unaffected. A same-layout width-3 A/B showed a 1.6% regression when vectorizing one-block measurements, so selection starts at active width 4.

## Verification

- full native Release-with-symbols test suite: 1,271 cases, 557,826 assertions
- full suite with `CLIFFT_FORCE_ISA=avx2`: 1,271 cases, 408,546 assertions
- full suite with `CLIFFT_FORCE_ISA=scalar`: 1,271 cases, 408,546 assertions
- no-runtime-dispatch generic build links successfully
- exhaustive scalar-oracle coverage for widths 3 through 6, all low-lane X masks, all Z masks, valid low pivots, both Pauli phase classes, and both measurement branches
- generated assembly contains packed AVX-512 permutations, FMA operations, and compact AVX stores
- required pre-commit checks pass

Checksums match main for every paired benchmark.

Contributes to #280.