### PR TITLE
ci: run the cross-platform suite on Linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Covers GCC and Linux platform behavior on the architecture of
+          # the published aarch64 wheel; no other pull-request job runs on
+          # arm64.
+          - label: Linux arm64
+            os: ubuntu-24.04-arm
+            install-deps: sudo apt-get update && sudo apt-get install -y ninja-build
+            skbuild-type: Debug
+            skbuild-cmake-args: ""
           - label: macOS
             os: macos-latest
             install-deps: brew install ninja


### PR DESCRIPTION
## Summary

Implements item 2 of #329: `release.yml` publishes a Linux aarch64 wheel, but no routine CI builds or tests Linux on arm64. This adds `ubuntu-24.04-arm` to the existing cross-platform matrix at the generic CPU baseline, running the full non-benchmark Debug C++ suite and the full Python suite, matching the macOS and Windows legs. The display name follows the existing pattern (`cross-platform (Linux arm64)`), so branch-protection entries stay stable.

Notes:
- ccache comes from the same `ccache-action` install path (`apt-get`), which is architecture-independent; the cache key (`Linux-ccache-Debug-generic`) does not collide with the x86 jobs, which use the `x86-64-v2` baseline.
- arm64 hosted runners have been GA for public repositories since 2025-08 (the "public preview" caveat in the issue predated that), so the leg can be considered for required status once a few runs confirm the observed duration.
- On arm64 the build takes the portable ARM baseline (no runtime dispatch), so the suite exercises the scalar kernels, `clifft.runtime_isa()` reports `scalar`, and the new ISA tests pass unchanged.

## Test plan

The leg validates itself on this PR: watch `cross-platform (Linux arm64)` for the full C++ and Python suites. No behavior of existing jobs changes (pre-commit `--all-files` passes; the other matrix entries are untouched).

- [x] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
