### PR TITLE
perf(sampling): vectorize new-X instrument expansion

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(clifft_core STATIC
     sampling/executor.cc
     sampling/fused_rotation.cc
     sampling/fused_rotation_dispatch.cc
+    sampling/instrument_activation_dispatch.cc
     sampling/kernels.cc
     sampling/sampler.cc
     sampling/state.cc

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -230,10 +230,11 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     has_instruments_ = true;
                     const bool new_x_activation = activates_new_x(typed, planned.active_after);
-                    const NewXInstrumentKernel new_x_kernel =
-                        new_x_activation
-                            ? resolve_new_x_instrument_kernel(planned.active_before, runtime_isa)
-                            : NewXInstrumentKernel::NotApplicable;
+                    std::optional<NewXInstrumentKernel> new_x_kernel;
+                    if (new_x_activation) {
+                        new_x_kernel =
+                            resolve_new_x_instrument_kernel(planned.active_before, runtime_isa);
+                    }
                     std::optional<PreparedMeasurement> measurement;
                     if (typed.mode == InstrumentMode::Active ||
                         (typed.mode == InstrumentMode::Activate && !new_x_activation)) {

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -230,8 +230,10 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     has_instruments_ = true;
                     const bool new_x_activation = activates_new_x(typed, planned.active_after);
-                    const NewXInstrumentKernel new_x_kernel = resolve_new_x_instrument_kernel(
-                        new_x_activation, planned.active_before, runtime_isa);
+                    const NewXInstrumentKernel new_x_kernel =
+                        new_x_activation
+                            ? resolve_new_x_instrument_kernel(planned.active_before, runtime_isa)
+                            : NewXInstrumentKernel::NotApplicable;
                     std::optional<PreparedMeasurement> measurement;
                     if (typed.mode == InstrumentMode::Active ||
                         (typed.mode == InstrumentMode::Activate && !new_x_activation)) {

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -230,6 +230,8 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     has_instruments_ = true;
                     const bool new_x_activation = activates_new_x(typed, planned.active_after);
+                    const NewXInstrumentKernel new_x_kernel = resolve_new_x_instrument_kernel(
+                        new_x_activation, planned.active_before, runtime_isa);
                     std::optional<PreparedMeasurement> measurement;
                     if (typed.mode == InstrumentMode::Active ||
                         (typed.mode == InstrumentMode::Activate && !new_x_activation)) {
@@ -242,7 +244,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
                         measurement = prepare_measurement(typed.source, width, pivot);
                     }
                     actions_.emplace_back(ExecuteInstrument{
-                        typed.mode, new_x_activation, prepare_expression(typed.sign),
+                        typed.mode, new_x_kernel, prepare_expression(typed.sign),
                         std::move(measurement), index(typed.site),
                         typed.destination_flip.has_value()
                             ? std::optional<uint32_t>{index(*typed.destination_flip)}
@@ -334,7 +336,7 @@ size_t ExecutablePlan::num_new_x_instrument_activations() const {
     return static_cast<size_t>(
         std::count_if(actions_.begin(), actions_.end(), [](const Action& action) {
             const auto* instrument = std::get_if<ExecuteInstrument>(&action);
-            return instrument != nullptr && instrument->activates_new_x;
+            return instrument != nullptr && instrument->activates_new_x();
         }));
 }
 

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -3,6 +3,7 @@
 #include "clifft/sampling/active_measurement_dispatch.h"
 #include "clifft/sampling/direct_rotation_dispatch.h"
 #include "clifft/sampling/fused_rotation_dispatch.h"
+#include "clifft/sampling/instrument_activation_dispatch.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
 
@@ -172,11 +173,15 @@ class ExecutablePlan {
         InstrumentMode mode = InstrumentMode::Classical;
         // Lowering identifies the exact new-coordinate X shape so execution
         // need not rediscover instrument topology inside the hot loop.
-        bool activates_new_x = false;
+        NewXInstrumentKernel new_x_kernel = NewXInstrumentKernel::NotApplicable;
         PreparedExpression sign;
         std::optional<PreparedMeasurement> measurement;
         uint32_t site = 0;
         std::optional<uint32_t> destination_flip;
+
+        [[nodiscard]] bool activates_new_x() const noexcept {
+            return new_x_kernel != NewXInstrumentKernel::NotApplicable;
+        }
     };
 
     static_assert(sizeof(ExecuteInstrument) == 104,

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -173,15 +173,13 @@ class ExecutablePlan {
         InstrumentMode mode = InstrumentMode::Classical;
         // Lowering identifies the exact new-coordinate X shape so execution
         // need not rediscover instrument topology inside the hot loop.
-        NewXInstrumentKernel new_x_kernel = NewXInstrumentKernel::NotApplicable;
+        std::optional<NewXInstrumentKernel> new_x_kernel;
         PreparedExpression sign;
         std::optional<PreparedMeasurement> measurement;
         uint32_t site = 0;
         std::optional<uint32_t> destination_flip;
 
-        [[nodiscard]] bool activates_new_x() const noexcept {
-            return new_x_kernel != NewXInstrumentKernel::NotApplicable;
-        }
+        [[nodiscard]] bool activates_new_x() const noexcept { return new_x_kernel.has_value(); }
     };
 
     static_assert(sizeof(ExecuteInstrument) == 104,

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -563,7 +563,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
                "a selected no-fire branch must have positive probability");
         if (action.activates_new_x()) {
             apply_new_x_instrument_no_fire_dispatched(state_, factor_zero, factor_one,
-                                                      no_fire_probability, action.new_x_kernel);
+                                                      no_fire_probability, *action.new_x_kernel);
         } else {
             apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
                                      no_fire_probability);

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -526,9 +526,9 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
         return;
     }
 
-    assert((action.activates_new_x || action.measurement.has_value()) &&
+    assert((action.activates_new_x() || action.measurement.has_value()) &&
            "active instrument requires a kernel or prepared source measurement");
-    if (action.mode == InstrumentMode::Activate && !action.activates_new_x) {
+    if (action.mode == InstrumentMode::Activate && !action.activates_new_x()) {
         activate_zero_coordinate(state_);
     }
     const bool sign = evaluate(action.sign);
@@ -537,8 +537,8 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
     // retains any residual floating-point norm drift instead of reducing and
     // renormalizing it inside this activation.
     const MeasurementProbabilities eigen_populations =
-        action.activates_new_x ? MeasurementProbabilities{0.5, 0.5}
-                               : measurement_probabilities(state_, *action.measurement);
+        action.activates_new_x() ? MeasurementProbabilities{0.5, 0.5}
+                                 : measurement_probabilities(state_, *action.measurement);
     const double total = eigen_populations.total();
     const double epsilon = kMeasurementDustEpsilon * total;
     const double physical_zero = eigen_populations.for_branch(sign);
@@ -561,8 +561,9 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
                                            factor_one * factor_one * eigen_populations.one;
         assert(no_fire_probability > 0.0 &&
                "a selected no-fire branch must have positive probability");
-        if (action.activates_new_x) {
-            apply_new_x_instrument_no_fire(state_, factor_zero, factor_one, no_fire_probability);
+        if (action.activates_new_x()) {
+            apply_new_x_instrument_no_fire(state_, factor_zero, factor_one, no_fire_probability,
+                                           action.new_x_kernel);
         } else {
             apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
                                      no_fire_probability);
@@ -571,7 +572,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
     }
 
     const bool eigen_branch = (*fired_source != 0) ^ sign;
-    if (action.activates_new_x) {
+    if (action.activates_new_x()) {
         collapse_new_x_instrument_source(state_, eigen_branch,
                                          eigen_populations.for_branch(eigen_branch));
     } else {

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -562,8 +562,8 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
         assert(no_fire_probability > 0.0 &&
                "a selected no-fire branch must have positive probability");
         if (action.activates_new_x()) {
-            apply_new_x_instrument_no_fire(state_, factor_zero, factor_one, no_fire_probability,
-                                           action.new_x_kernel);
+            apply_new_x_instrument_no_fire_dispatched(state_, factor_zero, factor_one,
+                                                      no_fire_probability, action.new_x_kernel);
         } else {
             apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
                                      no_fire_probability);

--- a/src/clifft/sampling/instrument_activation_dispatch.cc
+++ b/src/clifft/sampling/instrument_activation_dispatch.cc
@@ -1,0 +1,62 @@
+#include "clifft/sampling/instrument_activation_dispatch.h"
+
+#include "clifft/sampling/direct_rotation_simd.h"
+#include "clifft/sampling/instrument_activation_simd.h"
+#include "clifft/util/runtime_isa.h"
+
+#include <cassert>
+
+namespace clifft::sampling {
+
+namespace {
+
+// One four-coefficient block was neutral in the direct microbenchmark, while
+// every wider measured width won; smaller states stay on the scalar path.
+constexpr uint32_t kMinAvx2ActiveWidth = 2;
+static_assert(uint64_t{1} << kMinAvx2ActiveWidth == kAvx2DoubleLanes);
+
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+
+const internal::RuntimeIsa kResolvedInstrumentActivationIsa = internal::runtime_isa();
+
+#endif
+
+}  // namespace
+
+NewXInstrumentKernel resolve_new_x_instrument_kernel(bool activates_new_x, uint32_t active_width,
+                                                     internal::RuntimeIsa runtime_isa) noexcept {
+    if (!activates_new_x) {
+        return NewXInstrumentKernel::NotApplicable;
+    }
+    if (runtime_isa == internal::RuntimeIsa::Avx2 && active_width >= kMinAvx2ActiveWidth) {
+        return NewXInstrumentKernel::Avx2;
+    }
+    return NewXInstrumentKernel::Scalar;
+}
+
+void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
+                                    double no_fire_probability,
+                                    NewXInstrumentKernel kernel) noexcept {
+    assert(kernel != NewXInstrumentKernel::NotApplicable &&
+           "new-X instrument dispatch requires an applicable kernel");
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    assert(kernel == resolve_new_x_instrument_kernel(true, state.active_width(),
+                                                     kResolvedInstrumentActivationIsa) &&
+           "new-X instrument kernel must match the process ISA");
+    if (kernel == NewXInstrumentKernel::Avx2) {
+        if (kResolvedInstrumentActivationIsa == internal::RuntimeIsa::Avx2) {
+            apply_new_x_instrument_no_fire_avx2(state, factor_zero, factor_one,
+                                                no_fire_probability);
+            return;
+        }
+        assert(false && "AVX2 new-X instrument kernel requires the AVX2 process ISA");
+    }
+#else
+    assert(kernel == NewXInstrumentKernel::Scalar &&
+           "portable new-X instrument dispatch requires the scalar kernel");
+    static_cast<void>(kernel);
+#endif
+    apply_new_x_instrument_no_fire(state, factor_zero, factor_one, no_fire_probability);
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/instrument_activation_dispatch.cc
+++ b/src/clifft/sampling/instrument_activation_dispatch.cc
@@ -23,33 +23,35 @@ const internal::RuntimeIsa kResolvedInstrumentActivationIsa = internal::runtime_
 
 }  // namespace
 
-NewXInstrumentKernel resolve_new_x_instrument_kernel(bool activates_new_x, uint32_t active_width,
+NewXInstrumentKernel resolve_new_x_instrument_kernel(uint32_t active_width,
                                                      internal::RuntimeIsa runtime_isa) noexcept {
-    if (!activates_new_x) {
-        return NewXInstrumentKernel::NotApplicable;
-    }
-    if (runtime_isa == internal::RuntimeIsa::Avx2 && active_width >= kMinAvx2ActiveWidth) {
+    // The AVX-512 tier includes every feature required by the AVX2 kernel, and
+    // reusing it avoids falling back to baseline scalar code in portable wheels.
+    if ((runtime_isa == internal::RuntimeIsa::Avx2 ||
+         runtime_isa == internal::RuntimeIsa::Avx512) &&
+        active_width >= kMinAvx2ActiveWidth) {
         return NewXInstrumentKernel::Avx2;
     }
     return NewXInstrumentKernel::Scalar;
 }
 
-void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
-                                    double no_fire_probability,
-                                    NewXInstrumentKernel kernel) noexcept {
+void apply_new_x_instrument_no_fire_dispatched(State& state, double factor_zero, double factor_one,
+                                               double no_fire_probability,
+                                               NewXInstrumentKernel kernel) noexcept {
     assert(kernel != NewXInstrumentKernel::NotApplicable &&
            "new-X instrument dispatch requires an applicable kernel");
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-    assert(kernel == resolve_new_x_instrument_kernel(true, state.active_width(),
+    assert(kernel == resolve_new_x_instrument_kernel(state.active_width(),
                                                      kResolvedInstrumentActivationIsa) &&
            "new-X instrument kernel must match the process ISA");
     if (kernel == NewXInstrumentKernel::Avx2) {
-        if (kResolvedInstrumentActivationIsa == internal::RuntimeIsa::Avx2) {
+        if (kResolvedInstrumentActivationIsa == internal::RuntimeIsa::Avx2 ||
+            kResolvedInstrumentActivationIsa == internal::RuntimeIsa::Avx512) {
             apply_new_x_instrument_no_fire_avx2(state, factor_zero, factor_one,
                                                 no_fire_probability);
             return;
         }
-        assert(false && "AVX2 new-X instrument kernel requires the AVX2 process ISA");
+        assert(false && "AVX2 new-X instrument kernel requires an AVX2-capable process ISA");
     }
 #else
     assert(kernel == NewXInstrumentKernel::Scalar &&

--- a/src/clifft/sampling/instrument_activation_dispatch.cc
+++ b/src/clifft/sampling/instrument_activation_dispatch.cc
@@ -38,8 +38,6 @@ NewXInstrumentKernel resolve_new_x_instrument_kernel(uint32_t active_width,
 void apply_new_x_instrument_no_fire_dispatched(State& state, double factor_zero, double factor_one,
                                                double no_fire_probability,
                                                NewXInstrumentKernel kernel) noexcept {
-    assert(kernel != NewXInstrumentKernel::NotApplicable &&
-           "new-X instrument dispatch requires an applicable kernel");
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
     assert(kernel == resolve_new_x_instrument_kernel(state.active_width(),
                                                      kResolvedInstrumentActivationIsa) &&

--- a/src/clifft/sampling/instrument_activation_dispatch.h
+++ b/src/clifft/sampling/instrument_activation_dispatch.h
@@ -20,10 +20,10 @@ enum class NewXInstrumentKernel : uint8_t {
 static_assert(sizeof(NewXInstrumentKernel) == 1);
 
 [[nodiscard]] NewXInstrumentKernel resolve_new_x_instrument_kernel(
-    bool activates_new_x, uint32_t active_width, internal::RuntimeIsa runtime_isa) noexcept;
+    uint32_t active_width, internal::RuntimeIsa runtime_isa) noexcept;
 
-void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
-                                    double no_fire_probability,
-                                    NewXInstrumentKernel kernel) noexcept;
+void apply_new_x_instrument_no_fire_dispatched(State& state, double factor_zero, double factor_one,
+                                               double no_fire_probability,
+                                               NewXInstrumentKernel kernel) noexcept;
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/instrument_activation_dispatch.h
+++ b/src/clifft/sampling/instrument_activation_dispatch.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "clifft/sampling/kernels.h"
+
+#include <cstdint>
+
+namespace clifft::internal {
+enum class RuntimeIsa;
+}
+
+namespace clifft::sampling {
+
+// Architecture-neutral selection stored in a prepared instrument action.
+enum class NewXInstrumentKernel : uint8_t {
+    NotApplicable,
+    Scalar,
+    Avx2,
+};
+
+static_assert(sizeof(NewXInstrumentKernel) == 1);
+
+[[nodiscard]] NewXInstrumentKernel resolve_new_x_instrument_kernel(
+    bool activates_new_x, uint32_t active_width, internal::RuntimeIsa runtime_isa) noexcept;
+
+void apply_new_x_instrument_no_fire(State& state, double factor_zero, double factor_one,
+                                    double no_fire_probability,
+                                    NewXInstrumentKernel kernel) noexcept;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/instrument_activation_dispatch.h
+++ b/src/clifft/sampling/instrument_activation_dispatch.h
@@ -12,7 +12,6 @@ namespace clifft::sampling {
 
 // Architecture-neutral selection stored in a prepared instrument action.
 enum class NewXInstrumentKernel : uint8_t {
-    NotApplicable,
     Scalar,
     Avx2,
 };

--- a/src/clifft/sampling/instrument_activation_simd.h
+++ b/src/clifft/sampling/instrument_activation_simd.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "clifft/sampling/kernels.h"
+
+namespace clifft::sampling {
+
+void apply_new_x_instrument_no_fire_avx2(State& state, double factor_zero, double factor_one,
+                                         double no_fire_probability) noexcept;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -5,6 +5,7 @@
 #include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
+#include "clifft/sampling/instrument_activation_simd.h"
 
 #include <array>
 #include <bit>
@@ -480,6 +481,30 @@ FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(const PreparedFusedRota
     }
 
     return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx2};
+}
+
+void apply_new_x_instrument_no_fire_avx2(State& state, double factor_zero, double factor_one,
+                                         double no_fire_probability) noexcept {
+    assert(state.active_width() >= 2 && state.active_width() < state.max_active_width() &&
+           "AVX2 new-X activation requires at least one vector block and spare capacity");
+    assert(factor_zero >= 0.0 && factor_zero <= 1.0 && factor_one >= 0.0 && factor_one <= 1.0 &&
+           std::isfinite(no_fire_probability) && no_fire_probability > 0.0 &&
+           "AVX2 new-X no-fire expansion requires valid factors and probability");
+    const double inv_norm = 1.0 / std::sqrt(no_fire_probability);
+    const __m256d identity_factor = _mm256_set1_pd(0.5 * (factor_zero + factor_one) * inv_norm);
+    const __m256d pauli_factor = _mm256_set1_pd(0.5 * (factor_zero - factor_one) * inv_norm);
+    const uint64_t old_size = state.size();
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    for (uint64_t basis = 0; basis < old_size; basis += kLanes) {
+        const __m256d input_real = _mm256_load_pd(real + basis);
+        const __m256d input_imag = _mm256_load_pd(imag + basis);
+        _mm256_store_pd(real + basis, _mm256_mul_pd(identity_factor, input_real));
+        _mm256_store_pd(imag + basis, _mm256_mul_pd(identity_factor, input_imag));
+        _mm256_store_pd(real + old_size + basis, _mm256_mul_pd(pauli_factor, input_real));
+        _mm256_store_pd(imag + old_size + basis, _mm256_mul_pd(pauli_factor, input_imag));
+    }
+    state.set_active_width(state.active_width() + 1);
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -6,6 +6,7 @@
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/instrument_activation_simd.h"
+#include "clifft/util/numeric.h"
 
 #include <array>
 #include <bit>
@@ -404,7 +405,7 @@ void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& m
     assert(state.active_width() == measurement.pauli.active_width &&
            !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
            measurement.pivot < 2 && measurement.pauli.active_width >= 2 &&
-           std::isfinite(branch_probability) && branch_probability > 0.0 &&
+           is_finite_robust(branch_probability) && branch_probability > 0.0 &&
            "AVX2 active measurement requires a positive-probability low-lane pairing");
     if (measurement.pauli.even_phase.real() != 0.0) {
         collapse_active_measurement_avx2_impl<true>(state, measurement, branch, branch_probability);
@@ -488,7 +489,7 @@ void apply_new_x_instrument_no_fire_avx2(State& state, double factor_zero, doubl
     assert(state.active_width() >= 2 && state.active_width() < state.max_active_width() &&
            "AVX2 new-X activation requires at least one vector block and spare capacity");
     assert(factor_zero >= 0.0 && factor_zero <= 1.0 && factor_one >= 0.0 && factor_one <= 1.0 &&
-           std::isfinite(no_fire_probability) && no_fire_probability > 0.0 &&
+           is_finite_robust(no_fire_probability) && no_fire_probability > 0.0 &&
            "AVX2 new-X no-fire expansion requires valid factors and probability");
     const double inv_norm = 1.0 / std::sqrt(no_fire_probability);
     const __m256d identity_factor = _mm256_set1_pd(0.5 * (factor_zero + factor_one) * inv_norm);

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -5,6 +5,7 @@
 #include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
+#include "clifft/util/numeric.h"
 
 #include <array>
 #include <bit>
@@ -411,7 +412,7 @@ void collapse_active_measurement_avx512(State& state, const PreparedMeasurement&
     assert(state.active_width() == measurement.pauli.active_width &&
            !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
            measurement.pivot < 3 && measurement.pauli.active_width >= 3 &&
-           std::isfinite(branch_probability) && branch_probability > 0.0 &&
+           is_finite_robust(branch_probability) && branch_probability > 0.0 &&
            "AVX-512 active measurement requires a positive-probability low-lane pairing");
     if (measurement.pauli.even_phase.real() != 0.0) {
         collapse_active_measurement_avx512_impl<true>(state, measurement, branch,

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/active_measurement_dispatch.h"
 #include "clifft/sampling/direct_rotation_dispatch.h"
+#include "clifft/sampling/instrument_activation_dispatch.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/util/runtime_isa.h"
 
@@ -34,6 +35,7 @@ using clifft::sampling::DirectRotationKernel;
 using clifft::sampling::expectation_value;
 using clifft::sampling::measurement_probabilities;
 using clifft::sampling::MeasurementProbabilities;
+using clifft::sampling::NewXInstrumentKernel;
 using clifft::sampling::prepare_measurement;
 using clifft::sampling::prepare_pauli;
 using clifft::sampling::prepare_promotion;
@@ -41,6 +43,7 @@ using clifft::sampling::prepare_rotation;
 using clifft::sampling::PreparedMeasurement;
 using clifft::sampling::resolve_active_measurement_kernel;
 using clifft::sampling::resolve_direct_rotation_kernel;
+using clifft::sampling::resolve_new_x_instrument_kernel;
 using clifft::sampling::State;
 using clifft::test::check_complex;
 using clifft::test::dense_axis_rotation;
@@ -381,6 +384,21 @@ TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b01, 0b110}, 3, 0, RuntimeIsa::Scalar) == ActiveMeasurementKernel::Scalar);
 }
 
+TEST_CASE("New X instrument SIMD selection preserves scalar boundaries") {
+    REQUIRE(resolve_new_x_instrument_kernel(false, 3, RuntimeIsa::Avx2) ==
+            NewXInstrumentKernel::NotApplicable);
+    REQUIRE(resolve_new_x_instrument_kernel(true, 1, RuntimeIsa::Avx2) ==
+            NewXInstrumentKernel::Scalar);
+    REQUIRE(resolve_new_x_instrument_kernel(true, 2, RuntimeIsa::Avx2) ==
+            NewXInstrumentKernel::Avx2);
+    REQUIRE(resolve_new_x_instrument_kernel(true, 8, RuntimeIsa::Avx2) ==
+            NewXInstrumentKernel::Avx2);
+    REQUIRE(resolve_new_x_instrument_kernel(true, 8, RuntimeIsa::Scalar) ==
+            NewXInstrumentKernel::Scalar);
+    REQUIRE(resolve_new_x_instrument_kernel(true, 8, RuntimeIsa::Avx512) ==
+            NewXInstrumentKernel::Scalar);
+}
+
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {
     for (uint32_t active_width = 0; active_width <= 4; ++active_width) {
         const uint64_t mask_limit = uint64_t{1} << active_width;
@@ -702,6 +720,36 @@ TEST_CASE("Sampling new X instrument activation matches the generic widened sour
                                              kExactPopulations.for_branch(branch));
             require_vectors_close(coefficients(collapse_actual), coefficients(collapse_oracle));
             REQUIRE(collapse_actual.active_width() == expanded_width);
+        }
+    }
+}
+
+TEST_CASE("Sampling AVX2 new X instrument activation matches scalar") {
+    if (clifft::internal::runtime_isa() != RuntimeIsa::Avx2) {
+        return;
+    }
+
+    for (uint32_t initial_width = 2; initial_width <= 8; ++initial_width) {
+        CAPTURE(initial_width);
+        const std::vector<std::complex<double>> input = deterministic_state(initial_width);
+        for (const auto& [factor_zero, factor_one] :
+             {std::pair{0.8, 0.3}, std::pair{0.3, 0.8}, std::pair{0.6, 0.6}, std::pair{1.0, 0.0},
+              std::pair{0.0, 1.0}, std::pair{1.0, 1.0}}) {
+            CAPTURE(factor_zero, factor_one);
+            const double no_fire_probability =
+                0.5 * factor_zero * factor_zero + 0.5 * factor_one * factor_one;
+
+            State expected(initial_width + 1, initial_width);
+            load_state(expected, input);
+            apply_new_x_instrument_no_fire(expected, factor_zero, factor_one, no_fire_probability);
+
+            State actual(initial_width + 1, initial_width);
+            load_state(actual, input);
+            apply_new_x_instrument_no_fire(actual, factor_zero, factor_one, no_fire_probability,
+                                           NewXInstrumentKernel::Avx2);
+
+            require_vectors_close(coefficients(actual), coefficients(expected));
+            REQUIRE(actual.active_width() == initial_width + 1);
         }
     }
 }

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -25,6 +25,7 @@ using clifft::sampling::ActiveMeasurementKernel;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::apply_instrument_no_fire;
 using clifft::sampling::apply_new_x_instrument_no_fire;
+using clifft::sampling::apply_new_x_instrument_no_fire_dispatched;
 using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
 using clifft::sampling::collapse_active_measurement;
@@ -385,18 +386,11 @@ TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
 }
 
 TEST_CASE("New X instrument SIMD selection preserves scalar boundaries") {
-    REQUIRE(resolve_new_x_instrument_kernel(false, 3, RuntimeIsa::Avx2) ==
-            NewXInstrumentKernel::NotApplicable);
-    REQUIRE(resolve_new_x_instrument_kernel(true, 1, RuntimeIsa::Avx2) ==
-            NewXInstrumentKernel::Scalar);
-    REQUIRE(resolve_new_x_instrument_kernel(true, 2, RuntimeIsa::Avx2) ==
-            NewXInstrumentKernel::Avx2);
-    REQUIRE(resolve_new_x_instrument_kernel(true, 8, RuntimeIsa::Avx2) ==
-            NewXInstrumentKernel::Avx2);
-    REQUIRE(resolve_new_x_instrument_kernel(true, 8, RuntimeIsa::Scalar) ==
-            NewXInstrumentKernel::Scalar);
-    REQUIRE(resolve_new_x_instrument_kernel(true, 8, RuntimeIsa::Avx512) ==
-            NewXInstrumentKernel::Scalar);
+    REQUIRE(resolve_new_x_instrument_kernel(1, RuntimeIsa::Avx2) == NewXInstrumentKernel::Scalar);
+    REQUIRE(resolve_new_x_instrument_kernel(2, RuntimeIsa::Avx2) == NewXInstrumentKernel::Avx2);
+    REQUIRE(resolve_new_x_instrument_kernel(8, RuntimeIsa::Avx2) == NewXInstrumentKernel::Avx2);
+    REQUIRE(resolve_new_x_instrument_kernel(8, RuntimeIsa::Scalar) == NewXInstrumentKernel::Scalar);
+    REQUIRE(resolve_new_x_instrument_kernel(8, RuntimeIsa::Avx512) == NewXInstrumentKernel::Avx2);
 }
 
 TEST_CASE("Sampling kernel expectation values match the existing dense matrix oracle") {
@@ -725,7 +719,8 @@ TEST_CASE("Sampling new X instrument activation matches the generic widened sour
 }
 
 TEST_CASE("Sampling AVX2 new X instrument activation matches scalar") {
-    if (clifft::internal::runtime_isa() != RuntimeIsa::Avx2) {
+    const RuntimeIsa runtime_isa = clifft::internal::runtime_isa();
+    if (runtime_isa != RuntimeIsa::Avx2 && runtime_isa != RuntimeIsa::Avx512) {
         return;
     }
 
@@ -745,8 +740,8 @@ TEST_CASE("Sampling AVX2 new X instrument activation matches scalar") {
 
             State actual(initial_width + 1, initial_width);
             load_state(actual, input);
-            apply_new_x_instrument_no_fire(actual, factor_zero, factor_one, no_fire_probability,
-                                           NewXInstrumentKernel::Avx2);
+            apply_new_x_instrument_no_fire_dispatched(
+                actual, factor_zero, factor_one, no_fire_probability, NewXInstrumentKernel::Avx2);
 
             require_vectors_close(coefficients(actual), coefficients(expected));
             REQUIRE(actual.active_width() == initial_width + 1);


### PR DESCRIPTION
## Summary

- add a separately compiled AVX2 kernel for planner-selected new-coordinate X instrument no-fire expansions
- select it on AVX2 and AVX-512 runtime tiers while retaining the scalar path for scalar, ARM, WASM, and sub-vector-width states
- preserve the 104-byte instrument descriptor, allocation-free/exception-free execution, and the existing fired-source path
- represent circuit-determined applicability with an optional selector, keep the kernel enum ISA-only, and give the dispatch wrapper a distinct name so omitting the selector cannot silently bypass SIMD
- use fast-math-safe finite checks consistently in the AVX2 and AVX-512 active-measurement collapse kernels
- add selector-boundary and scalar-oracle coverage across widths, factor orderings, zero coefficients, and forced ISA modes

Closes #310.

## Performance evidence

Measurements compare exact main `7e8e301` with this branch from matched Release builds using `-O3 -DNDEBUG -g -fno-omit-frame-pointer`, the `x86-64-v2` baseline, forced AVX2 dispatch, one OpenMP thread, and CPU 2 affinity.

For the d17 r5 low-leakage noncomputational fixture, five balanced blocks each ran 3 x 500 shots with paired seed ranges:

| Revision/backend | Block times (s) | Median (s) |
|---|---|---:|
| main symbolic | 0.7214, 0.7783, 0.7611, 0.7945, 0.7724 | 0.7724 |
| candidate symbolic | 0.6862, 0.6876, 0.6643, 0.6795, 0.6655 | 0.6795 |
| main legacy | 0.6922, 0.6950, 0.7089, 0.7388, 0.7357 | 0.7089 |

The candidate is 12.0% lower time than main (1.14x speedup) and 4.2% lower time than the legacy median. All arms consumed identical output shapes/checksums.

Cycle profiles over 8 x 500 shots confirm the intended attribution:

- total sampled cycles: 7.204B -> 6.608B, down 8.3%
- new-X no-fire expansion: 23.5% scalar on main -> 14.2% AVX2 on the candidate
- the remaining leading costs are the unchanged AVX2 active-measurement probability and collapse kernels
- generated assembly contains `vbroadcastsd`, `vmovapd`, and packed `vmulpd` operations in the new kernel

A direct width sweep found the one-vector width neutral (1.01x) and wider target widths faster; widths 6 through 12 improved 1.67-2.25x. This supports the structural one-vector eligibility floor without adding a higher profitability cutoff.

Review also identified that an AVX-512 host using an `x86-64-v2` wheel would bypass the AVX2 specialization, unlike the earlier native build whose generic code could auto-vectorize. Five additional balanced 3 x 500-shot blocks compared the prior scalar routing with AVX2 reuse under forced AVX-512 dispatch:

| AVX-512 runtime route | Block times (s) | Median (s) |
|---|---|---:|
| scalar | 0.7313, 0.7141, 0.7093, 0.7506, 0.7188 | 0.7188 |
| existing AVX2 kernel | 0.6281, 0.6303, 0.6719, 0.6431, 0.6236 | 0.6303 |

Reusing the AVX2 kernel is 12.3% lower time with identical checksums. The AVX-512 runtime tier already requires AVX2, BMI2, and FMA, so this adds no unsupported instruction path.

Ordinary-sampling guards, which cannot select this instrument kernel, remained neutral in three balanced 3-iteration blocks. Paired candidate/main medians were 0.996x for coherent d5 r1 and 0.986x for QV-10 seed 44, with identical checksums.

## Test plan

- [x] C++ tests pass (`~[bench]`): all 1,279 cases under forced scalar, AVX2, and AVX-512 dispatch
- [x] focused AVX2 differential test: 12,360 assertions against the scalar oracle on AVX2 and AVX-512 runtime tiers
- [x] no-runtime-dispatch translation-unit compile check passes
- [ ] Python tests pass (`uv run pytest tests/python/ -v`) - C++-only change; covered by PR CI
- [ ] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`) - no Python or documentation change; covered by PR CI
- [x] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under the project's Apache-2.0 license.
- [x] This contribution was AI-assisted, the generated code has been reviewed, and the commit includes an `Assisted-by:` trailer.
