### PR TITLE
build: surface breaking changes in generated release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,11 @@ architecture cannot support it:
 - Never commit directly to `main`; use a feature branch.
 - Keep commits atomic and use conventional prefixes such as `feat:`, `fix:`,
   `test:`, and `docs:`.
-- Mark a commit that removes or renames a public API with a `!` after the type
-  (`feat(api)!:`) and a `BREAKING CHANGE:` footer describing the migration. The
-  changelog surfaces both; without them the entry reads as an ordinary feature.
+- Mark any backward-incompatible public API change, including removals and
+  renames, with a `!` after the type (`feat(api)!:`) and a `BREAKING CHANGE:`
+  footer describing the migration. Signature, return-type, default, and
+  behavioral changes count. The changelog surfaces both markers; without them
+  the entry reads as an ordinary feature.
 - Run `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
   before every commit, in addition to the tests appropriate for the change.
 - Include an `Assisted-by:` trailer identifying the agent that actually

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ architecture cannot support it:
 - Never commit directly to `main`; use a feature branch.
 - Keep commits atomic and use conventional prefixes such as `feat:`, `fix:`,
   `test:`, and `docs:`.
+- Mark a commit that removes or renames a public API with a `!` after the type
+  (`feat(api)!:`) and a `BREAKING CHANGE:` footer describing the migration. The
+  changelog surfaces both; without them the entry reads as an ordinary feature.
 - Run `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
   before every commit, in addition to the tests appropriate for the change.
 - Include an `Assisted-by:` trailer identifying the agent that actually

--- a/cliff.toml
+++ b/cliff.toml
@@ -31,7 +31,7 @@ body = """
           {% if commit.remote.pr_number %} in \
             [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})\
           {%- endif -%}
-          {% if commit.breaking and commit.breaking_description | trim != subject %} -- **BREAKING CHANGE:** {{ commit.breaking_description | trim }}{%- endif %}
+          {% if commit.breaking and commit.breaking_description | trim != subject %} -- **BREAKING CHANGE:** {{ commit.breaking_description | trim | replace(from="\n", to=" ") | replace(from="  ", to=" ") }}{%- endif %}
     {%- endfor %}
 {% endfor %}\n
 """

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,11 +25,13 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
-        - {{ commit.message | split(pat="\n") | first | trim }}\
+        {% set subject = commit.message | split(pat="\n") | first | trim -%}
+        - {% if commit.breaking %}**[breaking]** {% endif %}{{ subject }}\
           {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}
           {% if commit.remote.pr_number %} in \
             [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})\
-          {%- endif %}
+          {%- endif -%}
+          {% if commit.breaking and commit.breaking_description | trim != subject %} -- **BREAKING CHANGE:** {{ commit.breaking_description | trim }}{%- endif %}
     {%- endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Summary

`git cliff` strips the conventional-commit type, scope, and `!` marker when it emits an entry, and `cliff.toml`'s body template interpolated only the subject line. A commit typed `feat(api)!:` with a `BREAKING CHANGE:` footer therefore rendered as an ordinary feature, so release notes drafted from `git cliff --unreleased` carried no signal that a public API had been removed.

- mark breaking entries with `**[breaking]**`
- append the `BREAKING CHANGE:` footer text, suppressed when it merely repeats the subject (as it does for a `!`-only commit with no footer)
- flatten multi-paragraph footers to a single flowed line, so they cannot terminate the Markdown list item
- document the convention in `AGENTS.md`, since the template can only surface what the commit itself records

Found while reviewing #338, which added `feat(api)!:` and a `BREAKING CHANGE:` footer and still rendered as a plain feature.

## Verification

Rendered the full changelog with the old and new configs against a branch containing a footer-bearing breaking commit. The diff is exactly two lines; every other entry renders byte-identically.

Footer-bearing commit (`feat(api)!:` + `BREAKING CHANGE:`):

```diff
-- name active-width metrics consistently
+- **[breaking]** name active-width metrics consistently -- **BREAKING CHANGE:** clifft.noncomp.sample no longer accepts max_rank; use max_active_width. SamplingPlan, ExecutablePlan, and WASM compile results now name observed maxima peak_active_width.
```

`!`-only commit with no footer (#84) — marker applied, no duplicated description:

```diff
-- rename probability APIs and unify strong-simulation docs (#84) by @bachase in [#84](https://github.com/unitaryfoundation/clifft/pull/84)
+- **[breaking]** rename probability APIs and unify strong-simulation docs (#84) by @bachase in [#84](https://github.com/unitaryfoundation/clifft/pull/84)
```

Multi-paragraph footer, reproduced in a scratch repository. Before, the second paragraph escaped the list item and rendered as top-level prose:

```
- **[breaking]** rework the sampler entrypoint -- **BREAKING CHANGE:** first paragraph explaining the removal and the
replacement spelling.

Second paragraph with migration detail that must not escape the list item.
```

After:

```
- **[breaking]** rework the sampler entrypoint -- **BREAKING CHANGE:** first paragraph explaining the removal and the replacement spelling. Second paragraph with migration detail that must not escape the list item.
```

Flattening is applied on top of the marker commit and leaves the repository's own history byte-identical — only footers that actually span lines change.

- `uv run --frozen --only-group dev pre-commit run --all-files` (all hooks passed, both commits)

## Notes

`CHANGELOG.md` is hand-curated — it contains narrative prose the template cannot produce — so this changes drafting output only and no committed entry is rewritten. Released sections are untouched.

The breaking note renders inline rather than as a nested bullet, and multi-paragraph footers are flattened rather than indented, for the same reason: `trim = true` strips leading whitespace from every rendered line, so any indented continuation would flatten to a top-level one.
