### PR TITLE
ci: run on all pull requests and gate merges on one aggregate check

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -25,7 +25,10 @@ runs:
       if: steps.wasm-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        curl -fsSL -o /tmp/ccache.tar.xz \
+        curl --fail --silent --show-error --location \
+          --retry 3 --retry-delay 2 --retry-all-errors \
+          --connect-timeout 15 --max-time 180 \
+          --output /tmp/ccache.tar.xz \
           https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
         echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  /tmp/ccache.tar.xz" | sha256sum --check
         mkdir -p "$RUNNER_TEMP/ccache-bin"

--- a/.github/actions/setup-native-tools/action.yml
+++ b/.github/actions/setup-native-tools/action.yml
@@ -1,0 +1,53 @@
+name: Set Up Native CI Tools
+description: Install pinned Ninja, ccache, and optional QEMU binaries
+
+inputs:
+  install-qemu:
+    description: Install the pinned QEMU user-mode emulator
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install pinned native tools
+      shell: bash
+      env:
+        INSTALL_QEMU: ${{ inputs.install-qemu }}
+      run: |
+        set -euo pipefail
+
+        download() {
+          curl --fail --silent --show-error --location \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            --connect-timeout 15 --max-time 180 \
+            --output "$2" "$1"
+        }
+
+        tools_dir="$RUNNER_TEMP/clifft-native-tools"
+        mkdir -p "$tools_dir/bin"
+
+        download \
+          https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip \
+          "$tools_dir/ninja-linux.zip"
+        echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  $tools_dir/ninja-linux.zip" | sha256sum --check
+        unzip -o -q "$tools_dir/ninja-linux.zip" -d "$tools_dir/bin"
+
+        download \
+          https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz \
+          "$tools_dir/ccache.tar.xz"
+        echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  $tools_dir/ccache.tar.xz" | sha256sum --check
+        tar -C "$tools_dir" -xf "$tools_dir/ccache.tar.xz" \
+          ccache-4.10.2-linux-x86_64/ccache
+        mv "$tools_dir/ccache-4.10.2-linux-x86_64/ccache" "$tools_dir/bin/ccache"
+
+        echo "$tools_dir/bin" >> "$GITHUB_PATH"
+
+        if [[ "$INSTALL_QEMU" == "true" ]]; then
+          download \
+            https://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_8.2.2+ds-0ubuntu1_amd64.deb \
+            "$tools_dir/qemu-user-static.deb"
+          echo "83ad62bfe0e28a5645cb6a40d8b99e7a629fdac9e1a9cea9949d1c59a01322c7  $tools_dir/qemu-user-static.deb" | sha256sum --check
+          dpkg-deb -x "$tools_dir/qemu-user-static.deb" "$tools_dir/qemu-user-static"
+          echo "QEMU_X86_64=$tools_dir/qemu-user-static/usr/bin/qemu-x86_64-static" >> "$GITHUB_ENV"
+        fi

--- a/.github/actions/setup-native-tools/action.yml
+++ b/.github/actions/setup-native-tools/action.yml
@@ -1,7 +1,11 @@
 name: Set Up Native CI Tools
-description: Install pinned Ninja, ccache, and optional QEMU binaries
+description: Install pinned native build and emulation tools
 
 inputs:
+  install-build-tools:
+    description: Install the pinned Ninja and ccache binaries
+    required: false
+    default: "true"
   install-qemu:
     description: Install the pinned QEMU user-mode emulator
     required: false
@@ -13,6 +17,7 @@ runs:
     - name: Install pinned native tools
       shell: bash
       env:
+        INSTALL_BUILD_TOOLS: ${{ inputs.install-build-tools }}
         INSTALL_QEMU: ${{ inputs.install-qemu }}
       run: |
         set -euo pipefail
@@ -27,21 +32,23 @@ runs:
         tools_dir="$RUNNER_TEMP/clifft-native-tools"
         mkdir -p "$tools_dir/bin"
 
-        download \
-          https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip \
-          "$tools_dir/ninja-linux.zip"
-        echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  $tools_dir/ninja-linux.zip" | sha256sum --check
-        unzip -o -q "$tools_dir/ninja-linux.zip" -d "$tools_dir/bin"
+        if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
+          download \
+            https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip \
+            "$tools_dir/ninja-linux.zip"
+          echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  $tools_dir/ninja-linux.zip" | sha256sum --check
+          unzip -o -q "$tools_dir/ninja-linux.zip" -d "$tools_dir/bin"
 
-        download \
-          https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz \
-          "$tools_dir/ccache.tar.xz"
-        echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  $tools_dir/ccache.tar.xz" | sha256sum --check
-        tar -C "$tools_dir" -xf "$tools_dir/ccache.tar.xz" \
-          ccache-4.10.2-linux-x86_64/ccache
-        mv "$tools_dir/ccache-4.10.2-linux-x86_64/ccache" "$tools_dir/bin/ccache"
+          download \
+            https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz \
+            "$tools_dir/ccache.tar.xz"
+          echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  $tools_dir/ccache.tar.xz" | sha256sum --check
+          tar -C "$tools_dir" -xf "$tools_dir/ccache.tar.xz" \
+            ccache-4.10.2-linux-x86_64/ccache
+          mv "$tools_dir/ccache-4.10.2-linux-x86_64/ccache" "$tools_dir/bin/ccache"
 
-        echo "$tools_dir/bin" >> "$GITHUB_PATH"
+          echo "$tools_dir/bin" >> "$GITHUB_PATH"
+        fi
 
         if [[ "$INSTALL_QEMU" == "true" ]]; then
           download \

--- a/.github/scripts/wheel_smoke.sh
+++ b/.github/scripts/wheel_smoke.sh
@@ -29,7 +29,8 @@
 #   wheel_smoke.sh sde  skx     avx512 pass  avx512  # SDE force avx512 explicitly
 #
 # Requires:
-#   - qemu mode: qemu-x86_64 in PATH.
+#   - qemu mode: the QEMU_X86_64 env var pointing at the qemu-x86_64
+#     binary, or qemu-x86_64 in PATH.
 #   - sde mode: the SDE64 env var pointing at the sde64 binary, or sde64 in PATH.
 #   - PYTHON env var (or `python` in PATH) pointing at an interpreter
 #     with clifft installed.
@@ -73,8 +74,8 @@ esac
 
 PYTHON="${PYTHON:-python3}"
 
-if [ "$emulator" = "qemu" ] && ! command -v qemu-x86_64 >/dev/null 2>&1; then
-    echo "error: qemu-x86_64 not found in PATH" >&2
+if [ "$emulator" = "qemu" ] && ! command -v "${QEMU_X86_64:-qemu-x86_64}" >/dev/null 2>&1; then
+    echo "error: ${QEMU_X86_64:-qemu-x86_64} not found" >&2
     exit 2
 fi
 if [ "$emulator" = "sde" ] && ! command -v "${SDE64:-sde64}" >/dev/null 2>&1; then
@@ -104,7 +105,7 @@ if [ "$emulator" = "qemu" ]; then
     if [ "$force_isa" != "auto" ]; then
         qemu_env+=(-E "CLIFFT_FORCE_ISA=$force_isa")
     fi
-    output=$(qemu-x86_64 -cpu "$cpu_model" "${qemu_env[@]}" "$PYTHON" -c "$script" 2>&1)
+    output=$("${QEMU_X86_64:-qemu-x86_64}" -cpu "$cpu_model" "${qemu_env[@]}" "$PYTHON" -c "$script" 2>&1)
     exit_code=$?
 else
     # SDE children inherit the environment, so export CLIFFT_FORCE_ISA
@@ -123,7 +124,7 @@ if [ "$expected" = "pass" ]; then
         echo "FAIL: expected pass but got exit code $exit_code" >&2
         if [ "$emulator" = "qemu" ]; then
             echo "available qemu cpus (truncated):" >&2
-            qemu-x86_64 -cpu help 2>&1 | head -30 >&2
+            "${QEMU_X86_64:-qemu-x86_64}" -cpu help 2>&1 | head -30 >&2
         fi
         exit 1
     fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   wasm:
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -32,6 +33,7 @@ jobs:
             node --experimental-vm-modules src/wasm/test_wasm.mjs
 
   lint:
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -66,6 +68,7 @@ jobs:
         run: uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
 
   playground-lint:
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -88,6 +91,7 @@ jobs:
         run: cd playground && npm run lint
 
   build-and-test:
+    timeout-minutes: 45
     runs-on: ubuntu-24.04
     env:
       CMAKE_BUILD_TYPE: Debug
@@ -246,6 +250,7 @@ jobs:
         run: uv run --locked pytest --codeblocks docs/ README.md -v
 
   release-cpp-smoke:
+    timeout-minutes: 45
     runs-on: ubuntu-24.04
     env:
       CMAKE_BUILD_TYPE: Release
@@ -377,6 +382,7 @@ jobs:
             skbuild-type: RelWithDebInfo
             skbuild-cmake-args: "-DCLIFFT_FORCE_ASSERTS=ON"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     env:
       CMAKE_BUILD_TYPE: Debug
       SKBUILD_CMAKE_BUILD_TYPE: ${{ matrix.skbuild-type }}
@@ -447,6 +453,7 @@ jobs:
   # silently drop out of enforcement, and it reports success only when
   # every needed job succeeded.
   ci-gate:
+    timeout-minutes: 10
     if: always()
     needs:
       - wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'playground/**'
-      - '*.md'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/pr_preview.yml'
 
 permissions:
   contents: read
@@ -447,3 +441,22 @@ jobs:
 
       - name: Run Python tests
         run: uv run --locked pytest tests/python/ -n logical --maxprocesses 4 -v
+
+  # Single aggregate check for branch protection. Requiring this job
+  # instead of enumerating every job means new or renamed jobs cannot
+  # silently drop out of enforcement, and it reports success only when
+  # every needed job succeeded.
+  ci-gate:
+    if: always()
+    needs:
+      - wasm
+      - lint
+      - playground-lint
+      - build-and-test
+      - release-cpp-smoke
+      - cross-platform
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require every needed job to succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install ninja and ccache
-        run: |
-          curl -fsSL -o /tmp/ninja-linux.zip \
-            https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
-          echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  /tmp/ninja-linux.zip" | sha256sum --check
-          sudo unzip -o -q /tmp/ninja-linux.zip -d /usr/local/bin
-          curl -fsSL -o /tmp/ccache.tar.xz \
-            https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
-          echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  /tmp/ccache.tar.xz" | sha256sum --check
-          tar -C /tmp -xf /tmp/ccache.tar.xz ccache-4.10.2-linux-x86_64/ccache
-          sudo mv /tmp/ccache-4.10.2-linux-x86_64/ccache /usr/local/bin/ccache
+        uses: ./.github/actions/setup-native-tools
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -263,31 +254,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Every tool comes from a pinned, checksum-verified download so
-      # this job does not depend on the runner's apt mirror, which has
-      # stalled mid-fetch for an hour at a time. The static qemu build
-      # is the same version apt installs on this image, taken from the
-      # noble release pocket, whose pool URLs are permanent.
+      # Direct, checksum-verified downloads avoid apt metadata and dependency
+      # fetches. QEMU is intentionally pinned to Noble's stable GA package;
+      # this smoke needs reproducible CPU emulation rather than distro updates.
       - name: Install pinned build and emulation tools
-        run: |
-          curl -fsSL -o /tmp/ninja-linux.zip \
-            https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
-          echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  /tmp/ninja-linux.zip" | sha256sum --check
-          sudo unzip -o -q /tmp/ninja-linux.zip -d /usr/local/bin
-          curl -fsSL -o /tmp/ccache.tar.xz \
-            https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
-          echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  /tmp/ccache.tar.xz" | sha256sum --check
-          tar -C /tmp -xf /tmp/ccache.tar.xz ccache-4.10.2-linux-x86_64/ccache
-          sudo mv /tmp/ccache-4.10.2-linux-x86_64/ccache /usr/local/bin/ccache
-          curl -fsSL -o /tmp/qemu-user-static.deb \
-            https://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_8.2.2+ds-0ubuntu1_amd64.deb
-          echo "83ad62bfe0e28a5645cb6a40d8b99e7a629fdac9e1a9cea9949d1c59a01322c7  /tmp/qemu-user-static.deb" | sha256sum --check
-          dpkg-deb -x /tmp/qemu-user-static.deb /tmp/qemu-user-static
-          echo "QEMU_X86_64=/tmp/qemu-user-static/usr/bin/qemu-x86_64-static" >> "$GITHUB_ENV"
+        uses: ./.github/actions/setup-native-tools
+        with:
+          install-qemu: "true"
 
       - name: Install Intel SDE
         run: |
-          curl -fsSL -o /tmp/sde.tar.xz \
+          curl --fail --silent --show-error --location \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            --connect-timeout 15 --max-time 180 \
+            --output /tmp/sde.tar.xz \
             https://downloadmirror.intel.com/924984/sde-external-10.13.1-2026-07-28-lin.tar.xz
           echo "94e97d623fec54385686e1e7ba65ebc9941748c05ee451423948334892bf2b50  /tmp/sde.tar.xz" | sha256sum --check
           tar -C "$RUNNER_TEMP" -xf /tmp/sde.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,8 +263,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The Azure apt mirror intermittently stalls mid-fetch with no
+      # timeout of its own; bound each fetch and tolerate a partial
+      # index refresh so a mirror outage degrades to a fast, bounded
+      # failure instead of hanging the job.
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build qemu-user ccache
+        run: |
+          sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 || true
+          sudo apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=30 ninja-build qemu-user ccache
 
       - name: Install Intel SDE
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,14 +263,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # The Azure apt mirror intermittently stalls mid-fetch with no
-      # timeout of its own; bound each fetch and tolerate a partial
-      # index refresh so a mirror outage degrades to a fast, bounded
-      # failure instead of hanging the job.
-      - name: Install system dependencies
+      # Every tool comes from a pinned, checksum-verified download so
+      # this job does not depend on the runner's apt mirror, which has
+      # stalled mid-fetch for an hour at a time. The static qemu build
+      # is the same version apt installs on this image, taken from the
+      # noble release pocket, whose pool URLs are permanent.
+      - name: Install pinned build and emulation tools
         run: |
-          sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 || true
-          sudo apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=30 ninja-build qemu-user ccache
+          curl -fsSL -o /tmp/ninja-linux.zip \
+            https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+          echo "6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255  /tmp/ninja-linux.zip" | sha256sum --check
+          sudo unzip -o -q /tmp/ninja-linux.zip -d /usr/local/bin
+          curl -fsSL -o /tmp/ccache.tar.xz \
+            https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz
+          echo "80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18  /tmp/ccache.tar.xz" | sha256sum --check
+          tar -C /tmp -xf /tmp/ccache.tar.xz ccache-4.10.2-linux-x86_64/ccache
+          sudo mv /tmp/ccache-4.10.2-linux-x86_64/ccache /usr/local/bin/ccache
+          curl -fsSL -o /tmp/qemu-user-static.deb \
+            https://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_8.2.2+ds-0ubuntu1_amd64.deb
+          echo "83ad62bfe0e28a5645cb6a40d8b99e7a629fdac9e1a9cea9949d1c59a01322c7  /tmp/qemu-user-static.deb" | sha256sum --check
+          dpkg-deb -x /tmp/qemu-user-static.deb /tmp/qemu-user-static
+          echo "QEMU_X86_64=/tmp/qemu-user-static/usr/bin/qemu-x86_64-static" >> "$GITHUB_ENV"
 
       - name: Install Intel SDE
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,12 @@ jobs:
       # AVX-512 backend deterministically. Skipped on other arches/OSes
       # since both emulators are x86_64-specific and the other matrix
       # entries use the generic baseline.
-      - name: Install qemu-user (Linux x86_64 wheel only)
+      - name: Install QEMU (Linux x86_64 wheel only)
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
-        run: sudo apt-get update && sudo apt-get install -y qemu-user
+        uses: ./.github/actions/setup-native-tools
+        with:
+          install-build-tools: "false"
+          install-qemu: "true"
 
       - name: Install Intel SDE (Linux x86_64 wheel only)
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,10 @@ jobs:
       - name: Install Intel SDE (Linux x86_64 wheel only)
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
         run: |
-          curl -fsSL -o /tmp/sde.tar.xz \
+          curl --fail --silent --show-error --location \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            --connect-timeout 15 --max-time 180 \
+            --output /tmp/sde.tar.xz \
             https://downloadmirror.intel.com/924984/sde-external-10.13.1-2026-07-28-lin.tar.xz
           echo "94e97d623fec54385686e1e7ba65ebc9941748c05ee451423948334892bf2b50  /tmp/sde.tar.xz" | sha256sum --check
           tar -C "$RUNNER_TEMP" -xf /tmp/sde.tar.xz

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=500]
       - id: check-merge-conflict
+
+  # GitHub Actions workflow linting
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -97,12 +97,24 @@ the ordinary dispatch loop and kernels, where exceptions and allocations are
 deliberately avoided.
 
 The C++ suite runs through default dispatch, forced scalar execution, and
-forced AVX2 execution when the CI host supports it. Focused kernel tests also
-compare AVX-512 implementations against the scalar reference on capable
-hosts. Cross-platform builds exercise configurations without runtime dispatch,
-and release smoke tests emulate older x86 CPUs so architecture-specific
-instructions cannot leak into fallback paths. WebAssembly has a separate smoke
-suite for compilation, plan inspection, and browser sampling.
+forced AVX2 and AVX-512 execution when the CI runner's CPU supports them.
+Focused kernel tests also compare the AVX2 and AVX-512 implementations
+against the scalar reference on capable hosts. The
+Release smoke job runs an emulated CPU matrix: QEMU legs cover sub-AVX2 hosts
+and confirm that `CLIFFT_FORCE_ISA` traps cleanly on incompatible CPUs
+instead of executing an unsupported instruction, and Intel SDE legs pinned to
+a Skylake-X model make AVX-512 kernel execution deterministic in CI, since
+QEMU's TCG engine cannot execute AVX-512 instructions. Passing legs also
+check the resolved ISA through `clifft.runtime_isa()`. That same job runs the
+full Python suite against an optimized (non-Debug) extension built with
+`assert()` kept active, so release codegen is checked against the same
+invariants as debug builds. Cross-platform jobs cover Linux arm64, macOS, and
+Windows. WebAssembly has a separate smoke suite for compilation, plan
+inspection, and browser sampling.
+
+A nightly workflow runs the C++ suite under ThreadSanitizer and under
+AddressSanitizer combined with UndefinedBehaviorSanitizer. A weekly workflow
+records combined C++ and Python coverage.
 
 ## Running the Tests
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -96,25 +96,16 @@ they reach execution. Debug builds additionally assert internal invariants in
 the ordinary dispatch loop and kernels, where exceptions and allocations are
 deliberately avoided.
 
-The C++ suite runs through default dispatch, forced scalar execution, and
-forced AVX2 and AVX-512 execution when the CI runner's CPU supports them.
-Focused kernel tests also compare the AVX2 and AVX-512 implementations
-against the scalar reference on capable hosts. The
-Release smoke job runs an emulated CPU matrix: QEMU legs cover sub-AVX2 hosts
-and confirm that `CLIFFT_FORCE_ISA` traps cleanly on incompatible CPUs
-instead of executing an unsupported instruction, and Intel SDE legs pinned to
-a Skylake-X model make AVX-512 kernel execution deterministic in CI, since
-QEMU's TCG engine cannot execute AVX-512 instructions. Passing legs also
-check the resolved ISA through `clifft.runtime_isa()`. That same job runs the
-full Python suite against an optimized (non-Debug) extension built with
-`assert()` kept active, so release codegen is checked against the same
-invariants as debug builds. Cross-platform jobs cover Linux arm64, macOS, and
-Windows. WebAssembly has a separate smoke suite for compilation, plan
-inspection, and browser sampling.
+CI exercises the scalar, AVX2, and AVX-512 execution paths. Native runners
+cover the instruction sets available on their hosts, while emulation provides
+deterministic coverage of older x86 CPUs and AVX-512. These tests verify both
+automatic backend selection and clean rejection of forced, unsupported
+backends. The Release smoke job also runs the full Python suite against an
+optimized build with internal assertions enabled.
 
-A nightly workflow runs the C++ suite under ThreadSanitizer and under
-AddressSanitizer combined with UndefinedBehaviorSanitizer. A weekly workflow
-records combined C++ and Python coverage.
+Separate jobs cover Linux arm64, macOS, Windows, and WebAssembly. Nightly
+sanitizer jobs check for memory errors, undefined behavior, and data races,
+while a weekly job records combined C++ and Python coverage.
 
 ## Running the Tests
 


### PR DESCRIPTION
## Summary

Closes the PR-trigger holes and adds merge enforcement plumbing:

- **Run CI on every pull request.** The `paths-ignore` list skipped the entire workflow for docs-, playground-, and root-markdown-only PRs — which silently skipped `playground-lint` (ESLint; the preview workflow's `tsc -b && vite build` covers type-checking but not lint) and the docs/README code-block tests. CI's parallel critical path is ~3½ minutes, so always-run is cheap.
- **Add a `ci-gate` aggregate job** that succeeds only when every needed job succeeded (fails on failure/cancelled/skipped). Branch protection can require this one stable check instead of enumerating jobs; new or renamed jobs can't silently drop out of enforcement. Note the coupling: removing `paths-ignore` is a prerequisite — a path-skipped workflow never reports, which would leave a required check pending forever.
- **Add actionlint** to pre-commit (pinned v1.7.12). Zero findings on the current workflows; this matters mainly for the scheduled/release workflows that can't exercise themselves on PRs.
- **Bound every job with `timeout-minutes`** (generous multiples of observed durations). Added after this PR's own first run demonstrated the need: `release-cpp-smoke` hung for ~55 minutes on `apt-get` — the same runner-infrastructure hang that stalled the 2026-08-19 benchmark run — and without a bound it would consume the 6-hour default; once `ci-gate` is required, that would block merging for 6 hours.
- **Remove apt from `release-cpp-smoke` entirely.** During this PR's runs the Azure apt mirror stalled mid-fetch (zero output for 64 minutes; parallel `archive.ubuntu.com` fetches succeeded) — the same incident class as the 2026-08-19 benchmark hang — and apt's own `Acquire` timeouts demonstrably did not bound the stall. The job now installs ninja, ccache, and a static qemu-user build from pinned, checksum-verified downloads (the qemu deb is the exact version apt installs today, from the permanent noble release pocket), matching the job's existing SDE pin; `wheel_smoke.sh` gains a `QEMU_X86_64` override alongside `SDE64`.
- **Refresh `docs/development/testing.md`** to describe current coverage: gated native AVX2/AVX-512 legs, QEMU sub-AVX2/trap legs, deterministic SDE AVX-512 execution with `runtime_isa()` verification, the optimized-with-asserts Python suite, Linux arm64, and the nightly TSan and ASan+UBSan workflows.

After merge, the repo-settings side is manual: require `ci-gate` (and `check-title`) in branch protection.

## Test plan

`ci-gate` validates itself on this PR — it must appear and pass. actionlint ran clean over all workflows; YAML parse and pre-commit checks pass.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.



