### PR TITLE
refactor(sampling): plan directly from HIR

### DIFF
--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -147,6 +147,25 @@ struct PlanningRequirements {
     bool supports_final_state_queries = true;
 };
 
+bool operation_supports_final_state_queries(OpType type) {
+    switch (type) {
+        case OpType::T_GATE:
+        case OpType::PHASE_ROTATION:
+        case OpType::EXP_VAL:
+            return true;
+        case OpType::MEASURE:
+        case OpType::CONDITIONAL_PAULI:
+        case OpType::NOISE:
+        case OpType::READOUT_NOISE:
+        case OpType::INSTRUMENT:
+        case OpType::DETECTOR:
+        case OpType::OBSERVABLE:
+        case OpType::NUM_OP_TYPES:
+            return false;
+    }
+    return false;
+}
+
 PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
     PlanningRequirements result;
     auto add = [&](size_t amount) {
@@ -158,15 +177,14 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
 
     for (size_t i = 0; i < hir.ops.size(); ++i) {
         const HeisenbergOp& op = hir.ops[i];
+        result.supports_final_state_queries &= operation_supports_final_state_queries(op.op_type());
         switch (op.op_type()) {
             case OpType::MEASURE:
             case OpType::READOUT_NOISE:
             case OpType::INSTRUMENT:
-                result.supports_final_state_queries = false;
                 add(1);
                 break;
             case OpType::NOISE: {
-                result.supports_final_state_queries = false;
                 const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
                 if (site_index >= hir.noise_sites.size()) {
                     throw std::invalid_argument("sampling planner noise site is out of range");
@@ -184,7 +202,6 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
             case OpType::CONDITIONAL_PAULI:
             case OpType::DETECTOR:
             case OpType::OBSERVABLE:
-                result.supports_final_state_queries = false;
                 break;
             case OpType::NUM_OP_TYPES:
                 throw std::invalid_argument("sampling planner does not support HIR operation " +
@@ -307,14 +324,18 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
     return outcome;
 }
 
-void process_instrument(const Pauli& body, const Pauli& destination_flip,
-                        const AffineBool& initial_sign, InstrumentSiteId site,
-                        SymbolId destination_flip_symbol, uint32_t next_noise_site,
-                        uint32_t symbol_prefix_size, bool neglect_damping, SamplingPlan& plan,
-                        uint32_t& active_width, CoordinateFrame& coordinates,
+void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t next_noise_site,
+                        SamplingPlan& plan, uint32_t& active_width, CoordinateFrame& coordinates,
                         SymbolicPauliFrame& symbolic_frame) {
+    const InstrumentSiteId site{static_cast<uint32_t>(op.instrument_site_idx())};
+    const InstrumentSite& hir_site = hir.instrument_sites.at(index(site));
+    const SymbolId destination_flip_symbol = reserve_symbol(plan);
+    const uint32_t symbol_prefix_size = static_cast<uint32_t>(plan.symbols.size());
+    const Pauli body = pauli_from_hir(hir, op);
+    const Pauli destination_flip = pauli_from_mask(hir, hir_site.destination_flip_mask);
     const InstrumentDistribution& distribution = plan.instrument_distributions.at(index(site));
-    ResolvedPauli resolved = resolve_pauli(body, initial_sign, coordinates, symbolic_frame);
+    ResolvedPauli resolved =
+        resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
 
     InstrumentMode mode = InstrumentMode::Classical;
@@ -325,7 +346,7 @@ void process_instrument(const Pauli& body, const Pauli& destination_flip,
     if (dormant_pivot.has_value()) {
         // Equal no-fire factors normalize away. Otherwise exact damping needs
         // the dormant-coherent source represented in the dense state.
-        if (neglect_damping || distribution.p_fire[0] == distribution.p_fire[1]) {
+        if (hir.neglect_instrument_damping || distribution.p_fire[0] == distribution.p_fire[1]) {
             mode = InstrumentMode::DormantTrap;
             sign = AffineBool{};
         } else {
@@ -431,8 +452,10 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     uint32_t detector_index = 0;
     uint32_t next_noise_site = 0;
     uint32_t next_instrument_site = 0;
+    bool supports_final_state_queries = true;
     for (size_t i = 0; i < hir.ops.size(); ++i) {
         const HeisenbergOp& op = hir.ops[i];
+        supports_final_state_queries &= operation_supports_final_state_queries(op.op_type());
         switch (op.op_type()) {
             case OpType::T_GATE: {
                 const double half_turns = op.is_dagger() ? -0.25 : 0.25;
@@ -484,9 +507,9 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     if (channel.prob == 0.0) {
                         continue;
                     }
-                    const SymbolId symbol = reserve_symbol(plan);
-                    plan.symbols[index(symbol)] =
-                        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{site_index}};
+                    const SymbolId symbol{static_cast<uint32_t>(plan.symbols.size())};
+                    plan.symbols.push_back(
+                        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{site_index}});
                     plan_site.outcomes.push_back(PresampledNoiseOutcome{symbol, channel.prob});
                     const Pauli body = noise_pauli_from_hir(hir, channel.mask);
                     symbolic_frame.apply(body, AffineBool::symbol(symbol));
@@ -526,14 +549,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     throw std::invalid_argument(
                         "sampling planner instrument omits its destination flip");
                 }
-                const SymbolId destination_flip_symbol = reserve_symbol(plan);
-                const uint32_t symbol_prefix_size = static_cast<uint32_t>(plan.symbols.size());
-                const Pauli body = pauli_from_hir(hir, op);
-                const Pauli destination_flip = pauli_from_mask(hir, site.destination_flip_mask);
-                process_instrument(body, destination_flip, AffineBool(hir.sign(op)),
-                                   InstrumentSiteId{site_index}, destination_flip_symbol,
-                                   next_noise_site, symbol_prefix_size,
-                                   hir.neglect_instrument_damping, plan, active_width, coordinates,
+                process_instrument(hir, op, next_noise_site, plan, active_width, coordinates,
                                    symbolic_frame);
                 ++next_instrument_site;
                 break;
@@ -593,6 +609,9 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
 
     if (plan.symbols.size() != requirements.symbol_count) {
         throw std::logic_error("sampling planner symbol prepass disagrees with HIR lowering");
+    }
+    if (supports_final_state_queries != requirements.supports_final_state_queries) {
+        throw std::logic_error("sampling planner final-state prepass disagrees with HIR lowering");
     }
     if (detector_index != hir.num_detectors) {
         throw std::invalid_argument("sampling planner detector count is inconsistent with HIR");

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -17,9 +17,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 #include <utility>
-#include <variant>
 #include <vector>
 
 namespace clifft::sampling {
@@ -32,9 +30,6 @@ using internal::CoordinateFrame;
 using internal::dormant_promotion_frame;
 using internal::SymbolicPauliFrame;
 
-template <typename>
-inline constexpr bool kAlwaysFalse = false;
-
 void compose_final_tableau(SamplingPlan& plan, const Tableau& new_basis_in_old_coordinates) {
     if (plan.final_tableau.has_value()) {
         // A.then(B) represents B * A. The frame maps new coordinates into
@@ -42,80 +37,6 @@ void compose_final_tableau(SamplingPlan& plan, const Tableau& new_basis_in_old_c
         plan.final_tableau = new_basis_in_old_coordinates.then(*plan.final_tableau);
     }
 }
-
-struct PendingRotation {
-    Pauli body;
-    double half_turns = 0.0;
-    AffineBool sign;
-};
-
-struct PendingMeasurement {
-    Pauli body;
-    AffineBool sign;
-    RecordSlot record{};
-    SymbolId branch{};
-};
-
-struct PendingExpectation {
-    Pauli body;
-    AffineBool sign;
-    ExpValSlot exp_val{};
-};
-
-struct PendingConditionalPauli {
-    Pauli body;
-    RecordSlot controller{};
-};
-
-struct PendingNoiseChannel {
-    Pauli body;
-    SymbolId symbol{};
-};
-
-struct PendingNoise {
-    std::vector<PendingNoiseChannel> channels;
-};
-
-struct PendingReadoutNoise {
-    RecordSlot record{};
-    double prob_zero_to_one = 0.0;
-    double prob_one_to_zero = 0.0;
-    SymbolId flip{};
-};
-
-struct PendingInstrument {
-    // Source observable and computational destination correction stay in the
-    // initial HIR coordinates used by the cumulative symbolic Pauli frame.
-    Pauli body;
-    Pauli destination_flip;
-    // Maps the source observable's eigenspaces to physical G and E; earlier
-    // stochastic outcomes can make this mapping symbolic.
-    AffineBool sign;
-    // Indexes both the plan-owned distribution and its continuation boundary.
-    InstrumentSiteId site{};
-    // Reserved in HIR order so coordinate evolution cannot renumber the prefix.
-    SymbolId destination_flip_symbol{};
-    // Continuations retain only noise and symbols preceding this HIR site.
-    uint32_t next_noise_site = 0;
-    uint32_t symbol_prefix_size = 0;
-    bool neglect_damping = false;
-};
-
-struct PendingDetector {
-    std::vector<RecordSlot> records;
-    DetectorSlot detector{};
-    bool expected = false;
-    bool postselected = false;
-};
-
-struct PendingObservable {
-    std::vector<RecordSlot> records;
-    ObservableSlot observable{};
-};
-
-using PendingOperation = std::variant<PendingRotation, PendingMeasurement, PendingExpectation,
-                                      PendingConditionalPauli, PendingNoise, PendingReadoutNoise,
-                                      PendingInstrument, PendingDetector, PendingObservable>;
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
@@ -217,30 +138,70 @@ void multiply_phase(std::complex<double>& weight, double angle) {
     weight *= std::complex<double>(std::cos(angle), std::sin(angle));
 }
 
-std::vector<RecordSlot> record_slots(const std::vector<uint32_t>& records) {
-    std::vector<RecordSlot> result;
-    result.reserve(records.size());
-    for (uint32_t record : records) {
-        result.push_back(RecordSlot{record});
-    }
-    return result;
-}
-
 bool option_bit(std::span<const uint8_t> values, uint32_t index) {
     return index < values.size() && values[index] != 0;
 }
 
-std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, SamplingPlan& plan,
-                                                         SamplingPlanOptions options) {
-    std::vector<PendingOperation> pending;
-    pending.reserve(hir.ops.size());
+struct PlanningRequirements {
+    uint32_t symbol_count = 0;
+    bool supports_final_state_queries = true;
+};
+
+PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
+    PlanningRequirements result;
+    auto add = [&](size_t amount) {
+        if (amount > std::numeric_limits<uint32_t>::max() - result.symbol_count) {
+            throw std::length_error("sampling planner symbol count exceeds uint32 range");
+        }
+        result.symbol_count += static_cast<uint32_t>(amount);
+    };
+
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        const HeisenbergOp& op = hir.ops[i];
+        switch (op.op_type()) {
+            case OpType::MEASURE:
+            case OpType::READOUT_NOISE:
+            case OpType::INSTRUMENT:
+                result.supports_final_state_queries = false;
+                add(1);
+                break;
+            case OpType::NOISE: {
+                result.supports_final_state_queries = false;
+                const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
+                if (site_index >= hir.noise_sites.size()) {
+                    throw std::invalid_argument("sampling planner noise site is out of range");
+                }
+                const NoiseSite& site = hir.noise_sites[site_index];
+                add(std::ranges::count_if(site.channels, [](const NoiseChannel& channel) {
+                    return channel.prob != 0.0;
+                }));
+                break;
+            }
+            case OpType::T_GATE:
+            case OpType::PHASE_ROTATION:
+            case OpType::EXP_VAL:
+                break;
+            case OpType::CONDITIONAL_PAULI:
+            case OpType::DETECTOR:
+            case OpType::OBSERVABLE:
+                result.supports_final_state_queries = false;
+                break;
+            case OpType::NUM_OP_TYPES:
+                throw std::invalid_argument("sampling planner does not support HIR operation " +
+                                            op_type_to_str(op.op_type()) + " at index " +
+                                            std::to_string(i));
+        }
+    }
+    return result;
+}
+
+void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
     plan.presampled_noise_sites.resize(hir.noise_sites.size());
     for (uint32_t site = 0; site < hir.noise_sites.size(); ++site) {
         plan.presampled_noise_sites[site].site = NoiseSiteId{site};
         plan.presampled_noise_sites[site].total_probability =
             hir.noise_sites[site].total_probability;
     }
-    std::vector<bool> seen_noise_sites(hir.noise_sites.size(), false);
     plan.instrument_distributions.reserve(hir.instrument_sites.size());
     for (uint32_t site = 0; site < hir.instrument_sites.size(); ++site) {
         const InstrumentProbabilities& probabilities = hir.instrument_sites[site].probabilities;
@@ -255,179 +216,18 @@ std::vector<PendingOperation> queue_supported_operations(const HirModule& hir, S
         }
         plan.instrument_distributions.push_back(distribution);
     }
-
-    uint32_t detector_index = 0;
-    uint32_t next_noise_site = 0;
-    uint32_t next_instrument_site = 0;
-    bool final_state_queries_supported = true;
-
-    for (size_t i = 0; i < hir.ops.size(); ++i) {
-        const HeisenbergOp& op = hir.ops[i];
-        switch (op.op_type()) {
-            case OpType::T_GATE: {
-                const double half_turns = op.is_dagger() ? -0.25 : 0.25;
-                pending.emplace_back(
-                    PendingRotation{pauli_from_hir(hir, op), half_turns, AffineBool(hir.sign(op))});
-                multiply_phase(plan.global_weight,
-                               (op.is_dagger() ? -1.0 : 1.0) * std::numbers::pi / 8.0);
-                break;
-            }
-            case OpType::PHASE_ROTATION: {
-                pending.emplace_back(
-                    PendingRotation{pauli_from_hir(hir, op), op.alpha(), AffineBool(hir.sign(op))});
-                const double signed_alpha = hir.sign(op) ? -op.alpha() : op.alpha();
-                multiply_phase(plan.global_weight, signed_alpha * std::numbers::pi / 2.0);
-                break;
-            }
-            case OpType::MEASURE:
-                final_state_queries_supported = false;
-                pending.emplace_back(PendingMeasurement{
-                    pauli_from_hir(hir, op), AffineBool(hir.sign(op)),
-                    RecordSlot{static_cast<uint32_t>(op.meas_record_idx())}, reserve_symbol(plan)});
-                break;
-            case OpType::CONDITIONAL_PAULI:
-                final_state_queries_supported = false;
-                pending.emplace_back(PendingConditionalPauli{
-                    pauli_from_hir(hir, op),
-                    RecordSlot{static_cast<uint32_t>(op.controlling_meas())}});
-                break;
-            case OpType::NOISE: {
-                final_state_queries_supported = false;
-                const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
-                if (site_index >= hir.noise_sites.size()) {
-                    throw std::invalid_argument("sampling planner noise site is out of range");
-                }
-                if (seen_noise_sites[site_index]) {
-                    throw std::invalid_argument(
-                        "sampling planner encountered a duplicate noise site");
-                }
-                if (site_index != next_noise_site) {
-                    throw std::invalid_argument(
-                        "sampling planner noise sites are not in circuit order");
-                }
-                ++next_noise_site;
-                seen_noise_sites[site_index] = true;
-                const NoiseSite& hir_site = hir.noise_sites[site_index];
-                PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];
-                PendingNoise noise;
-                noise.channels.reserve(hir_site.channels.size());
-                plan_site.outcomes.reserve(hir_site.channels.size());
-                for (const NoiseChannel& channel : hir_site.channels) {
-                    if (channel.prob == 0.0) {
-                        continue;
-                    }
-                    const SymbolId symbol{static_cast<uint32_t>(plan.symbols.size())};
-                    plan.symbols.push_back(
-                        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{site_index}});
-                    plan_site.outcomes.push_back(PresampledNoiseOutcome{symbol, channel.prob});
-                    noise.channels.push_back(
-                        PendingNoiseChannel{noise_pauli_from_hir(hir, channel.mask), symbol});
-                }
-                pending.emplace_back(std::move(noise));
-                break;
-            }
-            case OpType::READOUT_NOISE: {
-                final_state_queries_supported = false;
-                const uint32_t entry_index = static_cast<uint32_t>(op.readout_noise_idx());
-                if (entry_index >= hir.readout_noise.size()) {
-                    throw std::invalid_argument("sampling planner readout entry is out of range");
-                }
-                const ReadoutNoiseEntry& entry = hir.readout_noise[entry_index];
-                pending.emplace_back(
-                    PendingReadoutNoise{RecordSlot{entry.meas_idx}, entry.prob_zero_to_one,
-                                        entry.prob_one_to_zero, reserve_symbol(plan)});
-                break;
-            }
-            case OpType::INSTRUMENT: {
-                final_state_queries_supported = false;
-                const uint32_t site_index = static_cast<uint32_t>(op.instrument_site_idx());
-                if (site_index >= hir.instrument_sites.size() ||
-                    site_index != next_instrument_site) {
-                    throw std::invalid_argument(
-                        "sampling planner instrument site is out of range or circuit order");
-                }
-                const InstrumentSite& site = hir.instrument_sites[site_index];
-                if (site.destination_flip_mask == kNoMask) {
-                    throw std::invalid_argument(
-                        "sampling planner instrument omits its destination flip");
-                }
-                const SymbolId flip = reserve_symbol(plan);
-                pending.emplace_back(PendingInstrument{
-                    pauli_from_hir(hir, op), pauli_from_mask(hir, site.destination_flip_mask),
-                    AffineBool(hir.sign(op)), InstrumentSiteId{site_index}, flip, next_noise_site,
-                    static_cast<uint32_t>(plan.symbols.size()), hir.neglect_instrument_damping});
-                ++next_instrument_site;
-                break;
-            }
-            case OpType::DETECTOR: {
-                final_state_queries_supported = false;
-                const uint32_t targets_index = static_cast<uint32_t>(op.detector_idx());
-                if (targets_index >= hir.detector_targets.size() ||
-                    detector_index >= hir.num_detectors) {
-                    throw std::invalid_argument("sampling planner detector is out of range");
-                }
-                pending.emplace_back(PendingDetector{
-                    record_slots(hir.detector_targets[targets_index]), DetectorSlot{detector_index},
-                    option_bit(options.expected_detectors, detector_index),
-                    option_bit(options.postselection_mask, detector_index)});
-                ++detector_index;
-                break;
-            }
-            case OpType::OBSERVABLE: {
-                final_state_queries_supported = false;
-                const uint32_t targets_index = op.observable_target_list_idx();
-                const uint32_t observable_index = static_cast<uint32_t>(op.observable_idx());
-                if (targets_index >= hir.observable_targets.size() ||
-                    observable_index >= hir.num_observables) {
-                    throw std::invalid_argument("sampling planner observable is out of range");
-                }
-                pending.emplace_back(
-                    PendingObservable{record_slots(hir.observable_targets[targets_index]),
-                                      ObservableSlot{observable_index}});
-                break;
-            }
-            case OpType::EXP_VAL: {
-                const uint32_t exp_val_index = static_cast<uint32_t>(op.exp_val_idx());
-                if (exp_val_index >= hir.num_exp_vals) {
-                    throw std::invalid_argument(
-                        "sampling planner expectation slot is out of range");
-                }
-                pending.emplace_back(PendingExpectation{
-                    pauli_from_hir(hir, op), AffineBool(hir.sign(op)), ExpValSlot{exp_val_index}});
-                break;
-            }
-            case OpType::NUM_OP_TYPES:
-                throw std::invalid_argument("sampling planner does not support HIR operation " +
-                                            op_type_to_str(op.op_type()) + " at index " +
-                                            std::to_string(i));
-        }
-    }
-    if (detector_index != hir.num_detectors) {
-        throw std::invalid_argument("sampling planner detector count is inconsistent with HIR");
-    }
-    if (!std::ranges::all_of(seen_noise_sites, [](bool seen) { return seen; })) {
-        throw std::invalid_argument("sampling planner noise-site table is inconsistent with HIR");
-    }
-    if (next_instrument_site != hir.instrument_sites.size()) {
-        throw std::invalid_argument(
-            "sampling planner instrument-site table is inconsistent with HIR");
-    }
-    if (final_state_queries_supported) {
-        plan.final_tableau = hir.final_tableau;
-    }
-    return pending;
 }
 
-void process_rotation(const PendingRotation& rotation, SamplingPlan& plan, uint32_t& active_width,
-                      CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame) {
-    ResolvedPauli resolved =
-        resolve_pauli(rotation.body, rotation.sign, coordinates, symbolic_frame);
+void process_rotation(const Pauli& body, double half_turns, const AffineBool& sign,
+                      SamplingPlan& plan, uint32_t& active_width, CoordinateFrame& coordinates,
+                      SymbolicPauliFrame& symbolic_frame) {
+    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (!dormant_pivot.has_value()) {
         plan.actions.push_back(
             PlannedAction{active_width, active_width,
                           RotateActivePauli{active_projection(resolved.body, active_width),
-                                            rotation.half_turns, std::move(resolved.sign)}});
+                                            half_turns, std::move(resolved.sign)}});
         return;
     }
 
@@ -447,37 +247,35 @@ void process_rotation(const PendingRotation& rotation, SamplingPlan& plan, uint3
     coordinates.promote_dormant(resolved.body, active_width, *dormant_pivot);
     plan.actions.push_back(
         PlannedAction{active_width, active_width + 1,
-                      PromoteDormantRotation{rotation.half_turns, std::move(resolved.sign)}});
+                      PromoteDormantRotation{half_turns, std::move(resolved.sign)}});
     ++active_width;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
 }
 
-AffineBool process_measurement(const PendingMeasurement& measurement, SamplingPlan& plan,
-                               uint32_t& active_width, CoordinateFrame& coordinates,
-                               SymbolicPauliFrame& symbolic_frame) {
-    ResolvedPauli resolved =
-        resolve_pauli(measurement.body, measurement.sign, coordinates, symbolic_frame);
+AffineBool process_measurement(const Pauli& body, const AffineBool& sign, RecordSlot record,
+                               SymbolId branch, SamplingPlan& plan, uint32_t& active_width,
+                               CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame) {
+    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (dormant_pivot.has_value()) {
         coordinates.measure_dormant(resolved.body, *dormant_pivot);
 
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-        const SymbolId branch = measurement.branch;
         define_symbol(plan, branch, SymbolKind::Branch, action_index);
         Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, *dormant_pivot));
         correction.sign = false;
         symbolic_frame.apply(correction, AffineBool::symbol(branch));
         const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
-        plan.actions.push_back(PlannedAction{
-            active_width, active_width,
-            MeasureDormantRandom{*dormant_pivot, branch, outcome, measurement.record}});
+        plan.actions.push_back(
+            PlannedAction{active_width, active_width,
+                          MeasureDormantRandom{*dormant_pivot, branch, outcome, record}});
         return outcome;
     }
 
     const ActivePauli active = active_projection(resolved.body, active_width);
     if (active.is_identity()) {
-        plan.actions.push_back(PlannedAction{active_width, active_width,
-                                             RecordClassical{resolved.sign, measurement.record}});
+        plan.actions.push_back(
+            PlannedAction{active_width, active_width, RecordClassical{resolved.sign, record}});
         return resolved.sign;
     }
 
@@ -497,7 +295,6 @@ AffineBool process_measurement(const PendingMeasurement& measurement, SamplingPl
     coordinates.measure_active(active_body, active_width, *pivot);
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-    const SymbolId branch = measurement.branch;
     define_symbol(plan, branch, SymbolKind::Branch, action_index);
     Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, active_width - 1));
     correction.sign = false;
@@ -505,18 +302,19 @@ AffineBool process_measurement(const PendingMeasurement& measurement, SamplingPl
     const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
     plan.actions.push_back(
         PlannedAction{active_width, active_width - 1,
-                      MeasureActivePauli{active, *pivot, branch, outcome, measurement.record}});
+                      MeasureActivePauli{active, *pivot, branch, outcome, record}});
     --active_width;
     return outcome;
 }
 
-void process_instrument(const PendingInstrument& instrument, SamplingPlan& plan,
+void process_instrument(const Pauli& body, const Pauli& destination_flip,
+                        const AffineBool& initial_sign, InstrumentSiteId site,
+                        SymbolId destination_flip_symbol, uint32_t next_noise_site,
+                        uint32_t symbol_prefix_size, bool neglect_damping, SamplingPlan& plan,
                         uint32_t& active_width, CoordinateFrame& coordinates,
                         SymbolicPauliFrame& symbolic_frame) {
-    const InstrumentDistribution& distribution =
-        plan.instrument_distributions.at(index(instrument.site));
-    ResolvedPauli resolved =
-        resolve_pauli(instrument.body, instrument.sign, coordinates, symbolic_frame);
+    const InstrumentDistribution& distribution = plan.instrument_distributions.at(index(site));
+    ResolvedPauli resolved = resolve_pauli(body, initial_sign, coordinates, symbolic_frame);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
 
     InstrumentMode mode = InstrumentMode::Classical;
@@ -527,7 +325,7 @@ void process_instrument(const PendingInstrument& instrument, SamplingPlan& plan,
     if (dormant_pivot.has_value()) {
         // Equal no-fire factors normalize away. Otherwise exact damping needs
         // the dormant-coherent source represented in the dense state.
-        if (instrument.neglect_damping || distribution.p_fire[0] == distribution.p_fire[1]) {
+        if (neglect_damping || distribution.p_fire[0] == distribution.p_fire[1]) {
             mode = InstrumentMode::DormantTrap;
             sign = AffineBool{};
         } else {
@@ -556,24 +354,20 @@ void process_instrument(const PendingInstrument& instrument, SamplingPlan& plan,
     if (mode != InstrumentMode::DormantTrap) {
         // Only an in-line computational destination needs the reserved flip;
         // a trapped continuation resolves its destination instead.
-        destination_symbol = instrument.destination_flip_symbol;
-        define_symbol(plan, instrument.destination_flip_symbol, SymbolKind::Instrument,
-                      action_index);
+        destination_symbol = destination_flip_symbol;
+        define_symbol(plan, destination_flip_symbol, SymbolKind::Instrument, action_index);
     }
-    plan.actions.push_back(
-        PlannedAction{active_width, active_after,
-                      ApplyInstrument{instrument.site, mode, source, sign, destination_symbol}});
+    plan.actions.push_back(PlannedAction{
+        active_width, active_after, ApplyInstrument{site, mode, source, sign, destination_symbol}});
 
     if (destination_symbol.has_value()) {
-        symbolic_frame.apply(instrument.destination_flip, AffineBool::symbol(*destination_symbol));
+        symbolic_frame.apply(destination_flip, AffineBool::symbol(*destination_symbol));
     }
     active_width = active_after;
     plan.max_active_width = std::max(plan.max_active_width, active_width);
     // A trapped shot resumes here so it cannot execute the instrument twice.
-    plan.actions.push_back(
-        PlannedAction{active_width, active_width,
-                      InstrumentBoundary{instrument.site, instrument.next_noise_site,
-                                         instrument.symbol_prefix_size}});
+    plan.actions.push_back(PlannedAction{
+        active_width, active_width, InstrumentBoundary{site, next_noise_site, symbol_prefix_size}});
 }
 
 }  // namespace
@@ -590,12 +384,16 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     plan.num_exp_vals = hir.num_exp_vals;
     plan.global_weight = hir.global_weight;
 
-    const std::vector<PendingOperation> pending = queue_supported_operations(hir, plan, options);
-    if (plan.symbols.size() > std::numeric_limits<uint32_t>::max()) {
-        throw std::length_error("sampling planner symbol count exceeds uint32 range");
+    // The packed symbolic frame needs its row count up front. Count only;
+    // operations and their Paulis are consumed directly from HIR below.
+    const PlanningRequirements requirements = inspect_planning_requirements(hir);
+    plan.symbols.reserve(requirements.symbol_count);
+    initialize_site_metadata(hir, plan);
+    if (requirements.supports_final_state_queries) {
+        plan.final_tableau = hir.final_tableau;
     }
     CoordinateFrame coordinates(hir.num_qubits);
-    SymbolicPauliFrame symbolic_frame(hir.num_qubits, static_cast<uint32_t>(plan.symbols.size()));
+    SymbolicPauliFrame symbolic_frame(hir.num_qubits, requirements.symbol_count);
     std::vector<std::optional<AffineBool>> record_values(static_cast<size_t>(hir.num_measurements) +
                                                          hir.num_hidden_measurements);
     std::vector<AffineBool> observable_values(hir.num_observables);
@@ -620,76 +418,192 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
         record_values[record_index] = std::move(value);
     };
 
-    auto record_parity = [&](const std::vector<RecordSlot>& records,
+    auto record_parity = [&](const std::vector<uint32_t>& records,
                              size_t operation_index) -> AffineBool {
         AffineBool result;
-        for (RecordSlot record : records) {
-            result ^= require_record(record, operation_index);
+        for (uint32_t record : records) {
+            result ^= require_record(RecordSlot{record}, operation_index);
         }
         return result;
     };
 
     uint32_t active_width = plan.initial_active_width;
-    for (size_t i = 0; i < pending.size(); ++i) {
-        std::visit(
-            [&](const auto& operation) {
-                using T = std::decay_t<decltype(operation)>;
-                if constexpr (std::is_same_v<T, PendingRotation>) {
-                    process_rotation(operation, plan, active_width, coordinates, symbolic_frame);
-                } else if constexpr (std::is_same_v<T, PendingMeasurement>) {
-                    const AffineBool outcome = process_measurement(operation, plan, active_width,
-                                                                   coordinates, symbolic_frame);
-                    assign_record(operation.record, outcome, i);
-                } else if constexpr (std::is_same_v<T, PendingConditionalPauli>) {
-                    symbolic_frame.apply(operation.body, require_record(operation.controller, i));
-                } else if constexpr (std::is_same_v<T, PendingNoise>) {
-                    for (const PendingNoiseChannel& channel : operation.channels) {
-                        symbolic_frame.apply(channel.body, AffineBool::symbol(channel.symbol));
-                    }
-                } else if constexpr (std::is_same_v<T, PendingReadoutNoise>) {
-                    const AffineBool source = require_record(operation.record, i);
-                    if (operation.prob_zero_to_one == 0.0 && operation.prob_one_to_zero == 0.0) {
-                        return;
-                    }
-                    const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-                    const SymbolId flip = operation.flip;
-                    define_symbol(plan, flip, SymbolKind::Readout, action_index);
-                    plan.actions.push_back(PlannedAction{
-                        active_width, active_width,
-                        ApplyReadoutNoise{flip, source, operation.record,
-                                          operation.prob_zero_to_one, operation.prob_one_to_zero}});
-                    record_values[index(operation.record)] = source ^ AffineBool::symbol(flip);
-                } else if constexpr (std::is_same_v<T, PendingExpectation>) {
-                    ResolvedPauli resolved =
-                        resolve_pauli(operation.body, operation.sign, coordinates, symbolic_frame);
-                    const bool is_zero =
-                        first_x_at_or_above(resolved.body, active_width).has_value();
-                    plan.actions.push_back(PlannedAction{
-                        active_width, active_width,
-                        WriteExpectationValue{
-                            is_zero ? std::nullopt
-                                    : std::optional<ActivePauli>{active_projection(resolved.body,
-                                                                                   active_width)},
-                            is_zero ? AffineBool{} : std::move(resolved.sign), operation.exp_val}});
-                } else if constexpr (std::is_same_v<T, PendingInstrument>) {
-                    process_instrument(operation, plan, active_width, coordinates, symbolic_frame);
-                } else if constexpr (std::is_same_v<T, PendingDetector>) {
-                    AffineBool outcome = record_parity(operation.records, i);
-                    outcome ^= operation.expected;
-                    plan.actions.push_back(PlannedAction{
-                        active_width, active_width,
-                        WriteDetector{outcome, operation.detector, operation.postselected}});
-                    plan.has_postselection |= operation.postselected;
-                } else if constexpr (std::is_same_v<T, PendingObservable>) {
-                    observable_values[index(operation.observable)] ^=
-                        record_parity(operation.records, i);
-                } else {
-                    static_assert(kAlwaysFalse<T>, "Unhandled pending operation alternative");
+    uint32_t detector_index = 0;
+    uint32_t next_noise_site = 0;
+    uint32_t next_instrument_site = 0;
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        const HeisenbergOp& op = hir.ops[i];
+        switch (op.op_type()) {
+            case OpType::T_GATE: {
+                const double half_turns = op.is_dagger() ? -0.25 : 0.25;
+                const Pauli body = pauli_from_hir(hir, op);
+                process_rotation(body, half_turns, AffineBool(hir.sign(op)), plan, active_width,
+                                 coordinates, symbolic_frame);
+                multiply_phase(plan.global_weight,
+                               (op.is_dagger() ? -1.0 : 1.0) * std::numbers::pi / 8.0);
+                break;
+            }
+            case OpType::PHASE_ROTATION: {
+                const Pauli body = pauli_from_hir(hir, op);
+                process_rotation(body, op.alpha(), AffineBool(hir.sign(op)), plan, active_width,
+                                 coordinates, symbolic_frame);
+                const double signed_alpha = hir.sign(op) ? -op.alpha() : op.alpha();
+                multiply_phase(plan.global_weight, signed_alpha * std::numbers::pi / 2.0);
+                break;
+            }
+            case OpType::MEASURE: {
+                const RecordSlot record{static_cast<uint32_t>(op.meas_record_idx())};
+                const SymbolId branch = reserve_symbol(plan);
+                const Pauli body = pauli_from_hir(hir, op);
+                const AffineBool outcome =
+                    process_measurement(body, AffineBool(hir.sign(op)), record, branch, plan,
+                                        active_width, coordinates, symbolic_frame);
+                assign_record(record, outcome, i);
+                break;
+            }
+            case OpType::CONDITIONAL_PAULI: {
+                const RecordSlot controller{static_cast<uint32_t>(op.controlling_meas())};
+                const Pauli body = pauli_from_hir(hir, op);
+                symbolic_frame.apply(body, require_record(controller, i));
+                break;
+            }
+            case OpType::NOISE: {
+                const uint32_t site_index = static_cast<uint32_t>(op.noise_site_idx());
+                if (site_index >= hir.noise_sites.size()) {
+                    throw std::invalid_argument("sampling planner noise site is out of range");
                 }
-            },
-            pending[i]);
+                if (site_index != next_noise_site) {
+                    throw std::invalid_argument(
+                        "sampling planner noise sites are not in circuit order");
+                }
+                ++next_noise_site;
+                const NoiseSite& hir_site = hir.noise_sites[site_index];
+                PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];
+                plan_site.outcomes.reserve(hir_site.channels.size());
+                for (const NoiseChannel& channel : hir_site.channels) {
+                    if (channel.prob == 0.0) {
+                        continue;
+                    }
+                    const SymbolId symbol = reserve_symbol(plan);
+                    plan.symbols[index(symbol)] =
+                        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{site_index}};
+                    plan_site.outcomes.push_back(PresampledNoiseOutcome{symbol, channel.prob});
+                    const Pauli body = noise_pauli_from_hir(hir, channel.mask);
+                    symbolic_frame.apply(body, AffineBool::symbol(symbol));
+                }
+                break;
+            }
+            case OpType::READOUT_NOISE: {
+                const uint32_t entry_index = static_cast<uint32_t>(op.readout_noise_idx());
+                if (entry_index >= hir.readout_noise.size()) {
+                    throw std::invalid_argument("sampling planner readout entry is out of range");
+                }
+                const ReadoutNoiseEntry& entry = hir.readout_noise[entry_index];
+                const RecordSlot record{entry.meas_idx};
+                const SymbolId flip = reserve_symbol(plan);
+                const AffineBool source = require_record(record, i);
+                if (entry.prob_zero_to_one == 0.0 && entry.prob_one_to_zero == 0.0) {
+                    break;
+                }
+                const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
+                define_symbol(plan, flip, SymbolKind::Readout, action_index);
+                plan.actions.push_back(
+                    PlannedAction{active_width, active_width,
+                                  ApplyReadoutNoise{flip, source, record, entry.prob_zero_to_one,
+                                                    entry.prob_one_to_zero}});
+                record_values[index(record)] = source ^ AffineBool::symbol(flip);
+                break;
+            }
+            case OpType::INSTRUMENT: {
+                const uint32_t site_index = static_cast<uint32_t>(op.instrument_site_idx());
+                if (site_index >= hir.instrument_sites.size() ||
+                    site_index != next_instrument_site) {
+                    throw std::invalid_argument(
+                        "sampling planner instrument site is out of range or circuit order");
+                }
+                const InstrumentSite& site = hir.instrument_sites[site_index];
+                if (site.destination_flip_mask == kNoMask) {
+                    throw std::invalid_argument(
+                        "sampling planner instrument omits its destination flip");
+                }
+                const SymbolId destination_flip_symbol = reserve_symbol(plan);
+                const uint32_t symbol_prefix_size = static_cast<uint32_t>(plan.symbols.size());
+                const Pauli body = pauli_from_hir(hir, op);
+                const Pauli destination_flip = pauli_from_mask(hir, site.destination_flip_mask);
+                process_instrument(body, destination_flip, AffineBool(hir.sign(op)),
+                                   InstrumentSiteId{site_index}, destination_flip_symbol,
+                                   next_noise_site, symbol_prefix_size,
+                                   hir.neglect_instrument_damping, plan, active_width, coordinates,
+                                   symbolic_frame);
+                ++next_instrument_site;
+                break;
+            }
+            case OpType::DETECTOR: {
+                const uint32_t targets_index = static_cast<uint32_t>(op.detector_idx());
+                if (targets_index >= hir.detector_targets.size() ||
+                    detector_index >= hir.num_detectors) {
+                    throw std::invalid_argument("sampling planner detector is out of range");
+                }
+                AffineBool outcome = record_parity(hir.detector_targets[targets_index], i);
+                outcome ^= option_bit(options.expected_detectors, detector_index);
+                const bool postselected = option_bit(options.postselection_mask, detector_index);
+                plan.actions.push_back(PlannedAction{
+                    active_width, active_width,
+                    WriteDetector{outcome, DetectorSlot{detector_index}, postselected}});
+                plan.has_postselection |= postselected;
+                ++detector_index;
+                break;
+            }
+            case OpType::OBSERVABLE: {
+                const uint32_t targets_index = op.observable_target_list_idx();
+                const uint32_t observable_index = static_cast<uint32_t>(op.observable_idx());
+                if (targets_index >= hir.observable_targets.size() ||
+                    observable_index >= hir.num_observables) {
+                    throw std::invalid_argument("sampling planner observable is out of range");
+                }
+                observable_values[observable_index] ^=
+                    record_parity(hir.observable_targets[targets_index], i);
+                break;
+            }
+            case OpType::EXP_VAL: {
+                const uint32_t exp_val_index = static_cast<uint32_t>(op.exp_val_idx());
+                if (exp_val_index >= hir.num_exp_vals) {
+                    throw std::invalid_argument(
+                        "sampling planner expectation slot is out of range");
+                }
+                const Pauli body = pauli_from_hir(hir, op);
+                ResolvedPauli resolved =
+                    resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame);
+                const bool is_zero = first_x_at_or_above(resolved.body, active_width).has_value();
+                plan.actions.push_back(PlannedAction{
+                    active_width, active_width,
+                    WriteExpectationValue{is_zero ? std::nullopt
+                                                  : std::optional<ActivePauli>{active_projection(
+                                                        resolved.body, active_width)},
+                                          is_zero ? AffineBool{} : std::move(resolved.sign),
+                                          ExpValSlot{exp_val_index}}});
+                break;
+            }
+            case OpType::NUM_OP_TYPES:
+                throw std::invalid_argument("sampling planner does not support HIR operation " +
+                                            op_type_to_str(op.op_type()) + " at index " +
+                                            std::to_string(i));
+        }
     }
 
+    if (plan.symbols.size() != requirements.symbol_count) {
+        throw std::logic_error("sampling planner symbol prepass disagrees with HIR lowering");
+    }
+    if (detector_index != hir.num_detectors) {
+        throw std::invalid_argument("sampling planner detector count is inconsistent with HIR");
+    }
+    if (next_noise_site != hir.noise_sites.size()) {
+        throw std::invalid_argument("sampling planner noise-site table is inconsistent with HIR");
+    }
+    if (next_instrument_site != hir.instrument_sites.size()) {
+        throw std::invalid_argument(
+            "sampling planner instrument-site table is inconsistent with HIR");
+    }
     for (uint32_t observable = 0; observable < observable_values.size(); ++observable) {
         observable_values[observable] ^= option_bit(options.expected_observables, observable);
         plan.actions.push_back(PlannedAction{

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -6,6 +6,7 @@
 #include "instrument_test_helpers.h"
 #include "test_helpers.h"
 
+#include <algorithm>
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -261,6 +262,34 @@ TEST_CASE("Sampling planner keeps prefix symbols stable across continuation suff
     REQUIRE(find_instrument(short_plan).destination_flip ==
             find_instrument(longer_plan).destination_flip);
     REQUIRE(longer_plan.symbols.size() == short_plan.symbols.size() + 1);
+}
+
+TEST_CASE("Sampling planner preserves mixed symbol order at instrument boundaries") {
+    const clifft::InstrumentTraceOptions options = clifft::test::source_dependent_jump_options();
+    const SamplingPlan plan = plan_sampling(clifft::trace(clifft::parse(R"(
+        X_ERROR(0.1) 0
+        H 0
+        M 0
+        READOUT_NOISE(0.1, 0.2) rec[-1]
+        LEVEL_TRANSITION[jump] 0
+        X_ERROR(0.3) 0
+    )"),
+                                                          &options));
+
+    REQUIRE(plan.symbols.size() == 5);
+    REQUIRE(plan.symbols[0].kind == SymbolKind::Presampled);
+    REQUIRE(plan.symbols[1].kind == SymbolKind::Branch);
+    REQUIRE(plan.symbols[2].kind == SymbolKind::Readout);
+    REQUIRE(plan.symbols[3].kind == SymbolKind::Instrument);
+    REQUIRE(plan.symbols[4].kind == SymbolKind::Presampled);
+
+    const auto boundary = std::ranges::find_if(plan.actions, [](const auto& action) {
+        return std::holds_alternative<InstrumentBoundary>(action.action);
+    });
+    REQUIRE(boundary != plan.actions.end());
+    const InstrumentBoundary& instrument = std::get<InstrumentBoundary>(boundary->action);
+    REQUIRE(instrument.next_noise_site == 1);
+    REQUIRE(instrument.symbol_prefix_size == 4);
 }
 
 TEST_CASE("Sampling planner collapses active measurements and propagates branches") {


### PR DESCRIPTION
## Summary

- remove the obsolete `PendingOperation` staging variant and its owned Pauli copies
- retain a lightweight HIR prepass only for the information required before planning: packed symbolic-frame size and final-state-query eligibility
- walk HIR directly while evolving the coordinate and symbolic Pauli frames and emitting `SamplingPlan` actions
- consume detector, observable, and noise metadata without intermediate planner-only representations
- cover mixed presampled, branch, readout, and instrument symbol ordering across a continuation boundary

The coordinate and symbolic frames now propagate changes forward, so nothing rewrites a pending suffix. The prepass remains necessary because `SymbolicPauliFrame` uses fixed packed storage whose row count must be known before direct planning begins.

This does not change the `HIR -> SamplingPlan -> ExecutablePlan -> Executor` boundaries or any execution representation.

## Performance

Five alternating baseline/branch rounds, GCC 13.3, native `RelWithDebInfo` compile-profiler build. Values are medians in milliseconds.

| Circuit | Stage | Main | This PR | Change |
| --- | ---: | ---: | ---: | ---: |
| target-QEC | plan | 0.405 | 0.313 | -22.8% |
| target-QEC | total | 0.826 | 0.720 | -12.8% |
| cultivation d5 | plan | 4.746 | 3.834 | -19.2% |
| cultivation d5 | total | 8.946 | 7.921 | -11.4% |
| QV-20 seed 42 | plan | 2.492 | 2.449 | -1.7% |
| QV-20 seed 42 | total | 14.968 | 15.004 | +0.2% |

QV-20 total compile time is prepare-dominated; its +0.2% change is within the alternating-run spread.

## Verification

- `ctest --test-dir build -E '^Bench:' -j4 --output-on-failure` (1,283 tests)
- exact final-state/statevector planner coverage
- target-QEC plan characterization digest remains unchanged
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Related to #247 and discussion #298.
