### PR TITLE
docs: prepare v0.8.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ on:
     # PyPI publishing requires a version tag push.
     inputs:
       test_version:
-        description: "Version for TestPyPI (e.g. 0.1.0.dev1). Required because PyPI rejects local version specifiers from untagged builds."
+        description: "Version for TestPyPI (e.g. 0.8.0.dev1). Required because PyPI rejects local version specifiers from untagged builds."
         required: true
-        default: "0.1.0.dev1"
+        default: "0.8.0.dev1"
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] - 2026-08-18
+
+Clifft 0.8.0 replaces the original localized-Pauli Schrodinger virtual
+machine (SVM) with a symbolic-coordinate compiler and sampler. The new
+planner resolves Clifford coordinates, affine Pauli-frame effects, active
+Pauli shapes, and symbolic dependencies ahead of time, while prepared scalar,
+AVX2, and AVX-512 kernels apply multi-coordinate operations directly. The
+usual `compile()` and sampling APIs retain their output contracts, and the
+new path also powers exact state queries and leakage/loss continuations.
+
+Across the release benchmark corpus, the new sampler is faster than the SVM
+on five of seven real workloads and remains close on the other two. See
+[Symbolic Sampling in Clifft](https://unitaryfoundation.github.io/clifft/updates/symbolic-sampling/)
+for the design, API migration guide, matched benchmark results, and method
+provenance.
+
+### Added
+
+- Added `Program.inspect()` and `Program.inspect_action()` for diagnostic
+  views of prepared sampling plans. The playground now presents the same
+  symbolic plan with circuit-source provenance.
+- Added generalized Pauli-product phase gates: Clifford `SPP` / `SPP_DAG`
+  and non-Clifford `TPP` / `TPP_DAG`.
+- Added the `LEAKAGE(p)` circuit annotation for source-preserving transitions
+  from `g` to `leak_g` and `e` to `leak_e`.
+- Added `Program.peak_active_width` as the canonical name for the largest
+  dense active-state width. `Program.peak_rank` remains as a deprecated alias
+  for this release.
+
+### Changed
+
+- `clifft.compile()` now returns the symbolic sampling `Program`. It is an
+  opaque, reusable compiled program rather than an iterable bytecode module;
+  `num_actions` replaces `num_instructions` for diagnostic action counts.
+- `clifft.noncomp.sample(..., max_rank=...)` is now
+  `clifft.noncomp.sample(..., max_active_width=...)`.
+- The default optimizer removes rotations whose phase is unobservable at a
+  later terminal measurement, including safe cases across resets, disjoint
+  conditional corrections, noise, and classical bookkeeping.
+- A fixed seed remains reproducible for a fixed version and call, but sampled
+  rows need not match v0.7 because the new executor has a different random
+  number schedule.
+
+### Removed
+
+- Removed the SVM, public `Opcode`, `Instruction`, bytecode `Program`
+  iteration and inspection helpers (`source_map`, `active_k_history`, and
+  `as_dict()`), bytecode pass APIs, and the `bytecode_passes` argument to
+  `compile()`. Use `Program.inspect()` for diagnostic plan text; HIR passes
+  remain the supported compiler-customization boundary.
+- Removed the mutable `State` / `execute()` inspection workflow. Use
+  `get_statevector(program)` for eligible final states.
+- Removed the SVM backend and OpenMP controls: `svm_backend()`,
+  `get_num_threads()`, and `set_num_threads()`. Parallel sampling and
+  intra-shot parallel kernels are tracked as future work.
+
+### Fixed
+
+- Reject invalid inverted targets instead of accepting inversion on
+  operations where it has no defined meaning.
+- Harden noncomputational continuation planning and reuse its storage without
+  changing trajectory semantics.
+
 ## [0.7.0] - 2026-07-31
 
 Clifft 0.7.0 adds experimental simulation of leakage and loss through the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.8.0] - 2026-08-18
 
 Clifft 0.8.0 replaces the original localized-Pauli Schrodinger virtual
-machine (SVM) with a symbolic-coordinate compiler and sampler. The new
-planner resolves Clifford coordinates, affine Pauli-frame effects, active
+machine (SVM) with a symbolic-coordinate compiler and sampler. Drawing on the
+recent [SymFT paper](https://arxiv.org/abs/2607.28600) and
+[reference implementation](https://github.com/haoliri0/SOFT), the new backend
+combines symbolic Clifford-Pauli-frame factorization and adaptive
+stabilizer-coordinate planning with Clifft's
+[original factored active-state representation](https://arxiv.org/abs/2604.27058).
+Its planner resolves Clifford coordinates, affine Pauli-frame effects, active
 Pauli shapes, and symbolic dependencies ahead of time, while prepared scalar,
-AVX2, and AVX-512 kernels apply multi-coordinate operations directly. The
-usual `compile()` and sampling APIs retain their output contracts, and the
-new path also powers exact state queries and leakage/loss continuations.
+AVX2, and AVX-512 kernels apply multi-coordinate operations directly. The usual
+`compile()` and sampling APIs retain their output contracts, and the new path
+also powers exact state queries and leakage/loss continuations.
 
 Across the release benchmark corpus, the new sampler is faster than the SVM
 on five of seven real workloads and remains close on the other two. See
@@ -27,12 +32,15 @@ provenance.
   views of prepared sampling plans. The playground now presents the same
   symbolic plan with circuit-source provenance.
 - Added generalized Pauli-product phase gates: Clifford `SPP` / `SPP_DAG`
-  and non-Clifford `TPP` / `TPP_DAG`.
+  and non-Clifford `TPP` / `TPP_DAG` by @danielgaskins in
+  [#333](https://github.com/unitaryfoundation/clifft/pull/333).
 - Added the `LEAKAGE(p)` circuit annotation for source-preserving transitions
-  from `g` to `leak_g` and `e` to `leak_e`.
+  from `g` to `leak_g` and `e` to `leak_e` by @bachase in
+  [#244](https://github.com/unitaryfoundation/clifft/pull/244).
 - Added `Program.peak_active_width` as the canonical name for the largest
   dense active-state width. `Program.peak_rank` remains as a deprecated alias
-  for this release.
+  for this release, by @bachase in
+  [#338](https://github.com/unitaryfoundation/clifft/pull/338).
 
 ### Changed
 
@@ -43,7 +51,9 @@ provenance.
   `clifft.noncomp.sample(..., max_active_width=...)`.
 - The default optimizer removes rotations whose phase is unobservable at a
   later terminal measurement, including safe cases across resets, disjoint
-  conditional corrections, noise, and classical bookkeeping.
+  conditional corrections, noise, and classical bookkeeping, by @bachase in
+  [#239](https://github.com/unitaryfoundation/clifft/pull/239) and
+  [#243](https://github.com/unitaryfoundation/clifft/pull/243).
 - A fixed seed remains reproducible for a fixed version and call, but sampled
   rows need not match v0.7 because the new executor has a different random
   number schedule.
@@ -64,7 +74,8 @@ provenance.
 ### Fixed
 
 - Reject invalid inverted targets instead of accepting inversion on
-  operations where it has no defined meaning.
+  operations where it has no defined meaning, by @bachase in
+  [#241](https://github.com/unitaryfoundation/clifft/pull/241).
 - Harden noncomputational continuation planning and reuse its storage without
   changing trajectory semantics.
 

--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -18,6 +18,9 @@ struct Overloaded : Visitors... {
     using Visitors::operator()...;
 };
 
+template <class... Visitors>
+Overloaded(Visitors...) -> Overloaded<Visitors...>;
+
 std::string_view backend_name(ExecutorBackend backend) {
     switch (backend) {
         case ExecutorBackend::Scalar:


### PR DESCRIPTION
## Summary

- add a curated v0.8.0 changelog entry
- consolidate the symbolic sampler migration into one release-level update instead of listing its development PRs
- summarize the independent gates, leakage, inspection, naming, compatibility, and correctness changes
- update the manual TestPyPI workflow default to `0.8.0.dev1`
- keep executable-plan inspection compatible with the AppleClang 15 release-wheel toolchain

## Release validation

- [x] Debug C++ suite: 831 non-benchmark tests
- [x] Python suite: 801 tests
- [x] strict MkDocs build
- [x] documentation codeblocks: 32 passed, 7 skipped
- [x] playground lint and production build
- [x] clean WASM rebuild and smoke test
- [x] `x86-64-v2` sdist and `cp312-abi3` wheel build with version `0.8.0.dev1`
- [x] wheel export audit and public-API smoke on Python 3.13
- [x] forced scalar, AVX2, and AVX-512 wheel execution
- [x] build/install from the sdist and export/API smoke on Python 3.12
- [x] full sdist and Linux x86-64, Linux arm64, macOS arm64, and Windows wheel matrix
- [x] Linux wheel QEMU smoke on Haswell and Nehalem, including forced-ISA fallback checks
- [x] trusted publish of `0.8.0.dev1` to TestPyPI ([workflow](https://github.com/unitaryfoundation/clifft/actions/runs/32176226205))
- [x] clean TestPyPI install, export audit, public compile/sample/inspection/statevector smoke, and forced scalar/AVX2 execution
- [x] pre-commit on all files

The three untracked benchmark investigation files in the working directory are unrelated and are not part of this PR.
