### PR TITLE
ci: round-trip the packaging pipeline on every pull request

### DIFF
--- a/.github/scripts/artifact_smoke.py
+++ b/.github/scripts/artifact_smoke.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Smoke-test an installed clifft artifact (wheel or sdist build).
+
+Must be run from the repository root -- the qv10.stim fixture path
+below is relative. The QEMU/SDE wheel-smoke wrapper and the release
+workflow's abi3-verification step both parse this script's stdout:
+they grep for the ``isa=`` line and the trailing ``smoke ok`` line, so
+keep those markers stable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import clifft
+
+
+def parse_python_version(value: str) -> tuple[int, int]:
+    try:
+        major, minor = value.split(".")
+        return int(major), int(minor)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected X.Y, got {value!r}") from exc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expect-python",
+        type=parse_python_version,
+        default=None,
+        metavar="X.Y",
+        help="fail unless the running interpreter is exactly this major.minor version",
+    )
+    args = parser.parse_args()
+
+    if args.expect_python is not None and sys.version_info[:2] != args.expect_python:
+        expected = ".".join(str(part) for part in args.expect_python)
+        got = ".".join(str(part) for part in sys.version_info[:2])
+        print(f"error: expected python {expected}, got {got}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"python={sys.version.split()[0]}", flush=True)
+    print(f"version={clifft.__version__}  baseline={clifft.CPU_BASELINE}", flush=True)
+    print(f"isa={clifft.runtime_isa()}", flush=True)
+
+    symbolic = clifft.compile(Path("tests/fixtures/qv10.stim").read_text())
+    result = clifft.sample(symbolic, shots=1, seed=280)
+    assert result.measurements.shape[0] == 1, result.measurements.shape
+
+    prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
+    ps = clifft.record_probabilities(prog, ["00", "11"])
+    assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
+
+    print("smoke ok", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/wheel_smoke.sh
+++ b/.github/scripts/wheel_smoke.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Emulated-CPU wheel smoke for clifft.
 #
-# Runs a tiny clifft program under an x86 emulator to verify that the
-# installed wheel/extension dispatches correctly across CPU generations.
+# Runs the shared artifact_smoke.py program under an x86 emulator to
+# verify that the installed wheel/extension dispatches correctly
+# across CPU generations.
 # Catches the "AVX-512 leaks into the AVX-2 dispatch code path" class of
 # bug deterministically (it would SIGILL the emulated CPU) and validates
 # that `CLIFFT_FORCE_ISA` traps fire cleanly on incompatible hosts.
@@ -83,19 +84,6 @@ if [ "$emulator" = "sde" ] && ! command -v "${SDE64:-sde64}" >/dev/null 2>&1; th
     exit 2
 fi
 
-script='from pathlib import Path
-import clifft
-print(f"version={clifft.__version__}  baseline={clifft.CPU_BASELINE}", flush=True)
-print(f"isa={clifft.runtime_isa()}", flush=True)
-symbolic = clifft.compile(Path("tests/fixtures/qv10.stim").read_text())
-result = clifft.sample(symbolic, shots=1, seed=280)
-assert result.measurements.shape[0] == 1, result.measurements.shape
-prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-ps = clifft.record_probabilities(prog, ["00", "11"])
-assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
-print("smoke ok", flush=True)
-'
-
 echo "==> wheel_smoke: emulator=$emulator cpu=$cpu_model force=$force_isa expected=$expected"
 
 if [ "$emulator" = "qemu" ]; then
@@ -105,7 +93,7 @@ if [ "$emulator" = "qemu" ]; then
     if [ "$force_isa" != "auto" ]; then
         qemu_env+=(-E "CLIFFT_FORCE_ISA=$force_isa")
     fi
-    output=$("${QEMU_X86_64:-qemu-x86_64}" -cpu "$cpu_model" "${qemu_env[@]}" "$PYTHON" -c "$script" 2>&1)
+    output=$("${QEMU_X86_64:-qemu-x86_64}" -cpu "$cpu_model" "${qemu_env[@]}" "$PYTHON" .github/scripts/artifact_smoke.py 2>&1)
     exit_code=$?
 else
     # SDE children inherit the environment, so export CLIFFT_FORCE_ISA
@@ -113,7 +101,7 @@ else
     if [ "$force_isa" != "auto" ]; then
         export CLIFFT_FORCE_ISA="$force_isa"
     fi
-    output=$("${SDE64:-sde64}" -"$cpu_model" -- "$PYTHON" -c "$script" 2>&1)
+    output=$("${SDE64:-sde64}" -"$cpu_model" -- "$PYTHON" .github/scripts/artifact_smoke.py 2>&1)
     exit_code=$?
 fi
 echo "$output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,75 @@ jobs:
       - name: SDE smoke -- Skylake-X + FORCE_ISA=avx512
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512
 
+  # Round-trips the packaging pipeline on every pull request: the sdist
+  # must be complete and buildable, it must produce a cp312-abi3 wheel,
+  # and that wheel must install and run on the newest stable CPython,
+  # which is newer than the 3.12 interpreter the wheel targets. The
+  # release workflow separately smokes the exact published artifact.
+  package-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CLIFFT_CPU_BASELINE: x86-64-v2
+      SKBUILD_CMAKE_BUILD_TYPE: Release
+      CMAKE_GENERATOR: Ninja
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_COMPILERCHECK: content
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for setuptools-scm
+
+      - name: Install ninja and ccache
+        uses: ./.github/actions/setup-native-tools
+
+      # Same key as release-cpp-smoke (Release build, same CPU baseline),
+      # so this job reuses that job's ccache instead of building cold.
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ccache-Release-${{ env.CLIFFT_CPU_BASELINE }}
+          # Caches saved from PR runs are scoped to the PR ref and cannot be
+          # reused elsewhere; saving only on main limits repo cache eviction.
+          save: ${{ github.ref == 'refs/heads/main' }}
+          evict-old-files: job
+
+      - name: Setup uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: uv build --sdist
+
+      # Build from the sdist, not the checkout, so a file missing from
+      # the sdist manifest fails here instead of only at publish time.
+      - name: Build wheel from sdist
+        run: uv build --wheel --out-dir wheelhouse dist/*.tar.gz
+
+      # Catches a silent regression of the wheel.py-api pin.
+      - name: Assert the wheel is stable-ABI (cp312-abi3)
+        run: ls wheelhouse/clifft-*cp312-abi3*.whl
+
+      - name: Install the wheel on the newest stable CPython
+        run: |
+          uv venv --python 3.14 .abi3-venv
+          uv pip install --python .abi3-venv/bin/python wheelhouse/*.whl
+
+      - name: Run the packaging smoke
+        run: .abi3-venv/bin/python .github/scripts/artifact_smoke.py --expect-python 3.14
+
+      # The suite adds interpreter-behavior coverage for the wrapper; PRs
+      # get the focused smoke above.
+      - name: Run Python tests against the installed wheel (main only)
+        if: github.event_name == 'push'
+        run: |
+          uv pip install --python .abi3-venv/bin/python --group dev
+          .abi3-venv/bin/python -m pytest tests/python/ -n logical --maxprocesses 4 -v
+
   cross-platform:
     name: cross-platform (${{ matrix.label }})
     strategy:
@@ -460,6 +529,7 @@ jobs:
       - playground-lint
       - build-and-test
       - release-cpp-smoke
+      - package-smoke
       - cross-platform
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,11 +415,16 @@ jobs:
         run: .abi3-venv/bin/python .github/scripts/artifact_smoke.py --expect-python 3.14
 
       # The suite adds interpreter-behavior coverage for the wrapper; PRs
-      # get the focused smoke above.
+      # get the focused smoke above. Test dependencies install at their
+      # locked versions so an unrelated PyPI release cannot fail this
+      # main-only step; the wheel stays the artifact under test.
       - name: Run Python tests against the installed wheel (main only)
         if: github.event_name == 'push'
         run: |
-          uv pip install --python .abi3-venv/bin/python --group dev
+          uv export --frozen --only-group dev --no-emit-project \
+            --output-file /tmp/dev-requirements.txt
+          uv pip install --python .abi3-venv/bin/python \
+            --requirements /tmp/dev-requirements.txt
           .abi3-venv/bin/python -m pytest tests/python/ -n logical --maxprocesses 4 -v
 
   cross-platform:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,20 +164,7 @@ jobs:
         run: |
           uv venv --python 3.14 .abi3-venv
           uv pip install --python .abi3-venv/bin/python wheelhouse/*.whl
-          .abi3-venv/bin/python - <<'PY'
-          import sys
-          from pathlib import Path
-          import clifft
-          assert sys.version_info[:2] == (3, 14), sys.version_info
-          print(f"python={sys.version.split()[0]} clifft={clifft.__version__} isa={clifft.runtime_isa()}")
-          symbolic = clifft.compile(Path("tests/fixtures/qv10.stim").read_text())
-          result = clifft.sample(symbolic, shots=1, seed=280)
-          assert result.measurements.shape[0] == 1, result.measurements.shape
-          prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
-          ps = clifft.record_probabilities(prog, ["00", "11"])
-          assert abs(float(ps[0]) - 0.5) < 1e-12 and abs(float(ps[1]) - 0.5) < 1e-12, ps
-          print("abi3 smoke ok")
-          PY
+          .abi3-venv/bin/python .github/scripts/artifact_smoke.py --expect-python 3.14
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Round-trips the packaging pipeline on every pull request, closing the two remaining packaging gaps from the CI review:

- **The sdist was published but never built from or installed** — cibuildwheel builds from the checkout, so an incomplete sdist manifest would ship silently. The new `package-smoke` job builds the sdist, then builds the wheel *from that sdist*.
- **Newest-CPython compatibility was checked only at release time**, though the things that break it (binding changes, wrapper changes, dependency floors) land on ordinary PRs. The job installs the `cp312-abi3` wheel on CPython 3.14 with release-like settings (`x86-64-v2`, Release) and runs a focused artifact smoke; pushes to `main` additionally run the **full Python suite against the installed wheel** (never `uv sync` after the wheel exists, so the tests exercise the artifact, not a rebuilt checkout), with test dependencies installed at their `uv.lock` versions so an unrelated PyPI release cannot fail this main-only step. A dedicated step asserts the `cp312-abi3` tag, catching a silent `wheel.py-api` regression.
- **The duplicated smoke program is consolidated**: the inline script in `wheel_smoke.sh` and the release workflow's abi3 heredoc are now one shared `.github/scripts/artifact_smoke.py` (same output contract: `isa=` line, `smoke ok`). The release-time check of the exact published artifact stays in place.
- `package-smoke` is registered in `ci-gate`'s needs, so it's enforced with no branch-protection change.

## Test plan

Validated locally end to end: sdist → wheel-from-sdist (`uv build` accepts the sdist path directly) → `cp312-abi3` tag assert → install on CPython 3.14.2 → shared smoke passes; `wheel_smoke.sh` under SDE Skylake-X passes with `isa=avx512` verified via the shared script; and the full 803-test suite passes against the installed wheel on 3.14 in ~9 s (the dev dependency group installs cleanly on 3.14). The PR-time path also validates itself on this PR — watch `package-smoke` and `ci-gate`.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.

