### PR TITLE
feat(api)!: derive sampling RNG streams per shot

### DIFF
--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -236,6 +236,8 @@ assert (r1.measurements == r2.measurements).all()  # Identical
 ```
 
 If `seed` is omitted or set to `None`, Clifft uses hardware entropy from the operating system.
+Each shot derives an independent random stream from the call seed and its shot
+index. Seeded results therefore do not depend on how shots are scheduled.
 
 ## Importance Sampling (Forced k-Faults)
 

--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -1,30 +1,13 @@
 #include "clifft/noncomp/sample.h"
 
-#include "clifft/noncomp/seed.h"
 #include "clifft/noncomp/trajectory_driver.h"
-#include "clifft/util/xoshiro.h"
+#include "clifft/util/shot_seed.h"
 
-#include <array>
 #include <stdexcept>
 
 namespace clifft {
 
 namespace {
-
-SeedRoot make_seed_root(uint32_t shots, std::optional<uint64_t> seed) {
-    if (seed.has_value()) {
-        return seed_root_from_seed(*seed);
-    }
-    SeedRoot root{};
-    if (shots > 0) {
-        const std::array<uint64_t, 4> words = entropy_seed_words();
-        root.w[0] = words[0];
-        root.w[1] = words[1];
-        root.w[2] = words[2];
-        root.w[3] = words[3];
-    }
-    return root;
-}
 
 void validate_noncomputational_entry(const Circuit& circuit) {
     if (circuit.num_exp_vals != 0) {

--- a/src/clifft/noncomp/sample.h
+++ b/src/clifft/noncomp/sample.h
@@ -7,7 +7,7 @@
 // ordinary sample records plus final-status and herald sidecars.
 //
 // Randomness is deterministic in `seed`: per-shot driver and executor streams
-// derive from domain-separated sub-seeds (seed.h). Stochastic classifier
+// derive from domain-separated sub-seeds (shot_seed.h). Stochastic classifier
 // bits are drawn by the executor's own stream at the rewriter's READOUT_NOISE
 // sites. With no seed, a global seed is drawn from OS entropy and the
 // run is non-reproducible.

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -10,14 +10,13 @@
 //
 // Driver draws (initial levels, transition destinations, classical outcomes,
 // and herald flags) use one per-shot stream. Executor measurements, noise, and
-// transition decisions use a separate per-shot stream; see seed.h.
+// transition decisions use a separate per-shot stream; see shot_seed.h.
 
 #include "clifft/noncomp/trajectory_driver.h"
 
 #include "clifft/frontend/frontend.h"
 #include "clifft/noncomp/instrument_options.h"
 #include "clifft/noncomp/rewriter.h"
-#include "clifft/noncomp/seed.h"
 #include "clifft/noncomp/status_walk.h"
 #include "clifft/noncomp/transition_hooks.h"
 #include "clifft/noncomp/transition_instrument.h"
@@ -25,6 +24,7 @@
 #include "clifft/optimizer/pass_registry.h"
 #include "clifft/sampling/executor.h"
 #include "clifft/sampling/planner.h"
+#include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
 
 #include <cassert>

--- a/src/clifft/noncomp/trajectory_driver.h
+++ b/src/clifft/noncomp/trajectory_driver.h
@@ -15,7 +15,7 @@
 #include "clifft/circuit/circuit.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/sample.h"
-#include "clifft/noncomp/seed.h"
+#include "clifft/util/shot_seed.h"
 
 #include <cstdint>
 #include <optional>

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -2,14 +2,21 @@
 
 #include "clifft/sampling/executor.h"
 #include "clifft/util/fault_sampling.h"
+#include "clifft/util/shot_seed.h"
 
 #include <algorithm>
+#include <array>
 #include <limits>
 #include <stdexcept>
 
 namespace clifft::sampling {
 
 namespace {
+
+void reseed_executor_for_shot(Executor& executor, const SeedRoot& root, uint32_t shot) noexcept {
+    const std::array<uint64_t, 4> words = derive_state(root, shot, kSamplingExecutorDomain);
+    executor.reseed_full(words[0], words[1], words[2], words[3]);
+}
 
 template <typename RunShot>
 SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
@@ -30,30 +37,22 @@ SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
         return result;
     }
 
-    auto run = [&](Executor& executor) {
-        for (uint32_t shot = 0; shot < shots; ++shot) {
-            run_shot(executor);
-            std::ranges::copy(executor.visible_records(),
-                              result.measurements.begin() +
-                                  static_cast<size_t>(shot) * plan.num_visible_records());
-            std::ranges::copy(
-                executor.detectors(),
-                result.detectors.begin() + static_cast<size_t>(shot) * plan.num_detectors());
-            std::ranges::copy(
-                executor.observables(),
-                result.observables.begin() + static_cast<size_t>(shot) * plan.num_observables());
-            std::ranges::copy(
-                executor.exp_vals(),
-                result.exp_vals.begin() + static_cast<size_t>(shot) * plan.num_exp_vals());
-        }
-    };
-    if (seed.has_value()) {
-        Executor executor(plan, *seed);
-        run(executor);
-    } else {
-        Executor executor(plan);
-        executor.reseed_from_entropy();
-        run(executor);
+    const SeedRoot root = make_seed_root(shots, seed);
+    Executor executor(plan);
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        reseed_executor_for_shot(executor, root, shot);
+        run_shot(executor);
+        std::ranges::copy(
+            executor.visible_records(),
+            result.measurements.begin() + static_cast<size_t>(shot) * plan.num_visible_records());
+        std::ranges::copy(
+            executor.detectors(),
+            result.detectors.begin() + static_cast<size_t>(shot) * plan.num_detectors());
+        std::ranges::copy(
+            executor.observables(),
+            result.observables.begin() + static_cast<size_t>(shot) * plan.num_observables());
+        std::ranges::copy(executor.exp_vals(), result.exp_vals.begin() +
+                                                   static_cast<size_t>(shot) * plan.num_exp_vals());
     }
     return result;
 }
@@ -80,40 +79,33 @@ SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_
         result.observables.reserve(checked_reserve(plan.num_observables()));
         result.exp_vals.reserve(checked_reserve(plan.num_exp_vals()));
     }
-    auto run = [&](Executor& executor) {
-        for (uint32_t shot = 0; shot < shots; ++shot) {
-            run_shot(executor);
-            if (executor.discarded()) {
-                continue;
-            }
-            ++result.passed_shots;
-            bool logical_error = false;
-            for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
-                const bool value = executor.observables()[observable] != 0;
-                result.observable_ones[observable] += static_cast<uint64_t>(value);
-                logical_error |= value;
-            }
-            result.logical_errors += static_cast<uint32_t>(logical_error);
-            if (keep_records) {
-                result.measurements.insert(result.measurements.end(),
-                                           executor.visible_records().begin(),
-                                           executor.visible_records().end());
-                result.detectors.insert(result.detectors.end(), executor.detectors().begin(),
-                                        executor.detectors().end());
-                result.observables.insert(result.observables.end(), executor.observables().begin(),
-                                          executor.observables().end());
-                result.exp_vals.insert(result.exp_vals.end(), executor.exp_vals().begin(),
-                                       executor.exp_vals().end());
-            }
+    const SeedRoot root = make_seed_root(shots, seed);
+    Executor executor(plan);
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        reseed_executor_for_shot(executor, root, shot);
+        run_shot(executor);
+        if (executor.discarded()) {
+            continue;
         }
-    };
-    if (seed.has_value()) {
-        Executor executor(plan, *seed);
-        run(executor);
-    } else {
-        Executor executor(plan);
-        executor.reseed_from_entropy();
-        run(executor);
+        ++result.passed_shots;
+        bool logical_error = false;
+        for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
+            const bool value = executor.observables()[observable] != 0;
+            result.observable_ones[observable] += static_cast<uint64_t>(value);
+            logical_error |= value;
+        }
+        result.logical_errors += static_cast<uint32_t>(logical_error);
+        if (keep_records) {
+            result.measurements.insert(result.measurements.end(),
+                                       executor.visible_records().begin(),
+                                       executor.visible_records().end());
+            result.detectors.insert(result.detectors.end(), executor.detectors().begin(),
+                                    executor.detectors().end());
+            result.observables.insert(result.observables.end(), executor.observables().begin(),
+                                      executor.observables().end());
+            result.exp_vals.insert(result.exp_vals.end(), executor.exp_vals().begin(),
+                                   executor.exp_vals().end());
+        }
     }
     return result;
 }

--- a/src/clifft/util/fault_sampling.cc
+++ b/src/clifft/util/fault_sampling.cc
@@ -54,6 +54,7 @@ KFaultSampler::KFaultSampler(std::span<const double> probabilities, uint32_t k) 
         uncertain_sites_, [&](uint32_t site) { return probabilities[site] == first_probability; });
     if (uniform_mode_) {
         uniform_pool_ = uncertain_sites_;
+        swap_targets_.resize(remaining_k_);
         return;
     }
 

--- a/src/clifft/util/fault_sampling.h
+++ b/src/clifft/util/fault_sampling.h
@@ -36,12 +36,16 @@ class KFaultSampler {
                 assert(draw >= 0.0 && draw < 1.0 && "fault selection draw must be in [0, 1)");
                 const uint32_t pick = j + static_cast<uint32_t>(draw * remaining);
                 std::swap(uniform_pool_[j], uniform_pool_[pick]);
+                swap_targets_[j] = pick;
             }
-            // Keep the pool permutation across calls so a seeded sampler has
-            // one stable RNG evolution while still returning circuit order.
-            std::sort(uniform_pool_.begin(), uniform_pool_.begin() + remaining_k_);
             for (uint32_t j = 0; j < remaining_k_; ++j) {
                 selected_sites_.push_back(uniform_pool_[j]);
+            }
+            // Restore the canonical pool so a shot's subset depends only on
+            // its own RNG stream, not on which earlier shots used this worker.
+            for (uint32_t j = remaining_k_; j > 0; --j) {
+                const uint32_t index = j - 1;
+                std::swap(uniform_pool_[index], uniform_pool_[swap_targets_[index]]);
             }
         } else {
             const uint32_t count = static_cast<uint32_t>(uncertain_sites_.size());
@@ -83,6 +87,7 @@ class KFaultSampler {
     std::vector<double> odds_ratios_;
     std::vector<double> dp_;
     std::vector<uint32_t> uniform_pool_;
+    std::vector<uint32_t> swap_targets_;
     std::vector<uint32_t> selected_sites_;
 };
 

--- a/src/clifft/util/shot_seed.h
+++ b/src/clifft/util/shot_seed.h
@@ -1,24 +1,22 @@
 #pragma once
 
-// Derives separate per-shot RNG states for the driver and executor. Keeping these
-// streams separate means that adding a driver-side random draw cannot consume
-// from or shift the executor's measurement sequence. Unseeded runs start with 256
-// bits of OS entropy; seeded runs expand the user's 64-bit seed
-// deterministically. Within either stream, different shots always receive
-// different 256-bit states. Each state word is mixed differently, so a match
-// in one word does not automatically repeat in the other three. For
-// independently generated roots, a given pair of states matches with
-// probability about 2^-256.
+// Derives deterministic per-shot RNG states from one call-level seed root.
+// A shot's stream depends only on the root, its global shot index, and a
+// domain label, so scheduling and worker count cannot change seeded results.
 
 #include "clifft/util/xoshiro.h"
 
 #include <array>
 #include <cstdint>
+#include <optional>
 
 namespace clifft {
 
-// Driver-side draws (initial levels, trap destinations, classical
-// consults, herald flags) vs. the in-executor Born measurement randomness.
+// Ordinary and fixed-fault sampling use one executor stream per shot.
+inline constexpr uint64_t kSamplingExecutorDomain = 0x01;
+
+// Driver-side trajectory draws (initial levels, trap destinations, classical
+// consults, and herald flags) must not shift in-executor Born randomness.
 inline constexpr uint64_t kTrajectoryDriverDomain = 0x11;
 inline constexpr uint64_t kTrajectoryExecutorDomain = 0x12;
 
@@ -36,9 +34,24 @@ inline SeedRoot seed_root_from_seed(uint64_t seed) {
     return root;
 }
 
-// Uses the SplitMix64 golden-gamma constant and mixing finalizer:
-// https://prng.di.unimi.it/splitmix64.c
-//
+// Seeded calls expand the user seed. Unseeded calls read OS entropy once and
+// derive every shot from that root. Zero-shot calls deliberately read no
+// entropy so their observable behavior stays empty and side-effect free.
+inline SeedRoot make_seed_root(uint32_t shots, std::optional<uint64_t> seed) {
+    if (seed.has_value()) {
+        return seed_root_from_seed(*seed);
+    }
+    SeedRoot root{};
+    if (shots != 0) {
+        const std::array<uint64_t, 4> words = entropy_seed_words();
+        root.w[0] = words[0];
+        root.w[1] = words[1];
+        root.w[2] = words[2];
+        root.w[3] = words[3];
+    }
+    return root;
+}
+
 // The odd shot multiplier preserves distinct shot indices modulo 2^64.
 // Including the word number in the stream label prevents a match in one
 // state word from automatically repeating in all four.

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -57,6 +57,21 @@ TEST_CASE("Conditioned fault sampler honors certain and impossible sites") {
     CHECK_THROWS_AS(clifft::KFaultSampler(probabilities, 4), std::invalid_argument);
 }
 
+TEST_CASE("Conditioned uniform fault draws do not retain prior-shot permutations") {
+    clifft::KFaultSampler sampler(std::array<double, 5>{0.2, 0.2, 0.2, 0.2, 0.2}, 2);
+    const std::array<double, 2> draws{0.7, 0.1};
+
+    size_t cursor = 0;
+    const auto first_span = sampler.sample([&]() { return draws[cursor++]; });
+    const std::vector<uint32_t> first(first_span.begin(), first_span.end());
+
+    cursor = 0;
+    const auto second_span = sampler.sample([&]() { return draws[cursor++]; });
+    const std::vector<uint32_t> second(second_span.begin(), second_span.end());
+
+    REQUIRE(second == first);
+}
+
 // =============================================================================
 // noise_site_probabilities
 // =============================================================================

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -5,6 +5,7 @@
 #include "clifft/sampling/sampler.h"
 #include "clifft/sampling/state_queries.h"
 #include "clifft/util/noise_sampling.h"
+#include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
 
 #include "instrument_test_helpers.h"
@@ -1263,6 +1264,24 @@ TEST_CASE("Sampling executor presamples mutually exclusive Pauli noise") {
     REQUIRE(q0_ones < 5500);
     REQUIRE(q1_ones > 2000);
     REQUIRE(q1_ones < 3000);
+}
+
+TEST_CASE("Sampling driver derives an independent RNG stream for each shot") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse("H 0\nM 0"));
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(hir));
+    constexpr uint32_t shots = 32;
+    constexpr uint64_t seed = 9182;
+    const clifft::sampling::SamplingResult result =
+        clifft::sampling::sample(executable, shots, seed);
+    const clifft::SeedRoot root = clifft::seed_root_from_seed(seed);
+    Executor executor(executable);
+
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const auto words = clifft::derive_state(root, shot, clifft::kSamplingExecutorDomain);
+        executor.reseed_full(words[0], words[1], words[2], words[3]);
+        executor.run_shot();
+        REQUIRE(result.measurements[shot] == executor.visible_records()[0]);
+    }
 }
 
 TEST_CASE("Sampling survivor execution normalizes and rejects detectors") {

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -9,7 +9,7 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/sample.h"
-#include "clifft/noncomp/seed.h"
+#include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
 
 #include "noncomp_test_helpers.h"


### PR DESCRIPTION
## Summary
- move the existing trajectory seed derivation into shared sampling infrastructure
- derive ordinary and fixed-fault RNG state from the call seed plus global shot index
- restore uniform fixed-fault sampler state after every shot so worker assignment cannot affect results
- document scheduling-independent seeded results

This is the RNG-contract prerequisite for #343 and the first PR in the cross-shot parallelism stack.

## Breaking change
Seeded sample, sample_survivors, sample_k, and sample_k_survivors rows change relative to v0.8. Calls remain reproducible, and future worker counts/scheduling will produce the same rows for a given seed.

## Validation
- ctest --test-dir build -E Bench --output-on-failure: 830 passed
- just py-test: 800 passed, 1 skipped
- just docs-build
- just py-doctest: 32 passed, 7 skipped
- just lint