### PR TITLE
ci: build the coverage-instrumented extension in Debug

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Install Python package with coverage
         run: uv sync --locked
         env:
-          CMAKE_ARGS: "-DCLIFFT_COVERAGE=ON"
-          SKBUILD_BUILD_TYPE: Debug
+          SKBUILD_CMAKE_ARGS: "-DCLIFFT_COVERAGE=ON"
+          SKBUILD_CMAKE_BUILD_TYPE: Debug
 
       # Reset counters before Python tests
       - name: Reset coverage counters
@@ -83,10 +83,6 @@ jobs:
 
       - name: Capture C++ coverage from Python tests
         run: |
-          # Find where scikit-build put the build
-          BUILD_DIR=$(find build -name '*.gcda' -printf '%h\n' 2>/dev/null | head -1 || echo "build")
-          echo "Found .gcda files in: $BUILD_DIR"
-
           lcov --capture \
                --directory . \
                --output-file build/cpp-from-python.info \


### PR DESCRIPTION
## Summary

Fixes the coverage workflow's stale scikit-build configuration: it set `SKBUILD_BUILD_TYPE`, which scikit-build-core does not read, so the Python-test half of C++ coverage was captured from an instrumented but Release-optimized extension (the `CMAKE_ARGS` coverage flag *was* honored), distorting line and branch attribution. Switch to `SKBUILD_CMAKE_BUILD_TYPE: Debug` and pass the flag via `SKBUILD_CMAKE_ARGS` to match every other workflow's convention. Also removes a computed-but-unused `BUILD_DIR` lookup in the capture step.

## Test plan

Validated locally with the corrected env: the extension builds Debug+instrumented into the in-tree `build/cp312-abi3-*` dir (`.gcno` present at compile), and `.gcda` counters appear after running pytest — exactly what the workflow's `lcov --capture --directory .` consumes. The workflow itself is weekly/dispatch; next scheduled run (or a manual dispatch) confirms end to end.

- [x] Pre-commit checks pass

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.
