### PR TITLE
refactor(sampling): clarify pipeline boundaries

### DIFF
--- a/src/clifft/sampling/direct_rotation_dispatch.cc
+++ b/src/clifft/sampling/direct_rotation_dispatch.cc
@@ -55,8 +55,8 @@ DirectRotationKernel select_direct_rotation_avx512(const PreparedRotation& rotat
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
 
 // The selected ISA is process-wide, while each action stores only a shape. A
-// predicted branch and direct call are cheaper here than the SVM's function
-// pointer pattern, which amortizes one indirect call over an entire program.
+// predicted branch keeps function pointers and architecture-specific types out
+// of the compact action descriptor.
 const internal::RuntimeIsa kResolvedDirectRotationIsa = internal::runtime_isa();
 
 #endif

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -60,8 +60,8 @@ class ExecutablePlan {
     friend class Executor;
     friend class ExecutablePlanBuilder;
 
-    // Compact handles embedded in actions. Registers refer to the prepared
-    // affine-expression storage owned near the end of this class.
+    // To keep actions compact, register_id refers to expression details in the
+    // storage near the end of this class.
     struct PreparedExpression {
         uint32_t register_id = 0;
     };
@@ -134,7 +134,7 @@ class ExecutablePlan {
     static_assert(sizeof(ExecuteActiveMeasurement) == 88,
                   "active measurement dispatch must not expand its action descriptor");
 
-    // Classical output and symbol actions.
+    // Measurement records and derived symbols.
     struct ExecuteDormantMeasurement {
         PreparedExpression correction;
         uint32_t branch = 0;
@@ -151,6 +151,7 @@ class ExecutablePlan {
         uint32_t symbol = 0;
     };
 
+    // Stochastic readout and derived circuit outputs.
     struct ExecuteReadoutNoise {
         PreparedExpression source;
         uint32_t flip = 0;
@@ -171,14 +172,15 @@ class ExecutablePlan {
         uint32_t observable = 0;
     };
 
+    // Exact expectation-value probe of the current state.
     struct ExecuteExpectation {
         std::optional<PreparedPauli> active_projection;
         PreparedExpression sign;
         uint32_t exp_val = 0;
     };
 
-    // Instrument modes become distinct concrete forms so the hot executor does
-    // not branch over semantic optionals that planning has already resolved.
+    // Each instrument mode has a separate action type so sampling does not
+    // check the mode on every shot.
     struct ExecuteClassicalInstrument {
         PreparedExpression sign;
         uint32_t site = 0;
@@ -286,6 +288,7 @@ class ExecutablePlan {
     std::optional<stim::Tableau<kStimWidth>> final_tableau_;
 
     // Affine register initialization and reverse symbol dependencies.
+
     // Constants are indexed by PreparedExpression::register_id. The dependency
     // vectors form CSR: targets[offsets[symbol]..offsets[symbol + 1]) lists the
     // expression registers toggled when that symbol is true.
@@ -294,6 +297,7 @@ class ExecutablePlan {
     std::vector<uint32_t> expression_dependency_targets_;
 
     // Presampled inputs and their circuit-site distributions.
+
     // Maps each dense presampled input position to its plan-local SymbolId.
     // The constructor records those ids in ascending order.
     std::vector<uint32_t> presampled_symbols_;
@@ -302,9 +306,11 @@ class ExecutablePlan {
     std::vector<PreparedNoiseSite> noise_sites_;
     std::vector<double> noise_hazards_;
 
-    // Continuation metadata, prepared fused descriptors, and the hot action
-    // stream. Actions refer to side storage by stable indices.
+    // Input distributions consulted when instruments fire.
     std::vector<InstrumentDistribution> instrument_distributions_;
+
+    // Continuation offsets, prepared fused descriptors, and the hot action
+    // stream. Actions refer to side storage by stable indices.
     std::vector<uint32_t> instrument_resume_offsets_;
     std::vector<PreparedFusedRotationExecution> fused_rotations_;
     std::vector<PreparedDynamicFusedRotationExecution> dynamic_fused_rotations_;

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -60,10 +60,14 @@ class ExecutablePlan {
     friend class Executor;
     friend class ExecutablePlanBuilder;
 
+    // Compact handles embedded in actions. Registers refer to the prepared
+    // affine-expression storage owned near the end of this class.
     struct PreparedExpression {
         uint32_t register_id = 0;
     };
 
+    // CPU action descriptors. They contain only fixed operands and indices;
+    // lowering has already selected topology and any applicable kernel shape.
     struct ExecuteRotation {
         // Geometry and trigonometric weights shared by every implementation.
         PreparedRotation rotation;
@@ -130,6 +134,7 @@ class ExecutablePlan {
     static_assert(sizeof(ExecuteActiveMeasurement) == 88,
                   "active measurement dispatch must not expand its action descriptor");
 
+    // Classical output and symbol actions.
     struct ExecuteDormantMeasurement {
         PreparedExpression correction;
         uint32_t branch = 0;
@@ -172,6 +177,8 @@ class ExecutablePlan {
         uint32_t exp_val = 0;
     };
 
+    // Instrument modes become distinct concrete forms so the hot executor does
+    // not branch over semantic optionals that planning has already resolved.
     struct ExecuteClassicalInstrument {
         PreparedExpression sign;
         uint32_t site = 0;
@@ -238,6 +245,8 @@ class ExecutablePlan {
         uint32_t symbol_prefix_size = 0;
     };
 
+    // Prepared input distributions used before dispatch and at continuation
+    // boundaries.
     struct PreparedNoiseOutcome {
         uint32_t symbol = 0;
         double cumulative_probability = 0.0;
@@ -258,6 +267,7 @@ class ExecutablePlan {
                      ExecuteDetector, ExecuteObservable, ExecuteExpectation, ExecuteInstrument,
                      ExecuteBoundary>;
 
+    // Immutable plan metadata and externally visible dimensions.
     uint32_t num_qubits_ = 0;
     uint32_t initial_active_width_ = 0;
     uint32_t max_active_width_ = 0;
@@ -274,12 +284,16 @@ class ExecutablePlan {
     uint32_t initial_noise_end_ = 0;
     std::complex<double> global_weight_ = {1.0, 0.0};
     std::optional<stim::Tableau<kStimWidth>> final_tableau_;
+
+    // Affine register initialization and reverse symbol dependencies.
     // Constants are indexed by PreparedExpression::register_id. The dependency
     // vectors form CSR: targets[offsets[symbol]..offsets[symbol + 1]) lists the
     // expression registers toggled when that symbol is true.
     std::vector<uint8_t> expression_register_constants_;
     std::vector<uint32_t> expression_dependency_offsets_;
     std::vector<uint32_t> expression_dependency_targets_;
+
+    // Presampled inputs and their circuit-site distributions.
     // Maps each dense presampled input position to its plan-local SymbolId.
     // The constructor records those ids in ascending order.
     std::vector<uint32_t> presampled_symbols_;
@@ -287,6 +301,9 @@ class ExecutablePlan {
     std::vector<PreparedNoiseOutcome> noise_outcomes_;
     std::vector<PreparedNoiseSite> noise_sites_;
     std::vector<double> noise_hazards_;
+
+    // Continuation metadata, prepared fused descriptors, and the hot action
+    // stream. Actions refer to side storage by stable indices.
     std::vector<InstrumentDistribution> instrument_distributions_;
     std::vector<uint32_t> instrument_resume_offsets_;
     std::vector<PreparedFusedRotationExecution> fused_rotations_;

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -51,7 +51,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::compile() {
     clifft::internal::validate_runtime_isa(runtime_isa_);
     initialize_program();
     prepare_noise_and_boundaries();
-    lower_actions();
+    lower_action_stream();
     build_expression_dependencies();
     validate_executable_plan();
 }
@@ -326,7 +326,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
         planned.action);
 }
 
-CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_actions() {
+CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action_stream() {
     size_t planned_index = 0;
     size_t boundary_index = 0;
     while (planned_index < source_.actions.size()) {

--- a/src/clifft/sampling/executable_plan_builder.h
+++ b/src/clifft/sampling/executable_plan_builder.h
@@ -22,12 +22,24 @@ class ExecutablePlanBuilder {
     static void build(ExecutablePlan& output, const SamplingPlan& source);
     ExecutablePlanBuilder(ExecutablePlan& output, const SamplingPlan& source);
 
+    // Coordinates the one-shot lowering stages below.
     void compile();
+
+    // Reserve fixed program storage and initialize plan-wide indices.
     void initialize_program();
+
+    // Prepare presampled distributions and continuation segment boundaries.
     void prepare_noise_and_boundaries();
-    void lower_actions();
+
+    // Scan semantic actions once, selecting CPU descriptors and bounded
+    // adjacent-rotation fusion without introducing a general pass pipeline.
+    void lower_action_stream();
     void lower_action(const PlannedAction& planned, size_t& boundary_index);
+
+    // Transpose action-order affine terms into symbol-to-register CSR storage.
     void build_expression_dependencies();
+
+    // Check construction-only invariants in Debug builds.
     void validate_executable_plan() const;
     [[nodiscard]] size_t estimate_expression_terms() const;
 

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -28,7 +28,7 @@ struct MeasurementBranchClassification {
     bool clamped_dust = false;
 };
 
-MeasurementBranchClassification classify_measurement_branch(
+[[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept {
     const double total = probabilities.total();
     assert(is_finite_robust(probabilities.zero) && probabilities.zero >= 0.0 &&

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -15,7 +15,18 @@ namespace {
 
 constexpr double kLogHalf = -std::numbers::ln2;
 
-}  // namespace
+// Zero and one identify the selected Pauli eigenvalue branch before affine
+// corrections turn that branch into a physical measurement record.
+enum class MeasurementBranchKind : uint8_t {
+    Random,
+    DeterministicZero,
+    DeterministicOne,
+};
+
+struct MeasurementBranchClassification {
+    MeasurementBranchKind kind = MeasurementBranchKind::Random;
+    bool clamped_dust = false;
+};
 
 MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept {
@@ -35,6 +46,8 @@ MeasurementBranchClassification classify_measurement_branch(
     }
     return {.kind = MeasurementBranchKind::Random};
 }
+
+}  // namespace
 
 Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
     : root_plan_(&plan),

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -179,9 +179,11 @@ class Executor {
     template <typename Action>
     void execute_quantum_instrument(const Action& action) noexcept;
 
-    // The caller-owned root plan must outlive this executor. plan_ normally
-    // points to it, but temporarily borrows a caller-owned continuation while
-    // a trapped shot resumes; return_to_root_plan releases that borrow.
+    // The caller-owned root plan must outlive this executor. After resume(),
+    // plan_ keeps borrowing that continuation for accessors and any later
+    // resume validation. A successful resume replaces the borrow, while
+    // return_to_root_plan releases the final one. A throwing resume does not
+    // release whichever continuation was current when it threw.
     const ExecutablePlan* root_plan_;
     const ExecutablePlan* plan_;
 
@@ -194,18 +196,25 @@ class Executor {
     std::vector<uint8_t> observables_;
     std::vector<double> exp_vals_;
 
-    // Reset bookkeeping and alternate replay/fixed-fault controls share the
-    // same preallocated action loop.
+    // resume() can force a hidden trace-out record in the continuation.
     std::vector<uint8_t> forced_record_mask_;
     std::vector<uint8_t> forced_record_values_;
+
+    // Reset only the presampled symbols that were true on the previous shot.
     std::vector<uint32_t> previous_presampled_ones_;
+
+    // Fixed-fault-count sampling supplies its selected circuit sites here.
     std::span<const uint32_t> forced_fault_sites_;
     uint32_t forced_fault_cursor_ = 0;
 
-    // Per-shot control state and lifetime telemetry.
+    // RNG position deliberately persists across shots.
     Xoshiro256PlusPlus rng_;
+
+    // Per-shot control state.
     bool discarded_ = false;
     std::optional<InstrumentTrap> pending_trap_;
+
+    // Lifetime numerical telemetry; reset_shot does not clear it.
     uint64_t dust_clamps_ = 0;
 };
 

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -16,19 +16,6 @@ class KFaultSampler;
 
 namespace clifft::sampling {
 
-// Zero and one identify the selected Pauli eigenvalue branch before affine
-// sign corrections turn that branch into a physical measurement record.
-enum class MeasurementBranchKind : uint8_t {
-    Random,
-    DeterministicZero,
-    DeterministicOne,
-};
-
-struct MeasurementBranchClassification {
-    MeasurementBranchKind kind = MeasurementBranchKind::Random;
-    bool clamped_dust = false;
-};
-
 // Describes whether a requested record can occur and, if so, its conditional
 // joint log probability. The probability is meaningful only when reachable.
 struct ReplayResult {
@@ -46,9 +33,6 @@ struct ForcedTraceOut {
     RecordSlot record{};
     uint8_t source = 0;
 };
-
-[[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
-    MeasurementProbabilities probabilities) noexcept;
 
 // Holds the dense active-coordinate coefficients and global scalar, Boolean
 // symbols carrying stochastic frame dependencies, visible and hidden records,
@@ -195,8 +179,13 @@ class Executor {
     template <typename Action>
     void execute_quantum_instrument(const Action& action) noexcept;
 
+    // The caller-owned root plan must outlive this executor. plan_ normally
+    // points to it, but temporarily borrows a caller-owned continuation while
+    // a trapped shot resumes; return_to_root_plan releases that borrow.
     const ExecutablePlan* root_plan_;
     const ExecutablePlan* plan_;
+
+    // Capacity is allocated before ordinary dispatch and reused across shots.
     State state_;
     std::vector<uint8_t> symbols_;
     std::vector<uint8_t> expression_registers_;
@@ -204,11 +193,16 @@ class Executor {
     std::vector<uint8_t> detectors_;
     std::vector<uint8_t> observables_;
     std::vector<double> exp_vals_;
+
+    // Reset bookkeeping and alternate replay/fixed-fault controls share the
+    // same preallocated action loop.
     std::vector<uint8_t> forced_record_mask_;
     std::vector<uint8_t> forced_record_values_;
     std::vector<uint32_t> previous_presampled_ones_;
     std::span<const uint32_t> forced_fault_sites_;
     uint32_t forced_fault_cursor_ = 0;
+
+    // Per-shot control state and lifetime telemetry.
     Xoshiro256PlusPlus rng_;
     bool discarded_ = false;
     std::optional<InstrumentTrap> pending_trap_;

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -8,10 +8,8 @@
 
 namespace clifft::sampling {
 
-// This file defines the architecture-neutral kernel descriptors and scalar
-// operations. Shape-specific *_dispatch files select an implementation once
-// during executable lowering; explicit x86 implementations live in the
-// separately compiled kernels_avx2.cc and kernels_avx512.cc translation units.
+// Portable descriptors and scalar kernel entry points used by CPU execution.
+// ISA-specific selection and implementations stay outside this header.
 
 // Describes a Pauli operation to apply to the state vector. Its masks and
 // precomputed index values identify affected coefficients without referring to

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -8,6 +8,11 @@
 
 namespace clifft::sampling {
 
+// This file defines the architecture-neutral kernel descriptors and scalar
+// operations. Shape-specific *_dispatch files select an implementation once
+// during executable lowering; explicit x86 implementations live in the
+// separately compiled kernels_avx2.cc and kernels_avx512.cc translation units.
+
 // Describes a Pauli operation to apply to the state vector. Its masks and
 // precomputed index values identify affected coefficients without referring to
 // the State's storage.

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -1,5 +1,5 @@
-// AVX-512F+AVX-512DQ sampling kernels. This translation unit is compiled
-// with the same explicit AVX2/BMI2/FMA/AVX-512 flags as the SVM AVX-512 path.
+// AVX-512F+AVX-512DQ sampling kernels. This translation unit is compiled with
+// explicit AVX2/BMI2/FMA/AVX-512 flags so portable code retains its baseline ISA.
 
 #include "clifft/sampling/active_measurement_simd.h"
 #include "clifft/sampling/direct_rotation_simd.h"

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -33,8 +33,8 @@
 
 namespace clifft::sampling {
 
-// Symbols are plan-local Boolean slots with one value per shot. They carry
-// stochastic events, measurement branches, or named parities.
+// A symbol is a plan-local Boolean variable representing a sampled circuit
+// outcome or a parity derived from earlier symbols.
 enum class SymbolKind : uint8_t {
     Unused,      // Stable operation-order slot that this compiled plan does not need.
     Presampled,  // Available before the action stream, such as sampled noise.

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -33,9 +33,19 @@
 
 namespace clifft::sampling {
 
-// A symbol is a plan-local Boolean value assigned once per shot. It represents
-// a presampled stochastic event, a sampled measurement branch, or a named
-// parity derived from earlier symbols.
+// Symbols are plan-local Boolean slots with one value per shot. They carry
+// stochastic events, measurement branches, or named parities.
+enum class SymbolKind : uint8_t {
+    Unused,      // Stable operation-order slot that this compiled plan does not need.
+    Presampled,  // Available before the action stream, such as sampled noise.
+    Derived,     // Computed as a parity of previously available symbols.
+    Branch,      // Sampled while applying a measurement action.
+    Readout,     // Sampled from a record-dependent readout channel.
+    Instrument,  // Records an in-line computational instrument destination flip.
+};
+
+// Strongly typed plan-local indices prevent unrelated storage from being
+// indexed interchangeably.
 enum class SymbolId : uint32_t {};
 enum class RecordSlot : uint32_t {};
 enum class NoiseSiteId : uint32_t {};
@@ -44,8 +54,6 @@ enum class DetectorSlot : uint32_t {};
 enum class ObservableSlot : uint32_t {};
 enum class ExpValSlot : uint32_t {};
 
-// Keep the IDs non-interchangeable while giving every sampling layer one
-// explicit operation for indexing their plan-owned storage.
 [[nodiscard]] constexpr uint32_t index(SymbolId id) noexcept {
     return static_cast<uint32_t>(id);
 }
@@ -67,15 +75,6 @@ enum class ExpValSlot : uint32_t {};
 [[nodiscard]] constexpr uint32_t index(ExpValSlot slot) noexcept {
     return static_cast<uint32_t>(slot);
 }
-
-enum class SymbolKind : uint8_t {
-    Unused,      // Stable operation-order slot that this compiled plan does not need.
-    Presampled,  // Available before the action stream, such as sampled noise.
-    Derived,     // Computed as a parity of previously available symbols.
-    Branch,      // Sampled while applying a measurement action.
-    Readout,     // Sampled from a record-dependent readout channel.
-    Instrument,  // Records an in-line computational instrument destination flip.
-};
 
 // A parity expression over plan symbols, optionally XORed with true. For
 // example, s0 ^ s2 ^ true can track how sampled noise and a measurement branch
@@ -263,13 +262,15 @@ using SamplingAction = std::variant<RotateActivePauli, PromoteDormantRotation, M
                                     WriteExpectationValue, ApplyInstrument, InstrumentBoundary>;
 
 struct PlannedAction {
+    // Dense active-coordinate widths immediately before and after this action.
+    // Validation checks that adjacent actions form one continuous width chain.
     uint32_t active_before = 0;
     uint32_t active_after = 0;
     SamplingAction action;
 };
 
-// SamplingPlan::validate enforces the legal field combinations and verifies
-// that definition metadata agrees with the referenced action.
+// Describes how one symbol is populated. SamplingPlan::validate checks each
+// kind's legal fields and its agreement with the referenced defining action.
 struct SymbolInfo {
     SymbolKind kind = SymbolKind::Unused;
 
@@ -311,9 +312,9 @@ struct SamplingPlan {
     uint32_t num_qubits = 0;
 
     // Active width is the number of stabilizer coordinates represented in the
-    // dense coefficient state, which contains 2^active_width entries. It is the
-    // descriptive name for legacy active_k. The planner computes its maximum
-    // while emitting actions so runtime lowering can preallocate storage.
+    // dense coefficient state, which contains 2^active_width entries. The
+    // planner computes its maximum while emitting actions so runtime lowering
+    // can preallocate storage.
     uint32_t initial_active_width = 0;
     uint32_t max_active_width = 0;
     uint32_t num_visible_records = 0;

--- a/src/clifft/sampling/planner.h
+++ b/src/clifft/sampling/planner.h
@@ -7,18 +7,21 @@
 
 namespace clifft::sampling {
 
-// Builds the executor-independent sampling plan for the supported optimized
-// HIR subset. The planner performs all stabilizer-coordinate changes and
-// symbolic dependency discovery before execution.
-//
+// Sampling pipeline:
+//   optimized HirModule -> SamplingPlan -> ExecutablePlan -> Executor -> results
+// The planner produces the executor-independent semantic action stream. CPU
+// lowering then prepares fixed descriptors, and an Executor owns mutable state
+// for one shot at a time. The sampler entry points drive repeated shots and
+// collect their outputs.
 struct SamplingPlanOptions {
     std::span<const uint8_t> postselection_mask;
     std::span<const uint8_t> expected_detectors;
     std::span<const uint8_t> expected_observables;
 };
 
-// Exact-state probes remain outside this sampling-only plan. Instruments lower
-// to explicit state actions and continuation boundaries.
+// EXP_VAL probes become plan actions. Exact final-state queries instead retain
+// a coordinate map only for eligible unitary HIR. Instruments become explicit
+// state actions followed by continuation boundaries.
 [[nodiscard]] SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options = {});
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/planner.h
+++ b/src/clifft/sampling/planner.h
@@ -7,12 +7,9 @@
 
 namespace clifft::sampling {
 
-// Sampling pipeline:
-//   optimized HirModule -> SamplingPlan -> ExecutablePlan -> Executor -> results
-// The planner produces the executor-independent semantic action stream. CPU
-// lowering then prepares fixed descriptors, and an Executor owns mutable state
-// for one shot at a time. The sampler entry points drive repeated shots and
-// collect their outputs.
+// Builds the executor-independent sampling plan for the supported optimized
+// HIR subset. The planner performs all stabilizer-coordinate changes and
+// symbolic dependency discovery before execution.
 struct SamplingPlanOptions {
     std::span<const uint8_t> postselection_mask;
     std::span<const uint8_t> expected_detectors;

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -10,8 +10,13 @@
 
 namespace clifft::sampling {
 
-// ExecutablePlan lowers immutable work once, Executor runs one mutable shot,
-// and these entry points allocate and collect results across repeated shots.
+// Sampling pipeline:
+//   optimized HirModule -> SamplingPlan -> ExecutablePlan -> Executor -> results
+// Planning produces semantic actions, lowering prepares fixed CPU descriptors,
+// Executor owns mutable state for one shot, and the functions below drive
+// repeated shots and collect their outputs.
+
+// Collected row-major outputs from ordinary or fixed-fault-count sampling.
 struct SamplingResult {
     std::vector<uint8_t> measurements;
     std::vector<uint8_t> detectors;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -33,7 +33,6 @@ using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::apply_rotation;
 using clifft::sampling::ApplyInstrument;
-using clifft::sampling::classify_measurement_branch;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
@@ -46,7 +45,6 @@ using clifft::sampling::InstrumentMode;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
-using clifft::sampling::MeasurementBranchKind;
 using clifft::sampling::MeasurementProbabilities;
 using clifft::sampling::NoiseSiteId;
 using clifft::sampling::PlannedAction;
@@ -353,23 +351,6 @@ TEST_CASE("Sampling executor does not draw for empty noise sites") {
         CAPTURE(shot);
         REQUIRE(executor.visible_records()[0] == expected);
     }
-}
-
-TEST_CASE("Sampling executor classifies measurement dust without drawing") {
-    const auto zero = classify_measurement_branch(MeasurementProbabilities{1.0, 0.0});
-    REQUIRE(zero.kind == MeasurementBranchKind::DeterministicZero);
-    REQUIRE_FALSE(zero.clamped_dust);
-
-    const auto dusty_zero = classify_measurement_branch(MeasurementProbabilities{1.0, 1e-30});
-    REQUIRE(dusty_zero.kind == MeasurementBranchKind::DeterministicZero);
-    REQUIRE(dusty_zero.clamped_dust);
-
-    const auto dusty_one = classify_measurement_branch(MeasurementProbabilities{1e-30, 1.0});
-    REQUIRE(dusty_one.kind == MeasurementBranchKind::DeterministicOne);
-    REQUIRE(dusty_one.clamped_dust);
-
-    const auto random = classify_measurement_branch(MeasurementProbabilities{0.25, 0.75});
-    REQUIRE(random.kind == MeasurementBranchKind::Random);
 }
 
 TEST_CASE("Sampling executor evaluates presampled and derived affine symbols") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -45,7 +45,6 @@ using clifft::sampling::InstrumentMode;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
-using clifft::sampling::MeasurementProbabilities;
 using clifft::sampling::NoiseSiteId;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::prepare_rotation;
@@ -697,23 +696,42 @@ TEST_CASE("Sampling expression registers preserve noisy postselection") {
 }
 
 TEST_CASE("Sampling replay applies active measurement dust policy") {
-    const ExecutablePlan dusty(active_then_dormant_plan(1e-10));
-    Executor survivor(dusty);
-    const ReplayResult survivor_result = survivor.replay_shot(std::array<uint8_t, 2>{0, 1});
-    REQUIRE(survivor_result.reachable);
-    REQUIRE_THAT(survivor_result.log_probability, Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
-    REQUIRE(survivor.dust_clamps() == 1);
+    SECTION("dust on the one branch") {
+        const ExecutablePlan dusty(active_then_dormant_plan(1e-10));
+        Executor survivor(dusty);
+        const ReplayResult survivor_result = survivor.replay_shot(std::array<uint8_t, 2>{0, 1});
+        REQUIRE(survivor_result.reachable);
+        REQUIRE_THAT(survivor_result.log_probability,
+                     Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
+        REQUIRE(survivor.dust_clamps() == 1);
 
-    Executor dust_branch(dusty);
-    const ReplayResult dust_result = dust_branch.replay_shot(std::array<uint8_t, 2>{1, 0});
-    REQUIRE_FALSE(dust_result.reachable);
-    REQUIRE(dust_branch.dust_clamps() == 1);
+        Executor dust_branch(dusty);
+        const ReplayResult dust_result = dust_branch.replay_shot(std::array<uint8_t, 2>{1, 0});
+        REQUIRE_FALSE(dust_result.reachable);
+        REQUIRE(dust_branch.dust_clamps() == 1);
 
-    const ExecutablePlan exact(active_then_dormant_plan(0.0));
-    Executor impossible_exact(exact);
-    const ReplayResult exact_result = impossible_exact.replay_shot(std::array<uint8_t, 2>{1, 0});
-    REQUIRE_FALSE(exact_result.reachable);
-    REQUIRE(impossible_exact.dust_clamps() == 0);
+        const ExecutablePlan exact(active_then_dormant_plan(0.0));
+        Executor impossible_exact(exact);
+        const ReplayResult exact_result =
+            impossible_exact.replay_shot(std::array<uint8_t, 2>{1, 0});
+        REQUIRE_FALSE(exact_result.reachable);
+        REQUIRE(impossible_exact.dust_clamps() == 0);
+    }
+
+    SECTION("dust on the zero branch") {
+        const ExecutablePlan dusty(active_then_dormant_plan(1.0 - 1e-10));
+        Executor survivor(dusty);
+        const ReplayResult survivor_result = survivor.replay_shot(std::array<uint8_t, 2>{1, 1});
+        REQUIRE(survivor_result.reachable);
+        REQUIRE_THAT(survivor_result.log_probability,
+                     Catch::Matchers::WithinAbs(std::log(0.5), 1e-15));
+        REQUIRE(survivor.dust_clamps() == 1);
+
+        Executor dust_branch(dusty);
+        const ReplayResult dust_result = dust_branch.replay_shot(std::array<uint8_t, 2>{0, 0});
+        REQUIRE_FALSE(dust_result.reachable);
+        REQUIRE(dust_branch.dust_clamps() == 1);
+    }
 }
 
 TEST_CASE("Sampling replay accumulates active and dormant log probabilities") {
@@ -766,6 +784,21 @@ TEST_CASE("Sampling executor clamps positive active measurement dust") {
     executor.run_shot();
 
     REQUIRE(executor.visible_records()[0] == 0);
+    REQUIRE(executor.visible_records()[1] == expected_dormant_branch);
+    REQUIRE(executor.dust_clamps() == 1);
+}
+
+TEST_CASE("Sampling executor clamps active measurement dust to branch one") {
+    const ExecutablePlan executable(active_then_dormant_plan(1.0 - 1e-10));
+    Executor executor(executable, 456);
+    clifft::Xoshiro256PlusPlus expected_rng(456);
+    const bool expected_dormant_branch = expected_rng.next_double() >= 0.5;
+    const bool branch_if_active_had_drawn = expected_rng.next_double() >= 0.5;
+    REQUIRE(expected_dormant_branch != branch_if_active_had_drawn);
+
+    executor.run_shot();
+
+    REQUIRE(executor.visible_records()[0] == 1);
     REQUIRE(executor.visible_records()[1] == expected_dormant_branch);
     REQUIRE(executor.dust_clamps() == 1);
 }


### PR DESCRIPTION
## Summary

- document the symbolic sampling path from optimized HIR through planning, CPU lowering, per-shot execution, and result collection
- organize executable descriptors and storage by responsibility, and name the single action-stream lowering stage explicitly
- clarify continuation-plan ownership and the portable/ISA-specific kernel boundary
- keep measurement-branch classification private to the executor instead of exposing it solely for a direct unit test

This is a behavior-neutral navigation and terminology cleanup following the symbolic-backend cutover. It deliberately does not move directories, merge the plan builder back into another translation unit, alter `SamplingPlan` validation, change executable storage, or redesign SIMD dispatch.

## Verification

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `cmake --build build -j4`
- `ctest --test-dir build -E '^Bench:' -j4 --output-on-failure` — 1,283/1,283 passed

The removed direct classifier test covered a test-only interface. Executor-level tests retain end-to-end coverage of both deterministic branches, numerical-dust clamping, replay reachability, and RNG consumption, including asymmetric dust on either branch.

## Performance

Five alternating rounds compared this branch with exact baseline `30114fd` in separate GCC 13.3 RelWithDebInfo/native builds:

| Circuit | Plan | Prepare | Total |
| --- | ---: | ---: | ---: |
| target-QEC | -1.02% | -1.02% | -0.95% |
| cultivation d5 | -0.90% | -2.02% | -0.02% |
| QV20 seed 42 | +0.01% | +0.15% | -0.26% |

The changes are neutral within run-to-run noise. GCC also inlined the now-private measurement classifier, reducing the generated sizes of `sample_active_branch` from 261 to 215 bytes and `force_active_branch` from 215 to 189 bytes.

Related to #247 and discussion #298.
