### PR TITLE
feat(api)!: name active-width metrics consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,11 +149,11 @@ Beyond the probability work, 0.4.0 lands a scheduled benchmark-history workflow 
 
 ## [0.3.0] - 2026-05-08
 
-This release adds strong simulation for unitary circuits through exact computational-basis probability queries of the factored state. The new `clifft.probabilities()` API evaluates selected bitstrings without materializing the full $2^n$ statevector, so sparse output queries can scale with active rank rather than output-space size. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/guide/strong-simulation/) for examples.
+This release adds strong simulation for unitary circuits through exact computational-basis probability queries of the factored state. The new `clifft.probabilities()` API evaluates selected bitstrings without materializing the full $2^n$ statevector, so sparse output queries can scale with active width rather than output-space size. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/guide/strong-simulation/) for examples.
 
 Clifft 0.3.0 also removes the old compile-time qubit ceiling by moving Pauli mask storage to runtime-width arenas. That fixed-width limit kept the early implementation simple and fast; the new arena path keeps the overhead localized while supporting circuits above the former inline-width bound.
 
-The release also improves performance in the playground for larger circuits. The prior playground had some pauses when unnecessarily re-rendering the current program counter line in the active dimensions timeline.
+The release also improves performance in the playground for larger circuits. The prior playground had some pauses when unnecessarily re-rendering the current program counter line in the active-width timeline.
 
 ### Bug Fixes
 

--- a/docs/guide/importance-sampling.md
+++ b/docs/guide/importance-sampling.md
@@ -87,7 +87,7 @@ prog = clifft.compile(
     hir_passes=clifft.default_hir_pass_manager(),
 )
 
-print(f"Peak active width: {prog.peak_rank}")  # 4 (only 2^4 = 16 amplitudes)
+print(f"Peak active width: {prog.peak_active_width}")  # 4 (only 2^4 = 16 amplitudes)
 print(f"Detectors:      {prog.num_detectors}")    # 20
 print(f"Observables:    {prog.num_observables}")   # 1
 

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -332,7 +332,7 @@ semantics and active-width cost are described in
   cost.
 - **`seed`**: same contract as ordinary sampling: a fixed seed is fully
   reproducible, `None` uses hardware entropy.
-- **`max_rank`**: caps the compiled peak active width before allocating or
+- **`max_active_width`**: caps the compiled peak active width before allocating or
   growing the state for that module.
   The cap applies to each compiled module, including branches a given shot
   never takes, so it is conservative.

--- a/docs/guide/scripts/importance_sampling_tutorial.py
+++ b/docs/guide/scripts/importance_sampling_tutorial.py
@@ -129,7 +129,9 @@ def run_stratified_is(
 
     site_probs: NDArray[np.float64] = prog.noise_site_probabilities
     n_sites = len(site_probs)
-    print(f"  peak_active_width={prog.peak_rank}, {num_det} detectors, {n_sites} noise sites")
+    print(
+        f"  peak_active_width={prog.peak_active_width}, {num_det} detectors, {n_sites} noise sites"
+    )
 
     pmf = uniform_fault_pmf(site_probs, MAX_K)
 

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -260,13 +260,12 @@ See the [Importance Sampling Tutorial](importance-sampling.md) for a complete wa
 
 ## Performance and Limits
 
-Clifft's simulation cost is controlled primarily by the peak active width,
-which the current API reports as `program.peak_rank`, rather than by the total
-number of physical qubits. The executor stores and updates a dense active state
-of dimension $2^k$, where $k$ is the number of simultaneously active symbolic
-coordinates.
+Clifft's simulation cost is controlled primarily by `program.peak_active_width`,
+rather than by the total number of physical qubits. The executor stores and
+updates a dense active state of dimension $2^k$, where $k$ is the number of
+simultaneously active symbolic coordinates.
 
 This means Clifft can handle circuits with many physical qubits when
 non-Clifford effects remain localized. It also means performance degrades as
-`program.peak_rank` grows: circuits with large sustained active width approach
+`program.peak_active_width` grows: circuits with large sustained active width approach
 the cost of dense state-vector simulation.

--- a/docs/guide/strong-simulation.md
+++ b/docs/guide/strong-simulation.md
@@ -89,7 +89,7 @@ bitstrings = [
 ps = clifft.basis_probabilities(program, bitstrings)
 
 print(f"qubits: {program.num_qubits}")
-print(f"peak active width: {program.peak_rank}")
+print(f"peak active width: {program.peak_active_width}")
 for bitstring, probability in zip(bitstrings, ps):
     print(f"{bitstring}: {probability:.12g}")
 ```
@@ -294,11 +294,10 @@ though, and the difference can be 100×+ in either direction:
   amortization, but the compiler's `StatevectorSqueezePass` can reorder
   measurements next to their non-Clifford gates to reduce active width early.
 
-A practical way to choose: compile both forms and read off
-`program.peak_rank`, which currently reports peak active width. When the
-*measured* form has a noticeably lower peak active width than the unitary
-form, `record_probabilities()` is typically faster per query. When the two
-widths match, `basis_probabilities()` wins
+A practical way to choose is to compile both forms and compare their
+`program.peak_active_width` values. When the *measured* form has a noticeably
+lower peak active width than the unitary form, `record_probabilities()` is
+typically faster per query. When the two widths match, `basis_probabilities()` wins
 because it amortizes plan execution across queries.
 
 ```python
@@ -319,11 +318,11 @@ H 0 1 2 3 4
 unitary = clifft.compile(circuit)
 measured = clifft.compile(circuit + "\nM 0 1 2 3 4")
 
-print(f"basis_probabilities()  peak active width: {unitary.peak_rank}")
-print(f"record_probabilities() peak active width: {measured.peak_rank}")
+print(f"basis_probabilities()  peak active width: {unitary.peak_active_width}")
+print(f"record_probabilities() peak active width: {measured.peak_active_width}")
 ```
 
-A gap in `peak_rank` indicates roughly a
+A gap in `peak_active_width` indicates roughly a
 $2^{(k_{\text{unitary}} - k_{\text{measured}})}$ speedup ceiling for
 `record_probabilities()` over `basis_probabilities()` on this circuit,
 independent of batch size. At equal peak active width,

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -77,7 +77,7 @@ def define_env(env: Any) -> None:
             "python_name": "StatevectorSqueezePass",
             "summary": "Minimizes peak active width by reordering HIR operations.",
             "detail": (
-                "Attempts to reduce `peak_rank` by compacting qubit lifetimes. "
+                "Attempts to reduce `peak_active_width` by compacting qubit lifetimes. "
                 "Sweep 1 (leftward) bubbles MEASURE ops as early as possible. "
                 "Sweep 2 (rightward) bubbles T_GATE and PHASE_ROTATION ops as "
                 "late as possible. Measurements reduce active width sooner, "

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -588,7 +588,11 @@ export default function App() {
       {stats && (
         <div className="stats-bar">
           {formatStat("Qubits", stats.num_qubits, baselineStats?.num_qubits)}
-          {formatStat("Peak k", stats.max_active_width, baselineStats?.max_active_width)}
+          {formatStat(
+            "Peak active width",
+            stats.peak_active_width,
+            baselineStats?.peak_active_width,
+          )}
           {formatStat("T gates", stats.num_t_gates, baselineStats?.num_t_gates)}
           {formatStat("Measurements", stats.num_measurements, baselineStats?.num_measurements)}
           {formatStat("HIR ops", stats.hir_ops.length, baselineStats?.hir_ops.length)}
@@ -757,7 +761,7 @@ export default function App() {
             <Allotment defaultSizes={[50, 50]}>
               <Allotment.Pane>
                 <div className="chart-pane" data-tour="active-dim">
-                  <div className="chart-label">Active Dimensions (k) Timeline</div>
+                  <div className="chart-label">Active Width (k) Timeline</div>
                   <div className="chart-container">
                     <KHistoryChart
                       history={stats?.active_width_history ?? []}

--- a/playground/src/components/GuidedTour.tsx
+++ b/playground/src/components/GuidedTour.tsx
@@ -77,10 +77,10 @@ const STEPS: TourStep[] = [
     `,
   },
   {
-    title: "Active Dimension Timeline",
+    title: "Active Width Timeline",
     target: '[data-tour="active-dim"]',
     html: `
-      <p>This chart tracks the active dimension <code>k</code> across the
+      <p>This chart tracks the active width <code>k</code> across the
       sampling plan. Clifft's active state vector has size <code>2^k</code>, so
       keeping <code>k</code> small is the key to fast simulation.</p>
       <p><code>k</code> grows when a dormant coordinate is promoted into the

--- a/playground/src/components/HistogramChart.tsx
+++ b/playground/src/components/HistogramChart.tsx
@@ -52,9 +52,9 @@ export function HistogramChart({ result, elapsedMs, colors }: Props) {
           <>
             <strong>Circuit too large for browser simulation.</strong>
             <br />
-            Peak rank exceeds 24 (~256 MB statevector). Near-Clifford circuits
-            with many qubits but few T gates have low peak rank and should work
-            fine. Use the native Python CLI for high-rank circuits.
+            Peak active width exceeds 24 (~256 MB statevector). Near-Clifford
+            circuits with many qubits but few T gates have low peak active width
+            and should work fine. Use the native Python CLI for wider circuits.
           </>
         ) : isNoncompAnnotationError(result.error) ? (
           <NoncompNotice />

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -12,7 +12,7 @@ export interface PlanActionRange {
 export interface CompileSuccess {
   error?: undefined;
   num_qubits: number;
-  max_active_width: number;
+  peak_active_width: number;
   num_measurements: number;
   num_t_gates: number;
   hir_ops: string[];

--- a/src/clifft/noncomp/policy.h
+++ b/src/clifft/noncomp/policy.h
@@ -8,7 +8,7 @@ namespace clifft {
 
 // Exact applies the no-jump back-action for source-dependent transition
 // rates. On a coherent dormant qubit, this may promote the qubit into the
-// active state and increase the active dimension. Neglect avoids that cost by
+// active state and increase the active width. Neglect avoids that cost by
 // omitting the back-action, introducing a survivorship tilt of order
 // |p_g - p_e|. It remains exact when the total transition rate is
 // source-independent. Fired transitions retain their source and destination

--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -39,9 +39,10 @@ void validate_noncomputational_entry(const Circuit& circuit) {
 NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                const NonComputationalModel& model, uint32_t shots,
                                                std::optional<uint64_t> seed,
-                                               std::optional<uint32_t> max_rank) {
+                                               std::optional<uint32_t> max_active_width) {
     validate_noncomputational_entry(circuit);
-    return run_trajectory_driver(circuit, model, shots, make_seed_root(shots, seed), max_rank);
+    return run_trajectory_driver(circuit, model, shots, make_seed_root(shots, seed),
+                                 max_active_width);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/sample.h
+++ b/src/clifft/noncomp/sample.h
@@ -54,12 +54,12 @@ struct NonComputationalSample {
 // classifier the model does not provide. (Classifier shape -- two or
 // three symbols, stochastic columns -- is the model's own construction
 // contract, enforced before a circuit ever meets it.)
-// `max_rank` caps the compiled peak rank. Compilation reports the first
+// `max_active_width` caps the compiled peak active width. Compilation reports the first
 // offending active width before allocating or growing the executor state.
 // Unlimited when unset.
-NonComputationalSample sample_noncomputational(const Circuit& circuit,
-                                               const NonComputationalModel& model, uint32_t shots,
-                                               std::optional<uint64_t> seed = std::nullopt,
-                                               std::optional<uint32_t> max_rank = std::nullopt);
+NonComputationalSample sample_noncomputational(
+    const Circuit& circuit, const NonComputationalModel& model, uint32_t shots,
+    std::optional<uint64_t> seed = std::nullopt,
+    std::optional<uint32_t> max_active_width = std::nullopt);
 
 }  // namespace clifft

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -391,14 +391,15 @@ void prepend_initial_excited_preparations(Circuit& circuit, std::span<const Leve
                          std::make_move_iterator(preparations.end()));
 }
 
-void check_sampling_max_rank(const sampling::SamplingPlan& plan, std::optional<uint32_t> max_rank) {
-    if (!max_rank.has_value() || plan.max_active_width <= *max_rank) {
+void enforce_sampling_active_width_cap(const sampling::SamplingPlan& plan,
+                                       std::optional<uint32_t> max_active_width_cap) {
+    if (!max_active_width_cap.has_value() || plan.peak_active_width <= *max_active_width_cap) {
         return;
     }
     std::string site;
     if (plan.source_map.has_value()) {
         for (size_t action = 0; action < plan.actions.size(); ++action) {
-            if (plan.actions[action].active_after <= *max_rank) {
+            if (plan.actions[action].active_after <= *max_active_width_cap) {
                 continue;
             }
             const std::span<const uint32_t> lines = plan.source_map->lines_for(action);
@@ -409,14 +410,15 @@ void check_sampling_max_rank(const sampling::SamplingPlan& plan, std::optional<u
         }
     }
     throw std::invalid_argument(
-        "sample_noncomputational: planned active width " + std::to_string(plan.max_active_width) +
-        " exceeds max_rank " + std::to_string(*max_rank) + site +
-        "; consider damping=\"neglect\" for high-rate sites or a larger max_rank");
+        "sample_noncomputational: planned peak active width " +
+        std::to_string(plan.peak_active_width) + " exceeds max_active_width " +
+        std::to_string(*max_active_width_cap) + site +
+        "; consider damping=\"neglect\" for high-rate sites or a larger max_active_width");
 }
 
 SamplingCompiledContinuation compile_sampling_continuation(
     ContinuationRewrite rewrite, const std::vector<uint8_t>& herald_flags,
-    const InstrumentTraceOptions& instrument_options, std::optional<uint32_t> max_rank,
+    const InstrumentTraceOptions& instrument_options, std::optional<uint32_t> max_active_width_cap,
     std::span<const Level> initial_levels) {
     Circuit patched = std::move(rewrite.circuit);
     patch_heralded_measurements(patched, rewrite.classified_measurements, herald_flags);
@@ -424,7 +426,7 @@ SamplingCompiledContinuation compile_sampling_continuation(
     TracedContinuation traced =
         trace_continuation(std::move(patched), rewrite.forced_traceout_node, instrument_options);
     sampling::SamplingPlan plan = sampling::plan_sampling(traced.hir);
-    if (max_rank.has_value() && plan.max_active_width > *max_rank) {
+    if (max_active_width_cap.has_value() && plan.peak_active_width > *max_active_width_cap) {
         // Source provenance is retained only on the exceptional diagnostic
         // path; successful continuations can be numerous and do not need it.
         const sampling::SamplingPlan diagnostic =
@@ -432,7 +434,7 @@ SamplingCompiledContinuation compile_sampling_continuation(
                                                  .expected_detectors = {},
                                                  .expected_observables = {},
                                                  .retain_source_map = true});
-        check_sampling_max_rank(diagnostic, max_rank);
+        enforce_sampling_active_width_cap(diagnostic, max_active_width_cap);
     }
     if (plan.num_instrument_sites != rewrite.site_targets.size()) {
         throw std::logic_error("sample_noncomputational: sampling plan has " +
@@ -555,7 +557,7 @@ Circuit prepare_trajectory_circuit(const Circuit& circuit, const NonComputationa
 NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                              const NonComputationalModel& model, uint32_t shots,
                                              const SeedRoot& root,
-                                             std::optional<uint32_t> max_rank) {
+                                             std::optional<uint32_t> max_active_width_cap) {
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
@@ -624,8 +626,9 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
             extend_classical_outcomes(annotated, events, model, driver_rng);
             ContinuationRewrite rewrite = rewrite_continuation(annotated, events, false, model);
             const std::vector<uint8_t> flags = flags_for(rewrite);
-            shot_start.emplace(compile_sampling_continuation(
-                std::move(rewrite), flags, instrument_options, max_rank, initial_levels));
+            shot_start.emplace(compile_sampling_continuation(std::move(rewrite), flags,
+                                                             instrument_options,
+                                                             max_active_width_cap, initial_levels));
             continuation = &*shot_start;
         } else {
             if (!all_ground_start.has_value()) {
@@ -633,8 +636,9 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                     rewrite_continuation(annotated, no_events, false, model);
                 assert(rewrite.classified_measurements.empty() &&
                        "an all-ground continuation has no classified measurements");
-                all_ground_start.emplace(compile_sampling_continuation(
-                    std::move(rewrite), {}, instrument_options, max_rank, initial_levels));
+                all_ground_start.emplace(
+                    compile_sampling_continuation(std::move(rewrite), {}, instrument_options,
+                                                  max_active_width_cap, initial_levels));
             }
             continuation = &*all_ground_start;
         }
@@ -699,9 +703,10 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
             ContinuationRewrite next_rewrite =
                 rewrite_continuation(annotated, events, force, model);
             const std::vector<uint8_t> next_flags = flags_for(next_rewrite);
-            auto next = std::make_unique<SamplingCompiledContinuation>(
-                compile_sampling_continuation(std::move(next_rewrite), next_flags,
-                                              instrument_options, max_rank, initial_levels));
+            auto next =
+                std::make_unique<SamplingCompiledContinuation>(compile_sampling_continuation(
+                    std::move(next_rewrite), next_flags, instrument_options, max_active_width_cap,
+                    initial_levels));
 
             std::optional<sampling::ForcedTraceOut> forced_trace_out;
             if (force) {

--- a/src/clifft/noncomp/trajectory_driver.h
+++ b/src/clifft/noncomp/trajectory_driver.h
@@ -25,6 +25,6 @@ namespace clifft {
 NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                              const NonComputationalModel& model, uint32_t shots,
                                              const SeedRoot& root,
-                                             std::optional<uint32_t> max_rank);
+                                             std::optional<uint32_t> max_active_width_cap);
 
 }  // namespace clifft

--- a/src/clifft/optimizer/statevector_squeeze_pass.h
+++ b/src/clifft/optimizer/statevector_squeeze_pass.h
@@ -9,8 +9,8 @@ namespace clifft {
 /// - Sweep 2 (rightward): bubbles T_GATE and PHASE_ROTATION
 ///   ops as late as possible
 ///
-/// This reduces peak_rank by compacting qubit lifetimes: measurements free
-/// active dimensions sooner, and non-Clifford expansions are deferred.
+/// This reduces peak active width by compacting qubit lifetimes: measurements free
+/// active coordinates sooner, and non-Clifford expansions are deferred.
 class StatevectorSqueezePass : public HirPass {
   public:
     void run(HirModule& hir) override;

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -32,7 +32,7 @@ PreparedFusedRotationExecution::PreparedFusedRotationExecution(PreparedFusedRota
 ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     : num_qubits_(plan.num_qubits),
       initial_active_width_(plan.initial_active_width),
-      max_active_width_(plan.max_active_width),
+      peak_active_width_(plan.peak_active_width),
       num_visible_records_(plan.num_visible_records),
       num_hidden_records_(plan.num_hidden_records),
       num_detectors_(plan.num_detectors),

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -55,7 +55,7 @@ class ExecutablePlan {
     explicit ExecutablePlan(const SamplingPlan& plan);
 
     [[nodiscard]] uint32_t num_qubits() const { return num_qubits_; }
-    [[nodiscard]] uint32_t max_active_width() const { return max_active_width_; }
+    [[nodiscard]] uint32_t peak_active_width() const { return peak_active_width_; }
     [[nodiscard]] uint32_t num_visible_records() const { return num_visible_records_; }
     [[nodiscard]] uint32_t num_hidden_records() const { return num_hidden_records_; }
     [[nodiscard]] uint32_t num_detectors() const { return num_detectors_; }
@@ -310,7 +310,7 @@ class ExecutablePlan {
     // Immutable plan metadata and externally visible dimensions.
     uint32_t num_qubits_ = 0;
     uint32_t initial_active_width_ = 0;
-    uint32_t max_active_width_ = 0;
+    uint32_t peak_active_width_ = 0;
     uint32_t num_visible_records_ = 0;
     uint32_t num_hidden_records_ = 0;
     uint32_t num_detectors_ = 0;

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -52,7 +52,7 @@ struct MeasurementBranchClassification {
 Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
     : root_plan_(&plan),
       plan_(&plan),
-      state_(plan.max_active_width_, plan.initial_active_width_, plan.global_weight_),
+      state_(plan.peak_active_width_, plan.initial_active_width_, plan.global_weight_),
       symbols_(plan.num_symbols_, 0),
       expression_registers_(plan.expression_register_constants_),
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
@@ -144,7 +144,7 @@ void Executor::resume(const ExecutablePlan& continuation,
             "sampling continuation requires distributions for every presampled symbol");
     }
 
-    state_.ensure_capacity(continuation.max_active_width_);
+    state_.ensure_capacity(continuation.peak_active_width_);
     symbols_.resize(std::max(symbols_.size(), static_cast<size_t>(continuation.num_symbols_)), 0);
     std::fill(symbols_.begin() + boundary->symbol_prefix_size, symbols_.end(), uint8_t{0});
     expression_registers_.resize(

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -520,12 +520,12 @@ void SamplingPlan::validate() const {
     if (initial_active_width > num_qubits) {
         invalid_plan("initial active width exceeds qubit count");
     }
-    if (max_active_width > num_qubits || max_active_width < initial_active_width) {
-        invalid_plan("maximum active width is inconsistent with plan dimensions");
+    if (peak_active_width > num_qubits || peak_active_width < initial_active_width) {
+        invalid_plan("peak active width is inconsistent with plan dimensions");
     }
-    if (max_active_width >= kDenseActiveWidthLimit) {
-        invalid_plan("maximum active width must be below " +
-                     std::to_string(kDenseActiveWidthLimit) + " for dense coefficient storage");
+    if (peak_active_width >= kDenseActiveWidthLimit) {
+        invalid_plan("peak active width must be below " + std::to_string(kDenseActiveWidthLimit) +
+                     " for dense coefficient storage");
     }
     const uint64_t total_records = static_cast<uint64_t>(num_visible_records) + num_hidden_records;
     if (total_records > std::numeric_limits<uint32_t>::max()) {
@@ -690,7 +690,7 @@ void SamplingPlan::validate() const {
     }
 
     uint32_t active_width = initial_active_width;
-    uint32_t observed_max = active_width;
+    uint32_t observed_peak = active_width;
     std::unordered_set<uint32_t> written_records;
     std::unordered_set<uint32_t> written_detectors;
     std::unordered_set<uint32_t> written_observables;
@@ -878,10 +878,10 @@ void SamplingPlan::validate() const {
             planned.action);
 
         active_width = planned.active_after;
-        observed_max = std::max(observed_max, active_width);
+        observed_peak = std::max(observed_peak, active_width);
     }
-    if (observed_max != max_active_width) {
-        invalid_plan("declared maximum active width does not match the action stream");
+    if (observed_peak != peak_active_width) {
+        invalid_plan("declared peak active width does not match the action stream");
     }
     if (written_records.size() != total_records) {
         invalid_plan("declared record count does not match the action stream");
@@ -906,7 +906,7 @@ std::string SamplingPlan::inspect() const {
     std::ostringstream out;
     out << std::setprecision(17);
     out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
-        << " max_width=" << max_active_width << " visible_records=" << num_visible_records
+        << " peak_width=" << peak_active_width << " visible_records=" << num_visible_records
         << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
         << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
         << " observables=" << num_observables << " exp_vals=" << num_exp_vals

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -330,10 +330,10 @@ struct SamplingPlan {
 
     // Active width is the number of stabilizer coordinates represented in the
     // dense coefficient state, which contains 2^active_width entries. The
-    // planner computes its maximum while emitting actions so runtime lowering
+    // planner computes the peak while emitting actions so runtime lowering
     // can preallocate storage.
     uint32_t initial_active_width = 0;
-    uint32_t max_active_width = 0;
+    uint32_t peak_active_width = 0;
     uint32_t num_visible_records = 0;
     uint32_t num_hidden_records = 0;
     uint32_t num_noise_sites = 0;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -269,7 +269,7 @@ bool process_rotation(const Pauli& body, double half_turns, const AffineBool& si
                                 PromoteDormantRotation{half_turns, std::move(resolved.sign)}},
                   source_lines);
     ++active_width;
-    plan.max_active_width = std::max(plan.max_active_width, active_width);
+    plan.peak_active_width = std::max(plan.peak_active_width, active_width);
     return true;
 }
 
@@ -396,7 +396,7 @@ void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t n
         symbolic_frame.apply(destination_flip, AffineBool::symbol(*destination_symbol));
     }
     active_width = active_after;
-    plan.max_active_width = std::max(plan.max_active_width, active_width);
+    plan.peak_active_width = std::max(plan.peak_active_width, active_width);
     // A trapped shot resumes here so it cannot execute the instrument twice.
     append_action(plan,
                   PlannedAction{active_width, active_width,

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -120,16 +120,16 @@ void register_noncomp(nb::module_& m) {
     m.def(
         "_sample_noncomputational",
         [](const clifft::Circuit& circuit, const clifft::NonComputationalModel& model,
-           uint32_t shots, std::optional<uint64_t> seed, std::optional<uint32_t> max_rank) {
+           uint32_t shots, std::optional<uint64_t> seed, std::optional<uint32_t> max_active_width) {
             clifft::NonComputationalSample r;
             {
                 nb::gil_scoped_release release;
-                r = clifft::sample_noncomputational(circuit, model, shots, seed, max_rank);
+                r = clifft::sample_noncomputational(circuit, model, shots, seed, max_active_width);
             }
             return noncomp_sample_to_python(std::move(r), shots);
         },
         nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
-        nb::arg("max_rank") = nb::none(),
+        nb::arg("max_active_width") = nb::none(),
         "Sample a noncomputational model with the symbolic-coordinate backend.");
 }
 
@@ -547,7 +547,7 @@ NB_MODULE(_clifft_core, m) {
     nb::class_<clifft::StatevectorSqueezePass, clifft::HirPass>(
         m, "StatevectorSqueezePass",
         "Bidirectional bubble sort: moves measurements leftward and\n"
-        "non-Clifford gates rightward to minimize peak active rank.")
+        "non-Clifford gates rightward to minimize peak active width.")
         .def(nb::init<>());
 
     nb::class_<clifft::RemoveNoisePass, clifft::HirPass>(
@@ -607,7 +607,18 @@ NB_MODULE(_clifft_core, m) {
 
     nb::class_<clifft::sampling::ExecutablePlan>(m, "Program",
                                                  "A compiled symbolic-coordinate program")
-        .def_prop_ro("peak_rank", &clifft::sampling::ExecutablePlan::max_active_width)
+        .def_prop_ro("peak_active_width", &clifft::sampling::ExecutablePlan::peak_active_width,
+                     "Largest active width reached by the compiled program.")
+        .def_prop_ro(
+            "peak_rank",
+            [](const clifft::sampling::ExecutablePlan& p) {
+                if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Program.peak_rank is deprecated; use peak_active_width", 1) < 0) {
+                    throw nb::python_error();
+                }
+                return p.peak_active_width();
+            },
+            "Deprecated alias for peak_active_width.")
         .def_prop_ro("num_qubits", &clifft::sampling::ExecutablePlan::num_qubits)
         .def_prop_ro("num_measurements", &clifft::sampling::ExecutablePlan::num_visible_records)
         .def_prop_ro("num_hidden_measurements",
@@ -628,7 +639,7 @@ NB_MODULE(_clifft_core, m) {
             "Per-site total fault probabilities: quantum noise sites followed by readout noise.")
         .def("__repr__", [](const clifft::sampling::ExecutablePlan& p) {
             return "Program(" + std::to_string(p.num_actions()) +
-                   " actions, peak_rank=" + std::to_string(p.max_active_width()) + ", " +
+                   " actions, peak_active_width=" + std::to_string(p.peak_active_width()) + ", " +
                    std::to_string(p.num_visible_records()) + " measurements)";
         });
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -140,7 +140,7 @@ class Model:
             transition probability differs between ``g`` and ``e`` for a
             coherent qubit that is not yet represented in the state vector.
             ``"exact"`` (the default) adds the qubit to the state vector at
-            that site, increasing peak rank by one. ``"neglect"`` avoids the
+            that site, increasing peak active width by one. ``"neglect"`` avoids the
             expansion but omits the state update caused by observing that no
             transition occurred. It is exact when ``g`` and ``e`` have the
             same total transition probability; otherwise the bias is of order
@@ -290,7 +290,7 @@ def sample(
     model: Model,
     shots: int,
     seed: int | None = None,
-    max_rank: int | None = None,
+    max_active_width: int | None = None,
 ) -> NonComputationalSample:
     """Sample ``circuit`` under ``model`` for ``shots`` shots.
 
@@ -313,7 +313,7 @@ def sample(
         seed: Seed for reproducible sampling. The same seed and arguments
             produce identical results. When ``None``, each call uses fresh OS
             entropy.
-        max_rank: Optional cap on the peak rank of every compiled
+        max_active_width: Optional cap on the peak active width of every compiled
             continuation. The check is conservative because a continuation
             may contain branches that the current shot will not take.
 
@@ -324,14 +324,14 @@ def sample(
 
     Raises:
         ValueError: If a model or circuit contract is violated, an annotation
-            is malformed, or a continuation exceeds ``max_rank``.
+            is malformed, or a continuation exceeds ``max_active_width``.
     """
     return _sample_with(
         circuit,
         model,
         shots,
         seed,
-        max_rank,
+        max_active_width,
         _clifft_core._sample_noncomputational,
     )
 
@@ -341,13 +341,13 @@ def _sample_with(
     model: Model,
     shots: int,
     seed: int | None,
-    max_rank: int | None,
+    max_active_width: int | None,
     sampler: Callable,
 ) -> NonComputationalSample:
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)
     meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs = sampler(
-        circuit, model._handle, shots, seed, max_rank
+        circuit, model._handle, shots, seed, max_active_width
     )
     return NonComputationalSample(
         meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs

--- a/src/wasm/bindings.cc
+++ b/src/wasm/bindings.cc
@@ -32,7 +32,7 @@ using json = nlohmann::json;
 
 constexpr uint32_t MAX_SHOTS = 100000;
 constexpr uint32_t MAX_OPS = 50000;
-constexpr uint32_t MAX_ACTIVE_WIDTH = 24;
+constexpr uint32_t MAX_BROWSER_ACTIVE_WIDTH = 24;
 
 struct PipelineResult {
     clifft::HirModule hir;
@@ -162,7 +162,7 @@ std::string compile_to_json(const std::string& source, const std::string& passes
 
     json j = {
         {"num_qubits", plan.num_qubits},
-        {"max_active_width", plan.max_active_width},
+        {"peak_active_width", plan.peak_active_width},
         {"num_measurements", plan.num_visible_records},
         {"num_t_gates", hir.num_t_gates()},
         {"hir_ops", hir_strs},
@@ -227,7 +227,7 @@ std::string simulate_wasm(const std::string& source, uint32_t shots,
     }
     const auto& program = *result.program;
 
-    if (program.max_active_width() > MAX_ACTIVE_WIDTH) {
+    if (program.peak_active_width() > MAX_BROWSER_ACTIVE_WIDTH) {
         return json({{"error", "MemoryLimitExceeded"}}).dump();
     }
 

--- a/src/wasm/test_wasm.mjs
+++ b/src/wasm/test_wasm.mjs
@@ -35,7 +35,7 @@ const result = JSON.parse(json);
 
 console.log("compile_to_json result:");
 console.log("  num_qubits:", result.num_qubits);
-console.log("  max_active_width:", result.max_active_width);
+console.log("  peak_active_width:", result.peak_active_width);
 console.log("  hir_ops:", result.hir_ops.length, "ops");
 console.log("  sampling_plan:", result.sampling_plan.length, "actions");
 console.log("  wasm_program:", result.wasm_program.length, "actions");
@@ -45,7 +45,7 @@ console.log("  sampling_plan_source_map sample:", result.sampling_plan_source_ma
 
 assert.equal(result.error, undefined, "Expected no error");
 assert.equal(result.num_qubits, 1, "Expected 1 qubit");
-assert.ok(result.max_active_width >= 0, "Expected max_active_width >= 0");
+assert.ok(result.peak_active_width >= 0, "Expected peak_active_width >= 0");
 assert.ok(result.hir_ops.length > 0, "Expected HIR ops");
 assert.ok(result.sampling_plan.length > 0, "Expected sampling plan actions");
 assert.ok(result.wasm_program.length > 0, "Expected WASM program actions");

--- a/tests/python/test_basis_probabilities.py
+++ b/tests/python/test_basis_probabilities.py
@@ -254,13 +254,13 @@ def test_probabilities_match_qiskit_for_random_small_circuits(
     )
 
 
-def test_probabilities_supports_active_rank_beyond_dense_statevector_limit(
+def test_probabilities_supports_active_width_beyond_dense_statevector_limit(
     basis_probabilities_api: Any,
 ) -> None:
     circuit = "\n".join(f"H {q}\nT {q}" for q in range(12))
     prog = basis_probabilities_api.compile(circuit)
     assert prog.num_qubits == 12
-    assert prog.peak_rank > 10
+    assert prog.peak_active_width > 10
     with pytest.raises(RuntimeError, match="Statevector expansion limited"):
         clifft.get_statevector(prog)
 
@@ -287,13 +287,13 @@ def test_probabilities_match_formula_for_continuous_z_rotation(
     )
 
 
-def test_probabilities_sum_to_one_at_high_active_rank(basis_probabilities_api: Any) -> None:
-    # Unitarity invariant on a circuit whose peak_rank exceeds the
+def test_probabilities_sum_to_one_at_high_active_width(basis_probabilities_api: Any) -> None:
+    # Unitarity invariant on a circuit whose peak active width exceeds the
     # statevector-expansion limit, so this catches normalization regressions
     # that the small-circuit statevector cross-check cannot.
     circuit = "\n".join(f"H {q}\nT {q}" for q in range(12))
     prog = basis_probabilities_api.compile(circuit)
-    assert prog.peak_rank > 10
+    assert prog.peak_active_width > 10
     n = prog.num_qubits
     bitstrings = [format(i, f"0{n}b") for i in range(1 << n)]
     np.testing.assert_allclose(
@@ -349,14 +349,14 @@ def _statevector_probs(prog: clifft.Program) -> npt.NDArray[np.float64]:
     return cast(npt.NDArray[np.float64], np.abs(clifft.get_statevector(prog)) ** 2)
 
 
-def test_probabilities_pure_clifford_zero_active_rank(basis_probabilities_api: Any) -> None:
-    # Pure Clifford circuit: peak_rank == 0, so the Gray code walk degenerates
+def test_probabilities_pure_clifford_zero_active_width(basis_probabilities_api: Any) -> None:
+    # Pure Clifford circuit: peak active width is zero, so the Gray code walk degenerates
     # to a single iteration (r_A = 0). The H-on-every-qubit prefix makes the
     # inverse tableau's Z-block fully X-rotated, so every dormant column is a
     # pivot and the fast path engages.
     circuit = "H 0\nH 1\nH 2\nCX 0 1\nCX 1 2\nS 0"
     prog = basis_probabilities_api.compile(circuit)
-    assert prog.peak_rank == 0
+    assert prog.peak_active_width == 0
 
     bitstrings = _all_bitstrings(prog.num_qubits)
     np.testing.assert_allclose(

--- a/tests/python/test_compile_passes.py
+++ b/tests/python/test_compile_passes.py
@@ -16,7 +16,7 @@ def test_compile_default_matches_explicit_pipeline() -> None:
     manual = clifft.lower(hir)
 
     assert compiled.num_actions == manual.num_actions
-    assert compiled.peak_rank == manual.peak_rank
+    assert compiled.peak_active_width == manual.peak_active_width
 
 
 def test_compile_explicit_none_skips_optimization() -> None:
@@ -25,14 +25,14 @@ def test_compile_explicit_none_skips_optimization() -> None:
     manual = clifft.lower(clifft.trace(clifft.parse(text)))
 
     assert compiled.num_actions == manual.num_actions
-    assert compiled.peak_rank == manual.peak_rank
+    assert compiled.peak_active_width == manual.peak_active_width
 
 
 def test_hir_passes_reduce_t_cancellation() -> None:
     text = "H 0\nT 0\nT_DAG 0\nM 0"
     unoptimized = clifft.compile(text, hir_passes=None)
     optimized = clifft.compile(text)
-    assert optimized.peak_rank <= unoptimized.peak_rank
+    assert optimized.peak_active_width <= unoptimized.peak_active_width
 
 
 def test_compile_postselection_with_passes() -> None:
@@ -61,4 +61,4 @@ def test_custom_pass_manager_via_compile() -> None:
     manager = clifft.HirPassManager()
     manager.add(clifft.PeepholeFusionPass())
     program = clifft.compile("H 0\nT 0\nT_DAG 0\nM 0", hir_passes=manager)
-    assert program.peak_rank == 0
+    assert program.peak_active_width == 0

--- a/tests/python/test_detector_oracle.py
+++ b/tests/python/test_detector_oracle.py
@@ -259,7 +259,7 @@ class TestActiveInterfereErrorTracking:
         """Error frame tracking must survive OP_MEAS_ACTIVE_INTERFERE.
 
         H 0 -> |+>
-        T 0 -> creates active dimension (interference required)
+        T 0 -> creates an active coordinate (interference required)
         X_ERROR(1) 0 -> error_parity = 1
         M 0 -> OP_MEAS_ACTIVE_INTERFERE + array compaction
         M 0 -> deterministic re-measurement (checks error frame integrity)

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -496,12 +496,12 @@ def test_policy_knob_strings_validate():
 def test_loss_only_exact_damping_stays_at_stabilizer_cost(noncomp_sampling_api):
     """Equal per-source rates (LOSS always qualifies) take the trap-form
     lowering under damping="exact", so a loss-only model compiles at the
-    neglect rank -- max_rank=0 passes -- while the physics stays exact:
+    neglect width -- max_active_width=0 passes -- while the physics stays exact:
     survivors keep full interference and the loss rate is right."""
     circuit = "H 0\nLOSS(0.3) 0\nH 0\nM 0"
     cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
     model = noncomp.Model(classifier=cls)  # damping="exact" default
-    r = noncomp_sampling_api(circuit, model, shots=4000, seed=17, max_rank=0)
+    r = noncomp_sampling_api(circuit, model, shots=4000, seed=17, max_active_width=0)
     meas = r.measurements[:, 0]
     lost = r.final_status[:, 0] == noncomp.QubitStatus.LOST
     # Survivors: the H .. H sandwich returns |0> deterministically; a lost
@@ -513,23 +513,25 @@ def test_loss_only_exact_damping_stays_at_stabilizer_cost(noncomp_sampling_api):
 
 
 def test_loss_on_many_coherent_qubits_compiles_flat(noncomp_sampling_api):
-    """Per-qubit LOSS sites do not accumulate rank under damping="exact"."""
+    """Per-qubit LOSS sites do not accumulate active width under damping="exact"."""
     circuit = (
         "".join(f"H {i}\n" for i in range(5))
         + "".join(f"LOSS(0.01) {i}\n" for i in range(5))
         + "".join(f"H {i}\nM {i}\n" for i in range(5))
     )
     cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
-    r = noncomp_sampling_api(circuit, noncomp.Model(classifier=cls), shots=8, seed=3, max_rank=0)
+    r = noncomp_sampling_api(
+        circuit, noncomp.Model(classifier=cls), shots=8, seed=3, max_active_width=0
+    )
     assert r.num_measurements == 5
 
 
-def test_max_rank_rejects_over_budget_exact_but_neglect_fits(noncomp_sampling_api):
+def test_max_active_width_rejects_over_budget_exact_but_neglect_fits(noncomp_sampling_api):
     # A source-dependent leak (only out of e) on a coherent dormant qubit is
     # genuinely non-Clifford: damping="exact" expands it into the amplitude
-    # array, adding one to the compiled rank per site. Three H-prefixed sites
+    # array, adding one to the compiled active width per site. Three H-prefixed sites
     # push the peak to 3, over a cap of 2, so exact rejects (naming the
-    # offending line); damping="neglect" keeps the rank flat and fits.
+    # offending line); damping="neglect" keeps the active width flat and fits.
     leak_from_e = _zeros(5, 5)
     leak_from_e[LEAK_E][noncomp.Level.E] = 0.2  # T[to][from]; nothing out of g
     circuit = (
@@ -546,16 +548,16 @@ def test_max_rank_rejects_over_budget_exact_but_neglect_fits(noncomp_sampling_ap
             damping=damping,
         )
 
-    with pytest.raises(ValueError, match="max_rank"):
-        noncomp_sampling_api(circuit, model("exact"), shots=4, seed=1, max_rank=2)
+    with pytest.raises(ValueError, match="max_active_width"):
+        noncomp_sampling_api(circuit, model("exact"), shots=4, seed=1, max_active_width=2)
 
-    r = noncomp_sampling_api(circuit, model("neglect"), shots=4, seed=1, max_rank=2)
+    r = noncomp_sampling_api(circuit, model("neglect"), shots=4, seed=1, max_active_width=2)
     assert r.num_measurements == 3
 
 
-def test_max_rank_ignores_the_unreachable_all_computational_module(noncomp_sampling_api):
+def test_max_active_width_ignores_the_unreachable_all_computational_module(noncomp_sampling_api):
     """A model whose initial state has zero computational mass never runs the
-    no-event module; its rank must not be able to reject the run."""
+    no-event module; its active width must not be able to reject the run."""
     circuit = (
         "H 0\n"
         + "".join(f"CX 0 {i}\n" for i in range(1, 6))
@@ -564,11 +566,13 @@ def test_max_rank_ignores_the_unreachable_all_computational_module(noncomp_sampl
     )
     cls = noncomp.Classifier([[1, 0, 1, 0, 0], [0, 1, 0, 1, 1]])
     # Control: with computational initials the no-event module is real and
-    # its rank exceeds the cap -- this is what makes the test discriminating.
-    with pytest.raises(ValueError, match="max_rank"):
-        noncomp_sampling_api(circuit, noncomp.Model(classifier=cls), shots=4, seed=3, max_rank=0)
+    # its active width exceeds the cap -- this is what makes the test discriminating.
+    with pytest.raises(ValueError, match="max_active_width"):
+        noncomp_sampling_api(
+            circuit, noncomp.Model(classifier=cls), shots=4, seed=3, max_active_width=0
+        )
     lost = noncomp.Model(initial_state=[0, 0, 0, 0, 1], classifier=cls)
-    r = noncomp_sampling_api(circuit, lost, shots=16, seed=3, max_rank=0)
+    r = noncomp_sampling_api(circuit, lost, shots=16, seed=3, max_active_width=0)
     assert (r.final_status == noncomp.QubitStatus.LOST).all()
     # The lost column reads symbol 1 with certainty: a raw readout of the
     # dropped-everything |0> carriers would give 0, so all-1 records verify

--- a/tests/python/test_optimization_invariants.py
+++ b/tests/python/test_optimization_invariants.py
@@ -23,7 +23,7 @@ from utils_fuzzing import (
 
 import clifft
 
-_MAX_PEAK_RANK = 12
+_MAX_PEAK_ACTIVE_WIDTH = 12
 _SEEDS = [0, 1, 2, 3, 4]
 
 # Default HIR pipeline against statevectors.
@@ -121,8 +121,8 @@ class TestDefaultOptimizerStatisticalEquivalence:
 
         base = clifft.compile(circuit, hir_passes=None)
         optimized = clifft.compile(circuit)
-        assert base.peak_rank <= _MAX_PEAK_RANK
-        assert optimized.peak_rank <= _MAX_PEAK_RANK
+        assert base.peak_active_width <= _MAX_PEAK_ACTIVE_WIDTH
+        assert optimized.peak_active_width <= _MAX_PEAK_ACTIVE_WIDTH
 
         base_result = clifft.sample(base, _STAT_SHOTS, seed=seed)
         optimized_result = clifft.sample(optimized, _STAT_SHOTS, seed=seed)

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -99,8 +99,8 @@ class TestTerminalMeasurementPhaseElimination:
             exact_circuit,
             hir_passes=_peephole_pass_manager(),
         )
-        assert exact_baseline.peak_rank == 2
-        assert exact_optimized.peak_rank == 0
+        assert exact_baseline.peak_active_width == 2
+        assert exact_optimized.peak_active_width == 0
 
         records = ["00", "01", "10", "11"]
         np.testing.assert_allclose(
@@ -123,8 +123,8 @@ class TestTerminalMeasurementPhaseElimination:
             noisy_circuit,
             hir_passes=_peephole_pass_manager(),
         )
-        assert baseline.peak_rank == 2
-        assert optimized.peak_rank == 0
+        assert baseline.peak_active_width == 2
+        assert optimized.peak_active_width == 0
 
         shots = 30_000
         baseline_result = clifft.sample(baseline, shots, seed=242)
@@ -165,8 +165,8 @@ class TestTerminalMeasurementPhaseElimination:
             clifft.record_probabilities(baseline, records),
             atol=1e-12,
         )
-        assert baseline.peak_rank == 1
-        assert optimized.peak_rank == 0
+        assert baseline.peak_active_width == 1
+        assert optimized.peak_active_width == 0
 
     def test_noisy_broadcast_distribution_and_classical_outputs(self) -> None:
         """The real noisy rewrite preserves the complete record distribution."""
@@ -186,8 +186,8 @@ class TestTerminalMeasurementPhaseElimination:
             circuit,
             hir_passes=_peephole_pass_manager(),
         )
-        assert baseline.peak_rank == 2
-        assert optimized.peak_rank == 0
+        assert baseline.peak_active_width == 2
+        assert optimized.peak_active_width == 0
 
         shots = 30_000
         baseline_result = clifft.sample(baseline, shots, seed=238)
@@ -351,12 +351,12 @@ def _bounded_t_mirror_circuit(
 
 
 class TestMirrorTGateAnnihilation:
-    """Verify peephole optimizer achieves peak_rank=0 on mirror circuits.
+    """Verify the peephole optimizer reaches zero peak active width on mirror circuits.
 
     Mirror circuits have structure U U-dag = I. Without the optimizer,
-    each T gate expands the active Schrodinger array (peak_rank up to
+    each T gate expands the active Schrodinger array (peak active width up to
     t_count). With the optimizer, all T/T-dag pairs should cancel
-    completely, leaving peak_rank=0 (pure Clifford).
+    completely, leaving zero peak active width (pure Clifford).
     """
 
     NUM_QUBITS = 40
@@ -364,7 +364,7 @@ class TestMirrorTGateAnnihilation:
 
     @pytest.mark.parametrize("t_count", [4, 8, 12])
     @pytest.mark.parametrize("seed", range(5))
-    def test_mirror_peak_rank_zero(self, t_count: int, seed: int) -> None:
+    def test_mirror_has_zero_peak_active_width(self, t_count: int, seed: int) -> None:
         """Optimizer cancels all T gates in mirror circuits."""
         circuit = _bounded_t_mirror_circuit(self.NUM_QUBITS, self.CLIFFORD_DEPTH, t_count, seed)
         meas = "M " + " ".join(str(i) for i in range(self.NUM_QUBITS))
@@ -374,10 +374,10 @@ class TestMirrorTGateAnnihilation:
         prog_optimized = _compile_optimized(circuit_with_meas)
 
         assert (
-            prog_baseline.peak_rank <= t_count
-        ), f"Baseline peak_rank={prog_baseline.peak_rank} > t_count={t_count}"
-        assert prog_optimized.peak_rank == 0, (
-            f"Optimized peak_rank={prog_optimized.peak_rank}, expected 0 "
+            prog_baseline.peak_active_width <= t_count
+        ), f"Baseline peak_active_width={prog_baseline.peak_active_width} > t_count={t_count}"
+        assert prog_optimized.peak_active_width == 0, (
+            f"Optimized peak_active_width={prog_optimized.peak_active_width}, expected 0 "
             f"(t_count={t_count}, seed={seed})"
         )
 
@@ -389,7 +389,7 @@ class TestMirrorTGateAnnihilation:
         circuit_with_meas = circuit + "\n" + meas
 
         prog = _compile_optimized(circuit_with_meas)
-        assert prog.peak_rank == 0
+        assert prog.peak_active_width == 0
 
         result = clifft.sample(prog, 1000, seed=seed)
         nonzero = int(result.measurements.sum(axis=1).astype(bool).sum())

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -1,5 +1,6 @@
 """Python integration tests for clifft.compile and clifft.sample."""
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -19,25 +20,37 @@ class TestCompile:
     def test_compile_simple(self) -> None:
         """Compile a simple circuit."""
         prog = clifft.compile("H 0\nT 0\nM 0", hir_passes=None)
-        assert prog.peak_rank == 1
+        assert prog.peak_active_width == 1
         assert prog.num_measurements == 1
         assert prog.num_actions >= 1
 
+    def test_peak_rank_is_a_deprecated_alias(self) -> None:
+        prog = clifft.compile("H 0\nT 0", hir_passes=None)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            expected = prog.peak_active_width
+        with pytest.warns(DeprecationWarning, match="peak_active_width"):
+            assert prog.peak_rank == expected
+
+    def test_repr_names_peak_active_width(self) -> None:
+        prog = clifft.compile("H 0\nT 0", hir_passes=None)
+        assert ", peak_active_width=1, " in repr(prog)
+
     def test_compile_pure_clifford(self) -> None:
-        """Pure Clifford circuit has peak_rank 0."""
+        """Pure Clifford circuits have peak active width zero."""
         prog = clifft.compile("H 0\nCX 0 1\nM 0\nM 1")
-        assert prog.peak_rank == 0
+        assert prog.peak_active_width == 0
         assert prog.num_measurements == 2
 
     def test_compile_multiple_t_gates(self) -> None:
-        """Multiple independent T gates increase peak_rank."""
+        """Multiple independent T gates increase peak active width."""
         prog = clifft.compile("""
             H 0
             H 1
             T 0
             T 1
         """)
-        assert prog.peak_rank == 2
+        assert prog.peak_active_width == 2
 
     def test_lower_returns_the_public_program_type(self) -> None:
         """Explicit parse and trace use the same production lowering boundary."""
@@ -113,7 +126,7 @@ class TestSample:
         lines.append("M 0")
 
         program = sampling_api.compile("\n".join(lines), hir_passes=None)
-        assert program.peak_rank == 2
+        assert program.peak_active_width == 2
 
         result = sampling_api.sample(program, shots=64, seed=7)
         assert result.measurements.shape == (64, rounds + 1)

--- a/tests/python/test_statevector_squeeze.py
+++ b/tests/python/test_statevector_squeeze.py
@@ -1,6 +1,6 @@
 """Tests for the StatevectorSqueezePass.
 
-Validates that bidirectional bubble sort of HIR operations reduces peak_rank
+Validates that bidirectional bubble sort of HIR operations reduces peak active width
 by compacting qubit lifetimes, while preserving circuit semantics.
 """
 
@@ -26,36 +26,39 @@ def _clifft_statevector(circuit_str: str, **compile_kwargs: Any) -> np.ndarray:
     return np.asarray(clifft.get_statevector(clifft.compile(circuit_str, **compile_kwargs)))
 
 
-class TestSqueezeBasicPeakRankReduction:
-    """Core squeeze test: prove peak_rank drops when qubit lifetimes are compacted."""
+class TestSqueezeBasicPeakActiveWidthReduction:
+    """Prove peak active width drops when qubit lifetimes are compacted."""
 
-    def test_two_independent_qubits_squeeze_reduces_rank(self) -> None:
-        """H 0; T 0; H 1; T 1; M 0; M 1 should squeeze below peak_rank 2.
+    def test_two_independent_qubits_squeeze_reduces_width(self) -> None:
+        """H 0; T 0; H 1; T 1; M 0; M 1 should squeeze below peak active width 2.
 
-        Without squeezing, both qubits are active simultaneously (peak_rank=2).
+        Without squeezing, both qubits are active simultaneously (peak active width 2).
         With squeezing, measurements bubble left and T gates bubble right.
         Since T and M on the same single-qubit Pauli axis commute (symplectic
         inner product = 0), the squeezer reorders all measurements before all
-        T gates, resolving everything as dormant and reducing peak_rank to 0.
+        T gates, resolving everything as dormant and reducing peak active width to 0.
         """
         circuit = "H 0\nT 0\nH 1\nT 1\nM 0\nM 1"
 
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert base.peak_rank == 2, f"Expected baseline peak_rank=2, got {base.peak_rank}"
         assert (
-            squeezed.peak_rank < base.peak_rank
-        ), f"Expected squeezed peak_rank < {base.peak_rank}, got {squeezed.peak_rank}"
+            base.peak_active_width == 2
+        ), f"Expected baseline peak_active_width=2, got {base.peak_active_width}"
+        assert squeezed.peak_active_width < base.peak_active_width, (
+            f"Expected squeezed peak_active_width < {base.peak_active_width}, "
+            f"got {squeezed.peak_active_width}"
+        )
 
     def test_three_independent_qubits(self) -> None:
-        """Three independent qubits: squeeze should reduce peak_rank."""
+        """Three independent qubits: squeeze should reduce peak active width."""
         circuit = "H 0\nT 0\nH 1\nT 1\nH 2\nT 2\nM 0\nM 1\nM 2"
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert base.peak_rank == 3
-        assert squeezed.peak_rank < base.peak_rank
+        assert base.peak_active_width == 3
+        assert squeezed.peak_active_width < base.peak_active_width
 
     def test_squeeze_sampling_correctness(self, sampling_api: Any) -> None:
         """Sampling results must be statistically identical with and without squeeze."""
@@ -87,7 +90,7 @@ class TestSqueezeBasicPeakRankReduction:
         base = sampling_api.compile(circuit, hir_passes=None)
         squeezed = sampling_api.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        # Verify sampling correctness regardless of peak_rank change
+        # Verify sampling correctness regardless of the peak active-width change.
         shots = 10_000
         base_result = sampling_api.sample(base, shots, seed=42)
         squeezed_result = sampling_api.sample(squeezed, shots, seed=42)
@@ -108,11 +111,11 @@ class TestSqueezeBasicPeakRankReduction:
         base = clifft.compile(circuit_str, hir_passes=None)
         squeezed = clifft.compile(circuit_str, hir_passes=_squeeze_only_pass_manager())
 
-        # Both should have peak_rank=1 since the noise barrier blocks
+        # Both should have peak active width 1 since the noise barrier blocks
         # the measurement from bubbling past X_ERROR
-        assert squeezed.peak_rank == base.peak_rank, (
-            f"Squeezer changed peak_rank through noise barrier: "
-            f"{base.peak_rank} -> {squeezed.peak_rank}"
+        assert squeezed.peak_active_width == base.peak_active_width, (
+            f"Squeezer changed peak_active_width through noise barrier: "
+            f"{base.peak_active_width} -> {squeezed.peak_active_width}"
         )
 
 
@@ -130,8 +133,8 @@ class TestSqueezeClassicalDataflow:
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert base.peak_rank == 2
-        assert squeezed.peak_rank == 0
+        assert base.peak_active_width == 2
+        assert squeezed.peak_active_width == 0
 
     def test_measure_blocked_by_own_detector(self) -> None:
         """M 0 must NOT bubble past a DETECTOR that references meas_idx 0."""
@@ -193,8 +196,8 @@ class TestSqueezeClassicalDataflow:
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert base.peak_rank == 2
-        assert squeezed.peak_rank == 0
+        assert base.peak_active_width == 2
+        assert squeezed.peak_active_width == 0
 
     def test_qec_style_detector_passthrough_sampling(self) -> None:
         """Verify sampling correctness when measurements bubble past detectors.
@@ -208,7 +211,7 @@ class TestSqueezeClassicalDataflow:
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert squeezed.peak_rank < base.peak_rank
+        assert squeezed.peak_active_width < base.peak_active_width
 
         base_result = clifft.sample(base, shots, seed=99)
         squeezed_result = clifft.sample(squeezed, shots, seed=99)
@@ -250,7 +253,7 @@ class TestSqueezeSweep2Expansion:
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         # With squeeze, the measurements should compact before the rotations
-        assert squeezed.peak_rank <= base.peak_rank
+        assert squeezed.peak_active_width <= base.peak_active_width
 
 
 class TestSqueezeEdgeCases:
@@ -261,21 +264,21 @@ class TestSqueezeEdgeCases:
         circuit = "H 0\nM 0"
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
-        assert base.peak_rank == squeezed.peak_rank
+        assert base.peak_active_width == squeezed.peak_active_width
 
     def test_empty_circuit(self) -> None:
         """Empty circuit should not crash the squeezer."""
         circuit = ""
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
-        assert base.peak_rank == squeezed.peak_rank == 0
+        assert base.peak_active_width == squeezed.peak_active_width == 0
 
     def test_all_cliffords_no_squeeze_needed(self) -> None:
         """Pure Clifford circuit: squeezer runs but nothing expands."""
         circuit = "H 0\nCX 0 1\nS 0\nM 0\nM 1"
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
-        assert squeezed.peak_rank == base.peak_rank
+        assert squeezed.peak_active_width == base.peak_active_width
 
     def test_squeeze_idempotent(self) -> None:
         """Running the squeezer twice should produce the same result as once."""
@@ -287,7 +290,7 @@ class TestSqueezeEdgeCases:
 
         once = clifft.compile(circuit, hir_passes=pm1)
         twice = clifft.compile(circuit, hir_passes=pm2)
-        assert once.peak_rank == twice.peak_rank
+        assert once.peak_active_width == twice.peak_active_width
 
     def test_squeeze_with_default_pipeline(self) -> None:
         """Squeeze pass works correctly in the full default pipeline."""
@@ -386,7 +389,7 @@ class TestSqueezeProbabilisticReordering:
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
         # M 1 should bubble past X_ERROR(0) and M 0 since masks commute
-        assert squeezed.peak_rank < base.peak_rank
+        assert squeezed.peak_active_width < base.peak_active_width
 
         base_result = clifft.sample(base, self._SHOTS, seed=10)
         squeezed_result = clifft.sample(squeezed, self._SHOTS, seed=10)
@@ -405,7 +408,7 @@ class TestSqueezeProbabilisticReordering:
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert squeezed.peak_rank < base.peak_rank
+        assert squeezed.peak_active_width < base.peak_active_width
 
         base_result = clifft.sample(base, shots, seed=77)
         squeezed_result = clifft.sample(squeezed, shots, seed=77)
@@ -473,7 +476,7 @@ class TestSqueezeProbabilisticReordering:
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 
-        assert squeezed.peak_rank < base.peak_rank
+        assert squeezed.peak_active_width < base.peak_active_width
 
         base_result = clifft.sample(base, shots, seed=123)
         squeezed_result = clifft.sample(squeezed, shots, seed=123)

--- a/tests/python/utils_fuzzing.py
+++ b/tests/python/utils_fuzzing.py
@@ -176,7 +176,7 @@ def generate_star_graph_stress_circuit(num_qubits: int, depth: int, seed: int) -
 
 # Maximum total T-gates in the uncomputation ladder's forward pass.
 # Each unique T-gate can expand active_k by 1 in the unoptimized baseline,
-# so this directly bounds peak_rank.
+# so this directly bounds peak active width.
 _LADDER_MAX_T_GATES = 10
 
 
@@ -194,7 +194,7 @@ def generate_uncomputation_ladder(
     must produce identical stochastic records.
 
     Memory bound: T gates restricted to qubits 0..3 AND total T-count
-    capped at _LADDER_MAX_T_GATES to keep peak_rank bounded.
+    capped at _LADDER_MAX_T_GATES to keep peak active width bounded.
 
     Args:
         num_qubits: Total number of qubits in the circuit.

--- a/tests/test_benchmarks.cc
+++ b/tests/test_benchmarks.cc
@@ -63,7 +63,7 @@ static std::string surface_code_text(uint32_t distance, uint64_t rounds, double 
 
 // EXP_VAL-heavy synthetic circuit: prepares a Clifford state on n qubits,
 // then evaluates `num_probes` weight-3 multi-Pauli expectation values per shot.
-// Stays at peak_rank=0 (fully Clifford prep) so the cost is dominated by the
+// Stays at zero peak active width (fully Clifford prep) so the cost is dominated by the
 // EXP_VAL frame-conjugation path.
 static std::string exp_val_heavy_text(uint32_t num_qubits, uint32_t num_probes) {
     std::ostringstream s;
@@ -87,12 +87,12 @@ static std::string exp_val_heavy_text(uint32_t num_qubits, uint32_t num_probes) 
 }
 
 // ---------------------------------------------------------------------------
-// QV-10: 10 qubits, peak_rank=10, dense SU(4) layers with measurements.
+// QV-10: 10 qubits, peak active width 10, dense SU(4) layers with measurements.
 // ~1ms/shot baseline -> 100 shots ~= 100ms.
 // ---------------------------------------------------------------------------
 TEST_CASE("Bench: QV-10 sampling 100 shots", "[bench]") {
     auto mod = compile_circuit(fixture("qv10.stim"));
-    REQUIRE(mod.max_active_width() == 10);
+    REQUIRE(mod.peak_active_width() == 10);
 
     BENCHMARK("QV-10 x100 shots") {
         return sampling::sample(mod, 100, 0);
@@ -100,13 +100,13 @@ TEST_CASE("Bench: QV-10 sampling 100 shots", "[bench]") {
 }
 
 // ---------------------------------------------------------------------------
-// Magic state cultivation d=5: 42 physical qubits, peak_rank=10,
+// Magic state cultivation d=5: 42 physical qubits, peak active width 10,
 // sparse QEC with noise, T gates, postselection.
 // ~0.09ms/shot baseline -> 1000 shots ~= 90ms.
 // ---------------------------------------------------------------------------
 TEST_CASE("Bench: cultivation d5 sampling 1000 shots", "[bench]") {
     auto mod = compile_circuit(fixture("cultivation_d5.stim"));
-    REQUIRE(mod.max_active_width() == 10);
+    REQUIRE(mod.peak_active_width() == 10);
 
     BENCHMARK("cultivation-d5 x1000 shots") {
         return sampling::sample_survivors(mod, 1000, 0, false);
@@ -115,12 +115,12 @@ TEST_CASE("Bench: cultivation d5 sampling 1000 shots", "[bench]") {
 
 // ---------------------------------------------------------------------------
 // Surface code d=7 r=7 p=1e-3: paper QEC throughput benchmark.
-// ~118 qubits, fully Clifford (peak_rank=0), low noise so most NOISE sites
+// ~118 qubits, fully Clifford (zero peak active width), low noise so most NOISE sites
 // stay silent. Throughput is dominated by symbolic actions and the gap-sampler.
 // ---------------------------------------------------------------------------
 TEST_CASE("Bench: surface d7 r7 p1e-3 sampling 10000 shots", "[bench]") {
     auto mod = compile_text(surface_code_text(7, 7, 1e-3));
-    REQUIRE(mod.max_active_width() == 0);
+    REQUIRE(mod.peak_active_width() == 0);
     REQUIRE(mod.num_qubits() <= 128);
 
     BENCHMARK("surface-d7-r7 p=1e-3 x10000 shots") {
@@ -148,7 +148,7 @@ TEST_CASE("Bench: surface d5 r5 high-noise APPLY_PAULI heavy", "[bench]") {
 // ---------------------------------------------------------------------------
 TEST_CASE("Bench: surface d11 r11 p1e-3 sampling 1000 shots", "[bench]") {
     auto mod = compile_text(surface_code_text(11, 11, 1e-3));
-    REQUIRE(mod.max_active_width() == 0);
+    REQUIRE(mod.peak_active_width() == 0);
     REQUIRE(mod.num_qubits() > 128);
 
     BENCHMARK("surface-d11-r11 p=1e-3 x1000 shots") {

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -37,7 +37,7 @@ SamplingPlan rotation_plan(uint32_t active_width, std::span<const RotateActivePa
     SamplingPlan plan;
     plan.num_qubits = active_width;
     plan.initial_active_width = active_width;
-    plan.max_active_width = active_width;
+    plan.peak_active_width = active_width;
     plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
     for (const RotateActivePauli& rotation : rotations) {
         plan.actions.push_back(PlannedAction{active_width, active_width, rotation});
@@ -52,7 +52,7 @@ void require_matches_scalar(const SamplingPlan& plan, uint8_t presampled_value,
     Executor executor(executable);
     executor.run_shot(std::array<uint8_t, 1>{presampled_value});
 
-    State expected(plan.max_active_width, plan.initial_active_width, plan.global_weight);
+    State expected(plan.peak_active_width, plan.initial_active_width, plan.global_weight);
     for (const PlannedAction& planned : plan.actions) {
         const auto& rotation = std::get<RotateActivePauli>(planned.action);
         bool sign = rotation.sign.constant();
@@ -187,7 +187,7 @@ TEST_CASE("Dynamic fused rotation matches scalar across affine sign values") {
     SamplingPlan plan;
     plan.num_qubits = 6;
     plan.initial_active_width = 6;
-    plan.max_active_width = 6;
+    plan.peak_active_width = 6;
     plan.symbols = {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
         SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -249,7 +249,7 @@ TEST_CASE("Peephole: terminal phases cross disjoint measure-reset corrections", 
 
             REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 0);
             REQUIRE(pass.cancellations() == 2);
-            REQUIRE(clifft::sampling::plan_sampling(hir).max_active_width == 0);
+            REQUIRE(clifft::sampling::plan_sampling(hir).peak_active_width == 0);
         }
     }
 }
@@ -264,7 +264,7 @@ TEST_CASE("Peephole: terminal phase belonging only to a later reset target is re
 
     REQUIRE(count_ops(hir, OpType::PHASE_ROTATION) == 0);
     REQUIRE(pass.cancellations() == 1);
-    REQUIRE(clifft::sampling::plan_sampling(hir).max_active_width == 0);
+    REQUIRE(clifft::sampling::plan_sampling(hir).peak_active_width == 0);
 }
 
 TEST_CASE("Peephole: disjoint feedback controlled by a crossed measurement is transparent",

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -68,7 +68,7 @@ namespace {
 SamplingPlan active_then_dormant_plan(double promotion_half_turns) {
     SamplingPlan plan;
     plan.num_qubits = 2;
-    plan.max_active_width = 1;
+    plan.peak_active_width = 1;
     plan.num_visible_records = 2;
     plan.symbols = {
         SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
@@ -289,7 +289,7 @@ TEST_CASE("Sampling executor evaluates presampled and derived affine symbols") {
 TEST_CASE("Sampling executor applies sampled symbols to later state actions") {
     SamplingPlan plan;
     plan.num_qubits = 2;
-    plan.max_active_width = 1;
+    plan.peak_active_width = 1;
     plan.num_visible_records = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
     plan.actions = {
@@ -330,7 +330,7 @@ TEST_CASE("Sampling executor fuses constant rotation orbits") {
         SamplingPlan plan;
         plan.num_qubits = active_width;
         plan.initial_active_width = active_width;
-        plan.max_active_width = active_width;
+        plan.peak_active_width = active_width;
         plan.symbols = {
             SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
         };
@@ -416,7 +416,7 @@ TEST_CASE("Sampling executor fuses constant rotation orbits") {
     SamplingPlan wide_selector_plan;
     wide_selector_plan.num_qubits = 6;
     wide_selector_plan.initial_active_width = 6;
-    wide_selector_plan.max_active_width = 6;
+    wide_selector_plan.peak_active_width = 6;
     for (uint32_t axis = 0; axis < 6; ++axis) {
         wide_selector_plan.actions.push_back(PlannedAction{
             6, 6, RotateActivePauli{{0, uint64_t{1} << axis}, 0.25, AffineBool(false)}});
@@ -427,7 +427,7 @@ TEST_CASE("Sampling executor fuses constant rotation orbits") {
 TEST_CASE("Sampling replay inverts affine records and preserves branch dependencies") {
     SamplingPlan plan;
     plan.num_qubits = 2;
-    plan.max_active_width = 1;
+    plan.peak_active_width = 1;
     plan.num_visible_records = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
     plan.actions = {
@@ -728,7 +728,7 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
     SamplingPlan plan;
     plan.num_qubits = 2;
     plan.initial_active_width = 1;
-    plan.max_active_width = 2;
+    plan.peak_active_width = 2;
     plan.num_instrument_sites = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
     plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
@@ -948,7 +948,7 @@ TEST_CASE("Sampling continuation rejects incompatible handoffs") {
     SECTION("boundary has the wrong live active width") {
         SamplingPlan continuation_plan = root_plan;
         continuation_plan.initial_active_width = 1;
-        continuation_plan.max_active_width = 1;
+        continuation_plan.peak_active_width = 1;
         continuation_plan.actions[0].active_before = 1;
         continuation_plan.actions[0].active_after = 1;
         continuation_plan.actions[1].active_before = 1;
@@ -1147,7 +1147,7 @@ TEST_CASE("Sampling continuation preserves fused rotation prefixes") {
     SamplingPlan root_plan;
     root_plan.num_qubits = kActiveWidth + 1;
     root_plan.initial_active_width = kActiveWidth;
-    root_plan.max_active_width = kActiveWidth;
+    root_plan.peak_active_width = kActiveWidth;
     root_plan.num_instrument_sites = 1;
     root_plan.instrument_distributions = {
         InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -47,7 +47,7 @@ SamplingPlan valid_plan() {
 
     SamplingPlan plan;
     plan.num_qubits = 2;
-    plan.max_active_width = 1;
+    plan.peak_active_width = 1;
     plan.num_visible_records = 1;
     plan.num_hidden_records = 1;
     plan.num_noise_sites = 1;
@@ -82,7 +82,7 @@ SamplingPlan valid_rotation_plan() {
     SamplingPlan plan;
     plan.num_qubits = 1;
     plan.initial_active_width = 1;
-    plan.max_active_width = 1;
+    plan.peak_active_width = 1;
     plan.actions = {
         PlannedAction{1, 1, RotateActivePauli{ActivePauli{1, 0}, 0.25, AffineBool{}}},
     };
@@ -151,7 +151,7 @@ TEST_CASE("Sampling plan validates symbolic and active state invariants") {
     REQUIRE_NOTHROW(plan.validate());
 
     const std::string text = plan.inspect();
-    REQUIRE(text.find("sampling_plan qubits=2 initial_width=0 max_width=1") != std::string::npos);
+    REQUIRE(text.find("sampling_plan qubits=2 initial_width=0 peak_width=1") != std::string::npos);
     REQUIRE(text.find("s0 kind=presampled noise_site=0") != std::string::npos);
     REQUIRE(text.find("1 active_width=1->0 dense_passes=2 measure_active") != std::string::npos);
     REQUIRE(text.find("outcome=s0 ^ s1 record=0") != std::string::npos);
@@ -297,7 +297,7 @@ TEST_CASE("Sampling plan rejects measurement pivots outside Pauli support") {
     SamplingPlan plan;
     plan.num_qubits = 2;
     plan.initial_active_width = 2;
-    plan.max_active_width = 2;
+    plan.peak_active_width = 2;
     plan.num_visible_records = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
     plan.actions = {
@@ -331,20 +331,20 @@ TEST_CASE("Sampling plan rejects invalid dimensions and action contracts") {
     SECTION("initial width exceeds the circuit") {
         SamplingPlan plan;
         plan.initial_active_width = 1;
-        plan.max_active_width = 1;
+        plan.peak_active_width = 1;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
-    SECTION("maximum width is below the initial width") {
+    SECTION("peak width is below the initial width") {
         SamplingPlan plan;
         plan.num_qubits = 1;
         plan.initial_active_width = 1;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
-    SECTION("declared maximum is not reached") {
+    SECTION("declared peak is not reached") {
         SamplingPlan plan = valid_plan();
-        plan.max_active_width = 2;
+        plan.peak_active_width = 2;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
@@ -506,7 +506,7 @@ TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
     SamplingPlan plan;
     plan.num_qubits = clifft::kDenseActiveWidthLimit;
     plan.initial_active_width = clifft::kDenseActiveWidthLimit;
-    plan.max_active_width = clifft::kDenseActiveWidthLimit;
+    plan.peak_active_width = clifft::kDenseActiveWidthLimit;
 
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
@@ -515,7 +515,7 @@ TEST_CASE("Sampling plan safely rejects a transition stream above dense width") 
     constexpr uint32_t kMalformedWidth = clifft::kDenseActiveWidthLimit + 10;
     SamplingPlan plan;
     plan.num_qubits = kMalformedWidth;
-    plan.max_active_width = clifft::kDenseActiveWidthLimit - 1;
+    plan.peak_active_width = clifft::kDenseActiveWidthLimit - 1;
     for (uint32_t width = 0; width < kMalformedWidth; ++width) {
         plan.actions.push_back(
             PlannedAction{width, width + 1, PromoteDormantRotation{0.25, AffineBool{}}});
@@ -549,7 +549,7 @@ TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
     SamplingPlan plan;
     plan.num_qubits = 1;
     plan.initial_active_width = 1;
-    plan.max_active_width = 1;
+    plan.peak_active_width = 1;
     plan.num_exp_vals = 2;
     plan.actions = {
         PlannedAction{1, 1,

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -86,7 +86,7 @@ TEST_CASE("Sampling planner preserves empty module metadata") {
     REQUIRE(plan.num_qubits == 3);
     REQUIRE(plan.global_weight == std::complex<double>{0.25, -0.5});
     REQUIRE(plan.initial_active_width == 0);
-    REQUIRE(plan.max_active_width == 0);
+    REQUIRE(plan.peak_active_width == 0);
     REQUIRE(plan.actions.empty());
     REQUIRE(plan.symbols.empty());
 }
@@ -98,7 +98,7 @@ TEST_CASE("Sampling planner promotes rotations and keeps later active support") 
 
     const SamplingPlan plan = plan_sampling(hir);
 
-    REQUIRE(plan.max_active_width == 1);
+    REQUIRE(plan.peak_active_width == 1);
     REQUIRE(plan.actions.size() == 2);
     const auto& promotion = action_as<PromoteDormantRotation>(plan, 0);
     REQUIRE(promotion.half_turns == 0.25);
@@ -117,7 +117,7 @@ TEST_CASE("Sampling planner emits direct multi-coordinate active Paulis") {
 
     const SamplingPlan plan = plan_sampling(hir);
 
-    REQUIRE(plan.max_active_width == 2);
+    REQUIRE(plan.peak_active_width == 2);
     REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[0].action));
     REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[1].action));
     const auto& rotation = action_as<RotateActivePauli>(plan, 2);
@@ -133,7 +133,7 @@ TEST_CASE("Sampling planner preserves high physical Pauli coordinates") {
 
     const SamplingPlan plan = plan_sampling(hir);
 
-    REQUIRE(plan.max_active_width == 1);
+    REQUIRE(plan.peak_active_width == 1);
     REQUIRE(std::holds_alternative<PromoteDormantRotation>(plan.actions[0].action));
     const auto& rotation = action_as<RotateActivePauli>(plan, 1);
     REQUIRE(rotation.pauli.x == 1);
@@ -283,7 +283,7 @@ TEST_CASE("Sampling planner fixes instrument source handling before execution") 
     REQUIRE(activated_instrument.source.z == 0);
     REQUIRE(activated_instrument.sign == AffineBool(false));
     REQUIRE(activated_instrument.destination_flip.has_value());
-    REQUIRE(activated.max_active_width == 2);
+    REQUIRE(activated.peak_active_width == 2);
     const auto& after_activation = action_as<MeasureActivePauli>(activated, 3);
     REQUIRE(after_activation.outcome ==
             (AffineBool::symbol(*activated_instrument.destination_flip) ^
@@ -294,7 +294,7 @@ TEST_CASE("Sampling planner fixes instrument source handling before execution") 
 
     const SamplingPlan neglected = plan_for("H 0\nLEVEL_TRANSITION[jump] 0", true);
     REQUIRE(instrument(neglected).mode == InstrumentMode::DormantTrap);
-    REQUIRE(neglected.max_active_width == 0);
+    REQUIRE(neglected.peak_active_width == 0);
 }
 
 TEST_CASE("Sampling planner keeps prefix symbols stable across continuation suffixes") {
@@ -613,5 +613,5 @@ TEST_CASE("Sampling planner target QEC plan characterization") {
     INFO(inspection);
     // After verifying that a reported inspection change is intentional, update
     // this digest to the new value shown by the failed assertion.
-    REQUIRE(fnv1a64(inspection) == 0xd795b8a081bb3a7dULL);
+    REQUIRE(fnv1a64(inspection) == 0xd6739c5e74e9339eULL);
 }

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -308,7 +308,7 @@ TEST_CASE("trajectory: a cross-domain word alias does not expand to a full-state
     }
 }
 
-TEST_CASE("trajectory: max_rank rejects an over-budget compile") {
+TEST_CASE("trajectory: max_active_width rejects an over-budget compile") {
     // Each dormant-random site under exact damping adds one to k: three H-prefixed
     // sites push the peak to 3, over a cap of 2.
     ModelSpec spec;
@@ -320,9 +320,9 @@ TEST_CASE("trajectory: max_rank rejects an over-budget compile") {
         "M 0\nM 1\nM 2");
 
     REQUIRE_THROWS_WITH(
-        sample_noncomputational(circuit, model, 5, 1, /*max_rank=*/2),
-        ContainsSubstring("exceeds max_rank 2 (first exceeded at circuit line 6); consider "
-                          "damping=\"neglect\" for high-rate sites or a larger max_rank"));
+        sample_noncomputational(circuit, model, 5, 1, /*max_active_width=*/2),
+        ContainsSubstring("exceeds max_active_width 2 (first exceeded at circuit line 6); consider "
+                          "damping=\"neglect\" for high-rate sites or a larger max_active_width"));
 }
 
 TEST_CASE("trajectory: a trap-form fire keeps the fire-side correlation") {
@@ -553,23 +553,23 @@ TEST_CASE("trajectory: a hand-written multi-target annotation traps on one targe
     }
 }
 
-TEST_CASE("trajectory: neglect keeps rank flat while exact damping expands") {
+TEST_CASE("trajectory: neglect keeps active width flat while exact damping expands") {
     ModelSpec spec;
     spec.leak_from_e = 0.3;  // source-dependent: the damp is non-scalar
     spec.damping = DampingPolicy::Neglect;
     auto model = make_driver_model(spec);
     auto circuit = parse("H 0\nLEVEL_TRANSITION[leak] 0\nH 0\nM 0");
 
-    // max_rank 0 admits the neglect compile (no expansion) and would
+    // max_active_width 0 admits the neglect compile (no expansion) and would
     // reject the exact-damping one (which adds one at the site).
-    auto result = sample_noncomputational(circuit, model, 50, 37, /*max_rank=*/0);
+    auto result = sample_noncomputational(circuit, model, 50, 37, /*max_active_width=*/0);
     REQUIRE(result.measurements.size() == 50);
 
     ModelSpec exact_spec = spec;
     exact_spec.damping = DampingPolicy::Exact;
-    REQUIRE_THROWS_WITH(
-        sample_noncomputational(circuit, make_driver_model(exact_spec), 50, 37, /*max_rank=*/0),
-        ContainsSubstring("exceeds max_rank 0"));
+    REQUIRE_THROWS_WITH(sample_noncomputational(circuit, make_driver_model(exact_spec), 50, 37,
+                                                /*max_active_width=*/0),
+                        ContainsSubstring("exceeds max_active_width 0"));
 }
 
 TEST_CASE("trajectory: ternary heralds keep a uniform visible bit") {
@@ -675,10 +675,10 @@ TEST_CASE("trajectory: hand-built annotation targets reject up front") {
 
 TEST_CASE("trajectory: a smaller starting module must not shrink the reused state") {
     // A leaked initial compiles a from-the-top continuation with more
-    // hidden record slots (the MR restore) but a smaller peak rank than
+    // hidden record slots (the MR restore) but a smaller peak active width than
     // the main line, whose expand_damp site needs the array. A shot
     // sequence interleaving both starting modules used to rebuild the
-    // state to the smaller module's rank while the tracker kept the
+    // state to the smaller module's capacity while the tracker kept the
     // maximum; the next main-line shot then overran its allocation --
     // caught by the Debug kernel assert, an out-of-bounds write in
     // Release.
@@ -1002,7 +1002,7 @@ TEST_CASE("trajectory: memory-X smoke measures two qubits after a low-rate leak 
     auto model = NonComputationalModel::from_spec(pure_initial_state(Level::G), {{"leak", leak}},
                                                   std::make_optional(classifier), policy);
     auto circuit = parse("RX 0 1\nLEVEL_TRANSITION[leak] 0 1\nMX 0 1");
-    // Equal-rate loss keeps stabilizer cost under exact damping: max_rank 0.
+    // Equal-rate loss keeps stabilizer cost under exact damping: max_active_width 0.
     constexpr uint32_t kShots = 2000;
     auto result = sample_noncomputational(circuit, model, kShots, 111, 0);
     REQUIRE(result.shots == kShots);
@@ -1405,12 +1405,12 @@ TEST_CASE("trajectory: a reset truly re-prepares a restored-lost qubit") {
     }
 }
 
-// max_rank boundary behavior
+// max_active_width boundary behavior
 
-TEST_CASE("trajectory: max_rank succeeds exactly at the required rank") {
+TEST_CASE("trajectory: max_active_width succeeds exactly at the required width") {
     // Reuses the over-cap circuit from the rejection test: three H-prefixed
-    // source-dependent sites push peak rank to 3 (over a cap of 2). The
-    // same circuit must succeed with max_rank = 3 (the actual required rank).
+    // source-dependent sites push peak active width to 3 (over a cap of 2). The
+    // same circuit must succeed with max_active_width = 3 (the required width).
     ModelSpec spec;
     spec.leak_from_e = 0.2;
     auto model = make_driver_model(spec);
@@ -1419,8 +1419,8 @@ TEST_CASE("trajectory: max_rank succeeds exactly at the required rank") {
         "LEVEL_TRANSITION[leak] 0\nLEVEL_TRANSITION[leak] 1\nLEVEL_TRANSITION[leak] 2\n"
         "M 0\nM 1\nM 2");
 
-    // max_rank = 3 is exactly the peak; must succeed.
-    auto result = sample_noncomputational(circuit, model, 5, 1, /*max_rank=*/3);
+    // max_active_width = 3 is exactly the peak; must succeed.
+    auto result = sample_noncomputational(circuit, model, 5, 1, /*max_active_width=*/3);
     REQUIRE(result.shots == 5);
     REQUIRE(result.num_measurements == 3);
 }
@@ -1445,9 +1445,11 @@ TEST_CASE("trajectory: different seeds produce different records") {
     REQUIRE(a.measurements != b.measurements);
 }
 
-TEST_CASE("trajectory: max_rank is not checked against the unreachable all-computational module") {
+TEST_CASE(
+    "trajectory: max_active_width is not checked against the unreachable all-computational "
+    "module") {
     // When every qubit starts lost, the no-event module is never used;
-    // its rank must not trigger a max_rank rejection.
+    // its active width must not trigger a max_active_width rejection.
     // The lost column reads symbol 1 with certainty: a raw readout of the
     // dropped-everything |0> carriers would give 0, so all-1 records verify
     // that the classifier wrote them.
@@ -1462,7 +1464,7 @@ TEST_CASE("trajectory: max_rank is not checked against the unreachable all-compu
         {1.0, 0.0, 0.0, 0.0, 0.0}, {}, std::make_optional(classifier_matrix),
         NonComputationalPolicy{});
 
-    // Circuit with T gates -- non-trivial rank.
+    // Circuit with T gates -- nonzero peak active width.
     const std::string circuit_str =
         "H 0\n"
         "CX 0 1\nCX 0 2\nCX 0 3\nCX 0 4\nCX 0 5\n"
@@ -1470,11 +1472,11 @@ TEST_CASE("trajectory: max_rank is not checked against the unreachable all-compu
         "M 0\nM 1\nM 2\nM 3\nM 4\nM 5\n";
     const Circuit circuit = parse(circuit_str);
 
-    // Ground model at max_rank=0 must throw (the no-event module exceeds it).
+    // Ground model at max_active_width=0 must throw (the no-event module exceeds it).
     REQUIRE_THROWS_WITH(sample_noncomputational(circuit, ground_model, 4, 1, 0),
-                        ContainsSubstring("max_rank"));
+                        ContainsSubstring("max_active_width"));
 
-    // Lost model at max_rank=0 must run (the no-event module is lazy).
+    // Lost model at max_active_width=0 must run (the no-event module is lazy).
     const NonComputationalSample r = sample_noncomputational(circuit, lost_model, 16, 1, 0);
     for (const uint8_t bit : r.measurements) {
         REQUIRE(bit == 1);

--- a/tools/bench/README.md
+++ b/tools/bench/README.md
@@ -20,7 +20,7 @@ uv run pytest tools/bench/ --benchmark-sort=name --benchmark-columns=Mean,StdDev
 |------|---------|-----------------|
 | `test_bench_qec.py` | d=3 surface code (`tests/fixtures/target_qec.stim`) | Compile and sample latency vs Stim |
 | `test_bench_deep_clifford.py` | 50-qubit, 5000 random Cliffords | Pure Clifford compile/sample throughput |
-| `test_bench_qv.py` | 20-qubit Quantum Volume (`fixtures/qv20_seed42.stim`) | Large statevector (peak rank 20) per-shot throughput |
+| `test_bench_qv.py` | 20-qubit Quantum Volume (`fixtures/qv20_seed42.stim`) | Large statevector (peak active width 20) per-shot throughput |
 | `test_bench_noncomp.py` | d=17, r=5 repetition-code memory with a hooked leak/loss layer | Noncomputational pipeline overhead and trap/continuation cost vs plain sampling |
 
 ## Fixtures
@@ -28,5 +28,5 @@ uv run pytest tools/bench/ --benchmark-sort=name --benchmark-columns=Mean,StdDev
 Pre-generated circuit files live in `fixtures/`:
 
 - **`qv20_seed42.stim`** — 20-qubit Quantum Volume circuit (seed=42) in Stim-superset
-  format. Peak rank 20 (2^20 = 1M complex amplitudes, 16 MB statevector).
+  format. Peak active width 20 (2^20 = 1M complex amplitudes, 16 MB statevector).
   Useful for profiling dense active-state kernels.

--- a/tools/bench/test_bench_deep_clifford.py
+++ b/tools/bench/test_bench_deep_clifford.py
@@ -84,7 +84,7 @@ def test_00_deep_clifford_info(record_property: Any) -> None:
     record_property("total_cliffords", total_cliffords)
     record_property("measurements", m_count)
     record_property("clifft_actions", program.num_actions)
-    record_property("clifft_peak_rank", program.peak_rank)
+    record_property("clifft_peak_active_width", program.peak_active_width)
 
     compression = total_cliffords / program.num_actions if program.num_actions else 0
 

--- a/tools/bench/test_bench_qv.py
+++ b/tools/bench/test_bench_qv.py
@@ -1,6 +1,6 @@
 """Performance benchmarks for large-statevector circuits.
 
-Uses a pre-generated 20-qubit Quantum Volume circuit (peak rank 20,
+Uses a pre-generated 20-qubit Quantum Volume circuit (peak active width 20,
 16 MB statevector) to measure per-shot throughput when dense active-state
 kernels dominate execution time.
 

--- a/tools/profile/profile_compile.cpp
+++ b/tools/profile/profile_compile.cpp
@@ -150,7 +150,7 @@ int main() {
     samples.reserve(iterations);
 
     size_t parsed_ops = 0;
-    uint32_t max_active_width = 0;
+    uint32_t peak_active_width = 0;
     uint32_t total_qubits = 0;
     size_t planned_actions = 0;
     size_t executable_actions = 0;
@@ -199,7 +199,7 @@ int main() {
         if (iter == 0) {
             planned_actions = plan.actions.size();
             planned_symbols = plan.symbols.size();
-            max_active_width = plan.max_active_width;
+            peak_active_width = plan.peak_active_width;
             estimated_symbolic_frame_bytes =
                 clifft::sampling::internal::SymbolicPauliFrame::estimated_workspace_bytes(
                     total_qubits, static_cast<uint32_t>(planned_symbols));
@@ -224,7 +224,7 @@ int main() {
             std::cout << "  prepare: " << t.prepare_ms << " ms\n";
             std::cout << "  total:  " << total_ms(t) << " ms\n";
             std::cout << "Module: " << total_qubits << " qubits, ";
-            std::cout << "max_active_width " << max_active_width << ", " << parsed_ops
+            std::cout << "peak_active_width " << peak_active_width << ", " << parsed_ops
                       << " parsed ops, " << planned_actions << " -> " << executable_actions
                       << " actions, " << planned_symbols << " symbols, "
                       << estimated_symbolic_frame_bytes

--- a/tools/profile/profile_probability.cpp
+++ b/tools/profile/profile_probability.cpp
@@ -205,8 +205,8 @@ int main() {
     std::cout << " done (" << prepare_ms << " ms, " << program.num_actions() << " actions)\n";
 
     std::cout << "\nCompilation total: " << (parse_ms + trace_ms + prepare_ms) << " ms\n";
-    std::cout << "Peak active width: " << program.max_active_width() << " (statevector size: 2^"
-              << program.max_active_width() << " = " << (1ULL << program.max_active_width())
+    std::cout << "Peak active width: " << program.peak_active_width() << " (statevector size: 2^"
+              << program.peak_active_width() << " = " << (1ULL << program.peak_active_width())
               << ")\n\n";
 
     // Build query bitmasks. Random uniform bitstrings cover both in-support


### PR DESCRIPTION
## Summary

- expose `Program.peak_active_width` as the canonical public metric and retain `Program.peak_rank` as a deprecated compatibility alias
- name observed peaks `peak_active_width` consistently in `SamplingPlan`, `ExecutablePlan`, WASM compile results, the playground, tests, and profiling tools
- rename the experimental noncomputational `max_rank` cap to `max_active_width`, with internal `_cap` names that distinguish it from observed peaks
- replace stale user-facing rank and active-dimension wording while preserving genuine linear-algebra rank and the `2^k` active-state dimension

The noncomputational argument is a clean rename: unlike the property alias, no `max_rank` compatibility shim is added because this API remains experimental.

## Breaking changes

- `clifft.noncomp.sample(max_rank=...)` becomes `max_active_width=...`
- the C++ sampling-plan peak and executable-plan accessor become `peak_active_width`
- the WASM compile result uses `peak_active_width` instead of `max_active_width`

`Program.peak_rank` remains available temporarily and emits `DeprecationWarning`.

## Performance

This changes names, diagnostics, and inspection output only. Planning, execution, and kernel behavior are unchanged, so no runtime performance change is expected.

## Verification

- Debug C++ build
- `ctest --test-dir build -E '^Bench:' --output-on-failure` (812 passed)
- `pytest -q tests/python` (785 passed)
- production playground TypeScript/Vite build
- Emscripten WASM build and Node smoke suite
- strict MkDocs build
- documentation codeblocks (31 passed, 7 skipped)
- pre-commit hooks
- tracked-file semantic audit separating observed peaks, user caps, state allocation capacity, and genuine algebraic rank

Closes #335
