### PR TITLE
perf(sampling): update planner coordinate frames in place

### DIFF
--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -28,9 +28,7 @@ namespace {
 
 using Pauli = internal::PlannerPauli;
 using Tableau = internal::PlannerTableau;
-using internal::active_measurement_frame;
 using internal::CoordinateFrame;
-using internal::dormant_measurement_frame;
 using internal::dormant_promotion_frame;
 using internal::SymbolicPauliFrame;
 
@@ -439,9 +437,11 @@ void process_rotation(const PendingRotation& rotation, SamplingPlan& plan, uint3
             ", but the dense-state limit is " + std::to_string(kDenseActiveWidthLimit));
     }
 
-    const Tableau frame = dormant_promotion_frame(resolved.body, active_width, *dormant_pivot);
-    coordinates.change_basis(frame);
-    compose_final_tableau(plan, frame);
+    if (plan.final_tableau.has_value()) {
+        compose_final_tableau(plan,
+                              dormant_promotion_frame(resolved.body, active_width, *dormant_pivot));
+    }
+    coordinates.promote_dormant(resolved.body, active_width, *dormant_pivot);
     plan.actions.push_back(
         PlannedAction{active_width, active_width + 1,
                       PromoteDormantRotation{rotation.half_turns, std::move(resolved.sign)}});
@@ -456,8 +456,7 @@ AffineBool process_measurement(const PendingMeasurement& measurement, SamplingPl
         resolve_pauli(measurement.body, measurement.sign, coordinates, symbolic_frame);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (dormant_pivot.has_value()) {
-        const Tableau frame = dormant_measurement_frame(resolved.body, *dormant_pivot);
-        coordinates.change_basis(frame);
+        coordinates.measure_dormant(resolved.body, *dormant_pivot);
 
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
         const SymbolId branch = measurement.branch;
@@ -492,8 +491,7 @@ AffineBool process_measurement(const PendingMeasurement& measurement, SamplingPl
         active_body.xs[q] = resolved.body.xs[q];
         active_body.zs[q] = resolved.body.zs[q];
     }
-    const Tableau frame = active_measurement_frame(active_body, active_width, *pivot);
-    coordinates.change_basis(frame);
+    coordinates.measure_active(active_body, active_width, *pivot);
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     const SymbolId branch = measurement.branch;
@@ -536,9 +534,7 @@ void process_instrument(const PendingInstrument& instrument, SamplingPlan& plan,
                                           ", but the dense-state limit is " +
                                           std::to_string(kDenseActiveWidthLimit));
             }
-            const Tableau frame =
-                dormant_promotion_frame(resolved.body, active_width, *dormant_pivot);
-            coordinates.change_basis(frame);
+            coordinates.promote_dormant(resolved.body, active_width, *dormant_pivot);
             ++active_after;
             mode = InstrumentMode::Activate;
             // The promotion frame installs this observable as the next X

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -438,6 +438,9 @@ void process_rotation(const PendingRotation& rotation, SamplingPlan& plan, uint3
     }
 
     if (plan.final_tableau.has_value()) {
+        // Final-state queries track a separate physical map and still need the
+        // generic frame. The coordinate map uses the structured update below
+        // to avoid a second generic tableau composition.
         compose_final_tableau(plan,
                               dormant_promotion_frame(resolved.body, active_width, *dormant_pivot));
     }

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -141,6 +141,9 @@ void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordi
     assert(current_to_initial_.satisfies_invariants());
 }
 
+// These transformations preserve the symplectic relations by construction.
+// A full invariant scan is cubic in Debug builds, so exhaustive equivalence
+// tests validate them instead of rescanning the tableau after every event.
 void CoordinateFrame::promote_dormant(const PlannerPauli& promoted, uint32_t active_width,
                                       uint32_t dormant_pivot) {
     const uint32_t n = static_cast<uint32_t>(current_to_initial_.num_qubits);
@@ -173,7 +176,6 @@ void CoordinateFrame::promote_dormant(const PlannerPauli& promoted, uint32_t act
     }
     current_to_initial_.xs[active_width] = mapped_promoted;
     current_to_initial_.zs[active_width] = pivot_stabilizer;
-    assert(current_to_initial_.satisfies_invariants());
 }
 
 void CoordinateFrame::measure_dormant(const PlannerPauli& measured, uint32_t dormant_pivot) {
@@ -197,7 +199,6 @@ void CoordinateFrame::measure_dormant(const PlannerPauli& measured, uint32_t dor
     }
     current_to_initial_.xs[dormant_pivot] = pivot_stabilizer;
     current_to_initial_.zs[dormant_pivot] = mapped_measured;
-    assert(current_to_initial_.satisfies_invariants());
 }
 
 void CoordinateFrame::measure_active(const PlannerPauli& measured, uint32_t active_width,
@@ -235,7 +236,6 @@ void CoordinateFrame::measure_active(const PlannerPauli& measured, uint32_t acti
     }
     current_to_initial_.xs[active_width - 1] = pivot_conjugate;
     current_to_initial_.zs[active_width - 1] = mapped_measured;
-    assert(current_to_initial_.satisfies_invariants());
 }
 
 void CoordinateFrame::invalidate_reverse_cache() {
@@ -369,6 +369,10 @@ PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted, uint32_t ac
     PlannerTableau frame(n);
     const PlannerPauli old_stabilizer = single_z(n, dormant_pivot);
 
+    // CoordinateFrame::promote_dormant is the in-place production twin. This
+    // builder remains necessary for final-state maps and as its test oracle;
+    // keep their pivot ordering and fixups in sync.
+    //
     // The rows express the new coordinate generators in the old basis. Making
     // the promoted Pauli the next X generator turns its rotation into a
     // single-coordinate expansion; the stabilizer products keep every other
@@ -418,6 +422,10 @@ PlannerTableau dormant_measurement_frame(const PlannerPauli& measured, uint32_t 
     PlannerTableau frame(n);
     const PlannerPauli old_stabilizer = single_z(n, dormant_pivot);
 
+    // CoordinateFrame::measure_dormant is the in-place production twin. This
+    // builder is its independent test oracle; keep their pivot replacement and
+    // fixups in sync.
+    //
     // Replacing one dormant Z generator with the measured Pauli represents the
     // collapsed eigenspace without changing the dense coefficient state.
     for (uint32_t q = 0; q < n; ++q) {
@@ -453,6 +461,10 @@ PlannerTableau active_measurement_frame(const PlannerPauli& measured, uint32_t a
     const PlannerPauli pivot_x = single_x(n, pivot);
     const PlannerPauli pivot_z = single_z(n, pivot);
 
+    // CoordinateFrame::measure_active is the in-place production twin. This
+    // builder is its independent test oracle; keep their pivot compaction and
+    // fixups in sync.
+    //
     // Moving the measured Pauli to the last active Z generator gives the
     // direct measurement kernel one coordinate to remove. The cumulative
     // frame maps later operations into the remaining packed coordinates.

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -128,8 +128,7 @@ PlannerPauli CoordinateFrame::to_initial(const PlannerPauli& current) const {
 }
 
 void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordinates) {
-    initial_to_current_.reset();
-    direct_reverse_lookups_ = 0;
+    invalidate_reverse_cache();
     PlannerTableau previous(std::move(current_to_initial_));
     assert(new_basis_in_old_coordinates.num_qubits == previous.num_qubits);
     current_to_initial_ = PlannerTableau(new_basis_in_old_coordinates.num_qubits);
@@ -140,6 +139,108 @@ void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordi
                                 previous);
     }
     assert(current_to_initial_.satisfies_invariants());
+}
+
+void CoordinateFrame::promote_dormant(const PlannerPauli& promoted, uint32_t active_width,
+                                      uint32_t dormant_pivot) {
+    const uint32_t n = static_cast<uint32_t>(current_to_initial_.num_qubits);
+    assert(promoted.num_qubits == n && active_width < n && dormant_pivot >= active_width &&
+           dormant_pivot < n);
+
+    PlannerPauli mapped_promoted = to_initial(promoted);
+    PlannerPauli pivot_stabilizer(current_to_initial_.zs[dormant_pivot]);
+    invalidate_reverse_cache();
+
+    // The new promoted pair replaces the selected dormant pair. Every other
+    // generator that anticommutes with the promoted Pauli acquires the old
+    // pivot stabilizer, preserving the same symplectic basis as the generic
+    // frame composition without materializing its identity rows.
+    for (uint32_t q = 0; q < n; ++q) {
+        if (q == dormant_pivot) {
+            continue;
+        }
+        if (promoted.zs[q]) {
+            current_to_initial_.xs[q] *= pivot_stabilizer;
+        }
+        if (promoted.xs[q]) {
+            current_to_initial_.zs[q] *= pivot_stabilizer;
+        }
+    }
+
+    for (uint32_t q = dormant_pivot; q > active_width; --q) {
+        current_to_initial_.xs[q] = current_to_initial_.xs[q - 1];
+        current_to_initial_.zs[q] = current_to_initial_.zs[q - 1];
+    }
+    current_to_initial_.xs[active_width] = mapped_promoted;
+    current_to_initial_.zs[active_width] = pivot_stabilizer;
+    assert(current_to_initial_.satisfies_invariants());
+}
+
+void CoordinateFrame::measure_dormant(const PlannerPauli& measured, uint32_t dormant_pivot) {
+    const uint32_t n = static_cast<uint32_t>(current_to_initial_.num_qubits);
+    assert(measured.num_qubits == n && dormant_pivot < n);
+
+    PlannerPauli mapped_measured = to_initial(measured);
+    PlannerPauli pivot_stabilizer(current_to_initial_.zs[dormant_pivot]);
+    invalidate_reverse_cache();
+
+    for (uint32_t q = 0; q < n; ++q) {
+        if (q == dormant_pivot) {
+            continue;
+        }
+        if (measured.zs[q]) {
+            current_to_initial_.xs[q] *= pivot_stabilizer;
+        }
+        if (measured.xs[q]) {
+            current_to_initial_.zs[q] *= pivot_stabilizer;
+        }
+    }
+    current_to_initial_.xs[dormant_pivot] = pivot_stabilizer;
+    current_to_initial_.zs[dormant_pivot] = mapped_measured;
+    assert(current_to_initial_.satisfies_invariants());
+}
+
+void CoordinateFrame::measure_active(const PlannerPauli& measured, uint32_t active_width,
+                                     uint32_t pivot) {
+    assert(measured.num_qubits == current_to_initial_.num_qubits && active_width > 0 &&
+           active_width <= current_to_initial_.num_qubits && pivot < active_width);
+
+    const bool diagonal = !has_x_below(measured, active_width);
+    PlannerPauli mapped_measured = to_initial(measured);
+    PlannerPauli pivot_conjugate(diagonal ? current_to_initial_.xs[pivot]
+                                          : current_to_initial_.zs[pivot]);
+    invalidate_reverse_cache();
+
+    for (uint32_t q = 0; q < active_width; ++q) {
+        if (q == pivot) {
+            continue;
+        }
+        if (diagonal) {
+            if (measured.zs[q]) {
+                current_to_initial_.xs[q] *= pivot_conjugate;
+            }
+        } else {
+            if (measured.xs[q]) {
+                current_to_initial_.zs[q] *= pivot_conjugate;
+            }
+            if (measured.zs[q]) {
+                current_to_initial_.xs[q] *= pivot_conjugate;
+            }
+        }
+    }
+
+    for (uint32_t q = pivot; q + 1 < active_width; ++q) {
+        current_to_initial_.xs[q] = current_to_initial_.xs[q + 1];
+        current_to_initial_.zs[q] = current_to_initial_.zs[q + 1];
+    }
+    current_to_initial_.xs[active_width - 1] = pivot_conjugate;
+    current_to_initial_.zs[active_width - 1] = mapped_measured;
+    assert(current_to_initial_.satisfies_invariants());
+}
+
+void CoordinateFrame::invalidate_reverse_cache() {
+    initial_to_current_.reset();
+    direct_reverse_lookups_ = 0;
 }
 
 size_t SymbolicPauliFrame::estimated_workspace_bytes(uint32_t num_qubits, uint32_t num_symbols) {

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -26,6 +26,15 @@ class CoordinateFrame {
 
     void change_basis(const PlannerTableau& new_basis_in_old_coordinates);
 
+    // Apply the planner's structured basis changes without constructing and
+    // composing an identity-heavy intermediate tableau. Inputs use the current
+    // coordinates, and the resulting coordinate order matches the generic
+    // frame constructors below.
+    void promote_dormant(const PlannerPauli& promoted, uint32_t active_width,
+                         uint32_t dormant_pivot);
+    void measure_dormant(const PlannerPauli& measured, uint32_t dormant_pivot);
+    void measure_active(const PlannerPauli& measured, uint32_t active_width, uint32_t pivot);
+
     [[nodiscard]] bool has_cached_inverse_for_testing() const {
         return initial_to_current_.has_value();
     }
@@ -37,6 +46,8 @@ class CoordinateFrame {
     std::optional<PlannerTableau> initial_to_current_;
     uint64_t direct_reverse_lookups_ = 0;
     std::vector<size_t> indices_;
+
+    void invalidate_reverse_cache();
 };
 
 // Tracks how sampled Boolean symbols contribute Pauli corrections in the

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -15,6 +16,60 @@ using clifft::sampling::internal::dormant_promotion_frame;
 using clifft::sampling::internal::PlannerPauli;
 using clifft::sampling::internal::PlannerTableau;
 using clifft::sampling::internal::SymbolicPauliFrame;
+
+namespace {
+
+PlannerPauli signed_pauli(uint32_t num_qubits, uint32_t body, bool sign) {
+    PlannerPauli result(num_qubits);
+    for (uint32_t q = 0; q < num_qubits; ++q) {
+        result.xs[q] = (body >> q) & 1U;
+        result.zs[q] = (body >> (q + num_qubits)) & 1U;
+    }
+    result.sign = sign;
+    return result;
+}
+
+PlannerTableau nontrivial_basis(uint32_t num_qubits) {
+    PlannerTableau result(num_qubits);
+    result.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
+    if (num_qubits > 1) {
+        result.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<clifft::kStimWidth>(), {1});
+        result.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(),
+                                      {0, num_qubits - 1});
+    }
+    return result;
+}
+
+void require_same_coordinate_map(const CoordinateFrame& direct, const CoordinateFrame& generic,
+                                 uint32_t num_qubits) {
+    for (uint32_t q = 0; q < num_qubits; ++q) {
+        CAPTURE(q);
+        PlannerPauli x(num_qubits);
+        x.xs[q] = true;
+        REQUIRE(direct.to_initial(x) == generic.to_initial(x));
+
+        PlannerPauli z(num_qubits);
+        z.zs[q] = true;
+        REQUIRE(direct.to_initial(z) == generic.to_initial(z));
+    }
+}
+
+std::optional<uint32_t> active_measurement_pivot(const PlannerPauli& measured,
+                                                 uint32_t active_width) {
+    for (uint32_t q = 0; q < active_width; ++q) {
+        if (measured.xs[q]) {
+            return q;
+        }
+    }
+    for (uint32_t q = 0; q < active_width; ++q) {
+        if (measured.zs[q]) {
+            return q;
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
 
 TEST_CASE("Planner coordinate frame round trips composed basis changes") {
     CoordinateFrame coordinates(3);
@@ -80,7 +135,7 @@ TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis")
     promoted.zs[0] = true;
     promoted.xs[2] = true;
     const PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 2);
-    coordinates.change_basis(promotion);
+    coordinates.promote_dormant(promoted, 1, 2);
     cumulative = promotion.then(cumulative);
     require_matches_inverse();
 
@@ -88,7 +143,7 @@ TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis")
     active.xs[0] = true;
     active.zs[1] = true;
     const PlannerTableau removal = active_measurement_frame(active, 2, 0);
-    coordinates.change_basis(removal);
+    coordinates.measure_active(active, 2, 0);
     cumulative = removal.then(cumulative);
     require_matches_inverse();
 
@@ -96,9 +151,87 @@ TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis")
     dormant.zs[0] = true;
     dormant.xs[2] = true;
     const PlannerTableau replacement = dormant_measurement_frame(dormant, 2);
-    coordinates.change_basis(replacement);
+    coordinates.measure_dormant(dormant, 2);
     cumulative = replacement.then(cumulative);
     require_matches_inverse();
+}
+
+TEST_CASE("Planner structured coordinate updates match generic frames") {
+    constexpr uint32_t kNumQubits = 3;
+    const PlannerTableau basis = nontrivial_basis(kNumQubits);
+
+    for (uint32_t active_width = 0; active_width < kNumQubits; ++active_width) {
+        for (uint32_t dormant_pivot = active_width; dormant_pivot < kNumQubits; ++dormant_pivot) {
+            for (uint32_t body = 0; body < 1U << (2 * kNumQubits); ++body) {
+                for (bool sign : {false, true}) {
+                    const PlannerPauli promoted = signed_pauli(kNumQubits, body, sign);
+                    bool is_selected_pivot = promoted.xs[dormant_pivot];
+                    for (uint32_t q = active_width; q < dormant_pivot; ++q) {
+                        is_selected_pivot &= !promoted.xs[q];
+                    }
+                    if (!is_selected_pivot) {
+                        continue;
+                    }
+                    CAPTURE(active_width, dormant_pivot, body, sign);
+
+                    CoordinateFrame direct(kNumQubits);
+                    CoordinateFrame generic(kNumQubits);
+                    direct.change_basis(basis);
+                    generic.change_basis(basis);
+                    direct.promote_dormant(promoted, active_width, dormant_pivot);
+                    generic.change_basis(
+                        dormant_promotion_frame(promoted, active_width, dormant_pivot));
+                    require_same_coordinate_map(direct, generic, kNumQubits);
+                }
+            }
+        }
+    }
+
+    for (uint32_t dormant_pivot = 0; dormant_pivot < kNumQubits; ++dormant_pivot) {
+        for (uint32_t body = 0; body < 1U << (2 * kNumQubits); ++body) {
+            for (bool sign : {false, true}) {
+                const PlannerPauli measured = signed_pauli(kNumQubits, body, sign);
+                if (!measured.xs[dormant_pivot]) {
+                    continue;
+                }
+                CAPTURE(dormant_pivot, body, sign);
+
+                CoordinateFrame direct(kNumQubits);
+                CoordinateFrame generic(kNumQubits);
+                direct.change_basis(basis);
+                generic.change_basis(basis);
+                direct.measure_dormant(measured, dormant_pivot);
+                generic.change_basis(dormant_measurement_frame(measured, dormant_pivot));
+                require_same_coordinate_map(direct, generic, kNumQubits);
+            }
+        }
+    }
+
+    for (uint32_t active_width = 1; active_width <= kNumQubits; ++active_width) {
+        const uint32_t body_limit = 1U << (2 * active_width);
+        for (uint32_t active_body = 1; active_body < body_limit; ++active_body) {
+            for (bool sign : {false, true}) {
+                PlannerPauli measured(kNumQubits);
+                for (uint32_t q = 0; q < active_width; ++q) {
+                    measured.xs[q] = (active_body >> q) & 1U;
+                    measured.zs[q] = (active_body >> (q + active_width)) & 1U;
+                }
+                measured.sign = sign;
+                const std::optional<uint32_t> pivot =
+                    active_measurement_pivot(measured, active_width);
+                REQUIRE(pivot.has_value());
+                CAPTURE(active_width, active_body, sign, *pivot);
+
+                CoordinateFrame direct(kNumQubits);
+                CoordinateFrame generic(kNumQubits);
+                direct.change_basis(basis);
+                generic.change_basis(basis);
+                direct.measure_active(measured, active_width, *pivot);
+                generic.change_basis(active_measurement_frame(measured, active_width, *pivot));
+                require_same_coordinate_map(direct, generic, kNumQubits);
+            }
+        }
+    }
 }
 
 TEST_CASE("Planner coordinate frame matches inverse across packed words") {

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -160,17 +160,38 @@ TEST_CASE("Planner coordinate frame matches inverse across packed words") {
     PlannerPauli promoted(kNumQubits);
     promoted.zs[0] = true;
     promoted.xs[69] = true;
-    apply_change(dormant_promotion_frame(promoted, 1, 69));
+    promoted.sign = true;
+    PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 69);
+    coordinates.promote_dormant(promoted, 1, 69);
+    cumulative = promotion.then(cumulative);
+    require_matches_inverse();
 
     PlannerPauli active(kNumQubits);
     active.xs[0] = true;
     active.zs[64] = true;
-    apply_change(active_measurement_frame(active, 65, 0));
+    active.sign = true;
+    PlannerTableau active_removal = active_measurement_frame(active, 65, 0);
+    coordinates.measure_active(active, 65, 0);
+    cumulative = active_removal.then(cumulative);
+    require_matches_inverse();
+
+    PlannerPauli diagonal(kNumQubits);
+    diagonal.zs[3] = true;
+    diagonal.zs[63] = true;
+    diagonal.sign = true;
+    PlannerTableau diagonal_removal = active_measurement_frame(diagonal, 64, 3);
+    coordinates.measure_active(diagonal, 64, 3);
+    cumulative = diagonal_removal.then(cumulative);
+    require_matches_inverse();
 
     PlannerPauli dormant(kNumQubits);
     dormant.zs[0] = true;
     dormant.xs[69] = true;
-    apply_change(dormant_measurement_frame(dormant, 69));
+    dormant.sign = true;
+    PlannerTableau dormant_replacement = dormant_measurement_frame(dormant, 69);
+    coordinates.measure_dormant(dormant, 69);
+    cumulative = dormant_replacement.then(cumulative);
+    require_matches_inverse();
 }
 
 TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
@@ -193,6 +214,21 @@ TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
     REQUIRE_FALSE(coordinates.has_cached_inverse_for_testing());
     REQUIRE(coordinates.to_current(initial) ==
             change.inverse().scatter_eval(initial.ref(), {0, 1, 2}));
+
+    for (uint32_t lookup = 0; lookup < 2 * kNumQubits; ++lookup) {
+        static_cast<void>(coordinates.to_current(initial));
+    }
+    REQUIRE(coordinates.has_cached_inverse_for_testing());
+
+    PlannerPauli promoted(kNumQubits);
+    promoted.zs[0] = true;
+    promoted.xs[2] = true;
+    promoted.sign = true;
+    const PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 2);
+    coordinates.promote_dormant(promoted, 1, 2);
+    REQUIRE_FALSE(coordinates.has_cached_inverse_for_testing());
+    REQUIRE(coordinates.to_current(initial) ==
+            promotion.then(change).inverse().scatter_eval(initial.ref(), {0, 1, 2}));
 }
 
 TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {


### PR DESCRIPTION
## Summary

- apply dormant promotion, dormant measurement, and active measurement basis changes directly to the planner's current-to-initial Stim tableau
- preserve the generic frame construction as the final-tableau fallback and as an independent test oracle
- preserve coordinate ordering, Pauli signs, and lazy reverse-map invalidation

This is the bounded follow-up to #296. It retains Stim, but adopts the useful part of the legacy/SymFT approach: mutate the known sparse generator rows directly instead of building an identity-heavy tableau, composing every row generically, and validating the entire tableau in Release.

## Performance

Matched Release builds used `-O3 -DNDEBUG -g -fno-omit-frame-pointer -ffast-math -march=native -mtune=native` on an AMD EPYC 9554P, pinned to one CPU. The table reports medians of three alternating blocks, with 50 compiles per block.

| circuit | #296 plan | branch plan | plan change | #296 total | branch total | total change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| surface d7 r7 | 21.98 ms | 15.49 ms | -29.5% | 26.83 ms | 20.04 ms | -25.3% |
| cultivation d5 | 11.41 ms | 10.08 ms | -11.7% | 16.03 ms | 14.69 ms | -8.4% |
| distillation | 5.31 ms | 1.69 ms | -68.2% | 6.29 ms | 2.68 ms | -57.3% |
| target QEC | 0.681 ms | 0.643 ms | -5.6% | 1.108 ms | 1.076 ms | -3.0% |
| coherent d5 r1 | 1.921 ms | 0.503 ms | -73.8% | 2.587 ms | 1.200 ms | -53.6% |
| QV-20 seed 47 | 2.878 ms | 2.564 ms | -10.9% | 16.003 ms | 15.731 ms | -1.7% |

The low-leakage noncomputational benchmark improved from a 302.5 ms #296 symbolic median to 213.7 ms, a 1.42x speedup. A fresh ten-block comparison measured 213.7 ms symbolic versus 207.9 ms legacy, leaving a 1.03x gap. All paired fixed-seed checksums matched.

Post-change profiles show this is a clean stopping point for this direction:

- noncomputational execution is now dominated by active measurement probability (20.0%), collapse (15.3%), and instrument expansion (11.8%); direct promotion itself is 0.35%
- surface compilation is led by `SymbolicPauliFrame::apply` (20.8%) and Stim bit access (14.3%); `CoordinateFrame::to_current` is 3.4%
- distillation compilation is led by symbolic-frame work and reverse coordinate lookup; direct dormant measurement is 0.55%

The branch does not claim total compile parity with legacy. A separate same-binary comparison measured these symbolic/legacy total compile ratios:

| circuit | symbolic / legacy compile time |
| --- | ---: |
| surface d7 r7 | 3.11x |
| cultivation d5 | 3.65x |
| distillation | 0.93x |
| target QEC | 1.66x |
| coherent d5 r1 | 1.37x |
| QV-20 seed 47 | 1.42x |

The remaining compilation gaps now have different causes: symbolic affine-frame propagation and bit access on surface/cultivation, and executable fused-rotation preparation on QV. They should not be folded into this basis-update change.

## Correctness and validation

- compare every direct transformation with the existing generic frame plus inverse oracle, including signed Paulis, diagonal and non-diagonal active measurements, and qubits crossing packed-word boundaries
- exhaustively compare every generator row across all valid three-qubit signed shapes and pivot boundaries
- verify direct transformations invalidate a previously materialized reverse-map cache
- full non-benchmark C++ suite in Debug: 1,275/1,275 passed
- full non-benchmark C++ suite in RelWithDebInfo: 1,275/1,275 passed
- Python suite: 1,254 passed
- documentation codeblocks: 30 passed, 7 skipped
- required pre-commit hooks: passed

Relates to #280.
