### PR TITLE
docs: replace opcode references with compiler IR

### DIFF
--- a/docs/compiler_ir.json
+++ b/docs/compiler_ir.json
@@ -147,7 +147,7 @@
     "WRITE_EXPECTATION": {
       "category": "Output",
       "summary": "Records a non-destructive Pauli expectation value of the current state.",
-      "detail": "Probes the expectation of a Pauli observable without collapsing anything. When an active projection is shown, one pass over the coefficient state computes it, with the sign expression conditioning its overall sign per shot. The word zero means planning already proved the expectation vanishes because the transformed observable has X or Y support outside the active coordinates.",
+      "detail": "Probes the expectation of a Pauli observable without collapsing anything. When an active projection is shown, one pass over the coefficient state computes it, with the sign expression conditioning its overall sign per shot. The zero marker means planning already proved the expectation vanishes because the transformed observable has X or Y support outside the active coordinates.",
       "operands": "Pauli product or zero, sign, exp_val"
     },
     "APPLY_INSTRUMENT": {

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -1,4 +1,4 @@
-"""MkDocs macros hook: loads HIR operation and pass metadata."""
+"""MkDocs macros hook: loads compiler IR and pass metadata."""
 
 import json
 from pathlib import Path
@@ -8,7 +8,7 @@ from typing import Any
 def define_env(env: Any) -> None:
     """Called by mkdocs-macros-plugin to inject template variables."""
     docs_dir = Path(env.conf["docs_dir"])
-    data_path = docs_dir / "opcodes.json"
+    data_path = docs_dir / "compiler_ir.json"
 
     with open(data_path) as f:
         data = json.load(f)
@@ -39,7 +39,7 @@ def define_env(env: Any) -> None:
     unknown_hir_categories = sorted(set(hir_by_category) - set(hir_categories_order))
     if unknown_hir_categories:
         raise ValueError(
-            "docs/opcodes.json contains HIR categories missing from docs/macros.py: "
+            "docs/compiler_ir.json contains HIR categories missing from docs/macros.py: "
             + ", ".join(unknown_hir_categories)
         )
 
@@ -69,7 +69,7 @@ def define_env(env: Any) -> None:
     unknown_plan_categories = sorted(set(plan_by_category) - set(plan_categories_order))
     if unknown_plan_categories:
         raise ValueError(
-            "docs/opcodes.json contains sampling-plan categories missing from docs/macros.py: "
+            "docs/compiler_ir.json contains sampling-plan categories missing from docs/macros.py: "
             + ", ".join(unknown_plan_categories)
         )
 

--- a/docs/reference/compiler-ir.md
+++ b/docs/reference/compiler-ir.md
@@ -1,9 +1,13 @@
-# Instruction Reference
+# Compiler IR Reference
 
-This page documents the operation types used by the Clifft compiler at both
-levels of the pipeline: the **Heisenberg IR** (HIR) produced by the front-end,
-and the **Sampling Plan actions** produced by the planner and executed by the
-sampling backend.
+This page documents two internal semantic representations used by the Clifft
+compiler: the **Heisenberg IR** (HIR) produced by the front end and the
+**Sampling Plan actions** produced by coordinate planning.
+
+These names and text formats support inspection and debugging. They are not a
+serialized program format, bytecode, or stable public ABI. User code should
+compile circuits into a `Program` and use the public sampling and exact-query
+APIs rather than depend on plan-action layout.
 
 The same data powers the hover tooltips in the
 [Playground]({{ playground_url }}).
@@ -18,8 +22,8 @@ The same data powers the hover tooltips in the
 
 The Heisenberg IR is the intermediate representation produced by the front-end.
 Clifford gates are absorbed into the offline Clifford frame $U_C$ and do not
-appear in the HIR. What remains are non-Clifford operations, measurements, and
-meta-instructions.
+appear in the HIR. What remains are non-Clifford operations, measurements,
+noise, feedback, and output metadata.
 
 {% for cat in hir_categories %}
 ### {{ cat }}
@@ -40,10 +44,16 @@ meta-instructions.
 
 ## Sampling Plan Actions
 
-The planner compiles optimized HIR into a sampling plan: a fixed sequence of
-actions in which every Clifford has been absorbed and every stochastic event
-appears as a Boolean **symbol**. The plan is what repeated sampling executes,
-and it is what the Playground's Sampling Plan panel displays.
+The planner compiles optimized HIR into a target-independent `SamplingPlan`: a
+fixed sequence of semantic actions in which every Clifford has been absorbed
+and every stochastic event appears as a Boolean **symbol**. The Playground's
+Sampling Plan panel displays this representation. Before repeated sampling,
+Clifft prepares a target-specific `ExecutablePlan` containing the compact
+descriptors, dependency tables, fused actions, and kernel selections consumed
+by the executor.
+
+See [Software Architecture](../theory/architecture.md) for the responsibilities
+of HIR, `SamplingPlan`, `ExecutablePlan`, and the executor.
 
 ### Reading a plan line
 
@@ -53,9 +63,9 @@ w1->0 MEASURE_ACTIVE Z0 pivot=0 branch=s3 outcome=s0^s1^s3 record=r0 passes=2
 
 * **`w<k>` / `w<k>-><k'>`** — the active width before (and, when it changes,
   after) the action. The dense coefficient state holds $2^k$ amplitudes for
-  the currently active symbolic coordinates.
+  the currently active stabilizer coordinates.
 * **Pauli products** such as `Z0` or `X0*Z1` are written over **active
-  symbolic coordinates, not physical qubits**. The Clifford frame maps
+  stabilizer coordinates, not physical qubits**. The coordinate frame maps
   between the two.
 * **Affine expressions** such as `1^s0^s3` are XORs of Boolean symbols, with
   a leading `1` for the affine constant. Symbols are sampled noise outcomes,
@@ -64,10 +74,12 @@ w1->0 MEASURE_ACTIVE Z0 pivot=0 branch=s3 outcome=s0^s1^s3 record=r0 passes=2
 * **Typed ids** name output slots: `r` measurement records, `d` detectors,
   `o` observables, `v` expectation values, and `s` symbols.
 * **`passes=<n>`** estimates full traversals of the dense coefficient state
-  for a direct lowering of the action; actions without it touch no dense
-  state.
+  before executable preparation combines or specializes operations. It is a
+  diagnostic cost estimate, not an execution ABI or a guarantee of the final
+  kernel count; actions without it require no dense-state traversal on their
+  own.
 
-### Action types
+### Semantic action types
 
 {% for cat in plan_categories %}
 #### {{ cat }}

--- a/docs/reference/compiler-ir.md
+++ b/docs/reference/compiler-ir.md
@@ -65,8 +65,9 @@ w1->0 MEASURE_ACTIVE Z0 pivot=0 branch=s3 outcome=s0^s1^s3 record=r0 passes=2
   after) the action. The dense coefficient state holds $2^k$ amplitudes for
   the currently active stabilizer coordinates.
 * **Pauli products** such as `Z0` or `X0*Z1` are written over **active
-  stabilizer coordinates, not physical qubits**. The coordinate frame maps
-  between the two.
+  stabilizer coordinates, not physical qubits**. The planner's coordinate
+  frame tracks the mapping between physical qubits and those packed
+  coordinates.
 * **Affine expressions** such as `1^s0^s3` are XORs of Boolean symbols, with
   a leading `1` for the affine constant. Symbols are sampled noise outcomes,
   measurement branches, or derived parities. The Playground's compact view

--- a/docs/reference/passes.md
+++ b/docs/reference/passes.md
@@ -22,6 +22,12 @@ pm.add(clifft.PeepholeFusionPass())
 pm.add(clifft.StatevectorSqueezePass())
 ```
 
+Optimization passes end at the HIR boundary. `SamplingPlan` is a private,
+target-independent semantic representation, not a second public pass pipeline.
+Executable preparation may combine adjacent actions and select specialized
+kernels for its target, but those transformations are implementation details,
+not public passes or a stable executable-plan ABI.
+
 ## Trajectory Safety Metadata
 
 Some workflows require measurements to remain in their original order,

--- a/docs/reference/passes.md
+++ b/docs/reference/passes.md
@@ -22,11 +22,9 @@ pm.add(clifft.PeepholeFusionPass())
 pm.add(clifft.StatevectorSqueezePass())
 ```
 
-Optimization passes end at the HIR boundary. `SamplingPlan` is a private,
-target-independent semantic representation, not a second public pass pipeline.
-Executable preparation may combine adjacent actions and select specialized
-kernels for its target, but those transformations are implementation details,
-not public passes or a stable executable-plan ABI.
+Optimization passes end at the HIR boundary; `SamplingPlan` is not a second
+public pass pipeline. See [Software Architecture](../theory/architecture.md)
+for the private planning and executable-preparation stages that follow.
 
 ## Trajectory Safety Metadata
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,7 @@ nav:
     - Noncomputational States: theory/noncomputational.md
   - Reference:
     - Supported Gates: reference/gates.md
-    - Instruction Reference: reference/instructions.md
+    - Compiler IR Reference: reference/compiler-ir.md
     - Optimization Passes: reference/passes.md
     - Python API: reference/python-api.md
   - Development:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,9 @@ hooks:
 
 plugins:
   - search
+  - redirects:
+      redirect_maps:
+        reference/instructions.md: reference/compiler-ir.md
   - macros:
       module_name: docs/macros
   - minify:

--- a/playground/src/languages.ts
+++ b/playground/src/languages.ts
@@ -2,7 +2,7 @@
 
 import type { languages, editor, IMarkdownString, Position } from "monaco-editor";
 import type { Monaco } from "@monaco-editor/react";
-import opcodeMetadata from "@docs/opcodes.json";
+import compilerIrMetadata from "@docs/compiler_ir.json";
 
 interface OpDoc {
   category: string;
@@ -12,8 +12,8 @@ interface OpDoc {
   display?: string[];
 }
 
-const hirMap = opcodeMetadata.hir_ops as Record<string, OpDoc>;
-const planActionMap = opcodeMetadata.plan_actions as Record<string, OpDoc>;
+const hirMap = compilerIrMetadata.hir_ops as Record<string, OpDoc>;
+const planActionMap = compilerIrMetadata.plan_actions as Record<string, OpDoc>;
 
 // Derived from the shared metadata so the tokenizer cannot drift from the
 // mnemonics documented in plan_actions.

--- a/playground/src/languages.ts
+++ b/playground/src/languages.ts
@@ -4,7 +4,7 @@ import type { languages, editor, IMarkdownString, Position } from "monaco-editor
 import type { Monaco } from "@monaco-editor/react";
 import compilerIrMetadata from "@docs/compiler_ir.json";
 
-interface OpDoc {
+interface DocEntry {
   category: string;
   summary: string;
   detail: string;
@@ -12,8 +12,8 @@ interface OpDoc {
   display?: string[];
 }
 
-const hirMap = compilerIrMetadata.hir_ops as Record<string, OpDoc>;
-const planActionMap = compilerIrMetadata.plan_actions as Record<string, OpDoc>;
+const hirMap = compilerIrMetadata.hir_ops as Record<string, DocEntry>;
+const planActionMap = compilerIrMetadata.plan_actions as Record<string, DocEntry>;
 
 // Derived from the shared metadata so the tokenizer cannot drift from the
 // mnemonics documented in plan_actions.
@@ -22,7 +22,7 @@ const planActionMnemonicPattern = new RegExp(
 );
 
 // Build a reverse lookup from HIR display names (T, T_DAG, MEASURE, etc.) to docs
-const hirDisplayMap: Record<string, OpDoc> = {};
+const hirDisplayMap: Record<string, DocEntry> = {};
 for (const [, doc] of Object.entries(hirMap)) {
   if (doc.display) {
     for (const name of doc.display) {
@@ -128,7 +128,7 @@ export const planLanguage: languages.IMonarchLanguage = {
 let registered = false;
 
 /** Format an HIR operation as Monaco-flavored Markdown for the hover widget. */
-function formatOperationHover(name: string, doc: OpDoc): IMarkdownString {
+function formatOperationHover(name: string, doc: DocEntry): IMarkdownString {
   const lines = [
     `**\`${name}\`** &mdash; _${doc.category}_`,
     "",

--- a/playground/tsconfig.app.json
+++ b/playground/tsconfig.app.json
@@ -28,5 +28,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src", "../docs/opcodes.json"]
+  "include": ["src", "../docs/compiler_ir.json"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ docs = [
     "mkdocs-material>=9.6",
     "mkdocs-macros-plugin>=1.0",
     "mkdocs-minify-plugin>=0.8",
+    "mkdocs-redirects>=1.2,<1.2.3",
     "mkdocstrings[python]>=1.0",
     "mike>=2.1",
     "pymdown-extensions>=10.7",

--- a/src/clifft/util/fault_sampling.h
+++ b/src/clifft/util/fault_sampling.h
@@ -37,8 +37,8 @@ class KFaultSampler {
                 const uint32_t pick = j + static_cast<uint32_t>(draw * remaining);
                 std::swap(uniform_pool_[j], uniform_pool_[pick]);
             }
-            // Preserve the legacy sampler's persistent-pool evolution as well
-            // as returning sites in circuit order.
+            // Keep the pool permutation across calls so a seeded sampler has
+            // one stable RNG evolution while still returning circuit order.
             std::sort(uniform_pool_.begin(), uniform_pool_.begin() + remaining_k_);
             for (uint32_t j = 0; j < remaining_k_; ++j) {
                 selected_sites_.push_back(uniform_pool_[j]);

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -13,9 +13,9 @@ namespace clifft {
 // planner must reject that width before allocation or bit-index arithmetic.
 inline constexpr uint32_t kDenseActiveWidthLimit = 60;
 
-// Relative epsilon shared by branch sampling and forced replay when
-// analytically-zero probabilities contain floating-point dust. This is part
-// of Clifft's record-reachability semantics.
+// Relative epsilon shared by measurement-branch handling and instrument
+// sampling when analytically-zero probabilities contain floating-point dust.
+// This is part of Clifft's record-reachability semantics.
 inline constexpr double kMeasurementDustEpsilon = 1e-18;
 
 // The IEEE 754 bit trick below assumes that layout. Make it explicit.

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -13,9 +13,9 @@ namespace clifft {
 // planner must reject that width before allocation or bit-index arithmetic.
 inline constexpr uint32_t kDenseActiveWidthLimit = 60;
 
-// Relative epsilon shared by sampling backends when analytically-zero branch
-// probabilities contain floating-point dust. This is part of Clifft's record
-// reachability semantics, including forced-outcome replay.
+// Relative epsilon shared by branch sampling and forced replay when
+// analytically-zero probabilities contain floating-point dust. This is part
+// of Clifft's record-reachability semantics.
 inline constexpr double kMeasurementDustEpsilon = 1e-18;
 
 // The IEEE 754 bit trick below assumes that layout. Make it explicit.

--- a/src/wasm/test_wasm.mjs
+++ b/src/wasm/test_wasm.mjs
@@ -12,10 +12,10 @@ const mod = await createModule();
 // Plan-action documentation, keyed by mnemonic (ROTATE_ACTIVE, MEASURE_ACTIVE,
 // etc.). Every sampling_plan mnemonic emitted below must have an entry here,
 // so a new planner action without documentation fails this smoke test.
-const opcodeMetadata = JSON.parse(
-    readFileSync(new URL("../../docs/opcodes.json", import.meta.url))
+const compilerIrMetadata = JSON.parse(
+    readFileSync(new URL("../../docs/compiler_ir.json", import.meta.url))
 );
-const planActions = opcodeMetadata.plan_actions;
+const planActions = compilerIrMetadata.plan_actions;
 
 // Default passes config (empty string = use defaults)
 const DEFAULTS = "";
@@ -92,7 +92,7 @@ assert.ok(
     "Expected at least one recognized SamplingPlan mnemonic"
 );
 
-// --- sampling_plan mnemonics stay in sync with docs/opcodes.json ---
+// --- sampling_plan mnemonics stay in sync with docs/compiler_ir.json ---
 // A new planner action that lands without a plan_actions entry should fail
 // this smoke test rather than shipping undocumented.
 function assertMnemonicsAreDocumented(samplingPlan) {
@@ -101,7 +101,7 @@ function assertMnemonicsAreDocumented(samplingPlan) {
         assert.ok(match, `sampling_plan line has no recognizable mnemonic: ${line}`);
         assert.ok(
             Object.prototype.hasOwnProperty.call(planActions, match[1]),
-            `sampling_plan mnemonic "${match[1]}" is missing a docs/opcodes.json plan_actions entry`
+            `sampling_plan mnemonic "${match[1]}" is missing a docs/compiler_ir.json plan_actions entry`
         );
     }
 }

--- a/tests/python/test_compiler_ir_docs.py
+++ b/tests/python/test_compiler_ir_docs.py
@@ -1,6 +1,7 @@
-"""Ensure every HIR op type is documented in docs/opcodes.json.
+"""Ensure every HIR op type is documented in docs/compiler_ir.json.
 
-This test parses the C++ HIR enum and verifies that docs/opcodes.json has a matching entry.
+This test parses the C++ HIR enum and verifies that the compiler IR metadata
+has a matching entry.
 """
 
 import json
@@ -12,7 +13,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 HIR_HEADER = ROOT / "src" / "clifft" / "frontend" / "hir.h"
-OPCODES_JSON = ROOT / "docs" / "opcodes.json"
+COMPILER_IR_JSON = ROOT / "docs" / "compiler_ir.json"
 
 # Sentinel values that should NOT have documentation entries
 SENTINELS = {"NUM_OP_TYPES"}
@@ -30,29 +31,29 @@ def _extract_enum_members(header: Path, enum_name: str) -> list[str]:
 
 
 @pytest.fixture(scope="module")
-def opcodes_data() -> dict[str, Any]:
-    with open(OPCODES_JSON) as f:
+def compiler_ir_data() -> dict[str, Any]:
+    with open(COMPILER_IR_JSON) as f:
         return json.load(f)  # type: ignore[no-any-return]
 
 
 class TestHirDocCompleteness:
-    """Every C++ OpType enum member must have a docs/opcodes.json entry."""
+    """Every C++ OpType enum member must have a compiler IR metadata entry."""
 
-    def test_all_hir_ops_documented(self, opcodes_data: dict[str, Any]) -> None:
+    def test_all_hir_ops_documented(self, compiler_ir_data: dict[str, Any]) -> None:
         cpp_ops = set(_extract_enum_members(HIR_HEADER, "OpType"))
-        json_ops = set(opcodes_data["hir_ops"].keys())
+        json_ops = set(compiler_ir_data["hir_ops"].keys())
         missing = cpp_ops - json_ops
         assert not missing, (
-            f"HIR OpTypes in C++ but missing from docs/opcodes.json: {sorted(missing)}. "
+            f"HIR OpTypes in C++ but missing from docs/compiler_ir.json: {sorted(missing)}. "
             f"Add entries for these op types to keep documentation complete."
         )
 
-    def test_no_stale_hir_docs(self, opcodes_data: dict[str, Any]) -> None:
+    def test_no_stale_hir_docs(self, compiler_ir_data: dict[str, Any]) -> None:
         cpp_ops = set(_extract_enum_members(HIR_HEADER, "OpType"))
-        json_ops = set(opcodes_data["hir_ops"].keys())
+        json_ops = set(compiler_ir_data["hir_ops"].keys())
         stale = json_ops - cpp_ops
         assert not stale, (
-            f"HIR OpTypes in docs/opcodes.json but removed from C++: {sorted(stale)}. "
+            f"HIR OpTypes in docs/compiler_ir.json but removed from C++: {sorted(stale)}. "
             f"Remove these stale entries."
         )
 
@@ -60,8 +61,15 @@ class TestHirDocCompleteness:
 class TestJsonStructure:
     """Validate that each entry has the required fields."""
 
-    def test_hir_entries_have_required_fields(self, opcodes_data: dict[str, Any]) -> None:
-        for name, doc in opcodes_data["hir_ops"].items():
+    def test_hir_entries_have_required_fields(self, compiler_ir_data: dict[str, Any]) -> None:
+        for name, doc in compiler_ir_data["hir_ops"].items():
             assert "category" in doc, f"{name} missing 'category'"
             assert "summary" in doc, f"{name} missing 'summary'"
             assert "detail" in doc, f"{name} missing 'detail'"
+
+    def test_plan_entries_have_required_fields(self, compiler_ir_data: dict[str, Any]) -> None:
+        for name, doc in compiler_ir_data["plan_actions"].items():
+            assert "category" in doc, f"{name} missing 'category'"
+            assert "summary" in doc, f"{name} missing 'summary'"
+            assert "detail" in doc, f"{name} missing 'detail'"
+            assert "operands" in doc, f"{name} missing 'operands'"

--- a/tests/python/test_compiler_ir_docs.py
+++ b/tests/python/test_compiler_ir_docs.py
@@ -1,7 +1,7 @@
-"""Ensure every HIR op type is documented in docs/compiler_ir.json.
+"""Validate the HIR and sampling-plan entries in docs/compiler_ir.json.
 
-This test parses the C++ HIR enum and verifies that the compiler IR metadata
-has a matching entry.
+These tests check HIR-op completeness against the C++ enum and require the
+documented fields used to render both HIR operations and sampling-plan actions.
 """
 
 import json

--- a/tests/python/test_detector_oracle.py
+++ b/tests/python/test_detector_oracle.py
@@ -256,12 +256,12 @@ class TestActiveInterfereErrorTracking:
     """Test error frame tracking through active interference and array compaction."""
 
     def test_x_error_with_active_interfere(self) -> None:
-        """Error frame tracking must survive OP_MEAS_ACTIVE_INTERFERE.
+        """Error-frame tracking must survive an active measurement.
 
         H 0 -> |+>
         T 0 -> creates an active coordinate (interference required)
         X_ERROR(1) 0 -> error_parity = 1
-        M 0 -> OP_MEAS_ACTIVE_INTERFERE + array compaction
+        M 0 -> MEASURE_ACTIVE + coefficient compaction
         M 0 -> deterministic re-measurement (checks error frame integrity)
         DETECTOR -> two consecutive measurements must always match
         """

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -220,19 +220,19 @@ def test_rejects_hidden_measurement_slots() -> None:
         clifft.record_probabilities(prog, ["00", "11"])
 
 
-def test_rejects_noise_opcodes() -> None:
+def test_rejects_noise_operations() -> None:
     prog = clifft.compile("X_ERROR(0.1) 0\nM 0")
     with pytest.raises(ValueError, match="pure-state evolution"):
         clifft.record_probabilities(prog, ["0"])
 
 
-def test_rejects_detector_opcodes() -> None:
+def test_rejects_detector_operations() -> None:
     prog = clifft.compile("M 0\nDETECTOR rec[-1]")
     with pytest.raises(ValueError, match="pure-state evolution"):
         clifft.record_probabilities(prog, ["0"])
 
 
-def test_rejects_observable_opcodes() -> None:
+def test_rejects_observable_operations() -> None:
     prog = clifft.compile("M 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
     with pytest.raises(ValueError, match="pure-state evolution"):
         clifft.record_probabilities(prog, ["0"])

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -483,10 +483,10 @@ class TestSamplingValidation:
         assert abs(stim_11 - 0.5) < tolerance, f"Stim |11>={stim_11} outside {tolerance:.4f} tol"
 
     def test_meas_active_interfere_y_observable(self, sampling_api: Any) -> None:
-        """OP_MEAS_ACTIVE_INTERFERE correctly computes interference with Y-phases."""
+        """An active Y measurement correctly computes phase-sensitive interference."""
         # H 0; T 0 rotates the state to (|0> + e^{ipi/4}|1>)/sqrt(2)
         # S 0 adds phase: (|0> + e^{i*3pi/4}|1>)/sqrt(2)
-        # MX 0 forces an OP_MEAS_ACTIVE_INTERFERE where the rewound observable is Y.
+        # MX 0 plans MEASURE_ACTIVE with a rewound Y observable.
         circuit = "H 0\nT 0\nS 0\nMX 0"
         prog = sampling_api.compile(circuit)
 

--- a/tests/test_inspection_format.cc
+++ b/tests/test_inspection_format.cc
@@ -188,7 +188,7 @@ TEST_CASE("Executable rotation prints a pairing index only for X-type prepared P
 TEST_CASE("Compact inspection mnemonics cover every SamplingAction and its docs entry") {
     // Adding, removing, or renaming a SamplingAction alternative changes this
     // count. Extend the action list below and the plan_actions table in
-    // docs/opcodes.json together, then update this assertion.
+    // docs/compiler_ir.json together, then update this assertion.
     static_assert(std::variant_size_v<SamplingAction> == 12);
 
     const SymbolId s0{0};
@@ -241,7 +241,7 @@ TEST_CASE("Compact inspection mnemonics cover every SamplingAction and its docs 
     // that the playground tokenizer and hover text derive from. This is a
     // plain substring search, not a JSON parser, so it only confirms the key
     // is present, not the shape of its value.
-    std::ifstream docs_file(std::string(CLIFFT_DOCS_DIR) + "/opcodes.json");
+    std::ifstream docs_file(std::string(CLIFFT_DOCS_DIR) + "/compiler_ir.json");
     REQUIRE(docs_file.is_open());
     const std::string docs_text((std::istreambuf_iterator<char>(docs_file)),
                                 std::istreambuf_iterator<char>());

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,7 @@ docs = [
     { name = "mkdocs-macros-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
+    { name = "mkdocs-redirects" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
 ]
@@ -170,6 +171,7 @@ docs = [
     { name = "mkdocs-macros-plugin", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.6" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
+    { name = "mkdocs-redirects", specifier = ">=1.2,<1.2.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0" },
     { name = "pymdown-extensions", specifier = ">=10.7" },
 ]
@@ -667,6 +669,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/67/fe4b77e7a8ae7628392e28b14122588beaf6078b53eb91c7ed000fd158ac/mkdocs-minify-plugin-0.8.0.tar.gz", hash = "sha256:bc11b78b8120d79e817308e2b11539d790d21445eb63df831e393f76e52e753d", size = 8366, upload-time = "2024-01-29T16:11:32.982Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/cd/2e8d0d92421916e2ea4ff97f10a544a9bd5588eb747556701c983581df13/mkdocs_minify_plugin-0.8.0-py3-none-any.whl", hash = "sha256:5fba1a3f7bd9a2142c9954a6559a57e946587b21f133165ece30ea145c66aee6", size = 6723, upload-time = "2024-01-29T16:11:31.851Z" },
+]
+
+[[package]]
+name = "mkdocs-redirects"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a8/6d44a6cf07e969c7420cb36ab287b0669da636a2044de38a7d2208d5a758/mkdocs_redirects-1.2.2.tar.gz", hash = "sha256:3094981b42ffab29313c2c1b8ac3969861109f58b2dd58c45fc81cd44bfa0095", size = 7162, upload-time = "2024-11-07T14:57:21.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ec/38443b1f2a3821bbcb24e46cd8ba979154417794d54baf949fefde1c2146/mkdocs_redirects-1.2.2-py3-none-any.whl", hash = "sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5", size = 6142, upload-time = "2024-11-07T14:57:19.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- rename the old opcode/instruction reference and shared metadata as a compiler-IR reference
- document HIR and `SamplingPlan` as internal semantic representations, with `ExecutablePlan` remaining target-private execution storage rather than a stable ABI
- keep the docs, playground tooltips, WASM smoke checks, and completeness tests on one shared source of truth
- remove stale legacy sampler and opcode terminology from current source and tests

The semantic HIR and plan-action metadata remains useful after the SVM removal, so this renames and clarifies it instead of deleting it with the obsolete bytecode documentation.

## Verification

- `ctest --test-dir build -E '^Bench:' --output-on-failure` (822 passed)
- `uv run --frozen pytest -q tests/python` (790 passed)
- `uv run --frozen pytest --codeblocks docs/ README.md -q` (31 passed, 7 skipped)
- `uv run --frozen --group docs mkdocs build --strict`
- `npm run build` in `playground/`
- rebuilt the WASM module and ran `node --experimental-vm-modules src/wasm/test_wasm.mjs`
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Closes #304.
