### PR TITLE
docs: use versioned stable links for docs-site URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ also powers exact state queries and leakage/loss continuations.
 
 Across the release benchmark corpus, the new sampler is faster than the SVM
 on five of seven real workloads and remains close on the other two. See
-[Symbolic Sampling in Clifft](https://unitaryfoundation.github.io/clifft/updates/symbolic-sampling/)
+[Symbolic Sampling in Clifft](https://unitaryfoundation.github.io/clifft/stable/updates/symbolic-sampling/)
 for the design, API migration guide, matched benchmark results, and method
 provenance.
 
@@ -89,8 +89,8 @@ Transitions can be attached to gates or placed explicitly in the circuit, and
 results include measurement records, detector and observable values, heralds,
 and final per-qubit status.
 
-The [Leakage and Loss guide](https://unitaryfoundation.github.io/clifft/guide/leakage-and-loss/)
-introduces the model and API. The [Delayed Loss tutorial](https://unitaryfoundation.github.io/clifft/guide/delayed-loss/)
+The [Leakage and Loss guide](https://unitaryfoundation.github.io/clifft/stable/guide/leakage-and-loss/)
+introduces the model and API. The [Delayed Loss tutorial](https://unitaryfoundation.github.io/clifft/stable/guide/delayed-loss/)
 applies it to a surface-code memory experiment, where losses of the same data
 qubit at different times produce the same final herald but different detector
 histories.
@@ -115,7 +115,7 @@ histories.
 
 Clifft 0.6.0 adds Stim-compatible correlated Pauli noise chains through
 `CORRELATED_ERROR` / `E` and `ELSE_CORRELATED_ERROR`. It also adds a dedicated
-[front-end integrations guide](https://unitaryfoundation.github.io/clifft/getting-started/integrations/)
+[front-end integrations guide](https://unitaryfoundation.github.io/clifft/stable/getting-started/integrations/)
 for using Clifft from Qiskit and Cirq through their separately maintained
 companion packages.
 
@@ -180,7 +180,7 @@ This patch makes Linux wheel CPU targeting consistent and portable across Clifft
 
 ## [0.4.0] - 2026-05-15
 
-This release expands strong simulation with a new `clifft.record_probabilities()` API that returns the joint probability `sample()` would assign to a given measurement record (or batch of records). Combined with the existing basis-probability path, Clifft now answers two complementary "what's the exact probability of …" questions: bitstring outcomes for unitary circuits, and measurement-record outcomes for circuits that contain measurements with or without classical feedback. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/guide/strong-simulation/) for both APIs side-by-side and more detail on when to choose one versus anothr.
+This release expands strong simulation with a new `clifft.record_probabilities()` API that returns the joint probability `sample()` would assign to a given measurement record (or batch of records). Combined with the existing basis-probability path, Clifft now answers two complementary "what's the exact probability of …" questions: bitstring outcomes for unitary circuits, and measurement-record outcomes for circuits that contain measurements with or without classical feedback. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/stable/guide/strong-simulation/) for both APIs side-by-side and more detail on when to choose one versus anothr.
 
 The probability surface is also faster and clearer. `basis_probabilities()` is roughly 17× faster on representative inputs via a Gray-code walk over X-generators when the dormant block reduces cleanly during RREF. As part of unifying the docs, the two queries were renamed to make the queried object explicit:
 
@@ -223,7 +223,7 @@ Beyond the probability work, 0.4.0 lands a scheduled benchmark-history workflow 
 
 ## [0.3.0] - 2026-05-08
 
-This release adds strong simulation for unitary circuits through exact computational-basis probability queries of the factored state. The new `clifft.probabilities()` API evaluates selected bitstrings without materializing the full $2^n$ statevector, so sparse output queries can scale with active width rather than output-space size. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/guide/strong-simulation/) for examples.
+This release adds strong simulation for unitary circuits through exact computational-basis probability queries of the factored state. The new `clifft.probabilities()` API evaluates selected bitstrings without materializing the full $2^n$ statevector, so sparse output queries can scale with active width rather than output-space size. See the [strong-simulation tutorial](https://unitaryfoundation.github.io/clifft/stable/guide/strong-simulation/) for examples.
 
 Clifft 0.3.0 also removes the old compile-time qubit ceiling by moving Pauli mask storage to runtime-width arenas. That fixed-width limit kept the early implementation simple and fast; the new arena path keeps the overhead localized while supporting circuits above the former inline-width bound.
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ representation. SymFT adds symbolic Clifford-Pauli-frame factorization,
 adaptive stabilizer-coordinate planning, and direct multi-coordinate kernels.
 Clifft's current sampler adopts these SymFT developments alongside
 Clifft-specific compiler, continuation, and API machinery.
-See the [theoretical overview](https://unitaryfoundation.github.io/clifft/theory/overview/#method-provenance)
+See the [theoretical overview](https://unitaryfoundation.github.io/clifft/stable/theory/overview/#method-provenance)
 for the fuller lineage and implementation boundaries. The
-[symbolic sampling update](https://unitaryfoundation.github.io/clifft/updates/symbolic-sampling/)
+[symbolic sampling update](https://unitaryfoundation.github.io/clifft/stable/updates/symbolic-sampling/)
 explains the migration from the original SVM and reports matched release-target
 benchmarks.
 
@@ -79,7 +79,7 @@ pip install clifft
 | Windows `amd64` | Supported |
 
 All other platforms and CPU families should build from source. See the
-[installation docs](https://unitaryfoundation.github.io/clifft/getting-started/installation/#from-source).
+[installation docs](https://unitaryfoundation.github.io/clifft/stable/getting-started/installation/#from-source).
 
 ## Quick Start
 
@@ -112,7 +112,7 @@ discoverable:
   converts parameter-resolved `cirq.Circuit` instances to Clifft text and
   provides a Cirq-style sampler backed by Clifft.
 
-See the [front-end integrations guide](https://unitaryfoundation.github.io/clifft/getting-started/integrations/)
+See the [front-end integrations guide](https://unitaryfoundation.github.io/clifft/stable/getting-started/integrations/)
 for installation commands, minimal examples, and current limitations.
 
 ## Citation
@@ -132,7 +132,7 @@ If you use Clifft in your work, please cite the arXiv [preprint](https://arxiv.o
 
 ## Development
 
-See the [building from source](https://unitaryfoundation.github.io/clifft/development/building/) guide for build
+See the [building from source](https://unitaryfoundation.github.io/clifft/stable/development/building/) guide for build
 instructions.
 
 ## AI Acknowledgement

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -45,6 +45,14 @@ This prepends only the unreleased changes since the previous tag and preserves
 older hand-edited release sections. Do not use `-o CHANGELOG.md` for routine
 releases unless you intentionally want to regenerate the entire changelog.
 
+Write documentation links in changelog entries (and the README) with the
+versioned `stable/` prefix, e.g.
+`https://unitaryfoundation.github.io/clifft/stable/guide/strong-simulation/`.
+The docs site only redirects at its root, so unversioned deep links 404; the
+GitHub release notes extracted from the changelog inherit whatever links are
+written here. The root `playground/` and `bench/` URLs are the intentional
+unversioned exceptions.
+
 Review, edit if needed (add the release summary, fix typos, clarify entries,
 remove noise), then commit:
 

--- a/playground/src/components/NoncompNotice.tsx
+++ b/playground/src/components/NoncompNotice.tsx
@@ -1,4 +1,4 @@
-const LEAKAGE_LOSS_GUIDE_URL = "https://unitaryfoundation.github.io/clifft/guide/leakage-and-loss/";
+const LEAKAGE_LOSS_GUIDE_URL = "https://unitaryfoundation.github.io/clifft/stable/guide/leakage-and-loss/";
 
 // Friendly explanation shown in place of the raw compiler error when a
 // pasted circuit uses LOSS or LEVEL_TRANSITION. Those annotations require a


### PR DESCRIPTION
The docs site is versioned with mike, and only the site root redirects (to `stable/`). Deep unversioned links like `https://unitaryfoundation.github.io/clifft/updates/symbolic-sampling/` are never redirected — they 404, or (until now) resolved to a stale pre-versioning site snapshot that was still sitting at the gh-pages root. The v0.8.0 release notes shipped one of these broken links.

This PR fixes the repo side:

- **CHANGELOG.md** — all six deep docs links now use the `stable/` prefix (each target was verified to exist under `stable/`). The GitHub release notes are extracted from here, so future releases inherit correct links.
- **README.md** — same for its five deep links. The docs badge, bare docs-root link, and the root `playground/` link are intentionally unversioned and unchanged.
- **playground/src/components/NoncompNotice.tsx** — the leakage-and-loss guide URL shown by the playground was also unversioned (404ing today); now points at `stable/`.
- **docs/development/releasing.md** — documents the `stable/`-prefix convention for changelog/README links, noting release notes inherit them and that root `playground/`/`bench/` are the deliberate exceptions.

Done separately (not in this diff): the published v0.8.0 release notes were edited to the exact-version `0.8.0/` link (matching how older releases were already fixed), and the stale pre-versioning snapshot was removed from the gh-pages root so unversioned deep URLs now 404 honestly instead of serving May-2026 content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)