### PR TITLE
perf(sampling): add AVX2 symbolic kernels

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -50,7 +50,7 @@ SKBUILD_CMAKE_ARGS="-DOpenMP_ROOT=$(brew --prefix libomp)" uv pip install -e .
 
 | Platform / CPU family | PyPI wheel | Source build | Notes |
 |---|---|---|---|
-| Linux `x86_64` with x86-64-v2 support | Supported | Supported | Wheel uses an `x86-64-v2` baseline and can dispatch to AVX2/BMI2/FMA or AVX-512 SVM paths on capable CPUs. |
+| Linux `x86_64` with x86-64-v2 support | Supported | Supported | Wheel uses an `x86-64-v2` baseline and can dispatch SVM and symbolic sampling kernels to AVX2/BMI2/FMA or AVX-512 paths on capable CPUs. |
 | Linux `x86_64` without x86-64-v2 support | Not supported | Supported | Use `pip install --no-binary clifft clifft` or build from a checkout. |
 | Linux `aarch64` | Supported | Supported | Wheels use a portable ARM baseline; local optimized builds default to native CPU tuning. |
 | macOS `arm64` | Supported | Supported | Wheels use a portable Apple Silicon baseline; local optimized builds are supported. |
@@ -63,7 +63,7 @@ SKBUILD_CMAKE_ARGS="-DOpenMP_ROOT=$(brew --prefix libomp)" uv pip install -e .
 - Published wheels use explicit portable baselines chosen in CI.
 - Local Python source builds and standalone C++ Release builds default to `CLIFFT_CPU_BASELINE=native`.
 - Supported values are `native`, `generic`, `x86-64-v2`, and `x86-64-v3`.
-- Linux `x86_64` wheels use `x86-64-v2` as the global baseline. Higher-ISA SVM paths are compiled separately and selected at runtime when the host supports them.
+- Linux `x86_64` wheels use `x86-64-v2` as the global baseline. Higher-ISA SVM and symbolic sampling kernels are compiled separately and selected at runtime when the host supports them.
 
 Override the default when needed:
 
@@ -112,7 +112,7 @@ cmake --build build -j
 | Release | `-DCMAKE_BUILD_TYPE=Release` | Benchmarking |
 | RelWithDebInfo | `-DCMAKE_BUILD_TYPE=RelWithDebInfo` | Profiling |
 
-For optimized source builds, `Release` and `RelWithDebInfo` default to native CPU tuning on the build machine. On x86 GNU/Clang builds, that keeps the AVX2 and AVX-512 SVM specializations available for runtime dispatch.
+For optimized source builds, `Release` and `RelWithDebInfo` default to native CPU tuning on the build machine. On x86 GNU/Clang builds, that keeps the AVX2 and AVX-512 SVM and symbolic sampling specializations available for runtime dispatch.
 
 !!! info "First build takes 10-15 minutes"
     Stim (a dependency) has many source files. Subsequent builds are incremental.

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -61,9 +61,13 @@ add_library(clifft_core STATIC
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)") AND NOT MSVC)
     target_sources(clifft_core PRIVATE
+        sampling/kernels_avx2.cc
         sampling/kernels_avx512.cc
         svm/svm_avx2.cc
         svm/svm_avx512.cc
+    )
+    set_source_files_properties(sampling/kernels_avx2.cc
+        PROPERTIES COMPILE_OPTIONS "-mavx2;-mbmi2;-mfma"
     )
     set_source_files_properties(svm/svm_avx2.cc
         PROPERTIES COMPILE_OPTIONS "-mavx2;-mbmi2;-mfma"

--- a/src/clifft/sampling/active_measurement_dispatch.cc
+++ b/src/clifft/sampling/active_measurement_dispatch.cc
@@ -10,21 +10,36 @@ namespace clifft::sampling {
 
 namespace {
 
-constexpr uint32_t kVectorLaneIndexBits = 3;
-static_assert(uint64_t{1} << kVectorLaneIndexBits == kAvx512DoubleLanes);
+constexpr uint32_t kAvx2LaneIndexBits = 2;
+constexpr uint32_t kAvx512LaneIndexBits = 3;
+static_assert(uint64_t{1} << kAvx2LaneIndexBits == kAvx2DoubleLanes);
+static_assert(uint64_t{1} << kAvx512LaneIndexBits == kAvx512DoubleLanes);
 
-// A single vector block regressed against the scalar probability-plus-collapse
-// pair on this host; two blocks amortize the vector setup.
-constexpr uint32_t kMinProfitableActiveWidth = 4;
+// A single AVX-512 block regressed against scalar on its performance host,
+// while the AVX2 probability-plus-collapse pair wins from one block onward.
+constexpr uint32_t kMinProfitableAvx2ActiveWidth = 2;
+constexpr uint32_t kMinProfitableAvx512ActiveWidth = 4;
 
-ActiveMeasurementKernel select_active_measurement_avx512(
-    const PreparedMeasurement& measurement) noexcept {
-    if (measurement.pauli.is_diagonal() || measurement.pauli.x >= kAvx512DoubleLanes ||
-        measurement.pivot >= kVectorLaneIndexBits ||
-        measurement.pauli.active_width < kMinProfitableActiveWidth) {
+ActiveMeasurementKernel select_active_measurement(const PreparedMeasurement& measurement,
+                                                  uint64_t vector_lanes, uint32_t lane_index_bits,
+                                                  uint32_t min_active_width) noexcept {
+    if (measurement.pauli.is_diagonal() || measurement.pauli.x >= vector_lanes ||
+        measurement.pivot >= lane_index_bits || measurement.pauli.active_width < min_active_width) {
         return ActiveMeasurementKernel::Scalar;
     }
     return ActiveMeasurementKernel::LanePaired;
+}
+
+ActiveMeasurementKernel select_active_measurement_avx2(
+    const PreparedMeasurement& measurement) noexcept {
+    return select_active_measurement(measurement, kAvx2DoubleLanes, kAvx2LaneIndexBits,
+                                     kMinProfitableAvx2ActiveWidth);
+}
+
+ActiveMeasurementKernel select_active_measurement_avx512(
+    const PreparedMeasurement& measurement) noexcept {
+    return select_active_measurement(measurement, kAvx512DoubleLanes, kAvx512LaneIndexBits,
+                                     kMinProfitableAvx512ActiveWidth);
 }
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
@@ -37,6 +52,9 @@ const internal::RuntimeIsa kResolvedActiveMeasurementIsa = internal::runtime_isa
 
 ActiveMeasurementKernel resolve_active_measurement_kernel(
     const PreparedMeasurement& measurement, internal::RuntimeIsa runtime_isa) noexcept {
+    if (runtime_isa == internal::RuntimeIsa::Avx2) {
+        return select_active_measurement_avx2(measurement);
+    }
     if (runtime_isa == internal::RuntimeIsa::Avx512) {
         return select_active_measurement_avx512(measurement);
     }
@@ -48,8 +66,11 @@ MeasurementProbabilities active_measurement_probabilities(const State& state,
                                                           ActiveMeasurementKernel kernel) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
     if (kernel == ActiveMeasurementKernel::LanePaired) {
+        if (kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx2) {
+            return active_measurement_probabilities_avx2(state, measurement);
+        }
         assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
-               "vector active measurement requires the selected AVX-512 implementation");
+               "vector active measurement requires a selected SIMD implementation");
         return active_measurement_probabilities_avx512(state, measurement);
     }
 #else
@@ -65,9 +86,13 @@ void collapse_active_measurement(State& state, const PreparedMeasurement& measur
                                  double branch_probability) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
     if (kernel == ActiveMeasurementKernel::LanePaired) {
-        assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
-               "vector active measurement requires the selected AVX-512 implementation");
-        collapse_active_measurement_avx512(state, measurement, branch, branch_probability);
+        if (kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx2) {
+            collapse_active_measurement_avx2(state, measurement, branch, branch_probability);
+        } else {
+            assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
+                   "vector active measurement requires a selected SIMD implementation");
+            collapse_active_measurement_avx512(state, measurement, branch, branch_probability);
+        }
         return;
     }
 #else

--- a/src/clifft/sampling/active_measurement_dispatch.cc
+++ b/src/clifft/sampling/active_measurement_dispatch.cc
@@ -65,13 +65,17 @@ MeasurementProbabilities active_measurement_probabilities(const State& state,
                                                           const PreparedMeasurement& measurement,
                                                           ActiveMeasurementKernel kernel) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    assert(kernel ==
+               resolve_active_measurement_kernel(measurement, kResolvedActiveMeasurementIsa) &&
+           "active measurement kernel must match the process ISA");
     if (kernel == ActiveMeasurementKernel::LanePaired) {
         if (kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx2) {
             return active_measurement_probabilities_avx2(state, measurement);
         }
-        assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
-               "vector active measurement requires a selected SIMD implementation");
-        return active_measurement_probabilities_avx512(state, measurement);
+        if (kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512) {
+            return active_measurement_probabilities_avx512(state, measurement);
+        }
+        assert(false && "vector active measurement requires a selected SIMD implementation");
     }
 #else
     assert(kernel == ActiveMeasurementKernel::Scalar &&
@@ -85,13 +89,17 @@ void collapse_active_measurement(State& state, const PreparedMeasurement& measur
                                  ActiveMeasurementKernel kernel, bool branch,
                                  double branch_probability) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    assert(kernel ==
+               resolve_active_measurement_kernel(measurement, kResolvedActiveMeasurementIsa) &&
+           "active measurement kernel must match the process ISA");
     if (kernel == ActiveMeasurementKernel::LanePaired) {
         if (kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx2) {
             collapse_active_measurement_avx2(state, measurement, branch, branch_probability);
-        } else {
-            assert(kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512 &&
-                   "vector active measurement requires a selected SIMD implementation");
+        } else if (kResolvedActiveMeasurementIsa == internal::RuntimeIsa::Avx512) {
             collapse_active_measurement_avx512(state, measurement, branch, branch_probability);
+        } else {
+            assert(false && "vector active measurement requires a selected SIMD implementation");
+            collapse_measurement(state, measurement, branch, branch_probability);
         }
         return;
     }

--- a/src/clifft/sampling/active_measurement_simd.h
+++ b/src/clifft/sampling/active_measurement_simd.h
@@ -4,8 +4,12 @@
 
 namespace clifft::sampling {
 
-// Linked only on x86-64 runtime-dispatch builds and called only after AVX-512
-// has been selected for this process and measurement shape.
+// Linked only on x86-64 runtime-dispatch builds and called only after the
+// corresponding ISA has been selected for this process and measurement shape.
+[[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx2(
+    const State& state, const PreparedMeasurement& measurement) noexcept;
+void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& measurement,
+                                      bool branch, double branch_probability) noexcept;
 [[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx512(
     const State& state, const PreparedMeasurement& measurement) noexcept;
 void collapse_active_measurement_avx512(State& state, const PreparedMeasurement& measurement,

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -9,31 +9,40 @@ namespace clifft::sampling {
 
 namespace {
 
-// One full vector block: the dense state must span the vector lanes before a
-// whole-block kernel is profitable or even addressable.
-constexpr uint32_t kMinVectorActiveWidth = 3;
-static_assert(uint64_t{1} << kMinVectorActiveWidth == kAvx512DoubleLanes);
+constexpr uint32_t kMinAvx2ActiveWidth = 2;
+constexpr uint32_t kMinAvx512ActiveWidth = 3;
+static_assert(uint64_t{1} << kMinAvx2ActiveWidth == kAvx2DoubleLanes);
+static_assert(uint64_t{1} << kMinAvx512ActiveWidth == kAvx512DoubleLanes);
 
-// Stride-16 pairing regressed against scalar at every measured active width,
-// so this pivot stays on the fallback until a kernel designed for it exists.
-constexpr uint64_t kPivotFourSelector = uint64_t{1} << 4;
-
-DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotation) noexcept {
+DirectRotationKernel select_direct_rotation(const PreparedRotation& rotation, uint64_t vector_lanes,
+                                            uint32_t min_active_width,
+                                            bool exclude_pivot_four) noexcept {
     if (rotation.pauli.is_identity()) {
         return DirectRotationKernel::Scalar;
     }
     if (rotation.pauli.is_diagonal()) {
-        return rotation.pauli.active_width >= kMinVectorActiveWidth ? DirectRotationKernel::Diagonal
-                                                                    : DirectRotationKernel::Scalar;
+        return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::Diagonal
+                                                               : DirectRotationKernel::Scalar;
     }
     const uint64_t pairing_bit = rotation.pauli.pair_selector;
-    if (pairing_bit < kAvx512DoubleLanes) {
-        return rotation.pauli.active_width >= kMinVectorActiveWidth
-                   ? DirectRotationKernel::LanePaired
-                   : DirectRotationKernel::Scalar;
+    if (pairing_bit < vector_lanes) {
+        return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::LanePaired
+                                                               : DirectRotationKernel::Scalar;
     }
-    return pairing_bit != kPivotFourSelector ? DirectRotationKernel::HighPivot
-                                             : DirectRotationKernel::Scalar;
+    if (exclude_pivot_four && pairing_bit == (uint64_t{1} << 4)) {
+        return DirectRotationKernel::Scalar;
+    }
+    return DirectRotationKernel::HighPivot;
+}
+
+DirectRotationKernel select_direct_rotation_avx2(const PreparedRotation& rotation) noexcept {
+    return select_direct_rotation(rotation, kAvx2DoubleLanes, kMinAvx2ActiveWidth, false);
+}
+
+DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotation) noexcept {
+    // Stride-16 pairing regressed against scalar at every measured active
+    // width on the AVX-512 performance host.
+    return select_direct_rotation(rotation, kAvx512DoubleLanes, kMinAvx512ActiveWidth, true);
 }
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
@@ -49,6 +58,9 @@ const internal::RuntimeIsa kResolvedDirectRotationIsa = internal::runtime_isa();
 
 DirectRotationKernel resolve_direct_rotation_kernel(const PreparedRotation& rotation,
                                                     internal::RuntimeIsa runtime_isa) noexcept {
+    if (runtime_isa == internal::RuntimeIsa::Avx2) {
+        return select_direct_rotation_avx2(rotation);
+    }
     if (runtime_isa == internal::RuntimeIsa::Avx512) {
         return select_direct_rotation_avx512(rotation);
     }
@@ -59,9 +71,13 @@ void apply_direct_rotation(State& state, const PreparedRotation& rotation,
                            DirectRotationKernel kernel, bool sign) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
     if (kernel != DirectRotationKernel::Scalar) {
-        assert(kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx512 &&
-               "vector direct rotation shape requires the selected AVX-512 implementation");
-        apply_direct_rotation_avx512(state, rotation, kernel, sign);
+        if (kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx2) {
+            apply_direct_rotation_avx2(state, rotation, kernel, sign);
+        } else {
+            assert(kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx512 &&
+                   "vector direct rotation requires a selected SIMD implementation");
+            apply_direct_rotation_avx512(state, rotation, kernel, sign);
+        }
         return;
     }
     apply_rotation(state, rotation, sign);

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -11,12 +11,14 @@ namespace {
 
 constexpr uint32_t kMinAvx2ActiveWidth = 2;
 constexpr uint32_t kMinAvx512ActiveWidth = 3;
+constexpr uint64_t kNoExcludedPairSelector = 0;
+constexpr uint64_t kPivotFourSelector = uint64_t{1} << 4;
 static_assert(uint64_t{1} << kMinAvx2ActiveWidth == kAvx2DoubleLanes);
 static_assert(uint64_t{1} << kMinAvx512ActiveWidth == kAvx512DoubleLanes);
 
 DirectRotationKernel select_direct_rotation(const PreparedRotation& rotation, uint64_t vector_lanes,
                                             uint32_t min_active_width,
-                                            bool exclude_pivot_four) noexcept {
+                                            uint64_t excluded_pair_selector) noexcept {
     if (rotation.pauli.is_identity()) {
         return DirectRotationKernel::Scalar;
     }
@@ -29,20 +31,24 @@ DirectRotationKernel select_direct_rotation(const PreparedRotation& rotation, ui
         return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::LanePaired
                                                                : DirectRotationKernel::Scalar;
     }
-    if (exclude_pivot_four && pairing_bit == (uint64_t{1} << 4)) {
+    if (pairing_bit == excluded_pair_selector) {
         return DirectRotationKernel::Scalar;
     }
     return DirectRotationKernel::HighPivot;
 }
 
 DirectRotationKernel select_direct_rotation_avx2(const PreparedRotation& rotation) noexcept {
-    return select_direct_rotation(rotation, kAvx2DoubleLanes, kMinAvx2ActiveWidth, false);
+    // Stride-16 pairing was neutral or faster than scalar across the measured
+    // AVX2 active widths, so every high pivot uses the vector kernel.
+    return select_direct_rotation(rotation, kAvx2DoubleLanes, kMinAvx2ActiveWidth,
+                                  kNoExcludedPairSelector);
 }
 
 DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotation) noexcept {
     // Stride-16 pairing regressed against scalar at every measured active
     // width on the AVX-512 performance host.
-    return select_direct_rotation(rotation, kAvx512DoubleLanes, kMinAvx512ActiveWidth, true);
+    return select_direct_rotation(rotation, kAvx512DoubleLanes, kMinAvx512ActiveWidth,
+                                  kPivotFourSelector);
 }
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
@@ -70,13 +76,16 @@ DirectRotationKernel resolve_direct_rotation_kernel(const PreparedRotation& rota
 void apply_direct_rotation(State& state, const PreparedRotation& rotation,
                            DirectRotationKernel kernel, bool sign) noexcept {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    assert(kernel == resolve_direct_rotation_kernel(rotation, kResolvedDirectRotationIsa) &&
+           "direct rotation kernel must match the process ISA");
     if (kernel != DirectRotationKernel::Scalar) {
         if (kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx2) {
             apply_direct_rotation_avx2(state, rotation, kernel, sign);
-        } else {
-            assert(kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx512 &&
-                   "vector direct rotation requires a selected SIMD implementation");
+        } else if (kResolvedDirectRotationIsa == internal::RuntimeIsa::Avx512) {
             apply_direct_rotation_avx512(state, rotation, kernel, sign);
+        } else {
+            assert(false && "vector direct rotation requires a selected SIMD implementation");
+            apply_rotation(state, rotation, sign);
         }
         return;
     }

--- a/src/clifft/sampling/direct_rotation_simd.h
+++ b/src/clifft/sampling/direct_rotation_simd.h
@@ -6,12 +6,18 @@
 
 namespace clifft::sampling {
 
+// Lane count of one 256-bit double vector. The portable selector uses this
+// value without exposing vector types outside the AVX2 translation unit.
+inline constexpr uint64_t kAvx2DoubleLanes = 4;
+
 // Lane count of one 512-bit double vector. Both the portable kernel selector
 // and the AVX-512 translation unit measure shape eligibility against it.
 inline constexpr uint64_t kAvx512DoubleLanes = 8;
 
-// This function is linked only on x86-64 runtime-dispatch builds and must be
-// called only after the dispatcher has selected AVX-512.
+// These functions are linked only on x86-64 runtime-dispatch builds and must
+// be called only after the dispatcher has selected their corresponding ISA.
+void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
+                                DirectRotationKernel kernel, bool sign) noexcept;
 void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
                                   DirectRotationKernel kernel, bool sign) noexcept;
 

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -267,6 +267,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     size_t planned_index = 0;
     while (planned_index < plan.actions.size()) {
         DynamicFusedRotationRun dynamic_run;
+        // AVX2 dynamic fusion regressed large active states despite helping
+        // narrower ones, so only the consistently profitable AVX-512 path lowers it.
         if (runtime_isa == internal::RuntimeIsa::Avx512) {
             dynamic_run = prepare_dynamic_fused_rotation_run(
                 std::span<const PlannedAction>(plan.actions).subspan(planned_index));

--- a/src/clifft/sampling/fused_rotation.cc
+++ b/src/clifft/sampling/fused_rotation.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/fused_rotation.h"
 
+#include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/kernels.h"
 
@@ -27,6 +28,8 @@ constexpr uint32_t kMaxFusedRotationSelectors = 5;
 // the sign rank and the minimum amount of eliminated work bounded.
 constexpr uint32_t kMaxFusedRotationSigns = 2;
 constexpr size_t kMinDynamicFusedRotationActions = 8;
+constexpr uint32_t kMinDynamicFusedRotationPivot =
+    static_cast<uint32_t>(std::countr_zero(kAvx512DoubleLanes));
 
 // A row-reduced basis for a vector subspace of GF(2)^64, where each bit is one
 // binary coordinate.
@@ -444,7 +447,8 @@ DynamicFusedRotationRun prepare_dynamic_fused_rotation_run(std::span<const Plann
 
     const std::vector<uint64_t> orbit_rows = orbit_basis.rows();
     if (result.action_count < kMinDynamicFusedRotationActions || !has_dynamic_sign ||
-        orbit_rows.size() != 2 || std::countr_zero(std::bit_floor(orbit_rows[0])) < 3) {
+        orbit_rows.size() != 2 ||
+        std::countr_zero(std::bit_floor(orbit_rows[0])) < kMinDynamicFusedRotationPivot) {
         return result;
     }
 

--- a/src/clifft/sampling/fused_rotation_dispatch.cc
+++ b/src/clifft/sampling/fused_rotation_dispatch.cc
@@ -18,7 +18,10 @@ PreparedFusedRotationExecution::PreparedFusedRotationExecution(PreparedFusedRota
         case internal::RuntimeIsa::Avx512:
             sidecar_ = prepare_fused_rotation_avx512_sidecar(rotation_);
             break;
-        default:
+        case internal::RuntimeIsa::Scalar:
+        case internal::RuntimeIsa::TrapAvx2:
+        case internal::RuntimeIsa::TrapAvx512:
+        case internal::RuntimeIsa::TrapUnknown:
             break;
     }
 #else

--- a/src/clifft/sampling/fused_rotation_dispatch.cc
+++ b/src/clifft/sampling/fused_rotation_dispatch.cc
@@ -11,8 +11,15 @@ PreparedFusedRotationExecution::PreparedFusedRotationExecution(PreparedFusedRota
                                                                internal::RuntimeIsa runtime_isa)
     : rotation_(std::move(rotation)) {
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    if (runtime_isa == internal::RuntimeIsa::Avx512) {
-        sidecar_ = prepare_fused_rotation_avx512_sidecar(rotation_);
+    switch (runtime_isa) {
+        case internal::RuntimeIsa::Avx2:
+            sidecar_ = prepare_fused_rotation_avx2_sidecar(rotation_);
+            break;
+        case internal::RuntimeIsa::Avx512:
+            sidecar_ = prepare_fused_rotation_avx512_sidecar(rotation_);
+            break;
+        default:
+            break;
     }
 #else
     (void)runtime_isa;

--- a/src/clifft/sampling/fused_rotation_simd.h
+++ b/src/clifft/sampling/fused_rotation_simd.h
@@ -4,8 +4,10 @@
 
 namespace clifft::sampling {
 
-// This function is linked only on x86-64 runtime-dispatch builds and must be
-// called only after the dispatcher has selected the AVX-512 implementation.
+// These functions are linked only on x86-64 runtime-dispatch builds and must
+// be called only after the dispatcher has selected their corresponding ISA.
+[[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(
+    const PreparedFusedRotation& rotation);
 [[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(
     const PreparedFusedRotation& rotation);
 

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -1,6 +1,7 @@
 // AVX2+BMI2+FMA sampling kernels. This translation unit is compiled with
 // explicit ISA flags so portable builds can select it at runtime.
 
+#include "clifft/sampling/active_measurement_simd.h"
 #include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
@@ -8,6 +9,7 @@
 #include <array>
 #include <bit>
 #include <cassert>
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
@@ -25,6 +27,7 @@ namespace {
 constexpr size_t kLanes = kAvx2DoubleLanes;
 constexpr size_t kDimension = 4;
 constexpr size_t kMatrixSize = kDimension * kDimension;
+constexpr double kInvSqrt2 = 0.707106781186547524400844362104849039;
 
 using LanePermutationIndices = std::array<int32_t, 2 * kLanes>;
 using LaneSigns = std::array<double, kLanes>;
@@ -54,6 +57,15 @@ constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
 alignas(32) constexpr auto kLanePermutations = make_lane_permutations();
 alignas(32) constexpr auto kLaneParitySigns = make_lane_parity_signs();
 
+alignas(32) constexpr std::array<LanePermutationIndices, 2> kMeasurementCompactionPermutations = {{
+    {0, 1, 4, 5, 0, 0, 0, 0},
+    {0, 1, 2, 3, 0, 0, 0, 0},
+}};
+alignas(32) constexpr std::array<LaneSigns, 2> kMeasurementSourceWeights = {{
+    {1.0, 0.0, 1.0, 0.0},
+    {1.0, 1.0, 0.0, 0.0},
+}};
+
 struct alignas(32) LanePermutation {
     LanePermutationIndices indices{};
 };
@@ -71,6 +83,12 @@ struct FusedRotationAvx2Sidecar {
 __m256d permute_lanes(__m256d input, __m256i permutation) noexcept {
     return _mm256_castsi256_pd(
         _mm256_permutevar8x32_epi32(_mm256_castpd_si256(input), permutation));
+}
+
+double reduce_add(__m256d value) noexcept {
+    const __m128d halves =
+        _mm_add_pd(_mm256_castpd256_pd128(value), _mm256_extractf128_pd(value, 1));
+    return _mm_cvtsd_f64(_mm_add_sd(halves, _mm_unpackhi_pd(halves, halves)));
 }
 
 __m256d signed_sine_lanes(uint64_t basis, uint64_t z, double sine) noexcept {
@@ -269,7 +287,122 @@ void apply_fused_rotation_avx2(State& state, const PreparedFusedRotation& rotati
     }
 }
 
+template <bool RealPhase>
+MeasurementProbabilities active_measurement_probabilities_avx2_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    const uint64_t lane_xor = measurement.pauli.x;
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const __m256d source_weights =
+        _mm256_load_pd(kMeasurementSourceWeights[measurement.pivot].data());
+    const double base_coefficient =
+        RealPhase ? measurement.pauli.even_phase.real() : -measurement.pauli.even_phase.imag();
+    __m256d zero_sum = _mm256_setzero_pd();
+    __m256d one_sum = _mm256_setzero_pd();
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m256d input_real = _mm256_load_pd(real + basis);
+        const __m256d input_imag = _mm256_load_pd(imag + basis);
+        const __m256d partner_real = permute_lanes(input_real, permutation);
+        const __m256d partner_imag = permute_lanes(input_imag, permutation);
+        const __m256d coefficient = signed_sine_lanes(basis, measurement.pauli.z, base_coefficient);
+
+        __m256d zero_real;
+        __m256d zero_imag;
+        __m256d one_real;
+        __m256d one_imag;
+        if constexpr (RealPhase) {
+            zero_real = _mm256_fmadd_pd(coefficient, partner_real, input_real);
+            zero_imag = _mm256_fmadd_pd(coefficient, partner_imag, input_imag);
+            one_real = _mm256_fnmadd_pd(coefficient, partner_real, input_real);
+            one_imag = _mm256_fnmadd_pd(coefficient, partner_imag, input_imag);
+        } else {
+            zero_real = _mm256_fnmadd_pd(coefficient, partner_imag, input_real);
+            zero_imag = _mm256_fmadd_pd(coefficient, partner_real, input_imag);
+            one_real = _mm256_fmadd_pd(coefficient, partner_imag, input_real);
+            one_imag = _mm256_fnmadd_pd(coefficient, partner_real, input_imag);
+        }
+        const __m256d zero_norm =
+            _mm256_fmadd_pd(zero_real, zero_real, _mm256_mul_pd(zero_imag, zero_imag));
+        const __m256d one_norm =
+            _mm256_fmadd_pd(one_real, one_real, _mm256_mul_pd(one_imag, one_imag));
+        zero_sum = _mm256_fmadd_pd(source_weights, zero_norm, zero_sum);
+        one_sum = _mm256_fmadd_pd(source_weights, one_norm, one_sum);
+    }
+    return MeasurementProbabilities{0.5 * reduce_add(zero_sum), 0.5 * reduce_add(one_sum)};
+}
+
+template <bool RealPhase>
+void collapse_active_measurement_avx2_impl(State& state, const PreparedMeasurement& measurement,
+                                           bool branch, double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t lane_xor = measurement.pauli.x;
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const __m256i compaction = _mm256_load_si256(reinterpret_cast<const __m256i*>(
+        kMeasurementCompactionPermutations[measurement.pivot].data()));
+    const double eigenvalue = branch ? -1.0 : 1.0;
+    const double base_coefficient = eigenvalue * (RealPhase ? measurement.pauli.even_phase.real()
+                                                            : -measurement.pauli.even_phase.imag());
+    const __m256d scale = _mm256_set1_pd(kInvSqrt2 / std::sqrt(branch_probability));
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m256d input_real = _mm256_load_pd(real + basis);
+        const __m256d input_imag = _mm256_load_pd(imag + basis);
+        const __m256d partner_real = permute_lanes(input_real, permutation);
+        const __m256d partner_imag = permute_lanes(input_imag, permutation);
+        const __m256d coefficient = signed_sine_lanes(basis, measurement.pauli.z, base_coefficient);
+
+        __m256d output_real;
+        __m256d output_imag;
+        if constexpr (RealPhase) {
+            output_real = _mm256_fmadd_pd(coefficient, partner_real, input_real);
+            output_imag = _mm256_fmadd_pd(coefficient, partner_imag, input_imag);
+        } else {
+            output_real = _mm256_fnmadd_pd(coefficient, partner_imag, input_real);
+            output_imag = _mm256_fmadd_pd(coefficient, partner_real, input_imag);
+        }
+        output_real = _mm256_mul_pd(scale, output_real);
+        output_imag = _mm256_mul_pd(scale, output_imag);
+        const __m128d compact_real = _mm256_castpd256_pd128(permute_lanes(output_real, compaction));
+        const __m128d compact_imag = _mm256_castpd256_pd128(permute_lanes(output_imag, compaction));
+        _mm_storeu_pd(real + basis / 2, compact_real);
+        _mm_storeu_pd(imag + basis / 2, compact_imag);
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 }  // namespace
+
+MeasurementProbabilities active_measurement_probabilities_avx2(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    assert(state.active_width() == measurement.pauli.active_width &&
+           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
+           measurement.pivot < 2 && measurement.pauli.active_width >= 2 &&
+           "AVX2 active measurement requires a low-lane Pauli pairing");
+    if (measurement.pauli.even_phase.real() != 0.0) {
+        return active_measurement_probabilities_avx2_impl<true>(state, measurement);
+    }
+    return active_measurement_probabilities_avx2_impl<false>(state, measurement);
+}
+
+void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& measurement,
+                                      bool branch, double branch_probability) noexcept {
+    assert(state.active_width() == measurement.pauli.active_width &&
+           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
+           measurement.pivot < 2 && measurement.pauli.active_width >= 2 &&
+           std::isfinite(branch_probability) && branch_probability > 0.0 &&
+           "AVX2 active measurement requires a positive-probability low-lane pairing");
+    if (measurement.pauli.even_phase.real() != 0.0) {
+        collapse_active_measurement_avx2_impl<true>(state, measurement, branch, branch_probability);
+    } else {
+        collapse_active_measurement_avx2_impl<false>(state, measurement, branch,
+                                                     branch_probability);
+    }
+}
 
 void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
                                 DirectRotationKernel kernel, bool sign) noexcept {

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -1,0 +1,342 @@
+// AVX2+BMI2+FMA sampling kernels. This translation unit is compiled with
+// explicit ISA flags so portable builds can select it at runtime.
+
+#include "clifft/sampling/direct_rotation_simd.h"
+#include "clifft/sampling/fused_rotation_simd.h"
+#include "clifft/sampling/indexing.h"
+
+#include <array>
+#include <bit>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <immintrin.h>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace clifft::sampling {
+
+namespace {
+
+// State stores real and imaginary parts separately. Matching lanes from the
+// two arrays therefore represent four consecutive complex amplitudes.
+constexpr size_t kLanes = kAvx2DoubleLanes;
+constexpr size_t kDimension = 4;
+constexpr size_t kMatrixSize = kDimension * kDimension;
+
+using LanePermutationIndices = std::array<int32_t, 2 * kLanes>;
+using LaneSigns = std::array<double, kLanes>;
+
+constexpr std::array<LanePermutationIndices, kLanes> make_lane_permutations() {
+    std::array<LanePermutationIndices, kLanes> result{};
+    for (size_t lane_xor = 0; lane_xor < kLanes; ++lane_xor) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            const int32_t source = static_cast<int32_t>(lane ^ lane_xor);
+            result[lane_xor][2 * lane] = 2 * source;
+            result[lane_xor][2 * lane + 1] = 2 * source + 1;
+        }
+    }
+    return result;
+}
+
+constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
+    std::array<LaneSigns, kLanes> result{};
+    for (size_t z = 0; z < kLanes; ++z) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            result[z][lane] = (std::popcount(z & lane) & 1U) != 0 ? -1.0 : 1.0;
+        }
+    }
+    return result;
+}
+
+alignas(32) constexpr auto kLanePermutations = make_lane_permutations();
+alignas(32) constexpr auto kLaneParitySigns = make_lane_parity_signs();
+
+struct alignas(32) LanePermutation {
+    LanePermutationIndices indices{};
+};
+
+struct alignas(32) LaneWeights {
+    std::array<double, kLanes> real{};
+    std::array<double, kLanes> imag{};
+};
+
+struct FusedRotationAvx2Sidecar {
+    std::array<LanePermutation, kDimension> permutations;
+    std::vector<LaneWeights> weights;
+};
+
+__m256d permute_lanes(__m256d input, __m256i permutation) noexcept {
+    return _mm256_castsi256_pd(
+        _mm256_permutevar8x32_epi32(_mm256_castpd_si256(input), permutation));
+}
+
+__m256d signed_sine_lanes(uint64_t basis, uint64_t z, double sine) noexcept {
+    const bool high_parity = (std::popcount(basis & z) & 1U) != 0;
+    const double block_sine = high_parity ? -sine : sine;
+    const __m256d lane_signs = _mm256_load_pd(kLaneParitySigns[z & (kLanes - 1)].data());
+    return _mm256_mul_pd(_mm256_set1_pd(block_sine), lane_signs);
+}
+
+void apply_diagonal_rotation_avx2(State& state, const PreparedRotation& rotation,
+                                  double sine) noexcept {
+    assert(rotation.pauli.is_diagonal() && !rotation.pauli.is_identity() &&
+           rotation.pauli.active_width >= 2 &&
+           "AVX2 diagonal rotation requires at least one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const __m256d cosine = _mm256_set1_pd(rotation.cosine);
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m256d input_real = _mm256_load_pd(real + basis);
+        const __m256d input_imag = _mm256_load_pd(imag + basis);
+        const __m256d signed_sine = signed_sine_lanes(basis, rotation.pauli.z, sine);
+        const __m256d output_real =
+            _mm256_fmadd_pd(signed_sine, input_imag, _mm256_mul_pd(cosine, input_real));
+        const __m256d output_imag =
+            _mm256_fnmadd_pd(signed_sine, input_real, _mm256_mul_pd(cosine, input_imag));
+        _mm256_store_pd(real + basis, output_real);
+        _mm256_store_pd(imag + basis, output_imag);
+    }
+}
+
+template <bool RealPhase>
+void apply_lane_paired_rotation_avx2(State& state, const PreparedRotation& rotation,
+                                     double sine) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector < kLanes &&
+           rotation.pauli.active_width >= 2 &&
+           "AVX2 lane-paired rotation requires at least one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const __m256d cosine = _mm256_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m256d input_real = _mm256_load_pd(real + basis);
+        const __m256d input_imag = _mm256_load_pd(imag + basis);
+        const __m256d partner_real = permute_lanes(input_real, permutation);
+        const __m256d partner_imag = permute_lanes(input_imag, permutation);
+        const __m256d basis_sine = signed_sine_lanes(basis, rotation.pauli.z, sine * base_phase);
+        const __m256d partner_sine =
+            RealPhase ? basis_sine : _mm256_sub_pd(_mm256_setzero_pd(), basis_sine);
+
+        __m256d output_real;
+        __m256d output_imag;
+        if constexpr (RealPhase) {
+            output_real =
+                _mm256_fmadd_pd(partner_sine, partner_imag, _mm256_mul_pd(cosine, input_real));
+            output_imag =
+                _mm256_fnmadd_pd(partner_sine, partner_real, _mm256_mul_pd(cosine, input_imag));
+        } else {
+            output_real =
+                _mm256_fmadd_pd(partner_sine, partner_real, _mm256_mul_pd(cosine, input_real));
+            output_imag =
+                _mm256_fmadd_pd(partner_sine, partner_imag, _mm256_mul_pd(cosine, input_imag));
+        }
+        _mm256_store_pd(real + basis, output_real);
+        _mm256_store_pd(imag + basis, output_imag);
+    }
+}
+
+template <bool RealPhase>
+void apply_nondiagonal_rotation_avx2(State& state, const PreparedRotation& rotation,
+                                     double sine) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector >= kLanes &&
+           "AVX2 non-diagonal rotation requires a high pairing pivot");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = rotation.pauli.pair_selector;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const __m256d cosine = _mm256_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+
+    for (uint64_t block = 0; block < state.size(); block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; offset += kLanes) {
+            const uint64_t left = block + offset;
+            const uint64_t right_base = (left ^ rotation.pauli.x) & ~(uint64_t{kLanes - 1});
+            const __m256d left_real = _mm256_load_pd(real + left);
+            const __m256d left_imag = _mm256_load_pd(imag + left);
+            const __m256d right_real =
+                permute_lanes(_mm256_load_pd(real + right_base), permutation);
+            const __m256d right_imag =
+                permute_lanes(_mm256_load_pd(imag + right_base), permutation);
+            const __m256d left_sine = signed_sine_lanes(left, rotation.pauli.z, even_left_sine);
+
+            __m256d output_left_real;
+            __m256d output_left_imag;
+            __m256d output_right_real;
+            __m256d output_right_imag;
+            if constexpr (RealPhase) {
+                output_left_real =
+                    _mm256_fmadd_pd(left_sine, right_imag, _mm256_mul_pd(cosine, left_real));
+                output_left_imag =
+                    _mm256_fnmadd_pd(left_sine, right_real, _mm256_mul_pd(cosine, left_imag));
+                output_right_real =
+                    _mm256_fmadd_pd(left_sine, left_imag, _mm256_mul_pd(cosine, right_real));
+                output_right_imag =
+                    _mm256_fnmadd_pd(left_sine, left_real, _mm256_mul_pd(cosine, right_imag));
+            } else {
+                output_left_real =
+                    _mm256_fnmadd_pd(left_sine, right_real, _mm256_mul_pd(cosine, left_real));
+                output_left_imag =
+                    _mm256_fnmadd_pd(left_sine, right_imag, _mm256_mul_pd(cosine, left_imag));
+                output_right_real =
+                    _mm256_fmadd_pd(left_sine, left_real, _mm256_mul_pd(cosine, right_real));
+                output_right_imag =
+                    _mm256_fmadd_pd(left_sine, left_imag, _mm256_mul_pd(cosine, right_imag));
+            }
+
+            _mm256_store_pd(real + left, output_left_real);
+            _mm256_store_pd(imag + left, output_left_imag);
+            _mm256_store_pd(real + right_base, permute_lanes(output_right_real, permutation));
+            _mm256_store_pd(imag + right_base, permute_lanes(output_right_imag, permutation));
+        }
+    }
+}
+
+void apply_fused_rotation_avx2(State& state, const PreparedFusedRotation& rotation,
+                               const void* opaque_sidecar) noexcept {
+    const auto& sidecar = *static_cast<const FusedRotationAvx2Sidecar*>(opaque_sidecar);
+    assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 2 &&
+           "AVX2 fused rotation requires a high-pivot rank-two orbit");
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+
+    const uint64_t orbit_count = state.size() / kDimension;
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+
+    for (uint64_t packed = 0; packed < orbit_count; packed += kLanes) {
+        uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
+        representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+        const LaneWeights* const matrix =
+            sidecar.weights.data() +
+            selector_index(representative, rotation.selector_masks) * kMatrixSize;
+
+        std::array<__m256d, kDimension> input_real;
+        std::array<__m256d, kDimension> input_imag;
+        for (size_t column = 0; column < kDimension; ++column) {
+            uint64_t index = representative;
+            if ((column & 1U) != 0) {
+                index ^= rotation.orbit_masks[0];
+            }
+            if ((column & 2U) != 0) {
+                index ^= rotation.orbit_masks[1];
+            }
+            const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+            const __m256i permutation = _mm256_load_si256(
+                reinterpret_cast<const __m256i*>(sidecar.permutations[column].indices.data()));
+            input_real[column] = permute_lanes(_mm256_load_pd(real + physical_base), permutation);
+            input_imag[column] = permute_lanes(_mm256_load_pd(imag + physical_base), permutation);
+        }
+
+        for (size_t row = 0; row < kDimension; ++row) {
+            __m256d output_real = _mm256_setzero_pd();
+            __m256d output_imag = _mm256_setzero_pd();
+            for (size_t column = 0; column < kDimension; ++column) {
+                const LaneWeights& weight = matrix[row * kDimension + column];
+                const __m256d weight_real = _mm256_load_pd(weight.real.data());
+                const __m256d weight_imag = _mm256_load_pd(weight.imag.data());
+                output_real = _mm256_fmadd_pd(weight_real, input_real[column], output_real);
+                output_real = _mm256_fnmadd_pd(weight_imag, input_imag[column], output_real);
+                output_imag = _mm256_fmadd_pd(weight_real, input_imag[column], output_imag);
+                output_imag = _mm256_fmadd_pd(weight_imag, input_real[column], output_imag);
+            }
+
+            uint64_t index = representative;
+            if ((row & 1U) != 0) {
+                index ^= rotation.orbit_masks[0];
+            }
+            if ((row & 2U) != 0) {
+                index ^= rotation.orbit_masks[1];
+            }
+            const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+            const __m256i permutation = _mm256_load_si256(
+                reinterpret_cast<const __m256i*>(sidecar.permutations[row].indices.data()));
+            _mm256_store_pd(real + physical_base, permute_lanes(output_real, permutation));
+            _mm256_store_pd(imag + physical_base, permute_lanes(output_imag, permutation));
+        }
+    }
+}
+
+}  // namespace
+
+void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
+                                DirectRotationKernel kernel, bool sign) noexcept {
+    assert(state.active_width() == rotation.pauli.active_width &&
+           "AVX2 rotation width must match the active state");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+    switch (kernel) {
+        case DirectRotationKernel::Diagonal:
+            apply_diagonal_rotation_avx2(state, rotation, sine);
+            return;
+        case DirectRotationKernel::HighPivot:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_nondiagonal_rotation_avx2<true>(state, rotation, sine);
+            } else {
+                apply_nondiagonal_rotation_avx2<false>(state, rotation, sine);
+            }
+            return;
+        case DirectRotationKernel::LanePaired:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_lane_paired_rotation_avx2<true>(state, rotation, sine);
+            } else {
+                apply_lane_paired_rotation_avx2<false>(state, rotation, sine);
+            }
+            return;
+        case DirectRotationKernel::Scalar:
+            assert(false && "scalar rotations must not enter the AVX2 kernel");
+            return;
+    }
+    assert(false && "unknown direct rotation kernel");
+}
+
+FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(const PreparedFusedRotation& rotation) {
+    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 2) {
+        return {};
+    }
+
+    auto sidecar = std::make_shared<FusedRotationAvx2Sidecar>();
+    for (size_t member = 0; member < kDimension; ++member) {
+        uint64_t mask = 0;
+        if ((member & 1U) != 0) {
+            mask ^= rotation.orbit_masks[0];
+        }
+        if ((member & 2U) != 0) {
+            mask ^= rotation.orbit_masks[1];
+        }
+        const uint64_t lane_xor = mask & (kLanes - 1);
+        sidecar->permutations[member].indices = kLanePermutations[lane_xor];
+    }
+
+    const size_t num_variants = size_t{1} << rotation.selector_masks.size();
+    assert(rotation.matrices.size() == num_variants * kMatrixSize &&
+           "fused rotation matrix table must cover every selector value");
+    sidecar->weights.resize(num_variants * kMatrixSize);
+    for (size_t base_selector = 0; base_selector < num_variants; ++base_selector) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            const size_t selector = base_selector ^ selector_index(lane, rotation.selector_masks);
+            for (size_t element = 0; element < kMatrixSize; ++element) {
+                const std::complex<double> weight =
+                    rotation.matrices[selector * kMatrixSize + element];
+                LaneWeights& expanded = sidecar->weights[base_selector * kMatrixSize + element];
+                expanded.real[lane] = weight.real();
+                expanded.imag[lane] = weight.imag();
+            }
+        }
+    }
+
+    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx2};
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -226,7 +226,8 @@ void apply_fused_rotation_avx2(State& state, const PreparedFusedRotation& rotati
                                const void* opaque_sidecar) noexcept {
     const auto& sidecar = *static_cast<const FusedRotationAvx2Sidecar*>(opaque_sidecar);
     assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 2 &&
-           "AVX2 fused rotation requires a high-pivot rank-two orbit");
+           rotation.orbit_pivots[0] < rotation.orbit_pivots[1] &&
+           "AVX2 fused rotation requires ordered high-pivot rank-two orbits");
     assert(state.active_width() == rotation.active_width &&
            "fused rotation width must match the active state");
 
@@ -292,16 +293,19 @@ MeasurementProbabilities active_measurement_probabilities_avx2_impl(
     const State& state, const PreparedMeasurement& measurement) noexcept {
     const double* const real = state.real_data();
     const double* const imag = state.imag_data();
-    const uint64_t lane_xor = measurement.pauli.x;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
     const __m256i permutation =
         _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
     const __m256d source_weights =
-        _mm256_load_pd(kMeasurementSourceWeights[measurement.pivot].data());
+        _mm256_load_pd(kMeasurementSourceWeights[measurement.pivot & 1U].data());
     const double base_coefficient =
         RealPhase ? measurement.pauli.even_phase.real() : -measurement.pauli.even_phase.imag();
     __m256d zero_sum = _mm256_setzero_pd();
     __m256d one_sum = _mm256_setzero_pd();
 
+    // For eigenvalue e in {+1, -1}, form both projected branches together.
+    // Only pivot-zero representatives contribute to their squared norms; the
+    // source weights select those two lanes without an AVX-512-style mask.
     for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
         const __m256d input_real = _mm256_load_pd(real + basis);
         const __m256d input_imag = _mm256_load_pd(imag + basis);
@@ -313,6 +317,8 @@ MeasurementProbabilities active_measurement_probabilities_avx2_impl(
         __m256d zero_imag;
         __m256d one_real;
         __m256d one_imag;
+        // Prepared Pauli phases are in {+1, -1, +i, -i}. Splitting their real
+        // and imaginary cases turns the complex multiply into fixed FMAs.
         if constexpr (RealPhase) {
             zero_real = _mm256_fmadd_pd(coefficient, partner_real, input_real);
             zero_imag = _mm256_fmadd_pd(coefficient, partner_imag, input_imag);
@@ -339,16 +345,19 @@ void collapse_active_measurement_avx2_impl(State& state, const PreparedMeasureme
                                            bool branch, double branch_probability) noexcept {
     double* const real = state.real_data();
     double* const imag = state.imag_data();
-    const uint64_t lane_xor = measurement.pauli.x;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
     const __m256i permutation =
         _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
     const __m256i compaction = _mm256_load_si256(reinterpret_cast<const __m256i*>(
-        kMeasurementCompactionPermutations[measurement.pivot].data()));
+        kMeasurementCompactionPermutations[measurement.pivot & 1U].data()));
     const double eigenvalue = branch ? -1.0 : 1.0;
     const double base_coefficient = eigenvalue * (RealPhase ? measurement.pauli.even_phase.real()
                                                             : -measurement.pauli.even_phase.imag());
     const __m256d scale = _mm256_set1_pd(kInvSqrt2 / std::sqrt(branch_probability));
 
+    // Removing either low-lane pivot maps each four-amplitude block to two
+    // consecutive outputs. Every source block is loaded before its compacted
+    // destination is written, so forward traversal cannot overwrite a future source.
     for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
         const __m256d input_real = _mm256_load_pd(real + basis);
         const __m256d input_imag = _mm256_load_pd(imag + basis);
@@ -435,7 +444,8 @@ void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
 }
 
 FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(const PreparedFusedRotation& rotation) {
-    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 2) {
+    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 2 ||
+        rotation.orbit_pivots[0] >= rotation.orbit_pivots[1]) {
         return {};
     }
 

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -231,7 +231,8 @@ void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rota
                                  const void* opaque_sidecar) noexcept {
     const auto& sidecar = *static_cast<const FusedRotationAvx512Sidecar*>(opaque_sidecar);
     assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 3 &&
-           "AVX-512 fused rotation requires a high-pivot rank-two orbit");
+           rotation.orbit_pivots[0] < rotation.orbit_pivots[1] &&
+           "AVX-512 fused rotation requires ordered high-pivot rank-two orbits");
     assert(state.active_width() == rotation.active_width &&
            "fused rotation width must match the active state");
 
@@ -298,7 +299,7 @@ MeasurementProbabilities active_measurement_probabilities_avx512_impl(
     const State& state, const PreparedMeasurement& measurement) noexcept {
     const double* const real = state.real_data();
     const double* const imag = state.imag_data();
-    const uint64_t lane_xor = measurement.pauli.x;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
     const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
     const __mmask8 source_mask = kMeasurementSourceMasks[measurement.pivot];
     const double base_coefficient =
@@ -350,7 +351,7 @@ void collapse_active_measurement_avx512_impl(State& state, const PreparedMeasure
                                              bool branch, double branch_probability) noexcept {
     double* const real = state.real_data();
     double* const imag = state.imag_data();
-    const uint64_t lane_xor = measurement.pauli.x;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
     const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
     const __m512i compaction =
         _mm512_load_si512(kMeasurementCompactionPermutations[measurement.pivot].data());
@@ -456,7 +457,8 @@ void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation
 // Host-specific preparation transposes selector matrices into lane-major
 // weights once, keeping both allocation and selector expansion out of shots.
 FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRotation& rotation) {
-    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 3) {
+    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 3 ||
+        rotation.orbit_pivots[0] >= rotation.orbit_pivots[1]) {
         return {};
     }
 

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -158,6 +158,8 @@ TEST_CASE("Dynamic fused rotation matches scalar across affine sign values") {
     REQUIRE(prepared_run.rotation->variants.size() == 4);
 
     const ExecutablePlan executable(plan);
+    // Dynamic-sign fusion is deliberately AVX-512-only; other ISAs retain the
+    // sequential rotations even though constant-sign fusion supports AVX2.
     const size_t expected_action_count =
         clifft::internal::runtime_isa() == clifft::internal::RuntimeIsa::Avx512 ? 1
                                                                                 : rotations.size();

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -328,6 +328,19 @@ TEST_CASE("Direct rotation SIMD matches scalar with intermediate high bits") {
 }
 
 TEST_CASE("Direct rotation SIMD matches scalar at vector boundaries") {
+    const std::array avx2_diagonal = {
+        RotateActivePauli{{0, 0b11}, 0.3, AffineBool::symbol(SymbolId{0})},
+    };
+    require_matches_scalar(rotation_plan(2, avx2_diagonal), 0, avx2_diagonal.size());
+    require_matches_scalar(rotation_plan(2, avx2_diagonal), 1, avx2_diagonal.size());
+
+    const std::array avx2_lane_paired = {
+        RotateActivePauli{{0b01, 0b10}, 0.2, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b10, 0b01}, -0.3, AffineBool::symbol(SymbolId{0})},
+    };
+    require_matches_scalar(rotation_plan(2, avx2_lane_paired), 0, avx2_lane_paired.size());
+    require_matches_scalar(rotation_plan(2, avx2_lane_paired), 1, avx2_lane_paired.size());
+
     const std::array diagonal = {
         RotateActivePauli{{0, 0b111}, 0.3, AffineBool::symbol(SymbolId{0})},
     };
@@ -348,4 +361,11 @@ TEST_CASE("Direct rotation SIMD matches scalar at vector boundaries") {
     };
     require_matches_scalar(rotation_plan(4, paired), 0, paired.size());
     require_matches_scalar(rotation_plan(4, paired), 1, paired.size());
+
+    const std::array pivot_four = {
+        RotateActivePauli{{0b110000, 0b101011}, 0.35, AffineBool::symbol(SymbolId{0})},
+        RotateActivePauli{{0b010000, 0b011101}, -0.2, AffineBool::symbol(SymbolId{0})},
+    };
+    require_matches_scalar(rotation_plan(6, pivot_four), 0, pivot_four.size());
+    require_matches_scalar(rotation_plan(6, pivot_four), 1, pivot_four.size());
 }

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -373,7 +373,10 @@ TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b001, 0b1110}, 4, 0) == ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b111, 0b101000}, 6, 2) == ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b1000, 0b0111}, 4, 3) == ActiveMeasurementKernel::Scalar);
-    REQUIRE(select({0b111, 0b101000}, 6, 2, RuntimeIsa::Avx2) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b01, 0b10}, 2, 0, RuntimeIsa::Avx2) == ActiveMeasurementKernel::LanePaired);
+    REQUIRE(select({0b01, 0b110}, 3, 0, RuntimeIsa::Avx2) == ActiveMeasurementKernel::LanePaired);
+    REQUIRE(select({0b10, 0b101}, 3, 1, RuntimeIsa::Avx2) == ActiveMeasurementKernel::LanePaired);
+    REQUIRE(select({0b100, 0b011}, 3, 2, RuntimeIsa::Avx2) == ActiveMeasurementKernel::Scalar);
 }
 
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {
@@ -498,26 +501,31 @@ TEST_CASE("Sampling kernels measurements match dense projectors for every small 
 }
 
 TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
-    if (clifft::internal::runtime_isa() != RuntimeIsa::Avx512) {
+    const RuntimeIsa runtime_isa = clifft::internal::runtime_isa();
+    if (runtime_isa != RuntimeIsa::Avx2 && runtime_isa != RuntimeIsa::Avx512) {
         return;
     }
 
-    for (uint32_t active_width = 3; active_width <= 6; ++active_width) {
+    const uint64_t vector_lanes = runtime_isa == RuntimeIsa::Avx512 ? 8 : 4;
+    const uint32_t lane_index_bits = runtime_isa == RuntimeIsa::Avx512 ? 3 : 2;
+    const uint32_t min_profitable_width = runtime_isa == RuntimeIsa::Avx512 ? 4 : 2;
+    for (uint32_t active_width = lane_index_bits; active_width <= 6; ++active_width) {
         const uint64_t z_limit = uint64_t{1} << active_width;
         const std::vector<std::complex<double>> input = deterministic_state(active_width);
-        for (uint64_t x = 1; x < 8; ++x) {
+        for (uint64_t x = 1; x < vector_lanes; ++x) {
             for (uint64_t z = 0; z < z_limit; ++z) {
                 for (uint32_t pivot : valid_measurement_pivots(x, z, active_width)) {
-                    if (pivot >= 3 || (x & (uint64_t{1} << pivot)) == 0) {
+                    if (pivot >= lane_index_bits || (x & (uint64_t{1} << pivot)) == 0) {
                         continue;
                     }
                     CAPTURE(active_width, x, z, pivot);
                     const PreparedMeasurement measurement =
                         prepare_measurement({x, z}, active_width, pivot);
                     const ActiveMeasurementKernel selected =
-                        resolve_active_measurement_kernel(measurement, RuntimeIsa::Avx512);
-                    REQUIRE(selected == (active_width >= 4 ? ActiveMeasurementKernel::LanePaired
-                                                           : ActiveMeasurementKernel::Scalar));
+                        resolve_active_measurement_kernel(measurement, runtime_isa);
+                    REQUIRE(selected == (active_width >= min_profitable_width
+                                             ? ActiveMeasurementKernel::LanePaired
+                                             : ActiveMeasurementKernel::Scalar));
 
                     State scalar_probability_state(active_width, active_width);
                     load_state(scalar_probability_state, input);

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -358,6 +358,7 @@ TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b01, 0b10}, 2, RuntimeIsa::Avx2) == DirectRotationKernel::LanePaired);
     REQUIRE(select({0b100, 0b011}, 3, RuntimeIsa::Avx2) == DirectRotationKernel::HighPivot);
     REQUIRE(select({0b10000, 0b01111}, 5, RuntimeIsa::Avx2) == DirectRotationKernel::HighPivot);
+    REQUIRE(select({0b01, 0b10}, 2, RuntimeIsa::Scalar) == DirectRotationKernel::Scalar);
 }
 
 TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
@@ -377,6 +378,7 @@ TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b01, 0b110}, 3, 0, RuntimeIsa::Avx2) == ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b10, 0b101}, 3, 1, RuntimeIsa::Avx2) == ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b100, 0b011}, 3, 2, RuntimeIsa::Avx2) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b01, 0b110}, 3, 0, RuntimeIsa::Scalar) == ActiveMeasurementKernel::Scalar);
 }
 
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {
@@ -509,7 +511,7 @@ TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
     const uint64_t vector_lanes = runtime_isa == RuntimeIsa::Avx512 ? 8 : 4;
     const uint32_t lane_index_bits = runtime_isa == RuntimeIsa::Avx512 ? 3 : 2;
     const uint32_t min_profitable_width = runtime_isa == RuntimeIsa::Avx512 ? 4 : 2;
-    for (uint32_t active_width = lane_index_bits; active_width <= 6; ++active_width) {
+    for (uint32_t active_width = min_profitable_width; active_width <= 6; ++active_width) {
         const uint64_t z_limit = uint64_t{1} << active_width;
         const std::vector<std::complex<double>> input = deterministic_state(active_width);
         for (uint64_t x = 1; x < vector_lanes; ++x) {

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -351,7 +351,13 @@ TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b1000, 0b0111}, 4) == DirectRotationKernel::HighPivot);
     REQUIRE(select({0b10000, 0b01111}, 5) == DirectRotationKernel::Scalar);
     REQUIRE(select({0b100000, 0b011111}, 6) == DirectRotationKernel::HighPivot);
-    REQUIRE(select({0b1000, 0b0111}, 4, RuntimeIsa::Avx2) == DirectRotationKernel::Scalar);
+
+    REQUIRE(select({0, 0b1}, 1, RuntimeIsa::Avx2) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0, 0b11}, 2, RuntimeIsa::Avx2) == DirectRotationKernel::Diagonal);
+    REQUIRE(select({0b1, 0b0}, 1, RuntimeIsa::Avx2) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b01, 0b10}, 2, RuntimeIsa::Avx2) == DirectRotationKernel::LanePaired);
+    REQUIRE(select({0b100, 0b011}, 3, RuntimeIsa::Avx2) == DirectRotationKernel::HighPivot);
+    REQUIRE(select({0b10000, 0b01111}, 5, RuntimeIsa::Avx2) == DirectRotationKernel::HighPivot);
 }
 
 TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {


### PR DESCRIPTION
## Summary

- add separately compiled AVX2/BMI2/FMA symbolic kernels for diagonal, lane-paired, and high-pivot direct Pauli rotations
- add an AVX2 high-pivot rank-two fused-U4 kernel with optional per-plan sidecars
- add AVX2 probability and collapse kernels for low-lane active Pauli measurements
- preserve ISA-neutral executable descriptors, the scalar correctness fallback, and the existing AVX-512 path
- validate ISA-dependent kernel tags and defensively bound SIMD table indices
- extend selector, boundary, and scalar-oracle coverage and document wheel runtime dispatch

Closes #285.

## Why these kernels

A wheel-like `x86-64-v2` build forced to AVX2 previously ran the symbolic active-state paths as scalar code. Profiles attributed 94.7% of QV-10 execution to scalar direct/fused rotations and 86.0% of coherent d5 r1 execution to scalar direct rotations. After vectorizing rotations, measurement probability and collapse still accounted for 25.9% of coherent d5 r1 cycles.

The implementation is deliberately bounded to the shapes supported by measurements:

- all non-identity direct rotations once the active state spans one four-double vector;
- rank-two fused U4 rotations whose lowest orbit pivot is at least two;
- active Pauli probability and collapse when both partners fit within one four-lane vector;
- no new dynamic-sign fusion or instrument kernels.

A prototype that also enabled the existing bounded dynamic-sign fusion on AVX2 improved QV-10 slightly but materially regressed QV-20. That extension is not included.

## Performance

AMD EPYC 9554P, GCC 13.3, one pinned core, `OMP_NUM_THREADS=1`, Release optimization with symbols/frame pointers, and an `x86-64-v2` global baseline. Times are seconds; lower is better.

| Workload | Symbolic scalar fallback | Symbolic AVX2 | Legacy AVX2 | Result |
|---|---:|---:|---:|---|
| QV-10 seed 44, 5k raw shots | 0.8168 | 0.2589 | 0.2386 | symbolic 3.15x faster than its fallback and 1.09x legacy time |
| QV-20 seed 49, one raw shot | 1.1673 | 0.2862 | 0.3308 | symbolic 4.08x faster than its fallback and 1.16x faster than legacy |
| coherent d5 r1, 20k survivor shots | 4.327 | 1.310 | 2.225 | symbolic 3.30x faster than its fallback and 1.70x faster than legacy |
| coherent d3 r3, 200k survivor shots | 0.7908 | 0.4602 | 0.6080 | symbolic 1.32x faster than legacy |
| k12/L512, 1k raw shots | 0.04330 | 0.02693 | 0.05442 | symbolic 2.02x faster than legacy |

Surface d7 r7 and distillation were neutral; cultivation d3 improved. On the AVX-512 host, the existing AVX-512 family remained faster than forcing AVX2 for coherent d5 r1 (1.415 vs 1.651 seconds per 20k shots), so this does not redirect AVX-512 execution through AVX2.

After this change, QV-10 profiles attribute 48.5% to AVX2 fused rotations, 14.3% to AVX2 direct rotations, and 23.1% to residual scalar fused shapes. In coherent d5 r1, AVX2 measurement kernels reduce the probability-plus-collapse share from 25.9% to 9.6%; AVX2 direct rotations are then the dominant 82.6% hot path.

The measurement census found that this existing AVX-512 shape covers essentially all measurement coefficient work in coherent d5 r1, a small fraction in coherent d3 r3, and none in the measured QV, cultivation, distillation, surface, or k12 fixtures because their active measurements are diagonal or absent. Probability-plus-collapse microbenchmarks were faster than scalar at every tested width 2-12 and both Pauli phase classes, from 1.10x at the hardest one-vector boundary to approximately 3x at practical widths. A matched on/off end-to-end comparison improved coherent d5 r1 by about 1.30x; structurally ineligible guards were neutral within run noise.

The optional fused sidecar payload is approximately 0.36 MiB for QV-10 seed 44 and 3.40 MiB for QV-20 seed 49. Scalar, ARM, WASM, and AVX-512 plans do not allocate the AVX2 sidecar.

## Portability

- the generic translation units compile at the wheel's `x86-64-v2` baseline and contain no YMM/ZMM instructions;
- `kernels_avx2.cc` alone compiles with `-mavx2 -mbmi2 -mfma`, and its assembly contains packed YMM permutations and FMAs;
- AVX-512 remains in its separately compiled translation unit;
- the existing release-wheel QEMU smoke test executes `experimental.compile` and `experimental.sample` on Haswell/AVX2 and scalar-emulated CPUs, guarding against higher-ISA leakage.

## Verification

- full non-benchmark C++ suite in both Release and Debug under forced AVX2: 1,277 test cases, 466,828 assertions
- full non-benchmark C++ suite in both Release and Debug under forced scalar: 1,277 test cases, 416,732 assertions
- full non-benchmark C++ suite in both Release and Debug under forced AVX-512: 1,277 test cases, 563,228 assertions
- direct-rotation and fused-rotation focused tests rerun after the final build in forced AVX2, scalar, and AVX-512 modes
- direct-kernel microbenchmarks at the width/pivot boundaries were neutral or faster than scalar; fused U4 was 1.9x-3.2x faster across widths 4-20
- exhaustive active-measurement differential coverage across AVX2 lane masks, Z masks, pivots, widths, branches, and both phase classes
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
