### PR TITLE
perf(sampling): fuse new-X instrument activation

### DIFF
--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -19,6 +19,11 @@ namespace {
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
 
+bool activates_new_x(const ApplyInstrument& instrument, uint32_t active_after) {
+    return instrument.mode == InstrumentMode::Activate && active_after > 0 &&
+           instrument.source.z == 0 && instrument.source.x == (uint64_t{1} << (active_after - 1));
+}
+
 }  // namespace
 
 ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
@@ -224,9 +229,10 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                                                              index(typed.exp_val)});
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     has_instruments_ = true;
+                    const bool new_x_activation = activates_new_x(typed, planned.active_after);
                     std::optional<PreparedMeasurement> measurement;
                     if (typed.mode == InstrumentMode::Active ||
-                        typed.mode == InstrumentMode::Activate) {
+                        (typed.mode == InstrumentMode::Activate && !new_x_activation)) {
                         const uint32_t width = typed.mode == InstrumentMode::Activate
                                                    ? planned.active_after
                                                    : planned.active_before;
@@ -235,11 +241,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                         const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
                         measurement = prepare_measurement(typed.source, width, pivot);
                     }
-                    const bool activates_new_x =
-                        typed.mode == InstrumentMode::Activate && typed.source.z == 0 &&
-                        typed.source.x == (uint64_t{1} << (planned.active_after - 1));
                     actions_.emplace_back(ExecuteInstrument{
-                        typed.mode, activates_new_x, prepare_expression(typed.sign),
+                        typed.mode, new_x_activation, prepare_expression(typed.sign),
                         std::move(measurement), index(typed.site),
                         typed.destination_flip.has_value()
                             ? std::optional<uint32_t>{index(*typed.destination_flip)}
@@ -323,6 +326,14 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
             expression_dependency_targets_[next_dependency[symbol]++] = register_id;
         }
     }
+}
+
+size_t ExecutablePlan::num_new_x_instrument_activations() const {
+    return static_cast<size_t>(
+        std::count_if(actions_.begin(), actions_.end(), [](const Action& action) {
+            const auto* instrument = std::get_if<ExecuteInstrument>(&action);
+            return instrument != nullptr && instrument->activates_new_x;
+        }));
 }
 
 std::vector<double> ExecutablePlan::noise_site_probabilities() const {

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -235,9 +235,12 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                         const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
                         measurement = prepare_measurement(typed.source, width, pivot);
                     }
+                    const bool activates_new_x =
+                        typed.mode == InstrumentMode::Activate && typed.source.z == 0 &&
+                        typed.source.x == (uint64_t{1} << (planned.active_after - 1));
                     actions_.emplace_back(ExecuteInstrument{
-                        typed.mode, prepare_expression(typed.sign), std::move(measurement),
-                        index(typed.site),
+                        typed.mode, activates_new_x, prepare_expression(typed.sign),
+                        std::move(measurement), index(typed.site),
                         typed.destination_flip.has_value()
                             ? std::optional<uint32_t>{index(*typed.destination_flip)}
                             : std::nullopt});

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -47,6 +47,7 @@ class ExecutablePlan {
         return static_cast<uint32_t>(presampled_symbols_.size());
     }
     [[nodiscard]] size_t num_actions() const { return actions_.size(); }
+    [[nodiscard]] size_t num_new_x_instrument_activations() const;
     [[nodiscard]] uint32_t num_unbound_presampled_symbols() const {
         return static_cast<uint32_t>(unbound_presampled_symbols_.size());
     }
@@ -177,6 +178,9 @@ class ExecutablePlan {
         uint32_t site = 0;
         std::optional<uint32_t> destination_flip;
     };
+
+    static_assert(sizeof(ExecuteInstrument) == 104,
+                  "instrument specialization must not expand its action descriptor");
 
     struct ExecuteBoundary {
         uint32_t site = 0;

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -169,6 +169,9 @@ class ExecutablePlan {
 
     struct ExecuteInstrument {
         InstrumentMode mode = InstrumentMode::Classical;
+        // Lowering identifies the exact new-coordinate X shape so execution
+        // need not rediscover instrument topology inside the hot loop.
+        bool activates_new_x = false;
         PreparedExpression sign;
         std::optional<PreparedMeasurement> measurement;
         uint32_t site = 0;

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -532,8 +532,10 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
         activate_zero_coordinate(state_);
     }
     const bool sign = evaluate(action.sign);
+    // The coefficients are normalized and the clean |0> coordinate has equal
+    // populations in the X eigenbasis, so this exact shape needs no reduction.
     const MeasurementProbabilities eigen_populations =
-        action.activates_new_x ? new_x_instrument_populations(state_)
+        action.activates_new_x ? MeasurementProbabilities{0.5, 0.5}
                                : measurement_probabilities(state_, *action.measurement);
     const double total = eigen_populations.total();
     const double epsilon = kMeasurementDustEpsilon * total;

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -526,14 +526,16 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
         return;
     }
 
-    assert(action.measurement.has_value() &&
-           "active instrument requires a prepared source measurement");
+    assert((action.activates_new_x || action.measurement.has_value()) &&
+           "active instrument requires a kernel or prepared source measurement");
     if (action.mode == InstrumentMode::Activate && !action.activates_new_x) {
         activate_zero_coordinate(state_);
     }
     const bool sign = evaluate(action.sign);
-    // The coefficients are normalized and the clean |0> coordinate has equal
-    // populations in the X eigenbasis, so this exact shape needs no reduction.
+    // Under the State normalization invariant, the clean |0> coordinate has
+    // exact half populations in the X eigenbasis. Using those semantic values
+    // retains any residual floating-point norm drift instead of reducing and
+    // renormalizing it inside this activation.
     const MeasurementProbabilities eigen_populations =
         action.activates_new_x ? MeasurementProbabilities{0.5, 0.5}
                                : measurement_probabilities(state_, *action.measurement);

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -528,12 +528,13 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
 
     assert(action.measurement.has_value() &&
            "active instrument requires a prepared source measurement");
-    if (action.mode == InstrumentMode::Activate) {
+    if (action.mode == InstrumentMode::Activate && !action.activates_new_x) {
         activate_zero_coordinate(state_);
     }
     const bool sign = evaluate(action.sign);
     const MeasurementProbabilities eigen_populations =
-        measurement_probabilities(state_, *action.measurement);
+        action.activates_new_x ? new_x_instrument_populations(state_)
+                               : measurement_probabilities(state_, *action.measurement);
     const double total = eigen_populations.total();
     const double epsilon = kMeasurementDustEpsilon * total;
     const double physical_zero = eigen_populations.for_branch(sign);
@@ -556,14 +557,23 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
                                            factor_one * factor_one * eigen_populations.one;
         assert(no_fire_probability > 0.0 &&
                "a selected no-fire branch must have positive probability");
-        apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
-                                 no_fire_probability);
+        if (action.activates_new_x) {
+            apply_new_x_instrument_no_fire(state_, factor_zero, factor_one, no_fire_probability);
+        } else {
+            apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
+                                     no_fire_probability);
+        }
         return;
     }
 
     const bool eigen_branch = (*fired_source != 0) ^ sign;
-    collapse_instrument_source(state_, action.measurement->pauli, eigen_branch,
-                               eigen_populations.for_branch(eigen_branch));
+    if (action.activates_new_x) {
+        collapse_new_x_instrument_source(state_, eigen_branch,
+                                         eigen_populations.for_branch(eigen_branch));
+    } else {
+        collapse_instrument_source(state_, action.measurement->pauli, eigen_branch,
+                                   eigen_populations.for_branch(eigen_branch));
+    }
     finish_fire(*fired_source);
 }
 

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -287,6 +287,67 @@ void activate_zero_coordinate(State& state) noexcept {
     state.set_active_width(state.active_width() + 1);
 }
 
+MeasurementProbabilities new_x_instrument_populations(const State& state) noexcept {
+    // A new |0> coordinate has equal populations in the X eigenbasis. Applying
+    // f0 Pi+ + f1 Pi- therefore expands each old coefficient with amplitudes
+    // (f0 + f1) / 2 and (f0 - f1) / 2, avoiding a zero-fill and two generic
+    // paired traversals of the wider state.
+    double total = 0.0;
+    for (uint64_t basis = 0; basis < state.size(); ++basis) {
+        const double real = state.real_data()[basis];
+        const double imag = state.imag_data()[basis];
+        total += real * real + imag * imag;
+    }
+    const double branch_probability = 0.5 * total;
+    return {branch_probability, branch_probability};
+}
+
+void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
+                                    double no_fire_probability) noexcept {
+    assert(state.active_width() < state.max_active_width() &&
+           "instrument activation must fit the sampling state allocation");
+    assert(factor_zero >= 0.0 && factor_zero <= 1.0 && factor_one >= 0.0 && factor_one <= 1.0 &&
+           no_fire_probability > 0.0 && is_finite_robust(no_fire_probability) &&
+           "instrument no-fire expansion requires valid factors and probability");
+    const double inv_norm = 1.0 / std::sqrt(no_fire_probability);
+    const double identity_factor = 0.5 * (factor_zero + factor_one) * inv_norm;
+    const double pauli_factor = 0.5 * (factor_zero - factor_one) * inv_norm;
+    const uint64_t old_size = state.size();
+    double* real = state.real_data();
+    double* imag = state.imag_data();
+    for (uint64_t basis = 0; basis < old_size; ++basis) {
+        const double input_real = real[basis];
+        const double input_imag = imag[basis];
+        real[basis] = identity_factor * input_real;
+        imag[basis] = identity_factor * input_imag;
+        real[old_size + basis] = pauli_factor * input_real;
+        imag[old_size + basis] = pauli_factor * input_imag;
+    }
+    state.set_active_width(state.active_width() + 1);
+}
+
+void collapse_new_x_instrument_source(State& state, bool branch,
+                                      double branch_probability) noexcept {
+    assert(state.active_width() < state.max_active_width() &&
+           "instrument activation must fit the sampling state allocation");
+    assert(branch_probability > 0.0 && is_finite_robust(branch_probability) &&
+           "instrument collapse expansion requires a positive finite probability");
+    const double scale = 0.5 / std::sqrt(branch_probability);
+    const double upper_scale = branch ? -scale : scale;
+    const uint64_t old_size = state.size();
+    double* real = state.real_data();
+    double* imag = state.imag_data();
+    for (uint64_t basis = 0; basis < old_size; ++basis) {
+        const double input_real = real[basis];
+        const double input_imag = imag[basis];
+        real[basis] = scale * input_real;
+        imag[basis] = scale * input_imag;
+        real[old_size + basis] = upper_scale * input_real;
+        imag[old_size + basis] = upper_scale * input_imag;
+    }
+    state.set_active_width(state.active_width() + 1);
+}
+
 void apply_instrument_no_fire(State& state, const PreparedPauli& source, double factor_zero,
                               double factor_one, double no_fire_probability) noexcept {
     assert_descriptor_width(state, source);

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -287,23 +287,12 @@ void activate_zero_coordinate(State& state) noexcept {
     state.set_active_width(state.active_width() + 1);
 }
 
-MeasurementProbabilities new_x_instrument_populations(const State& state) noexcept {
+void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
+                                    double no_fire_probability) noexcept {
     // A new |0> coordinate has equal populations in the X eigenbasis. Applying
     // f0 Pi+ + f1 Pi- therefore expands each old coefficient with amplitudes
     // (f0 + f1) / 2 and (f0 - f1) / 2, avoiding a zero-fill and two generic
     // paired traversals of the wider state.
-    double total = 0.0;
-    for (uint64_t basis = 0; basis < state.size(); ++basis) {
-        const double real = state.real_data()[basis];
-        const double imag = state.imag_data()[basis];
-        total += real * real + imag * imag;
-    }
-    const double branch_probability = 0.5 * total;
-    return {branch_probability, branch_probability};
-}
-
-void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
-                                    double no_fire_probability) noexcept {
     assert(state.active_width() < state.max_active_width() &&
            "instrument activation must fit the sampling state allocation");
     assert(factor_zero >= 0.0 && factor_zero <= 1.0 && factor_one >= 0.0 && factor_one <= 1.0 &&

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -80,6 +80,11 @@ void collapse_measurement(State& state, const PreparedMeasurement& measurement, 
 // while filter and collapse keep the full coefficient array instead of
 // compacting a coordinate.
 void activate_zero_coordinate(State& state) noexcept;
+[[nodiscard]] MeasurementProbabilities new_x_instrument_populations(const State& state) noexcept;
+void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
+                                    double no_fire_probability) noexcept;
+void collapse_new_x_instrument_source(State& state, bool branch,
+                                      double branch_probability) noexcept;
 void apply_instrument_no_fire(State& state, const PreparedPauli& source, double factor_zero,
                               double factor_one, double no_fire_probability) noexcept;
 void collapse_instrument_source(State& state, const PreparedPauli& source, bool branch,

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -80,7 +80,6 @@ void collapse_measurement(State& state, const PreparedMeasurement& measurement, 
 // while filter and collapse keep the full coefficient array instead of
 // compacting a coordinate.
 void activate_zero_coordinate(State& state) noexcept;
-[[nodiscard]] MeasurementProbabilities new_x_instrument_populations(const State& state) noexcept;
 void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
                                     double no_fire_probability) noexcept;
 void collapse_new_x_instrument_source(State& state, bool branch,

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -817,6 +817,20 @@ TEST_CASE("Sampling executor prepares instrument boundaries before dispatch") {
     REQUIRE(executable.num_instrument_sites() == 1);
 }
 
+TEST_CASE("Sampling executable selects new X instrument activation") {
+    const clifft::InstrumentTraceOptions options = clifft::test::source_dependent_jump_options();
+    const auto compile = [&](std::string_view circuit) {
+        const clifft::HirModule hir = clifft::trace(clifft::parse(circuit), &options);
+        return ExecutablePlan(clifft::sampling::plan_sampling(hir));
+    };
+
+    const ExecutablePlan activating = compile("H 0\nT 0\nH 1\nLEVEL_TRANSITION[jump] 1\nM 1");
+    REQUIRE(activating.num_new_x_instrument_activations() == 1);
+
+    const ExecutablePlan already_active = compile("H 0\nT 0\nLEVEL_TRANSITION[jump] 0\nM 0");
+    REQUIRE(already_active.num_new_x_instrument_activations() == 0);
+}
+
 TEST_CASE("Sampling executor applies computational instrument destinations in line") {
     clifft::InstrumentTraceOptions options;
     clifft::InstrumentProbabilities reset;

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -23,15 +23,18 @@ using clifft::sampling::active_measurement_probabilities;
 using clifft::sampling::ActiveMeasurementKernel;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::apply_instrument_no_fire;
+using clifft::sampling::apply_new_x_instrument_no_fire;
 using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
 using clifft::sampling::collapse_active_measurement;
 using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
+using clifft::sampling::collapse_new_x_instrument_source;
 using clifft::sampling::DirectRotationKernel;
 using clifft::sampling::expectation_value;
 using clifft::sampling::measurement_probabilities;
 using clifft::sampling::MeasurementProbabilities;
+using clifft::sampling::new_x_instrument_populations;
 using clifft::sampling::prepare_measurement;
 using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
@@ -616,6 +619,66 @@ TEST_CASE("Sampling instrument activation adds a clean coordinate in existing st
         REQUIRE(state.imag_data()[i] == input[i].imag());
         REQUIRE(state.real_data()[input.size() + i] == 0.0);
         REQUIRE(state.imag_data()[input.size() + i] == 0.0);
+    }
+}
+
+TEST_CASE("Sampling new X instrument activation matches the generic widened source") {
+    constexpr uint32_t kInitialWidth = 3;
+    constexpr uint32_t kExpandedWidth = kInitialWidth + 1;
+    constexpr ActivePauli kNewX{uint64_t{1} << kInitialWidth, 0};
+    const PreparedMeasurement measurement =
+        prepare_measurement(kNewX, kExpandedWidth, kInitialWidth);
+    const std::vector<std::complex<double>> input = deterministic_state(kInitialWidth);
+
+    State population_oracle(kExpandedWidth, kInitialWidth);
+    load_state(population_oracle, input);
+    activate_zero_coordinate(population_oracle);
+    const MeasurementProbabilities expected_populations =
+        measurement_probabilities(population_oracle, measurement);
+
+    State population_actual(kExpandedWidth, kInitialWidth);
+    load_state(population_actual, input);
+    const MeasurementProbabilities actual_populations =
+        new_x_instrument_populations(population_actual);
+    REQUIRE_THAT(actual_populations.zero,
+                 Catch::Matchers::WithinAbs(expected_populations.zero, kTolerance));
+    REQUIRE_THAT(actual_populations.one,
+                 Catch::Matchers::WithinAbs(expected_populations.one, kTolerance));
+    REQUIRE(population_actual.active_width() == kInitialWidth);
+
+    for (const auto& [factor_zero, factor_one] : {std::pair{0.8, 0.3}, std::pair{0.3, 0.8}}) {
+        CAPTURE(factor_zero, factor_one);
+        const double no_fire_probability = factor_zero * factor_zero * expected_populations.zero +
+                                           factor_one * factor_one * expected_populations.one;
+
+        State no_fire_oracle(kExpandedWidth, kInitialWidth);
+        load_state(no_fire_oracle, input);
+        activate_zero_coordinate(no_fire_oracle);
+        apply_instrument_no_fire(no_fire_oracle, measurement.pauli, factor_zero, factor_one,
+                                 no_fire_probability);
+
+        State no_fire_actual(kExpandedWidth, kInitialWidth);
+        load_state(no_fire_actual, input);
+        apply_new_x_instrument_no_fire(no_fire_actual, factor_zero, factor_one,
+                                       no_fire_probability);
+        require_vectors_close(coefficients(no_fire_actual), coefficients(no_fire_oracle));
+        REQUIRE(no_fire_actual.active_width() == kExpandedWidth);
+    }
+
+    for (bool branch : {false, true}) {
+        CAPTURE(branch);
+        State collapse_oracle(kExpandedWidth, kInitialWidth);
+        load_state(collapse_oracle, input);
+        activate_zero_coordinate(collapse_oracle);
+        collapse_instrument_source(collapse_oracle, measurement.pauli, branch,
+                                   expected_populations.for_branch(branch));
+
+        State collapse_actual(kExpandedWidth, kInitialWidth);
+        load_state(collapse_actual, input);
+        collapse_new_x_instrument_source(collapse_actual, branch,
+                                         actual_populations.for_branch(branch));
+        require_vectors_close(coefficients(collapse_actual), coefficients(collapse_oracle));
+        REQUIRE(collapse_actual.active_width() == kExpandedWidth);
     }
 }
 

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -34,7 +34,6 @@ using clifft::sampling::DirectRotationKernel;
 using clifft::sampling::expectation_value;
 using clifft::sampling::measurement_probabilities;
 using clifft::sampling::MeasurementProbabilities;
-using clifft::sampling::new_x_instrument_populations;
 using clifft::sampling::prepare_measurement;
 using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
@@ -636,15 +635,11 @@ TEST_CASE("Sampling new X instrument activation matches the generic widened sour
     const MeasurementProbabilities expected_populations =
         measurement_probabilities(population_oracle, measurement);
 
-    State population_actual(kExpandedWidth, kInitialWidth);
-    load_state(population_actual, input);
-    const MeasurementProbabilities actual_populations =
-        new_x_instrument_populations(population_actual);
+    const MeasurementProbabilities actual_populations{0.5, 0.5};
     REQUIRE_THAT(actual_populations.zero,
                  Catch::Matchers::WithinAbs(expected_populations.zero, kTolerance));
     REQUIRE_THAT(actual_populations.one,
                  Catch::Matchers::WithinAbs(expected_populations.one, kTolerance));
-    REQUIRE(population_actual.active_width() == kInitialWidth);
 
     for (const auto& [factor_zero, factor_one] : {std::pair{0.8, 0.3}, std::pair{0.3, 0.8}}) {
         CAPTURE(factor_zero, factor_one);

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -622,58 +622,71 @@ TEST_CASE("Sampling instrument activation adds a clean coordinate in existing st
 }
 
 TEST_CASE("Sampling new X instrument activation matches the generic widened source") {
-    constexpr uint32_t kInitialWidth = 3;
-    constexpr uint32_t kExpandedWidth = kInitialWidth + 1;
-    constexpr ActivePauli kNewX{uint64_t{1} << kInitialWidth, 0};
-    const PreparedMeasurement measurement =
-        prepare_measurement(kNewX, kExpandedWidth, kInitialWidth);
-    const std::vector<std::complex<double>> input = deterministic_state(kInitialWidth);
+    for (uint32_t initial_width : {0U, 3U}) {
+        CAPTURE(initial_width);
+        const uint32_t expanded_width = initial_width + 1;
+        const ActivePauli new_x{uint64_t{1} << initial_width, 0};
+        const PreparedMeasurement measurement =
+            prepare_measurement(new_x, expanded_width, initial_width);
+        const std::vector<std::complex<double>> input = deterministic_state(initial_width);
 
-    State population_oracle(kExpandedWidth, kInitialWidth);
-    load_state(population_oracle, input);
-    activate_zero_coordinate(population_oracle);
-    const MeasurementProbabilities expected_populations =
-        measurement_probabilities(population_oracle, measurement);
+        State population_oracle(expanded_width, initial_width);
+        load_state(population_oracle, input);
+        activate_zero_coordinate(population_oracle);
+        const MeasurementProbabilities expected_populations =
+            measurement_probabilities(population_oracle, measurement);
 
-    const MeasurementProbabilities actual_populations{0.5, 0.5};
-    REQUIRE_THAT(actual_populations.zero,
-                 Catch::Matchers::WithinAbs(expected_populations.zero, kTolerance));
-    REQUIRE_THAT(actual_populations.one,
-                 Catch::Matchers::WithinAbs(expected_populations.one, kTolerance));
+        constexpr MeasurementProbabilities kExactPopulations{0.5, 0.5};
+        REQUIRE_THAT(kExactPopulations.zero,
+                     Catch::Matchers::WithinAbs(expected_populations.zero, kTolerance));
+        REQUIRE_THAT(kExactPopulations.one,
+                     Catch::Matchers::WithinAbs(expected_populations.one, kTolerance));
 
-    for (const auto& [factor_zero, factor_one] : {std::pair{0.8, 0.3}, std::pair{0.3, 0.8}}) {
-        CAPTURE(factor_zero, factor_one);
-        const double no_fire_probability = factor_zero * factor_zero * expected_populations.zero +
-                                           factor_one * factor_one * expected_populations.one;
+        for (const auto& [factor_zero, factor_one] :
+             {std::pair{0.8, 0.3}, std::pair{0.3, 0.8}, std::pair{0.6, 0.6}}) {
+            CAPTURE(factor_zero, factor_one);
+            const double expected_no_fire_probability =
+                factor_zero * factor_zero * expected_populations.zero +
+                factor_one * factor_one * expected_populations.one;
+            const double actual_no_fire_probability =
+                factor_zero * factor_zero * kExactPopulations.zero +
+                factor_one * factor_one * kExactPopulations.one;
 
-        State no_fire_oracle(kExpandedWidth, kInitialWidth);
-        load_state(no_fire_oracle, input);
-        activate_zero_coordinate(no_fire_oracle);
-        apply_instrument_no_fire(no_fire_oracle, measurement.pauli, factor_zero, factor_one,
-                                 no_fire_probability);
+            State no_fire_oracle(expanded_width, initial_width);
+            load_state(no_fire_oracle, input);
+            activate_zero_coordinate(no_fire_oracle);
+            apply_instrument_no_fire(no_fire_oracle, measurement.pauli, factor_zero, factor_one,
+                                     expected_no_fire_probability);
 
-        State no_fire_actual(kExpandedWidth, kInitialWidth);
-        load_state(no_fire_actual, input);
-        apply_new_x_instrument_no_fire(no_fire_actual, factor_zero, factor_one,
-                                       no_fire_probability);
-        require_vectors_close(coefficients(no_fire_actual), coefficients(no_fire_oracle));
-        REQUIRE(no_fire_actual.active_width() == kExpandedWidth);
-    }
+            State no_fire_actual(expanded_width, initial_width);
+            load_state(no_fire_actual, input);
+            apply_new_x_instrument_no_fire(no_fire_actual, factor_zero, factor_one,
+                                           actual_no_fire_probability);
+            require_vectors_close(coefficients(no_fire_actual), coefficients(no_fire_oracle));
+            REQUIRE(no_fire_actual.active_width() == expanded_width);
+            if (factor_zero == factor_one) {
+                for (uint64_t basis = 0; basis < input.size(); ++basis) {
+                    REQUIRE(no_fire_actual.real_data()[input.size() + basis] == 0.0);
+                    REQUIRE(no_fire_actual.imag_data()[input.size() + basis] == 0.0);
+                }
+            }
+        }
 
-    for (bool branch : {false, true}) {
-        CAPTURE(branch);
-        State collapse_oracle(kExpandedWidth, kInitialWidth);
-        load_state(collapse_oracle, input);
-        activate_zero_coordinate(collapse_oracle);
-        collapse_instrument_source(collapse_oracle, measurement.pauli, branch,
-                                   expected_populations.for_branch(branch));
+        for (bool branch : {false, true}) {
+            CAPTURE(branch);
+            State collapse_oracle(expanded_width, initial_width);
+            load_state(collapse_oracle, input);
+            activate_zero_coordinate(collapse_oracle);
+            collapse_instrument_source(collapse_oracle, measurement.pauli, branch,
+                                       expected_populations.for_branch(branch));
 
-        State collapse_actual(kExpandedWidth, kInitialWidth);
-        load_state(collapse_actual, input);
-        collapse_new_x_instrument_source(collapse_actual, branch,
-                                         actual_populations.for_branch(branch));
-        require_vectors_close(coefficients(collapse_actual), coefficients(collapse_oracle));
-        REQUIRE(collapse_actual.active_width() == kExpandedWidth);
+            State collapse_actual(expanded_width, initial_width);
+            load_state(collapse_actual, input);
+            collapse_new_x_instrument_source(collapse_actual, branch,
+                                             kExactPopulations.for_branch(branch));
+            require_vectors_close(coefficients(collapse_actual), coefficients(collapse_oracle));
+            REQUIRE(collapse_actual.active_width() == expanded_width);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- recognize activating instruments whose prepared source is X on the newly introduced coordinate during `SamplingPlan` to `ExecutablePlan` lowering
- use the normalized-state invariant and the clean `|0>` coordinate to assign exact 50/50 X-eigenstate populations without a coefficient reduction
- expand no-fire and fired branches directly, avoiding the wider-state zero fill and generic population/filter or collapse traversals
- preserve the existing generic instrument path for every other source shape
- expose structural selection metadata so tests catch planner changes that silently disable the specialization

For exact source-dependent damping, activation itself is unavoidable: the no-fire operator changes the relative source-eigenstate weights. The planner already canonicalizes a dormant source into X on the next coordinate. This PR specializes that resulting execution shape, analogous to the legacy `OP_INSTRUMENT_EXPAND` kernel, without adding runtime topology discovery.

The selector occupies existing `ExecuteInstrument` padding: a compile-time invariant keeps that descriptor at 104 bytes, and the action variant remains 112 bytes. Specialized actions do not prepare or store an unused generic measurement descriptor.

Detailed attribution and reproduction context are recorded in #280: https://github.com/unitaryfoundation/clifft/issues/280#issuecomment-5253908561

### Performance

Release `-O3 -DNDEBUG -g -fno-omit-frame-pointer -march=native`, AMD EPYC 9554P, one thread pinned to CPU 3, d17 r5 with source-dependent low leakage/loss, 500 shots. Ten samples per implementation used fresh paired seeds and balanced positions:

| Implementation | Median | Relative to legacy |
|---|---:|---:|
| main legacy | 0.210 s | 1.00x |
| main symbolic | 1.110 s | 5.29x |
| PR symbolic | 0.692 s | 3.29x |

The PR is **1.61x faster than main symbolic**, with every paired main/PR sample improving. Checksums prove results were consumed; they are not treated as a cross-backend RNG-parity requirement.

I separately compared a norm-reduction prototype with exact 50/50 populations. Ten paired samples improved from a 0.745 s median to 0.710 s, a further 5.0%. All five balanced `perf stat` pairs also used fewer cycles, instructions, and branches, so the exact form is retained.

The post-change profile moves the remaining bottleneck into continuation/planner tableau work. The direct no-fire expansion is about 4% of cycles; the former generic instrument population and filter hot paths are gone. Ordinary coherent and QV sampling plans do not select this path and were neutral guards.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build-profile --output-on-failure`)
  - all 1,276 Release tests, including benchmark tests, pass in `build-profile`
  - lowering tests assert that a planner-generated new-X activation selects the specialization and an already-active source does not
  - the kernel oracle covers widths 0 and 3, both factor orderings, equal factors with an exact-zero upper half, and both collapse branches
  - all instrument and trajectory tests pass in Debug
- [x] Python tests pass (`uv run pytest tests/python/ -v`; covered by CI `build-and-test`)
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`; covered by CI `build-and-test`)
- [x] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
