### PR TITLE
refactor(sampling): specialize instrument actions

### DIFF
--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -29,7 +29,8 @@ size_t ExecutablePlan::num_new_x_instrument_activations() const {
     return static_cast<size_t>(
         std::count_if(actions_.begin(), actions_.end(), [](const Action& action) {
             const auto* instrument = std::get_if<ExecuteInstrument>(&action);
-            return instrument != nullptr && instrument->activates_new_x();
+            return instrument != nullptr &&
+                   std::holds_alternative<ExecuteNewXInstrumentActivation>(instrument->action);
         }));
 }
 

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -30,7 +30,7 @@ size_t ExecutablePlan::num_new_x_instrument_activations() const {
         std::count_if(actions_.begin(), actions_.end(), [](const Action& action) {
             const auto* instrument = std::get_if<ExecuteInstrument>(&action);
             return instrument != nullptr &&
-                   std::holds_alternative<ExecuteNewXInstrumentActivation>(instrument->action);
+                   std::holds_alternative<ExecuteNewXInstrumentActivation>(instrument->form);
         }));
 }
 

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -188,6 +188,10 @@ class ExecutablePlan {
         uint32_t destination_flip = 0;
     };
 
+    // These forms intentionally store the same prepared operands but remain
+    // distinct so dispatch encodes whether a clean coordinate must be added.
+    // The current planner selects new-X activation, while validated plans and
+    // future planners may still require the generic measured-source fallback.
     struct ExecuteMeasuredInstrumentActivation {
         PreparedMeasurement measurement;
         PreparedExpression sign;
@@ -219,8 +223,11 @@ class ExecutablePlan {
                      ExecuteNewXInstrumentActivation>;
 
     struct ExecuteInstrument {
-        InstrumentAction action;
+        InstrumentAction form;
     };
+
+    static_assert(sizeof(ExecuteInstrument) <= 96,
+                  "instrument specialization must preserve the compact descriptor");
 
     struct ExecuteBoundary {
         uint32_t site = 0;

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -171,21 +171,56 @@ class ExecutablePlan {
         uint32_t exp_val = 0;
     };
 
-    struct ExecuteInstrument {
-        InstrumentMode mode = InstrumentMode::Classical;
-        // Lowering identifies the exact new-coordinate X shape so execution
-        // need not rediscover instrument topology inside the hot loop.
-        std::optional<NewXInstrumentKernel> new_x_kernel;
+    struct ExecuteClassicalInstrument {
         PreparedExpression sign;
-        std::optional<PreparedMeasurement> measurement;
         uint32_t site = 0;
-        std::optional<uint32_t> destination_flip;
-
-        [[nodiscard]] bool activates_new_x() const noexcept { return new_x_kernel.has_value(); }
+        uint32_t destination_flip = 0;
     };
 
-    static_assert(sizeof(ExecuteInstrument) == 104,
-                  "instrument specialization must not expand its action descriptor");
+    struct ExecuteDormantInstrumentTrap {
+        uint32_t site = 0;
+    };
+
+    struct ExecuteActiveInstrument {
+        PreparedMeasurement measurement;
+        PreparedExpression sign;
+        uint32_t site = 0;
+        uint32_t destination_flip = 0;
+    };
+
+    struct ExecuteMeasuredInstrumentActivation {
+        PreparedMeasurement measurement;
+        PreparedExpression sign;
+        uint32_t site = 0;
+        uint32_t destination_flip = 0;
+    };
+
+    struct ExecuteNewXInstrumentActivation {
+        PreparedExpression sign;
+        uint32_t site = 0;
+        uint32_t destination_flip = 0;
+        // Lowering identifies the exact new-coordinate X shape so execution
+        // need not rediscover instrument topology inside the hot loop.
+        NewXInstrumentKernel kernel = NewXInstrumentKernel::Scalar;
+    };
+
+    static_assert(sizeof(ExecuteActiveInstrument) == 88,
+                  "active instrument specialization must remain compact");
+    static_assert(sizeof(ExecuteMeasuredInstrumentActivation) == 88,
+                  "instrument activation specialization must remain compact");
+
+    // Keep the concrete forms behind one outer alternative so instrument-free
+    // dispatch retains its existing visit table. The trivial dormant form must
+    // remain first because GCC queries the nested variant's default alternative
+    // before the enclosing ExecutablePlan is complete.
+    using InstrumentAction =
+        std::variant<ExecuteDormantInstrumentTrap, ExecuteClassicalInstrument,
+                     ExecuteActiveInstrument, ExecuteMeasuredInstrumentActivation,
+                     ExecuteNewXInstrumentActivation>;
+
+    struct ExecuteInstrument {
+        InstrumentAction action;
+    };
 
     struct ExecuteBoundary {
         uint32_t site = 0;

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -255,28 +255,50 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
                     index(typed.exp_val)});
             } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                 output_.has_instruments_ = true;
-                const bool new_x_activation = activates_new_x(typed, planned.active_after);
-                std::optional<NewXInstrumentKernel> new_x_kernel;
-                if (new_x_activation) {
-                    new_x_kernel =
-                        resolve_new_x_instrument_kernel(planned.active_before, runtime_isa_);
+                if (typed.mode == InstrumentMode::DormantTrap) {
+                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                        ExecutablePlan::ExecuteDormantInstrumentTrap{index(typed.site)}});
+                    return;
                 }
-                std::optional<PreparedMeasurement> measurement;
-                if (typed.mode == InstrumentMode::Active ||
-                    (typed.mode == InstrumentMode::Activate && !new_x_activation)) {
-                    const uint32_t width = typed.mode == InstrumentMode::Activate
-                                               ? planned.active_after
-                                               : planned.active_before;
-                    const uint64_t support = typed.source.x != 0 ? typed.source.x : typed.source.z;
-                    const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
-                    measurement = prepare_measurement(typed.source, width, pivot);
+
+                assert(typed.destination_flip.has_value() &&
+                       "validated in-line instrument must define a destination flip");
+                const uint32_t site = index(typed.site);
+                const uint32_t destination_flip = index(*typed.destination_flip);
+                if (typed.mode == InstrumentMode::Classical) {
+                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                        ExecutablePlan::ExecuteClassicalInstrument{prepare_expression(typed.sign),
+                                                                   site, destination_flip}});
+                    return;
                 }
-                output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
-                    typed.mode, new_x_kernel, prepare_expression(typed.sign),
-                    std::move(measurement), index(typed.site),
-                    typed.destination_flip.has_value()
-                        ? std::optional<uint32_t>{index(*typed.destination_flip)}
-                        : std::nullopt});
+
+                if (activates_new_x(typed, planned.active_after)) {
+                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                        ExecutablePlan::ExecuteNewXInstrumentActivation{
+                            prepare_expression(typed.sign), site, destination_flip,
+                            resolve_new_x_instrument_kernel(planned.active_before, runtime_isa_)}});
+                    return;
+                }
+
+                const uint32_t width = typed.mode == InstrumentMode::Activate
+                                           ? planned.active_after
+                                           : planned.active_before;
+                const uint64_t support = typed.source.x != 0 ? typed.source.x : typed.source.z;
+                const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
+                PreparedMeasurement measurement = prepare_measurement(typed.source, width, pivot);
+                if (typed.mode == InstrumentMode::Activate) {
+                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                        ExecutablePlan::ExecuteMeasuredInstrumentActivation{
+                            std::move(measurement), prepare_expression(typed.sign), site,
+                            destination_flip}});
+                } else {
+                    assert(typed.mode == InstrumentMode::Active &&
+                           "validated instrument mode must have a concrete lowering");
+                    output_.actions_.emplace_back(
+                        ExecutablePlan::ExecuteInstrument{ExecutablePlan::ExecuteActiveInstrument{
+                            std::move(measurement), prepare_expression(typed.sign), site,
+                            destination_flip}});
+                }
             } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                 const uint32_t noise_end = boundary_index + 1 < boundary_noise_starts_.size()
                                                ? boundary_noise_starts_[boundary_index + 1]
@@ -423,9 +445,20 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteExpectation>) {
                     validate_expression(typed.sign);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {
-                    validate_expression(typed.sign);
-                    assert(typed.site < output_.instrument_distributions_.size() &&
-                           "instrument site is out of range");
+                    std::visit(
+                        [&](const auto& instrument) {
+                            using Instrument = std::decay_t<decltype(instrument)>;
+                            assert(instrument.site < output_.instrument_distributions_.size() &&
+                                   "instrument site is out of range");
+                            if constexpr (!std::is_same_v<
+                                              Instrument,
+                                              ExecutablePlan::ExecuteDormantInstrumentTrap>) {
+                                validate_expression(instrument.sign);
+                                assert(instrument.destination_flip < output_.num_symbols_ &&
+                                       "instrument destination flip is out of range");
+                            }
+                        },
+                        typed.action);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary>) {
                     assert(typed.site < output_.instrument_resume_offsets_.size() &&
                            "instrument boundary site is out of range");

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -255,50 +255,57 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
                     index(typed.exp_val)});
             } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                 output_.has_instruments_ = true;
-                if (typed.mode == InstrumentMode::DormantTrap) {
-                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
-                        ExecutablePlan::ExecuteDormantInstrumentTrap{index(typed.site)}});
-                    return;
-                }
-
-                assert(typed.destination_flip.has_value() &&
-                       "validated in-line instrument must define a destination flip");
                 const uint32_t site = index(typed.site);
-                const uint32_t destination_flip = index(*typed.destination_flip);
-                if (typed.mode == InstrumentMode::Classical) {
-                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
-                        ExecutablePlan::ExecuteClassicalInstrument{prepare_expression(typed.sign),
-                                                                   site, destination_flip}});
-                    return;
+                switch (typed.mode) {
+                    case InstrumentMode::DormantTrap:
+                        output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                            ExecutablePlan::ExecuteDormantInstrumentTrap{site}});
+                        return;
+                    case InstrumentMode::Classical: {
+                        assert(typed.destination_flip.has_value() &&
+                               "validated in-line instrument must define a destination flip");
+                        output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                            ExecutablePlan::ExecuteClassicalInstrument{
+                                prepare_expression(typed.sign), site,
+                                index(*typed.destination_flip)}});
+                        return;
+                    }
+                    case InstrumentMode::Active: {
+                        assert(typed.destination_flip.has_value() &&
+                               "validated in-line instrument must define a destination flip");
+                        const uint64_t support =
+                            typed.source.x != 0 ? typed.source.x : typed.source.z;
+                        const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
+                        output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                            ExecutablePlan::ExecuteActiveInstrument{
+                                prepare_measurement(typed.source, planned.active_before, pivot),
+                                prepare_expression(typed.sign), site,
+                                index(*typed.destination_flip)}});
+                        return;
+                    }
+                    case InstrumentMode::Activate: {
+                        assert(typed.destination_flip.has_value() &&
+                               "validated in-line instrument must define a destination flip");
+                        const uint32_t destination_flip = index(*typed.destination_flip);
+                        if (activates_new_x(typed, planned.active_after)) {
+                            output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                                ExecutablePlan::ExecuteNewXInstrumentActivation{
+                                    prepare_expression(typed.sign), site, destination_flip,
+                                    resolve_new_x_instrument_kernel(planned.active_before,
+                                                                    runtime_isa_)}});
+                            return;
+                        }
+                        const uint64_t support =
+                            typed.source.x != 0 ? typed.source.x : typed.source.z;
+                        const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
+                        output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
+                            ExecutablePlan::ExecuteMeasuredInstrumentActivation{
+                                prepare_measurement(typed.source, planned.active_after, pivot),
+                                prepare_expression(typed.sign), site, destination_flip}});
+                        return;
+                    }
                 }
-
-                if (activates_new_x(typed, planned.active_after)) {
-                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
-                        ExecutablePlan::ExecuteNewXInstrumentActivation{
-                            prepare_expression(typed.sign), site, destination_flip,
-                            resolve_new_x_instrument_kernel(planned.active_before, runtime_isa_)}});
-                    return;
-                }
-
-                const uint32_t width = typed.mode == InstrumentMode::Activate
-                                           ? planned.active_after
-                                           : planned.active_before;
-                const uint64_t support = typed.source.x != 0 ? typed.source.x : typed.source.z;
-                const uint32_t pivot = static_cast<uint32_t>(std::countr_zero(support));
-                PreparedMeasurement measurement = prepare_measurement(typed.source, width, pivot);
-                if (typed.mode == InstrumentMode::Activate) {
-                    output_.actions_.emplace_back(ExecutablePlan::ExecuteInstrument{
-                        ExecutablePlan::ExecuteMeasuredInstrumentActivation{
-                            std::move(measurement), prepare_expression(typed.sign), site,
-                            destination_flip}});
-                } else {
-                    assert(typed.mode == InstrumentMode::Active &&
-                           "validated instrument mode must have a concrete lowering");
-                    output_.actions_.emplace_back(
-                        ExecutablePlan::ExecuteInstrument{ExecutablePlan::ExecuteActiveInstrument{
-                            std::move(measurement), prepare_expression(typed.sign), site,
-                            destination_flip}});
-                }
+                throw std::logic_error("validated instrument mode has no executable lowering");
             } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                 const uint32_t noise_end = boundary_index + 1 < boundary_noise_starts_.size()
                                                ? boundary_noise_starts_[boundary_index + 1]
@@ -458,7 +465,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
                                        "instrument destination flip is out of range");
                             }
                         },
-                        typed.action);
+                        typed.form);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary>) {
                     assert(typed.site < output_.instrument_resume_offsets_.size() &&
                            "instrument boundary site is out of range");

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -469,76 +469,83 @@ void Executor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
     exp_vals_[action.exp_val] = evaluate(action.sign) ? -value : value;
 }
 
-template <bool ForceRecords>
-void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
-                              std::span<const uint8_t>, ReplayResult& result) noexcept {
-    if constexpr (ForceRecords) {
-        result.reachable = false;
+void Executor::trap_instrument(uint32_t site, uint8_t source, bool destination_pending) noexcept {
+    pending_trap_ = InstrumentTrap{InstrumentSiteId{site}, source, destination_pending};
+}
+
+void Executor::finish_instrument_fire(uint32_t site, uint32_t destination_flip, uint8_t source,
+                                      const InstrumentDistribution& distribution) noexcept {
+    assert(distribution.p_fire[source] > 0.0 &&
+           "a fired instrument source must have positive mass");
+    const double draw = rng_.next_double() * distribution.p_fire[source];
+    int destination = -1;
+    if (draw < distribution.p_computational_dest[source][0]) {
+        destination = 0;
+    } else if (draw < distribution.p_computational_dest[source][0] +
+                          distribution.p_computational_dest[source][1]) {
+        destination = 1;
+    }
+    if (destination < 0) {
+        trap_instrument(site, source, false);
+    } else if (destination != source) {
+        assign_symbol(destination_flip, true);
+    }
+}
+
+void Executor::execute_instrument(
+    const ExecutablePlan::ExecuteClassicalInstrument& action) noexcept {
+    assert(action.site < plan_->instrument_distributions_.size() &&
+           "instrument action must reference a prepared distribution");
+    const InstrumentDistribution& distribution = plan_->instrument_distributions_[action.site];
+    assign_symbol(action.destination_flip, false);
+    const uint8_t source = static_cast<uint8_t>(evaluate(action.sign));
+    if (rng_.next_double() < distribution.p_fire[source]) {
+        finish_instrument_fire(action.site, action.destination_flip, source, distribution);
+    }
+}
+
+void Executor::execute_instrument(
+    const ExecutablePlan::ExecuteDormantInstrumentTrap& action) noexcept {
+    assert(action.site < plan_->instrument_distributions_.size() &&
+           "instrument action must reference a prepared distribution");
+    const InstrumentDistribution& distribution = plan_->instrument_distributions_[action.site];
+    const double mass = distribution.p_fire[0] + distribution.p_fire[1];
+    if (rng_.next_double() * 2.0 >= mass) {
         return;
     }
+    const uint8_t source =
+        rng_.next_double() * mass < distribution.p_fire[0] ? uint8_t{0} : uint8_t{1};
+    trap_instrument(action.site, source, true);
+}
+
+template <typename Action>
+void Executor::execute_quantum_instrument(const Action& action) noexcept {
+    constexpr bool kActivatesCoordinate =
+        std::is_same_v<Action, ExecutablePlan::ExecuteMeasuredInstrumentActivation>;
+    constexpr bool kActivatesNewX =
+        std::is_same_v<Action, ExecutablePlan::ExecuteNewXInstrumentActivation>;
+    static_assert(std::is_same_v<Action, ExecutablePlan::ExecuteActiveInstrument> ||
+                  kActivatesCoordinate || kActivatesNewX);
 
     assert(action.site < plan_->instrument_distributions_.size() &&
            "instrument action must reference a prepared distribution");
     const InstrumentDistribution& distribution = plan_->instrument_distributions_[action.site];
-    if (action.destination_flip.has_value()) {
-        assign_symbol(*action.destination_flip, false);
-    }
-
-    auto trap = [&](uint8_t source, bool destination_pending) {
-        pending_trap_ = InstrumentTrap{InstrumentSiteId{action.site}, source, destination_pending};
-    };
-    auto finish_fire = [&](uint8_t source) {
-        assert(distribution.p_fire[source] > 0.0 &&
-               "a fired instrument source must have positive mass");
-        const double draw = rng_.next_double() * distribution.p_fire[source];
-        int destination = -1;
-        if (draw < distribution.p_computational_dest[source][0]) {
-            destination = 0;
-        } else if (draw < distribution.p_computational_dest[source][0] +
-                              distribution.p_computational_dest[source][1]) {
-            destination = 1;
-        }
-        if (destination < 0) {
-            trap(source, false);
-        } else if (destination != source) {
-            assert(action.destination_flip.has_value() &&
-                   "in-line instrument requires a destination-flip symbol");
-            assign_symbol(*action.destination_flip, true);
-        }
-    };
-
-    if (action.mode == InstrumentMode::Classical) {
-        const uint8_t source = static_cast<uint8_t>(evaluate(action.sign));
-        if (rng_.next_double() < distribution.p_fire[source]) {
-            finish_fire(source);
-        }
-        return;
-    }
-
-    if (action.mode == InstrumentMode::DormantTrap) {
-        const double mass = distribution.p_fire[0] + distribution.p_fire[1];
-        if (rng_.next_double() * 2.0 >= mass) {
-            return;
-        }
-        const uint8_t source =
-            rng_.next_double() * mass < distribution.p_fire[0] ? uint8_t{0} : uint8_t{1};
-        trap(source, true);
-        return;
-    }
-
-    assert((action.activates_new_x() || action.measurement.has_value()) &&
-           "active instrument requires a kernel or prepared source measurement");
-    if (action.mode == InstrumentMode::Activate && !action.activates_new_x()) {
+    assign_symbol(action.destination_flip, false);
+    if constexpr (kActivatesCoordinate) {
         activate_zero_coordinate(state_);
     }
     const bool sign = evaluate(action.sign);
-    // Under the State normalization invariant, the clean |0> coordinate has
-    // exact half populations in the X eigenbasis. Using those semantic values
-    // retains any residual floating-point norm drift instead of reducing and
-    // renormalizing it inside this activation.
-    const MeasurementProbabilities eigen_populations =
-        action.activates_new_x() ? MeasurementProbabilities{0.5, 0.5}
-                                 : measurement_probabilities(state_, *action.measurement);
+    const MeasurementProbabilities eigen_populations = [&]() noexcept {
+        if constexpr (kActivatesNewX) {
+            // Under the State normalization invariant, the clean |0> coordinate has
+            // exact half populations in the X eigenbasis. Using those semantic values
+            // retains any residual floating-point norm drift instead of reducing and
+            // renormalizing it inside this activation.
+            return MeasurementProbabilities{0.5, 0.5};
+        } else {
+            return measurement_probabilities(state_, action.measurement);
+        }
+    }();
     const double total = eigen_populations.total();
     const double epsilon = kMeasurementDustEpsilon * total;
     const double physical_zero = eigen_populations.for_branch(sign);
@@ -561,25 +568,50 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
                                            factor_one * factor_one * eigen_populations.one;
         assert(no_fire_probability > 0.0 &&
                "a selected no-fire branch must have positive probability");
-        if (action.activates_new_x()) {
+        if constexpr (kActivatesNewX) {
             apply_new_x_instrument_no_fire_dispatched(state_, factor_zero, factor_one,
-                                                      no_fire_probability, *action.new_x_kernel);
+                                                      no_fire_probability, action.kernel);
         } else {
-            apply_instrument_no_fire(state_, action.measurement->pauli, factor_zero, factor_one,
+            apply_instrument_no_fire(state_, action.measurement.pauli, factor_zero, factor_one,
                                      no_fire_probability);
         }
         return;
     }
 
     const bool eigen_branch = (*fired_source != 0) ^ sign;
-    if (action.activates_new_x()) {
+    if constexpr (kActivatesNewX) {
         collapse_new_x_instrument_source(state_, eigen_branch,
                                          eigen_populations.for_branch(eigen_branch));
     } else {
-        collapse_instrument_source(state_, action.measurement->pauli, eigen_branch,
+        collapse_instrument_source(state_, action.measurement.pauli, eigen_branch,
                                    eigen_populations.for_branch(eigen_branch));
     }
-    finish_fire(*fired_source);
+    finish_instrument_fire(action.site, action.destination_flip, *fired_source, distribution);
+}
+
+void Executor::execute_instrument(const ExecutablePlan::ExecuteActiveInstrument& action) noexcept {
+    execute_quantum_instrument(action);
+}
+
+void Executor::execute_instrument(
+    const ExecutablePlan::ExecuteMeasuredInstrumentActivation& action) noexcept {
+    execute_quantum_instrument(action);
+}
+
+void Executor::execute_instrument(
+    const ExecutablePlan::ExecuteNewXInstrumentActivation& action) noexcept {
+    execute_quantum_instrument(action);
+}
+
+template <bool ForceRecords>
+void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
+                              std::span<const uint8_t>, ReplayResult& result) noexcept {
+    if constexpr (ForceRecords) {
+        result.reachable = false;
+    } else {
+        std::visit([&](const auto& instrument) noexcept { execute_instrument(instrument); },
+                   action.action);
+    }
 }
 
 template <bool SampleNoise>

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -610,7 +610,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
         result.reachable = false;
     } else {
         std::visit([&](const auto& instrument) noexcept { execute_instrument(instrument); },
-                   action.action);
+                   action.form);
     }
 }
 

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -183,6 +183,17 @@ class Executor {
     [[nodiscard]] std::optional<double> force_active_branch(MeasurementProbabilities probabilities,
                                                             bool branch) noexcept;
     [[nodiscard]] bool sample_dormant_branch() noexcept;
+    void trap_instrument(uint32_t site, uint8_t source, bool destination_pending) noexcept;
+    void finish_instrument_fire(uint32_t site, uint32_t destination_flip, uint8_t source,
+                                const InstrumentDistribution& distribution) noexcept;
+    void execute_instrument(const ExecutablePlan::ExecuteClassicalInstrument& action) noexcept;
+    void execute_instrument(const ExecutablePlan::ExecuteDormantInstrumentTrap& action) noexcept;
+    void execute_instrument(const ExecutablePlan::ExecuteActiveInstrument& action) noexcept;
+    void execute_instrument(
+        const ExecutablePlan::ExecuteMeasuredInstrumentActivation& action) noexcept;
+    void execute_instrument(const ExecutablePlan::ExecuteNewXInstrumentActivation& action) noexcept;
+    template <typename Action>
+    void execute_quantum_instrument(const Action& action) noexcept;
 
     const ExecutablePlan* root_plan_;
     const ExecutablePlan* plan_;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -831,6 +831,36 @@ TEST_CASE("Sampling executable selects new X instrument activation") {
     REQUIRE(already_active.num_new_x_instrument_activations() == 0);
 }
 
+TEST_CASE("Sampling executable preserves generic instrument activation") {
+    SamplingPlan plan;
+    plan.num_qubits = 2;
+    plan.initial_active_width = 1;
+    plan.max_active_width = 2;
+    plan.num_instrument_sites = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
+    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
+    plan.actions = {
+        PlannedAction{1, 2,
+                      ApplyInstrument{InstrumentSiteId{0}, InstrumentMode::Activate,
+                                      ActivePauli{0, 0b10}, AffineBool{}, SymbolId{0}}},
+        PlannedAction{2, 2, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
+    };
+
+    const ExecutablePlan executable(plan);
+    REQUIRE(executable.num_new_x_instrument_activations() == 0);
+
+    Executor executor(executable, 19);
+    executor.run_shot();
+
+    REQUIRE_FALSE(executor.pending_trap().has_value());
+    REQUIRE(executor.state().active_width() == 2);
+    REQUIRE(executor.symbols()[0] == 0);
+    REQUIRE(executor.state().real_data()[0] == 1.0);
+    REQUIRE(executor.state().real_data()[1] == 0.0);
+    REQUIRE(executor.state().real_data()[2] == 0.0);
+    REQUIRE(executor.state().real_data()[3] == 0.0);
+}
+
 TEST_CASE("Sampling executor applies computational instrument destinations in line") {
     clifft::InstrumentTraceOptions options;
     clifft::InstrumentProbabilities reset;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -861,6 +861,24 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
     REQUIRE(executor.state().real_data()[3] == 0.0);
 }
 
+TEST_CASE("Sampling executable rejects unrecognized instrument modes") {
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.num_instrument_sites = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
+    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
+    plan.actions = {
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{InstrumentSiteId{0},
+                            static_cast<InstrumentMode>(std::numeric_limits<uint8_t>::max()),
+                            ActivePauli{}, AffineBool{}, SymbolId{0}}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
+    };
+
+    REQUIRE_THROWS_AS(ExecutablePlan(plan), std::logic_error);
+}
+
 TEST_CASE("Sampling executor applies computational instrument destinations in line") {
     clifft::InstrumentTraceOptions options;
     clifft::InstrumentProbabilities reset;


### PR DESCRIPTION
## Summary

- lower planned instrument modes into five concrete prepared execution forms
- retain one outer `ExecuteInstrument` action so the common action visitor does not grow
- remove hot mode and optional-field checks while preserving classical, dormant-trap, active, generic-activation, and new-X behavior
- add a generic activation regression test alongside the existing new-X structural coverage

Closes #318. Follows discussion #298 and tracker #247.

## History

This PR was developed as the direct child of #316. It is now rebased onto that PR's squash merge on `main`, and its diff contains one focused commit.

## Design

The first prototype put all five forms in the global action variant. Clean measurement showed that broadening the global visitor affected unrelated ordinary dispatch. The final design instead nests the concrete forms behind the existing instrument alternative. That keeps the global visitor vocabulary unchanged while still making instrument execution type-directed.

The dormant form remains the first nested alternative because GCC queries nested variant default constructibility before `ExecutablePlan` is complete.

On GCC 13 with libstdc++, the largest concrete descriptor is 88 bytes, the nested instrument variant is 96 bytes, and the global action shrinks from 112 to 104 bytes.

## Measurement

Same x86-64-v2 Release build, pinned AMD EPYC 9554P:

- generated repetition-code d17 r5, low-leakage noncomputational model, 1000 shots: median 0.428851 s -> 0.417111 s, 2.74% faster
- target-QEC ordinary survivor sampling, 2,000,000 shots: 12,174,163,579 -> 12,174,162,920 instructions and 1,914,439,953 -> 1,914,439,717 branches
- coherent d3 r3 ordinary survivor sampling, 300,000 shots: 11,374,793,240 -> 11,374,791,794 instructions and 870,360,723 -> 870,360,712 branches
- full record/detector/observable/status/herald hash over 2000 noncomputational shots with seed 281: identical (`10590764395167317276`)

The richer typed lowering has a small compile tradeoff on narrow plans: isolated prepare medians rose about 4-5% on target-QEC and cultivation d5, corresponding to about 5 us and 100 us respectively, or roughly 2% end-to-end. QV-20 prepare and total time remained neutral within the alternating-run noise.

## Validation

- `clifft_tests ~[bench]`: 1,280 cases, 575,601 assertions
- same full non-benchmark suite under forced scalar, AVX2, and AVX-512 dispatch
- GCC 13 and Clang 18 no-runtime-dispatch compilation of the changed production translation units
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
