### PR TITLE
ci: run the full Python suite on the optimized extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,16 +314,25 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
-      - name: Install Python package (release baseline)
+      # assert() stays active in the optimized extension so the full
+      # Python suite checks invariants through GCC optimized codegen and
+      # -ffast-math. ISA dispatch does not depend on NDEBUG, so the
+      # emulated smokes below reuse this wheel; the published artifact
+      # keeps its own smoke in the release workflow.
+      - name: Install Python package (release baseline, asserts on)
         env:
           SKBUILD_CMAKE_BUILD_TYPE: Release
+          SKBUILD_CMAKE_ARGS: "-DCLIFFT_FORCE_ASSERTS=ON"
         run: |
           uv venv .smoke-venv
           . .smoke-venv/bin/activate
-          uv sync --locked --active --no-dev
+          uv sync --locked --active
 
       - name: Audit Python extension exports
         run: .smoke-venv/bin/python tools/ci/audit_python_exports.py
+
+      - name: Run Python tests (optimized extension)
+        run: .smoke-venv/bin/python -m pytest tests/python/ -n logical --maxprocesses 4 -v
 
       # Run a small QEMU-emulated CPU matrix against the release-baseline
       # Python install. Catches AVX-512 leakage into the AVX-2 dispatch


### PR DESCRIPTION
## Summary

Implements item 3 of #329. `release-cpp-smoke` already built an optimized Python extension, but only ran the export audit and emulated ISA smokes against it — optimized Python coverage stopped there. This keeps `assert()` active via `CLIFFT_FORCE_ASSERTS=ON` and runs the full Python suite against that extension, covering GCC optimized code generation and `-ffast-math` through the public API. The exact Release C++ suite in the same job is untouched (normal `NDEBUG` behavior preserved). The smoke venv now installs test dependencies (drops `--no-dev`), and the QEMU/SDE smokes reuse the asserts-on wheel since ISA dispatch does not depend on `NDEBUG` — the published artifact keeps its own smoke in the release workflow.

## Test plan

Validated locally on a Release + `CLIFFT_FORCE_ASSERTS=ON` + `x86-64-v2` extension (GCC, `-ffast-math`): full Python suite passes 803/803. The new step also validates itself on this PR — watch `release-cpp-smoke` and its duration.

- [x] Python tests pass (`uv run pytest tests/python/ -v`)
- [x] Pre-commit checks pass (via the commit hook and this PR's lint job)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
