### PR TITLE
refactor(sampling): clarify symbolic backend contracts

### DIFF
--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -987,8 +987,9 @@ NonComputationalSample run_sampling_trajectory_driver(const Circuit& circuit,
         }
 
         // Executor borrows its current plan. Pointer-own each replacement so
-        // its address remains stable from resume() until the next continuation
-        // has taken over or return_to_root_plan() releases the final borrow.
+        // its address remains stable. resume() must install next->program before
+        // moving next into this slot destroys the previously borrowed plan;
+        // return_to_root_plan() releases the final borrow.
         std::unique_ptr<SamplingCompiledContinuation> shot_continuation;
         std::optional<sampling::Executor> shot_executor;
         sampling::Executor* executor = nullptr;

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -986,6 +986,9 @@ NonComputationalSample run_sampling_trajectory_driver(const Circuit& circuit,
             continuation = &*all_ground_start;
         }
 
+        // Executor borrows its current plan. Pointer-own each replacement so
+        // its address remains stable from resume() until the next continuation
+        // has taken over or return_to_root_plan() releases the final borrow.
         std::unique_ptr<SamplingCompiledContinuation> shot_continuation;
         std::optional<sampling::Executor> shot_executor;
         sampling::Executor* executor = nullptr;

--- a/src/clifft/sampling/active_measurement_dispatch.cc
+++ b/src/clifft/sampling/active_measurement_dispatch.cc
@@ -1,7 +1,7 @@
 #include "clifft/sampling/active_measurement_dispatch.h"
 
 #include "clifft/sampling/active_measurement_simd.h"
-#include "clifft/sampling/direct_rotation_simd.h"
+#include "clifft/sampling/simd_width.h"
 #include "clifft/util/runtime_isa.h"
 
 #include <cassert>

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -1,6 +1,7 @@
 #include "clifft/sampling/direct_rotation_dispatch.h"
 
 #include "clifft/sampling/direct_rotation_simd.h"
+#include "clifft/sampling/simd_width.h"
 #include "clifft/util/runtime_isa.h"
 
 #include <cassert>

--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -11,14 +11,14 @@ namespace {
 
 constexpr uint32_t kMinAvx2ActiveWidth = 2;
 constexpr uint32_t kMinAvx512ActiveWidth = 3;
-constexpr uint64_t kNoExcludedPairSelector = 0;
-constexpr uint64_t kPivotFourSelector = uint64_t{1} << 4;
+constexpr uint64_t kNoExcludedPairingBit = 0;
+constexpr uint64_t kPivotFourPairingBit = uint64_t{1} << 4;
 static_assert(uint64_t{1} << kMinAvx2ActiveWidth == kAvx2DoubleLanes);
 static_assert(uint64_t{1} << kMinAvx512ActiveWidth == kAvx512DoubleLanes);
 
 DirectRotationKernel select_direct_rotation(const PreparedRotation& rotation, uint64_t vector_lanes,
                                             uint32_t min_active_width,
-                                            uint64_t excluded_pair_selector) noexcept {
+                                            uint64_t excluded_pairing_bit) noexcept {
     if (rotation.pauli.is_identity()) {
         return DirectRotationKernel::Scalar;
     }
@@ -26,12 +26,12 @@ DirectRotationKernel select_direct_rotation(const PreparedRotation& rotation, ui
         return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::Diagonal
                                                                : DirectRotationKernel::Scalar;
     }
-    const uint64_t pairing_bit = rotation.pauli.pair_selector;
+    const uint64_t pairing_bit = rotation.pauli.pairing_bit;
     if (pairing_bit < vector_lanes) {
         return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::LanePaired
                                                                : DirectRotationKernel::Scalar;
     }
-    if (pairing_bit == excluded_pair_selector) {
+    if (pairing_bit == excluded_pairing_bit) {
         return DirectRotationKernel::Scalar;
     }
     return DirectRotationKernel::HighPivot;
@@ -41,14 +41,14 @@ DirectRotationKernel select_direct_rotation_avx2(const PreparedRotation& rotatio
     // Stride-16 pairing was neutral or faster than scalar across the measured
     // AVX2 active widths, so every high pivot uses the vector kernel.
     return select_direct_rotation(rotation, kAvx2DoubleLanes, kMinAvx2ActiveWidth,
-                                  kNoExcludedPairSelector);
+                                  kNoExcludedPairingBit);
 }
 
 DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotation) noexcept {
     // Stride-16 pairing regressed against scalar at every measured active
     // width on the AVX-512 performance host.
     return select_direct_rotation(rotation, kAvx512DoubleLanes, kMinAvx512ActiveWidth,
-                                  kPivotFourSelector);
+                                  kPivotFourPairingBit);
 }
 
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)

--- a/src/clifft/sampling/direct_rotation_simd.h
+++ b/src/clifft/sampling/direct_rotation_simd.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "clifft/sampling/direct_rotation_dispatch.h"
-#include "clifft/sampling/simd_width.h"
 
 namespace clifft::sampling {
 

--- a/src/clifft/sampling/direct_rotation_simd.h
+++ b/src/clifft/sampling/direct_rotation_simd.h
@@ -1,18 +1,9 @@
 #pragma once
 
 #include "clifft/sampling/direct_rotation_dispatch.h"
-
-#include <cstdint>
+#include "clifft/sampling/simd_width.h"
 
 namespace clifft::sampling {
-
-// Lane count of one 256-bit double vector. The portable selector uses this
-// value without exposing vector types outside the AVX2 translation unit.
-inline constexpr uint64_t kAvx2DoubleLanes = 4;
-
-// Lane count of one 512-bit double vector. Both the portable kernel selector
-// and the AVX-512 translation unit measure shape eligibility against it.
-inline constexpr uint64_t kAvx512DoubleLanes = 8;
 
 // These functions are linked only on x86-64 runtime-dispatch builds and must
 // be called only after the dispatcher has selected their corresponding ISA.

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -19,6 +19,9 @@ namespace {
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
 
+// Moving these small lowering helpers out of the constructor stopped non-LTO
+// Release builds from inlining them and measurably regressed small-plan
+// preparation, so preserve that previously implicit optimization here.
 #if defined(_MSC_VER)
 #define CLIFFT_BUILDER_FORCE_INLINE __forceinline
 #elif defined(__GNUC__) || defined(__clang__)

--- a/src/clifft/sampling/fused_rotation.cc
+++ b/src/clifft/sampling/fused_rotation.cc
@@ -1,8 +1,8 @@
 #include "clifft/sampling/fused_rotation.h"
 
-#include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/kernels.h"
+#include "clifft/sampling/simd_width.h"
 
 #include <algorithm>
 #include <array>

--- a/src/clifft/sampling/instrument_activation_dispatch.cc
+++ b/src/clifft/sampling/instrument_activation_dispatch.cc
@@ -1,7 +1,7 @@
 #include "clifft/sampling/instrument_activation_dispatch.h"
 
-#include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/instrument_activation_simd.h"
+#include "clifft/sampling/simd_width.h"
 #include "clifft/util/runtime_isa.h"
 
 #include <cassert>

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -41,7 +41,7 @@ void apply_nondiagonal_rotation(State& state, const PreparedRotation& rotation,
     double* const real = state.real_data();
     double* const imag = state.imag_data();
     const uint64_t size = state.size();
-    const uint64_t pair_stride = rotation.pauli.pair_selector;
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
     const uint64_t pair_period = pair_stride << 1;
     const double base_phase =
         RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
@@ -115,7 +115,7 @@ PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width) {
     return PreparedPauli{.active_width = active_width,
                          .x = pauli.x,
                          .z = pauli.z,
-                         .pair_selector = std::bit_floor(pauli.x),
+                         .pairing_bit = std::bit_floor(pauli.x),
                          .even_phase = kIPowers[overlap & 3U]};
 }
 
@@ -361,7 +361,7 @@ void apply_instrument_no_fire(State& state, const PreparedPauli& source, double 
     const double identity_factor = 0.5 * (factor_zero + factor_one);
     const double pauli_factor = 0.5 * (factor_zero - factor_one);
     for (uint64_t left = 0; left < size; ++left) {
-        if ((left & source.pair_selector) != 0) {
+        if ((left & source.pairing_bit) != 0) {
             continue;
         }
         const uint64_t right = left ^ source.x;
@@ -403,7 +403,7 @@ void collapse_instrument_source(State& state, const PreparedPauli& source, bool 
     const double eigenvalue = branch ? -1.0 : 1.0;
     const double scale = 0.5 * inv_norm;
     for (uint64_t left = 0; left < size; ++left) {
-        if ((left & source.pair_selector) != 0) {
+        if ((left & source.pairing_bit) != 0) {
             continue;
         }
         const uint64_t right = left ^ source.x;

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -15,6 +15,8 @@ struct PreparedPauli {
     uint32_t active_width = 0;
     uint64_t x = 0;
     uint64_t z = 0;
+    // Highest set X bit. It selects the pair stride and half-space for a
+    // non-diagonal Pauli, and is zero only when the Pauli is diagonal.
     uint64_t pairing_bit = 0;
     std::complex<double> even_phase = {1.0, 0.0};
 

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -15,7 +15,7 @@ struct PreparedPauli {
     uint32_t active_width = 0;
     uint64_t x = 0;
     uint64_t z = 0;
-    uint64_t pair_selector = 0;
+    uint64_t pairing_bit = 0;
     std::complex<double> even_phase = {1.0, 0.0};
 
     [[nodiscard]] bool is_identity() const { return x == 0 && z == 0; }

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -124,7 +124,7 @@ void apply_diagonal_rotation_avx2(State& state, const PreparedRotation& rotation
 template <bool RealPhase>
 void apply_lane_paired_rotation_avx2(State& state, const PreparedRotation& rotation,
                                      double sine) noexcept {
-    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector < kLanes &&
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit < kLanes &&
            rotation.pauli.active_width >= 2 &&
            "AVX2 lane-paired rotation requires at least one vector block");
     double* const real = state.real_data();
@@ -166,11 +166,11 @@ void apply_lane_paired_rotation_avx2(State& state, const PreparedRotation& rotat
 template <bool RealPhase>
 void apply_nondiagonal_rotation_avx2(State& state, const PreparedRotation& rotation,
                                      double sine) noexcept {
-    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector >= kLanes &&
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit >= kLanes &&
            "AVX2 non-diagonal rotation requires a high pairing pivot");
     double* const real = state.real_data();
     double* const imag = state.imag_data();
-    const uint64_t pair_stride = rotation.pauli.pair_selector;
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
     const uint64_t pair_period = pair_stride << 1;
     const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
     const __m256i permutation =

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -6,6 +6,7 @@
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/instrument_activation_simd.h"
+#include "clifft/sampling/simd_width.h"
 #include "clifft/util/numeric.h"
 
 #include <array>

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -122,7 +122,7 @@ void apply_diagonal_rotation_avx512(State& state, const PreparedRotation& rotati
 template <bool RealPhase>
 void apply_lane_paired_rotation_avx512(State& state, const PreparedRotation& rotation,
                                        double sine) noexcept {
-    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector < kLanes &&
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit < kLanes &&
            rotation.pauli.active_width >= 3 &&
            "AVX-512 lane-paired rotation requires one vector block");
     double* const real = state.real_data();
@@ -166,11 +166,11 @@ void apply_lane_paired_rotation_avx512(State& state, const PreparedRotation& rot
 template <bool RealPhase>
 void apply_nondiagonal_rotation_avx512(State& state, const PreparedRotation& rotation,
                                        double sine) noexcept {
-    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pair_selector >= kLanes &&
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit >= kLanes &&
            "AVX-512 non-diagonal rotation requires a high pairing pivot");
     double* const real = state.real_data();
     double* const imag = state.imag_data();
-    const uint64_t pair_stride = rotation.pauli.pair_selector;
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
     const uint64_t pair_period = pair_stride << 1;
     const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
     const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -5,6 +5,7 @@
 #include "clifft/sampling/direct_rotation_simd.h"
 #include "clifft/sampling/fused_rotation_simd.h"
 #include "clifft/sampling/indexing.h"
+#include "clifft/sampling/simd_width.h"
 #include "clifft/util/numeric.h"
 
 #include <array>

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -113,6 +113,30 @@ std::string_view instrument_mode_name(InstrumentMode mode) {
     return "unknown";
 }
 
+constexpr bool is_recognized_symbol_kind(SymbolKind kind) {
+    switch (kind) {
+        case SymbolKind::Unused:
+        case SymbolKind::Presampled:
+        case SymbolKind::Derived:
+        case SymbolKind::Branch:
+        case SymbolKind::Readout:
+        case SymbolKind::Instrument:
+            return true;
+    }
+    return false;
+}
+
+constexpr bool is_recognized_instrument_mode(InstrumentMode mode) {
+    switch (mode) {
+        case InstrumentMode::Classical:
+        case InstrumentMode::Active:
+        case InstrumentMode::Activate:
+        case InstrumentMode::DormantTrap:
+            return true;
+    }
+    return false;
+}
+
 std::string format_mask(uint64_t mask) {
     std::ostringstream out;
     out << "0x" << std::hex << std::setw(16) << std::setfill('0') << mask;
@@ -490,6 +514,9 @@ void SamplingPlan::validate() const {
 
     for (uint32_t symbol_index = 0; symbol_index < symbols.size(); ++symbol_index) {
         const SymbolInfo& info = symbols[symbol_index];
+        if (!is_recognized_symbol_kind(info.kind)) {
+            invalid_plan("symbol s" + std::to_string(symbol_index) + " has an unrecognized kind");
+        }
         if (info.noise_site.has_value() &&
             (info.kind != SymbolKind::Presampled || index(*info.noise_site) >= num_noise_sites)) {
             invalid_plan("symbol s" + std::to_string(symbol_index) +
@@ -671,6 +698,9 @@ void SamplingPlan::validate() const {
                         invalid_plan("instrument action has an invalid or out-of-order site id");
                     }
                     const bool width_unchanged = planned.active_after == planned.active_before;
+                    if (!is_recognized_instrument_mode(typed.mode)) {
+                        invalid_plan("instrument action has an unrecognized mode");
+                    }
                     switch (typed.mode) {
                         case InstrumentMode::Classical:
                             if (!width_unchanged || !typed.source.is_identity()) {

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -10,7 +10,7 @@
 // device lowering belong to execution-specific layers, which should lower it
 // to packed, preallocated storage before entering per-shot hot loops.
 //
-// An active coordinate is represented explicitly in the dense coefficient
+// An active coordinate is represented explicitly in the dense 2^k coefficient
 // state. A dormant coordinate remains stabilizer-only until an operation makes
 // it active. Affine symbols are per-shot Boolean values that carry stochastic
 // dependencies without expanding the coefficient state.

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -10,6 +10,11 @@
 // device lowering belong to execution-specific layers, which should lower it
 // to packed, preallocated storage before entering per-shot hot loops.
 //
+// An active coordinate is represented explicitly in the dense coefficient
+// state. A dormant coordinate remains stabilizer-only until an operation makes
+// it active. Affine symbols are per-shot Boolean values that carry stochastic
+// dependencies without expanding the coefficient state.
+//
 // The symbolic-expression and stabilizer-coordinate split is informed by:
 // SymFT: Universal Fault-Tolerant Quantum Circuit Simulation via Symbolic
 // Clifford--Pauli Frames and Stabilizer Coordinates, arXiv:2607.28600.

--- a/src/clifft/sampling/simd_width.h
+++ b/src/clifft/sampling/simd_width.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace clifft::sampling {
+
+// Architecture-neutral lane counts used to select SIMD kernels without
+// exposing vector types outside their ISA-specific translation units.
+inline constexpr uint64_t kAvx2DoubleLanes = 4;
+inline constexpr uint64_t kAvx512DoubleLanes = 8;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/simd_width.h
+++ b/src/clifft/sampling/simd_width.h
@@ -4,9 +4,12 @@
 
 namespace clifft::sampling {
 
-// Architecture-neutral lane counts used to select SIMD kernels without
-// exposing vector types outside their ISA-specific translation units.
+// Number of double lanes in one 256-bit vector. Portable selectors use this
+// value without exposing vector types outside ISA-specific translation units.
 inline constexpr uint64_t kAvx2DoubleLanes = 4;
+
+// Number of double lanes in one 512-bit vector. Portable selectors use this
+// value without exposing vector types outside ISA-specific translation units.
 inline constexpr uint64_t kAvx512DoubleLanes = 8;
 
 }  // namespace clifft::sampling

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -964,7 +964,7 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("expected_detectors") = std::vector<uint8_t>{},
         nb::arg("expected_observables") = std::vector<uint8_t>{},
         nb::arg("normalize_syndromes") = false, nb::arg("hir_passes") = nb::none(),
-        "Compile a circuit into the experimental scalar sampling backend.");
+        "Compile a circuit into the experimental symbolic-coordinate sampling backend.");
 
     m.def(
         "_sample_experimental_sampling",
@@ -986,7 +986,7 @@ NB_MODULE(_clifft_core, m) {
             return nb::make_tuple(measurements, detectors, observables, exp_vals);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
-        "Sample an experimental scalar sampling program.");
+        "Sample an experimental symbolic-coordinate sampling program.");
 
     m.def(
         "_sample_survivors_experimental_sampling",
@@ -1084,7 +1084,7 @@ NB_MODULE(_clifft_core, m) {
             return vec_to_numpy(std::move(probabilities), {size});
         },
         nb::arg("program"), nb::arg("basis_masks"),
-        "Return experimental scalar sampling computational-basis probabilities.");
+        "Return experimental symbolic-coordinate computational-basis probabilities.");
 
     m.def(
         "_get_statevector_experimental_sampling",
@@ -1115,7 +1115,7 @@ NB_MODULE(_clifft_core, m) {
             return vec_to_numpy(std::move(log_probabilities), {size});
         },
         nb::arg("program"), nb::arg("records"),
-        "Return experimental scalar sampling record log probabilities.");
+        "Return experimental symbolic-coordinate record log probabilities.");
 
     m.def(
         "lower",

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1015,7 +1015,8 @@ NB_MODULE(_clifft_core, m) {
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false,
-        "Sample survivor counts and optional records from an experimental program.");
+        "Sample survivor counts and optional records from an experimental "
+        "symbolic-coordinate program.");
 
     m.def(
         "_sample_k_experimental_sampling",
@@ -1037,7 +1038,7 @@ NB_MODULE(_clifft_core, m) {
             return nb::make_tuple(measurements, detectors, observables, exp_vals);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
-        "Sample an experimental program with exactly k forced fault sites.");
+        "Sample an experimental symbolic-coordinate program with exactly k forced fault sites.");
 
     m.def(
         "_sample_k_survivors_experimental_sampling",
@@ -1067,7 +1068,8 @@ NB_MODULE(_clifft_core, m) {
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false,
-        "Sample experimental survivors with exactly k forced fault sites.");
+        "Sample survivors from an experimental symbolic-coordinate program with exactly k "
+        "forced fault sites.");
 
     m.def(
         "_basis_probabilities_experimental_sampling",
@@ -1098,7 +1100,7 @@ NB_MODULE(_clifft_core, m) {
             return vec_to_numpy(std::move(statevector), {size});
         },
         nb::arg("program"),
-        "Expand an experimental pure-state sampling program into a dense statevector.");
+        "Expand an experimental symbolic-coordinate program into a dense statevector.");
 
     m.def(
         "_record_probabilities_experimental_sampling",

--- a/src/python/clifft/experimental.py
+++ b/src/python/clifft/experimental.py
@@ -54,7 +54,7 @@ def compile(
     normalize_syndromes: bool = False,
     hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
 ) -> Program:
-    """Compile Stim text for the experimental scalar sampling backend.
+    """Compile Stim text for the experimental symbolic-coordinate sampling backend.
 
     The default HIR optimization pipeline matches :func:`clifft.compile`;
     pass ``None`` to skip it.

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -23,6 +23,7 @@
 #include <numbers>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -859,6 +860,24 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
     REQUIRE(executor.state().real_data()[1] == 0.0);
     REQUIRE(executor.state().real_data()[2] == 0.0);
     REQUIRE(executor.state().real_data()[3] == 0.0);
+}
+
+TEST_CASE("Sampling executable validates its source plan before lowering") {
+    SamplingPlan plan;
+    plan.num_qubits = 1;
+    plan.num_instrument_sites = 1;
+    plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
+    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
+    plan.actions = {
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{InstrumentSiteId{0},
+                            static_cast<InstrumentMode>(std::numeric_limits<uint8_t>::max()),
+                            ActivePauli{}, AffineBool{}, SymbolId{0}}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
+    };
+
+    REQUIRE_THROWS_AS(ExecutablePlan(plan), std::invalid_argument);
 }
 
 TEST_CASE("Sampling executor applies computational instrument destinations in line") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -861,24 +861,6 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
     REQUIRE(executor.state().real_data()[3] == 0.0);
 }
 
-TEST_CASE("Sampling executable rejects unrecognized instrument modes") {
-    SamplingPlan plan;
-    plan.num_qubits = 1;
-    plan.num_instrument_sites = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
-    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
-    plan.actions = {
-        PlannedAction{
-            0, 0,
-            ApplyInstrument{InstrumentSiteId{0},
-                            static_cast<InstrumentMode>(std::numeric_limits<uint8_t>::max()),
-                            ActivePauli{}, AffineBool{}, SymbolId{0}}},
-        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
-    };
-
-    REQUIRE_THROWS_AS(ExecutablePlan(plan), std::logic_error);
-}
-
 TEST_CASE("Sampling executor applies computational instrument destinations in line") {
     clifft::InstrumentTraceOptions options;
     clifft::InstrumentProbabilities reset;

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -816,7 +816,7 @@ TEST_CASE("Sampling kernels compose across collapse and promotion") {
 }
 
 TEST_CASE("Sampling kernel preparation precomputes non-diagonal pairing metadata") {
-    REQUIRE(prepare_rotation({0b101, 0}, 3, 0.25).pauli.pair_selector == 0b100);
+    REQUIRE(prepare_rotation({0b101, 0}, 3, 0.25).pauli.pairing_bit == 0b100);
 }
 
 TEST_CASE("Sampling kernel preparation rejects malformed inputs") {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -235,6 +235,12 @@ TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
         std::get<DefineSymbol>(plan.actions[2].action).value = AffineBool::symbol(SymbolId{2});
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
+
+    SECTION("symbol kind is unrecognized") {
+        SamplingPlan plan = valid_plan();
+        plan.symbols[2].kind = static_cast<SymbolKind>(std::numeric_limits<uint8_t>::max());
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
 }
 
 TEST_CASE("Sampling plan rejects Pauli bits above active width") {
@@ -393,6 +399,13 @@ TEST_CASE("Sampling plan rejects invalid dimensions and action contracts") {
     SECTION("instrument site is out of range") {
         SamplingPlan plan = valid_plan();
         std::get<InstrumentBoundary>(plan.actions[5].action).site = InstrumentSiteId{1};
+        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
+    }
+
+    SECTION("instrument mode is unrecognized") {
+        SamplingPlan plan = valid_plan();
+        std::get<ApplyInstrument>(plan.actions[4].action).mode =
+            static_cast<InstrumentMode>(std::numeric_limits<uint8_t>::max());
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 }


### PR DESCRIPTION
## Summary

- reject unrecognized symbol kinds and instrument modes at the SamplingPlan validation boundary
- clarify active, dormant, and affine terminology plus builder and continuation lifetime rationale
- describe the experimental API as the symbolic-coordinate backend
- centralize architecture-neutral SIMD lane widths
- rename PreparedPauli pair_selector to pairing_bit

No CI configuration changes are included.

## Performance

Compared exact main 73398fd with c398aa4 using separate GCC 13.3 Release builds with O3, fast-math, and native tuning. Measurements used three alternating baseline/branch blocks pinned to one CPU with one OpenMP thread.

| Compile workload | Plan | Prepare | Total |
| --- | ---: | ---: | ---: |
| target-QEC | -1.46% | -1.41% | -1.36% |
| cultivation d5 | -0.88% | -1.37% | -1.01% |
| QV-20 | +1.86% | +0.85% | +0.99% |

| Execution workload | Change |
| --- | ---: |
| target-QEC survivors, 5 million shots per sample | +0.11% |
| QV-20 raw, 15 shots per sample | -0.70% |

These changes are within run-to-run noise. Paired checksums matched. The scalar, AVX2, AVX-512, dispatch, executor, and executable-builder object files are byte-for-byte identical between revisions, confirming the metadata rename and header cleanup do not change execution code generation.

## Verification

- full non-benchmark C++ suite: 1,280 tests passed
- focused scalar kernel suite: 151,783 assertions in 25 cases passed
- focused AVX2 kernel suite: 201,879 assertions in 25 cases passed
- pre-commit run --all-files passed