### PR TITLE
ci: run cross-platform checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,18 +307,21 @@ jobs:
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh Nehalem avx2 fail
 
   cross-platform:
+    name: cross-platform (${{ matrix.label }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - label: macOS
+            os: macos-latest
             install-deps: brew install ninja libomp
             skbuild-type: Debug
             skbuild-cmake-args: ""
           # MSVC Debug wheels make the Python suite several times slower than
           # every other platform, so Windows tests an optimized wheel that
           # keeps assert() active instead.
-          - os: windows-latest
+          - label: Windows
+            os: windows-latest
             install-deps: ""
             skbuild-type: RelWithDebInfo
             skbuild-cmake-args: "-DCLIFFT_FORCE_ASSERTS=ON"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,19 +307,26 @@ jobs:
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh Nehalem avx2 fail
 
   cross-platform:
-    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: macos-latest
             install-deps: brew install ninja libomp
+            skbuild-type: Debug
+            skbuild-cmake-args: ""
+          # MSVC Debug wheels make the Python suite several times slower than
+          # every other platform, so Windows tests an optimized wheel that
+          # keeps assert() active instead.
           - os: windows-latest
             install-deps: ""
+            skbuild-type: RelWithDebInfo
+            skbuild-cmake-args: "-DCLIFFT_FORCE_ASSERTS=ON"
     runs-on: ${{ matrix.os }}
     env:
       CMAKE_BUILD_TYPE: Debug
-      SKBUILD_CMAKE_BUILD_TYPE: Debug
+      SKBUILD_CMAKE_BUILD_TYPE: ${{ matrix.skbuild-type }}
+      SKBUILD_CMAKE_ARGS: ${{ matrix.skbuild-cmake-args }}
       CLIFFT_CPU_BASELINE: generic
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,22 @@ endif()
 # Export compile_commands.json for IDE support
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Keep assert() active in optimized configurations. Assertion coverage is this
+# project's primary internal-invariant check, so CI can pair it with optimized
+# code where a full Debug build is too slow.
+option(CLIFFT_FORCE_ASSERTS "Keep assert() active regardless of build type" OFF)
+if(CLIFFT_FORCE_ASSERTS)
+    foreach(lang C CXX)
+        foreach(config RELEASE RELWITHDEBINFO MINSIZEREL)
+            string(REPLACE "/DNDEBUG" "" CMAKE_${lang}_FLAGS_${config}
+                   "${CMAKE_${lang}_FLAGS_${config}}")
+            string(REPLACE "-DNDEBUG" "" CMAKE_${lang}_FLAGS_${config}
+                   "${CMAKE_${lang}_FLAGS_${config}}")
+        endforeach()
+    endforeach()
+    message(STATUS "CLIFFT_FORCE_ASSERTS: assert() remains active in optimized configurations")
+endif()
+
 # Compiler warnings
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(-Wall -Wextra -Wpedantic)


### PR DESCRIPTION
## Summary

- run the cross-platform (Windows, macOS) job on pull requests instead of only on pushes to `main`, since standard hosted runners are free for public repositories
- add a `CLIFFT_FORCE_ASSERTS` CMake option that strips `NDEBUG` from optimized configurations so `assert()` coverage survives outside Debug builds
- build the Windows Python wheel as `RelWithDebInfo` with `CLIFFT_FORCE_ASSERTS=ON`; MSVC Debug wheels (`/Od` plus checked iterators) made the Windows Python test step several times slower than every other platform

The C++ test suites remain full Debug on both platforms, and macOS keeps the Debug wheel, so a true Debug extension still runs in CI on every change. Two platform link/layout breaks have now reached `main` undetected because this job did not gate merges; measured on the latest green run the job costs 4.7 min (macOS) and 8.3 min (Windows), with the Windows Python test step (225 s under the Debug wheel) expected to shrink substantially under the optimized-with-asserts wheel.

## Verification

- native `RelWithDebInfo` configure with `-DCLIFFT_FORCE_ASSERTS=ON`: compile commands for clifft and vendored stim retain `-O2` and contain no `NDEBUG`
- wheel build through the exact CI environment (`SKBUILD_CMAKE_BUILD_TYPE=RelWithDebInfo`, `SKBUILD_CMAKE_ARGS=-DCLIFFT_FORCE_ASSERTS=ON`, `uv sync --locked`): zero `NDEBUG` occurrences in the scikit-build compile database
- full Python suite against that wheel: 1,034 passed in 14.65 s
- `pre-commit` on the changed files passes
- the cross-platform job on this PR run is itself the end-to-end test of the change

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
