### PR TITLE
ci: publish benchmark history from a short dedicated job

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,6 +95,8 @@ jobs:
           python3 tools/ci/audit_build_flags.py \
             --compile-commands build/compile_commands.json
 
+      # Each run writes to a temporary name and renames only on success,
+      # so a failed command cannot upload a partial file as a valid result.
       - name: Run Catch2 benchmarks (scalar)
         # Action parser requires the console reporter (XML is not yet
         # supported by benchmark-action/github-action-benchmark@v1).
@@ -103,7 +105,8 @@ jobs:
         run: |
           build/tests/clifft_tests "[bench]" \
             --reporter console \
-            --out cpp-bench-scalar.txt
+            --out cpp-bench-scalar.txt.tmp
+          mv cpp-bench-scalar.txt.tmp cpp-bench-scalar.txt
 
       - name: Run Catch2 benchmarks (AVX2)
         if: steps.cpu_modes.outputs.avx2 == 'true'
@@ -112,7 +115,8 @@ jobs:
         run: |
           build/tests/clifft_tests "[bench]" \
             --reporter console \
-            --out cpp-bench-avx2.txt
+            --out cpp-bench-avx2.txt.tmp
+          mv cpp-bench-avx2.txt.tmp cpp-bench-avx2.txt
 
       - name: Run Catch2 benchmarks (AVX-512)
         if: steps.cpu_modes.outputs.avx512 == 'true'
@@ -121,7 +125,8 @@ jobs:
         run: |
           build/tests/clifft_tests "[bench]" \
             --reporter console \
-            --out cpp-bench-avx512.txt
+            --out cpp-bench-avx512.txt.tmp
+          mv cpp-bench-avx512.txt.tmp cpp-bench-avx512.txt
 
       - name: Upload benchmark results
         if: ${{ !cancelled() }}
@@ -163,7 +168,8 @@ jobs:
         run: |
           uv run --locked pytest tools/bench/ \
             --benchmark-only \
-            --benchmark-json=python-bench.json
+            --benchmark-json=python-bench.json.tmp
+          mv python-bench.json.tmp python-bench.json
 
       - name: Upload benchmark results
         if: ${{ !cancelled() }}
@@ -192,15 +198,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # A pattern that matches no artifacts succeeds with an empty
+      # workspace, so any failure of this step is a real download error.
       - name: Download benchmark results
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           pattern: bench-*-results
           merge-multiple: true
 
       - name: Publish scalar C++ benchmarks to gh-pages
-        if: ${{ hashFiles('cpp-bench-scalar.txt') != '' }}
+        if: ${{ !cancelled() && hashFiles('cpp-bench-scalar.txt') != '' }}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: C++ Catch2 benchmarks (scalar)
@@ -216,7 +223,7 @@ jobs:
           comment-on-alert: false
 
       - name: Publish AVX2 C++ benchmarks to gh-pages
-        if: ${{ hashFiles('cpp-bench-avx2.txt') != '' }}
+        if: ${{ !cancelled() && hashFiles('cpp-bench-avx2.txt') != '' }}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: C++ Catch2 benchmarks (AVX2)
@@ -231,7 +238,7 @@ jobs:
           comment-on-alert: false
 
       - name: Publish AVX-512 C++ benchmarks to gh-pages
-        if: ${{ hashFiles('cpp-bench-avx512.txt') != '' }}
+        if: ${{ !cancelled() && hashFiles('cpp-bench-avx512.txt') != '' }}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: C++ Catch2 benchmarks (AVX-512)
@@ -246,7 +253,7 @@ jobs:
           comment-on-alert: false
 
       - name: Publish to gh-pages
-        if: ${{ hashFiles('python-bench.json') != '' }}
+        if: ${{ !cancelled() && hashFiles('python-bench.json') != '' }}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Python pytest-benchmark suite

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,11 @@ name: Benchmark history
 # and bench/python. Each path hosts a Chart.js viewer rendered by
 # benchmark-action/github-action-benchmark.
 #
+# The bench-cpp and bench-python jobs run in parallel and upload their
+# results as artifacts; only the final publish job holds the shared
+# gh-pages lock, so a slow build or benchmark run no longer blocks
+# other gh-pages publishers.
+#
 # Triggers: daily at 06:17 UTC and on manual dispatch. Not run on PRs.
 # Scope is record-only — no alerts, no PR comments, no CI failures on
 # regression. See docs/development/benchmark-history.md.
@@ -16,12 +21,6 @@ on:
 
 permissions:
   contents: write
-
-concurrency:
-  # Share the gh-pages-writer group with docs.yml, release.yml, and the
-  # PR preview workflow so scheduled bench runs cannot race a mike push.
-  group: docs-deploy
-  cancel-in-progress: false
 
 jobs:
   bench-cpp:
@@ -106,21 +105,6 @@ jobs:
             --reporter console \
             --out cpp-bench-scalar.txt
 
-      - name: Publish scalar C++ benchmarks to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: C++ Catch2 benchmarks (scalar)
-          tool: catch2
-          output-file-path: cpp-bench-scalar.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: bench/cpp-scalar
-          auto-push: true
-          # Record-only mode: alerts and comments are out of scope per #38.
-          alert-threshold: '200%'
-          fail-on-alert: false
-          comment-on-alert: false
-
       - name: Run Catch2 benchmarks (AVX2)
         if: steps.cpu_modes.outputs.avx2 == 'true'
         env:
@@ -129,21 +113,6 @@ jobs:
           build/tests/clifft_tests "[bench]" \
             --reporter console \
             --out cpp-bench-avx2.txt
-
-      - name: Publish AVX2 C++ benchmarks to gh-pages
-        if: steps.cpu_modes.outputs.avx2 == 'true'
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: C++ Catch2 benchmarks (AVX2)
-          tool: catch2
-          output-file-path: cpp-bench-avx2.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: bench/cpp-avx2
-          auto-push: true
-          alert-threshold: '200%'
-          fail-on-alert: false
-          comment-on-alert: false
 
       - name: Run Catch2 benchmarks (AVX-512)
         if: steps.cpu_modes.outputs.avx512 == 'true'
@@ -154,30 +123,15 @@ jobs:
             --reporter console \
             --out cpp-bench-avx512.txt
 
-      - name: Publish AVX-512 C++ benchmarks to gh-pages
-        if: steps.cpu_modes.outputs.avx512 == 'true'
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: Upload benchmark results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
-          name: C++ Catch2 benchmarks (AVX-512)
-          tool: catch2
-          output-file-path: cpp-bench-avx512.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: bench/cpp-avx512
-          auto-push: true
-          alert-threshold: '200%'
-          fail-on-alert: false
-          comment-on-alert: false
+          name: bench-cpp-results
+          path: cpp-bench-*.txt
+          if-no-files-found: ignore
 
   bench-python:
-    # Wait for bench-cpp before pushing so the two jobs don't race each
-    # other on gh-pages. `always() && !cancelled()` keeps the "a C++
-    # failure doesn't gate Python history" property intact (Python runs
-    # even if bench-cpp failed) while honoring explicit workflow
-    # cancellation -- a bare `always()` would publish data even on a
-    # cancelled run.
-    needs: bench-cpp
-    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
@@ -211,7 +165,88 @@ jobs:
             --benchmark-only \
             --benchmark-json=python-bench.json
 
+      - name: Upload benchmark results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-python-results
+          path: python-bench.json
+          if-no-files-found: ignore
+
+  publish:
+    # A C++ failure doesn't gate Python history and vice versa: publish
+    # whatever results the two bench jobs produced even if one of them
+    # failed, but not on explicit workflow cancellation.
+    needs: [bench-cpp, bench-python]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    concurrency:
+      # Share the gh-pages-writer group with docs.yml, release.yml, and the
+      # PR preview workflow so scheduled bench runs cannot race a mike push.
+      # Only this publish step holds the lock -- benchmark compilation and
+      # runtime happen in bench-cpp/bench-python above, outside the group.
+      group: docs-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download benchmark results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: bench-*-results
+          merge-multiple: true
+
+      - name: Publish scalar C++ benchmarks to gh-pages
+        if: ${{ hashFiles('cpp-bench-scalar.txt') != '' }}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Catch2 benchmarks (scalar)
+          tool: catch2
+          output-file-path: cpp-bench-scalar.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench/cpp-scalar
+          auto-push: true
+          # Record-only mode: alerts and comments are out of scope per #38.
+          alert-threshold: '200%'
+          fail-on-alert: false
+          comment-on-alert: false
+
+      - name: Publish AVX2 C++ benchmarks to gh-pages
+        if: ${{ hashFiles('cpp-bench-avx2.txt') != '' }}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Catch2 benchmarks (AVX2)
+          tool: catch2
+          output-file-path: cpp-bench-avx2.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench/cpp-avx2
+          auto-push: true
+          alert-threshold: '200%'
+          fail-on-alert: false
+          comment-on-alert: false
+
+      - name: Publish AVX-512 C++ benchmarks to gh-pages
+        if: ${{ hashFiles('cpp-bench-avx512.txt') != '' }}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: C++ Catch2 benchmarks (AVX-512)
+          tool: catch2
+          output-file-path: cpp-bench-avx512.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench/cpp-avx512
+          auto-push: true
+          alert-threshold: '200%'
+          fail-on-alert: false
+          comment-on-alert: false
+
       - name: Publish to gh-pages
+        if: ${{ hashFiles('python-bench.json') != '' }}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Python pytest-benchmark suite


### PR DESCRIPTION
## Summary

The benchmark workflow held the shared `docs-deploy` concurrency group (shared with docs.yml, release.yml, and PR previews) for its entire runtime — up to its 60-minute timeout. The 2026-08-19 scheduled run demonstrated the failure mode: it hung after ~4 minutes and blocked every gh-pages publisher for the remaining hour.

Restructure: `bench-cpp` and `bench-python` now run in parallel with no lock (the old `needs:` chain existed only to serialize gh-pages pushes), upload results as artifacts, and a dedicated `publish` job (15-minute timeout) downloads them and runs the four `benchmark-action` publishes while alone holding `docs-deploy`. Publish steps are gated on `hashFiles(...)` so exactly the results that were produced get published — preserving the existing "a C++ failure doesn't gate Python history" property, now in both directions, and the partial-publish behavior when a later ISA mode fails. On cancellation nothing uploads and the publish job (and lock) is never entered.

One note versus the ideal: `benchmark-action@v1` with `auto-push` makes one gh-pages commit per publish step (up to four per run). Collapsing to a single commit would mean replacing the action; the incident's failure mode — a long-held lock — is what this fixes.

Review fixes applied: benchmark outputs write to temporary names and rename only on success (a failed command cannot upload a partial file as publishable); the artifact download no longer uses `continue-on-error` (the pattern form already succeeds on zero matches, so failures are real errors); every publish step's condition is explicitly `!cancelled() && hashFiles(...)` so one failed publish does not implicitly skip the remaining histories.

## Test plan

YAML parses; actionlint clean. The workflow is schedule/dispatch-only, so it can't run on this PR — after merge, a `workflow_dispatch` run confirms the artifact handoff and gated publishes (I can trigger and watch it).

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.

