### PR TITLE
refactor(sampling): clarify executor modes and dependencies

### DIFF
--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -3,6 +3,7 @@
 #include "clifft/sampling/executable_plan_builder.h"
 
 #include <algorithm>
+#include <cassert>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -43,6 +44,25 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       instrument_distributions_(plan.instrument_distributions) {
     // Keep construction-only lowering state out of the immutable executable.
     ExecutablePlanBuilder::build(*this, plan);
+}
+
+void ExecutablePlan::ExpressionDependencies::validate(uint32_t num_symbols,
+                                                      size_t num_registers) const noexcept {
+#ifndef NDEBUG
+    assert(offsets_.size() == static_cast<size_t>(num_symbols) + 1 &&
+           "expression dependency offsets have the wrong size");
+    assert(!offsets_.empty() && offsets_.front() == 0 && offsets_.back() == targets_.size() &&
+           "expression dependency ranges are inconsistent");
+    for (size_t i = 1; i < offsets_.size(); ++i) {
+        assert(offsets_[i] >= offsets_[i - 1] && "expression dependency offsets are not ordered");
+    }
+    for (uint32_t target : targets_) {
+        assert(target < num_registers && "expression dependency target is out of range");
+    }
+#else
+    static_cast<void>(num_symbols);
+    static_cast<void>(num_registers);
+#endif
 }
 
 size_t ExecutablePlan::num_new_x_instrument_activations() const {

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -89,10 +89,6 @@ class ExecutablePlan {
     // Construction transposes expression terms into one contiguous range per symbol.
     class ExpressionDependencies {
       public:
-        [[nodiscard]] static ExpressionDependencies build(
-            uint32_t num_symbols, std::span<const uint32_t> expression_terms,
-            std::span<const uint32_t> expression_term_begins);
-
         [[nodiscard]] std::span<const uint32_t> dependent_registers(
             uint32_t symbol) const noexcept {
             assert(static_cast<size_t>(symbol) + 1 < offsets_.size() &&
@@ -102,9 +98,14 @@ class ExecutablePlan {
             return std::span<const uint32_t>(targets_).subspan(begin, end - begin);
         }
 
+      private:
+        friend class ExecutablePlanBuilder;
+
+        [[nodiscard]] static ExpressionDependencies build(
+            uint32_t num_symbols, std::span<const uint32_t> expression_terms,
+            std::span<const uint32_t> expression_term_begins);
         void validate(uint32_t num_symbols, size_t num_registers) const noexcept;
 
-      private:
         std::vector<uint32_t> offsets_;
         std::vector<uint32_t> targets_;
     };

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -4,10 +4,12 @@
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/plan.h"
 
+#include <cassert>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <variant>
 #include <vector>
 
@@ -81,6 +83,30 @@ class ExecutablePlan {
     // storage near the end of this class.
     struct PreparedExpression {
         uint32_t register_id = 0;
+    };
+
+    // Reverse index used to update affine registers when a symbol becomes true.
+    // Construction transposes expression terms into one contiguous range per symbol.
+    class ExpressionDependencies {
+      public:
+        [[nodiscard]] static ExpressionDependencies build(
+            uint32_t num_symbols, std::span<const uint32_t> expression_terms,
+            std::span<const uint32_t> expression_term_begins);
+
+        [[nodiscard]] std::span<const uint32_t> dependent_registers(
+            uint32_t symbol) const noexcept {
+            assert(static_cast<size_t>(symbol) + 1 < offsets_.size() &&
+                   "assigned symbol must have an expression dependency range");
+            const uint32_t begin = offsets_[symbol];
+            const uint32_t end = offsets_[symbol + 1];
+            return std::span<const uint32_t>(targets_).subspan(begin, end - begin);
+        }
+
+        void validate(uint32_t num_symbols, size_t num_registers) const noexcept;
+
+      private:
+        std::vector<uint32_t> offsets_;
+        std::vector<uint32_t> targets_;
     };
 
     // CPU action descriptors. They contain only fixed operands and indices;
@@ -286,12 +312,9 @@ class ExecutablePlan {
 
     // Affine register initialization and reverse symbol dependencies.
 
-    // Constants are indexed by PreparedExpression::register_id. The dependency
-    // vectors form CSR: targets[offsets[symbol]..offsets[symbol + 1]) lists the
-    // expression registers toggled when that symbol is true.
+    // Constants are indexed by PreparedExpression::register_id.
     std::vector<uint8_t> expression_register_constants_;
-    std::vector<uint32_t> expression_dependency_offsets_;
-    std::vector<uint32_t> expression_dependency_targets_;
+    ExpressionDependencies expression_dependencies_;
 
     // Presampled inputs and their circuit-site distributions.
 

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -41,6 +41,14 @@ CLIFFT_BUILDER_FORCE_INLINE ExecutablePlan::ExpressionDependencies
 ExecutablePlan::ExpressionDependencies::build(uint32_t num_symbols,
                                               std::span<const uint32_t> expression_terms,
                                               std::span<const uint32_t> expression_term_begins) {
+    assert((expression_term_begins.empty() || expression_term_begins.front() == 0) &&
+           "the first expression must begin at the start of the term tape");
+    assert(std::ranges::is_sorted(expression_term_begins) &&
+           "expression term ranges must be ordered");
+    assert((expression_term_begins.empty() ||
+            expression_term_begins.back() <= expression_terms.size()) &&
+           "expression term ranges must stay inside the term tape");
+
     ExpressionDependencies result;
     result.offsets_.assign(static_cast<size_t>(num_symbols) + 1, 0);
     for (uint32_t symbol : expression_terms) {
@@ -405,25 +413,6 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action_stream() {
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::build_expression_dependencies() {
     output_.expression_dependencies_ = ExecutablePlan::ExpressionDependencies::build(
         output_.num_symbols_, expression_terms_, expression_term_begins_);
-}
-
-void ExecutablePlan::ExpressionDependencies::validate(uint32_t num_symbols,
-                                                      size_t num_registers) const noexcept {
-#ifndef NDEBUG
-    assert(offsets_.size() == static_cast<size_t>(num_symbols) + 1 &&
-           "expression dependency offsets have the wrong size");
-    assert(!offsets_.empty() && offsets_.front() == 0 && offsets_.back() == targets_.size() &&
-           "expression dependency ranges are inconsistent");
-    for (size_t i = 1; i < offsets_.size(); ++i) {
-        assert(offsets_[i] >= offsets_[i - 1] && "expression dependency offsets are not ordered");
-    }
-    for (uint32_t target : targets_) {
-        assert(target < num_registers && "expression dependency target is out of range");
-    }
-#else
-    static_cast<void>(num_symbols);
-    static_cast<void>(num_registers);
-#endif
 }
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan() const {

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -37,6 +37,35 @@ bool activates_new_x(const ApplyInstrument& instrument, uint32_t active_after) {
 
 }  // namespace
 
+CLIFFT_BUILDER_FORCE_INLINE ExecutablePlan::ExpressionDependencies
+ExecutablePlan::ExpressionDependencies::build(uint32_t num_symbols,
+                                              std::span<const uint32_t> expression_terms,
+                                              std::span<const uint32_t> expression_term_begins) {
+    ExpressionDependencies result;
+    result.offsets_.assign(static_cast<size_t>(num_symbols) + 1, 0);
+    for (uint32_t symbol : expression_terms) {
+        assert(symbol < num_symbols && "expression term must refer to a plan symbol");
+        ++result.offsets_[static_cast<size_t>(symbol) + 1];
+    }
+    for (size_t i = 1; i < result.offsets_.size(); ++i) {
+        result.offsets_[i] += result.offsets_[i - 1];
+    }
+    result.targets_.resize(expression_terms.size());
+    std::vector<uint32_t> next_dependency = result.offsets_;
+    for (size_t expression = 0; expression < expression_term_begins.size(); ++expression) {
+        const uint32_t register_id = static_cast<uint32_t>(expression);
+        const uint32_t begin = expression_term_begins[expression];
+        const uint32_t end = expression + 1 < expression_term_begins.size()
+                                 ? expression_term_begins[expression + 1]
+                                 : static_cast<uint32_t>(expression_terms.size());
+        for (uint32_t i = begin; i < end; ++i) {
+            const uint32_t symbol = expression_terms[i];
+            result.targets_[next_dependency[symbol]++] = register_id;
+        }
+    }
+    return result;
+}
+
 void ExecutablePlanBuilder::build(ExecutablePlan& output, const SamplingPlan& source) {
     ExecutablePlanBuilder builder(output, source);
     builder.compile();
@@ -374,49 +403,35 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action_stream() {
 }
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::build_expression_dependencies() {
-    output_.expression_dependency_offsets_.assign(static_cast<size_t>(output_.num_symbols_) + 1, 0);
-    for (uint32_t symbol : expression_terms_) {
-        ++output_.expression_dependency_offsets_[static_cast<size_t>(symbol) + 1];
+    output_.expression_dependencies_ = ExecutablePlan::ExpressionDependencies::build(
+        output_.num_symbols_, expression_terms_, expression_term_begins_);
+}
+
+void ExecutablePlan::ExpressionDependencies::validate(uint32_t num_symbols,
+                                                      size_t num_registers) const noexcept {
+#ifndef NDEBUG
+    assert(offsets_.size() == static_cast<size_t>(num_symbols) + 1 &&
+           "expression dependency offsets have the wrong size");
+    assert(!offsets_.empty() && offsets_.front() == 0 && offsets_.back() == targets_.size() &&
+           "expression dependency ranges are inconsistent");
+    for (size_t i = 1; i < offsets_.size(); ++i) {
+        assert(offsets_[i] >= offsets_[i - 1] && "expression dependency offsets are not ordered");
     }
-    for (size_t i = 1; i < output_.expression_dependency_offsets_.size(); ++i) {
-        output_.expression_dependency_offsets_[i] += output_.expression_dependency_offsets_[i - 1];
+    for (uint32_t target : targets_) {
+        assert(target < num_registers && "expression dependency target is out of range");
     }
-    output_.expression_dependency_targets_.resize(expression_terms_.size());
-    std::vector<uint32_t> next_dependency = output_.expression_dependency_offsets_;
-    for (size_t expression = 0; expression < expression_term_begins_.size(); ++expression) {
-        const uint32_t register_id = static_cast<uint32_t>(expression);
-        const uint32_t begin = expression_term_begins_[expression];
-        const uint32_t end = expression + 1 < expression_term_begins_.size()
-                                 ? expression_term_begins_[expression + 1]
-                                 : static_cast<uint32_t>(expression_terms_.size());
-        for (uint32_t i = begin; i < end; ++i) {
-            const uint32_t symbol = expression_terms_[i];
-            output_.expression_dependency_targets_[next_dependency[symbol]++] = register_id;
-        }
-    }
+#else
+    static_cast<void>(num_symbols);
+    static_cast<void>(num_registers);
+#endif
 }
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan() const {
 #ifndef NDEBUG
     assert(expression_term_begins_.size() == output_.expression_register_constants_.size() &&
            "expression register storage is inconsistent");
-    assert(output_.expression_dependency_offsets_.size() ==
-               static_cast<size_t>(output_.num_symbols_) + 1 &&
-           "expression dependency offsets have the wrong size");
-    assert(!output_.expression_dependency_offsets_.empty() &&
-           output_.expression_dependency_offsets_.front() == 0 &&
-           output_.expression_dependency_offsets_.back() ==
-               output_.expression_dependency_targets_.size() &&
-           "expression dependency ranges are inconsistent");
-    for (size_t i = 1; i < output_.expression_dependency_offsets_.size(); ++i) {
-        assert(output_.expression_dependency_offsets_[i] >=
-                   output_.expression_dependency_offsets_[i - 1] &&
-               "expression dependency offsets are not ordered");
-    }
-    for (uint32_t target : output_.expression_dependency_targets_) {
-        assert(target < output_.expression_register_constants_.size() &&
-               "expression dependency target is out of range");
-    }
+    output_.expression_dependencies_.validate(output_.num_symbols_,
+                                              output_.expression_register_constants_.size());
 
     auto validate_expression = [&](ExecutablePlan::PreparedExpression expression) {
         assert(expression.register_id < output_.expression_register_constants_.size() &&

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -225,12 +225,7 @@ void Executor::initialize_expression_registers(const ExecutablePlan& plan,
 }
 
 void Executor::propagate_true_symbol(const ExecutablePlan& plan, uint32_t symbol) noexcept {
-    assert(static_cast<size_t>(symbol) + 1 < plan.expression_dependency_offsets_.size() &&
-           "assigned symbol must have an expression dependency range");
-    const uint32_t begin = plan.expression_dependency_offsets_[symbol];
-    const uint32_t end = plan.expression_dependency_offsets_[symbol + 1];
-    for (uint32_t i = begin; i < end; ++i) {
-        const uint32_t register_id = plan.expression_dependency_targets_[i];
+    for (uint32_t register_id : plan.expression_dependencies_.dependent_registers(symbol)) {
         assert(register_id < expression_registers_.size() &&
                "expression dependency must refer to a preallocated register");
         expression_registers_[register_id] ^= uint8_t{1};

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -72,14 +72,14 @@ void Executor::run_shot() noexcept {
            "automatic execution requires every presampled symbol to have a distribution");
     reset_shot();
     sample_presampled_noise(0, plan_->initial_noise_end_);
-    (void)execute_actions_for_backend<false, true, false>({});
+    (void)execute_actions_for_backend<ShotMode::SampleNoise>({});
 }
 
 void Executor::run_shot(std::span<const uint8_t> presampled_values) noexcept {
     plan_ = root_plan_;
     reset_shot();
     assign_presampled_values(presampled_values);
-    (void)execute_actions_for_backend<false, false, false>({});
+    (void)execute_actions_for_backend<ShotMode::UsePresampledNoise>({});
 }
 
 void Executor::run_shot(KFaultSampler& fault_sampler) noexcept {
@@ -91,7 +91,7 @@ void Executor::run_shot(KFaultSampler& fault_sampler) noexcept {
     forced_fault_sites_ = fault_sampler.sample([&]() noexcept { return rng_.next_double(); });
     forced_fault_cursor_ = 0;
     assign_forced_quantum_faults();
-    (void)execute_actions_for_backend<false, false, true>({});
+    (void)execute_actions_for_backend<ShotMode::FixedFaultCount>({});
     forced_fault_sites_ = {};
     forced_fault_cursor_ = 0;
 }
@@ -169,7 +169,7 @@ void Executor::resume(const ExecutablePlan& continuation,
 
     plan_ = &continuation;
     pending_trap_.reset();
-    (void)execute_actions_for_backend<false, true, false>({}, offset);
+    (void)execute_actions_for_backend<ShotMode::SampleNoise>({}, offset);
     if (forced_trace_out.has_value() && forced_record_mask_[index(forced_trace_out->record)] != 0) {
         throw std::logic_error("sampling continuation did not consume its forced trace-out record");
     }
@@ -191,7 +191,7 @@ ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
            "forced records must be Boolean");
     reset_shot();
     assign_presampled_values(presampled_values);
-    return execute_actions_for_backend<true, false, false>(forced_records);
+    return execute_actions_for_backend<ShotMode::ReplayRecords>(forced_records);
 }
 
 void Executor::reset_shot() noexcept {
@@ -319,7 +319,7 @@ void Executor::assign_forced_quantum_faults() noexcept {
     }
 }
 
-template <ExecutorBackend Backend, bool ForceRecords>
+template <ExecutorBackend Backend>
 void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     const bool sign = evaluate(action.sign);
@@ -337,7 +337,6 @@ void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
     }
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->fused_rotations_.size() &&
@@ -345,7 +344,6 @@ void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action
     plan_->fused_rotations_[action.rotation_index].apply(state_);
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->dynamic_fused_rotations_.size() &&
@@ -360,13 +358,12 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation&
     rotation.variants[variant].apply(state_);
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecutePromotion& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     apply_promotion(state_, action.promotion, evaluate(action.sign));
 }
 
-template <ExecutorBackend Backend, bool ForceRecords>
+template <ExecutorBackend Backend, Executor::ShotMode Mode>
 void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
                               std::span<const uint8_t> forced_records,
                               ReplayResult& result) noexcept {
@@ -385,7 +382,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
     }();
     const bool correction = evaluate(action.correction);
     bool branch = false;
-    if constexpr (ForceRecords) {
+    if constexpr (Mode == ShotMode::ReplayRecords) {
         branch = (forced_records[action.record] != 0) ^ correction;
         const std::optional<double> log_increment = force_active_branch(probabilities, branch);
         if (!log_increment.has_value()) {
@@ -419,13 +416,13 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
     records_[action.record] = static_cast<uint8_t>(branch ^ correction);
 }
 
-template <bool ForceRecords>
+template <Executor::ShotMode Mode>
 void Executor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
                               std::span<const uint8_t> forced_records,
                               ReplayResult& result) noexcept {
     const bool correction = evaluate(action.correction);
     bool branch = false;
-    if constexpr (ForceRecords) {
+    if constexpr (Mode == ShotMode::ReplayRecords) {
         branch = (forced_records[action.record] != 0) ^ correction;
         result.log_probability += kLogHalf;
     } else {
@@ -440,12 +437,12 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& a
     records_[action.record] = static_cast<uint8_t>(branch ^ correction);
 }
 
-template <bool ForceRecords>
+template <Executor::ShotMode Mode>
 void Executor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
                               std::span<const uint8_t> forced_records,
                               ReplayResult& result) noexcept {
     records_[action.record] = static_cast<uint8_t>(evaluate(action.outcome));
-    if constexpr (ForceRecords) {
+    if constexpr (Mode == ShotMode::ReplayRecords) {
         if (records_[action.record] != forced_records[action.record]) {
             result.reachable = false;
         }
@@ -456,23 +453,22 @@ void Executor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& acti
     }
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assign_symbol(action.symbol, evaluate(action.value));
 }
 
-template <bool ForceRecords, bool ForceFaults>
+template <Executor::ShotMode Mode>
 void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
                               std::span<const uint8_t>, ReplayResult& result) noexcept {
-    if constexpr (ForceRecords) {
+    if constexpr (Mode == ShotMode::ReplayRecords) {
         result.reachable = false;
     } else {
         const bool source = evaluate(action.source);
         assert(records_[action.record] == static_cast<uint8_t>(source) &&
                "readout source must match the current record value");
         bool flip = false;
-        if constexpr (ForceFaults) {
+        if constexpr (Mode == ShotMode::FixedFaultCount) {
             const uint32_t fault_site =
                 static_cast<uint32_t>(plan_->noise_sites_.size()) + action.site;
             assert((forced_fault_cursor_ >= forced_fault_sites_.size() ||
@@ -492,7 +488,6 @@ void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
     }
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteDetector& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     const bool outcome = evaluate(action.outcome);
@@ -500,13 +495,11 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDetector& action,
     discarded_ |= action.postselected && outcome;
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteObservable& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     observables_[action.observable] = static_cast<uint8_t>(evaluate(action.outcome));
 }
 
-template <bool ForceRecords>
 void Executor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.exp_val < exp_vals_.size() && "expectation slot must be preallocated");
@@ -668,10 +661,10 @@ void Executor::execute_instrument(
     execute_quantum_instrument<Backend>(action);
 }
 
-template <ExecutorBackend Backend, bool ForceRecords>
+template <ExecutorBackend Backend, Executor::ShotMode Mode>
 void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
                               std::span<const uint8_t>, ReplayResult& result) noexcept {
-    if constexpr (ForceRecords) {
+    if constexpr (Mode == ShotMode::ReplayRecords) {
         result.reachable = false;
     } else {
         std::visit(
@@ -688,15 +681,15 @@ void Executor::execute_action(const ExecutablePlan::ExecuteInstrument& action,
     }
 }
 
-template <bool SampleNoise>
+template <Executor::ShotMode Mode>
 void Executor::execute_action(const ExecutablePlan::ExecuteBoundary& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    if constexpr (SampleNoise) {
+    if constexpr (Mode == ShotMode::SampleNoise) {
         sample_presampled_noise(action.noise_begin, action.noise_end);
     }
 }
 
-template <ExecutorBackend Backend, bool ForceRecords, bool SampleNoise, bool ForceFaults>
+template <ExecutorBackend Backend, Executor::ShotMode Mode>
 ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                                        uint32_t begin) noexcept {
     ReplayResult result;
@@ -707,19 +700,23 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
             [&](const auto& typed) noexcept {
                 using T = std::decay_t<decltype(typed)>;
                 if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary>) {
-                    execute_action<SampleNoise>(typed, forced_records, result);
+                    execute_action<Mode>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
-                    execute_action<ForceRecords, ForceFaults>(typed, forced_records, result);
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation> ||
-                                     std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement> ||
+                    execute_action<Mode>(typed, forced_records, result);
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation>) {
+                    execute_action<Backend>(typed, forced_records, result);
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement> ||
                                      std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {
-                    execute_action<Backend, ForceRecords>(typed, forced_records, result);
+                    execute_action<Backend, Mode>(typed, forced_records, result);
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDormantMeasurement> ||
+                                     std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
+                    execute_action<Mode>(typed, forced_records, result);
                 } else {
-                    execute_action<ForceRecords>(typed, forced_records, result);
+                    execute_action(typed, forced_records, result);
                 }
             },
             action);
-        if constexpr (ForceRecords) {
+        if constexpr (Mode == ShotMode::ReplayRecords) {
             if (!result.reachable) {
                 return result;
             }
@@ -734,24 +731,21 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
     return result;
 }
 
-template <bool ForceRecords, bool SampleNoise, bool ForceFaults>
+template <Executor::ShotMode Mode>
 ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forced_records,
                                                    uint32_t begin) noexcept {
     switch (backend_) {
         case ExecutorBackend::Scalar:
-            return execute_actions<ExecutorBackend::Scalar, ForceRecords, SampleNoise, ForceFaults>(
-                forced_records, begin);
+            return execute_actions<ExecutorBackend::Scalar, Mode>(forced_records, begin);
         case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            return execute_actions<ExecutorBackend::Avx2, ForceRecords, SampleNoise, ForceFaults>(
-                forced_records, begin);
+            return execute_actions<ExecutorBackend::Avx2, Mode>(forced_records, begin);
 #else
             break;
 #endif
         case ExecutorBackend::Avx512:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            return execute_actions<ExecutorBackend::Avx512, ForceRecords, SampleNoise, ForceFaults>(
-                forced_records, begin);
+            return execute_actions<ExecutorBackend::Avx512, Mode>(forced_records, begin);
 #else
             break;
 #endif

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -694,18 +694,16 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
         std::visit(
             [&](const auto& typed) noexcept {
                 using T = std::decay_t<decltype(typed)>;
-                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary>) {
-                    execute_action<Mode>(typed, forced_records, result);
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
+                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteBoundary> ||
+                              std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise> ||
+                              std::is_same_v<T, ExecutablePlan::ExecuteDormantMeasurement> ||
+                              std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
                     execute_action<Mode>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation>) {
                     execute_action<Backend>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement> ||
                                      std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {
                     execute_action<Backend, Mode>(typed, forced_records, result);
-                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDormantMeasurement> ||
-                                     std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
-                    execute_action<Mode>(typed, forced_records, result);
                 } else {
                     execute_action(typed, forced_records, result);
                 }

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -106,6 +106,16 @@ class Executor {
     [[nodiscard]] uint64_t dust_clamps() const { return dust_clamps_; }
 
   private:
+    // Selects the complete per-shot policy at compile time. Keeping the four
+    // supported modes named prevents unsupported combinations of record,
+    // noise, and fixed-fault behavior from reaching the action loop.
+    enum class ShotMode : uint8_t {
+        SampleNoise,
+        UsePresampledNoise,
+        FixedFaultCount,
+        ReplayRecords,
+    };
+
     void reset_shot() noexcept;
     void assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept;
     void sample_presampled_noise(uint32_t begin, uint32_t end) noexcept;
@@ -116,52 +126,45 @@ class Executor {
     void initialize_expression_registers(const ExecutablePlan& plan,
                                          uint32_t symbol_prefix_size) noexcept;
 
-    template <bool ForceRecords, bool SampleNoise, bool ForceFaults>
+    template <ShotMode Mode>
     [[nodiscard]] ReplayResult execute_actions_for_backend(std::span<const uint8_t> forced_records,
                                                            uint32_t begin = 0) noexcept;
-    template <ExecutorBackend Backend, bool ForceRecords, bool SampleNoise, bool ForceFaults>
+    template <ExecutorBackend Backend, ShotMode Mode>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records,
                                                uint32_t begin = 0) noexcept;
-    template <ExecutorBackend Backend, bool ForceRecords>
+    template <ExecutorBackend Backend>
     void execute_action(const ExecutablePlan::ExecuteRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecutePromotion& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <ExecutorBackend Backend, bool ForceRecords>
+    template <ExecutorBackend Backend, ShotMode Mode>
     void execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
+    template <ShotMode Mode>
     void execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
+    template <ShotMode Mode>
     void execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords, bool ForceFaults>
+    template <ShotMode Mode>
     void execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteDetector& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteObservable& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool ForceRecords>
     void execute_action(const ExecutablePlan::ExecuteExpectation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <ExecutorBackend Backend, bool ForceRecords>
+    template <ExecutorBackend Backend, ShotMode Mode>
     void execute_action(const ExecutablePlan::ExecuteInstrument& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool SampleNoise>
+    template <ShotMode Mode>
     void execute_action(const ExecutablePlan::ExecuteBoundary& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
 


### PR DESCRIPTION
## Summary

- replace three Boolean executor template parameters with four named shot modes
- remove mode templates from action handlers whose behavior does not vary by shot policy
- encapsulate the expression dependency CSR behind a typed construction and lookup interface
- retain compile-time specialization, compact plan storage, and allocation-free hot execution

## Motivation

The previous Boolean template arguments allowed nonsensical combinations to be represented and made call sites such as `execute_actions<false, true, false>` difficult to review. The dependency offsets and targets likewise relied on parallel-vector correspondence at every construction and consumption site.

This keeps the same architecture and execution policies while making both invariants structural.

## Performance

Measured from the same GCC 13 RelWithDebInfo build with `-O2 -ffast-math -march=native -mtune=native`, using alternating processes pinned to an idle EPYC core.

- target-QEC prepare median: approximately 0.114 ms on both revisions; observed difference remained within about 1%
- cultivation-d5 and QV-20 preparation: neutral within run noise
- ordinary, survivor, fixed-k, presampled-value, and replay checksums matched
- execution showed no systematic regression; the expression-heavy presampled control improved after the compiler reduced the CSR range walk to a direct pointer loop
- the action descriptors and `ExecutablePlan` storage layout are unchanged

The dependency factory is force-inlined because this campaign previously measured fixed call overhead on small-plan preparation.

## Verification

- Debug full suite under `CLIFFT_FORCE_ISA=scalar`: 1,284 cases, 416,765 assertions
- Debug full suite under `CLIFFT_FORCE_ISA=avx2`: 1,284 cases, 479,221 assertions
- Debug full suite under `CLIFFT_FORCE_ISA=avx512`: 1,284 cases, 575,621 assertions
- Release non-benchmark suite: 1,284 cases passed
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Main currently has an unrelated cross-platform build failure with a separate fix in progress; this PR deliberately does not overlap that work.