### PR TITLE
feat(sampling): add cross-shot worker parallelism

### DIFF
--- a/docs/guide/importance-sampling.md
+++ b/docs/guide/importance-sampling.md
@@ -331,7 +331,7 @@ postselection. Key observations:
 
 ## API Reference
 
-### `clifft.sample_k(program, shots, k, seed=None)`
+### `clifft.sample_k(program, shots, k, seed=None, threads=1)`
 
 Sample with exactly `k` forced faults per shot. Returns
 a `SampleResult`, just like `clifft.sample()`. Results must be weighted by $P(K=k)$ for correct
@@ -344,7 +344,7 @@ discarded shots.
 Raises `ValueError` if the stratum has zero probability mass (e.g., `k`
 exceeds the number of non-zero-probability sites).
 
-### `clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False)`
+### `clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1)`
 
 Sample survivors with exactly `k` forced faults per shot. Returns a
 `SampleResult` whose `.measurements`, `.detectors`, and `.observables`

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -250,8 +250,10 @@ processes with CPU-affinity limits, set an explicit count if the reported
 hardware concurrency exceeds the available CPU quota.
 
 Workers dynamically claim contiguous shot ranges from a shared scheduler.
-Seeded rows and surviving-row order are identical for `threads=1`, an explicit
-worker count, and `threads="auto"`.
+With a fixed seed, changing `threads` produces exactly the same result.
+`sample()` and `sample_k()` keep each shot at the same row, and the survivor
+APIs return accepted shots in the same order as the corresponding one-thread
+run.
 
 Each worker owns a separate executor. Its dense coefficient and measurement
 scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -239,6 +239,25 @@ If `seed` is omitted or set to `None`, Clifft uses hardware entropy from the ope
 Each shot derives an independent random stream from the call seed and its shot
 index. Seeded results therefore do not depend on how shots are scheduled.
 
+## Parallel Shots
+
+`sample()`, `sample_survivors()`, `sample_k()`, and
+`sample_k_survivors()` accept a `threads` argument. It defaults to `1`, so
+existing calls remain serial. Pass a positive worker count to control resource
+use, or `threads="auto"` to use the implementation-reported hardware
+concurrency. Clifft never creates more workers than shots. In containers or
+processes with CPU-affinity limits, set an explicit count if the reported
+hardware concurrency exceeds the available CPU quota.
+
+Workers dynamically claim contiguous shot ranges from a shared scheduler.
+Seeded rows and surviving-row order are identical for `threads=1`, an explicit
+worker count, and `threads="auto"`.
+
+Each worker owns a separate executor. Its dense coefficient and measurement
+scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,
+plus symbolic state, records, and other executor metadata. Set an explicit
+worker count when memory is more constrained than CPU availability.
+
 ## Importance Sampling (Forced k-Faults)
 
 For circuits where logical errors are rare, standard Monte Carlo can require an impractical number of shots. Clifft provides stratified importance sampling via `sample_k` and `sample_k_survivors`, which force exactly `k` physical faults per shot. Results from different `k` strata must be combined using the corresponding Poisson-binomial probability $P(K = k)$.
@@ -254,8 +273,8 @@ result = clifft.sample_k_survivors(prog, shots=50_000, k=3, seed=42)
 
 Key API:
 
-- **`clifft.sample_k(program, shots, k, seed=None)`** -- Like `sample()`, but forces exactly `k` faults. Only valid for programs without post-selection; post-selected programs must use `sample_k_survivors()`. Returns a `SampleResult` with `.measurements`, `.detectors`, and `.observables`.
-- **`clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False)`** -- Like `sample_survivors()`, but forces exactly `k` faults. Returns a `SampleResult` whose arrays contain only surviving shots plus survivor metadata.
+- **`clifft.sample_k(program, shots, k, seed=None, threads=1)`** -- Like `sample()`, but forces exactly `k` faults. Only valid for programs without post-selection; post-selected programs must use `sample_k_survivors()`. Returns a `SampleResult` with `.measurements`, `.detectors`, and `.observables`.
+- **`clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1)`** -- Like `sample_survivors()`, but forces exactly `k` faults. Returns a `SampleResult` whose arrays contain only surviving shots plus survivor metadata.
 - **`program.noise_site_probabilities`** -- 1D NumPy array of per-site fault probabilities, with quantum noise sites followed by readout noise entries. Use this for computing the Poisson-binomial PMF.
 
 See the [Importance Sampling Tutorial](importance-sampling.md) for a complete walkthrough.

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -74,6 +74,9 @@ target_link_libraries(clifft_core PUBLIC
 
 target_link_libraries(clifft_core PRIVATE fast_float)
 
+find_package(Threads REQUIRED)
+target_link_libraries(clifft_core PUBLIC Threads::Threads)
+
 target_compile_features(clifft_core PUBLIC cxx_std_20)
 
 # Code coverage instrumentation (only for Clifft code, not dependencies)

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -2,11 +2,13 @@
 
 #include "clifft/sampling/executor.h"
 #include "clifft/util/fault_sampling.h"
+#include "clifft/util/shot_parallel.h"
 #include "clifft/util/shot_seed.h"
 
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 
 namespace clifft::sampling {
@@ -18,9 +20,70 @@ void reseed_executor_for_shot(Executor& executor, const SeedRoot& root, uint32_t
     executor.reseed_full(words[0], words[1], words[2], words[3]);
 }
 
-template <typename RunShot>
+struct SamplingWorker {
+    explicit SamplingWorker(const ExecutablePlan& plan) : executor(plan) {}
+
+    Executor executor;
+};
+
+struct ConditionedSamplingWorker {
+    ConditionedSamplingWorker(const ExecutablePlan& plan, std::span<const double> probabilities,
+                              uint32_t k)
+        : executor(plan), fault_sampler(probabilities, k) {}
+
+    Executor executor;
+    KFaultSampler fault_sampler;
+};
+
+struct SurvivorCounts {
+    explicit SurvivorCounts(uint32_t num_observables) : observable_ones(num_observables, 0) {}
+
+    uint32_t passed_shots = 0;
+    uint32_t logical_errors = 0;
+    std::vector<uint64_t> observable_ones;
+};
+
+struct SurvivorWorker {
+    explicit SurvivorWorker(const ExecutablePlan& plan)
+        : executor(plan), counts(plan.num_observables()) {}
+
+    Executor executor;
+    SurvivorCounts counts;
+};
+
+struct ConditionedSurvivorWorker {
+    ConditionedSurvivorWorker(const ExecutablePlan& plan, std::span<const double> probabilities,
+                              uint32_t k)
+        : executor(plan), fault_sampler(probabilities, k), counts(plan.num_observables()) {}
+
+    Executor executor;
+    KFaultSampler fault_sampler;
+    SurvivorCounts counts;
+};
+
+template <typename T>
+void compact_survivor_rows(std::vector<T>& values, std::span<const uint8_t> survived, size_t stride,
+                           uint32_t passed_shots) {
+    if (stride != 0) {
+        size_t output_row = 0;
+        for (size_t shot = 0; shot < survived.size(); ++shot) {
+            if (survived[shot] == 0) {
+                continue;
+            }
+            if (output_row != shot) {
+                std::copy_n(values.begin() + shot * stride, stride,
+                            values.begin() + output_row * stride);
+            }
+            ++output_row;
+        }
+    }
+    values.resize(static_cast<size_t>(passed_shots) * stride);
+}
+
+template <typename MakeWorker, typename RunShot>
 SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
-                                 std::optional<uint64_t> seed, RunShot&& run_shot) {
+                                 std::optional<uint64_t> seed, uint32_t threads,
+                                 MakeWorker&& make_worker, RunShot&& run_shot) {
     auto checked_size = [shots](size_t stride) {
         if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
             throw std::length_error("sampling output size exceeds size_t range");
@@ -38,28 +101,35 @@ SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
     }
 
     const SeedRoot root = make_seed_root(shots, seed);
-    Executor executor(plan);
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        reseed_executor_for_shot(executor, root, shot);
-        run_shot(executor);
-        std::ranges::copy(
-            executor.visible_records(),
-            result.measurements.begin() + static_cast<size_t>(shot) * plan.num_visible_records());
-        std::ranges::copy(
-            executor.detectors(),
-            result.detectors.begin() + static_cast<size_t>(shot) * plan.num_detectors());
-        std::ranges::copy(
-            executor.observables(),
-            result.observables.begin() + static_cast<size_t>(shot) * plan.num_observables());
-        std::ranges::copy(executor.exp_vals(), result.exp_vals.begin() +
-                                                   static_cast<size_t>(shot) * plan.num_exp_vals());
-    }
+    (void)run_shot_ranges(
+        shots, threads, std::forward<MakeWorker>(make_worker),
+        [&](auto& worker_handle, ShotRange range) {
+            auto& worker = *worker_handle;
+            Executor& executor = worker.executor;
+            for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                reseed_executor_for_shot(executor, root, shot);
+                run_shot(worker);
+                std::ranges::copy(executor.visible_records(),
+                                  result.measurements.begin() +
+                                      static_cast<size_t>(shot) * plan.num_visible_records());
+                std::ranges::copy(
+                    executor.detectors(),
+                    result.detectors.begin() + static_cast<size_t>(shot) * plan.num_detectors());
+                std::ranges::copy(executor.observables(),
+                                  result.observables.begin() +
+                                      static_cast<size_t>(shot) * plan.num_observables());
+                std::ranges::copy(
+                    executor.exp_vals(),
+                    result.exp_vals.begin() + static_cast<size_t>(shot) * plan.num_exp_vals());
+            }
+        });
     return result;
 }
 
-template <typename RunShot>
+template <typename MakeWorker, typename RunShot>
 SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_t shots,
                                              std::optional<uint64_t> seed, bool keep_records,
+                                             uint32_t threads, MakeWorker&& make_worker,
                                              RunShot&& run_shot) {
     SamplingSurvivorResult result;
     result.total_shots = shots;
@@ -74,45 +144,73 @@ SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_
             }
             return static_cast<size_t>(shots) * stride;
         };
-        result.measurements.reserve(checked_reserve(plan.num_visible_records()));
-        result.detectors.reserve(checked_reserve(plan.num_detectors()));
-        result.observables.reserve(checked_reserve(plan.num_observables()));
-        result.exp_vals.reserve(checked_reserve(plan.num_exp_vals()));
+        result.measurements.resize(checked_reserve(plan.num_visible_records()));
+        result.detectors.resize(checked_reserve(plan.num_detectors()));
+        result.observables.resize(checked_reserve(plan.num_observables()));
+        result.exp_vals.resize(checked_reserve(plan.num_exp_vals()));
     }
+    std::vector<uint8_t> survived(keep_records ? shots : 0, 0);
     const SeedRoot root = make_seed_root(shots, seed);
-    Executor executor(plan);
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        reseed_executor_for_shot(executor, root, shot);
-        run_shot(executor);
-        if (executor.discarded()) {
-            continue;
-        }
-        ++result.passed_shots;
-        bool logical_error = false;
+    auto workers = run_shot_ranges(
+        shots, threads, std::forward<MakeWorker>(make_worker),
+        [&](auto& worker_handle, ShotRange range) {
+            auto& worker = *worker_handle;
+            Executor& executor = worker.executor;
+            SurvivorCounts& counts = worker.counts;
+            for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                reseed_executor_for_shot(executor, root, shot);
+                run_shot(worker);
+                if (executor.discarded()) {
+                    continue;
+                }
+                ++counts.passed_shots;
+                bool logical_error = false;
+                for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
+                    const bool value = executor.observables()[observable] != 0;
+                    counts.observable_ones[observable] += static_cast<uint64_t>(value);
+                    logical_error |= value;
+                }
+                counts.logical_errors += static_cast<uint32_t>(logical_error);
+                if (keep_records) {
+                    survived[shot] = 1;
+                    std::ranges::copy(executor.visible_records(),
+                                      result.measurements.begin() +
+                                          static_cast<size_t>(shot) * plan.num_visible_records());
+                    std::ranges::copy(executor.detectors(),
+                                      result.detectors.begin() +
+                                          static_cast<size_t>(shot) * plan.num_detectors());
+                    std::ranges::copy(executor.observables(),
+                                      result.observables.begin() +
+                                          static_cast<size_t>(shot) * plan.num_observables());
+                    std::ranges::copy(
+                        executor.exp_vals(),
+                        result.exp_vals.begin() + static_cast<size_t>(shot) * plan.num_exp_vals());
+                }
+            }
+        });
+    for (const auto& worker : workers) {
+        result.passed_shots += worker->counts.passed_shots;
+        result.logical_errors += worker->counts.logical_errors;
         for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
-            const bool value = executor.observables()[observable] != 0;
-            result.observable_ones[observable] += static_cast<uint64_t>(value);
-            logical_error |= value;
+            result.observable_ones[observable] += worker->counts.observable_ones[observable];
         }
-        result.logical_errors += static_cast<uint32_t>(logical_error);
-        if (keep_records) {
-            result.measurements.insert(result.measurements.end(),
-                                       executor.visible_records().begin(),
-                                       executor.visible_records().end());
-            result.detectors.insert(result.detectors.end(), executor.detectors().begin(),
-                                    executor.detectors().end());
-            result.observables.insert(result.observables.end(), executor.observables().begin(),
-                                      executor.observables().end());
-            result.exp_vals.insert(result.exp_vals.end(), executor.exp_vals().begin(),
-                                   executor.exp_vals().end());
-        }
+    }
+    if (keep_records) {
+        compact_survivor_rows(result.measurements, survived, plan.num_visible_records(),
+                              result.passed_shots);
+        compact_survivor_rows(result.detectors, survived, plan.num_detectors(),
+                              result.passed_shots);
+        compact_survivor_rows(result.observables, survived, plan.num_observables(),
+                              result.passed_shots);
+        compact_survivor_rows(result.exp_vals, survived, plan.num_exp_vals(), result.passed_shots);
     }
     return result;
 }
 
 }  // namespace
 
-SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed) {
+SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed,
+                      uint32_t threads) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "fixed-plan sampling does not support instrument traps; use the trajectory driver");
@@ -126,17 +224,20 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
             "fixed-row sampling does not support postselection; use sample_survivors");
     }
 
-    return sample_fixed_rows(plan, shots, seed,
-                             [](Executor& executor) noexcept { executor.run_shot(); });
+    return sample_fixed_rows(
+        plan, shots, seed, threads,
+        [&](uint32_t) { return std::make_unique<SamplingWorker>(plan); },
+        [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
 }
 
 std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
-                                    std::optional<uint64_t> seed) {
-    return sample(plan, shots, seed).measurements;
+                                    std::optional<uint64_t> seed, uint32_t threads) {
+    return sample(plan, shots, seed, threads).measurements;
 }
 
 SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
-                                        std::optional<uint64_t> seed, bool keep_records) {
+                                        std::optional<uint64_t> seed, bool keep_records,
+                                        uint32_t threads) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "survivor sampling does not support instrument traps; use the trajectory driver");
@@ -146,12 +247,14 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
             "survivor sampling requires a distribution for every presampled symbol");
     }
 
-    return sample_surviving_rows(plan, shots, seed, keep_records,
-                                 [](Executor& executor) noexcept { executor.run_shot(); });
+    return sample_surviving_rows(
+        plan, shots, seed, keep_records, threads,
+        [&](uint32_t) { return std::make_unique<SurvivorWorker>(plan); },
+        [](SurvivorWorker& worker) noexcept { worker.executor.run_shot(); });
 }
 
 SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
-                        std::optional<uint64_t> seed) {
+                        std::optional<uint64_t> seed, uint32_t threads) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "forced-fault sampling does not support instrument traps or trajectory drivers");
@@ -166,16 +269,25 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
             "sample_k_survivors");
     }
     if (shots == 0) {
-        return sample_fixed_rows(plan, shots, seed,
-                                 [](Executor& executor) noexcept { executor.run_shot(); });
+        return sample_fixed_rows(
+            plan, shots, seed, threads,
+            [&](uint32_t) { return std::make_unique<SamplingWorker>(plan); },
+            [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
     }
-    KFaultSampler fault_sampler(plan.noise_site_probabilities(), k);
+    const std::vector<double> probabilities = plan.noise_site_probabilities();
     return sample_fixed_rows(
-        plan, shots, seed, [&](Executor& executor) noexcept { executor.run_shot(fault_sampler); });
+        plan, shots, seed, threads,
+        [&](uint32_t) {
+            return std::make_unique<ConditionedSamplingWorker>(plan, probabilities, k);
+        },
+        [](ConditionedSamplingWorker& worker) noexcept {
+            worker.executor.run_shot(worker.fault_sampler);
+        });
 }
 
 SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
-                                          std::optional<uint64_t> seed, bool keep_records) {
+                                          std::optional<uint64_t> seed, bool keep_records,
+                                          uint32_t threads) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "forced-fault survivor sampling does not support instrument traps or trajectory "
@@ -186,13 +298,20 @@ SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t s
             "forced-fault survivor sampling requires a distribution for every presampled symbol");
     }
     if (shots == 0) {
-        return sample_surviving_rows(plan, shots, seed, keep_records,
-                                     [](Executor& executor) noexcept { executor.run_shot(); });
+        return sample_surviving_rows(
+            plan, shots, seed, keep_records, threads,
+            [&](uint32_t) { return std::make_unique<SurvivorWorker>(plan); },
+            [](SurvivorWorker& worker) noexcept { worker.executor.run_shot(); });
     }
-    KFaultSampler fault_sampler(plan.noise_site_probabilities(), k);
-    return sample_surviving_rows(plan, shots, seed, keep_records, [&](Executor& executor) noexcept {
-        executor.run_shot(fault_sampler);
-    });
+    const std::vector<double> probabilities = plan.noise_site_probabilities();
+    return sample_surviving_rows(
+        plan, shots, seed, keep_records, threads,
+        [&](uint32_t) {
+            return std::make_unique<ConditionedSurvivorWorker>(plan, probabilities, k);
+        },
+        [](ConditionedSurvivorWorker& worker) noexcept {
+            worker.executor.run_shot(worker.fault_sampler);
+        });
 }
 
 std::vector<double> record_log_probabilities(const ExecutablePlan& plan,

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -39,8 +39,12 @@ struct SamplingSurvivorResult {
 // plan and executor are prepared once, and all output is allocated before the
 // first shot enters hot execution. Plans with presampled symbols are rejected
 // until their sampling distribution is part of the executable contract.
+// threads=0 selects the implementation-reported hardware concurrency; the
+// public Python API spells this as threads="auto". Explicit worker counts are
+// capped at the number of shots.
 [[nodiscard]] std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
-                                                  std::optional<uint64_t> seed = std::nullopt);
+                                                  std::optional<uint64_t> seed = std::nullopt,
+                                                  uint32_t threads = 1);
 
 // Replays each row-major visible record and returns its joint log probability.
 // Unreachable records map to the lowest finite double because release builds
@@ -52,18 +56,22 @@ struct SamplingSurvivorResult {
                                                            size_t num_records);
 
 [[nodiscard]] SamplingResult sample(const ExecutablePlan& plan, uint32_t shots,
-                                    std::optional<uint64_t> seed = std::nullopt);
+                                    std::optional<uint64_t> seed = std::nullopt,
+                                    uint32_t threads = 1);
 
 [[nodiscard]] SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
                                                       std::optional<uint64_t> seed = std::nullopt,
-                                                      bool keep_records = false);
+                                                      bool keep_records = false,
+                                                      uint32_t threads = 1);
 
 [[nodiscard]] SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
-                                      std::optional<uint64_t> seed = std::nullopt);
+                                      std::optional<uint64_t> seed = std::nullopt,
+                                      uint32_t threads = 1);
 
 [[nodiscard]] SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots,
                                                         uint32_t k,
                                                         std::optional<uint64_t> seed = std::nullopt,
-                                                        bool keep_records = false);
+                                                        bool keep_records = false,
+                                                        uint32_t threads = 1);
 
 }  // namespace clifft::sampling

--- a/src/clifft/util/shot_parallel.h
+++ b/src/clifft/util/shot_parallel.h
@@ -1,0 +1,144 @@
+#pragma once
+
+// Shared cross-shot scheduling for sampling frontends. The worker factory
+// creates every fully allocated context before this helper starts dispatch,
+// then workers claim disjoint global shot ranges dynamically.
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace clifft {
+
+struct ShotRange {
+    uint32_t begin = 0;
+    uint32_t end = 0;
+};
+
+// requested_threads == 0 selects the implementation-reported hardware
+// concurrency. A shot batch never creates more workers than shots, and
+// environments without native threads use the serial implementation.
+inline uint32_t resolve_shot_worker_count(uint32_t shots, uint32_t requested_threads) noexcept {
+    if (shots == 0) {
+        return 0;
+    }
+#if defined(__EMSCRIPTEN__)
+    (void)requested_threads;
+    return 1;
+#else
+    uint32_t workers = requested_threads;
+    if (workers == 0) {
+        workers = std::thread::hardware_concurrency();
+        if (workers == 0) {
+            workers = 1;
+        }
+    }
+    return std::min(workers, shots);
+#endif
+}
+
+inline uint32_t shot_chunk_size(uint32_t shots, uint32_t workers) noexcept {
+    assert(workers != 0 && "shot chunking requires at least one worker");
+    constexpr uint64_t kTargetChunksPerWorker = 8;
+    const uint64_t target_chunks = static_cast<uint64_t>(workers) * kTargetChunksPerWorker;
+    return static_cast<uint32_t>(
+        std::max<uint64_t>(1, (static_cast<uint64_t>(shots) + target_chunks - 1) / target_chunks));
+}
+
+// make_worker(index) runs for every worker before any range is dispatched.
+// run_range(worker_handle, range) may execute concurrently for different
+// handles. If it throws, remaining work is cancelled, all threads are joined,
+// and the first exception is rethrown on the calling thread.
+template <typename MakeWorker, typename RunRange>
+auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWorker&& make_worker,
+                     RunRange&& run_range) {
+    using WorkerHandle = std::remove_cvref_t<std::invoke_result_t<MakeWorker, uint32_t>>;
+    const uint32_t worker_count = resolve_shot_worker_count(shots, requested_threads);
+    std::vector<WorkerHandle> workers;
+    workers.reserve(worker_count);
+    for (uint32_t worker = 0; worker < worker_count; ++worker) {
+        workers.emplace_back(std::invoke(make_worker, worker));
+    }
+    if (worker_count == 0) {
+        return workers;
+    }
+    if (worker_count == 1) {
+        std::invoke(run_range, workers[0], ShotRange{0, shots});
+        return workers;
+    }
+
+#if defined(__EMSCRIPTEN__)
+    std::invoke(run_range, workers[0], ShotRange{0, shots});
+#else
+    const uint32_t chunk_size = shot_chunk_size(shots, worker_count);
+    std::atomic<uint64_t> next_shot{0};
+    std::atomic<bool> cancelled{false};
+    std::exception_ptr first_error;
+    std::mutex error_mutex;
+
+    auto worker_loop = [&](uint32_t worker) noexcept {
+        try {
+            while (!cancelled.load(std::memory_order_relaxed)) {
+                const uint64_t begin = next_shot.fetch_add(chunk_size, std::memory_order_relaxed);
+                if (begin >= shots) {
+                    return;
+                }
+                const uint64_t end = std::min<uint64_t>(begin + chunk_size, shots);
+                std::invoke(run_range, workers[worker],
+                            ShotRange{static_cast<uint32_t>(begin), static_cast<uint32_t>(end)});
+            }
+        } catch (...) {
+            {
+                std::lock_guard lock(error_mutex);
+                if (first_error == nullptr) {
+                    first_error = std::current_exception();
+                }
+            }
+            cancelled.store(true, std::memory_order_relaxed);
+        }
+    };
+
+    // std::thread keeps the documented compiler-library floor. This guard is
+    // needed because constructing a later thread can throw after earlier ones
+    // have started; every exit must join those threads before destroying them.
+    struct JoiningThreads {
+        std::vector<std::thread>& threads;
+
+        ~JoiningThreads() {
+            for (std::thread& thread : threads) {
+                if (thread.joinable()) {
+                    thread.join();
+                }
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(worker_count - 1);
+    {
+        JoiningThreads joining{threads};
+        try {
+            for (uint32_t worker = 1; worker < worker_count; ++worker) {
+                threads.emplace_back(worker_loop, worker);
+            }
+        } catch (...) {
+            cancelled.store(true, std::memory_order_relaxed);
+            throw;
+        }
+        worker_loop(0);
+    }
+    if (first_error != nullptr) {
+        std::rethrow_exception(first_error);
+    }
+#endif
+    return workers;
+}
+
+}  // namespace clifft

--- a/src/clifft/util/shot_parallel.h
+++ b/src/clifft/util/shot_parallel.h
@@ -105,9 +105,10 @@ auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWorker&& ma
         }
     };
 
-    // std::thread keeps the documented compiler-library floor. This guard is
-    // needed because constructing a later thread can throw after earlier ones
-    // have started; every exit must join those threads before destroying them.
+    // std::jthread is unavailable on some of the minimum compiler and standard
+    // library versions we support. This lifetime helper ensures every std::thread
+    // is joined, including when constructing a later thread throws after earlier
+    // workers have started.
     struct JoiningThreads {
         std::vector<std::thread>& threads;
 

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -20,19 +20,38 @@
 #include "clifft/util/runtime_isa.h"
 #include "clifft/util/version.h"
 
+#include <limits>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/map.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
+#include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 #include <span>
 #include <stdexcept>
+#include <variant>
 
 namespace nb = nanobind;
 
 namespace {
+
+using ThreadOption = std::variant<int64_t, std::string>;
+
+uint32_t parse_thread_option(const ThreadOption& option) {
+    if (const auto* name = std::get_if<std::string>(&option)) {
+        if (*name == "auto") {
+            return 0;
+        }
+        throw std::invalid_argument("threads must be a positive integer or 'auto'");
+    }
+    const int64_t count = std::get<int64_t>(option);
+    if (count <= 0 || static_cast<uint64_t>(count) > std::numeric_limits<uint32_t>::max()) {
+        throw std::invalid_argument("threads must be a positive integer or 'auto'");
+    }
+    return static_cast<uint32_t>(count);
+}
 
 // Zero-copy transfer: move a std::vector into a numpy array via capsule ownership.
 // Uses unique_ptr for exception safety: if capsule construction throws,
@@ -722,17 +741,18 @@ NB_MODULE(_clifft_core, m) {
     m.def(
         "sample",
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
-           std::optional<uint64_t> seed) {
+           std::optional<uint64_t> seed, const ThreadOption& thread_option) {
             if (program.has_postselection()) {
                 throw nb::value_error(
                     "sample() cannot be used with post-selected programs because it "
                     "returns a fixed number of rows and cannot discard shots. "
                     "Use sample_survivors(program, shots, keep_records=True) instead.");
             }
+            const uint32_t threads = parse_thread_option(thread_option);
             clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                result = clifft::sampling::sample(program, shots, seed);
+                result = clifft::sampling::sample(program, shots, seed, threads);
             }
 
             auto meas_arr = vec_to_numpy(std::move(result.measurements),
@@ -748,27 +768,31 @@ NB_MODULE(_clifft_core, m) {
                                             nb::none(), nb::none(), ev_arr);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
+        nb::arg("threads") = int64_t{1},
         "Run a compiled program and return a SampleResult.\n\n"
         "Raises ValueError for post-selected programs because fixed-row output\n"
         "cannot represent discarded shots. Use sample_survivors() instead.\n\n"
-        "If seed is None (default), uses hardware entropy.\n\n"
+        "If seed is None (default), uses hardware entropy. threads is a positive\n"
+        "worker count or 'auto' to use the implementation-reported hardware\n"
+        "concurrency; it defaults to 1.\n\n"
         "Returns a SampleResult with .measurements, .detectors, .observables attributes.\n"
         "Supports tuple unpacking: m, d, o = clifft.sample(prog, shots)");
 
     m.def(
         "sample_k",
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
-           std::optional<uint64_t> seed) {
+           std::optional<uint64_t> seed, const ThreadOption& thread_option) {
             if (program.has_postselection()) {
                 throw nb::value_error(
                     "sample_k() cannot be used with post-selected programs because it "
                     "returns a fixed number of rows and cannot discard shots. "
                     "Use sample_k_survivors(program, shots, k, keep_records=True) instead.");
             }
+            const uint32_t threads = parse_thread_option(thread_option);
             clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                result = clifft::sampling::sample_k(program, shots, k, seed);
+                result = clifft::sampling::sample_k(program, shots, k, seed, threads);
             }
 
             auto meas_arr = vec_to_numpy(std::move(result.measurements),
@@ -784,6 +808,7 @@ NB_MODULE(_clifft_core, m) {
                                             nb::none(), nb::none(), ev_arr);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
+        nb::arg("threads") = int64_t{1},
         "Sample with exactly k forced faults per shot (importance sampling).\n\n"
         "Sites are drawn from the exact conditional Poisson-Binomial\n"
         "distribution. Results are conditioned on K=k and must be combined\n"
@@ -796,7 +821,9 @@ NB_MODULE(_clifft_core, m) {
         "Raises ValueError if the k-fault stratum has zero probability mass\n"
         "(e.g. k exceeds the number of non-zero-probability sites).\n\n"
         "When all site probabilities are equal, an O(k) Fisher-Yates\n"
-        "sampler is used automatically.\n\n"
+        "sampler is used automatically. threads is a positive worker count\n"
+        "or 'auto' to use the implementation-reported hardware concurrency;\n"
+        "it defaults to 1.\n\n"
         "Returns a SampleResult with .measurements, .detectors, .observables attributes.\n"
         "Supports tuple unpacking: m, d, o = clifft.sample_k(prog, shots, k)");
 
@@ -831,24 +858,28 @@ NB_MODULE(_clifft_core, m) {
     m.def(
         "sample_k_survivors",
         [make_survivor_result](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
-                               uint32_t k, std::optional<uint64_t> seed, bool keep_records) {
+                               uint32_t k, std::optional<uint64_t> seed, bool keep_records,
+                               const ThreadOption& thread_option) {
+            const uint32_t threads = parse_thread_option(thread_option);
             clifft::sampling::SamplingSurvivorResult result;
             {
                 nb::gil_scoped_release release;
-                result =
-                    clifft::sampling::sample_k_survivors(program, shots, k, seed, keep_records);
+                result = clifft::sampling::sample_k_survivors(program, shots, k, seed, keep_records,
+                                                              threads);
             }
             return make_survivor_result(std::move(result), program, keep_records);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
-        nb::arg("keep_records") = false,
+        nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
         "Sample survivors with exactly k forced faults per shot.\n\n"
         "Results are conditioned on K=k. To estimate the overall logical\n"
         "error rate across strata, weight numerator and denominator\n"
         "separately to account for k-dependent survival probability:\n"
         "  p_fail = sum(P(K=k)*logical_errors_k/shots_k)\n"
         "         / sum(P(K=k)*passed_k/shots_k)\n\n"
-        "Raises ValueError if the k-fault stratum has zero probability mass.\n\n"
+        "Raises ValueError if the k-fault stratum has zero probability mass.\n"
+        "threads is a positive worker count or 'auto' to use the\n"
+        "implementation-reported hardware concurrency; it defaults to 1.\n\n"
         "Returns a SampleResult. Survivor metadata is always populated via\n"
         ".total_shots, .passed_shots, .discards, .logical_errors, and\n"
         ".observable_ones. Per-shot record arrays\n"
@@ -858,18 +889,23 @@ NB_MODULE(_clifft_core, m) {
     m.def(
         "sample_survivors",
         [make_survivor_result](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
-                               std::optional<uint64_t> seed, bool keep_records) {
+                               std::optional<uint64_t> seed, bool keep_records,
+                               const ThreadOption& thread_option) {
+            const uint32_t threads = parse_thread_option(thread_option);
             clifft::sampling::SamplingSurvivorResult result;
             {
                 nb::gil_scoped_release release;
-                result = clifft::sampling::sample_survivors(program, shots, seed, keep_records);
+                result =
+                    clifft::sampling::sample_survivors(program, shots, seed, keep_records, threads);
             }
             return make_survivor_result(std::move(result), program, keep_records);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
-        nb::arg("keep_records") = false,
+        nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
         "Sample shots and return results only for surviving (non-discarded) shots.\n\n"
-        "If seed is None (default), uses hardware entropy.\n\n"
+        "If seed is None (default), uses hardware entropy. threads is a positive\n"
+        "worker count or 'auto' to use the implementation-reported hardware\n"
+        "concurrency; it defaults to 1.\n\n"
         "Returns a SampleResult. Survivor metadata is always populated via\n"
         ".total_shots, .passed_shots, .discards, .logical_errors, and\n"
         ".observable_ones. Per-shot record arrays\n"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(clifft_tests
     test_source_map.cc
     test_importance_sampling.cc
     test_runtime_isa.cc
+    test_shot_parallel.cc
     test_fuzz.cc
     test_noncomp_value_types.cc
     test_noncomp_transition_instrument.cc

--- a/tests/python/test_importance_sampling.py
+++ b/tests/python/test_importance_sampling.py
@@ -154,6 +154,12 @@ class TestSampleK(_ImportanceBackendMixin):
         np.testing.assert_array_equal(r1.detectors, r2.detectors)
         np.testing.assert_array_equal(r1.observables, r2.observables)
 
+    def test_threads_preserve_seeded_rows(self) -> None:
+        prog = self.compile("X_ERROR(0.1) 0 1 2\nM 0 1 2")
+        serial = self.sampling_api.sample_k(prog, shots=257, k=1, seed=99, threads=1)
+        threaded = self.sampling_api.sample_k(prog, shots=257, k=1, seed=99, threads="auto")
+        np.testing.assert_array_equal(threaded.measurements, serial.measurements)
+
     def test_readout_noise_forcing(self) -> None:
         """k=1 with only readout noise should flip every shot."""
         prog = self.compile(
@@ -206,6 +212,24 @@ class TestSampleKSurvivors(_ImportanceBackendMixin):
         assert result.measurements.shape == (passed, prog.num_measurements)
         assert result.detectors.shape == (passed, prog.num_detectors)
         assert result.observables.shape == (passed, prog.num_observables)
+
+    def test_threads_preserve_seeded_survivors(self) -> None:
+        prog = self.sampling_api.compile(
+            "X_ERROR(0.1) 0 1 2\nM 0 1 2\nDETECTOR rec[-3]\n" "OBSERVABLE_INCLUDE(0) rec[-1]",
+            postselection_mask=[1],
+        )
+        serial = self.sampling_api.sample_k_survivors(
+            prog, shots=257, k=1, seed=100, keep_records=True, threads=1
+        )
+        threaded = self.sampling_api.sample_k_survivors(
+            prog, shots=257, k=1, seed=100, keep_records=True, threads=3
+        )
+        assert threaded.passed_shots == serial.passed_shots
+        assert threaded.logical_errors == serial.logical_errors
+        np.testing.assert_array_equal(threaded.observable_ones, serial.observable_ones)
+        np.testing.assert_array_equal(threaded.measurements, serial.measurements)
+        np.testing.assert_array_equal(threaded.detectors, serial.detectors)
+        np.testing.assert_array_equal(threaded.observables, serial.observables)
 
 
 class TestImportanceSamplingEndToEnd(_ImportanceBackendMixin):

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -139,6 +139,25 @@ class TestSample:
         result2 = sampling_api.sample(prog, 100, seed=12345)
         assert np.array_equal(result1.measurements, result2.measurements)
 
+    @pytest.mark.parametrize("threads", [2, "auto"])
+    def test_sample_threads_preserve_seeded_rows(self, sampling_api: Any, threads: Any) -> None:
+        """Worker count and dynamic scheduling do not change seeded rows."""
+        prog = sampling_api.compile(
+            "H 0 1\nT 0\nM 0 1\nDETECTOR rec[-2] rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]"
+        )
+        serial = sampling_api.sample(prog, 257, seed=12345, threads=1)
+        threaded = sampling_api.sample(prog, 257, seed=12345, threads=threads)
+        np.testing.assert_array_equal(threaded.measurements, serial.measurements)
+        np.testing.assert_array_equal(threaded.detectors, serial.detectors)
+        np.testing.assert_array_equal(threaded.observables, serial.observables)
+
+    @pytest.mark.parametrize("threads", [0, -1, "all", 1.5])
+    def test_sample_rejects_invalid_threads(self, sampling_api: Any, threads: Any) -> None:
+        """Only positive integers and the auto sentinel are accepted."""
+        prog = sampling_api.compile("M 0")
+        with pytest.raises((TypeError, ValueError), match="threads|incompatible"):
+            sampling_api.sample(prog, 1, threads=threads)
+
     def test_sample_different_seeds(self, sampling_api: Any) -> None:
         """Different seeds produce different results."""
         prog = sampling_api.compile("H 0\nM 0")
@@ -827,6 +846,24 @@ class TestSampleSurvivors:
         assert np.all(result.detectors[:, 0] == 0)
         # All surviving observables should be 0
         assert np.all(result.observables == 0)
+
+    @pytest.mark.parametrize("threads", [3, "auto"])
+    def test_threads_preserve_survivor_rows(self, sampling_api: Any, threads: Any) -> None:
+        """Survivor compaction remains ordered across worker schedules."""
+        prog = sampling_api.compile(
+            "H 0\nM 0\nDETECTOR rec[-1]\nH 1\nM 1\nOBSERVABLE_INCLUDE(0) rec[-1]",
+            postselection_mask=[1],
+        )
+        serial = sampling_api.sample_survivors(prog, 257, seed=54321, keep_records=True, threads=1)
+        threaded = sampling_api.sample_survivors(
+            prog, 257, seed=54321, keep_records=True, threads=threads
+        )
+        assert threaded.passed_shots == serial.passed_shots
+        assert threaded.logical_errors == serial.logical_errors
+        np.testing.assert_array_equal(threaded.observable_ones, serial.observable_ones)
+        np.testing.assert_array_equal(threaded.measurements, serial.measurements)
+        np.testing.assert_array_equal(threaded.detectors, serial.detectors)
+        np.testing.assert_array_equal(threaded.observables, serial.observables)
 
     def test_no_postselection_all_pass(self, sampling_api: Any) -> None:
         """Without postselection, all shots pass."""

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -535,6 +535,43 @@ TEST_CASE("Symbolic conditioned survivors preserve normalized outputs") {
                               [](uint8_t value) { return value == 0; }));
 }
 
+TEST_CASE("Threaded conditioned sampling preserves seeded rows and survivors") {
+    auto fixed = compile_circuit(R"(
+        X_ERROR(0.1) 0 1 2
+        M 0 1 2
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )");
+    const clifft::sampling::SamplingResult fixed_serial =
+        clifft::sampling::sample_k(fixed, 257, 1, 47, 1);
+    const clifft::sampling::SamplingResult fixed_threaded =
+        clifft::sampling::sample_k(fixed, 257, 1, 47, 3);
+    REQUIRE(fixed_threaded.measurements == fixed_serial.measurements);
+    REQUIRE(fixed_threaded.detectors == fixed_serial.detectors);
+    REQUIRE(fixed_threaded.observables == fixed_serial.observables);
+    REQUIRE(fixed_threaded.exp_vals == fixed_serial.exp_vals);
+
+    const std::array<uint8_t, 1> postselection{1};
+    auto survivors = compile_circuit(R"(
+        X_ERROR(0.1) 0 1 2
+        M 0 1 2
+        DETECTOR rec[-3]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )",
+                                     postselection);
+    const clifft::sampling::SamplingSurvivorResult survivor_serial =
+        clifft::sampling::sample_k_survivors(survivors, 257, 1, 48, true, 1);
+    const clifft::sampling::SamplingSurvivorResult survivor_threaded =
+        clifft::sampling::sample_k_survivors(survivors, 257, 1, 48, true, 3);
+    REQUIRE(survivor_threaded.total_shots == survivor_serial.total_shots);
+    REQUIRE(survivor_threaded.passed_shots == survivor_serial.passed_shots);
+    REQUIRE(survivor_threaded.logical_errors == survivor_serial.logical_errors);
+    REQUIRE(survivor_threaded.observable_ones == survivor_serial.observable_ones);
+    REQUIRE(survivor_threaded.measurements == survivor_serial.measurements);
+    REQUIRE(survivor_threaded.detectors == survivor_serial.detectors);
+    REQUIRE(survivor_threaded.observables == survivor_serial.observables);
+    REQUIRE(survivor_threaded.exp_vals == survivor_serial.exp_vals);
+}
+
 TEST_CASE("Symbolic conditioned sampling rejects asymmetric readout noise") {
     auto program = compile_circuit("M 0\nREADOUT_NOISE(0.1, 0.2) rec[-1]\n");
     CHECK_THROWS_WITH(program.noise_site_probabilities(),

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1284,6 +1284,60 @@ TEST_CASE("Sampling driver derives an independent RNG stream for each shot") {
     }
 }
 
+TEST_CASE("Threaded fixed-row sampling preserves seeded shot order") {
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+        H 0 1
+        T 0
+        M 0 1
+        DETECTOR rec[-2] rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        EXP_VAL Z0
+    )"))));
+    const clifft::sampling::SamplingResult serial =
+        clifft::sampling::sample(executable, 257, uint64_t{9183}, 1);
+
+    for (uint32_t threads : std::array<uint32_t, 2>{2, 0}) {
+        const clifft::sampling::SamplingResult threaded =
+            clifft::sampling::sample(executable, 257, uint64_t{9183}, threads);
+        CAPTURE(threads);
+        REQUIRE(threaded.measurements == serial.measurements);
+        REQUIRE(threaded.detectors == serial.detectors);
+        REQUIRE(threaded.observables == serial.observables);
+        REQUIRE(threaded.exp_vals == serial.exp_vals);
+    }
+}
+
+TEST_CASE("Threaded survivor sampling preserves seeded survivors and records") {
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+            H 0
+            M 0
+            DETECTOR rec[-1]
+            H 1
+            M 1
+            OBSERVABLE_INCLUDE(0) rec[-1]
+            EXP_VAL Z1
+        )")),
+                                        {.postselection_mask = postselection}));
+    const clifft::sampling::SamplingSurvivorResult serial =
+        clifft::sampling::sample_survivors(executable, 257, uint64_t{9184}, true, 1);
+
+    for (uint32_t threads : std::array<uint32_t, 2>{3, 0}) {
+        const clifft::sampling::SamplingSurvivorResult threaded =
+            clifft::sampling::sample_survivors(executable, 257, uint64_t{9184}, true, threads);
+        CAPTURE(threads);
+        REQUIRE(threaded.total_shots == serial.total_shots);
+        REQUIRE(threaded.passed_shots == serial.passed_shots);
+        REQUIRE(threaded.logical_errors == serial.logical_errors);
+        REQUIRE(threaded.observable_ones == serial.observable_ones);
+        REQUIRE(threaded.measurements == serial.measurements);
+        REQUIRE(threaded.detectors == serial.detectors);
+        REQUIRE(threaded.observables == serial.observables);
+        REQUIRE(threaded.exp_vals == serial.exp_vals);
+    }
+}
+
 TEST_CASE("Sampling survivor execution normalizes and rejects detectors") {
     const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
         H 0

--- a/tests/test_shot_parallel.cc
+++ b/tests/test_shot_parallel.cc
@@ -1,0 +1,111 @@
+#include "clifft/util/shot_parallel.h"
+
+#include <array>
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+
+TEST_CASE("Shot scheduler resolves bounded worker counts") {
+    REQUIRE(clifft::resolve_shot_worker_count(0, 0) == 0);
+    REQUIRE(clifft::resolve_shot_worker_count(1, 0) == 1);
+    REQUIRE(clifft::resolve_shot_worker_count(3, 1) == 1);
+    REQUIRE(clifft::resolve_shot_worker_count(3, 99) == 3);
+}
+
+TEST_CASE("Shot scheduler constructs workers before dispatch and visits each shot") {
+    constexpr uint32_t shots = 64;
+    constexpr uint32_t worker_count = 4;
+    std::atomic<uint32_t> constructed{0};
+    std::atomic<bool> dispatched_early{false};
+    std::array<std::atomic<uint32_t>, shots> visits{};
+
+    auto workers = clifft::run_shot_ranges(
+        shots, worker_count,
+        [&](uint32_t worker) {
+            constructed.fetch_add(1, std::memory_order_relaxed);
+            return std::make_unique<uint32_t>(worker);
+        },
+        [&](const auto&, clifft::ShotRange range) {
+            if (constructed.load(std::memory_order_relaxed) != worker_count) {
+                dispatched_early.store(true, std::memory_order_relaxed);
+            }
+            for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                visits[shot].fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+    REQUIRE(workers.size() == worker_count);
+    REQUIRE_FALSE(dispatched_early.load(std::memory_order_relaxed));
+    for (const auto& count : visits) {
+        REQUIRE(count.load(std::memory_order_relaxed) == 1);
+    }
+}
+
+TEST_CASE("Shot scheduler joins workers before rethrowing a range error") {
+    const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    const auto wait_until_deadline = [&](const auto& predicate) {
+        while (!predicate()) {
+            if (std::chrono::steady_clock::now() >= wait_deadline) {
+                return false;
+            }
+            std::this_thread::yield();
+        }
+        return true;
+    };
+
+    std::atomic<bool> background_started{false};
+    std::atomic<bool> caller_worker_started{false};
+    std::atomic<bool> allow_background_finish{false};
+    std::atomic<bool> background_finished{false};
+    std::atomic<bool> caller_returned{false};
+    std::exception_ptr caller_error;
+
+    std::thread caller([&] {
+        try {
+            clifft::run_shot_ranges(
+                32, 2, [](uint32_t worker) { return std::make_unique<uint32_t>(worker); },
+                [&](const auto& worker, clifft::ShotRange) {
+                    if (*worker == 1) {
+                        background_started.store(true, std::memory_order_release);
+                        if (!wait_until_deadline([&] {
+                                return allow_background_finish.load(std::memory_order_acquire);
+                            })) {
+                            throw std::runtime_error("timed out waiting for background release");
+                        }
+                        background_finished.store(true, std::memory_order_release);
+                        return;
+                    }
+                    caller_worker_started.store(true, std::memory_order_release);
+                    if (!wait_until_deadline(
+                            [&] { return background_started.load(std::memory_order_acquire); })) {
+                        throw std::runtime_error("timed out waiting for background worker");
+                    }
+                    throw std::runtime_error("range failed");
+                });
+        } catch (...) {
+            caller_error = std::current_exception();
+        }
+        caller_returned.store(true, std::memory_order_release);
+    });
+
+    const bool workers_started = wait_until_deadline([&] {
+        return background_started.load(std::memory_order_acquire) &&
+               caller_worker_started.load(std::memory_order_acquire);
+    });
+    const bool returned_before_release = caller_returned.load(std::memory_order_acquire);
+    // Release and join before asserting so a timeout cannot strand a joinable thread.
+    allow_background_finish.store(true, std::memory_order_release);
+    caller.join();
+
+    REQUIRE(workers_started);
+    REQUIRE_FALSE(returned_before_release);
+    REQUIRE(background_finished.load(std::memory_order_acquire));
+    REQUIRE(caller_error != nullptr);
+    REQUIRE_THROWS_WITH(std::rethrow_exception(caller_error), "range failed");
+}


### PR DESCRIPTION
## Summary

- add one shared atomic chunk scheduler with preconstructed worker contexts and join-safe exception propagation
- parallelize `sample`, `sample_survivors`, `sample_k`, and `sample_k_survivors` across independent per-worker executors
- preserve exact seeded rows, survivor order, and metadata across worker counts
- default to `threads=1`; accept positive counts or `threads="auto"` for the implementation-reported hardware concurrency, capped at the shot count
- document per-worker active-state memory scaling

Depends on #352. Closes #343 once the stack reaches `main`.

## Local scaling smoke tests

Release build on a 14-logical-CPU Apple Silicon host, active width 10:

- fixed rows, 2,000 shots: 353k shots/s at 1 worker; 684k at 2; 1.16M at 4; 2.14M at auto
- postselection-heavy, 10,000 attempts: 705k attempts/s at 1 worker; 1.39M at 2; 2.66M at 4; 5.92M at auto
- every worker count produced identical seeded rows and exactly 4,921 survivors in the postselection case

These are implementation smoke tests, not published benchmark claims.

## Validation

- full native non-benchmark suite
- join-and-rethrow synchronization test: 100 consecutive passes under both default and forced-scalar ISA
- `just py-test`: 810 passed, 1 skipped
- focused Python threading tests: 10 passed
- `just docs-build`
- `just py-doctest`: 32 passed, 7 skipped
- `just lint`

Wasm remains serial through the Emscripten compile-time path. The local `just test-wasm` recipe could not start because Docker Desktop was not running; CI exercises that build.
