### PR TITLE
feat(noncomp): add cross-shot worker parallelism

### DIFF
--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -332,6 +332,13 @@ semantics and active-width cost are described in
   cost.
 - **`seed`**: same contract as ordinary sampling: a fixed seed is fully
   reproducible, `None` uses hardware entropy.
+- **`threads`** (default `1`): number of cross-shot workers. Use a positive
+  integer to bound resource use or `"auto"` for the implementation-reported
+  hardware concurrency.
+  Workers dynamically claim shot ranges because trajectories can require
+  different numbers of continuations. A fixed seed produces identical rows,
+  sidecars, and ordering for every worker count. Each worker owns its executor
+  and compiled continuations, so memory use grows with the worker count.
 - **`max_active_width`**: caps the compiled peak active width before allocating or
   growing the state for that module.
   The cap applies to each compiled module, including branches a given shot

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -241,13 +241,13 @@ index. Seeded results therefore do not depend on how shots are scheduled.
 
 ## Parallel Shots
 
-`sample()`, `sample_survivors()`, `sample_k()`, and
-`sample_k_survivors()` accept a `threads` argument. It defaults to `1`, so
-existing calls remain serial. Pass a positive worker count to control resource
-use, or `threads="auto"` to use the implementation-reported hardware
-concurrency. Clifft never creates more workers than shots. In containers or
-processes with CPU-affinity limits, set an explicit count if the reported
-hardware concurrency exceeds the available CPU quota.
+`sample()`, `sample_survivors()`, `sample_k()`, `sample_k_survivors()`, and
+[`noncomp.sample()`](leakage-and-loss.md) accept a `threads` argument. It
+defaults to `1`, so existing calls remain serial. Pass a positive worker count
+to control resource use, or `threads="auto"` to use the implementation-reported
+hardware concurrency. Clifft never creates more workers than shots. In
+containers or processes with CPU-affinity limits, set an explicit count if the
+reported hardware concurrency exceeds the available CPU quota.
 
 Workers dynamically claim contiguous shot ranges from a shared scheduler.
 With a fixed seed, changing `threads` produces exactly the same result.
@@ -259,6 +259,8 @@ Each worker owns a separate executor. Its dense coefficient and measurement
 scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,
 plus symbolic state, records, and other executor metadata. Set an explicit
 worker count when memory is more constrained than CPU availability.
+Noncomputational workers also own their trajectory continuations and compile
+new continuations independently as their shots encounter jumps.
 
 ## Importance Sampling (Forced k-Faults)
 

--- a/src/clifft/noncomp/sample.cc
+++ b/src/clifft/noncomp/sample.cc
@@ -22,10 +22,11 @@ void validate_noncomputational_entry(const Circuit& circuit) {
 NonComputationalSample sample_noncomputational(const Circuit& circuit,
                                                const NonComputationalModel& model, uint32_t shots,
                                                std::optional<uint64_t> seed,
-                                               std::optional<uint32_t> max_active_width) {
+                                               std::optional<uint32_t> max_active_width,
+                                               uint32_t threads) {
     validate_noncomputational_entry(circuit);
     return run_trajectory_driver(circuit, model, shots, make_seed_root(shots, seed),
-                                 max_active_width);
+                                 max_active_width, threads);
 }
 
 }  // namespace clifft

--- a/src/clifft/noncomp/sample.h
+++ b/src/clifft/noncomp/sample.h
@@ -57,9 +57,11 @@ struct NonComputationalSample {
 // `max_active_width` caps the compiled peak active width. Compilation reports the first
 // offending active width before allocating or growing the executor state.
 // Unlimited when unset.
+// `threads` selects cross-shot workers. One worker is used by default; zero
+// selects the implementation-reported hardware concurrency.
 NonComputationalSample sample_noncomputational(
     const Circuit& circuit, const NonComputationalModel& model, uint32_t shots,
     std::optional<uint64_t> seed = std::nullopt,
-    std::optional<uint32_t> max_active_width = std::nullopt);
+    std::optional<uint32_t> max_active_width = std::nullopt, uint32_t threads = 1);
 
 }  // namespace clifft

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -24,9 +24,11 @@
 #include "clifft/optimizer/pass_registry.h"
 #include "clifft/sampling/executor.h"
 #include "clifft/sampling/planner.h"
+#include "clifft/util/shot_parallel.h"
 #include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <iterator>
@@ -282,6 +284,13 @@ struct SamplingCompiledContinuation {
     std::vector<AnnotationTarget> site_targets;
     std::vector<QubitStatus> final_status;
     std::optional<size_t> forced_traceout_slot;
+};
+
+struct TrajectoryWorker {
+    // The all-ground path remains lazy because a noncomputational initial
+    // state can make it unreachable, including paths rejected by a width cap.
+    std::optional<SamplingCompiledContinuation> all_ground_start;
+    std::optional<sampling::Executor> all_ground_executor;
 };
 
 // Build the HIR pass pipeline from default passes that preserve measurement
@@ -557,7 +566,8 @@ Circuit prepare_trajectory_circuit(const Circuit& circuit, const NonComputationa
 NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                              const NonComputationalModel& model, uint32_t shots,
                                              const SeedRoot& root,
-                                             std::optional<uint32_t> max_active_width_cap) {
+                                             std::optional<uint32_t> max_active_width_cap,
+                                             uint32_t threads) {
     NonComputationalSample result;
     result.shots = shots;
     result.num_qubits = circuit.num_qubits;
@@ -572,19 +582,16 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
     }
 
     const size_t shot_count = shots;
-    result.measurements.reserve(shot_count * circuit.num_measurements);
-    result.detectors.reserve(shot_count * circuit.num_detectors);
-    result.observables.reserve(shot_count * circuit.num_observables);
-    result.final_status.reserve(shot_count * circuit.num_qubits);
-    result.heralds.reserve(shot_count * circuit.num_measurements);
+    result.measurements.resize(shot_count * circuit.num_measurements);
+    result.detectors.resize(shot_count * circuit.num_detectors);
+    result.observables.resize(shot_count * circuit.num_observables);
+    result.final_status.resize(shot_count * circuit.num_qubits);
+    result.heralds.resize(shot_count * circuit.num_measurements);
 
     const InstrumentTraceOptions instrument_options = instrument_trace_options(model);
     TrajectoryEvents no_events;
     no_events.initial_status.assign(circuit.num_qubits, QubitStatus::Computational);
-    std::optional<SamplingCompiledContinuation> all_ground_start;
-    std::optional<sampling::Executor> shared_executor;
-
-    for (uint32_t shot = 0; shot < shots; ++shot) {
+    auto run_shot = [&](TrajectoryWorker& worker, uint32_t shot) {
         const auto driver_words = derive_state(root, shot, kTrajectoryDriverDomain);
         Xoshiro256PlusPlus driver_rng(0);
         driver_rng.seed_full(driver_words[0], driver_words[1], driver_words[2], driver_words[3]);
@@ -631,16 +638,16 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                                              max_active_width_cap, initial_levels));
             continuation = &*shot_start;
         } else {
-            if (!all_ground_start.has_value()) {
+            if (!worker.all_ground_start.has_value()) {
                 ContinuationRewrite rewrite =
                     rewrite_continuation(annotated, no_events, false, model);
                 assert(rewrite.classified_measurements.empty() &&
                        "an all-ground continuation has no classified measurements");
-                all_ground_start.emplace(
+                worker.all_ground_start.emplace(
                     compile_sampling_continuation(std::move(rewrite), {}, instrument_options,
                                                   max_active_width_cap, initial_levels));
             }
-            continuation = &*all_ground_start;
+            continuation = &*worker.all_ground_start;
         }
 
         // Executor borrows its current plan. Pointer-own each replacement so
@@ -651,10 +658,10 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
         std::optional<sampling::Executor> shot_executor;
         sampling::Executor* executor = nullptr;
         if (uses_shared_start) {
-            if (!shared_executor.has_value()) {
-                shared_executor.emplace(continuation->program);
+            if (!worker.all_ground_executor.has_value()) {
+                worker.all_ground_executor.emplace(continuation->program);
             }
-            executor = &*shared_executor;
+            executor = &*worker.all_ground_executor;
         } else {
             shot_executor.emplace(continuation->program);
             executor = &*shot_executor;
@@ -726,21 +733,29 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
         }
 
         const std::span<const uint8_t> measurements = executor->visible_records();
-        result.measurements.insert(result.measurements.end(), measurements.begin(),
-                                   measurements.end());
+        std::copy(
+            measurements.begin(), measurements.end(),
+            result.measurements.begin() + static_cast<size_t>(shot) * circuit.num_measurements);
         const std::span<const uint8_t> detectors = executor->detectors();
-        result.detectors.insert(result.detectors.end(), detectors.begin(), detectors.end());
+        std::copy(detectors.begin(), detectors.end(),
+                  result.detectors.begin() + static_cast<size_t>(shot) * circuit.num_detectors);
         const std::span<const uint8_t> observables = executor->observables();
-        result.observables.insert(result.observables.end(), observables.begin(), observables.end());
+        std::copy(observables.begin(), observables.end(),
+                  result.observables.begin() + static_cast<size_t>(shot) * circuit.num_observables);
         executor->return_to_root_plan();
-        result.final_status.insert(result.final_status.end(), continuation->final_status.begin(),
-                                   continuation->final_status.end());
-        std::vector<uint8_t> shot_heralds(circuit.num_measurements, 0);
+        std::copy(continuation->final_status.begin(), continuation->final_status.end(),
+                  result.final_status.begin() + static_cast<size_t>(shot) * circuit.num_qubits);
         for (const auto& [slot, flag] : herald_flags) {
-            shot_heralds[slot] = flag;
+            result.heralds[static_cast<size_t>(shot) * circuit.num_measurements + slot] = flag;
         }
-        result.heralds.insert(result.heralds.end(), shot_heralds.begin(), shot_heralds.end());
-    }
+    };
+    run_shot_ranges(
+        shots, threads, [](uint32_t) { return std::make_unique<TrajectoryWorker>(); },
+        [&](const std::unique_ptr<TrajectoryWorker>& worker, ShotRange range) {
+            for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                run_shot(*worker, shot);
+            }
+        });
 
     return result;
 }

--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -287,10 +287,11 @@ struct SamplingCompiledContinuation {
 };
 
 struct TrajectoryWorker {
-    // The all-ground path remains lazy because a noncomputational initial
-    // state can make it unreachable, including paths rejected by a width cap.
-    std::optional<SamplingCompiledContinuation> all_ground_start;
-    std::optional<sampling::Executor> all_ground_executor;
+    // The start shared by shots whose initial levels are all G remains lazy:
+    // other initial levels can make it unreachable, including when compiling it
+    // would exceed the active-width cap.
+    std::optional<SamplingCompiledContinuation> shared_start;
+    std::optional<sampling::Executor> shared_start_executor;
 };
 
 // Build the HIR pass pipeline from default passes that preserve measurement
@@ -638,16 +639,16 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                                              max_active_width_cap, initial_levels));
             continuation = &*shot_start;
         } else {
-            if (!worker.all_ground_start.has_value()) {
+            if (!worker.shared_start.has_value()) {
                 ContinuationRewrite rewrite =
                     rewrite_continuation(annotated, no_events, false, model);
                 assert(rewrite.classified_measurements.empty() &&
-                       "an all-ground continuation has no classified measurements");
-                worker.all_ground_start.emplace(
+                       "the shared initial continuation has no classified measurements");
+                worker.shared_start.emplace(
                     compile_sampling_continuation(std::move(rewrite), {}, instrument_options,
                                                   max_active_width_cap, initial_levels));
             }
-            continuation = &*worker.all_ground_start;
+            continuation = &*worker.shared_start;
         }
 
         // Executor borrows its current plan. Pointer-own each replacement so
@@ -658,10 +659,10 @@ NonComputationalSample run_trajectory_driver(const Circuit& circuit,
         std::optional<sampling::Executor> shot_executor;
         sampling::Executor* executor = nullptr;
         if (uses_shared_start) {
-            if (!worker.all_ground_executor.has_value()) {
-                worker.all_ground_executor.emplace(continuation->program);
+            if (!worker.shared_start_executor.has_value()) {
+                worker.shared_start_executor.emplace(continuation->program);
             }
-            executor = &*worker.all_ground_executor;
+            executor = &*worker.shared_start_executor;
         } else {
             shot_executor.emplace(continuation->program);
             executor = &*shot_executor;

--- a/src/clifft/noncomp/trajectory_driver.h
+++ b/src/clifft/noncomp/trajectory_driver.h
@@ -25,6 +25,7 @@ namespace clifft {
 NonComputationalSample run_trajectory_driver(const Circuit& circuit,
                                              const NonComputationalModel& model, uint32_t shots,
                                              const SeedRoot& root,
-                                             std::optional<uint32_t> max_active_width_cap);
+                                             std::optional<uint32_t> max_active_width_cap,
+                                             uint32_t threads);
 
 }  // namespace clifft

--- a/src/clifft/util/shot_parallel.h
+++ b/src/clifft/util/shot_parallel.h
@@ -1,8 +1,10 @@
 #pragma once
 
 // Shared cross-shot scheduling for sampling frontends. The worker factory
-// creates every fully allocated context before this helper starts dispatch,
-// then workers claim disjoint global shot ranges dynamically.
+// creates every base context before this helper starts dispatch, then workers
+// claim disjoint global shot ranges dynamically. Fixed-plan samplers fully
+// allocate those contexts up front; trajectory samplers may grow them only at
+// explicit continuation boundaries.
 
 #include <algorithm>
 #include <atomic>

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -140,16 +140,19 @@ void register_noncomp(nb::module_& m) {
     m.def(
         "_sample_noncomputational",
         [](const clifft::Circuit& circuit, const clifft::NonComputationalModel& model,
-           uint32_t shots, std::optional<uint64_t> seed, std::optional<uint32_t> max_active_width) {
+           uint32_t shots, std::optional<uint64_t> seed, std::optional<uint32_t> max_active_width,
+           const ThreadOption& threads) {
+            const uint32_t thread_count = parse_thread_option(threads);
             clifft::NonComputationalSample r;
             {
                 nb::gil_scoped_release release;
-                r = clifft::sample_noncomputational(circuit, model, shots, seed, max_active_width);
+                r = clifft::sample_noncomputational(circuit, model, shots, seed, max_active_width,
+                                                    thread_count);
             }
             return noncomp_sample_to_python(std::move(r), shots);
         },
         nb::arg("circuit"), nb::arg("model"), nb::arg("shots"), nb::arg("seed") = nb::none(),
-        nb::arg("max_active_width") = nb::none(),
+        nb::arg("max_active_width") = nb::none(), nb::arg("threads") = ThreadOption{int64_t{1}},
         "Sample a noncomputational model with Clifft's sampler.");
 }
 

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
-from typing import Callable, Iterator
+from typing import Callable, Iterator, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -291,6 +291,7 @@ def sample(
     shots: int,
     seed: int | None = None,
     max_active_width: int | None = None,
+    threads: int | Literal["auto"] = 1,
 ) -> NonComputationalSample:
     """Sample ``circuit`` under ``model`` for ``shots`` shots.
 
@@ -316,6 +317,9 @@ def sample(
         max_active_width: Optional cap on the peak active width of every compiled
             continuation. The check is conservative because a continuation
             may contain branches that the current shot will not take.
+        threads: Number of cross-shot workers. Defaults to 1. Pass ``"auto"``
+            to use the implementation-reported hardware concurrency. Seeded
+            results are identical for every worker count.
 
     Returns:
         [NonComputationalSample][clifft.noncomp.NonComputationalSample]
@@ -332,6 +336,7 @@ def sample(
         shots,
         seed,
         max_active_width,
+        threads,
         _clifft_core._sample_noncomputational,
     )
 
@@ -342,12 +347,13 @@ def _sample_with(
     shots: int,
     seed: int | None,
     max_active_width: int | None,
+    threads: int | Literal["auto"],
     sampler: Callable,
 ) -> NonComputationalSample:
     if isinstance(circuit, str):
         circuit = _clifft_core.parse(circuit)
     meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs = sampler(
-        circuit, model._handle, shots, seed, max_active_width
+        circuit, model._handle, shots, seed, max_active_width, threads
     )
     return NonComputationalSample(
         meas, det, obs, status, heralds, num_qubits, num_meas, num_det, num_obs

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -448,6 +448,30 @@ def test_deterministic_in_seed(noncomp_sampling_api):
     assert np.array_equal(a.final_status, b.final_status)
 
 
+@pytest.mark.parametrize("threads", [3, "auto"])
+def test_threads_preserve_seeded_rows_and_sidecars(threads):
+    model = noncomp.Model(
+        initial_state=[0.4, 0.3, 0.0, 0.3, 0.0],
+        transitions={"leak": transition_to(LEAK_E)},
+        classifier=classifier_for(LEAK_E, [0.2, 0.1, 0.7]),
+    )
+    circuit = (
+        "H 1\nCX 1 0\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n"
+        "DETECTOR rec[-1] rec[-2]\nOBSERVABLE_INCLUDE(0) rec[-1]\n"
+    )
+    serial = noncomp.sample(circuit, model, shots=257, seed=12345, threads=1)
+    parallel = noncomp.sample(circuit, model, shots=257, seed=12345, threads=threads)
+
+    for field in ("measurements", "detectors", "observables", "final_status", "heralds"):
+        assert np.array_equal(getattr(parallel, field), getattr(serial, field))
+
+
+@pytest.mark.parametrize("threads", [0, -1, "all", 1.5])
+def test_sample_rejects_invalid_threads(threads):
+    with pytest.raises((TypeError, ValueError), match="threads|incompatible"):
+        noncomp.sample("M 0", noncomp.Model(), shots=1, threads=threads)
+
+
 def test_different_seeds_differ(noncomp_sampling_api):
     # The companion to the determinism check: a different seed must actually
     # change the draws, so a fixed-sequence regression cannot masquerade as

--- a/tests/test_trajectory_driver.cc
+++ b/tests/test_trajectory_driver.cc
@@ -274,6 +274,34 @@ TEST_CASE("trajectory: same seed reproduces identical runs") {
     }
 }
 
+TEST_CASE("trajectory: worker counts preserve seeded rows and sidecars") {
+    ModelSpec spec;
+    spec.leak_from_g = 0.35;
+    spec.leak_from_e = 0.65;
+    spec.initial = {0.4, 0.3, 0.0, 0.3, 0.0};
+    const NonComputationalModel model = make_driver_model(spec);
+    const Circuit circuit = parse(
+        "H 1\nCX 1 0\nLEVEL_TRANSITION[leak] 0\nM 0\nM 1\n"
+        "DETECTOR rec[-1] rec[-2]\nOBSERVABLE_INCLUDE(0) rec[-1]\n");
+
+    const NonComputationalSample serial =
+        sample_noncomputational(circuit, model, 257, 12345, std::nullopt, 1);
+    for (const uint32_t threads : {3U, 0U}) {
+        const NonComputationalSample parallel =
+            sample_noncomputational(circuit, model, 257, 12345, std::nullopt, threads);
+        REQUIRE(parallel.shots == serial.shots);
+        REQUIRE(parallel.num_qubits == serial.num_qubits);
+        REQUIRE(parallel.num_measurements == serial.num_measurements);
+        REQUIRE(parallel.num_detectors == serial.num_detectors);
+        REQUIRE(parallel.num_observables == serial.num_observables);
+        REQUIRE(parallel.measurements == serial.measurements);
+        REQUIRE(parallel.detectors == serial.detectors);
+        REQUIRE(parallel.observables == serial.observables);
+        REQUIRE(parallel.final_status == serial.final_status);
+        REQUIRE(parallel.heralds == serial.heralds);
+    }
+}
+
 TEST_CASE("trajectory: the driver and executor seed streams are domain-separated") {
     // The host draws (initial levels, trap destinations, classifier consults)
     // and the in-executor Born draws run on independent streams; handing the same
@@ -320,7 +348,7 @@ TEST_CASE("trajectory: max_active_width rejects an over-budget compile") {
         "M 0\nM 1\nM 2");
 
     REQUIRE_THROWS_WITH(
-        sample_noncomputational(circuit, model, 5, 1, /*max_active_width=*/2),
+        sample_noncomputational(circuit, model, 5, 1, /*max_active_width=*/2, /*threads=*/3),
         ContainsSubstring("exceeds max_active_width 2 (first exceeded at circuit line 6); consider "
                           "damping=\"neglect\" for high-rate sites or a larger max_active_width"));
 }
@@ -1477,7 +1505,7 @@ TEST_CASE(
                         ContainsSubstring("max_active_width"));
 
     // Lost model at max_active_width=0 must run (the no-event module is lazy).
-    const NonComputationalSample r = sample_noncomputational(circuit, lost_model, 16, 1, 0);
+    const NonComputationalSample r = sample_noncomputational(circuit, lost_model, 16, 1, 0, 3);
     for (const uint8_t bit : r.measurements) {
         REQUIRE(bit == 1);
     }


### PR DESCRIPTION
## Summary

- reuse the shared dynamic shot-range scheduler for `noncomp.sample()`
- keep each worker's mutable trajectory state private, including its lazy all-ground continuation cache and executor
- preallocate result sidecars and write by global shot index, preserving deterministic row order
- expose `threads=1` by default and `threads="auto"` for the implementation-reported hardware concurrency in Python; C++ uses `threads=0` for auto
- document trajectory-specific load balancing and per-worker memory scaling

Workers claim ranges from the same atomic dispenser introduced in #354. This is useful for noncomputational sampling because different shots can compile and execute different numbers of continuations. The annotated circuit and model remain shared and immutable; continuation planning and executor mutation are worker-local.

The all-ground continuation remains lazy per worker. In particular, a shot population that starts entirely noncomputational does not compile or validate an unreachable all-computational module.

## Determinism

For a fixed seed, `threads=1`, explicit worker counts, and `threads="auto"` produce exactly identical measurements, detectors, observables, final-status sidecars, herald sidecars, and row ordering.

## Performance

Local release-build smoke benchmark on 14 logical CPUs, using exact-output checks before timing:

| Workload | 1 worker | 2 workers | 4 workers | auto |
| --- | ---: | ---: | ---: | ---: |
| All-ground 8-qubit trajectories | 234k shots/s | 452k shots/s | 865k shots/s | 2.10M shots/s |
| Variable continuation-heavy trajectories | 18.5k shots/s | 36.7k shots/s | 62.2k shots/s | 105k shots/s |

## Validation

- full native non-benchmark suite
- 816 Python tests passed, 1 expected skip
- join-and-rethrow synchronization test: 100 consecutive passes under both default and forced-scalar ISA
- strict documentation build
- 32 documentation code blocks passed, 7 skipped
- full pre-commit suite
- [ThreadSanitizer on final tip](https://github.com/unitaryfoundation/clifft/actions/runs/32267609034)

## Stack

Depends on #354, and therefore #352. No issue changes are needed for this final stack layer; #354 already closes #343.
