### PR TITLE
perf(sampling): streamline coordinate frame planning

### DIFF
--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -155,8 +155,7 @@ struct ResolvedPauli {
 };
 
 ResolvedPauli resolve_pauli(const Pauli& initial_body, const AffineBool& initial_sign,
-                            const CoordinateFrame& coordinates,
-                            SymbolicPauliFrame& symbolic_frame) {
+                            CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame) {
     AffineBool sign = initial_sign;
     sign ^= symbolic_frame.sign_for(initial_body);
     Pauli body = coordinates.to_current(initial_body);

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -91,6 +91,21 @@ CoordinateFrame::CoordinateFrame(uint32_t num_qubits)
     : current_to_initial_(num_qubits), indices_(identity_indices(num_qubits)) {}
 
 PlannerPauli CoordinateFrame::to_current(const PlannerPauli& initial) const {
+    if (initial_to_current_.has_value()) {
+        return initial_to_current_->scatter_eval(initial.ref(), indices_);
+    }
+
+    // Inverting an n-qubit tableau evaluates 2n generator rows. Use the same
+    // number of direct lookups as a conservative structural break-even before
+    // materializing the inverse for a lookup-heavy basis interval.
+    const uint64_t direct_lookup_limit =
+        std::max<uint64_t>(1, 2 * static_cast<uint64_t>(initial.num_qubits));
+    if (direct_reverse_lookups_ >= direct_lookup_limit) {
+        initial_to_current_.emplace(current_to_initial_.inverse());
+        return initial_to_current_->scatter_eval(initial.ref(), indices_);
+    }
+    ++direct_reverse_lookups_;
+
     PlannerPauli current(initial.num_qubits);
     for (uint32_t q = 0; q < initial.num_qubits; ++q) {
         // Coordinates in a symplectic basis are selected by commuting with its
@@ -113,6 +128,8 @@ PlannerPauli CoordinateFrame::to_initial(const PlannerPauli& current) const {
 }
 
 void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordinates) {
+    initial_to_current_.reset();
+    direct_reverse_lookups_ = 0;
     PlannerTableau previous(std::move(current_to_initial_));
     assert(new_basis_in_old_coordinates.num_qubits == previous.num_qubits);
     current_to_initial_ = PlannerTableau(new_basis_in_old_coordinates.num_qubits);

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -90,7 +90,7 @@ size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
 CoordinateFrame::CoordinateFrame(uint32_t num_qubits)
     : current_to_initial_(num_qubits), indices_(identity_indices(num_qubits)) {}
 
-PlannerPauli CoordinateFrame::to_current(const PlannerPauli& initial) const {
+PlannerPauli CoordinateFrame::to_current(const PlannerPauli& initial) {
     if (initial_to_current_.has_value()) {
         return initial_to_current_->scatter_eval(initial.ref(), indices_);
     }

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -6,6 +6,7 @@
 #include <limits>
 #include <numeric>
 #include <stdexcept>
+#include <utility>
 
 namespace clifft::sampling::internal {
 
@@ -53,6 +54,32 @@ bool has_x_below(const PlannerPauli& pauli, uint32_t end) {
     return false;
 }
 
+void evaluate_generator_into(stim::PauliStringRef<kStimWidth> destination,
+                             const stim::PauliStringRef<kStimWidth>& generator,
+                             const PlannerTableau& map) {
+    // Planner basis changes are sparse. Writing directly into tableau-owned
+    // rows avoids the owning Pauli allocation that Stim's generic composition
+    // performs for every X and Z generator.
+    destination.xs.clear();
+    destination.zs.clear();
+    destination.sign = generator.sign;
+    generator.for_each_active_pauli([&](size_t q) {
+        const bool x = generator.xs[q];
+        const bool z = generator.zs[q];
+        if (x && z) {
+            uint8_t log_i = 1;
+            log_i += destination.inplace_right_mul_returning_log_i_scalar(map.xs[q]);
+            log_i += destination.inplace_right_mul_returning_log_i_scalar(map.zs[q]);
+            assert((log_i & 1) == 0);
+            destination.sign ^= (log_i & 2) != 0;
+        } else if (x) {
+            destination *= map.xs[q];
+        } else {
+            destination *= map.zs[q];
+        }
+    });
+}
+
 size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
     static_cast<void>(SymbolicPauliFrame::estimated_workspace_bytes(num_qubits, num_symbols));
     return (static_cast<size_t>(num_symbols) + 63) / 64;
@@ -61,12 +88,24 @@ size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
 }  // namespace
 
 CoordinateFrame::CoordinateFrame(uint32_t num_qubits)
-    : current_to_initial_(num_qubits),
-      initial_to_current_(num_qubits),
-      indices_(identity_indices(num_qubits)) {}
+    : current_to_initial_(num_qubits), indices_(identity_indices(num_qubits)) {}
 
 PlannerPauli CoordinateFrame::to_current(const PlannerPauli& initial) const {
-    return initial_to_current_.scatter_eval(initial.ref(), indices_);
+    PlannerPauli current(initial.num_qubits);
+    for (uint32_t q = 0; q < initial.num_qubits; ++q) {
+        // Coordinates in a symplectic basis are selected by commuting with its
+        // opposite generator: Z generators select X and vice versa.
+        current.xs[q] = !initial.ref().commutes(current_to_initial_.zs[q]);
+        current.zs[q] = !initial.ref().commutes(current_to_initial_.xs[q]);
+    }
+
+    // Generator signs affect the sign, but not the symplectic coordinates. A
+    // forward evaluation recovers that phase without materializing an inverse.
+    const PlannerPauli round_trip = current_to_initial_.scatter_eval(current.ref(), indices_);
+    assert(round_trip.xs == initial.xs);
+    assert(round_trip.zs == initial.zs);
+    current.sign = static_cast<bool>(round_trip.sign) ^ static_cast<bool>(initial.sign);
+    return current;
 }
 
 PlannerPauli CoordinateFrame::to_initial(const PlannerPauli& current) const {
@@ -74,8 +113,16 @@ PlannerPauli CoordinateFrame::to_initial(const PlannerPauli& current) const {
 }
 
 void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordinates) {
-    current_to_initial_ = new_basis_in_old_coordinates.then(current_to_initial_);
-    initial_to_current_ = current_to_initial_.inverse();
+    PlannerTableau previous(std::move(current_to_initial_));
+    assert(new_basis_in_old_coordinates.num_qubits == previous.num_qubits);
+    current_to_initial_ = PlannerTableau(new_basis_in_old_coordinates.num_qubits);
+    for (size_t q = 0; q < new_basis_in_old_coordinates.num_qubits; ++q) {
+        evaluate_generator_into(current_to_initial_.xs[q], new_basis_in_old_coordinates.xs[q],
+                                previous);
+        evaluate_generator_into(current_to_initial_.zs[q], new_basis_in_old_coordinates.zs[q],
+                                previous);
+    }
+    assert(current_to_initial_.satisfies_invariants());
 }
 
 size_t SymbolicPauliFrame::estimated_workspace_bytes(uint32_t num_qubits, uint32_t num_symbols) {

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -26,11 +26,9 @@ class CoordinateFrame {
     void change_basis(const PlannerTableau& new_basis_in_old_coordinates);
 
   private:
-    // These two tableaus are maintained together so ordinary operations never
-    // pay for an inverse. The forward map is also needed when a sampled branch
-    // adds a Pauli correction expressed in the newly selected coordinates.
+    // The selected generators are enough to recover either direction. Keeping
+    // one tableau avoids rebuilding its cumulative inverse after each change.
     PlannerTableau current_to_initial_;
-    PlannerTableau initial_to_current_;
     std::vector<size_t> indices_;
 };
 

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -21,19 +21,21 @@ class CoordinateFrame {
   public:
     explicit CoordinateFrame(uint32_t num_qubits);
 
-    [[nodiscard]] PlannerPauli to_current(const PlannerPauli& initial) const;
+    [[nodiscard]] PlannerPauli to_current(const PlannerPauli& initial);
     [[nodiscard]] PlannerPauli to_initial(const PlannerPauli& current) const;
 
     void change_basis(const PlannerTableau& new_basis_in_old_coordinates);
 
-    [[nodiscard]] bool has_cached_inverse() const { return initial_to_current_.has_value(); }
+    [[nodiscard]] bool has_cached_inverse_for_testing() const {
+        return initial_to_current_.has_value();
+    }
 
   private:
     // The selected generators are enough to recover either direction. The
     // inverse is cached only when repeated reverse lookups can amortize it.
     PlannerTableau current_to_initial_;
-    mutable std::optional<PlannerTableau> initial_to_current_;
-    mutable uint64_t direct_reverse_lookups_ = 0;
+    std::optional<PlannerTableau> initial_to_current_;
+    uint64_t direct_reverse_lookups_ = 0;
     std::vector<size_t> indices_;
 };
 

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -25,10 +26,14 @@ class CoordinateFrame {
 
     void change_basis(const PlannerTableau& new_basis_in_old_coordinates);
 
+    [[nodiscard]] bool has_cached_inverse() const { return initial_to_current_.has_value(); }
+
   private:
-    // The selected generators are enough to recover either direction. Keeping
-    // one tableau avoids rebuilding its cumulative inverse after each change.
+    // The selected generators are enough to recover either direction. The
+    // inverse is cached only when repeated reverse lookups can amortize it.
     PlannerTableau current_to_initial_;
+    mutable std::optional<PlannerTableau> initial_to_current_;
+    mutable uint64_t direct_reverse_lookups_ = 0;
     std::vector<size_t> indices_;
 };
 

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -521,5 +521,9 @@ TEST_CASE("Sampling planner target QEC plan characterization") {
     REQUIRE(plan.symbols.size() == 2061);
     // The inspection includes every action field and affine expression, making
     // the production fixture a compact end-to-end planner characterization.
-    REQUIRE(fnv1a64(plan.inspect()) == 0xd795b8a081bb3a7dULL);
+    const std::string inspection = plan.inspect();
+    INFO(inspection);
+    // After verifying that a reported inspection change is intentional, update
+    // this digest to the new value shown by the failed assertion.
+    REQUIRE(fnv1a64(inspection) == 0xd795b8a081bb3a7dULL);
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -1,5 +1,6 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/sampling/planner.h"
 
 #include "instrument_test_helpers.h"
@@ -41,6 +42,10 @@ using clifft::test::Z;
 
 namespace {
 
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
 template <typename T>
 const T& action_as(const SamplingPlan& plan, size_t index) {
     return std::get<T>(plan.actions.at(index).action);
@@ -50,6 +55,15 @@ void require_global_phase(const SamplingPlan& plan, double angle) {
     const std::complex<double> expected{std::cos(angle), std::sin(angle)};
     REQUIRE_THAT(plan.global_weight.real(), Catch::Matchers::WithinAbs(expected.real(), 1e-12));
     REQUIRE_THAT(plan.global_weight.imag(), Catch::Matchers::WithinAbs(expected.imag(), 1e-12));
+}
+
+uint64_t fnv1a64(std::string_view text) {
+    uint64_t digest = 14695981039346656037ULL;
+    for (unsigned char byte : text) {
+        digest ^= byte;
+        digest *= 1099511628211ULL;
+    }
+    return digest;
 }
 
 }  // namespace
@@ -493,4 +507,19 @@ TEST_CASE("Sampling planner output is deterministic") {
     const SamplingPlan second = plan_sampling(hir);
 
     REQUIRE(first.inspect() == second.inspect());
+}
+
+TEST_CASE("Sampling planner target QEC plan characterization") {
+    clifft::Circuit circuit =
+        clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/target_qec.stim");
+    HirModule hir = clifft::trace(circuit);
+    auto passes = clifft::default_hir_pass_manager();
+    passes.run(hir);
+
+    const SamplingPlan plan = plan_sampling(hir);
+    REQUIRE(plan.actions.size() == 91);
+    REQUIRE(plan.symbols.size() == 2061);
+    // The inspection includes every action field and affine expression, making
+    // the production fixture a compact end-to-end planner characterization.
+    REQUIRE(fnv1a64(plan.inspect()) == 0xd795b8a081bb3a7dULL);
 }

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -126,6 +126,28 @@ TEST_CASE("Planner coordinate frame handles multiple packed words") {
     REQUIRE(coordinates.to_initial(coordinates.to_current(initial)) == initial);
 }
 
+TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
+    constexpr uint32_t kNumQubits = 3;
+    CoordinateFrame coordinates(kNumQubits);
+    PlannerPauli initial(kNumQubits);
+    initial.xs[0] = true;
+    initial.zs[2] = true;
+
+    for (uint32_t lookup = 0; lookup < 2 * kNumQubits; ++lookup) {
+        REQUIRE(coordinates.to_current(initial) == initial);
+        REQUIRE_FALSE(coordinates.has_cached_inverse());
+    }
+    REQUIRE(coordinates.to_current(initial) == initial);
+    REQUIRE(coordinates.has_cached_inverse());
+
+    PlannerTableau change(kNumQubits);
+    change.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
+    coordinates.change_basis(change);
+    REQUIRE_FALSE(coordinates.has_cached_inverse());
+    REQUIRE(coordinates.to_current(initial) ==
+            change.inverse().scatter_eval(initial.ref(), {0, 1, 2}));
+}
+
 TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
     SymbolicPauliFrame frame(2, 130);
     const AffineBool wide_condition(true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -101,29 +101,76 @@ TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis")
     require_matches_inverse();
 }
 
-TEST_CASE("Planner coordinate frame handles multiple packed words") {
+TEST_CASE("Planner coordinate frame matches inverse across packed words") {
     constexpr uint32_t kNumQubits = 70;
     CoordinateFrame coordinates(kNumQubits);
-    PlannerTableau change(kNumQubits);
-    change.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {64});
-    change.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(), {0, 64});
-    change.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<clifft::kStimWidth>(), {69});
-    change.inplace_scatter_append(stim::GATE_DATA.at("CZ").tableau<clifft::kStimWidth>(), {64, 69});
-    coordinates.change_basis(change);
-
-    PlannerPauli initial(kNumQubits);
-    initial.xs[0] = true;
-    initial.zs[64] = true;
-    initial.xs[69] = true;
-    initial.sign = true;
-
+    PlannerTableau cumulative(kNumQubits);
     std::vector<size_t> indices(kNumQubits);
     for (uint32_t q = 0; q < kNumQubits; ++q) {
         indices[q] = q;
     }
-    const PlannerTableau inverse = change.inverse();
-    REQUIRE(coordinates.to_current(initial) == inverse.scatter_eval(initial.ref(), indices));
-    REQUIRE(coordinates.to_initial(coordinates.to_current(initial)) == initial);
+
+    uint64_t random_state = 0x9e3779b97f4a7c15ULL;
+    const auto next_bits = [&] {
+        random_state ^= random_state << 13;
+        random_state ^= random_state >> 7;
+        random_state ^= random_state << 17;
+        return random_state;
+    };
+    const auto require_matches_inverse = [&] {
+        const PlannerTableau inverse = cumulative.inverse();
+        for (uint32_t sample = 0; sample < 32; ++sample) {
+            PlannerPauli initial(kNumQubits);
+            uint64_t x_bits = 0;
+            uint64_t z_bits = 0;
+            for (uint32_t q = 0; q < kNumQubits; ++q) {
+                if ((q & 63U) == 0) {
+                    x_bits = next_bits();
+                    z_bits = next_bits();
+                }
+                initial.xs[q] = (x_bits >> (q & 63U)) & 1U;
+                initial.zs[q] = (z_bits >> (q & 63U)) & 1U;
+            }
+            initial.xs[63] = (sample & 1U) != 0;
+            initial.zs[63] = (sample & 2U) != 0;
+            initial.xs[64] = (sample & 4U) != 0;
+            initial.zs[64] = (sample & 8U) != 0;
+            initial.sign = (sample & 16U) != 0;
+
+            const PlannerPauli expected = inverse.scatter_eval(initial.ref(), indices);
+            const PlannerPauli actual = coordinates.to_current(initial);
+            REQUIRE(actual == expected);
+            REQUIRE(coordinates.to_initial(actual) == initial);
+        }
+    };
+
+    const auto apply_change = [&](const PlannerTableau& change) {
+        coordinates.change_basis(change);
+        cumulative = change.then(cumulative);
+        require_matches_inverse();
+    };
+
+    PlannerTableau gates(kNumQubits);
+    gates.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {64});
+    gates.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(), {0, 64});
+    gates.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<clifft::kStimWidth>(), {69});
+    gates.inplace_scatter_append(stim::GATE_DATA.at("CZ").tableau<clifft::kStimWidth>(), {64, 69});
+    apply_change(gates);
+
+    PlannerPauli promoted(kNumQubits);
+    promoted.zs[0] = true;
+    promoted.xs[69] = true;
+    apply_change(dormant_promotion_frame(promoted, 1, 69));
+
+    PlannerPauli active(kNumQubits);
+    active.xs[0] = true;
+    active.zs[64] = true;
+    apply_change(active_measurement_frame(active, 65, 0));
+
+    PlannerPauli dormant(kNumQubits);
+    dormant.zs[0] = true;
+    dormant.xs[69] = true;
+    apply_change(dormant_measurement_frame(dormant, 69));
 }
 
 TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
@@ -135,15 +182,15 @@ TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
 
     for (uint32_t lookup = 0; lookup < 2 * kNumQubits; ++lookup) {
         REQUIRE(coordinates.to_current(initial) == initial);
-        REQUIRE_FALSE(coordinates.has_cached_inverse());
+        REQUIRE_FALSE(coordinates.has_cached_inverse_for_testing());
     }
     REQUIRE(coordinates.to_current(initial) == initial);
-    REQUIRE(coordinates.has_cached_inverse());
+    REQUIRE(coordinates.has_cached_inverse_for_testing());
 
     PlannerTableau change(kNumQubits);
     change.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
     coordinates.change_basis(change);
-    REQUIRE_FALSE(coordinates.has_cached_inverse());
+    REQUIRE_FALSE(coordinates.has_cached_inverse_for_testing());
     REQUIRE(coordinates.to_current(initial) ==
             change.inverse().scatter_eval(initial.ref(), {0, 1, 2}));
 }

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 using clifft::sampling::AffineBool;
@@ -37,6 +38,92 @@ TEST_CASE("Planner coordinate frame round trips composed basis changes") {
     coordinates.change_basis(second);
     const PlannerPauli after_second = coordinates.to_current(initial);
     REQUIRE(coordinates.to_initial(after_second) == initial);
+}
+
+TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis") {
+    constexpr uint32_t kNumQubits = 3;
+    CoordinateFrame coordinates(kNumQubits);
+    PlannerTableau cumulative(kNumQubits);
+    const std::vector<size_t> indices{0, 1, 2};
+
+    const auto require_matches_inverse = [&] {
+        const PlannerTableau inverse = cumulative.inverse();
+        for (uint32_t body = 0; body < 1U << (2 * kNumQubits); ++body) {
+            for (bool sign : {false, true}) {
+                PlannerPauli initial(kNumQubits);
+                for (uint32_t q = 0; q < kNumQubits; ++q) {
+                    initial.xs[q] = (body >> q) & 1U;
+                    initial.zs[q] = (body >> (q + kNumQubits)) & 1U;
+                }
+                initial.sign = sign;
+
+                const PlannerPauli expected = inverse.scatter_eval(initial.ref(), indices);
+                const PlannerPauli actual = coordinates.to_current(initial);
+                REQUIRE(actual == expected);
+                REQUIRE(coordinates.to_initial(actual) == initial);
+            }
+        }
+    };
+
+    require_matches_inverse();
+    for (const auto& [gate, targets] : std::vector<std::pair<const char*, std::vector<size_t>>>{
+             {"H", {0}}, {"S", {1}}, {"CX", {0, 1}}, {"SQRT_X", {2}}, {"CZ", {1, 2}}}) {
+        PlannerTableau change(kNumQubits);
+        change.inplace_scatter_append(stim::GATE_DATA.at(gate).tableau<clifft::kStimWidth>(),
+                                      targets);
+        coordinates.change_basis(change);
+        cumulative = change.then(cumulative);
+        require_matches_inverse();
+    }
+
+    PlannerPauli promoted(kNumQubits);
+    promoted.zs[0] = true;
+    promoted.xs[2] = true;
+    const PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 2);
+    coordinates.change_basis(promotion);
+    cumulative = promotion.then(cumulative);
+    require_matches_inverse();
+
+    PlannerPauli active(kNumQubits);
+    active.xs[0] = true;
+    active.zs[1] = true;
+    const PlannerTableau removal = active_measurement_frame(active, 2, 0);
+    coordinates.change_basis(removal);
+    cumulative = removal.then(cumulative);
+    require_matches_inverse();
+
+    PlannerPauli dormant(kNumQubits);
+    dormant.zs[0] = true;
+    dormant.xs[2] = true;
+    const PlannerTableau replacement = dormant_measurement_frame(dormant, 2);
+    coordinates.change_basis(replacement);
+    cumulative = replacement.then(cumulative);
+    require_matches_inverse();
+}
+
+TEST_CASE("Planner coordinate frame handles multiple packed words") {
+    constexpr uint32_t kNumQubits = 70;
+    CoordinateFrame coordinates(kNumQubits);
+    PlannerTableau change(kNumQubits);
+    change.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {64});
+    change.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(), {0, 64});
+    change.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<clifft::kStimWidth>(), {69});
+    change.inplace_scatter_append(stim::GATE_DATA.at("CZ").tableau<clifft::kStimWidth>(), {64, 69});
+    coordinates.change_basis(change);
+
+    PlannerPauli initial(kNumQubits);
+    initial.xs[0] = true;
+    initial.zs[64] = true;
+    initial.xs[69] = true;
+    initial.sign = true;
+
+    std::vector<size_t> indices(kNumQubits);
+    for (uint32_t q = 0; q < kNumQubits; ++q) {
+        indices[q] = q;
+    }
+    const PlannerTableau inverse = change.inverse();
+    REQUIRE(coordinates.to_current(initial) == inverse.scatter_eval(initial.ref(), indices));
+    REQUIRE(coordinates.to_initial(coordinates.to_current(initial)) == initial);
 }
 
 TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {


### PR DESCRIPTION
## Summary

- keep a single current-to-initial Stim tableau and compose sparse generator changes directly into its rows
- recover occasional reverse coordinates by symplectic commutation instead of rebuilding the cumulative inverse after every basis change
- lazily cache the inverse after `2n` reverse lookups in one basis interval, preserving change-heavy gains while amortizing lookup-heavy plans
- invalidate the cache on each basis change and cover activation/invalidation structurally

This is the bounded planner follow-up from #280. It combines the sparse, single-forward-frame design with a lazy inverse after profiling showed that always-direct reverse recovery helped the QEC fixtures but regressed lookup-heavy QV-20.

### Linux compile measurements

Five alternating RelWithDebInfo rounds with native CPU tuning; values are medians of per-process medians:

| Circuit | Iterations | Baseline plan | This PR plan | Plan change | Total change |
| --- | ---: | ---: | ---: | ---: | ---: |
| cultivation d5 | 200 | 18.154 ms | 10.667 ms | -41.2% | -33.3% |
| target QEC | 500 | 0.864 ms | 0.683 ms | -20.9% | -14.2% |
| QV-20 seed 42 | 200 | 3.461 ms | 2.783 ms | -19.6% | -4.4% |

For context, the always-direct prototype made QV-20 planning 14.6% slower. The lazy cache changes that result to a 19.6% improvement without weakening the QEC gains.

On the representative noncomputational fixture, ten paired 500-shot runs improved end-to-end symbolic time from a 0.702 s median on current main to 0.313 s here (2.25x faster), with identical checksums for every paired seed.

## Test plan

- [x] C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`) - 1,274 passed
- [x] Python tests pass (`uv run pytest tests/python/ -v`) - 1,254 passed
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`) - 30 passed, 7 skipped
- [x] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
