### PR TITLE
perf(sampling): streamline symbolic frame planning

### DIFF
--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -3,6 +3,7 @@
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <iomanip>
 #include <limits>
@@ -245,8 +246,17 @@ AffineBool::AffineBool(bool constant) : constant_(constant) {}
 AffineBool::AffineBool(bool constant, std::vector<SymbolId> terms)
     : constant_(constant), terms_(canonicalize_terms(std::move(terms))) {}
 
+AffineBool::AffineBool(bool constant, std::vector<SymbolId> terms, CanonicalTermsTag)
+    : constant_(constant), terms_(std::move(terms)) {
+    assert(is_canonical() && "trusted affine terms must be sorted and unique");
+}
+
 AffineBool AffineBool::symbol(SymbolId id) {
-    return AffineBool(false, {id});
+    return AffineBool(false, {id}, CanonicalTermsTag{});
+}
+
+AffineBool AffineBool::from_canonical_terms(bool constant, std::vector<SymbolId> terms) {
+    return AffineBool(constant, std::move(terms), CanonicalTermsTag{});
 }
 
 bool AffineBool::is_canonical() const {
@@ -279,6 +289,19 @@ AffineBool& AffineBool::operator^=(const AffineBool& other) {
         } else {
             terms_.insert(position, term);
         }
+        return *this;
+    }
+    terms_ = xor_terms(terms_, other.terms_);
+    return *this;
+}
+
+AffineBool& AffineBool::operator^=(AffineBool&& other) {
+    constant_ ^= other.constant_;
+    if (other.terms_.empty()) {
+        return *this;
+    }
+    if (terms_.empty()) {
+        terms_ = std::move(other.terms_);
         return *this;
     }
     terms_ = xor_terms(terms_, other.terms_);

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -296,16 +296,16 @@ AffineBool& AffineBool::operator^=(const AffineBool& other) {
 }
 
 AffineBool& AffineBool::operator^=(AffineBool&& other) {
-    constant_ ^= other.constant_;
     if (other.terms_.empty()) {
+        constant_ ^= other.constant_;
         return *this;
     }
     if (terms_.empty()) {
+        constant_ ^= other.constant_;
         terms_ = std::move(other.terms_);
         return *this;
     }
-    terms_ = xor_terms(terms_, other.terms_);
-    return *this;
+    return *this ^= static_cast<const AffineBool&>(other);
 }
 
 AffineBool& AffineBool::operator^=(bool value) {

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -83,16 +83,25 @@ class AffineBool {
     AffineBool(bool constant, std::vector<SymbolId> terms);
 
     [[nodiscard]] static AffineBool symbol(SymbolId id);
+    // Planner internals can preserve storage when they already produced the
+    // canonical ordering. Debug builds validate this precondition.
+    [[nodiscard]] static AffineBool from_canonical_terms(bool constant,
+                                                         std::vector<SymbolId> terms);
     [[nodiscard]] bool constant() const { return constant_; }
     [[nodiscard]] const std::vector<SymbolId>& terms() const { return terms_; }
     [[nodiscard]] bool is_canonical() const;
 
     AffineBool& operator^=(const AffineBool& other);
+    AffineBool& operator^=(AffineBool&& other);
     AffineBool& operator^=(bool value);
 
     friend bool operator==(const AffineBool&, const AffineBool&) = default;
 
   private:
+    struct CanonicalTermsTag {};
+
+    AffineBool(bool constant, std::vector<SymbolId> terms, CanonicalTermsTag);
+
     bool constant_ = false;
     std::vector<SymbolId> terms_;
 };

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -281,20 +281,24 @@ void SymbolicPauliFrame::apply(const PlannerPauli& correction, const AffineBool&
     // Noise corrections are usually one- or two-qubit Paulis. Iterating their
     // packed support avoids testing every physical qubit for each noise term.
     const size_t num_words = (static_cast<size_t>(num_qubits_) + 63) / 64;
+    const uint32_t tail_bits = num_qubits_ % 64;
+    const uint64_t last_word_mask = tail_bits == 0 ? ~uint64_t{0} : (uint64_t{1} << tail_bits) - 1;
     for (size_t word = 0; word < num_words; ++word) {
         const uint64_t x_bits = correction.xs.u64[word];
         const uint64_t z_bits = correction.zs.u64[word];
         uint64_t support = x_bits | z_bits;
+        if (word + 1 == num_words) {
+            support &= last_word_mask;
+        }
         while (support != 0) {
             const uint32_t bit = std::countr_zero(support);
-            const uint32_t q = static_cast<uint32_t>(64 * word + bit);
-            assert(q < num_qubits_ && "Pauli padding bits must be clear");
+            const uint32_t qubit = static_cast<uint32_t>(64 * word + bit);
             const uint64_t mask = uint64_t{1} << bit;
             if ((x_bits & mask) != 0) {
-                xor_condition(x_row(q), x_constants_[q], condition);
+                xor_condition(x_row(qubit), x_constants_[qubit], condition);
             }
             if ((z_bits & mask) != 0) {
-                xor_condition(z_row(q), z_constants_[q], condition);
+                xor_condition(z_row(qubit), z_constants_[qubit], condition);
             }
             support &= support - 1;
         }

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -277,12 +277,26 @@ SymbolicPauliFrame::SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols
 void SymbolicPauliFrame::apply(const PlannerPauli& correction, const AffineBool& condition) {
     assert(correction.num_qubits == num_qubits_ &&
            "symbolic Pauli correction width must match the planner frame");
-    for (uint32_t q = 0; q < num_qubits_; ++q) {
-        if (correction.xs[q]) {
-            xor_condition(x_row(q), x_constants_[q], condition);
-        }
-        if (correction.zs[q]) {
-            xor_condition(z_row(q), z_constants_[q], condition);
+
+    // Noise corrections are usually one- or two-qubit Paulis. Iterating their
+    // packed support avoids testing every physical qubit for each noise term.
+    const size_t num_words = (static_cast<size_t>(num_qubits_) + 63) / 64;
+    for (size_t word = 0; word < num_words; ++word) {
+        const uint64_t x_bits = correction.xs.u64[word];
+        const uint64_t z_bits = correction.zs.u64[word];
+        uint64_t support = x_bits | z_bits;
+        while (support != 0) {
+            const uint32_t bit = std::countr_zero(support);
+            const uint32_t q = static_cast<uint32_t>(64 * word + bit);
+            assert(q < num_qubits_ && "Pauli padding bits must be clear");
+            const uint64_t mask = uint64_t{1} << bit;
+            if ((x_bits & mask) != 0) {
+                xor_condition(x_row(q), x_constants_[q], condition);
+            }
+            if ((z_bits & mask) != 0) {
+                xor_condition(z_row(q), z_constants_[q], condition);
+            }
+            support &= support - 1;
         }
     }
 }
@@ -319,7 +333,9 @@ AffineBool SymbolicPauliFrame::sign_for(const PlannerPauli& observable) {
             word &= word - 1;
         }
     }
-    return AffineBool(constant, std::move(terms));
+    // Packed words are scanned from low to high and each set bit is visited
+    // once, so this list already satisfies AffineBool's canonical invariant.
+    return AffineBool::from_canonical_terms(constant, std::move(terms));
 }
 
 std::span<uint64_t> SymbolicPauliFrame::x_row(uint32_t q) {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -138,6 +138,12 @@ TEST_CASE("Sampling plan affine expressions are canonical") {
     REQUIRE(inserted.terms() == std::vector<SymbolId>{s0, s1, s2});
     inserted ^= AffineBool::symbol(s2);
     REQUIRE(inserted.terms() == std::vector<SymbolId>{s0, s1});
+
+    AffineBool moved;
+    moved ^= AffineBool(true, {s2, s0});
+    REQUIRE(moved == AffineBool(true, {s0, s2}));
+    moved ^= AffineBool(false, {s0, s1});
+    REQUIRE(moved == AffineBool(true, {s1, s2}));
 }
 
 TEST_CASE("Sampling plan validates symbolic and active state invariants") {

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -390,6 +390,45 @@ TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
     REQUIRE(SymbolicPauliFrame::estimated_workspace_bytes(2, 130) == 124);
 }
 
+TEST_CASE("Planner symbolic frame applies sparse corrections across packed words") {
+    constexpr uint32_t kNumQubits = 70;
+    SymbolicPauliFrame frame(kNumQubits, 130);
+    const AffineBool condition(true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});
+
+    PlannerPauli correction(kNumQubits);
+    correction.xs[0] = true;
+    correction.zs[1] = true;
+    correction.xs[63] = true;
+    correction.zs[63] = true;
+    correction.xs[64] = true;
+    correction.zs[65] = true;
+    correction.xs[69] = true;
+    correction.zs[69] = true;
+    frame.apply(correction, condition);
+
+    for (uint32_t q : {0U, 63U, 64U, 69U}) {
+        PlannerPauli observable(kNumQubits);
+        observable.zs[q] = true;
+        REQUIRE(frame.sign_for(observable) == condition);
+    }
+    for (uint32_t q : {1U, 63U, 65U, 69U}) {
+        PlannerPauli observable(kNumQubits);
+        observable.xs[q] = true;
+        REQUIRE(frame.sign_for(observable) == condition);
+    }
+
+    PlannerPauli unaffected(kNumQubits);
+    unaffected.xs[62] = true;
+    unaffected.zs[68] = true;
+    REQUIRE(frame.sign_for(unaffected) == AffineBool(false));
+
+    frame.apply(correction, condition);
+    PlannerPauli cancelled(kNumQubits);
+    cancelled.xs[69] = true;
+    cancelled.zs[69] = true;
+    REQUIRE(frame.sign_for(cancelled) == AffineBool(false));
+}
+
 TEST_CASE("Planner symbolic frame rejects unknown symbols") {
     SymbolicPauliFrame frame(1, 1);
     PlannerPauli correction(1);

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -437,6 +437,20 @@ TEST_CASE("Planner symbolic frame rejects unknown symbols") {
     REQUIRE_THROWS_AS(frame.apply(correction, AffineBool::symbol(SymbolId{1})), std::logic_error);
 }
 
+TEST_CASE("Planner symbolic frame masks active Pauli padding") {
+    constexpr uint32_t kNumQubits = 65;
+    SymbolicPauliFrame frame(kNumQubits, 1);
+    PlannerPauli correction(kNumQubits);
+    correction.xs[64] = true;
+    correction.xs.u64[1] |= uint64_t{1} << 5;
+
+    REQUIRE_NOTHROW(frame.apply(correction, AffineBool::symbol(SymbolId{0})));
+
+    PlannerPauli observable(kNumQubits);
+    observable.zs[64] = true;
+    REQUIRE(frame.sign_for(observable) == AffineBool::symbol(SymbolId{0}));
+}
+
 TEST_CASE("Planner promotion frame localizes the promoted observable") {
     PlannerPauli promoted(3);
     promoted.zs[0] = true;


### PR DESCRIPTION
## Summary

- iterate symbolic Pauli corrections through packed nonidentity support instead of querying every physical qubit through `stim::bit_ref`
- preserve affine terms emitted by packed symbolic-frame rows because they are already sorted and unique
- move temporary affine storage into empty XOR accumulators instead of allocating and copying it
- cover mixed X, Y, and Z corrections across packed-word boundaries and the affine move path

This is planner-only work. It does not change the executable plan, RNG schedule, sampling APIs, or hot execution.

## Performance

Measured from the same native Release build on an AMD EPYC 9554P, pinned to CPU 3. Primary cases use five alternating 200-compile blocks; numbers are medians of block medians. The baseline is merged `main` at `7141819`.

| Circuit | Baseline plan | PR plan | Change | Baseline total | PR total | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| surface d7 r7 | 15.31 ms | 6.32 ms | -58.7% | 20.06 ms | 10.91 ms | -45.6% |
| cultivation d5 | 9.17 ms | 4.51 ms | -50.8% | 13.47 ms | 8.63 ms | -35.9% |

Three alternating 100-compile guard blocks showed total compile-time improvements of 23.0% on cultivation d3, 23.5% on distillation, 22.1% on target-QEC, 8.3% on coherent d3 r3, and 5.7% on coherent d5 r1.

Five alternating 200-compile QV guard blocks were neutral within noise: QV-10 was +1.3% and QV-20 was +0.2% in total compile time. `SymbolicPauliFrame::apply` was below 0.2% of the QV-20 baseline profile, and QV compile time is dominated by executable preparation, so there is no causal regression signal from these planner changes.

Against current legacy compilation, the remaining absolute excess is approximately 4.36 ms on surface (10.91 versus 6.56 ms) and 4.75 ms on cultivation d5 (8.63 versus 3.88 ms). Post-change profiles are diffuse: affine XOR and allocation, coordinate lookup, plan validation, operation queuing, and executable lowering each account for only a few percent. This PR therefore stops before introducing broader storage or pass machinery.

## Test plan

- [x] C++ tests pass (`ctest --test-dir /tmp/clifft-direct-debug2 -E '^Bench:' --output-on-failure`): 1,276 tests
- [ ] Python tests pass (`uv run pytest tests/python/ -v`)
- [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`)
- [x] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)

Python and documentation coverage are left to CI because this change is confined to private C++ planner data structures.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.

Closes no issue; contributes to #280.
