### PR TITLE
ci: standardize tool setup, bound every job, drop scheduled-workflow apt

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+        uses: ./.github/actions/setup-native-tools
 
       - name: Print runner CPU info
         run: |
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+        uses: ./.github/actions/setup-native-tools
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -154,7 +154,7 @@ jobs:
           key: ${{ runner.os }}-ccache-bench-python-${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.12"
@@ -121,7 +121,7 @@ jobs:
           evict-old-files: job
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.12"
@@ -307,7 +307,7 @@ jobs:
         shell: bash
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.12"
@@ -409,7 +409,7 @@ jobs:
           evict-old-files: job
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,19 +15,26 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       CMAKE_BUILD_TYPE: Debug
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install system dependencies
+      - name: Install ninja and ccache
+        uses: ./.github/actions/setup-native-tools
+
+      # apt remains only for lcov, which has no pinned upstream binary;
+      # the wall-clock bound turns an Azure mirror stall into a fast
+      # failure instead of an hour-long hang.
+      - name: Install lcov
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build lcov
+          sudo timeout 300 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 || true
+          sudo timeout 300 apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=30 lcov
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   check-title:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - name: Validate conventional commit format
         env:

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     if: github.event.action != 'closed'
     permissions:
       contents: read
@@ -75,6 +76,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     if: github.event.pull_request.head.repo.fork == false
     concurrency:
       group: docs-deploy
@@ -103,6 +105,7 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
     concurrency:
       group: docs-deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,13 @@ jobs:
   # -----------------------------------------------------------
   sdist:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for setuptools-scm
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
 
@@ -68,6 +69,7 @@ jobs:
             cibw_archs: AMD64
             cpu_baseline: generic
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,7 +159,7 @@ jobs:
       # the version below when a newer stable CPython is supported.
       - name: Setup uv (Linux x86_64 wheel only)
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: Verify abi3 wheel on newest stable CPython (Linux x86_64 wheel only)
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
@@ -190,6 +192,7 @@ jobs:
   publish-testpypi:
     needs: [sdist, wheels]
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     environment: testpypi
     permissions:
       id-token: write  # Required for trusted publishing
@@ -212,6 +215,7 @@ jobs:
     # Only publish to PyPI on tag pushes — never on manual dispatch.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     environment: pypi
     permissions:
       id-token: write  # Required for trusted publishing
@@ -231,6 +235,7 @@ jobs:
     needs: [publish-pypi]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -266,6 +271,7 @@ jobs:
     needs: [github-release]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     concurrency:
       group: docs-deploy
       cancel-in-progress: false

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   tsan:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     env:
       CMAKE_BUILD_TYPE: Debug
       CMAKE_GENERATOR: Ninja
@@ -25,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+        uses: ./.github/actions/setup-native-tools
 
       - name: Configure C++ build with TSan
         run: |
@@ -49,6 +50,7 @@ jobs:
 
   asan-ubsan:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     env:
       CMAKE_BUILD_TYPE: Debug
       CMAKE_GENERATOR: Ninja
@@ -59,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+        uses: ./.github/actions/setup-native-tools
 
       # -fno-sanitize-recover=all turns UBSan diagnostics into failures
       # instead of warnings that pass the suite.


### PR DESCRIPTION
## Summary

Workflow hygiene, closing out the reviewed follow-up slate:

- **One setup-uv major**: every `astral-sh/setup-uv@v5` is now `@v6` (three jobs already used v6), identical `with:` blocks.
- **Timeouts everywhere**: every job that lacked `timeout-minutes` now has one (release 15-60, sanitizers 45, coverage 60, docs/preview 30), pr-title 5). ci.yml and bench.yml got theirs in earlier PRs; this finishes the set, so no job can consume the 6-hour default on a runner-infrastructure hang.
- **Scheduled workflows off apt**: sanitizers and benchmark jobs install pinned ninja/ccache via the `setup-native-tools` composite action, matching the pull-request path. Coverage keeps apt solely for lcov (no pinned upstream binary), wall-clock bounded so the known Azure mirror stall becomes a fast failure.

## Test plan

All 7 changed workflows parse; actionlint passes over the full workflow set. The scheduled workflows can't run on a PR; the next nightly sanitizers and weekly coverage runs (or a manual dispatch, which I can trigger after merge) confirm the composite-action path there — the identical step already runs green in ci.yml and the dispatched bench run.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.

