### PR TITLE
perf(sampling): fuse bounded dynamically signed rotations

### DIFF
--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -250,6 +250,29 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
 
     size_t planned_index = 0;
     while (planned_index < plan.actions.size()) {
+        DynamicFusedRotationRun dynamic_run;
+        if (runtime_isa == internal::RuntimeIsa::Avx512) {
+            dynamic_run = prepare_dynamic_fused_rotation_run(
+                std::span<const PlannedAction>(plan.actions).subspan(planned_index));
+        }
+        if (dynamic_run.rotation.has_value()) {
+            PreparedDynamicFusedRotation prepared = std::move(*dynamic_run.rotation);
+            PreparedDynamicFusedRotationExecution execution;
+            execution.sign_basis.reserve(prepared.sign_basis.size());
+            for (const AffineBool& sign : prepared.sign_basis) {
+                execution.sign_basis.push_back(prepare_expression(sign));
+            }
+            execution.variants.reserve(prepared.variants.size());
+            for (PreparedFusedRotation& variant : prepared.variants) {
+                execution.variants.emplace_back(std::move(variant), runtime_isa);
+            }
+            const uint32_t fused_index = static_cast<uint32_t>(dynamic_fused_rotations_.size());
+            dynamic_fused_rotations_.push_back(std::move(execution));
+            actions_.emplace_back(ExecuteDynamicFusedRotation{fused_index});
+            planned_index += dynamic_run.action_count;
+            continue;
+        }
+
         FusedRotationRun run = prepare_fused_rotation_run(
             std::span<const PlannedAction>(plan.actions).subspan(planned_index));
         if (run.rotation.has_value()) {

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -86,10 +86,19 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     expression_term_begins.reserve(plan.actions.size());
     expression_register_constants_.reserve(plan.actions.size());
 
+    auto ensure_expression_term_capacity = [&](size_t additional_terms) {
+        constexpr size_t kMaxExpressionTerms = std::numeric_limits<uint32_t>::max();
+        // Dynamic fusion can replace source signs with denser basis expressions,
+        // so the original-plan count is only a reserve estimate after lowering.
+        if (additional_terms > kMaxExpressionTerms - expression_terms.size()) {
+            throw std::length_error("sampling executable expression storage exceeds uint32 range");
+        }
+    };
     auto prepare_expression = [&](const AffineBool& expression) {
         if (expression_register_constants_.size() >= std::numeric_limits<uint32_t>::max()) {
             throw std::length_error("sampling executable expression count exceeds uint32 range");
         }
+        ensure_expression_term_capacity(expression.terms().size());
         const uint32_t register_id = static_cast<uint32_t>(expression_register_constants_.size());
         expression_term_begins.push_back(static_cast<uint32_t>(expression_terms.size()));
         expression_register_constants_.push_back(static_cast<uint8_t>(expression.constant()));
@@ -102,6 +111,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
         if (expression_register_constants_.size() >= std::numeric_limits<uint32_t>::max()) {
             throw std::length_error("sampling executable expression count exceeds uint32 range");
         }
+        ensure_expression_term_capacity(outcome.terms().size() - 1);
         const uint32_t register_id = static_cast<uint32_t>(expression_register_constants_.size());
         const uint32_t begin = static_cast<uint32_t>(expression_terms.size());
         expression_term_begins.push_back(begin);

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -79,6 +79,15 @@ class ExecutablePlan {
         uint32_t rotation_index = 0;
     };
 
+    struct ExecuteDynamicFusedRotation {
+        uint32_t rotation_index = 0;
+    };
+
+    struct PreparedDynamicFusedRotationExecution {
+        std::vector<PreparedExpression> sign_basis;
+        std::vector<PreparedFusedRotationExecution> variants;
+    };
+
     struct ExecutePromotion {
         PreparedPromotion promotion;
         PreparedExpression sign;
@@ -188,10 +197,11 @@ class ExecutablePlan {
     };
 
     using Action =
-        std::variant<ExecuteRotation, ExecuteFusedRotation, ExecutePromotion,
-                     ExecuteActiveMeasurement, ExecuteDormantMeasurement, ExecuteClassicalRecord,
-                     ExecuteSymbolDefinition, ExecuteReadoutNoise, ExecuteDetector,
-                     ExecuteObservable, ExecuteExpectation, ExecuteInstrument, ExecuteBoundary>;
+        std::variant<ExecuteRotation, ExecuteFusedRotation, ExecuteDynamicFusedRotation,
+                     ExecutePromotion, ExecuteActiveMeasurement, ExecuteDormantMeasurement,
+                     ExecuteClassicalRecord, ExecuteSymbolDefinition, ExecuteReadoutNoise,
+                     ExecuteDetector, ExecuteObservable, ExecuteExpectation, ExecuteInstrument,
+                     ExecuteBoundary>;
 
     uint32_t num_qubits_ = 0;
     uint32_t initial_active_width_ = 0;
@@ -225,6 +235,7 @@ class ExecutablePlan {
     std::vector<InstrumentDistribution> instrument_distributions_;
     std::vector<uint32_t> instrument_resume_offsets_;
     std::vector<PreparedFusedRotationExecution> fused_rotations_;
+    std::vector<PreparedDynamicFusedRotationExecution> dynamic_fused_rotations_;
     std::vector<Action> actions_;
 };
 

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -316,6 +316,21 @@ void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action
 }
 
 template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
+                              std::span<const uint8_t>, ReplayResult&) noexcept {
+    assert(action.rotation_index < plan_->dynamic_fused_rotations_.size() &&
+           "dynamic fused rotation action must reference prepared execution");
+    const auto& rotation = plan_->dynamic_fused_rotations_[action.rotation_index];
+    uint32_t variant = 0;
+    for (size_t i = 0; i < rotation.sign_basis.size(); ++i) {
+        variant |= static_cast<uint32_t>(evaluate(rotation.sign_basis[i])) << i;
+    }
+    assert(variant < rotation.variants.size() &&
+           "dynamic fused sign value must select a prepared variant");
+    rotation.variants[variant].apply(state_);
+}
+
+template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecutePromotion& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     apply_promotion(state_, action.promotion, evaluate(action.sign));

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -142,6 +142,9 @@ class Executor {
     void execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <bool ForceRecords>
+    void execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
+                        std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecutePromotion& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <bool ForceRecords>

--- a/src/clifft/sampling/fused_rotation.cc
+++ b/src/clifft/sampling/fused_rotation.cc
@@ -23,10 +23,25 @@ constexpr size_t kMinFusedRotationActions = 3;
 // bounds a descriptor at 32 matrices while covering the measured QV workloads.
 constexpr uint32_t kMaxFusedRotationSelectors = 5;
 
+// Sign variants grow the prepared matrix table exponentially, so keep both
+// the sign rank and the minimum amount of eliminated work bounded.
+constexpr uint32_t kMaxFusedRotationSigns = 2;
+constexpr size_t kMinDynamicFusedRotationActions = 8;
+
 // A row-reduced basis for a vector subspace of GF(2)^64, where each bit is one
 // binary coordinate.
 class BinaryBasis {
   public:
+    [[nodiscard]] bool contains(uint64_t value) const {
+        for (int pivot = 63; pivot >= 0; --pivot) {
+            const uint64_t bit = uint64_t{1} << pivot;
+            if ((value & bit) != 0 && rows_[pivot] != 0) {
+                value ^= rows_[pivot];
+            }
+        }
+        return value == 0;
+    }
+
     // Extends the span with value when it is independent. A dependent value
     // succeeds without changing the basis; false means the rank cap prevented
     // adding an independent value.
@@ -74,6 +89,70 @@ class BinaryBasis {
   private:
     std::array<uint64_t, 64> rows_{};
     uint32_t rank_ = 0;
+};
+
+// Triangular basis for affine expressions with their constant terms removed.
+// Coordinates let lowering precompute one matrix for each independent sign
+// assignment while execution evaluates only the basis expressions.
+class AffineBasis {
+  public:
+    [[nodiscard]] bool contains(const AffineBool& value) const {
+        AffineBool reduced(false, value.terms());
+        while (!reduced.terms().empty()) {
+            const uint32_t pivot = index(reduced.terms().back());
+            if (pivot >= rows_.size() || !rows_[pivot].has_value()) {
+                return false;
+            }
+            reduced ^= rows_[pivot]->expression;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool insert(const AffineBool& value, uint32_t max_rank) {
+        AffineBool reduced(false, value.terms());
+        while (!reduced.terms().empty()) {
+            const uint32_t pivot = index(reduced.terms().back());
+            if (pivot < rows_.size() && rows_[pivot].has_value()) {
+                reduced ^= rows_[pivot]->expression;
+                continue;
+            }
+            if (expressions_.size() == max_rank) {
+                return false;
+            }
+            if (pivot >= rows_.size()) {
+                rows_.resize(static_cast<size_t>(pivot) + 1);
+            }
+            const uint32_t coordinate = static_cast<uint32_t>(expressions_.size());
+            expressions_.push_back(reduced);
+            rows_[pivot] = Row{std::move(reduced), coordinate};
+            return true;
+        }
+        return true;
+    }
+
+    [[nodiscard]] uint32_t coordinates(const AffineBool& value) const {
+        AffineBool reduced(false, value.terms());
+        uint32_t result = 0;
+        while (!reduced.terms().empty()) {
+            const uint32_t pivot = index(reduced.terms().back());
+            assert(pivot < rows_.size() && rows_[pivot].has_value() &&
+                   "expression must belong to the prepared affine basis");
+            result ^= uint32_t{1} << rows_[pivot]->coordinate;
+            reduced ^= rows_[pivot]->expression;
+        }
+        return result;
+    }
+
+    [[nodiscard]] const std::vector<AffineBool>& expressions() const { return expressions_; }
+
+  private:
+    struct Row {
+        AffineBool expression;
+        uint32_t coordinate = 0;
+    };
+
+    std::vector<std::optional<Row>> rows_;
+    std::vector<AffineBool> expressions_;
 };
 
 // Expresses value in the supplied reduced basis, with bit i of the result
@@ -303,6 +382,102 @@ FusedRotationRun prepare_fused_rotation_run(std::span<const PlannedAction> actio
     if (result.action_count >= kMinFusedRotationActions) {
         result.rotation = prepare_fused_rotation(actions.first(result.action_count), orbit_basis);
     }
+    return result;
+}
+
+DynamicFusedRotationRun prepare_dynamic_fused_rotation_run(std::span<const PlannedAction> actions) {
+    DynamicFusedRotationRun result;
+    if (actions.size() < kMinDynamicFusedRotationActions) {
+        return result;
+    }
+    const PlannedAction& first = actions.front();
+    const auto* first_rotation = std::get_if<RotateActivePauli>(&first.action);
+    if (first_rotation == nullptr || first_rotation->pauli.is_identity()) {
+        return result;
+    }
+
+    // Reject ordinary high-rank runs without constructing affine expressions
+    // or clearing the full binary bases. Any eligible run must keep the first
+    // minimum-length prefix within the same two-dimensional X-mask span.
+    std::array<uint64_t, 2> prefix_basis{};
+    size_t prefix_rank = 0;
+    for (const PlannedAction& candidate : actions.first(kMinDynamicFusedRotationActions)) {
+        const auto* rotation = std::get_if<RotateActivePauli>(&candidate.action);
+        if (rotation == nullptr || rotation->pauli.is_identity() ||
+            candidate.active_before != first.active_before) {
+            return result;
+        }
+        uint64_t reduced = rotation->pauli.x;
+        for (size_t i = 0; i < prefix_rank; ++i) {
+            reduced = std::min(reduced, reduced ^ prefix_basis[i]);
+        }
+        if (reduced != 0) {
+            if (prefix_rank == prefix_basis.size()) {
+                return result;
+            }
+            prefix_basis[prefix_rank++] = reduced;
+        }
+    }
+
+    BinaryBasis orbit_basis;
+    AffineBasis sign_basis;
+    bool has_dynamic_sign = false;
+    while (result.action_count < actions.size()) {
+        const PlannedAction& candidate = actions[result.action_count];
+        const auto* rotation = std::get_if<RotateActivePauli>(&candidate.action);
+        if (rotation == nullptr || rotation->pauli.is_identity() ||
+            candidate.active_before != first.active_before) {
+            break;
+        }
+        if ((orbit_basis.rank() == 2 && !orbit_basis.contains(rotation->pauli.x)) ||
+            (sign_basis.expressions().size() == kMaxFusedRotationSigns &&
+             !sign_basis.contains(rotation->sign))) {
+            break;
+        }
+        [[maybe_unused]] const bool orbit_inserted = orbit_basis.insert(rotation->pauli.x, 2);
+        [[maybe_unused]] const bool sign_inserted =
+            sign_basis.insert(rotation->sign, kMaxFusedRotationSigns);
+        assert(orbit_inserted && sign_inserted && "prechecked bases must accept the rotation");
+        has_dynamic_sign |= !rotation->sign.terms().empty();
+        ++result.action_count;
+    }
+
+    const std::vector<uint64_t> orbit_rows = orbit_basis.rows();
+    if (result.action_count < kMinDynamicFusedRotationActions || !has_dynamic_sign ||
+        orbit_rows.size() != 2 || std::countr_zero(std::bit_floor(orbit_rows[0])) < 3) {
+        return result;
+    }
+
+    std::vector<uint32_t> sign_coordinates;
+    sign_coordinates.reserve(result.action_count);
+    for (size_t i = 0; i < result.action_count; ++i) {
+        const auto& rotation = std::get<RotateActivePauli>(actions[i].action);
+        sign_coordinates.push_back(sign_basis.coordinates(rotation.sign));
+    }
+
+    PreparedDynamicFusedRotation prepared;
+    prepared.sign_basis = sign_basis.expressions();
+    const size_t num_sign_variants = size_t{1} << prepared.sign_basis.size();
+    prepared.variants.reserve(num_sign_variants);
+    std::vector<PlannedAction> variant_actions(actions.begin(),
+                                               actions.begin() + result.action_count);
+    for (size_t variant = 0; variant < num_sign_variants; ++variant) {
+        for (size_t i = 0; i < result.action_count; ++i) {
+            const auto& source = std::get<RotateActivePauli>(actions[i].action);
+            auto& destination = std::get<RotateActivePauli>(variant_actions[i].action);
+            const bool sign =
+                source.sign.constant() !=
+                ((std::popcount(static_cast<uint32_t>(variant) & sign_coordinates[i]) & 1U) != 0);
+            destination.sign = AffineBool(sign);
+        }
+        std::optional<PreparedFusedRotation> rotation =
+            prepare_fused_rotation(variant_actions, orbit_basis);
+        if (!rotation.has_value()) {
+            return result;
+        }
+        prepared.variants.push_back(std::move(*rotation));
+    }
+    result.rotation = std::move(prepared);
     return result;
 }
 

--- a/src/clifft/sampling/fused_rotation.h
+++ b/src/clifft/sampling/fused_rotation.h
@@ -37,7 +37,22 @@ struct FusedRotationRun {
     std::optional<PreparedFusedRotation> rotation;
 };
 
+// A low-rank rotation run whose matrix depends on a small basis of per-shot
+// affine signs. Each sign assignment selects one ordinary prepared fused
+// rotation, so execution can reuse the existing kernels.
+struct PreparedDynamicFusedRotation {
+    std::vector<AffineBool> sign_basis;
+    std::vector<PreparedFusedRotation> variants;
+};
+
+struct DynamicFusedRotationRun {
+    size_t action_count = 0;
+    std::optional<PreparedDynamicFusedRotation> rotation;
+};
+
 [[nodiscard]] FusedRotationRun prepare_fused_rotation_run(std::span<const PlannedAction> actions);
+[[nodiscard]] DynamicFusedRotationRun prepare_dynamic_fused_rotation_run(
+    std::span<const PlannedAction> actions);
 void apply_fused_rotation(State& state, const PreparedFusedRotation& rotation) noexcept;
 
 }  // namespace clifft::sampling

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -1,5 +1,7 @@
 #include "clifft/sampling/executor.h"
+#include "clifft/sampling/fused_rotation.h"
 #include "clifft/sampling/kernels.h"
+#include "clifft/util/runtime_isa.h"
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
@@ -9,16 +11,19 @@
 #include <optional>
 #include <span>
 #include <variant>
+#include <vector>
 
 namespace {
 
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
+using clifft::sampling::apply_fused_rotation;
 using clifft::sampling::apply_rotation;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
 using clifft::sampling::index;
 using clifft::sampling::PlannedAction;
+using clifft::sampling::prepare_dynamic_fused_rotation_run;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
@@ -118,6 +123,117 @@ TEST_CASE("Fused rotation falls back for a rank three run") {
         RotateActivePauli{{0b100, 0b001}, 0.4, AffineBool(false)},
     };
     require_matches_scalar(rotation_plan(3, rotations), 0, 3);
+}
+
+TEST_CASE("Dynamic fused rotation matches scalar across affine sign values") {
+    const SymbolId first_sign{0};
+    const SymbolId second_sign{1};
+    const std::array rotations = {
+        RotateActivePauli{{0b001000, 0b000101}, 0.17, AffineBool::symbol(first_sign)},
+        RotateActivePauli{{0b100000, 0b010010}, -0.23, AffineBool::symbol(second_sign)},
+        RotateActivePauli{{0b101000, 0b100001}, 0.31, AffineBool(false, {first_sign, second_sign})},
+        RotateActivePauli{{0b001000, 0b001110}, -0.11, AffineBool(true, {first_sign})},
+        RotateActivePauli{{0b100000, 0b011001}, 0.29, AffineBool(true, {second_sign})},
+        RotateActivePauli{{0b101000, 0b100100}, -0.37, AffineBool(true, {first_sign, second_sign})},
+        RotateActivePauli{{0b001000, 0b010101}, 0.13, AffineBool(false)},
+        RotateActivePauli{{0b100000, 0b101010}, -0.19, AffineBool::symbol(first_sign)},
+    };
+
+    SamplingPlan plan;
+    plan.num_qubits = 6;
+    plan.initial_active_width = 6;
+    plan.max_active_width = 6;
+    plan.symbols = {
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
+        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
+    };
+    for (const RotateActivePauli& rotation : rotations) {
+        plan.actions.push_back(PlannedAction{6, 6, rotation});
+    }
+
+    const auto prepared_run = prepare_dynamic_fused_rotation_run(plan.actions);
+    REQUIRE(prepared_run.action_count == rotations.size());
+    REQUIRE(prepared_run.rotation.has_value());
+    REQUIRE(prepared_run.rotation->sign_basis.size() == 2);
+    REQUIRE(prepared_run.rotation->variants.size() == 4);
+
+    const ExecutablePlan executable(plan);
+    const size_t expected_action_count =
+        clifft::internal::runtime_isa() == clifft::internal::RuntimeIsa::Avx512 ? 1
+                                                                                : rotations.size();
+    REQUIRE(executable.num_actions() == expected_action_count);
+    for (uint8_t first_value : {uint8_t{0}, uint8_t{1}}) {
+        for (uint8_t second_value : {uint8_t{0}, uint8_t{1}}) {
+            const std::array values = {first_value, second_value};
+            Executor executor(executable);
+            executor.run_shot(values);
+
+            State expected(6, 6);
+            for (const RotateActivePauli& rotation : rotations) {
+                bool sign = rotation.sign.constant();
+                for (SymbolId term : rotation.sign.terms()) {
+                    sign ^= values[index(term)] != 0;
+                }
+                apply_rotation(expected, prepare_rotation(rotation.pauli, 6, rotation.half_turns),
+                               sign);
+            }
+
+            uint32_t variant = 0;
+            for (size_t i = 0; i < prepared_run.rotation->sign_basis.size(); ++i) {
+                const AffineBool& expression = prepared_run.rotation->sign_basis[i];
+                bool value = expression.constant();
+                for (SymbolId term : expression.terms()) {
+                    value ^= values[index(term)] != 0;
+                }
+                variant |= static_cast<uint32_t>(value) << i;
+            }
+            State prepared_state(6, 6);
+            apply_fused_rotation(prepared_state, prepared_run.rotation->variants[variant]);
+
+            for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+                CAPTURE(first_value, second_value, basis);
+                REQUIRE_THAT(executor.state().real_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.real_data()[basis], 1e-12));
+                REQUIRE_THAT(executor.state().imag_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.imag_data()[basis], 1e-12));
+                REQUIRE_THAT(prepared_state.real_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.real_data()[basis], 1e-12));
+                REQUIRE_THAT(prepared_state.imag_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.imag_data()[basis], 1e-12));
+            }
+        }
+    }
+}
+
+TEST_CASE("Dynamic fused rotation enforces bounded selection") {
+    const SymbolId first_sign{0};
+    const SymbolId second_sign{1};
+    constexpr std::array<uint64_t, 3> kXMasks = {0b001000, 0b100000, 0b101000};
+    const std::array signs = {AffineBool::symbol(first_sign), AffineBool::symbol(second_sign),
+                              AffineBool(false, {first_sign, second_sign})};
+    std::vector<PlannedAction> actions;
+    for (size_t i = 0; i < 8; ++i) {
+        actions.push_back(PlannedAction{
+            6, 6, RotateActivePauli{{kXMasks[i % 3], uint64_t{1} << (i % 6)}, 0.2, signs[i % 3]}});
+    }
+
+    REQUIRE(prepare_dynamic_fused_rotation_run(std::span(actions).first(7)).rotation ==
+            std::nullopt);
+
+    std::vector<PlannedAction> rank_three = actions;
+    std::get<RotateActivePauli>(rank_three[2].action).pauli.x = 0b010000;
+    REQUIRE(prepare_dynamic_fused_rotation_run(rank_three).rotation == std::nullopt);
+
+    std::vector<PlannedAction> sign_rank_three = actions;
+    std::get<RotateActivePauli>(sign_rank_three[2].action).sign = AffineBool::symbol(SymbolId{2});
+    REQUIRE(prepare_dynamic_fused_rotation_run(sign_rank_three).rotation == std::nullopt);
+
+    std::vector<PlannedAction> low_pivots = actions;
+    for (PlannedAction& planned : low_pivots) {
+        auto& rotation = std::get<RotateActivePauli>(planned.action);
+        rotation.pauli.x >>= 3;
+    }
+    REQUIRE(prepare_dynamic_fused_rotation_run(low_pivots).rotation == std::nullopt);
 }
 
 TEST_CASE("Direct rotation SIMD matches scalar across eligible shapes") {

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -236,6 +236,33 @@ TEST_CASE("Dynamic fused rotation enforces bounded selection") {
     REQUIRE(prepare_dynamic_fused_rotation_run(low_pivots).rotation == std::nullopt);
 }
 
+TEST_CASE("Dynamic fused rotation stops at execution barriers") {
+    const SymbolId first_sign{0};
+    const SymbolId second_sign{1};
+    constexpr std::array<uint64_t, 3> kXMasks = {0b001000, 0b100000, 0b101000};
+    const std::array signs = {AffineBool::symbol(first_sign), AffineBool::symbol(second_sign),
+                              AffineBool(false, {first_sign, second_sign})};
+    std::vector<PlannedAction> actions;
+    for (size_t i = 0; i < 8; ++i) {
+        actions.push_back(PlannedAction{
+            6, 6, RotateActivePauli{{kXMasks[i % 3], uint64_t{1} << (i % 6)}, 0.2, signs[i % 3]}});
+    }
+
+    std::vector<PlannedAction> identity_barrier = actions;
+    identity_barrier.push_back(
+        PlannedAction{6, 6, RotateActivePauli{{0, 0}, 0.25, AffineBool::symbol(first_sign)}});
+    const auto identity_run = prepare_dynamic_fused_rotation_run(identity_barrier);
+    REQUIRE(identity_run.action_count == actions.size());
+    REQUIRE(identity_run.rotation.has_value());
+
+    std::vector<PlannedAction> width_barrier = actions;
+    width_barrier.push_back(PlannedAction{
+        5, 5, RotateActivePauli{{0b001000, 0b000101}, 0.25, AffineBool::symbol(first_sign)}});
+    const auto width_run = prepare_dynamic_fused_rotation_run(width_barrier);
+    REQUIRE(width_run.action_count == actions.size());
+    REQUIRE(width_run.rotation.has_value());
+}
+
 TEST_CASE("Direct rotation SIMD matches scalar across eligible shapes") {
     const std::array rotations = {
         RotateActivePauli{{0, 0}, 0.125, AffineBool::symbol(SymbolId{0})},


### PR DESCRIPTION
## Summary

- Fuse long, same-width active-Pauli rotation runs when their X masks span a rank-two orbit and their dynamic signs span at most two affine bits.
- Precompute one U4 matrix table per sign assignment while lowering `SamplingPlan` to `ExecutablePlan`, then evaluate the sign basis once per shot and reuse the existing AVX-512 fused kernel for one coefficient sweep.
- Keep runs shorter than eight rotations, rank-three or low-pivot shapes, and non-AVX-512 hosts on the existing execution paths.

This is a bounded follow-up to #280. It does not add batching, OpenMP, a new bytecode layer, or a new architecture-specific kernel.

## Evidence and scope

The post-planning census found useful dynamic rank-two runs in QV, but none in surface d7 r7, cultivation d3/d5, distillation, coherent d3/d5, or k12/L512. Those QEC runtime plans therefore remain unchanged.

For QV-10 seed 44, the selected runs replace 37.0% of the current coefficient visits. Across QV-10 seeds 42-51, projected coverage varies from 7.3% to 37.0%.

Release build with symbols and frame pointers, pinned to one CPU, using three balanced 10,000-shot blocks:

| QV-10 seed | main | this PR | legacy | change from main |
| --- | ---: | ---: | ---: | ---: |
| 42 | 529.1 ms | 466.1 ms | 516.9 ms | 11.9% faster |
| 44 | 474.2 ms | 421.7 ms | 413.7 ms | 11.1% faster |
| 51 | 528.9 ms | 506.9 ms | 647.6 ms | 4.2% faster |

Thirty-shot QV-20 `perf stat` runs also improved:

| seed | sampling speedup | cycle reduction | instruction reduction |
| --- | ---: | ---: | ---: |
| 44 | 1.10x | 6.0% | 1.4% |
| 49 | 1.15x | 9.6% | 3.6% |

The counters include compilation while the sampling interval does not, so the cycle and instruction reductions are conservative for execution. A fresh QV-10 seed-44 profile reduced direct rotation from 14.2% of sampled cycles on main to 4.4%; the resulting fused kernels account for about 80%.

The bounded candidate scan keeps cultivation d5 compilation neutral. QV-10 seed-44 compilation increases by about 0.4 ms per plan and roughly 0.6-1.0 MiB of whole-process peak RSS. QV-20 seed-44 compilation was unchanged, with a 132 KiB whole-process peak-RSS increase.

## Correctness and portability

- Compare every affine sign assignment with both sequential scalar rotations and the prepared scalar fused oracle.
- Cover the length, X-rank, sign-rank, pivot, ISA, identity-barrier, and active-width boundaries.
- Enforce the 32-bit expression dependency-tape limit after lowering, including synthesized affine-basis expressions.
- Verify native, forced-scalar, and forced-AVX2 executor behavior.
- Preserve allocation-free and exception-free hot execution: all matrices and expressions are prepared during lowering.
- Reuse the ISA-neutral fused descriptor and existing separately compiled AVX-512 kernel.

## Verification

- `build-profile/tests/clifft_tests`: 1,274 test cases and 558,863 assertions passed.
- Focused dynamic-fusion tests passed under native, forced scalar, and forced AVX2 execution.
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Refs #280
