### PR TITLE
ci: verify the abi3 wheel on the newest stable CPython

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,34 @@ jobs:
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512
 
+      # The cp312-abi3 wheel is the only build per platform, so its
+      # packaging contract is forward compatibility: it must install and
+      # run on interpreters newer than the 3.12 it was built with. Bump
+      # the version below when a newer stable CPython is supported.
+      - name: Setup uv (Linux x86_64 wheel only)
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Verify abi3 wheel on newest stable CPython (Linux x86_64 wheel only)
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
+        run: |
+          uv venv --python 3.14 .abi3-venv
+          uv pip install --python .abi3-venv/bin/python wheelhouse/*.whl
+          .abi3-venv/bin/python - <<'PY'
+          import sys
+          from pathlib import Path
+          import clifft
+          assert sys.version_info[:2] == (3, 14), sys.version_info
+          print(f"python={sys.version.split()[0]} clifft={clifft.__version__} isa={clifft.runtime_isa()}")
+          symbolic = clifft.compile(Path("tests/fixtures/qv10.stim").read_text())
+          result = clifft.sample(symbolic, shots=1, seed=280)
+          assert result.measurements.shape[0] == 1, result.measurements.shape
+          prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+          ps = clifft.record_probabilities(prog, ["00", "11"])
+          assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
+          print("abi3 smoke ok")
+          PY
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
## Summary

Implements item 5 of #329. Clifft ships one `cp312-abi3` wheel per platform (nanobind stable ABI), built and tested only under CPython 3.12 — the packaging contract that was never checked is forward compatibility. This adds a step to the release workflow's Linux x86_64 wheel leg that installs the just-built wheel on CPython 3.14 (current newest stable) and runs a focused artifact smoke: interpreter-version assertion, `runtime_isa()`, `compile`/`sample` on the qv10 fixture, and exact Bell-pair record probabilities. The pinned version carries a comment to bump when a newer stable CPython is supported; expansion to every minor interpreter stays a follow-up if this finds value.

## Test plan

The release workflow only runs on tags/dispatch, so the step cannot run on this PR. Validated locally end to end: built the `cp312-abi3` wheel from this tree, installed it on CPython 3.14.2 with `uv pip` (numpy 2.5.2 resolves), and the exact smoke above passes. The next `workflow_dispatch` TestPyPI run or release tag exercises it on the runner.

- [x] abi3 wheel installs and passes the smoke on CPython 3.14 locally
- [x] Pre-commit checks pass (via the commit hook and this PR's lint job)

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to
  submit it) and I license it under this project's
  [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code
  and included an `Assisted-by:` git trailer in the commit message.
