### PR TITLE
docs: explain symbolic factored-state theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,19 @@ compiles them into symbolic-coordinate sampling plans. It is designed for
 circuits whose dominant structure is Clifford, but whose behavior depends on
 localized non-Clifford operations.
 
-The main simulation cost scales with the active dimension `k` of the dense state
-vector, rather than directly with the total number of physical qubits `n`.
-Non-Clifford operations can increase `k`, while measurements can reduce it.
+The dense active state has `2^k` amplitudes, where `k` is its active width. The
+main simulation cost therefore scales with `2^k`, rather than directly with the
+total number of physical qubits `n`. Non-Clifford operations can increase `k`,
+while measurements can reduce it.
 
-Clifft's symbolic sampling design draws on the
-[SymFT](https://arxiv.org/abs/2607.28600) method introduced by Wang Fang,
-Huazhe Lou, and Riling Li. In particular, it adapts symbolic
-Clifford-Pauli-frame factorization and adaptive stabilizer-coordinate planning.
+Clifft's original design established this factored active-state architecture.
+[SymFT](https://arxiv.org/abs/2607.28600), by Wang Fang, Huazhe Lou, and Riling
+Li, subsequently built on that foundation with symbolic Clifford-Pauli-frame
+factorization and adaptive stabilizer-coordinate planning. Clifft's current
+sampler brings these improvements back into Clifft alongside Clifft-specific
+planning, continuation, and API machinery.
 See the [theoretical overview](https://unitaryfoundation.github.io/clifft/theory/overview/#method-provenance)
-for the attribution and the boundary between the published method and Clifft's
-implementation choices.
+for the fuller lineage and implementation boundaries.
 
 ## Why Clifft?
 
@@ -48,7 +50,7 @@ implementation choices.
   without approximating the quantum state.
 - **Optimizing compiler pipeline**: resolve Clifford coordinates and symbolic
   dependencies once, then sample many shots from a prepared plan.
-- **Active-dimension scaling**: for low-magic circuits, runtime and memory scale
+- **Active-width scaling**: for low-magic circuits, runtime and memory scale
   with the localized active state rather than the full Hilbert space.
 
 For QEC workflows, Clifft also supports detector-based post-selection, survivor
@@ -108,7 +110,10 @@ for installation commands, minimal examples, and current limitations.
 
 ## Performance
 
-Clifft is designed for near-Clifford circuits where non-Clifford activity remains localized. In this regime, the dominant cost scales with the peak active dimension `k`, not directly with the total number of physical qubits.
+Clifft is designed for near-Clifford circuits where non-Clifford activity
+remains localized. In this regime, the dominant cost scales with the
+active-state dimension `2^k`, where `k` is the peak active width, not directly
+with the total number of physical qubits.
 
 <table>
   <thead>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The main simulation cost scales with the active dimension `k` of the dense state
 vector, rather than directly with the total number of physical qubits `n`.
 Non-Clifford operations can increase `k`, while measurements can reduce it.
 
+Clifft's symbolic sampling design draws on the
+[SymFT](https://arxiv.org/abs/2607.28600) method introduced by Wang Fang,
+Huazhe Lou, and Riling Li. In particular, it adapts symbolic
+Clifford-Pauli-frame factorization and adaptive stabilizer-coordinate planning.
+See the [theoretical overview](https://unitaryfoundation.github.io/clifft/theory/overview/#method-provenance)
+for the attribution and the boundary between the published method and Clifft's
+implementation choices.
+
 ## Why Clifft?
 
 - **Stim-compatible format and API**: parse Stim-format circuits with noise,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ main simulation cost therefore scales with `2^k`, rather than directly with the
 total number of physical qubits `n`. Non-Clifford operations can increase `k`,
 while measurements can reduce it.
 
-Clifft's original design established this factored active-state architecture.
+Clifft's original design established this factored active-state architecture,
+described in the [Clifft paper](https://arxiv.org/abs/2604.27058).
 [SymFT](https://arxiv.org/abs/2607.28600), by Wang Fang, Huazhe Lou, and Riling
 Li, subsequently built on that foundation with symbolic Clifford-Pauli-frame
 factorization and adaptive stabilizer-coordinate planning. Clifft's current

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -22,8 +22,8 @@ choices.
 ## Symbolic Clifford Coordinates
 
 Sampling a circuit with noise or mid-circuit measurements produces a
-trajectory. At action boundary $j$, condition on the Boolean outcomes
-$s_{\le j}$ sampled so far. The resulting pure state has the factorization
+trajectory. After planned step $j$, let $s_{\le j}$ denote the Boolean outcomes
+sampled so far. The resulting pure state has the factorization
 
 $$
 |\psi_j(s_{\le j})\rangle
@@ -41,8 +41,8 @@ $$
 The factors have distinct roles:
 
 - **$C_j$ (Clifford coordinate map):** Maps the current stabilizer coordinates
-  into the physical qubit basis. Its evolution is determined during
-  compilation and planning, not by per-shot tableau operations.
+  into the physical qubit basis. The front end and planner determine its
+  evolution before sampling; a shot performs no tableau operations.
 
 - **$P_j(s_{\le j})$ (Pauli frame):** Represents branch-dependent Pauli
   corrections from noise, measurement outcomes, and classical feedback. It is
@@ -61,11 +61,12 @@ The factors have distinct roles:
 - **$\gamma_j$ (global scalar):** Carries a common complex weight and phase
   outside the active coefficient array.
 
-Active and dormant coordinates are not subsets of physical qubits. A planned
-Clifford basis change can change the physical Pauli support of every coordinate
-while preserving this factorization. "Active width" therefore means the number
-of stabilizer coordinates represented in the dense coefficient array, not the
-number of physical qubits touched by the circuit.
+Active and dormant coordinates are basis elements, not subsets of physical
+qubits. After Clifford gates change the basis, one coordinate may represent a
+different, possibly multi-qubit, physical Pauli without changing the size of
+the active array. "Active width" therefore means the number of stabilizer
+coordinates represented in the dense coefficient array, not the number of
+physical qubits touched by the circuit.
 
 For a normalized physical circuit, the unconditional noisy state is the
 ensemble over trajectories,
@@ -92,12 +93,19 @@ measurements can return coordinates to the dormant set, so fault-tolerant
 circuits may retain a small $k_{\max}$ even when they contain hundreds of
 physical qubits.
 
-## Compiling the Pauli Frame into Symbolic Signs
+## Planning Pauli-Frame Effects as Symbolic Signs
+
+The main symbolic idea is to resolve the branch-dependent Pauli frame during
+planning instead of updating it after every event in every shot. Following the
+symbolic-frame strategy introduced by
+[Fang, Lou, and Li](https://arxiv.org/abs/2607.28600), the planner expresses
+each relevant dependence as an affine formula of Boolean symbols and attaches
+the resulting sign to the affected operation.
 
 Each stochastic event needed later in a shot receives a Boolean symbol. A
 symbol may represent a presampled Pauli fault, a sampled measurement branch, a
-readout flip, an instrument outcome, or a named parity of earlier symbols.
-Classical effects are represented as affine Boolean expressions,
+readout flip, or an [instrument outcome](noncomputational.md). These effects
+are represented as affine Boolean expressions,
 
 $$
 \ell(s) = c \oplus \bigoplus_{r \in R} s_r.
@@ -112,67 +120,94 @@ P_j(s)^\dagger Q P_j(s)
 (-1)^{\ell_Q(s)} Q.
 $$
 
-Following the symbolic-frame strategy introduced by
-[Fang, Lou, and Li](https://arxiv.org/abs/2607.28600), the planner computes
-$\ell_Q$ once and attaches it to the planned operation. It also maps the
-unsigned body of $Q$ into the current stabilizer coordinates. Operations that
-need coefficient work are consequently represented by an active-coordinate
-Pauli and an affine sign, rather than by a physical Pauli string plus a mutable
-runtime frame.
+The planner computes $\ell_Q$ once and maps the unsigned body of $Q$ into the
+current stabilizer coordinates. An operation that needs coefficient work is
+therefore represented by an active-coordinate Pauli and an affine sign, rather
+than by a physical Pauli string plus a mutable runtime frame.
 
-The full symbolic Pauli frame is planning workspace. Before hot execution, its
-effects have been lowered into plan expressions, expression registers, and
-record outcomes. A shot evaluates those prepared expressions as symbols become
-available; it does not update an $n$-qubit Pauli frame after each fault or
-measurement.
+As a result, a shot does not carry and update an $n$-qubit Pauli frame after
+each fault or measurement. It evaluates the prepared expressions as their
+symbols become available and uses the realized signs when applying rotations,
+measurements, and output actions.
 
 ## Adaptive Stabilizer Coordinates
 
 The planner maintains a stabilizer-destabilizer basis in which the first
-$k_j$ coordinates are active and the remainder are dormant. It resolves basis
-changes, Pauli support, measurement pivots, and active-width transitions once
-for all shots. The resulting semantic actions have the following effects:
+$k_j$ coordinates are active and the remainder are dormant. In this basis,
+each dormant coordinate is in $|0\rangle$ and has $Z$ as its stabilizer. A
+promotion moves a dormant coordinate into the dense state when it must carry
+coherent amplitudes; a planned measurement and collapse can return an active
+coordinate to the dormant set.
 
-| Situation | Planned state action | Width transition |
-|---|---|---|
-| Pauli rotation supported on active coordinates | Rotate the active Pauli directly | $k \to k$ |
-| Rotation requiring dormant coherent support | Promote one dormant coordinate, then rotate | $k \to k+1$ |
-| Measurement with active support | Sample and collapse, then remove the planned pivot | $k \to k-1$ |
-| Random measurement resolved in the dormant space | Replace a dormant stabilizer and define a branch symbol | $k \to k$ |
-| Deterministic record or derived parity | Update only symbolic or record state | $k \to k$ |
+The planner resolves these changes once for all shots. Some representative
+cases are:
+
+| Situation | Example | Planned state action | Width |
+|---|---|---|---|
+| Rotation already supported on active coordinates | A mapped $Z$ rotation that touches only active coordinates | Rotate the active Pauli directly | $k \to k$ |
+| Rotation requiring dormant coherent support | An $X$-axis pi/4 rotation on a dormant $|0\rangle$ coordinate | Promote the coordinate, then rotate | $k \to k+1$ |
+| Measurement with active support | A mapped $Z$ measurement that touches the active state | Sample and collapse, then remove the chosen coordinate | $k \to k-1$ |
+| Random measurement in dormant space | An $X$ measurement of a dormant $|0\rangle$ coordinate | Replace its stabilizer and define the sampled branch | $k \to k$ |
+| Classical result | A deterministic $Z$ record or a detector parity of earlier records | Update only symbols, records, or outputs | $k \to k$ |
 
 This is Clifft's adaptation of SymFT's adaptive stabilizer-coordinate planning.
-A promotion installs the required Pauli as the next active generator. An active
-measurement selects a compile-time basis and pivot that permit the measured
-coordinate to be removed after collapse. A dormant random measurement changes
-the stabilizer description and symbolic correction without traversing the
-dense coefficient array.
+For an active measurement, the planner chooses a basis and array dimension that
+can be removed after collapse. A random dormant measurement changes the
+stabilizer description and symbolic correction without traversing the dense
+coefficient array.
 
-Instruments use the same state model. Depending on their source, they may act
-classically, filter or collapse the existing active state, promote a coordinate,
-or stop at an explicit continuation boundary.
+[Transition instruments](noncomputational.md) use the same state model. They
+may act classically, filter or collapse the active state, promote a coordinate,
+or stop execution so that a trajectory-specific continuation can be prepared.
 
-## Semantic Sampling Pipeline
+## From a Circuit to Samples
 
-At the semantic level, the symbolic sampling path is
+The boxes below are stored representations. The text between them describes
+the work that transforms one representation into the next.
 
 ```text
-Circuit
-  -> Heisenberg IR (HIR)
-  -> optimized HIR
-  -> symbolic-coordinate planner
-  -> SamplingPlan
-  -> target executable lowering
-  -> ExecutablePlan
-  -> Executor
-  -> records, detectors, observables, and other results
+[Circuit text]
+      |
+      | Parse and absorb Clifford gates
+      v
+[Heisenberg IR]
+      |
+      | Fuse, cancel, and simplify Pauli operations
+      v
+[Optimized HIR]
+      |
+      | Choose coordinates and derive symbolic dependencies
+      v
+[SamplingPlan]
+      |
+      | Prepare fixed storage, fusion, and scalar or SIMD kernels
+      v
+[ExecutablePlan]
+      |
+      | Reuse for every shot
+      v
+[Records, detectors, observables, and other results]
 ```
 
-The front end absorbs physical Clifford operations into an offline tableau and
-maps relevant operations into the Heisenberg basis. HIR optimization reasons
-algebraically about the resulting Pauli operations. The symbolic-coordinate
-planner then performs all stabilizer-coordinate changes and symbolic dependency
-discovery before emitting `SamplingPlan`.
+### Clifford Trace
+
+The front end turns circuit text into the operations Clifft needs to simulate.
+It absorbs physical Clifford gates into an offline tableau and maps rotations,
+measurements, noise, feedback, detectors, and observables into the Heisenberg
+basis. These operations form the Heisenberg IR, or HIR.
+
+### HIR Optimization
+
+HIR passes use Pauli algebra and dataflow to fuse or cancel operations and,
+when safe, shorten how long coordinates must remain active. This reduces the
+work handed to the planner without fixing a runtime representation.
+
+### Coordinate Planning
+
+The symbolic-coordinate planner decides which coordinates are active at each
+step. It also resolves basis changes, Pauli support, measurement collapse, and
+the symbolic signs described above. The result is a `SamplingPlan` that gives
+every shot the same semantic sequence of possible actions.
 
 `SamplingPlan` is the executor-independent semantic boundary. It describes
 symbols, affine expressions, active-coordinate actions, width transitions,
@@ -180,21 +215,33 @@ records, outputs, noise sites, instruments, and continuation boundaries. It
 does not select an ISA, SIMD kernel, descriptor layout, or target-specific
 fusion.
 
-Target executable lowering prepares expressions, descriptors, fusion products,
-and kernels for a particular executor. The executor owns the mutable per-shot
-coefficient, scratch, symbol, record, output, and RNG state. Ordinary dispatch
-uses only prepared actions: it performs no tableau evolution, commutation
-analysis, Pauli localization, coordinate selection, or dependency discovery.
+### Executable-Plan Preparation
+
+Preparation turns the semantic plan into fixed storage for a particular CPU
+executor. It arranges symbolic dependencies for incremental evaluation,
+combines supported rotation runs, and selects scalar or architecture-specific
+kernels. Coefficient, scratch, symbol, record, output, and RNG storage is sized
+before the hot loop begins.
+
+### Sampling
+
+The executor reuses the prepared plan for every shot. It samples fault and
+measurement symbols, evaluates the affected expressions, and applies prepared
+active-state actions. It performs no tableau evolution, commutation analysis,
+Pauli localization, coordinate selection, or dependency discovery.
 
 ## Continuations and Noncomputational Trajectories
 
-A noncomputational transition can invalidate the remaining compiled operations
-for one trajectory. At an explicit instrument boundary, Clifft may stop,
-rewrite the remaining circuit for the sampled site status, plan a continuation,
-and resume. The continuation preserves the live coefficients, coordinate
-meaning and order, active width, symbol and record values, and RNG position.
-The same factored trajectory state therefore spans the boundary even though the
-replacement suffix is compiled later.
+A noncomputational transition, such as leakage or loss, can change whether
+later gates still act quantum mechanically on a site. Clifft therefore places
+explicit boundaries after relevant instruments. A boundary is a prepared point
+where ordinary execution may stop so that the remaining circuit can be
+rewritten for that trajectory's sampled site status.
+
+Clifft then plans a continuation and resumes. The continuation preserves the
+live coefficients, coordinate meaning and order, active width, symbol and
+record values, and RNG position. The same factored trajectory state therefore
+spans the boundary even though the replacement suffix is planned later.
 
 See [Noncomputational States](noncomputational.md) for the hybrid
 quantum-classical model.
@@ -214,6 +261,9 @@ exponential component still scales with the active width.
 For eligible programs with measurements, `clifft.record_probabilities()`
 evaluates selected measurement records exactly without sampling.
 
+See [Basis-State Probabilities](basis_probabilities.md) and
+[Strong Simulation with Exact Probabilities](../guide/strong-simulation.md).
+
 ## References
 
 - Bradley A. Chase and Farrokh Labib, "Clifft: Fast Exact Simulation of
@@ -222,5 +272,4 @@ evaluates selected measurement records exactly without sampling.
 - Wang Fang, Huazhe Lou, and Riling Li, "SymFT: Universal Fault-Tolerant
   Quantum Circuit Simulation via Symbolic Clifford-Pauli Frames and Stabilizer
   Coordinates," [arXiv:2607.28600](https://arxiv.org/abs/2607.28600)
-  (quant-ph), 2026. DOI:
-  [10.48550/arXiv.2607.28600](https://doi.org/10.48550/arXiv.2607.28600).
+  (quant-ph), 2026.

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -146,9 +146,9 @@ cases are:
 | Situation | Example | Planned state action | Width |
 |---|---|---|---|
 | Rotation already supported on active coordinates | A mapped $Z$ rotation that touches only active coordinates | Rotate the active Pauli directly | $k \to k$ |
-| Rotation requiring dormant coherent support | An $X$-axis pi/4 rotation on a dormant $|0\rangle$ coordinate | Promote the coordinate, then rotate | $k \to k+1$ |
+| Rotation requiring dormant coherent support | An $X$-axis pi/4 rotation on a dormant $\lvert 0\rangle$ coordinate | Promote the coordinate, then rotate | $k \to k+1$ |
 | Measurement with active support | A mapped $Z$ measurement that touches the active state | Sample and collapse, then remove the chosen coordinate | $k \to k-1$ |
-| Random measurement in dormant space | An $X$ measurement of a dormant $|0\rangle$ coordinate | Replace its stabilizer and define the sampled branch | $k \to k$ |
+| Random measurement in dormant space | An $X$ measurement of a dormant $\lvert 0\rangle$ coordinate | Replace its stabilizer and define the sampled branch | $k \to k$ |
 | Classical result | A deterministic $Z$ record or a detector parity of earlier records | Update only symbols, records, or outputs | $k \to k$ |
 
 This is Clifft's adaptation of SymFT's adaptive stabilizer-coordinate planning.

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -1,107 +1,226 @@
 # Theoretical Overview
 
-Clifft is a compiler and execution engine for universal quantum circuits. For
-circuits whose non-Clifford effects remain localized, it reduces the
-exponential part of exact simulation from the total qubit count to a dynamic
-active dimension.
+Clifft is a compiler and execution engine for exact simulation of universal
+quantum circuits. For circuits where non-Clifford effects remain localized,
+it confines exponential work to a dynamic active dimension instead of the
+total physical-qubit count.
 
-More details are in our [arXiv preprint](https://arxiv.org/abs/2604.27058).
+## Method Provenance
+
+The factored active-state model is part of Clifft's original simulation
+design, described by Bradley A. Chase and Farrokh Labib in the
+[Clifft paper](https://arxiv.org/abs/2604.27058).
+
+The symbolic sampling strategy described below draws directly on
+[SymFT](https://arxiv.org/abs/2607.28600), introduced by Wang Fang, Huazhe
+Lou, and Riling Li. In particular, Clifft adapts SymFT's symbolic
+Clifford-Pauli-frame factorization and adaptive stabilizer-coordinate
+planning. `SamplingPlan`, target-specific executable lowering, instruments and
+continuations, and the executor organization are Clifft-specific implementation
+choices.
 
 ## Symbolic Clifford Coordinates
 
-The compiler absorbs deterministic Clifford evolution into an offline frame.
-Measurements, noise outcomes, and conditional operations become affine
-Boolean expressions, while the genuinely interfering degrees of freedom are
-represented by a dense complex state over $k$ active symbolic coordinates.
+Sampling a circuit with noise or mid-circuit measurements produces a
+trajectory. At action boundary $j$, condition on the Boolean outcomes
+$s_{\le j}$ sampled so far. The resulting pure state has the factorization
 
-The dense array has $2^k$ entries. Physical circuits may contain many more
-than $k$ qubits because dormant Clifford structure remains in the symbolic
-frame. Non-Clifford rotations and active measurements can add coordinates;
-measurements can also remove them. The largest width reached by a compiled
-program is exposed as `program.peak_rank`.
+$$
+|\psi_j(s_{\le j})\rangle
+=
+\gamma_j(s_{\le j})\,
+C_j\,
+P_j(s_{\le j})\,
+\Big(
+|\phi_j(s_{\le j})\rangle_{A_j}
+\otimes
+|0\rangle_{D_j}
+\Big).
+$$
 
-For magic-state preparation, distillation, and related QEC circuits, frequent
-measurements can keep this active width small even when the physical circuit
-contains hundreds of qubits. Clifft then allocates $2^{k_max}$ amplitudes
-instead of $2^n$.
+The factors have distinct roles:
 
-## Compilation and Execution
+- **$C_j$ (Clifford coordinate map):** Maps the current stabilizer coordinates
+  into the physical qubit basis. Its evolution is determined during
+  compilation and planning, not by per-shot tableau operations.
+
+- **$P_j(s_{\le j})$ (Pauli frame):** Represents branch-dependent Pauli
+  corrections from noise, measurement outcomes, and classical feedback. It is
+  a mathematical component of the trajectory state, but the symbolic executor
+  does not materialize it as a mutable $n$-qubit runtime frame.
+
+- **$A_j$ and $D_j$ (active and dormant coordinates):** Partition the current
+  stabilizer coordinates into an ordered active prefix of width $k_j$ and
+  $n-k_j$ dormant coordinates. Dormant coordinates are stabilized in the
+  computational zero state in this basis.
+
+- **$|\phi_j\rangle_{A_j}$ (active coefficient state):** A dense complex array
+  of size $2^{k_j}$ containing the non-Clifford interference. Ordinary sampling
+  keeps this coefficient state normalized up to floating-point drift.
+
+- **$\gamma_j$ (global scalar):** Carries a common complex weight and phase
+  outside the active coefficient array.
+
+Active and dormant coordinates are not subsets of physical qubits. A planned
+Clifford basis change can change the physical Pauli support of every coordinate
+while preserving this factorization. "Active width" therefore means the number
+of stabilizer coordinates represented in the dense coefficient array, not the
+number of physical qubits touched by the circuit.
+
+For a normalized physical circuit, the unconditional noisy state is the
+ensemble over trajectories,
+
+$$
+\rho_j
+=
+\mathbb{E}_{s_{\le j}}
+\left[
+|\psi_j(s_{\le j})\rangle
+\langle\psi_j(s_{\le j})|
+\right].
+$$
+
+Clifft samples members of this ensemble rather than materializing the full
+density matrix.
+
+### Why the Factorization Matters
+
+The dense active array is the only state component with exponential size. If
+$k_{\max}$ is the largest active width reached by a plan, coefficient and
+scratch storage scale as $O(2^{k_{\max}})$ instead of $O(2^n)$. Frequent
+measurements can return coordinates to the dormant set, so fault-tolerant
+circuits may retain a small $k_{\max}$ even when they contain hundreds of
+physical qubits.
+
+## Compiling the Pauli Frame into Symbolic Signs
+
+Each stochastic event needed later in a shot receives a Boolean symbol. A
+symbol may represent a presampled Pauli fault, a sampled measurement branch, a
+readout flip, an instrument outcome, or a named parity of earlier symbols.
+Classical effects are represented as affine Boolean expressions,
+
+$$
+\ell(s) = c \oplus \bigoplus_{r \in R} s_r.
+$$
+
+For any Pauli observable or operation $Q$, conjugation by the trajectory's
+Pauli frame can change only its sign:
+
+$$
+P_j(s)^\dagger Q P_j(s)
+=
+(-1)^{\ell_Q(s)} Q.
+$$
+
+Following the symbolic-frame strategy introduced by
+[Fang, Lou, and Li](https://arxiv.org/abs/2607.28600), the planner computes
+$\ell_Q$ once and attaches it to the planned operation. It also maps the
+unsigned body of $Q$ into the current stabilizer coordinates. Operations that
+need coefficient work are consequently represented by an active-coordinate
+Pauli and an affine sign, rather than by a physical Pauli string plus a mutable
+runtime frame.
+
+The full symbolic Pauli frame is planning workspace. Before hot execution, its
+effects have been lowered into plan expressions, expression registers, and
+record outcomes. A shot evaluates those prepared expressions as symbols become
+available; it does not update an $n$-qubit Pauli frame after each fault or
+measurement.
+
+## Adaptive Stabilizer Coordinates
+
+The planner maintains a stabilizer-destabilizer basis in which the first
+$k_j$ coordinates are active and the remainder are dormant. It resolves basis
+changes, Pauli support, measurement pivots, and active-width transitions once
+for all shots. The resulting semantic actions have the following effects:
+
+| Situation | Planned state action | Width transition |
+|---|---|---|
+| Pauli rotation supported on active coordinates | Rotate the active Pauli directly | $k \to k$ |
+| Rotation requiring dormant coherent support | Promote one dormant coordinate, then rotate | $k \to k+1$ |
+| Measurement with active support | Sample and collapse, then remove the planned pivot | $k \to k-1$ |
+| Random measurement resolved in the dormant space | Replace a dormant stabilizer and define a branch symbol | $k \to k$ |
+| Deterministic record or derived parity | Update only symbolic or record state | $k \to k$ |
+
+This is Clifft's adaptation of SymFT's adaptive stabilizer-coordinate planning.
+A promotion installs the required Pauli as the next active generator. An active
+measurement selects a compile-time basis and pivot that permit the measured
+coordinate to be removed after collapse. A dormant random measurement changes
+the stabilizer description and symbolic correction without traversing the
+dense coefficient array.
+
+Instruments use the same state model. Depending on their source, they may act
+classically, filter or collapse the existing active state, promote a coordinate,
+or stop at an explicit continuation boundary.
+
+## Semantic Sampling Pipeline
+
+At the semantic level, the symbolic sampling path is
 
 ```text
-Circuit text
-    |
-    v
-Parse and Clifford trace
-    |  Absorb Clifford gates and emit Heisenberg IR operations.
-    v
-Heisenberg IR
-    |  Fuse/cancel operations and reduce active lifetimes.
-    v
-Optimized HIR
-    |  Choose active coordinates and derive affine dependencies.
-    v
-Sampling plan
-    |  Prepare fixed action storage and select scalar/SIMD kernels.
-    v
-Executable program
-    |  Reuse the plan for every shot.
-    v
-Measurement, detector, observable, and expectation-value results
+Circuit
+  -> Heisenberg IR (HIR)
+  -> optimized HIR
+  -> symbolic-coordinate planner
+  -> SamplingPlan
+  -> target executable lowering
+  -> ExecutablePlan
+  -> Executor
+  -> records, detectors, observables, and other results
 ```
 
-### Clifford Trace
+The front end absorbs physical Clifford operations into an offline tableau and
+maps relevant operations into the Heisenberg basis. HIR optimization reasons
+algebraically about the resulting Pauli operations. The symbolic-coordinate
+planner then performs all stabilizer-coordinate changes and symbolic dependency
+discovery before emitting `SamplingPlan`.
 
-The front end uses Stim's tableau implementation to absorb physical Clifford
-operations. For an explicit operation $P$, it computes the corresponding
-Pauli in the current Clifford frame:
+`SamplingPlan` is the executor-independent semantic boundary. It describes
+symbols, affine expressions, active-coordinate actions, width transitions,
+records, outputs, noise sites, instruments, and continuation boundaries. It
+does not select an ISA, SIMD kernel, descriptor layout, or target-specific
+fusion.
 
-$$P_{frame} = U_C^\dagger P U_C$$
+Target executable lowering prepares expressions, descriptors, fusion products,
+and kernels for a particular executor. The executor owns the mutable per-shot
+coefficient, scratch, symbol, record, output, and RNG state. Ordinary dispatch
+uses only prepared actions: it performs no tableau evolution, commutation
+analysis, Pauli localization, coordinate selection, or dependency discovery.
 
-The resulting Heisenberg IR keeps rotations, measurements, noise, classical
-dependencies, detectors, and observables explicit without replaying every
-Clifford gate during each shot.
+## Continuations and Noncomputational Trajectories
 
-### HIR Optimization
+A noncomputational transition can invalidate the remaining compiled operations
+for one trajectory. At an explicit instrument boundary, Clifft may stop,
+rewrite the remaining circuit for the sampled site status, plan a continuation,
+and resume. The continuation preserves the live coefficients, coordinate
+meaning and order, active width, symbol and record values, and RNG position.
+The same factored trajectory state therefore spans the boundary even though the
+replacement suffix is compiled later.
 
-HIR passes use Pauli algebra and dataflow information to fuse or cancel
-operations and, when safe, shorten active-coordinate lifetimes. This work is
-performed before the runtime representation is fixed.
+See [Noncomputational States](noncomputational.md) for the hybrid
+quantum-classical model.
 
-### Coordinate Planning
+## Exact Final-State Queries
 
-The planner chooses coordinates for consecutive operations, records
-active-width transitions, and converts measurement and noise dependencies into
-affine expressions. It also computes the descriptors needed by rotations,
-measurements, transition instruments, and exact-output queries.
+For eligible pure-state plans, Clifft retains the final Clifford coordinate map
+needed to relate the active coefficient state back to physical qubits. This
+metadata is not read by ordinary sampling dispatch. It supports exact queries
+such as dense statevector expansion and sparse computational-basis
+probabilities.
 
-### Executable-Plan Preparation
+[`clifft.basis_probabilities()`](basis_probabilities.md) computes selected
+full-register probabilities without expanding the full $2^n$ statevector. Its
+exponential component still scales with the active width.
 
-Preparation transposes symbolic dependencies for incremental evaluation,
-combines supported rotation runs, and selects scalar or architecture-specific
-kernels. All coefficient, record, expression, and scratch storage is sized
-before the hot dispatch loop.
+For eligible programs with measurements, `clifft.record_probabilities()`
+evaluates selected measurement records exactly without sampling.
 
-### Sampling
+## References
 
-Each shot assigns presampled fault symbols, evaluates dynamic expressions, and
-applies the prepared active-state actions. Runtime execution performs no
-tableau evolution, Pauli localization, commutation analysis, or dependency
-discovery.
-
-!!! note "Leakage and loss trajectories"
-    A sampled transition can change which later operations remain physical.
-    `clifft.noncomp.sample` therefore compiles and resumes symbolic-coordinate
-    continuations at explicit transition boundaries. See
-    [Noncomputational States](noncomputational.md).
-
-## Exact Queries
-
-For pure-unitary programs, `clifft.basis_probabilities()` computes selected
-full-register computational-basis probabilities without expanding all $2^n$
-amplitudes. `clifft.get_statevector()` performs that full expansion when a
-dense state is useful for small-circuit debugging. Programs with measurements
-can use `clifft.record_probabilities()` to evaluate selected measurement
-records exactly.
-
-See [Basis-State Probabilities](basis_probabilities.md) and
-[Strong Simulation with Exact Probabilities](../guide/strong-simulation.md).
+- Bradley A. Chase and Farrokh Labib, "Clifft: Fast Exact Simulation of
+  Near-Clifford Quantum Circuits," [arXiv:2604.27058](https://arxiv.org/abs/2604.27058),
+  2026.
+- Wang Fang, Huazhe Lou, and Riling Li, "SymFT: Universal Fault-Tolerant
+  Quantum Circuit Simulation via Symbolic Clifford-Pauli Frames and Stabilizer
+  Coordinates," [arXiv:2607.28600](https://arxiv.org/abs/2607.28600)
+  (quant-ph), 2026. DOI:
+  [10.48550/arXiv.2607.28600](https://doi.org/10.48550/arXiv.2607.28600).

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -46,7 +46,7 @@ The factors have distinct roles:
 
 - **$P_j(s_{\le j})$ (Pauli frame):** Represents branch-dependent Pauli
   corrections from noise, measurement outcomes, and classical feedback. It is
-  a mathematical component of the trajectory state, but the symbolic executor
+  a mathematical component of the trajectory state, but the sampling executor
   does not materialize it as a mutable $n$-qubit runtime frame.
 
 - **$A_j$ and $D_j$ (active and dormant coordinates):** Partition the current

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -15,9 +15,9 @@ The symbolic sampling strategy described below draws directly on
 [SymFT](https://arxiv.org/abs/2607.28600), introduced by Wang Fang, Huazhe
 Lou, and Riling Li. In particular, Clifft adapts SymFT's symbolic
 Clifford-Pauli-frame factorization and adaptive stabilizer-coordinate
-planning. `SamplingPlan`, target-specific executable lowering, instruments and
-continuations, and the executor organization are Clifft-specific implementation
-choices.
+planning. `SamplingPlan`, host-specific executable preparation, instruments
+and continuations, and the executor organization are Clifft-specific
+implementation choices.
 
 ## Symbolic Clifford Coordinates
 
@@ -162,8 +162,8 @@ or stop execution so that a trajectory-specific continuation can be prepared.
 
 ## From a Circuit to Samples
 
-The boxes below are stored representations. The text between them describes
-the work that transforms one representation into the next.
+The boxes below name the main compiler and runtime objects. The text between
+them describes the work that prepares or consumes each object.
 
 ```text
 [Circuit text]
@@ -184,7 +184,11 @@ the work that transforms one representation into the next.
       v
 [ExecutablePlan]
       |
-      | Reuse for every shot
+      | Allocate reusable shot state
+      v
+[Executor]
+      |
+      | Run shots and collect outputs
       v
 [Records, detectors, observables, and other results]
 ```
@@ -217,18 +221,21 @@ fusion.
 
 ### Executable-Plan Preparation
 
-Preparation turns the semantic plan into fixed storage for a particular CPU
-executor. It arranges symbolic dependencies for incremental evaluation,
-combines supported rotation runs, and selects scalar or architecture-specific
-kernels. Coefficient, scratch, symbol, record, output, and RNG storage is sized
-before the hot loop begins.
+Preparation turns the semantic plan into fixed storage for the selected
+executor backend. It arranges symbolic dependencies for incremental
+evaluation, combines supported rotation runs, and selects scalar or
+architecture-specific kernels. On x86 builds with runtime dispatch, this
+selects the scalar, AVX2, or AVX-512 backend once for the plan; portable builds
+use the scalar backend.
 
 ### Sampling
 
-The executor reuses the prepared plan for every shot. It samples fault and
-measurement symbols, evaluates the affected expressions, and applies prepared
-active-state actions. It performs no tableau evolution, commutation analysis,
-Pauli localization, coordinate selection, or dependency discovery.
+The executor allocates coefficient, scratch, symbol, record, output, and RNG
+storage before the hot loop, then reuses the prepared plan and that storage for
+every shot. It samples fault and measurement symbols, evaluates the affected
+expressions, and applies prepared active-state actions. It performs no tableau
+evolution, commutation analysis, Pauli localization, coordinate selection, or
+dependency discovery.
 
 ## Continuations and Noncomputational Trajectories
 
@@ -258,8 +265,10 @@ probabilities.
 full-register probabilities without expanding the full $2^n$ statevector. Its
 exponential component still scales with the active width.
 
-For eligible programs with measurements, `clifft.record_probabilities()`
-evaluates selected measurement records exactly without sampling.
+For pure-state programs whose only stochastic events and outputs are visible
+measurements, and which do not use postselection,
+`clifft.record_probabilities()` evaluates selected records exactly without
+sampling.
 
 See [Basis-State Probabilities](basis_probabilities.md) and
 [Strong Simulation with Exact Probabilities](../guide/strong-simulation.md).

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -2,21 +2,21 @@
 
 Clifft is a compiler and execution engine for exact simulation of universal
 quantum circuits. For circuits where non-Clifford effects remain localized,
-it confines exponential work to a dynamic active dimension instead of the
-total physical-qubit count.
+it confines exponential work to an active-state dimension of $2^k$, set by the
+dynamic active width $k$, instead of the total physical-qubit count.
 
 ## Method Provenance
 
-The factored active-state model is part of Clifft's original simulation
-design, described by Bradley A. Chase and Farrokh Labib in the
+The original Clifft design established the factored active-state model,
+described by Bradley A. Chase and Farrokh Labib in the
 [Clifft paper](https://arxiv.org/abs/2604.27058).
 
-The symbolic sampling strategy described below draws directly on
-[SymFT](https://arxiv.org/abs/2607.28600), introduced by Wang Fang, Huazhe
-Lou, and Riling Li. In particular, Clifft adapts SymFT's symbolic
-Clifford-Pauli-frame factorization and adaptive stabilizer-coordinate
-planning. `SamplingPlan`, host-specific executable preparation, instruments
-and continuations, and the executor organization are Clifft-specific
+[SymFT](https://arxiv.org/abs/2607.28600), by Wang Fang, Huazhe Lou, and Riling
+Li, subsequently built on that foundation. It extended the design with
+symbolic Clifford-Pauli-frame factorization and adaptive stabilizer-coordinate
+planning. The current Clifft sampler brings these SymFT refinements back into
+Clifft. `SamplingPlan`, host-specific executable preparation, instruments and
+continuations, and the executor organization remain Clifft-specific
 implementation choices.
 
 ## Symbolic Clifford Coordinates
@@ -64,9 +64,10 @@ The factors have distinct roles:
 Active and dormant coordinates are basis elements, not subsets of physical
 qubits. After Clifford gates change the basis, one coordinate may represent a
 different, possibly multi-qubit, physical Pauli without changing the size of
-the active array. "Active width" therefore means the number of stabilizer
-coordinates represented in the dense coefficient array, not the number of
-physical qubits touched by the circuit.
+the active array. Throughout these docs, **active width** $k_j$ means the number
+of stabilizer coordinates represented in the dense coefficient array. The
+corresponding **active-state dimension** is $2^{k_j}$, the number of amplitudes
+in that array. Neither is the number of physical qubits touched by the circuit.
 
 For a normalized physical circuit, the unconditional noisy state is the
 ensemble over trajectories,


### PR DESCRIPTION
## Summary

- trace the method lineage from the original Clifft factored active-state design through the SymFT refinements adopted back into current Clifft
- name Wang Fang, Huazhe Lou, and Riling Li at first use and add the complete SymFT reference
- reserve active width for $k$ and active-state dimension for $2^k$
- define the state per sampled trajectory using active and dormant stabilizer coordinates
- explain affine Pauli-frame signs and adaptive coordinate transitions with concrete examples
- walk readers from circuit text through `SamplingPlan`, executable preparation, `Executor`, and per-shot results
- add visible method attribution to the README

This is the theory workstream from #301, rebased onto the symbolic-only main branch after the production cutover and legacy SVM removal in #321 and #334. The remaining documentation issues will audit the current user-facing pages and add final performance and release material rather than duplicate this theory page. The long-form migration and performance update is tracked in #322.

Closes #307

## Validation

- [x] `just docs-build`
- [x] `just py-doctest` — 31 passed, 7 skipped
- [x] `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`