### PR TITLE
feat(inspection): compact sampling-plan text format; single playground plan panel

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -47,6 +47,36 @@ def define_env(env: Any) -> None:
     env.variables["hir_categories"] = [c for c in hir_categories_order if hir_by_category.get(c)]
     env.variables["hir_by_category"] = hir_by_category
 
+    # -- Sampling plan actions --
+    plan_actions = data.get("plan_actions", {})
+    plan_categories_order = [
+        "Rotation",
+        "Measurement",
+        "Classical",
+        "Output",
+        "Instrument",
+    ]
+    plan_by_category: dict[str, list[dict[str, object]]] = {}
+    for cat in plan_categories_order:
+        plan_by_category[cat] = []
+    for name, info in plan_actions.items():
+        cat = info.get("category", "")
+        entry = {"name": name, **info}
+        if cat not in plan_by_category:
+            plan_by_category[cat] = []
+        plan_by_category[cat].append(entry)
+
+    unknown_plan_categories = sorted(set(plan_by_category) - set(plan_categories_order))
+    if unknown_plan_categories:
+        raise ValueError(
+            "docs/opcodes.json contains sampling-plan categories missing from docs/macros.py: "
+            + ", ".join(unknown_plan_categories)
+        )
+
+    env.variables["plan_actions"] = plan_actions
+    env.variables["plan_categories"] = [c for c in plan_categories_order if plan_by_category.get(c)]
+    env.variables["plan_by_category"] = plan_by_category
+
     # -- Optimization passes --
     # Hardcoded from pass_registry.h (single source of truth in C++).
     # When a new pass is added in C++, add it here too.

--- a/docs/opcodes.json
+++ b/docs/opcodes.json
@@ -4,61 +4,163 @@
       "category": "Non-Clifford",
       "summary": "T or T-dagger gate: pi/8 phase rotation on a Pauli product.",
       "detail": "The primary non-Clifford operation. Applies exp(i*pi/8 * P) where P is the Pauli product shown (e.g. +X0*Z1). T_DAG applies the conjugate rotation. These cannot be absorbed into the offline Clifford frame U_C and remain explicit through sampling-plan preparation.",
-      "display": ["T", "T_DAG"]
+      "display": [
+        "T",
+        "T_DAG"
+      ]
     },
     "MEASURE": {
       "category": "Measurement",
       "summary": "Destructive measurement of a Pauli observable.",
       "detail": "Measures the Pauli product shown (e.g. +X0, -Z0*Z1) and stores the outcome in the measurement record. The Pauli is the effective observable after the Heisenberg mapping U_C^dag P U_C -- it may differ from the original circuit's measurement basis.",
-      "display": ["MEASURE"]
+      "display": [
+        "MEASURE"
+      ]
     },
     "CONDITIONAL_PAULI": {
       "category": "Feedback",
       "summary": "Classical feedback: apply Pauli correction conditioned on a measurement.",
       "detail": "If the referenced measurement record entry is 1, applies the shown Pauli product to the frame. Implements feed-forward operations like teleportation corrections and QEC feedback.",
-      "display": ["IF", "THEN"]
+      "display": [
+        "IF",
+        "THEN"
+      ]
     },
     "NOISE": {
       "category": "Noise",
       "summary": "Stochastic Pauli noise channel.",
       "detail": "Represents a noise process (depolarizing, dephasing, etc.) that may randomly apply a Pauli operator. References a NoiseSite side-table with the channel probabilities.",
-      "display": ["NOISE"]
+      "display": [
+        "NOISE"
+      ]
     },
     "READOUT_NOISE": {
       "category": "Noise",
       "summary": "Classical bit-flip noise on a measurement result.",
       "detail": "Models measurement readout errors as a classical bit-flip probability applied to the measurement record after the quantum measurement.",
-      "display": ["READOUT_NOISE"]
+      "display": [
+        "READOUT_NOISE"
+      ]
     },
     "DETECTOR": {
       "category": "QEC",
       "summary": "Detector: parity check over measurement records.",
       "detail": "Defines a parity check (XOR) over a set of measurement record entries. In error correction, detectors flag syndrome changes between rounds.",
-      "display": ["DETECTOR"]
+      "display": [
+        "DETECTOR"
+      ]
     },
     "OBSERVABLE": {
       "category": "QEC",
       "summary": "Logical observable accumulator.",
       "detail": "Accumulates measurement record parities into a logical observable for error correction tracking.",
-      "display": ["OBSERVABLE"]
+      "display": [
+        "OBSERVABLE"
+      ]
     },
     "PHASE_ROTATION": {
       "category": "Non-Clifford",
       "summary": "Continuous Z-rotation by angle alpha (half-turns) on a Pauli product.",
       "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. The front-end factors out the global phase e^{-i*alpha*pi/2} into global_weight. All single-qubit rotations and multi-qubit Pauli rotations are reduced to this HIR type via Clifford absorption.",
-      "display": ["PHASE_ROTATION"]
+      "display": [
+        "PHASE_ROTATION"
+      ]
     },
     "EXP_VAL": {
       "category": "Measurement",
       "summary": "Non-destructive expectation value of a rewound Pauli product.",
       "detail": "Evaluates <P> for the rewound Pauli product P at the point in the circuit where the probe appears. Does not collapse the state, mutate the Pauli frame, or affect measurement, detector, or observable records.",
-      "display": ["EXP_VAL"]
+      "display": [
+        "EXP_VAL"
+      ]
     },
     "INSTRUMENT": {
       "category": "Instrument",
       "summary": "State-dependent jump site: a transition instrument on one qubit.",
       "detail": "Carries the rewound source observable Z_q and references an InstrumentSite side table with per-source fire probabilities and computational-destination splits. Instruments are optimization fences so a recompiled continuation preserves the prefix consumed by an already-running executor.",
-      "display": ["INSTRUMENT"]
+      "display": [
+        "INSTRUMENT"
+      ]
+    }
+  },
+  "plan_actions": {
+    "ROTATE_ACTIVE": {
+      "category": "Rotation",
+      "summary": "Rotation about a Pauli product on the active coordinates.",
+      "detail": "Applies exp(-i*pi*half_turns/2 * P) where P is the Pauli product shown over active symbolic coordinates. This traverses the dense 2^k coefficient state. When the per-shot sign expression evaluates true the rotation direction is reversed; this is how earlier stochastic events such as noise and measurement branches steer later physics without re-planning.",
+      "operands": "Pauli product, half_turns, sign"
+    },
+    "ROTATE_PHASE": {
+      "category": "Rotation",
+      "summary": "Sign-conditioned global phase from a rotation whose Pauli reduced to the identity.",
+      "detail": "A rotation whose Pauli product commuted to the identity during planning. It multiplies the global scalar by a phase that depends on the per-shot sign expression and does not traverse the coefficient state. It matters for interference later in the circuit and for record-probability queries, not for measurement statistics at this point.",
+      "operands": "half_turns, sign"
+    },
+    "PROMOTE_DORMANT": {
+      "category": "Rotation",
+      "summary": "Grows the active state by one coordinate and applies the rotation that introduced it.",
+      "detail": "A non-Clifford rotation on a coordinate that was stabilizer-only until now. The active width increases by one, doubling the coefficient state, and the promoting rotation is applied in the same pass. Later operations were already rewritten into the new basis during planning. The sign expression conditions the rotation direction per shot.",
+      "operands": "half_turns, sign"
+    },
+    "MEASURE_ACTIVE": {
+      "category": "Measurement",
+      "summary": "Measures a Pauli product on the active coordinates, collapsing the coefficient state.",
+      "detail": "Samples the branch symbol from the coefficient amplitudes and collapses onto the selected eigenspace. The pivot coordinate is removed afterwards, so the active width decreases by one and the coefficient state halves. The record bit is the raw branch XORed with the outcome expression's corrections from earlier stochastic events.",
+      "operands": "Pauli product, pivot, branch, outcome, record"
+    },
+    "MEASURE_DORMANT": {
+      "category": "Measurement",
+      "summary": "Measures a random-outcome Pauli outside the active coefficient state.",
+      "detail": "The measured observable anticommutes with a dormant stabilizer, so the outcome is an unbiased coin flip handled algebraically: the branch symbol is sampled, the dormant stabilizer at the pivot is replaced, and the coefficient state is untouched. The record bit combines the branch with the outcome expression's corrections.",
+      "operands": "pivot, branch, outcome, record"
+    },
+    "RECORD_CLASSICAL": {
+      "category": "Classical",
+      "summary": "Writes a deterministic expression to the measurement record.",
+      "detail": "Used when a measurement outcome is fully determined by the initial state and earlier symbols, such as a stabilizer measurement whose value follows from the frame. No state work is needed: the record bit is the affine expression, an XOR of earlier symbols and an optional constant.",
+      "operands": "outcome, record"
+    },
+    "DEFINE_SYMBOL": {
+      "category": "Classical",
+      "summary": "Names an affine expression as a reusable symbol without writing a record.",
+      "detail": "Gives a parity of previously available symbols its own symbol id so later actions can reference it compactly. Pure bookkeeping: no record slot is written and no state is touched.",
+      "operands": "symbol, value"
+    },
+    "READOUT_NOISE": {
+      "category": "Classical",
+      "summary": "Samples whether a completed measurement record flips.",
+      "detail": "Classical readout error applied after a record is written. The flip probability may depend on the record's value before the flip (p01 versus p10), so the flip symbol is defined at this circuit position instead of being presampled before the shot. The record slot is updated in place.",
+      "operands": "flip, source, record, p01, p10"
+    },
+    "WRITE_DETECTOR": {
+      "category": "Output",
+      "summary": "Writes a detector parity; with postselect, a nonzero parity rejects the shot.",
+      "detail": "The outcome expression already includes the noiseless reference parity, so the written bit is 1 exactly when the detector fired. When marked postselect, a nonzero value aborts the shot immediately.",
+      "operands": "outcome, detector"
+    },
+    "WRITE_OBSERVABLE": {
+      "category": "Output",
+      "summary": "Writes one fully accumulated logical observable bit.",
+      "detail": "The outcome expression combines every contributing measurement record and the noiseless reference parity, so the written bit is 1 exactly when the logical observable flipped.",
+      "operands": "outcome, observable"
+    },
+    "WRITE_EXPECTATION": {
+      "category": "Output",
+      "summary": "Records a non-destructive Pauli expectation value of the current state.",
+      "detail": "Probes the expectation of a Pauli observable without collapsing anything. When an active projection is shown, one pass over the coefficient state computes it, with the sign expression conditioning its overall sign per shot. The word zero means planning already proved the expectation vanishes because the transformed observable has X or Y support outside the active coordinates.",
+      "operands": "Pauli product or zero, sign, exp_val"
+    },
+    "APPLY_INSTRUMENT": {
+      "category": "Instrument",
+      "summary": "Evaluates a state-dependent transition site such as leakage, loss, or relaxation.",
+      "detail": "The transition fires with a probability that depends on which computational level the qubit occupies, so the source projector is evaluated against the live state. The mode records how the source enters the coefficient state: as a pure sign (classical), on existing active coordinates (active), by adding one coordinate (activate), or as a dormant-random trap resolved by a continuation. The flip symbol is true exactly when the sampled computational destination differs from its source.",
+      "operands": "Pauli product (omitted for identity sources), site, mode, sign, flip"
+    },
+    "INSTRUMENT_BOUNDARY": {
+      "category": "Instrument",
+      "summary": "Marks where a continuation may resume after an instrument traps.",
+      "detail": "Divides the plan into ahead-of-time execution segments. A continuation resumes at this marker with the live coefficients, active-coordinate meaning and order, symbol and record values, and RNG position preserved, then samples only the replacement suffix's remaining presampled noise.",
+      "operands": "site, next_noise_site, symbol_prefix_size"
     }
   }
 }

--- a/docs/opcodes.json
+++ b/docs/opcodes.json
@@ -93,7 +93,7 @@
     "ROTATE_PHASE": {
       "category": "Rotation",
       "summary": "Sign-conditioned global phase from a rotation whose Pauli reduced to the identity.",
-      "detail": "A rotation whose Pauli product commuted to the identity during planning. It multiplies the global scalar by a phase that depends on the per-shot sign expression and does not traverse the coefficient state. It matters for interference later in the circuit and for record-probability queries, not for measurement statistics at this point.",
+      "detail": "A rotation whose Pauli product reduced to the identity during planning. It multiplies the global scalar by a phase determined by the per-shot sign expression and does not traverse the coefficient state. The phase is retained so exact statevector reconstruction preserves the program's global phase; it does not affect sampling, later interference, basis probabilities, record probabilities, or expectation values.",
       "operands": "half_turns, sign"
     },
     "PROMOTE_DORMANT": {

--- a/docs/reference/instructions.md
+++ b/docs/reference/instructions.md
@@ -1,0 +1,85 @@
+# Instruction Reference
+
+This page documents the operation types used by the Clifft compiler at both
+levels of the pipeline: the **Heisenberg IR** (HIR) produced by the front-end,
+and the **Sampling Plan actions** produced by the planner and executed by the
+sampling backend.
+
+The same data powers the hover tooltips in the
+[Playground]({{ playground_url }}).
+
+!!! tip "Playground Tooltips"
+    In the Playground, hover over any HIR keyword or plan-action name to see
+    its description inline.
+
+---
+
+## HIR Operation Types
+
+The Heisenberg IR is the intermediate representation produced by the front-end.
+Clifford gates are absorbed into the offline Clifford frame $U_C$ and do not
+appear in the HIR. What remains are non-Clifford operations, measurements, and
+meta-instructions.
+
+{% for cat in hir_categories %}
+### {{ cat }}
+
+{% for op in hir_by_category[cat] %}
+{% for display_name in op.get('display', [op['name']]) %}
+#### `{{ display_name }}`
+{% endfor %}
+
+**{{ op['summary'] }}**
+
+{{ op['detail'] }}
+
+{% endfor %}
+{% endfor %}
+
+---
+
+## Sampling Plan Actions
+
+The planner compiles optimized HIR into a sampling plan: a fixed sequence of
+actions in which every Clifford has been absorbed and every stochastic event
+appears as a Boolean **symbol**. The plan is what repeated sampling executes,
+and it is what the Playground's Sampling Plan panel displays.
+
+### Reading a plan line
+
+```
+w1->0 MEASURE_ACTIVE Z0 pivot=0 branch=s3 outcome=s0^s1^s3 record=r0 passes=2
+```
+
+* **`w<k>` / `w<k>-><k'>`** — the active width before (and, when it changes,
+  after) the action. The dense coefficient state holds $2^k$ amplitudes for
+  the currently active symbolic coordinates.
+* **Pauli products** such as `Z0` or `X0*Z1` are written over **active
+  symbolic coordinates, not physical qubits**. The Clifford frame maps
+  between the two.
+* **Affine expressions** such as `1^s0^s3` are XORs of Boolean symbols, with
+  a leading `1` for the affine constant. Symbols are sampled noise outcomes,
+  measurement branches, or derived parities. The Playground's compact view
+  truncates long expressions and reports the omitted count as `...(+N)`.
+* **Typed ids** name output slots: `r` measurement records, `d` detectors,
+  `o` observables, `v` expectation values, and `s` symbols.
+* **`passes=<n>`** estimates full traversals of the dense coefficient state
+  for a direct lowering of the action; actions without it touch no dense
+  state.
+
+### Action types
+
+{% for cat in plan_categories %}
+#### {{ cat }}
+
+{% for op in plan_by_category[cat] %}
+##### `{{ op['name'] }}`
+
+**{{ op['summary'] }}**
+
+{{ op['detail'] }}
+
+**Operands:** `{{ op['operands'] }}`
+
+{% endfor %}
+{% endfor %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
     - Noncomputational States: theory/noncomputational.md
   - Reference:
     - Supported Gates: reference/gates.md
+    - Instruction Reference: reference/instructions.md
     - Optimization Passes: reference/passes.md
     - Python API: reference/python-api.md
   - Development:

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -338,6 +338,18 @@ export default function App() {
     const hirLines = reverseMaps.hir.get(srcLine) ?? [];
     const loweredLines = reverseMaps.lowered.get(srcLine) ?? [];
 
+    // Keep the counterpart lines in view when a click's target is
+    // scrolled off-screen (large circuits can span hundreds of lines).
+    // revealLineInCenterIfOutsideViewport only scrolls the viewport — it
+    // never moves the cursor/selection — so it can't feed back into the
+    // read-only editors' onDidChangeCursorPosition handlers, and it's a
+    // no-op when the line is already visible (harmless for the editor
+    // the user just clicked in).
+    sourceEditorRef.current?.revealLineInCenterIfOutsideViewport(srcLine);
+    if (hirLines.length > 0) {
+      hirEditorRef.current?.revealLineInCenterIfOutsideViewport(hirLines[0]);
+    }
+
     // Highlight the source line itself
     sourceDecosRef.current?.set([
       {
@@ -373,12 +385,20 @@ export default function App() {
     );
 
     if (loweredLines.length > 0) {
+      // Anchor the glyph on the specific action the user clicked, if it
+      // maps to this source line; otherwise fall back to the first
+      // action for the line (e.g. when navigation originated from the
+      // source or HIR panel, which don't pick a specific action).
+      const anchorLine =
+        cursorPlanAction !== null && loweredLines.includes(cursorPlanAction + 1)
+          ? cursorPlanAction + 1
+          : loweredLines[0];
       loweredActionDecosRef.current?.set([
         {
           range: {
-            startLineNumber: loweredLines[0],
+            startLineNumber: anchorLine,
             startColumn: 1,
-            endLineNumber: loweredLines[0],
+            endLineNumber: anchorLine,
             endColumn: 1,
           },
           options: {
@@ -386,10 +406,11 @@ export default function App() {
           },
         },
       ]);
+      loweredEditorRef.current?.revealLineInCenterIfOutsideViewport(anchorLine);
     } else {
       loweredActionDecosRef.current?.clear();
     }
-  }, [cursorSourceLine, compileResult, reverseMaps, rulerColor, diffView]);
+  }, [cursorSourceLine, cursorPlanAction, compileResult, reverseMaps, rulerColor, diffView]);
 
   // --- Editor mount handlers ---
   const onSourceMount: OnMount = (editor) => {

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -29,7 +29,6 @@ M 1
 const DEBOUNCE_MS = 200;
 const DEFAULT_SHOTS = 10000;
 const TOUR_SEEN_KEY = "clifft-tour-seen";
-type LoweredView = "sampling-plan" | "wasm-program";
 
 function getInitialSource(): string {
   const params = new URLSearchParams(window.location.search);
@@ -145,7 +144,6 @@ export default function App() {
   const [compileResult, setCompileResult] = useState<CompileResult | null>(null);
   const [baselineResult, setBaselineResult] = useState<CompileResult | null>(null);
   const [diffView, setDiffViewRaw] = useState(false);
-  const [loweredView, setLoweredView] = useState<LoweredView>("sampling-plan");
   const [simResult, setSimResult] = useState<SimulateResult | null>(null);
   const [simElapsedMs, setSimElapsedMs] = useState<number | null>(null);
   const [simulating, setSimulating] = useState(false);
@@ -170,16 +168,14 @@ export default function App() {
 
   // Ref to avoid stale closures in editor cursor handlers
   const compileResultRef = useRef<CompileResult | null>(null);
-  const loweredViewRef = useRef<LoweredView>(loweredView);
-  const renderedLoweredViewRef = useRef<LoweredView>(loweredView);
   const suppressReadOnlyCursorEventsRef = useRef(false);
 
   // Reverse source-map indices, built once per compile result. Each
   // forward source map is `outIdx -> source_line[]`; the cursor highlight
   // wants the inverse `source_line -> outIdx[]` so it can answer "which
-  // HIR/selected-lowering lines correspond to this source line" in O(1).
+  // HIR/sampling-plan lines correspond to this source line" in O(1).
   // firstPlan is the first semantic action for a source line, used by the
-  // active-width chart even when the prepared WASM program is displayed.
+  // active-width chart.
   //
   // A single forward entry can contain the same source line more than
   // once when an upstream pass merged provenance from fused / unrolled
@@ -209,12 +205,8 @@ export default function App() {
         if (!firstPlan.has(ln)) firstPlan.set(ln, i);
       }
     });
-    const selectedSourceMap =
-      loweredView === "sampling-plan"
-        ? compileResult.sampling_plan_source_map
-        : compileResult.wasm_program_source_map;
     const lowered = new Map<number, number[]>();
-    selectedSourceMap.forEach((lines: number[], i: number) => {
+    compileResult.sampling_plan_source_map.forEach((lines: number[], i: number) => {
       const monacoLine = i + 1;
       const unique = lines.length > 1 ? new Set(lines) : lines;
       for (const ln of unique) {
@@ -224,7 +216,7 @@ export default function App() {
       }
     });
     return { hir, lowered, firstPlan };
-  }, [compileResult, loweredView]);
+  }, [compileResult]);
 
   // Derived: which semantic action maps to the cursor source line.
   const highlightedPlanAction = useMemo(() => {
@@ -281,10 +273,6 @@ export default function App() {
     compileResultRef.current = compileResult;
   }, [compileResult]);
 
-  useEffect(() => {
-    loweredViewRef.current = loweredView;
-  }, [loweredView]);
-
   // Register custom languages once before any editor mounts
   const handleBeforeMount: BeforeMount = useCallback((monaco) => {
     registerLanguages(monaco);
@@ -322,14 +310,8 @@ export default function App() {
       return;
     }
     updateReadOnlyEditor(hirEditorRef.current, compileResult.hir_ops.join("\n"));
-    const lowered =
-      loweredView === "sampling-plan"
-        ? compileResult.sampling_plan
-        : compileResult.wasm_program;
-    const preserveSelection = renderedLoweredViewRef.current === loweredView;
-    updateReadOnlyEditor(loweredEditorRef.current, lowered.join("\n"), preserveSelection);
-    renderedLoweredViewRef.current = loweredView;
-  }, [compileResult, updateReadOnlyEditor, diffView, loweredView]);
+    updateReadOnlyEditor(loweredEditorRef.current, compileResult.sampling_plan.join("\n"));
+  }, [compileResult, updateReadOnlyEditor, diffView]);
 
   // --- Bidirectional highlighting (only in non-diff mode) ---
   useEffect(() => {
@@ -445,15 +427,8 @@ export default function App() {
       const cr = compileResultRef.current;
       if (!cr || !isCompileSuccess(cr)) return;
       const actionIdx = e.position.lineNumber - 1;
-      const planAction =
-        loweredViewRef.current === "sampling-plan"
-          ? actionIdx
-          : cr.wasm_program_plan_ranges[actionIdx]?.begin;
-      setCursorPlanAction(planAction ?? null);
-      const srcLines =
-        loweredViewRef.current === "sampling-plan"
-          ? cr.sampling_plan_source_map[actionIdx]
-          : cr.wasm_program_source_map[actionIdx];
+      setCursorPlanAction(actionIdx);
+      const srcLines = cr.sampling_plan_source_map[actionIdx];
       const validLine = srcLines?.find((l: number) => l >= 1);
       if (validLine !== undefined) {
         setCursorSourceLine(validLine);
@@ -544,15 +519,8 @@ export default function App() {
   // Diff content for DiffEditor
   const hirBaseline = baselineStats ? baselineStats.hir_ops.join("\n") : "";
   const hirOptimized = stats ? stats.hir_ops.join("\n") : "";
-  const loweredBaseline = baselineStats
-    ? (loweredView === "sampling-plan"
-        ? baselineStats.sampling_plan
-        : baselineStats.wasm_program
-      ).join("\n")
-    : "";
-  const loweredOptimized = stats
-    ? (loweredView === "sampling-plan" ? stats.sampling_plan : stats.wasm_program).join("\n")
-    : "";
+  const loweredBaseline = baselineStats ? baselineStats.sampling_plan.join("\n") : "";
+  const loweredOptimized = stats ? stats.sampling_plan.join("\n") : "";
 
   return (
     <div className="app">
@@ -600,11 +568,6 @@ export default function App() {
             "Plan actions",
             stats.sampling_plan.length,
             baselineStats?.sampling_plan.length,
-          )}
-          {formatStat(
-            "WASM actions",
-            stats.wasm_program.length,
-            baselineStats?.wasm_program.length,
           )}
         </div>
       )}
@@ -686,33 +649,7 @@ export default function App() {
               <Allotment.Pane>
                 <div className="editor-pane" data-tour="lowered">
                   <div className="editor-label">
-                    <span>
-                      {loweredView === "sampling-plan" ? "Sampling Plan" : "WASM Program"}
-                    </span>
-                    <span className="editor-view-toggle" aria-label="Lowered representation">
-                      <button
-                        type="button"
-                        className={loweredView === "sampling-plan" ? "active" : ""}
-                        onClick={() => {
-                          setCursorPlanAction(null);
-                          setLoweredView("sampling-plan");
-                        }}
-                        title="Show executor-independent semantic actions"
-                      >
-                        Plan
-                      </button>
-                      <button
-                        type="button"
-                        className={loweredView === "wasm-program" ? "active" : ""}
-                        onClick={() => {
-                          setCursorPlanAction(null);
-                          setLoweredView("wasm-program");
-                        }}
-                        title="Show prepared scalar WASM actions"
-                      >
-                        WASM
-                      </button>
-                    </span>
+                    <span>Sampling Plan</span>
                     {diffView && <span className="editor-label-badge">DIFF</span>}
                   </div>
                   {diffView ? (

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -50,17 +50,20 @@ const STEPS: TourStep[] = [
     html: `
       <p>The planner turns the HIR into semantic actions over stabilizer
       coordinates and Boolean symbols. This is the portable representation
-      used by Clifft's symbolic-coordinate backend.</p>
-      <p>Each line shows the active width before and after the action.
-      Operations with a nonzero <code>dense_passes</code> estimate touch the
-      active coefficient state.</p>
-      <p>Useful plan actions to look for:</p>
-      <ul>
-        <li><code>rotate_active</code> rotates within the current active state</li>
-        <li><code>promote_dormant</code> adds a coordinate to that state</li>
-        <li><code>measure_active</code> can collapse and remove a coordinate</li>
-        <li><code>record_classical</code> needs no coefficient work</li>
-      </ul>
+      used by Clifft's symbolic-coordinate backend. The uppercase names, like
+      <code>ROTATE_ACTIVE</code>, <code>PROMOTE_DORMANT</code>, and
+      <code>MEASURE_ACTIVE</code>, are the planner actions themselves &mdash;
+      hover over one to see an inline description of what it does.</p>
+      <p>Pauli factors such as <code>X0</code> and <code>Z1</code> refer to
+      active symbolic coordinates, not physical qubits. The <code>w&lt;k&gt;</code>
+      prefix on each line shows the active width before and, when it changes,
+      after the action; a trailing <code>passes=n</code> estimates how many
+      dense-state traversals the action costs, and lines without it touch no
+      dense state at all.</p>
+      <p>Expressions like <code>s0^s1^s3</code> are XORs of per-shot Boolean
+      symbols &mdash; noise draws, measurement branches, and the like. Long
+      expressions may be truncated as <code>...(+N)</code> in this panel; the
+      full expression still exists in the underlying plan.</p>
     `,
   },
   {

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -54,9 +54,6 @@ const STEPS: TourStep[] = [
       <p>Each line shows the active width before and after the action.
       Operations with a nonzero <code>dense_passes</code> estimate touch the
       active coefficient state.</p>
-      <p>Use the <code>WASM</code> toggle for the advanced view of actions
-      prepared for this browser's scalar WebAssembly executor. There you can
-      see lowering choices such as fused rotations and expression registers.</p>
       <p>Useful plan actions to look for:</p>
       <ul>
         <li><code>rotate_active</code> rotates within the current active state</li>

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -69,7 +69,7 @@ const STEPS: TourStep[] = [
   {
     title: "Source Map Highlighting",
     html: `
-      <p>Click any line in any editor to highlight the related lines in the
+      <p>Outside diff view, click any line in any editor to highlight the related lines in the
       other panels. Colored ticks in the scrollbars show where those related
       lines are.</p>
       <p>This lets you trace how a source instruction changes as it moves

--- a/playground/src/languages.ts
+++ b/playground/src/languages.ts
@@ -82,18 +82,39 @@ export const hirLanguage: languages.IMonarchLanguage = {
   },
 };
 
-// --- SamplingPlan and prepared WASM program language ---
+// --- SamplingPlan compact inspection language ---
+// Grammar: w<k>[-><k'>] <MNEMONIC> [<pauli>] key=value... [postselect] [passes=<n>]
 export const planLanguage: languages.IMonarchLanguage = {
   tokenizer: {
     root: [
-      [/\b[serdl]\d+\b/, "variable"],
-      [/\b(active_width|dense_passes|half_turns|sign|outcome|value|source|correction|kernel|mode|descriptor|pivot|pairing_bit|branch|record|detector|observable|exp_val|site|flip|p01|p10|postselected|cosine|sine|noise|symbol_prefix_size)=/, "attribute"],
-      [/\b[a-z][a-z0-9_]*(?=\s|$)/, "keyword"],
-      [/0x[0-9a-f]+/, "number.hex"],
+      // Width prefix: w0 or w0->1
+      [/\bw\d+(?:->\d+)?\b/, "keyword"],
+      // Action mnemonics (explicit list; avoids matching arbitrary identifiers)
+      [
+        /\b(?:ROTATE_ACTIVE|ROTATE_PHASE|PROMOTE_DORMANT|MEASURE_ACTIVE|MEASURE_DORMANT|RECORD_CLASSICAL|DEFINE_SYMBOL|READOUT_NOISE|WRITE_DETECTOR|WRITE_OBSERVABLE|WRITE_EXPECTATION|APPLY_INSTRUMENT|INSTRUMENT_BOUNDARY)\b/,
+        "keyword",
+      ],
+      // Flag words
+      [/\b(?:postselect|zero)\b/, "keyword"],
+      // Pauli factors: X0, Z1, Y2, and standalone identity I
+      [/\b[XYZ]\d+\b/, "type"],
+      [/\bI\b/, "type"],
+      // Typed ids: symbols, records, detectors, observables, expectation slots
+      [/\b[srdov]\d+\b/, "variable"],
+      // Attribute keys (key= as one token, matching how they appear in the plan text)
+      [
+        /\b(?:half_turns|sign|outcome|value|source|record|detector|observable|exp_val|site|mode|flip|p01|p10|pivot|branch|next_noise_site|symbol_prefix_size|passes)=/,
+        "attribute",
+      ],
+      // Truncated affine-expression tail: ...(+10)
+      [/\.\.\.\(\+\d+\)/, "comment"],
+      // Operators
       [/->/, "operator"],
-      [/\.\./, "operator"],
-      [/\b(?:\d+\.\d+(?:e[+-]?\d+)?|\d+e[+-]?\d+)\b/i, "number.float"],
-      [/\b\d+\b/, "number"],
+      [/[*^]/, "operator"],
+      // Numbers: integers, decimals, negatives, scientific notation
+      [/[+-]?\b\d+\.\d+(?:e[+-]?\d+)?\b/i, "number.float"],
+      [/[+-]?\b\d+e[+-]?\d+\b/i, "number.float"],
+      [/[+-]?\b\d+\b/, "number"],
     ],
   },
 };

--- a/playground/src/languages.ts
+++ b/playground/src/languages.ts
@@ -2,7 +2,7 @@
 
 import type { languages, editor, IMarkdownString, Position } from "monaco-editor";
 import type { Monaco } from "@monaco-editor/react";
-import hirMetadata from "@docs/opcodes.json";
+import opcodeMetadata from "@docs/opcodes.json";
 
 interface OpDoc {
   category: string;
@@ -12,7 +12,8 @@ interface OpDoc {
   display?: string[];
 }
 
-const hirMap = hirMetadata.hir_ops as Record<string, OpDoc>;
+const hirMap = opcodeMetadata.hir_ops as Record<string, OpDoc>;
+const planActionMap = opcodeMetadata.plan_actions as Record<string, OpDoc>;
 
 // Build a reverse lookup from HIR display names (T, T_DAG, MEASURE, etc.) to docs
 const hirDisplayMap: Record<string, OpDoc> = {};
@@ -186,6 +187,70 @@ export function registerLanguages(monaco: Monaco): void {
         },
         contents: [formatOperationHover(kwName, doc)],
       };
+    },
+  });
+
+  // SamplingPlan: hover over action mnemonics (ROTATE_ACTIVE, MEASURE_ACTIVE,
+  // etc.) and over the affine-expression attribute keys (sign, outcome,
+  // value, source).
+  const AFFINE_FIELD_NAMES = new Set(["sign", "outcome", "value", "source"]);
+  const AFFINE_EXPLAINER: IMarkdownString = {
+    value: [
+      "**Affine expression**",
+      "",
+      "- `^` is Boolean XOR over per-shot symbols.",
+      "- A leading `1^` is the affine constant (the expression is inverted).",
+      "- `...(+N)` means N further symbol terms were omitted from the compact display; the full expression exists in the plan.",
+    ].join("\n"),
+    isTrusted: true,
+  };
+
+  monaco.languages.registerHoverProvider("clifft-plan", {
+    provideHover(
+      model: editor.ITextModel,
+      position: Position,
+    ) {
+      const word = model.getWordAtPosition(position);
+      if (!word) return null;
+
+      const line = model.getLineContent(position.lineNumber);
+
+      // Action mnemonic: the ALL_CAPS token right after the width prefix.
+      const mnemonicMatch = line.match(/^w\d+(?:->\d+)?\s+([A-Z][A-Z0-9_]*)/);
+      if (mnemonicMatch) {
+        const mnemonic = mnemonicMatch[1];
+        const startCol = mnemonicMatch.index! + mnemonicMatch[0].length - mnemonic.length + 1;
+        const endCol = startCol + mnemonic.length;
+        if (position.column >= startCol && position.column <= endCol) {
+          const doc = planActionMap[mnemonic];
+          if (doc) {
+            return {
+              range: {
+                startLineNumber: position.lineNumber,
+                startColumn: startCol,
+                endLineNumber: position.lineNumber,
+                endColumn: endCol,
+              },
+              contents: [formatOperationHover(mnemonic, doc)],
+            };
+          }
+        }
+      }
+
+      // Affine-expression attribute keys: sign=, outcome=, value=, source=
+      if (AFFINE_FIELD_NAMES.has(word.word) && line[word.endColumn - 1] === "=") {
+        return {
+          range: {
+            startLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endLineNumber: position.lineNumber,
+            endColumn: word.endColumn,
+          },
+          contents: [AFFINE_EXPLAINER],
+        };
+      }
+
+      return null;
     },
   });
 }

--- a/playground/src/languages.ts
+++ b/playground/src/languages.ts
@@ -15,6 +15,12 @@ interface OpDoc {
 const hirMap = opcodeMetadata.hir_ops as Record<string, OpDoc>;
 const planActionMap = opcodeMetadata.plan_actions as Record<string, OpDoc>;
 
+// Derived from the shared metadata so the tokenizer cannot drift from the
+// mnemonics documented in plan_actions.
+const planActionMnemonicPattern = new RegExp(
+  "\\b(?:" + Object.keys(planActionMap).join("|") + ")\\b",
+);
+
 // Build a reverse lookup from HIR display names (T, T_DAG, MEASURE, etc.) to docs
 const hirDisplayMap: Record<string, OpDoc> = {};
 for (const [, doc] of Object.entries(hirMap)) {
@@ -90,11 +96,8 @@ export const planLanguage: languages.IMonarchLanguage = {
     root: [
       // Width prefix: w0 or w0->1
       [/\bw\d+(?:->\d+)?\b/, "keyword"],
-      // Action mnemonics (explicit list; avoids matching arbitrary identifiers)
-      [
-        /\b(?:ROTATE_ACTIVE|ROTATE_PHASE|PROMOTE_DORMANT|MEASURE_ACTIVE|MEASURE_DORMANT|RECORD_CLASSICAL|DEFINE_SYMBOL|READOUT_NOISE|WRITE_DETECTOR|WRITE_OBSERVABLE|WRITE_EXPECTATION|APPLY_INSTRUMENT|INSTRUMENT_BOUNDARY)\b/,
-        "keyword",
-      ],
+      // Action mnemonics (avoids matching arbitrary identifiers)
+      [planActionMnemonicPattern, "keyword"],
       // Flag words
       [/\b(?:postselect|zero)\b/, "keyword"],
       // Pauli factors: X0, Z1, Y2, and standalone identity I

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -4,11 +4,6 @@ export interface PassInfo {
   default: boolean;
 }
 
-export interface PlanActionRange {
-  begin: number;
-  end: number;
-}
-
 export interface CompileSuccess {
   error?: undefined;
   num_qubits: number;
@@ -17,11 +12,8 @@ export interface CompileSuccess {
   num_t_gates: number;
   hir_ops: string[];
   sampling_plan: string[];
-  wasm_program: string[];
   hir_source_map: number[][];
   sampling_plan_source_map: number[][];
-  wasm_program_source_map: number[][];
-  wasm_program_plan_ranges: PlanActionRange[];
   active_width_history: number[];
 }
 

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(clifft_core STATIC
     optimizer/remove_noise_pass.cc
     optimizer/statevector_squeeze_pass.cc
     sampling/plan.cc
+    sampling/plan_inspection.cc
     sampling/inspection_format.cc
     sampling/planner.cc
     sampling/planner_frame.cc

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(clifft_core STATIC
     optimizer/remove_noise_pass.cc
     optimizer/statevector_squeeze_pass.cc
     sampling/plan.cc
+    sampling/inspection_format.cc
     sampling/planner.cc
     sampling/planner_frame.cc
     sampling/kernel_dispatch.cc

--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -1,7 +1,8 @@
 #include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/inspection_format.h"
 
+#include <bit>
 #include <cassert>
-#include <iomanip>
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
@@ -64,8 +65,10 @@ std::string_view new_x_instrument_kernel_name(NewXInstrumentKernel kernel) {
 }
 
 void write_prepared_pauli(std::ostream& out, const PreparedPauli& pauli) {
-    out << "active_width=" << pauli.active_width << " x=0x" << std::hex << pauli.x << " z=0x"
-        << pauli.z << " pairing_bit=0x" << pauli.pairing_bit << std::dec;
+    out << 'w' << pauli.active_width << ' ' << format_pauli_product(pauli.x, pauli.z);
+    if (pauli.pairing_bit != 0) {
+        out << " pair=" << std::countr_zero(pauli.pairing_bit);
+    }
 }
 
 }  // namespace
@@ -89,28 +92,33 @@ std::string ExecutablePlan::inspect() const {
 std::string ExecutablePlan::inspect_action(size_t action) const {
     const Action& selected = actions_.at(action);
     std::ostringstream out;
-    out << std::setprecision(17);
     std::visit(
         Overloaded{
             [&](const ExecuteRotation& typed) {
-                out << "rotate ";
-                write_prepared_pauli(out, typed.rotation.pauli);
-                out << " cosine=" << typed.rotation.cosine << " sine=" << typed.rotation.sine
-                    << " sign=e" << typed.sign.register_id
+                if (typed.rotation.pauli.is_identity()) {
+                    out << "ROTATE_PHASE w" << typed.rotation.pauli.active_width;
+                } else {
+                    out << "ROTATE ";
+                    write_prepared_pauli(out, typed.rotation.pauli);
+                }
+                out << " cos=" << format_double_roundtrip(typed.rotation.cosine)
+                    << " sin=" << format_double_roundtrip(typed.rotation.sine) << " sign=e"
+                    << typed.sign.register_id
                     << " kernel=" << direct_rotation_kernel_name(typed.kernel);
             },
             [&](const ExecuteFusedRotation& typed) {
-                out << "fused_rotation descriptor=" << typed.rotation_index;
+                out << "FUSED_ROTATION descriptor=" << typed.rotation_index;
             },
             [&](const ExecuteDynamicFusedRotation& typed) {
-                out << "dynamic_fused_rotation descriptor=" << typed.rotation_index;
+                out << "DYNAMIC_FUSED_ROTATION descriptor=" << typed.rotation_index;
             },
             [&](const ExecutePromotion& typed) {
-                out << "promote cosine=" << typed.promotion.cosine
-                    << " sine=" << typed.promotion.sine << " sign=e" << typed.sign.register_id;
+                out << "PROMOTE cos=" << format_double_roundtrip(typed.promotion.cosine)
+                    << " sin=" << format_double_roundtrip(typed.promotion.sine) << " sign=e"
+                    << typed.sign.register_id;
             },
             [&](const ExecuteActiveMeasurement& typed) {
-                out << "measure_active ";
+                out << "MEASURE_ACTIVE ";
                 write_prepared_pauli(out, typed.measurement.pauli);
                 out << " pivot=" << typed.measurement.pivot << " branch=s" << typed.branch
                     << " record=r" << typed.record << " correction=e"
@@ -118,31 +126,35 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
                     << " kernel=" << active_measurement_kernel_name(typed.kernel);
             },
             [&](const ExecuteDormantMeasurement& typed) {
-                out << "measure_dormant branch=s" << typed.branch << " record=r" << typed.record
+                out << "MEASURE_DORMANT branch=s" << typed.branch << " record=r" << typed.record
                     << " correction=e" << typed.correction.register_id;
             },
             [&](const ExecuteClassicalRecord& typed) {
-                out << "record_classical record=r" << typed.record << " outcome=e"
+                out << "RECORD_CLASSICAL record=r" << typed.record << " outcome=e"
                     << typed.outcome.register_id;
             },
             [&](const ExecuteSymbolDefinition& typed) {
-                out << "define_symbol s" << typed.symbol << " value=e" << typed.value.register_id;
+                out << "DEFINE_SYMBOL s" << typed.symbol << " value=e" << typed.value.register_id;
             },
             [&](const ExecuteReadoutNoise& typed) {
-                out << "readout_noise site=" << typed.site << " flip=s" << typed.flip << " record=r"
+                out << "READOUT_NOISE site=" << typed.site << " flip=s" << typed.flip << " record=r"
                     << typed.record << " source=e" << typed.source.register_id
-                    << " p01=" << typed.prob_zero_to_one << " p10=" << typed.prob_one_to_zero;
+                    << " p01=" << format_double_roundtrip(typed.prob_zero_to_one)
+                    << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
             },
             [&](const ExecuteDetector& typed) {
-                out << "write_detector detector=d" << typed.detector << " outcome=e"
-                    << typed.outcome.register_id << " postselected=" << typed.postselected;
+                out << "WRITE_DETECTOR detector=d" << typed.detector << " outcome=e"
+                    << typed.outcome.register_id;
+                if (typed.postselected) {
+                    out << " postselect";
+                }
             },
             [&](const ExecuteObservable& typed) {
-                out << "write_observable observable=l" << typed.observable << " outcome=e"
+                out << "WRITE_OBSERVABLE observable=o" << typed.observable << " outcome=e"
                     << typed.outcome.register_id;
             },
             [&](const ExecuteExpectation& typed) {
-                out << "write_expectation exp_val=" << typed.exp_val << ' ';
+                out << "WRITE_EXPECTATION exp_val=v" << typed.exp_val << ' ';
                 if (typed.active_projection.has_value()) {
                     write_prepared_pauli(out, *typed.active_projection);
                     out << " sign=e" << typed.sign.register_id;
@@ -154,27 +166,27 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
                 std::visit(
                     Overloaded{
                         [&](const ExecuteDormantInstrumentTrap& instrument) {
-                            out << "instrument_dormant_trap site=" << instrument.site;
+                            out << "INSTRUMENT_DORMANT_TRAP site=" << instrument.site;
                         },
                         [&](const ExecuteClassicalInstrument& instrument) {
-                            out << "instrument_classical site=" << instrument.site << " sign=e"
+                            out << "INSTRUMENT_CLASSICAL site=" << instrument.site << " sign=e"
                                 << instrument.sign.register_id << " flip=s"
                                 << instrument.destination_flip;
                         },
                         [&](const ExecuteActiveInstrument& instrument) {
-                            out << "instrument_active site=" << instrument.site << ' ';
+                            out << "INSTRUMENT_ACTIVE site=" << instrument.site << ' ';
                             write_prepared_pauli(out, instrument.measurement.pauli);
                             out << " sign=e" << instrument.sign.register_id << " flip=s"
                                 << instrument.destination_flip;
                         },
                         [&](const ExecuteMeasuredInstrumentActivation& instrument) {
-                            out << "instrument_activate_measured site=" << instrument.site << ' ';
+                            out << "INSTRUMENT_ACTIVATE_MEASURED site=" << instrument.site << ' ';
                             write_prepared_pauli(out, instrument.measurement.pauli);
                             out << " sign=e" << instrument.sign.register_id << " flip=s"
                                 << instrument.destination_flip;
                         },
                         [&](const ExecuteNewXInstrumentActivation& instrument) {
-                            out << "instrument_activate_new_x site=" << instrument.site << " sign=e"
+                            out << "INSTRUMENT_ACTIVATE_NEW_X site=" << instrument.site << " sign=e"
                                 << instrument.sign.register_id << " flip=s"
                                 << instrument.destination_flip
                                 << " kernel=" << new_x_instrument_kernel_name(instrument.kernel);
@@ -183,7 +195,7 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
                     typed.form);
             },
             [&](const ExecuteBoundary& typed) {
-                out << "instrument_boundary site=" << typed.site
+                out << "INSTRUMENT_BOUNDARY site=" << typed.site
                     << " active_width=" << typed.active_width << " noise=[" << typed.noise_begin
                     << ',' << typed.noise_end << ')'
                     << " symbol_prefix_size=" << typed.symbol_prefix_size;

--- a/src/clifft/sampling/inspection_format.cc
+++ b/src/clifft/sampling/inspection_format.cc
@@ -1,0 +1,73 @@
+#include "clifft/sampling/inspection_format.h"
+
+#include <array>
+#include <bit>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace clifft::sampling {
+
+namespace {
+
+bool bit_identical(double left, double right) {
+    uint64_t left_bits = 0;
+    uint64_t right_bits = 0;
+    std::memcpy(&left_bits, &left, sizeof(left_bits));
+    std::memcpy(&right_bits, &right, sizeof(right_bits));
+    return left_bits == right_bits;
+}
+
+std::string format_with_precision(double value, int precision) {
+    std::array<char, 64> buffer{};
+    std::snprintf(buffer.data(), buffer.size(), "%.*g", precision, value);
+    return std::string(buffer.data());
+}
+
+}  // namespace
+
+std::string format_double_roundtrip(double value) {
+    for (const int precision : {15, 16, 17}) {
+        std::string candidate = format_with_precision(value, precision);
+        if (bit_identical(std::strtod(candidate.c_str(), nullptr), value)) {
+            return candidate;
+        }
+    }
+    return format_with_precision(value, 17);
+}
+
+std::string format_pauli_product(uint64_t x, uint64_t z) {
+    if (x == 0 && z == 0) {
+        return "I";
+    }
+    std::string out;
+    uint64_t remaining = x | z;
+    bool first = true;
+    while (remaining != 0) {
+        const int bit_index = std::countr_zero(remaining);
+        const uint64_t bit = uint64_t{1} << bit_index;
+        remaining &= remaining - 1;
+        if (!first) {
+            out += '*';
+        }
+        first = false;
+        if ((x & bit) != 0 && (z & bit) != 0) {
+            out += 'Y';
+        } else if ((x & bit) != 0) {
+            out += 'X';
+        } else {
+            out += 'Z';
+        }
+        out += std::to_string(bit_index);
+    }
+    return out;
+}
+
+std::string format_width_prefix(uint32_t before, uint32_t after) {
+    if (before == after) {
+        return "w" + std::to_string(before);
+    }
+    return "w" + std::to_string(before) + "->" + std::to_string(after);
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/inspection_format.h
+++ b/src/clifft/sampling/inspection_format.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Shared formatting primitives for the human-readable sampling-IR inspection
+// output produced by SamplingPlan and ExecutablePlan. Keeping these helpers in
+// one place gives both inspectors identical number and operand rendering.
+
+#include <cstdint>
+#include <string>
+
+namespace clifft::sampling {
+
+// Minimal-digits round-trip formatting: the shortest of the "%.15g", "%.16g",
+// and "%.17g" renderings whose strtod parse reproduces the input bit for bit.
+// Falls back to "%.17g" when no candidate round-trips, such as for NaN.
+[[nodiscard]] std::string format_double_roundtrip(double value);
+
+// Sparse Pauli product notation over ascending bit indices: each set bit
+// contributes X<i>, Z<i>, or Y<i> depending on which of x/z hold it, joined by
+// '*'. Both masks zero renders as "I".
+[[nodiscard]] std::string format_pauli_product(uint64_t x, uint64_t z);
+
+// Active-width prefix for one inspected action: "w<n>" when an action leaves
+// the active width unchanged, or "w<before>-><after>" when it changes.
+[[nodiscard]] std::string format_width_prefix(uint32_t before, uint32_t after);
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -1,15 +1,12 @@
 #include "clifft/sampling/plan.h"
 
-#include "clifft/sampling/inspection_format.h"
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <limits>
-#include <sstream>
 #include <stdexcept>
-#include <string_view>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
@@ -17,8 +14,6 @@
 namespace clifft::sampling {
 
 namespace {
-
-constexpr size_t kCompactInspectionExpressionTerms = 4;
 
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
@@ -63,72 +58,6 @@ std::vector<SymbolId> canonicalize_terms(std::vector<SymbolId> terms) {
     return result;
 }
 
-std::string format_expression(const AffineBool& expression,
-                              std::optional<size_t> max_terms = std::nullopt) {
-    // Unspaced XOR notation: the leading constant (if any) does not count
-    // against max_terms, which bounds only the number of symbol terms shown.
-    std::string out;
-    bool wrote = false;
-    if (expression.constant()) {
-        out += '1';
-        wrote = true;
-    }
-    const size_t terms_to_write =
-        std::min(expression.terms().size(), max_terms.value_or(expression.terms().size()));
-    for (SymbolId term : std::span(expression.terms()).first(terms_to_write)) {
-        if (wrote) {
-            out += '^';
-        }
-        out += 's';
-        out += std::to_string(index(term));
-        wrote = true;
-    }
-    const size_t omitted = expression.terms().size() - terms_to_write;
-    if (omitted > 0) {
-        if (wrote) {
-            out += '^';
-        }
-        out += "...(+" + std::to_string(omitted) + ")";
-        wrote = true;
-    }
-    if (!wrote) {
-        out += '0';
-    }
-    return out;
-}
-
-std::string_view symbol_kind_name(SymbolKind kind) {
-    switch (kind) {
-        case SymbolKind::Unused:
-            return "unused";
-        case SymbolKind::Presampled:
-            return "presampled";
-        case SymbolKind::Derived:
-            return "derived";
-        case SymbolKind::Branch:
-            return "branch";
-        case SymbolKind::Readout:
-            return "readout";
-        case SymbolKind::Instrument:
-            return "instrument";
-    }
-    return "unknown";
-}
-
-std::string_view instrument_mode_name(InstrumentMode mode) {
-    switch (mode) {
-        case InstrumentMode::Classical:
-            return "classical";
-        case InstrumentMode::Active:
-            return "active";
-        case InstrumentMode::Activate:
-            return "activate";
-        case InstrumentMode::DormantTrap:
-            return "dormant_trap";
-    }
-    return "unknown";
-}
-
 constexpr bool is_recognized_symbol_kind(SymbolKind kind) {
     switch (kind) {
         case SymbolKind::Unused:
@@ -151,113 +80,6 @@ constexpr bool is_recognized_instrument_mode(InstrumentMode mode) {
             return true;
     }
     return false;
-}
-
-// Writes the mnemonic, operand, and key=value fields for one action, without
-// the leading active-width prefix or dense-pass count. Both the full and
-// compact inspection forms share this body and differ only in how they wrap
-// it (see write_action_inspection_full / write_action_inspection_compact).
-void write_action_body(std::ostream& out, const SamplingAction& action,
-                       std::optional<size_t> max_expression_terms) {
-    std::visit(
-        [&](const auto& typed) {
-            using T = std::decay_t<decltype(typed)>;
-            if constexpr (std::is_same_v<T, RotateActivePauli>) {
-                if (typed.pauli.is_identity()) {
-                    out << "ROTATE_PHASE half_turns=" << format_double_roundtrip(typed.half_turns)
-                        << " sign=" << format_expression(typed.sign, max_expression_terms);
-                } else {
-                    out << "ROTATE_ACTIVE " << format_pauli_product(typed.pauli.x, typed.pauli.z)
-                        << " half_turns=" << format_double_roundtrip(typed.half_turns)
-                        << " sign=" << format_expression(typed.sign, max_expression_terms);
-                }
-            } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
-                out << "PROMOTE_DORMANT half_turns=" << format_double_roundtrip(typed.half_turns)
-                    << " sign=" << format_expression(typed.sign, max_expression_terms);
-            } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
-                out << "MEASURE_ACTIVE " << format_pauli_product(typed.pauli.x, typed.pauli.z)
-                    << " pivot=" << typed.active_pivot << " branch=s" << index(typed.branch)
-                    << " outcome=" << format_expression(typed.outcome, max_expression_terms)
-                    << " record=r" << index(typed.record);
-            } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
-                out << "MEASURE_DORMANT pivot=" << typed.dormant_pivot << " branch=s"
-                    << index(typed.branch)
-                    << " outcome=" << format_expression(typed.outcome, max_expression_terms)
-                    << " record=r" << index(typed.record);
-            } else if constexpr (std::is_same_v<T, RecordClassical>) {
-                out << "RECORD_CLASSICAL outcome="
-                    << format_expression(typed.outcome, max_expression_terms) << " record=r"
-                    << index(typed.record);
-            } else if constexpr (std::is_same_v<T, DefineSymbol>) {
-                out << "DEFINE_SYMBOL s" << index(typed.symbol)
-                    << " value=" << format_expression(typed.value, max_expression_terms);
-            } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
-                out << "READOUT_NOISE flip=s" << index(typed.flip)
-                    << " source=" << format_expression(typed.source, max_expression_terms)
-                    << " record=r" << index(typed.record)
-                    << " p01=" << format_double_roundtrip(typed.prob_zero_to_one)
-                    << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
-            } else if constexpr (std::is_same_v<T, WriteDetector>) {
-                out << "WRITE_DETECTOR outcome="
-                    << format_expression(typed.outcome, max_expression_terms) << " detector=d"
-                    << index(typed.detector);
-                if (typed.postselected) {
-                    out << " postselect";
-                }
-            } else if constexpr (std::is_same_v<T, WriteObservable>) {
-                out << "WRITE_OBSERVABLE outcome="
-                    << format_expression(typed.outcome, max_expression_terms) << " observable=o"
-                    << index(typed.observable);
-            } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
-                out << "WRITE_EXPECTATION ";
-                if (typed.active_projection.has_value()) {
-                    out << format_pauli_product(typed.active_projection->x,
-                                                typed.active_projection->z)
-                        << " sign=" << format_expression(typed.sign, max_expression_terms);
-                } else {
-                    out << "zero";
-                }
-                out << " exp_val=v" << index(typed.exp_val);
-            } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
-                out << "APPLY_INSTRUMENT ";
-                if (!typed.source.is_identity()) {
-                    out << format_pauli_product(typed.source.x, typed.source.z) << ' ';
-                }
-                out << "site=" << index(typed.site) << " mode=" << instrument_mode_name(typed.mode)
-                    << " sign=" << format_expression(typed.sign, max_expression_terms);
-                if (typed.destination_flip.has_value()) {
-                    out << " flip=s" << index(*typed.destination_flip);
-                }
-            } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
-                out << "INSTRUMENT_BOUNDARY site=" << index(typed.site)
-                    << " next_noise_site=" << typed.next_noise_site
-                    << " symbol_prefix_size=" << typed.symbol_prefix_size;
-            } else {
-                static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
-            }
-        },
-        action);
-}
-
-// Full form: <width> dense_passes=<n> <MNEMONIC> ... . Affine expressions are
-// never truncated.
-void write_action_inspection_full(std::ostream& out, const PlannedAction& planned) {
-    out << format_width_prefix(planned.active_before, planned.active_after)
-        << " dense_passes=" << predicted_dense_passes(planned.action) << ' ';
-    write_action_body(out, planned.action, std::nullopt);
-}
-
-// Compact form: <width> <MNEMONIC> ... [passes=<n>]. Affine expressions are
-// bounded to kCompactInspectionExpressionTerms symbol terms, and the trailing
-// pass count is written only for actions that touch the dense coefficient
-// state.
-void write_action_inspection_compact(std::ostream& out, const PlannedAction& planned) {
-    out << format_width_prefix(planned.active_before, planned.active_after) << ' ';
-    write_action_body(out, planned.action, kCompactInspectionExpressionTerms);
-    const uint32_t passes = predicted_dense_passes(planned.action);
-    if (passes > 0) {
-        out << " passes=" << passes;
-    }
 }
 
 [[noreturn]] void invalid_plan(std::string message) {
@@ -924,62 +746,6 @@ void SamplingPlan::validate() const {
         observed_instrument_boundaries != num_instrument_sites) {
         invalid_plan("declared instrument count does not match the action stream");
     }
-}
-
-std::string SamplingPlan::inspect() const {
-    validate();
-
-    std::ostringstream out;
-    out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
-        << " peak_width=" << peak_active_width << " visible_records=" << num_visible_records
-        << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
-        << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
-        << " observables=" << num_observables << " exp_vals=" << num_exp_vals
-        << " postselection=" << has_postselection
-        << " final_state_queries=" << final_tableau.has_value()
-        << " dust_epsilon=" << format_double_roundtrip(kMeasurementDustEpsilon) << '\n';
-    out << "global_weight=" << format_double_roundtrip(global_weight.real()) << ','
-        << format_double_roundtrip(global_weight.imag()) << '\n';
-    out << "symbols=" << symbols.size() << '\n';
-    for (uint32_t i = 0; i < symbols.size(); ++i) {
-        out << "  s" << i << " kind=" << symbol_kind_name(symbols[i].kind);
-        if (symbols[i].defining_action.has_value()) {
-            out << " action=" << *symbols[i].defining_action;
-        }
-        if (symbols[i].noise_site.has_value()) {
-            out << " noise_site=" << index(*symbols[i].noise_site);
-        }
-        out << '\n';
-    }
-    for (const PresampledNoiseSite& site : presampled_noise_sites) {
-        out << "  noise_site " << index(site.site)
-            << " probability=" << format_double_roundtrip(site.total_probability)
-            << " outcomes=" << site.outcomes.size();
-        for (const PresampledNoiseOutcome& outcome : site.outcomes) {
-            out << " s" << index(outcome.symbol) << ':'
-                << format_double_roundtrip(outcome.probability);
-        }
-        out << '\n';
-    }
-    out << "actions=" << actions.size() << '\n';
-    for (uint32_t i = 0; i < actions.size(); ++i) {
-        out << "  " << i << ' ' << inspect_action(i) << '\n';
-    }
-    return out.str();
-}
-
-std::string SamplingPlan::inspect_action(size_t action) const {
-    const PlannedAction& planned = actions.at(action);
-    std::ostringstream out;
-    write_action_inspection_full(out, planned);
-    return out.str();
-}
-
-std::string SamplingPlan::inspect_action_compact(size_t action) const {
-    const PlannedAction& planned = actions.at(action);
-    std::ostringstream out;
-    write_action_inspection_compact(out, planned);
-    return out.str();
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -1,11 +1,11 @@
 #include "clifft/sampling/plan.h"
 
+#include "clifft/sampling/inspection_format.h"
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <iomanip>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -18,7 +18,7 @@ namespace clifft::sampling {
 
 namespace {
 
-constexpr size_t kCompactInspectionExpressionTerms = 8;
+constexpr size_t kCompactInspectionExpressionTerms = 4;
 
 template <typename>
 inline constexpr bool kAlwaysFalse = false;
@@ -65,32 +65,36 @@ std::vector<SymbolId> canonicalize_terms(std::vector<SymbolId> terms) {
 
 std::string format_expression(const AffineBool& expression,
                               std::optional<size_t> max_terms = std::nullopt) {
-    std::ostringstream out;
+    // Unspaced XOR notation: the leading constant (if any) does not count
+    // against max_terms, which bounds only the number of symbol terms shown.
+    std::string out;
     bool wrote = false;
     if (expression.constant()) {
-        out << '1';
+        out += '1';
         wrote = true;
     }
     const size_t terms_to_write =
         std::min(expression.terms().size(), max_terms.value_or(expression.terms().size()));
     for (SymbolId term : std::span(expression.terms()).first(terms_to_write)) {
         if (wrote) {
-            out << " ^ ";
+            out += '^';
         }
-        out << 's' << index(term);
+        out += 's';
+        out += std::to_string(index(term));
         wrote = true;
     }
-    if (terms_to_write < expression.terms().size()) {
+    const size_t omitted = expression.terms().size() - terms_to_write;
+    if (omitted > 0) {
         if (wrote) {
-            out << " ^ ";
+            out += '^';
         }
-        out << "... (" << expression.terms().size() << " terms)";
+        out += "...(+" + std::to_string(omitted) + ")";
         wrote = true;
     }
     if (!wrote) {
-        out << '0';
+        out += '0';
     }
-    return out.str();
+    return out;
 }
 
 std::string_view symbol_kind_name(SymbolKind kind) {
@@ -149,89 +153,111 @@ constexpr bool is_recognized_instrument_mode(InstrumentMode mode) {
     return false;
 }
 
-std::string format_mask(uint64_t mask) {
-    std::ostringstream out;
-    out << "0x" << std::hex << std::setw(16) << std::setfill('0') << mask;
-    return out.str();
-}
-
-std::string format_pauli(const ActivePauli& pauli) {
-    std::ostringstream out;
-    out << "x=" << format_mask(pauli.x) << " z=" << format_mask(pauli.z);
-    return out.str();
-}
-
-void write_action_inspection(std::ostream& out, const PlannedAction& planned,
-                             std::optional<size_t> max_expression_terms = std::nullopt) {
-    out << "active_width=" << planned.active_before << "->" << planned.active_after
-        << " dense_passes=" << predicted_dense_passes(planned.action) << ' ';
+// Writes the mnemonic, operand, and key=value fields for one action, without
+// the leading active-width prefix or dense-pass count. Both the full and
+// compact inspection forms share this body and differ only in how they wrap
+// it (see write_action_inspection_full / write_action_inspection_compact).
+void write_action_body(std::ostream& out, const SamplingAction& action,
+                       std::optional<size_t> max_expression_terms) {
     std::visit(
         [&](const auto& typed) {
             using T = std::decay_t<decltype(typed)>;
             if constexpr (std::is_same_v<T, RotateActivePauli>) {
-                out << "rotate_active " << format_pauli(typed.pauli)
-                    << " half_turns=" << typed.half_turns
-                    << " sign=" << format_expression(typed.sign, max_expression_terms);
+                if (typed.pauli.is_identity()) {
+                    out << "ROTATE_PHASE half_turns=" << format_double_roundtrip(typed.half_turns)
+                        << " sign=" << format_expression(typed.sign, max_expression_terms);
+                } else {
+                    out << "ROTATE_ACTIVE " << format_pauli_product(typed.pauli.x, typed.pauli.z)
+                        << " half_turns=" << format_double_roundtrip(typed.half_turns)
+                        << " sign=" << format_expression(typed.sign, max_expression_terms);
+                }
             } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
-                out << "promote_dormant half_turns=" << typed.half_turns
+                out << "PROMOTE_DORMANT half_turns=" << format_double_roundtrip(typed.half_turns)
                     << " sign=" << format_expression(typed.sign, max_expression_terms);
             } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
-                out << "measure_active " << format_pauli(typed.pauli)
+                out << "MEASURE_ACTIVE " << format_pauli_product(typed.pauli.x, typed.pauli.z)
                     << " pivot=" << typed.active_pivot << " branch=s" << index(typed.branch)
                     << " outcome=" << format_expression(typed.outcome, max_expression_terms)
-                    << " record=" << index(typed.record);
+                    << " record=r" << index(typed.record);
             } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
-                out << "measure_dormant pivot=" << typed.dormant_pivot << " branch=s"
+                out << "MEASURE_DORMANT pivot=" << typed.dormant_pivot << " branch=s"
                     << index(typed.branch)
                     << " outcome=" << format_expression(typed.outcome, max_expression_terms)
-                    << " record=" << index(typed.record);
+                    << " record=r" << index(typed.record);
             } else if constexpr (std::is_same_v<T, RecordClassical>) {
-                out << "record_classical outcome="
-                    << format_expression(typed.outcome, max_expression_terms)
-                    << " record=" << index(typed.record);
+                out << "RECORD_CLASSICAL outcome="
+                    << format_expression(typed.outcome, max_expression_terms) << " record=r"
+                    << index(typed.record);
             } else if constexpr (std::is_same_v<T, DefineSymbol>) {
-                out << "define_symbol s" << index(typed.symbol)
+                out << "DEFINE_SYMBOL s" << index(typed.symbol)
                     << " value=" << format_expression(typed.value, max_expression_terms);
             } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
-                out << "readout_noise s" << index(typed.flip)
+                out << "READOUT_NOISE flip=s" << index(typed.flip)
                     << " source=" << format_expression(typed.source, max_expression_terms)
-                    << " record=" << index(typed.record) << " p01=" << typed.prob_zero_to_one
-                    << " p10=" << typed.prob_one_to_zero;
+                    << " record=r" << index(typed.record)
+                    << " p01=" << format_double_roundtrip(typed.prob_zero_to_one)
+                    << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
-                out << "write_detector outcome="
-                    << format_expression(typed.outcome, max_expression_terms)
-                    << " detector=" << index(typed.detector)
-                    << " postselected=" << typed.postselected;
+                out << "WRITE_DETECTOR outcome="
+                    << format_expression(typed.outcome, max_expression_terms) << " detector=d"
+                    << index(typed.detector);
+                if (typed.postselected) {
+                    out << " postselect";
+                }
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
-                out << "write_observable outcome="
-                    << format_expression(typed.outcome, max_expression_terms)
-                    << " observable=" << index(typed.observable);
+                out << "WRITE_OBSERVABLE outcome="
+                    << format_expression(typed.outcome, max_expression_terms) << " observable=o"
+                    << index(typed.observable);
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
-                out << "write_expectation ";
+                out << "WRITE_EXPECTATION ";
                 if (typed.active_projection.has_value()) {
-                    out << format_pauli(*typed.active_projection)
+                    out << format_pauli_product(typed.active_projection->x,
+                                                typed.active_projection->z)
                         << " sign=" << format_expression(typed.sign, max_expression_terms);
                 } else {
                     out << "zero";
                 }
-                out << " exp_val=" << index(typed.exp_val);
+                out << " exp_val=v" << index(typed.exp_val);
             } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
-                out << "apply_instrument site=" << index(typed.site)
-                    << " mode=" << instrument_mode_name(typed.mode) << ' '
-                    << format_pauli(typed.source)
+                out << "APPLY_INSTRUMENT ";
+                if (!typed.source.is_identity()) {
+                    out << format_pauli_product(typed.source.x, typed.source.z) << ' ';
+                }
+                out << "site=" << index(typed.site) << " mode=" << instrument_mode_name(typed.mode)
                     << " sign=" << format_expression(typed.sign, max_expression_terms);
                 if (typed.destination_flip.has_value()) {
                     out << " flip=s" << index(*typed.destination_flip);
                 }
             } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
-                out << "instrument_boundary site=" << index(typed.site)
+                out << "INSTRUMENT_BOUNDARY site=" << index(typed.site)
                     << " next_noise_site=" << typed.next_noise_site
                     << " symbol_prefix_size=" << typed.symbol_prefix_size;
             } else {
                 static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
             }
         },
-        planned.action);
+        action);
+}
+
+// Full form: <width> dense_passes=<n> <MNEMONIC> ... . Affine expressions are
+// never truncated.
+void write_action_inspection_full(std::ostream& out, const PlannedAction& planned) {
+    out << format_width_prefix(planned.active_before, planned.active_after)
+        << " dense_passes=" << predicted_dense_passes(planned.action) << ' ';
+    write_action_body(out, planned.action, std::nullopt);
+}
+
+// Compact form: <width> <MNEMONIC> ... [passes=<n>]. Affine expressions are
+// bounded to kCompactInspectionExpressionTerms symbol terms, and the trailing
+// pass count is written only for actions that touch the dense coefficient
+// state.
+void write_action_inspection_compact(std::ostream& out, const PlannedAction& planned) {
+    out << format_width_prefix(planned.active_before, planned.active_after) << ' ';
+    write_action_body(out, planned.action, kCompactInspectionExpressionTerms);
+    const uint32_t passes = predicted_dense_passes(planned.action);
+    if (passes > 0) {
+        out << " passes=" << passes;
+    }
 }
 
 [[noreturn]] void invalid_plan(std::string message) {
@@ -904,7 +930,6 @@ std::string SamplingPlan::inspect() const {
     validate();
 
     std::ostringstream out;
-    out << std::setprecision(17);
     out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
         << " peak_width=" << peak_active_width << " visible_records=" << num_visible_records
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
@@ -912,8 +937,9 @@ std::string SamplingPlan::inspect() const {
         << " observables=" << num_observables << " exp_vals=" << num_exp_vals
         << " postselection=" << has_postselection
         << " final_state_queries=" << final_tableau.has_value()
-        << " dust_epsilon=" << kMeasurementDustEpsilon << '\n';
-    out << "global_weight=" << global_weight.real() << ',' << global_weight.imag() << '\n';
+        << " dust_epsilon=" << format_double_roundtrip(kMeasurementDustEpsilon) << '\n';
+    out << "global_weight=" << format_double_roundtrip(global_weight.real()) << ','
+        << format_double_roundtrip(global_weight.imag()) << '\n';
     out << "symbols=" << symbols.size() << '\n';
     for (uint32_t i = 0; i < symbols.size(); ++i) {
         out << "  s" << i << " kind=" << symbol_kind_name(symbols[i].kind);
@@ -926,10 +952,12 @@ std::string SamplingPlan::inspect() const {
         out << '\n';
     }
     for (const PresampledNoiseSite& site : presampled_noise_sites) {
-        out << "  noise_site " << index(site.site) << " probability=" << site.total_probability
+        out << "  noise_site " << index(site.site)
+            << " probability=" << format_double_roundtrip(site.total_probability)
             << " outcomes=" << site.outcomes.size();
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
-            out << " s" << index(outcome.symbol) << ':' << outcome.probability;
+            out << " s" << index(outcome.symbol) << ':'
+                << format_double_roundtrip(outcome.probability);
         }
         out << '\n';
     }
@@ -943,16 +971,14 @@ std::string SamplingPlan::inspect() const {
 std::string SamplingPlan::inspect_action(size_t action) const {
     const PlannedAction& planned = actions.at(action);
     std::ostringstream out;
-    out << std::setprecision(17);
-    write_action_inspection(out, planned);
+    write_action_inspection_full(out, planned);
     return out.str();
 }
 
 std::string SamplingPlan::inspect_action_compact(size_t action) const {
     const PlannedAction& planned = actions.at(action);
     std::ostringstream out;
-    out << std::setprecision(17);
-    write_action_inspection(out, planned, kCompactInspectionExpressionTerms);
+    write_action_inspection_compact(out, planned);
     return out.str();
 }
 

--- a/src/clifft/sampling/plan_inspection.cc
+++ b/src/clifft/sampling/plan_inspection.cc
@@ -1,0 +1,250 @@
+#include "clifft/sampling/inspection_format.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/util/numeric.h"
+
+#include <algorithm>
+#include <sstream>
+#include <string_view>
+#include <type_traits>
+
+namespace clifft::sampling {
+
+namespace {
+
+constexpr size_t kCompactInspectionExpressionTerms = 4;
+
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
+std::string format_expression(const AffineBool& expression,
+                              std::optional<size_t> max_terms = std::nullopt) {
+    // Unspaced XOR notation: the leading constant (if any) does not count
+    // against max_terms, which bounds only the number of symbol terms shown.
+    std::string out;
+    bool wrote = false;
+    if (expression.constant()) {
+        out += '1';
+        wrote = true;
+    }
+    const size_t terms_to_write =
+        std::min(expression.terms().size(), max_terms.value_or(expression.terms().size()));
+    for (SymbolId term : std::span(expression.terms()).first(terms_to_write)) {
+        if (wrote) {
+            out += '^';
+        }
+        out += 's';
+        out += std::to_string(index(term));
+        wrote = true;
+    }
+    const size_t omitted = expression.terms().size() - terms_to_write;
+    if (omitted > 0) {
+        if (wrote) {
+            out += '^';
+        }
+        out += "...(+" + std::to_string(omitted) + ")";
+        wrote = true;
+    }
+    if (!wrote) {
+        out += '0';
+    }
+    return out;
+}
+
+std::string_view symbol_kind_name(SymbolKind kind) {
+    switch (kind) {
+        case SymbolKind::Unused:
+            return "unused";
+        case SymbolKind::Presampled:
+            return "presampled";
+        case SymbolKind::Derived:
+            return "derived";
+        case SymbolKind::Branch:
+            return "branch";
+        case SymbolKind::Readout:
+            return "readout";
+        case SymbolKind::Instrument:
+            return "instrument";
+    }
+    return "unknown";
+}
+
+std::string_view instrument_mode_name(InstrumentMode mode) {
+    switch (mode) {
+        case InstrumentMode::Classical:
+            return "classical";
+        case InstrumentMode::Active:
+            return "active";
+        case InstrumentMode::Activate:
+            return "activate";
+        case InstrumentMode::DormantTrap:
+            return "dormant_trap";
+    }
+    return "unknown";
+}
+
+// Writes the mnemonic, operand, and key=value fields for one action, without
+// the leading active-width prefix or dense-pass count. Both the full and
+// compact inspection forms share this body and differ only in how they wrap
+// it (see write_action_inspection_full / write_action_inspection_compact).
+void write_action_body(std::ostream& out, const SamplingAction& action,
+                       std::optional<size_t> max_expression_terms) {
+    std::visit(
+        [&](const auto& typed) {
+            using T = std::decay_t<decltype(typed)>;
+            if constexpr (std::is_same_v<T, RotateActivePauli>) {
+                if (typed.pauli.is_identity()) {
+                    out << "ROTATE_PHASE half_turns=" << format_double_roundtrip(typed.half_turns)
+                        << " sign=" << format_expression(typed.sign, max_expression_terms);
+                } else {
+                    out << "ROTATE_ACTIVE " << format_pauli_product(typed.pauli.x, typed.pauli.z)
+                        << " half_turns=" << format_double_roundtrip(typed.half_turns)
+                        << " sign=" << format_expression(typed.sign, max_expression_terms);
+                }
+            } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
+                out << "PROMOTE_DORMANT half_turns=" << format_double_roundtrip(typed.half_turns)
+                    << " sign=" << format_expression(typed.sign, max_expression_terms);
+            } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
+                out << "MEASURE_ACTIVE " << format_pauli_product(typed.pauli.x, typed.pauli.z)
+                    << " pivot=" << typed.active_pivot << " branch=s" << index(typed.branch)
+                    << " outcome=" << format_expression(typed.outcome, max_expression_terms)
+                    << " record=r" << index(typed.record);
+            } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
+                out << "MEASURE_DORMANT pivot=" << typed.dormant_pivot << " branch=s"
+                    << index(typed.branch)
+                    << " outcome=" << format_expression(typed.outcome, max_expression_terms)
+                    << " record=r" << index(typed.record);
+            } else if constexpr (std::is_same_v<T, RecordClassical>) {
+                out << "RECORD_CLASSICAL outcome="
+                    << format_expression(typed.outcome, max_expression_terms) << " record=r"
+                    << index(typed.record);
+            } else if constexpr (std::is_same_v<T, DefineSymbol>) {
+                out << "DEFINE_SYMBOL s" << index(typed.symbol)
+                    << " value=" << format_expression(typed.value, max_expression_terms);
+            } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
+                out << "READOUT_NOISE flip=s" << index(typed.flip)
+                    << " source=" << format_expression(typed.source, max_expression_terms)
+                    << " record=r" << index(typed.record)
+                    << " p01=" << format_double_roundtrip(typed.prob_zero_to_one)
+                    << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
+            } else if constexpr (std::is_same_v<T, WriteDetector>) {
+                out << "WRITE_DETECTOR outcome="
+                    << format_expression(typed.outcome, max_expression_terms) << " detector=d"
+                    << index(typed.detector);
+                if (typed.postselected) {
+                    out << " postselect";
+                }
+            } else if constexpr (std::is_same_v<T, WriteObservable>) {
+                out << "WRITE_OBSERVABLE outcome="
+                    << format_expression(typed.outcome, max_expression_terms) << " observable=o"
+                    << index(typed.observable);
+            } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                out << "WRITE_EXPECTATION ";
+                if (typed.active_projection.has_value()) {
+                    out << format_pauli_product(typed.active_projection->x,
+                                                typed.active_projection->z)
+                        << " sign=" << format_expression(typed.sign, max_expression_terms);
+                } else {
+                    out << "zero";
+                }
+                out << " exp_val=v" << index(typed.exp_val);
+            } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
+                out << "APPLY_INSTRUMENT ";
+                if (!typed.source.is_identity()) {
+                    out << format_pauli_product(typed.source.x, typed.source.z) << ' ';
+                }
+                out << "site=" << index(typed.site) << " mode=" << instrument_mode_name(typed.mode)
+                    << " sign=" << format_expression(typed.sign, max_expression_terms);
+                if (typed.destination_flip.has_value()) {
+                    out << " flip=s" << index(*typed.destination_flip);
+                }
+            } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
+                out << "INSTRUMENT_BOUNDARY site=" << index(typed.site)
+                    << " next_noise_site=" << typed.next_noise_site
+                    << " symbol_prefix_size=" << typed.symbol_prefix_size;
+            } else {
+                static_assert(kAlwaysFalse<T>, "Unhandled SamplingAction alternative");
+            }
+        },
+        action);
+}
+
+// Full form: <width> dense_passes=<n> <MNEMONIC> ... . Affine expressions are
+// never truncated.
+void write_action_inspection_full(std::ostream& out, const PlannedAction& planned) {
+    out << format_width_prefix(planned.active_before, planned.active_after)
+        << " dense_passes=" << predicted_dense_passes(planned.action) << ' ';
+    write_action_body(out, planned.action, std::nullopt);
+}
+
+// Compact form: <width> <MNEMONIC> ... [passes=<n>]. Affine expressions are
+// bounded to kCompactInspectionExpressionTerms symbol terms, and the trailing
+// pass count is written only for actions that touch the dense coefficient
+// state.
+void write_action_inspection_compact(std::ostream& out, const PlannedAction& planned) {
+    out << format_width_prefix(planned.active_before, planned.active_after) << ' ';
+    write_action_body(out, planned.action, kCompactInspectionExpressionTerms);
+    const uint32_t passes = predicted_dense_passes(planned.action);
+    if (passes > 0) {
+        out << " passes=" << passes;
+    }
+}
+
+}  // namespace
+
+std::string SamplingPlan::inspect() const {
+    validate();
+
+    std::ostringstream out;
+    out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
+        << " peak_width=" << peak_active_width << " visible_records=" << num_visible_records
+        << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
+        << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
+        << " observables=" << num_observables << " exp_vals=" << num_exp_vals
+        << " postselection=" << has_postselection
+        << " final_state_queries=" << final_tableau.has_value()
+        << " dust_epsilon=" << format_double_roundtrip(kMeasurementDustEpsilon) << '\n';
+    out << "global_weight=" << format_double_roundtrip(global_weight.real()) << ','
+        << format_double_roundtrip(global_weight.imag()) << '\n';
+    out << "symbols=" << symbols.size() << '\n';
+    for (uint32_t i = 0; i < symbols.size(); ++i) {
+        out << "  s" << i << " kind=" << symbol_kind_name(symbols[i].kind);
+        if (symbols[i].defining_action.has_value()) {
+            out << " action=" << *symbols[i].defining_action;
+        }
+        if (symbols[i].noise_site.has_value()) {
+            out << " noise_site=" << index(*symbols[i].noise_site);
+        }
+        out << '\n';
+    }
+    for (const PresampledNoiseSite& site : presampled_noise_sites) {
+        out << "  noise_site " << index(site.site)
+            << " probability=" << format_double_roundtrip(site.total_probability)
+            << " outcomes=" << site.outcomes.size();
+        for (const PresampledNoiseOutcome& outcome : site.outcomes) {
+            out << " s" << index(outcome.symbol) << ':'
+                << format_double_roundtrip(outcome.probability);
+        }
+        out << '\n';
+    }
+    out << "actions=" << actions.size() << '\n';
+    for (uint32_t i = 0; i < actions.size(); ++i) {
+        out << "  " << i << ' ' << inspect_action(i) << '\n';
+    }
+    return out.str();
+}
+
+std::string SamplingPlan::inspect_action(size_t action) const {
+    const PlannedAction& planned = actions.at(action);
+    std::ostringstream out;
+    write_action_inspection_full(out, planned);
+    return out.str();
+}
+
+std::string SamplingPlan::inspect_action_compact(size_t action) const {
+    const PlannedAction& planned = actions.at(action);
+    std::ostringstream out;
+    write_action_inspection_compact(out, planned);
+    return out.str();
+}
+
+}  // namespace clifft::sampling

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -637,6 +637,16 @@ NB_MODULE(_clifft_core, m) {
             },
             nb::rv_policy::move,
             "Per-site total fault probabilities: quantum noise sites followed by readout noise.")
+        .def("inspect", &clifft::sampling::ExecutablePlan::inspect,
+             "Deterministic human-readable diagnostic text for the whole lowered "
+             "CPU program.\n\n"
+             "The format is diagnostic output for debugging and tooling, not a "
+             "stable machine-readable interface.")
+        .def("inspect_action", &clifft::sampling::ExecutablePlan::inspect_action, nb::arg("action"),
+             "Deterministic human-readable diagnostic text for a single action "
+             "in the lowered CPU program.\n\n"
+             "The format is diagnostic output for debugging and tooling, not a "
+             "stable machine-readable interface.")
         .def("__repr__", [](const clifft::sampling::ExecutablePlan& p) {
             return "Program(" + std::to_string(p.num_actions()) +
                    " actions, peak_active_width=" + std::to_string(p.peak_active_width()) + ", " +

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/remove_noise_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan_inspection.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/inspection_format.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner_frame.cc

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/remove_noise_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/inspection_format.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner_frame.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/kernel_dispatch.cc

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -40,7 +40,6 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner_frame.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/kernel_dispatch.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan_inspection.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan_builder.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executor.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/fused_rotation.cc

--- a/src/wasm/bindings.cc
+++ b/src/wasm/bindings.cc
@@ -14,11 +14,9 @@
 #include "clifft/sampling/sampler.h"
 #include "clifft/util/hir_introspection.h"
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <emscripten/bind.h>
-#include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <sstream>
@@ -37,14 +35,16 @@ constexpr uint32_t MAX_BROWSER_ACTIVE_WIDTH = 24;
 struct PipelineResult {
     clifft::HirModule hir;
     std::optional<clifft::sampling::SamplingPlan> plan;
-    std::unique_ptr<clifft::sampling::ExecutablePlan> program;
+    std::optional<clifft::sampling::ExecutablePlan> program;
     std::string error;
 };
 
 // Parse passes_json: {"hir": [...]}
-// Empty string or "{}" means use defaults.
+// Empty string or "{}" means use defaults. build_executable lowers the
+// SamplingPlan into an ExecutablePlan; the compile-for-inspection path
+// leaves it unset since it only needs the SamplingPlan's own inspection.
 PipelineResult run_pipeline(const std::string& source, const std::string& passes_json,
-                            bool retain_source_map) {
+                            bool retain_source_map, bool build_executable) {
     PipelineResult result;
     try {
         auto circuit = clifft::parse(source, MAX_OPS);
@@ -78,7 +78,9 @@ PipelineResult run_pipeline(const std::string& source, const std::string& passes
         clifft::sampling::SamplingPlanOptions options;
         options.retain_source_map = retain_source_map;
         result.plan.emplace(clifft::sampling::plan_sampling(result.hir, options));
-        result.program = std::make_unique<clifft::sampling::ExecutablePlan>(*result.plan);
+        if (build_executable) {
+            result.program.emplace(*result.plan);
+        }
     } catch (const std::exception& e) {
         result.error = e.what();
     }
@@ -105,35 +107,14 @@ json source_map_json(const clifft::sampling::PlanSourceMap& source_map) {
     return entries;
 }
 
-json executable_source_map_json(const clifft::sampling::SamplingPlan& plan,
-                                const clifft::sampling::ExecutablePlan& program) {
-    json entries = json::array();
-    for (size_t i = 0; i < program.num_actions(); ++i) {
-        std::vector<uint32_t> source_lines;
-        const auto range = program.action_plan_range(i);
-        if (range.has_value()) {
-            for (uint32_t action = range->begin; action < range->end; ++action) {
-                for (uint32_t line : plan.source_map->lines_for(action)) {
-                    source_lines.push_back(line);
-                }
-            }
-        }
-        std::ranges::sort(source_lines);
-        source_lines.erase(std::unique(source_lines.begin(), source_lines.end()),
-                           source_lines.end());
-        entries.push_back(std::move(source_lines));
-    }
-    return entries;
-}
-
 std::string compile_to_json(const std::string& source, const std::string& passes_json) {
-    auto result = run_pipeline(source, passes_json, true);
+    auto result = run_pipeline(source, passes_json, /*retain_source_map=*/true,
+                               /*build_executable=*/false);
     if (!result.error.empty()) {
         return json({{"error", result.error}}).dump();
     }
     const auto& hir = result.hir;
     const auto& plan = *result.plan;
-    const auto& program = *result.program;
 
     std::vector<std::string> hir_strs;
     hir_strs.reserve(hir.ops.size());
@@ -151,15 +132,6 @@ std::string compile_to_json(const std::string& source, const std::string& passes
         active_width_history.push_back(plan.actions[i].active_after);
     }
 
-    std::vector<std::string> program_strs;
-    program_strs.reserve(program.num_actions());
-    json program_plan_ranges = json::array();
-    for (size_t i = 0; i < program.num_actions(); ++i) {
-        program_strs.push_back(program.inspect_action(i));
-        const auto range = program.action_plan_range(i).value();
-        program_plan_ranges.push_back({{"begin", range.begin}, {"end", range.end}});
-    }
-
     json j = {
         {"num_qubits", plan.num_qubits},
         {"peak_active_width", plan.peak_active_width},
@@ -167,11 +139,8 @@ std::string compile_to_json(const std::string& source, const std::string& passes
         {"num_t_gates", hir.num_t_gates()},
         {"hir_ops", hir_strs},
         {"sampling_plan", plan_strs},
-        {"wasm_program", program_strs},
         {"hir_source_map", hir.source_map},
         {"sampling_plan_source_map", source_map_json(*plan.source_map)},
-        {"wasm_program_source_map", executable_source_map_json(plan, program)},
-        {"wasm_program_plan_ranges", program_plan_ranges},
         {"active_width_history", active_width_history},
     };
     return j.dump();
@@ -221,7 +190,8 @@ std::string simulate_wasm(const std::string& source, uint32_t shots,
         return json({{"error", "ShotsLimitExceeded: max " + std::to_string(MAX_SHOTS)}}).dump();
     }
 
-    auto result = run_pipeline(source, passes_json, false);
+    auto result = run_pipeline(source, passes_json, /*retain_source_map=*/false,
+                               /*build_executable=*/true);
     if (!result.error.empty()) {
         return json({{"error", result.error}}).dump();
     }

--- a/src/wasm/test_wasm.mjs
+++ b/src/wasm/test_wasm.mjs
@@ -2,11 +2,20 @@
 // Run via: just test-wasm
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const createModule = require("../../build-wasm/clifft_wasm.js");
 
 const mod = await createModule();
+
+// Plan-action documentation, keyed by mnemonic (ROTATE_ACTIVE, MEASURE_ACTIVE,
+// etc.). Every sampling_plan mnemonic emitted below must have an entry here,
+// so a new planner action without documentation fails this smoke test.
+const opcodeMetadata = JSON.parse(
+    readFileSync(new URL("../../docs/opcodes.json", import.meta.url))
+);
+const planActions = opcodeMetadata.plan_actions;
 
 // Default passes config (empty string = use defaults)
 const DEFAULTS = "";
@@ -75,27 +84,28 @@ assert.ok(
     result.sampling_plan.some((line) => line.includes("record=r")),
     "Expected at least one sampling_plan line with a typed record id"
 );
-const SAMPLING_PLAN_MNEMONICS = [
-    "ROTATE_ACTIVE",
-    "ROTATE_PHASE",
-    "PROMOTE_DORMANT",
-    "MEASURE_ACTIVE",
-    "MEASURE_DORMANT",
-    "RECORD_CLASSICAL",
-    "DEFINE_SYMBOL",
-    "READOUT_NOISE",
-    "WRITE_DETECTOR",
-    "WRITE_OBSERVABLE",
-    "WRITE_EXPECTATION",
-    "APPLY_INSTRUMENT",
-    "INSTRUMENT_BOUNDARY",
-];
+const SAMPLING_PLAN_MNEMONICS = Object.keys(planActions);
 assert.ok(
     result.sampling_plan.some((line) =>
         SAMPLING_PLAN_MNEMONICS.some((mnemonic) => line.includes(mnemonic))
     ),
     "Expected at least one recognized SamplingPlan mnemonic"
 );
+
+// --- sampling_plan mnemonics stay in sync with docs/opcodes.json ---
+// A new planner action that lands without a plan_actions entry should fail
+// this smoke test rather than shipping undocumented.
+function assertMnemonicsAreDocumented(samplingPlan) {
+    for (const line of samplingPlan) {
+        const match = line.match(/^w\d+(?:->\d+)? ([A-Z][A-Z0-9_]*)\b/);
+        assert.ok(match, `sampling_plan line has no recognizable mnemonic: ${line}`);
+        assert.ok(
+            Object.prototype.hasOwnProperty.call(planActions, match[1]),
+            `sampling_plan mnemonic "${match[1]}" is missing a docs/opcodes.json plan_actions entry`
+        );
+    }
+}
+assertMnemonicsAreDocumented(result.sampling_plan);
 
 // --- optimize toggle via pass config ---
 // T T = S; peephole fusion should reduce 2 T ops to 1 S op
@@ -110,6 +120,8 @@ assert.ok(
     unopt.hir_ops.length > opt.hir_ops.length,
     "Optimized should have fewer ops (T+T fused to S)"
 );
+assertMnemonicsAreDocumented(unopt.sampling_plan);
+assertMnemonicsAreDocumented(opt.sampling_plan);
 
 // --- selective passes ---
 const hirOnlyJson = mod.compile_to_json(
@@ -120,6 +132,7 @@ const hirOnly = JSON.parse(hirOnlyJson);
 console.log("\nSelective passes (HIR only):");
 console.log("  HIR ops:", hirOnly.hir_ops.length);
 assert.ok(hirOnly.hir_ops.length <= opt.hir_ops.length, "HIR-only should still fuse T+T");
+assertMnemonicsAreDocumented(hirOnly.sampling_plan);
 
 const unknownPassConfig = JSON.parse(
     mod.compile_to_json("M 0", JSON.stringify({ hir: [], unknown: [] }))
@@ -146,6 +159,7 @@ assert.ok(
     truncationResult.sampling_plan.some((line) => line.includes("...(+")),
     "Expected a truncated affine expression for a six-term noise chain"
 );
+assertMnemonicsAreDocumented(truncationResult.sampling_plan);
 
 // --- simulate_wasm ---
 const simJson = mod.simulate_wasm("H 0\nM 0", 1000, DEFAULTS);

--- a/src/wasm/test_wasm.mjs
+++ b/src/wasm/test_wasm.mjs
@@ -38,7 +38,6 @@ console.log("  num_qubits:", result.num_qubits);
 console.log("  peak_active_width:", result.peak_active_width);
 console.log("  hir_ops:", result.hir_ops.length, "ops");
 console.log("  sampling_plan:", result.sampling_plan.length, "actions");
-console.log("  wasm_program:", result.wasm_program.length, "actions");
 console.log("  active_width_history:", result.active_width_history);
 console.log("  hir_source_map:", result.hir_source_map);
 console.log("  sampling_plan_source_map sample:", result.sampling_plan_source_map.slice(0, 3));
@@ -48,7 +47,6 @@ assert.equal(result.num_qubits, 1, "Expected 1 qubit");
 assert.ok(result.peak_active_width >= 0, "Expected peak_active_width >= 0");
 assert.ok(result.hir_ops.length > 0, "Expected HIR ops");
 assert.ok(result.sampling_plan.length > 0, "Expected sampling plan actions");
-assert.ok(result.wasm_program.length > 0, "Expected WASM program actions");
 assert.equal(
     result.active_width_history.length,
     result.sampling_plan.length,
@@ -59,11 +57,44 @@ assert.equal(
     result.sampling_plan.length,
     "source map parallel to sampling plan"
 );
-assert.equal(result.wasm_program_source_map.length, result.wasm_program.length);
-assert.equal(result.wasm_program_plan_ranges.length, result.wasm_program.length);
 assert.ok(
     result.sampling_plan_source_map.some((lines) => lines.includes(3)),
     "Expected plan provenance for the measurement source line"
+);
+
+// --- sampling_plan compact-format grammar checks ---
+// w<k>[-><k'>] <MNEMONIC> ...
+for (const line of result.sampling_plan) {
+    assert.match(
+        line,
+        /^w\d+(?:->\d+)? [A-Z][A-Z0-9_]*\b/,
+        `sampling_plan line does not match compact grammar: ${line}`
+    );
+}
+assert.ok(
+    result.sampling_plan.some((line) => line.includes("record=r")),
+    "Expected at least one sampling_plan line with a typed record id"
+);
+const SAMPLING_PLAN_MNEMONICS = [
+    "ROTATE_ACTIVE",
+    "ROTATE_PHASE",
+    "PROMOTE_DORMANT",
+    "MEASURE_ACTIVE",
+    "MEASURE_DORMANT",
+    "RECORD_CLASSICAL",
+    "DEFINE_SYMBOL",
+    "READOUT_NOISE",
+    "WRITE_DETECTOR",
+    "WRITE_OBSERVABLE",
+    "WRITE_EXPECTATION",
+    "APPLY_INSTRUMENT",
+    "INSTRUMENT_BOUNDARY",
+];
+assert.ok(
+    result.sampling_plan.some((line) =>
+        SAMPLING_PLAN_MNEMONICS.some((mnemonic) => line.includes(mnemonic))
+    ),
+    "Expected at least one recognized SamplingPlan mnemonic"
 );
 
 // --- optimize toggle via pass config ---
@@ -99,19 +130,21 @@ assert.match(
     "Unknown pass configuration keys should fail explicitly"
 );
 
-// --- executable provenance across lowering fusion ---
-const fusedSource = "H 0\nH 1\nT 0\nT 1\nT 0\nT 1\nT 0\nM 0";
-const fused = JSON.parse(mod.compile_to_json(fusedSource, NO_PASSES));
-const fusedAction = fused.wasm_program_plan_ranges.find((range) => range.end - range.begin > 1);
-assert.ok(fusedAction, "Expected one WASM action to cover a fused plan range");
-const fusedIndex = fused.wasm_program_plan_ranges.indexOf(fusedAction);
+// --- compact expression truncation ---
+// Six independent X_ERROR draws feeding one measurement push its outcome
+// expression past the compact form's four-term cap, so the printed line
+// should truncate with a "...(+N)" suffix instead of listing every term.
+const truncationLines = [];
+for (let i = 0; i < 6; i++) truncationLines.push("X_ERROR(0.01) 0");
+truncationLines.push("M 0");
+truncationLines.push("DETECTOR rec[-1]");
+const truncationSource = truncationLines.join("\n");
+const truncationResult = JSON.parse(mod.compile_to_json(truncationSource, DEFAULTS));
+assert.equal(truncationResult.error, undefined, "Expected no error for truncation circuit");
+console.log("\nTruncation test sampling_plan:", truncationResult.sampling_plan);
 assert.ok(
-    fused.wasm_program_source_map[fusedIndex].length > 1,
-    "Expected fused WASM action to retain source lines"
-);
-assert.ok(
-    fused.wasm_program.every((action) => !action.includes("OP_")),
-    "Expected prepared symbolic actions"
+    truncationResult.sampling_plan.some((line) => line.includes("...(+")),
+    "Expected a truncated affine expression for a six-term noise chain"
 );
 
 // --- simulate_wasm ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(clifft_tests PRIVATE
 # Provide absolute path to test fixture files so benchmarks work from any cwd.
 target_compile_definitions(clifft_tests PRIVATE
     CLIFFT_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures"
+    CLIFFT_DOCS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../docs"
 )
 
 # Tests that call the x86 kernel entry points directly can only link on

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(clifft_tests
     test_frontend.cc
     test_frontend_instruments.cc
     test_sampling_plan.cc
+    test_inspection_format.cc
     test_sampling_planner.cc
     test_sampling_planner_frame.cc
     test_sampling_executor.cc

--- a/tests/python/test_program_inspection.py
+++ b/tests/python/test_program_inspection.py
@@ -1,0 +1,33 @@
+"""Tests for the Program inspection bindings (inspect / inspect_action)."""
+
+import re
+
+import pytest
+
+import clifft
+
+CIRCUIT = "H 0\nCX 0 1\nM 0 1"
+
+
+def test_inspect_starts_with_header() -> None:
+    program = clifft.compile(CIRCUIT)
+    assert program.inspect().startswith("executable_plan backend=")
+
+
+def test_inspect_is_deterministic_across_compiles() -> None:
+    first = clifft.compile(CIRCUIT)
+    second = clifft.compile(CIRCUIT)
+    assert first.inspect() == second.inspect()
+
+
+def test_inspect_action_starts_with_uppercase_mnemonic() -> None:
+    program = clifft.compile(CIRCUIT)
+    text = program.inspect_action(0)
+    assert text
+    assert re.match(r"^[A-Z][A-Z0-9_]+\b", text)
+
+
+def test_inspect_action_out_of_range_raises_index_error() -> None:
+    program = clifft.compile(CIRCUIT)
+    with pytest.raises(IndexError):
+        program.inspect_action(program.num_actions)

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -93,9 +93,9 @@ TEST_CASE("Executable rotation inspection includes prepared weights") {
     const ExecutablePlan second(rotation_plan(4, second_rotation));
     const std::string inspection = first.inspect_action(0);
 
-    REQUIRE(inspection.find("pairing_bit=0x8") != std::string::npos);
-    REQUIRE(inspection.find(" cosine=") != std::string::npos);
-    REQUIRE(inspection.find(" sine=") != std::string::npos);
+    REQUIRE(inspection.find(" pair=3") != std::string::npos);
+    REQUIRE(inspection.find(" cos=") != std::string::npos);
+    REQUIRE(inspection.find(" sin=") != std::string::npos);
     REQUIRE(inspection != second.inspect_action(0));
 }
 
@@ -134,8 +134,8 @@ TEST_CASE("Executable plan preserves optional provenance across fusion") {
     const ExecutablePlan executable(inspected);
     REQUIRE(executable.num_actions() == 1);
     REQUIRE(executable.action_plan_range(0) == ExecutablePlan::PlanActionRange{0, 3});
-    REQUIRE(executable.inspect_action(0) == "fused_rotation descriptor=0");
-    REQUIRE(executable.inspect().find("plans=[0,3) fused_rotation descriptor=0") !=
+    REQUIRE(executable.inspect_action(0) == "FUSED_ROTATION descriptor=0");
+    REQUIRE(executable.inspect().find("plans=[0,3) FUSED_ROTATION descriptor=0") !=
             std::string::npos);
     REQUIRE_THROWS_AS(executable.action_plan_range(1), std::out_of_range);
 }

--- a/tests/test_inspection_format.cc
+++ b/tests/test_inspection_format.cc
@@ -7,25 +7,42 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <iterator>
 #include <numbers>
+#include <set>
 #include <string>
+#include <variant>
 #include <vector>
 
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
+using clifft::sampling::ApplyInstrument;
+using clifft::sampling::ApplyReadoutNoise;
+using clifft::sampling::DefineSymbol;
 using clifft::sampling::DetectorSlot;
 using clifft::sampling::ExecutablePlan;
+using clifft::sampling::ExpValSlot;
 using clifft::sampling::format_double_roundtrip;
 using clifft::sampling::format_pauli_product;
 using clifft::sampling::format_width_prefix;
+using clifft::sampling::InstrumentBoundary;
+using clifft::sampling::InstrumentMode;
+using clifft::sampling::InstrumentSiteId;
+using clifft::sampling::MeasureActivePauli;
+using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::ObservableSlot;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RecordSlot;
 using clifft::sampling::RotateActivePauli;
+using clifft::sampling::SamplingAction;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
 using clifft::sampling::WriteDetector;
+using clifft::sampling::WriteExpectationValue;
+using clifft::sampling::WriteObservable;
 
 namespace {
 
@@ -166,4 +183,70 @@ TEST_CASE("Executable rotation prints a pairing index only for X-type prepared P
     };
     const ExecutablePlan diagonal_executable(diagonal_plan);
     CHECK(diagonal_executable.inspect_action(0).find(" pair=") == std::string::npos);
+}
+
+TEST_CASE("Compact inspection mnemonics cover every SamplingAction and its docs entry") {
+    // Adding, removing, or renaming a SamplingAction alternative changes this
+    // count. Extend the action list below and the plan_actions table in
+    // docs/opcodes.json together, then update this assertion.
+    static_assert(std::variant_size_v<SamplingAction> == 12);
+
+    const SymbolId s0{0};
+    const AffineBool empty{};
+    const AffineBool branch_outcome = AffineBool::symbol(s0);
+
+    SamplingPlan plan;
+    plan.actions = {
+        // Rotation has two renderings that pick different mnemonics: an
+        // identity Pauli renders ROTATE_PHASE, a non-identity Pauli renders
+        // ROTATE_ACTIVE. Both are covered explicitly.
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{0, 0}, 0.25, empty}},
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.25, empty}},
+        PlannedAction{0, 1, PromoteDormantRotation{0.25, empty}},
+        PlannedAction{1, 0,
+                      MeasureActivePauli{ActivePauli{1, 0}, 0, s0, branch_outcome, RecordSlot{0}}},
+        PlannedAction{0, 0, MeasureDormantRandom{0, s0, branch_outcome, RecordSlot{0}}},
+        PlannedAction{0, 0, RecordClassical{empty, RecordSlot{0}}},
+        PlannedAction{0, 0, DefineSymbol{s0, empty}},
+        PlannedAction{0, 0, ApplyReadoutNoise{s0, empty, RecordSlot{0}, 0.0, 0.0}},
+        PlannedAction{0, 0, WriteDetector{empty, DetectorSlot{0}, false}},
+        PlannedAction{0, 0, WriteObservable{empty, ObservableSlot{0}}},
+        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, empty, ExpValSlot{0}}},
+        PlannedAction{0, 0,
+                      ApplyInstrument{InstrumentSiteId{0}, InstrumentMode::Classical, ActivePauli{},
+                                      empty, s0}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 0}},
+    };
+
+    std::set<std::string> mnemonics;
+    for (size_t i = 0; i < plan.actions.size(); ++i) {
+        const std::string compact = plan.inspect_action_compact(i);
+        // The compact form is "<width> <MNEMONIC> ...": the mnemonic is the
+        // token following the width prefix's single trailing space.
+        const size_t width_end = compact.find(' ');
+        REQUIRE(width_end != std::string::npos);
+        const size_t mnemonic_end = compact.find(' ', width_end + 1);
+        mnemonics.insert(compact.substr(width_end + 1, mnemonic_end - (width_end + 1)));
+    }
+
+    const std::set<std::string> expected = {
+        "ROTATE_ACTIVE",       "ROTATE_PHASE",     "PROMOTE_DORMANT",   "MEASURE_ACTIVE",
+        "MEASURE_DORMANT",     "RECORD_CLASSICAL", "DEFINE_SYMBOL",     "READOUT_NOISE",
+        "WRITE_DETECTOR",      "WRITE_OBSERVABLE", "WRITE_EXPECTATION", "APPLY_INSTRUMENT",
+        "INSTRUMENT_BOUNDARY",
+    };
+    REQUIRE(mnemonics == expected);
+
+    // Cross-check that every mnemonic also has an entry in the docs metadata
+    // that the playground tokenizer and hover text derive from. This is a
+    // plain substring search, not a JSON parser, so it only confirms the key
+    // is present, not the shape of its value.
+    std::ifstream docs_file(std::string(CLIFFT_DOCS_DIR) + "/opcodes.json");
+    REQUIRE(docs_file.is_open());
+    const std::string docs_text((std::istreambuf_iterator<char>(docs_file)),
+                                std::istreambuf_iterator<char>());
+    for (const std::string& name : expected) {
+        CAPTURE(name);
+        REQUIRE(docs_text.find("\"" + name + "\":") != std::string::npos);
+    }
 }

--- a/tests/test_inspection_format.cc
+++ b/tests/test_inspection_format.cc
@@ -1,0 +1,169 @@
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/inspection_format.h"
+#include "clifft/sampling/plan.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <numbers>
+#include <string>
+#include <vector>
+
+using clifft::sampling::ActivePauli;
+using clifft::sampling::AffineBool;
+using clifft::sampling::DetectorSlot;
+using clifft::sampling::ExecutablePlan;
+using clifft::sampling::format_double_roundtrip;
+using clifft::sampling::format_pauli_product;
+using clifft::sampling::format_width_prefix;
+using clifft::sampling::PlannedAction;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::RecordSlot;
+using clifft::sampling::RotateActivePauli;
+using clifft::sampling::SamplingPlan;
+using clifft::sampling::SymbolId;
+using clifft::sampling::WriteDetector;
+
+namespace {
+
+// Checks equality by bit pattern rather than value so -0.0 and NaN behave as
+// the format contract intends instead of relying on IEEE comparison rules.
+bool bit_identical(double left, double right) {
+    uint64_t left_bits = 0;
+    uint64_t right_bits = 0;
+    std::memcpy(&left_bits, &left, sizeof(left_bits));
+    std::memcpy(&right_bits, &right, sizeof(right_bits));
+    return left_bits == right_bits;
+}
+
+double round_trip_parse(const std::string& text) {
+    return std::strtod(text.c_str(), nullptr);
+}
+
+}  // namespace
+
+TEST_CASE("format_double_roundtrip renders minimal round-trip decimals") {
+    CHECK(format_double_roundtrip(0.02) == "0.02");
+    CHECK(format_double_roundtrip(0.04) == "0.04");
+    CHECK(format_double_roundtrip(0.25) == "0.25");
+    CHECK(format_double_roundtrip(-0.0) == "-0");
+
+    const double cos_pi_8 = std::cos(std::numbers::pi / 8.0);
+    CHECK(bit_identical(round_trip_parse(format_double_roundtrip(cos_pi_8)), cos_pi_8));
+
+    const double one_third = 1.0 / 3.0;
+    CHECK(bit_identical(round_trip_parse(format_double_roundtrip(one_third)), one_third));
+
+    const double tiny = 1e-308;
+    CHECK(bit_identical(round_trip_parse(format_double_roundtrip(tiny)), tiny));
+
+    const double huge = 1e100;
+    CHECK(bit_identical(round_trip_parse(format_double_roundtrip(huge)), huge));
+}
+
+TEST_CASE("format_pauli_product renders sparse ascending Pauli letters") {
+    CHECK(format_pauli_product(0, 0) == "I");
+    CHECK(format_pauli_product(1, 0) == "X0");
+    CHECK(format_pauli_product(0b101, 0b010) == "X0*Z1*X2");
+    CHECK(format_pauli_product(uint64_t{1} << 59, uint64_t{1} << 59) == "Y59");
+}
+
+TEST_CASE("format_width_prefix reports the active-width transition") {
+    CHECK(format_width_prefix(4, 4) == "w4");
+    CHECK(format_width_prefix(1, 0) == "w1->0");
+}
+
+TEST_CASE("Sampling plan promotion inspection starts with the width change and mnemonic") {
+    SamplingPlan plan;
+    plan.actions = {
+        PlannedAction{0, 1, PromoteDormantRotation{0.25, AffineBool{}}},
+    };
+
+    CHECK(plan.inspect_action_compact(0).starts_with("w0->1 PROMOTE_DORMANT"));
+}
+
+TEST_CASE("Rotation inspection renders ROTATE_PHASE without a Pauli operand for the identity") {
+    SamplingPlan plan;
+    plan.actions = {
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{0, 0}, 0.25, AffineBool{}}},
+    };
+
+    CHECK(plan.inspect_action(0) == "w1 dense_passes=0 ROTATE_PHASE half_turns=0.25 sign=0");
+}
+
+TEST_CASE("Full inspection reports dense_passes while compact reports a trailing passes field") {
+    SamplingPlan dense_plan;
+    dense_plan.actions = {
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.02, AffineBool{}}},
+    };
+    CHECK(dense_plan.inspect_action(0) ==
+          "w1 dense_passes=1 ROTATE_ACTIVE X0 half_turns=0.02 sign=0");
+    CHECK(dense_plan.inspect_action_compact(0) ==
+          "w1 ROTATE_ACTIVE X0 half_turns=0.02 sign=0 passes=1");
+
+    SamplingPlan classical_plan;
+    classical_plan.actions = {
+        PlannedAction{0, 0, RecordClassical{AffineBool{}, RecordSlot{0}}},
+    };
+    CHECK(classical_plan.inspect_action(0) ==
+          "w0 dense_passes=0 RECORD_CLASSICAL outcome=0 record=r0");
+    const std::string classical_compact = classical_plan.inspect_action_compact(0);
+    CHECK(classical_compact == "w0 RECORD_CLASSICAL outcome=0 record=r0");
+    CHECK(classical_compact.find("passes") == std::string::npos);
+}
+
+TEST_CASE("Compact inspection caps affine expressions at four symbol terms") {
+    std::vector<SymbolId> terms;
+    for (uint32_t i = 0; i < 14; ++i) {
+        terms.push_back(SymbolId{i});
+    }
+    SamplingPlan plan;
+    plan.actions = {
+        PlannedAction{0, 0, RecordClassical{AffineBool(false, terms), RecordSlot{0}}},
+    };
+
+    const std::string full = plan.inspect_action(0);
+    CHECK(full.find("s13") != std::string::npos);
+    CHECK(full.find("...(+") == std::string::npos);
+
+    const std::string compact = plan.inspect_action_compact(0);
+    CHECK(compact.find("outcome=s0^s1^s2^s3^...(+10)") != std::string::npos);
+    CHECK(compact.find("s4") == std::string::npos);
+}
+
+TEST_CASE("Detector inspection appends postselect only when the detector is postselected") {
+    SamplingPlan plan;
+    plan.actions = {
+        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{0}, true}},
+        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{1}, false}},
+    };
+
+    CHECK(plan.inspect_action(0) ==
+          "w0 dense_passes=0 WRITE_DETECTOR outcome=0 detector=d0 postselect");
+    CHECK(plan.inspect_action(1) == "w0 dense_passes=0 WRITE_DETECTOR outcome=0 detector=d1");
+}
+
+TEST_CASE("Executable rotation prints a pairing index only for X-type prepared Paulis") {
+    SamplingPlan x_type_plan;
+    x_type_plan.num_qubits = 1;
+    x_type_plan.initial_active_width = 1;
+    x_type_plan.peak_active_width = 1;
+    x_type_plan.actions = {
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}},
+    };
+    const ExecutablePlan x_type_executable(x_type_plan);
+    CHECK(x_type_executable.inspect_action(0).find(" pair=0") != std::string::npos);
+
+    SamplingPlan diagonal_plan;
+    diagonal_plan.num_qubits = 1;
+    diagonal_plan.initial_active_width = 1;
+    diagonal_plan.peak_active_width = 1;
+    diagonal_plan.actions = {
+        PlannedAction{1, 1, RotateActivePauli{ActivePauli{0, 1}, 0.25, AffineBool{}}},
+    };
+    const ExecutablePlan diagonal_executable(diagonal_plan);
+    CHECK(diagonal_executable.inspect_action(0).find(" pair=") == std::string::npos);
+}

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -153,10 +153,9 @@ TEST_CASE("Sampling plan validates symbolic and active state invariants") {
     const std::string text = plan.inspect();
     REQUIRE(text.find("sampling_plan qubits=2 initial_width=0 peak_width=1") != std::string::npos);
     REQUIRE(text.find("s0 kind=presampled noise_site=0") != std::string::npos);
-    REQUIRE(text.find("1 active_width=1->0 dense_passes=2 measure_active") != std::string::npos);
-    REQUIRE(text.find("outcome=s0 ^ s1 record=0") != std::string::npos);
-    REQUIRE(text.find("5 active_width=0->0 dense_passes=0 instrument_boundary site=0 ") !=
-            std::string::npos);
+    REQUIRE(text.find("1 w1->0 dense_passes=2 MEASURE_ACTIVE X0") != std::string::npos);
+    REQUIRE(text.find("outcome=s0^s1 record=r0") != std::string::npos);
+    REQUIRE(text.find("5 w0 dense_passes=0 INSTRUMENT_BOUNDARY site=0 ") != std::string::npos);
 }
 
 TEST_CASE("Sampling plan compact inspection bounds affine expressions") {
@@ -173,8 +172,8 @@ TEST_CASE("Sampling plan compact inspection bounds affine expressions") {
 
     REQUIRE(plan.inspect_action(0).find("s11") != std::string::npos);
     const std::string compact = plan.inspect_action_compact(0);
-    REQUIRE(compact.find("s7 ^ ... (12 terms)") != std::string::npos);
-    REQUIRE(compact.find("s8") == std::string::npos);
+    REQUIRE(compact.find("s0^s1^s2^s3^...(+8)") != std::string::npos);
+    REQUIRE(compact.find("s4") == std::string::npos);
 }
 
 TEST_CASE("Sampling plan rejects inconsistent noise site totals") {
@@ -542,7 +541,7 @@ TEST_CASE("Sampling plan distinguishes dormant branch labels from records") {
         AffineBool::symbol(branch) ^ true;
 
     REQUIRE_NOTHROW(plan.validate());
-    REQUIRE(plan.inspect().find("branch=s0 outcome=1 ^ s0 record=0") != std::string::npos);
+    REQUIRE(plan.inspect().find("branch=s0 outcome=1^s0 record=r0") != std::string::npos);
 }
 
 TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
@@ -559,8 +558,8 @@ TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
 
     REQUIRE_NOTHROW(plan.validate());
     const std::string text = plan.inspect();
-    REQUIRE(text.find("dense_passes=1 write_expectation") != std::string::npos);
-    REQUIRE(text.find("dense_passes=0 write_expectation zero exp_val=1") != std::string::npos);
+    REQUIRE(text.find("dense_passes=1 WRITE_EXPECTATION") != std::string::npos);
+    REQUIRE(text.find("dense_passes=0 WRITE_EXPECTATION zero exp_val=v1") != std::string::npos);
 
     SECTION("duplicate slot") {
         std::get<WriteExpectationValue>(plan.actions[1].action).exp_val = ExpValSlot{0};

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -218,7 +218,7 @@ TEST_CASE("Sampling planner retains source provenance only when requested") {
     REQUIRE(std::ranges::equal(inspected.source_map->lines_for(0), std::array<uint32_t, 1>{2}));
     REQUIRE(std::ranges::equal(inspected.source_map->lines_for(1), std::array<uint32_t, 1>{3}));
     REQUIRE(std::ranges::equal(inspected.source_map->lines_for(2), std::array<uint32_t, 1>{4}));
-    REQUIRE(inspected.inspect_action(0).find("promote_dormant") != std::string::npos);
+    REQUIRE(inspected.inspect_action(0).find("PROMOTE_DORMANT") != std::string::npos);
     REQUIRE_THROWS_AS(inspected.inspect_action(inspected.actions.size()), std::out_of_range);
 }
 
@@ -613,5 +613,5 @@ TEST_CASE("Sampling planner target QEC plan characterization") {
     INFO(inspection);
     // After verifying that a reported inspection change is intentional, update
     // this digest to the new value shown by the failed assertion.
-    REQUIRE(fnv1a64(inspection) == 0xd6739c5e74e9339eULL);
+    REQUIRE(fnv1a64(inspection) == 0x3582c678c0c8731cULL);
 }


### PR DESCRIPTION
## Summary

Makes the sampling-plan text as scannable as the old SVM disassembly, without changing any IR or execution semantics.

**Before / after** (same action, playground panel):

```
active_width=4->4 dense_passes=1 rotate_active x=0x0000000000000001 z=0x0000000000000000 half_turns=0.040000000000000001 sign=s18 ^ s20 ^ s21 ^ s27
w4 ROTATE_ACTIVE X0 half_turns=0.04 sign=s18^s20^s21^s27 passes=1
```

### Format (SamplingPlan and native ExecutablePlan inspection)

- Uppercase action mnemonics; identity-Pauli rotations render as `ROTATE_PHASE` with no operand.
- `w<k>[-><k'>]` active-width prefix on every line; full inspection keeps `dense_passes=` there, the compact form appends `passes=<n>` only for actions touching the dense state.
- Sparse Pauli-product operands (`X0*Z1*Y2`) over active symbolic coordinates, replacing zero-padded hex masks.
- Unspaced affine expressions (`1^s0^s3`); the compact form caps at four symbol terms with a `...(+N)` omitted-count suffix.
- Typed output slots: `r` records, `d` detectors, `o` observables, `v` expectation values; `postselect` appears only when enabled.
- Doubles use minimal-digits round-trip formatting (bit-exact via strtod check), replacing fixed 17-digit precision.

### Python

`Program.inspect()` and `Program.inspect_action(i)` are bound again, restoring printable diagnostics that were lost in the symbolic cutover.

### Playground

- The Sampling Plan / WASM Program toggle is gone: the compile path no longer lowers to an `ExecutablePlan` or serializes it, and the panel shows the semantic plan only (cursor sync, diff view, and stats simplified accordingly). Simulation still lowers and executes as before.
- New Monaco hovers: action mnemonics show descriptions from shared metadata, and the `sign`/`outcome`/`value`/`source` keys explain the affine-expression notation. The guided tour is rewritten for the new format.

### Docs

`docs/reference/instructions.md` is revived (it existed through v0.7.0 and was dropped in the symbolic cutover, leaving the HIR metadata rendered nowhere). The page keeps the HIR section and replaces the retired VM-opcode section with the sampling-plan action reference. Both it and the playground hovers render from a new `plan_actions` table in `docs/opcodes.json`, and the wasm smoke test fails if a planner action ever ships without a metadata entry.

## Verification

- Native Debug suite: 821 cases / 475k assertions pass; `ctest -E Bench` clean. The target-QEC characterization digest was updated after reviewing the new inspection output.
- Python: full `tests/python` suite (787 tests) passes against a Debug-built extension.
- Wasm: built with emsdk 3.1.74 (docker); `test_wasm.mjs` passes, including new grammar, typed-id, truncation, and mnemonic-documentation checks.
- Playground: `npm run lint` and `npm run build` clean.
- Docs: `mkdocs build --strict` (CI-identical invocation) passes.

Worth a quick manual pass in a browser: hover rendering on mnemonics and expression keys, the rewritten tour step, and cursor/source-map sync in normal and diff modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review feedback (round 1)

- Corrected the `ROTATE_PHASE` metadata: a unit-magnitude global phase cancels from all squared-amplitude quantities (sampling, interference, basis/record probabilities, expectation values); it is retained only so exact statevector reconstruction preserves the program's global phase.
- Tour now scopes the click-to-highlight hint to the normal (non-diff) view.
- Cross-panel clicks now scroll their mapped lines into view (`revealLineInCenterIfOutsideViewport`, no cursor movement), and the plan-panel glyph anchors on the specific clicked action. This is isolated in commit `af6e2b0d` so it can be reverted cleanly if the UX doesn't land well — please try it with the MSC d=3 cultivation circuit.


## Post-review updates

- Rebased onto main after #338 (`peak_active_width` naming): the rename is applied through every inspection surface (`peak_width=` header label, bindings, wasm field, playground), and the characterization digest was recomputed once for the label change. Full stack re-verified after the rebase (native Debug 822 cases, Python 789, wasm smoke, playground build, strict docs build).
- SamplingPlan inspection now lives in `plan_inspection.cc`, mirroring `executable_plan_inspection.cc`; a pure move, digest unchanged by it.
- New exhaustive guard: a test constructs every `SamplingAction` alternative and requires each emitted mnemonic to exist in `docs/opcodes.json`, with a variant-size static assert; the playground tokenizer now derives its mnemonic pattern from the same metadata.
