### PR TITLE
fix(tests): restrict direct x86 kernel tests to dispatch builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,15 @@ if(CLIFFT_COVERAGE)
     endif()
 endif()
 
+# x86-64 runtime dispatch compiles the AVX2/AVX-512 kernel translation units.
+# The core library and the tests that call those kernels directly must agree
+# on this one predicate, so it is decided once here.
+if((CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)") AND NOT MSVC)
+    set(CLIFFT_X86_RUNTIME_DISPATCH ON)
+else()
+    set(CLIFFT_X86_RUNTIME_DISPATCH OFF)
+endif()
+
 # Fetch external dependencies
 include(cmake/FetchStim.cmake)
 include(cmake/FetchFastFloat.cmake)

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(clifft_core STATIC
 )
 
 # x86-64 runtime dispatch: compile AVX2 and AVX-512 TUs with SIMD flags.
-if((CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)") AND NOT MSVC)
+if(CLIFFT_X86_RUNTIME_DISPATCH)
     target_sources(clifft_core PRIVATE
         sampling/kernels_avx2.cc
         sampling/kernels_avx512.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,12 @@ target_compile_definitions(clifft_tests PRIVATE
     CLIFFT_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures"
 )
 
+# Tests that call the x86 kernel entry points directly can only link on
+# platforms whose core library compiles the runtime-dispatch kernels.
+if(CLIFFT_X86_RUNTIME_DISPATCH)
+    target_compile_definitions(clifft_tests PRIVATE CLIFFT_TESTS_HAVE_X86_KERNELS)
+endif()
+
 # Code coverage instrumentation for test executable
 if(CLIFFT_COVERAGE)
     target_compile_options(clifft_tests PRIVATE --coverage)

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -18,17 +18,12 @@
 
 using clifft::internal::RuntimeIsa;
 using clifft::sampling::activate_zero_coordinate;
-using clifft::sampling::active_measurement_probabilities_avx2;
-using clifft::sampling::active_measurement_probabilities_avx512;
 using clifft::sampling::ActiveMeasurementKernel;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::apply_instrument_no_fire;
 using clifft::sampling::apply_new_x_instrument_no_fire;
-using clifft::sampling::apply_new_x_instrument_no_fire_avx2;
 using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
-using clifft::sampling::collapse_active_measurement_avx2;
-using clifft::sampling::collapse_active_measurement_avx512;
 using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
 using clifft::sampling::collapse_new_x_instrument_source;
@@ -52,6 +47,14 @@ using clifft::test::check_complex;
 using clifft::test::dense_axis_rotation;
 using clifft::test::dense_matvec;
 using clifft::test::DenseMatrix;
+
+#if defined(CLIFFT_TESTS_HAVE_X86_KERNELS)
+using clifft::sampling::active_measurement_probabilities_avx2;
+using clifft::sampling::active_measurement_probabilities_avx512;
+using clifft::sampling::apply_new_x_instrument_no_fire_avx2;
+using clifft::sampling::collapse_active_measurement_avx2;
+using clifft::sampling::collapse_active_measurement_avx512;
+#endif
 
 namespace {
 
@@ -532,6 +535,7 @@ TEST_CASE("Sampling kernels measurements match dense projectors for every small 
     }
 }
 
+#if defined(CLIFFT_TESTS_HAVE_X86_KERNELS)
 TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
     const RuntimeIsa runtime_isa = clifft::internal::runtime_isa();
     if (runtime_isa != RuntimeIsa::Avx2 && runtime_isa != RuntimeIsa::Avx512) {
@@ -603,6 +607,7 @@ TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
         }
     }
 }
+#endif
 
 TEST_CASE("Sampling instrument kernels match dense projectors without compacting") {
     constexpr double kFactorZero = 0.8;
@@ -746,6 +751,7 @@ TEST_CASE("Sampling new X instrument activation matches the generic widened sour
     }
 }
 
+#if defined(CLIFFT_TESTS_HAVE_X86_KERNELS)
 TEST_CASE("Sampling AVX2 new X instrument activation matches scalar") {
     const RuntimeIsa runtime_isa = clifft::internal::runtime_isa();
     if (runtime_isa != RuntimeIsa::Avx2 && runtime_isa != RuntimeIsa::Avx512) {
@@ -776,6 +782,7 @@ TEST_CASE("Sampling AVX2 new X instrument activation matches scalar") {
         }
     }
 }
+#endif
 
 TEST_CASE("Sampling kernels compose across collapse and promotion") {
     constexpr uint32_t kInitialWidth = 2;


### PR DESCRIPTION
## Summary

- decide the x86-64 runtime-dispatch platform predicate once at the top level and share it between the core library and the test target
- compile the two test cases that call the AVX2/AVX-512 kernel entry points directly only on platforms whose core library links those symbols

Fixes the cross-platform CI failure on `main` after #325: `test_sampling_kernels.cc` referenced `active_measurement_probabilities_avx2/_avx512`, `collapse_active_measurement_avx2/_avx512`, and `apply_new_x_instrument_no_fire_avx2` unconditionally, which fails to link on MSVC and macOS arm64 where the dispatch kernels are never compiled. The tests' runtime ISA guards cannot remove link-time references, so the guard must be at compile time. Sharing one CMake predicate keeps the library and test conditions from drifting apart.

## Verification

- x86-64 dispatch build: full non-benchmark Debug suite passes, 1,284 cases (both guarded tests included)
- simulated non-dispatch build (`-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm64`, reproducing the failing configuration): `clifft_tests` links with zero AVX kernel references and the full non-benchmark suite passes, 1,282 cases
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
