### PR TITLE
perf(frontend): canonicalize Clifford rotations during tracing

### DIFF
--- a/docs/compiler_ir.json
+++ b/docs/compiler_ir.json
@@ -61,7 +61,7 @@
     "PHASE_ROTATION": {
       "category": "Non-Clifford",
       "summary": "Continuous Z-rotation by angle alpha (half-turns) on a Pauli product.",
-      "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. The front-end factors out the global phase e^{-i*alpha*pi/2} into global_weight. All single-qubit rotations and multi-qubit Pauli rotations are reduced to this HIR type via Clifford absorption.",
+      "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. For rotations emitted as this HIR type, the front-end factors the source representation's global phase into global_weight. R_X, R_Y, and R_Z rotations within the documented 1e-12 half-turn canonicalization tolerance of a Clifford angle, including U3 components, are instead absorbed directly into the Clifford frame and emit no PHASE_ROTATION. The peephole pass uses the same tolerance when canonicalizing HIR rotations.",
       "display": [
         "PHASE_ROTATION"
       ]

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -93,6 +93,8 @@ def define_env(env: Any) -> None:
                 "Scans the HIR to cancel or fuse T/T_dag gates acting on the "
                 "same virtual Pauli axis using the symplectic inner product as "
                 "a commutation check. T+T fuses to S, T+T_dag cancels to identity. "
+                "Phase rotations within an absolute tolerance of 1e-12 half-turns "
+                "of supported Clifford or T angles are canonicalized. "
                 "It also removes a T gate or Pauli phase rotation when a later "
                 "same-axis measurement consumes the phase; intervening Pauli "
                 "noise is left in place."

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -103,6 +103,14 @@ parameters are in **half-turns** (multiply by pi to get radians).
 | `U3`  | `U3(theta,phi,lambda) target` | General SU(2) gate = `R_Z(phi) R_Y(theta) R_Z(lambda)` |
 | `U`   | `U(theta,phi,lambda) target` | Alias for `U3` |
 
+Finite angles within an absolute tolerance of `1e-12` half-turns of a multiple
+of `0.5`, such as `0.5`, `-1`, and `1.5`, are canonicalized to that Clifford
+rotation during tracing. This policy intentionally absorbs small numerical
+errors introduced by circuit generation or serialization; a deliberate
+overrotation smaller than the tolerance is therefore treated as the canonical
+Clifford. Deviations outside the tolerance remain continuous rotations. Each
+`U3` component receives the same treatment.
+
 !!! note "Name conflicts with Stim"
     Clifft uses `R_X`, `R_Y`, `R_Z` (with underscores) to avoid collision with
     Stim's `RX` / `RY` reset-in-basis instructions.

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <initializer_list>
 #include <numbers>
+#include <optional>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -43,6 +44,18 @@ void apply_single_qubit_clifford(stim::TableauSimulator<kStimWidth>& sim, GateTy
             return;
         case GateType::Z:
             sim.inv_state.prepend_Z(q);
+            return;
+        case GateType::SQRT_X:
+            sim.inv_state.prepend_SQRT_X_DAG(q);
+            return;
+        case GateType::SQRT_X_DAG:
+            sim.inv_state.prepend_SQRT_X(q);
+            return;
+        case GateType::SQRT_Y:
+            sim.inv_state.prepend_SQRT_Y_DAG(q);
+            return;
+        case GateType::SQRT_Y_DAG:
+            sim.inv_state.prepend_SQRT_Y(q);
             return;
         default:
             break;
@@ -266,6 +279,32 @@ void accumulate_rz_global_phase(HirModule& hir, double alpha) {
     hir.global_weight *= std::complex<double>(std::cos(angle), std::sin(angle));
 }
 
+// Absorb a native Clifford representative. Its omitted scalar phase is
+// permitted by the projective statevector contract.
+bool try_absorb_clifford_axis_rotation(stim::TableauSimulator<kStimWidth>& sim, uint32_t qubit,
+                                       double alpha, GateType sqrt_gate, GateType pauli_gate,
+                                       GateType sqrt_dag_gate) {
+    const auto rotation = classify_clifford_rotation(alpha);
+    if (!rotation.has_value()) {
+        return false;
+    }
+
+    switch (*rotation) {
+        case CliffordRotation::IDENTITY:
+            break;
+        case CliffordRotation::SQRT:
+            apply_single_qubit_clifford(sim, sqrt_gate, qubit);
+            break;
+        case CliffordRotation::PAULI:
+            apply_single_qubit_clifford(sim, pauli_gate, qubit);
+            break;
+        case CliffordRotation::SQRT_DAG:
+            apply_single_qubit_clifford(sim, sqrt_dag_gate, qubit);
+            break;
+    }
+    return true;
+}
+
 // Trace R_Z(alpha) on a single qubit: extract the rewound Z, emit
 // PHASE_ROTATION, accumulate global phase.
 //
@@ -275,6 +314,11 @@ void accumulate_rz_global_phase(HirModule& hir, double alpha) {
 // to the global phase accumulator so the tracked phase stays correct.
 void trace_rz(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir, uint32_t qubit,
               double alpha) {
+    if (try_absorb_clifford_axis_rotation(sim, qubit, alpha, GateType::S, GateType::Z,
+                                          GateType::S_DAG)) {
+        return;
+    }
+
     bool sign = false;
     hir.append_phase_rotation(alpha, [&](MutablePauliMaskView slot) {
         extract_rewound_z_into(sim, qubit, slot.x(), slot.z(), sign);
@@ -368,14 +412,23 @@ size_t count_pauli_masks(const Circuit& circuit) {
             case GateType::MX:
             case GateType::MY:
             case GateType::MPAD:
+                count += n_targets;
+                break;
             case GateType::R_Z:
             case GateType::R_X:
             case GateType::R_Y:
-                count += n_targets;
+                if (!classify_clifford_rotation(node.args[0]).has_value()) {
+                    count += n_targets;
+                }
                 break;
-            case GateType::U3:
-                count += 3 * n_targets;
+            case GateType::U3: {
+                size_t rotations_per_target = 0;
+                for (double alpha : node.args) {
+                    rotations_per_target += !classify_clifford_rotation(alpha).has_value();
+                }
+                count += rotations_per_target * n_targets;
                 break;
+            }
             case GateType::R_XX:
             case GateType::R_YY:
             case GateType::R_ZZ:
@@ -626,6 +679,11 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
             case GateType::R_X: {
                 double alpha = node.args[0];
                 for (const auto& target : node.targets) {
+                    if (try_absorb_clifford_axis_rotation(sim, target.value(), alpha,
+                                                          GateType::SQRT_X, GateType::X,
+                                                          GateType::SQRT_X_DAG)) {
+                        continue;
+                    }
                     size_t q = static_cast<size_t>(target.value());
                     sim.inv_state.prepend_H_XZ(q);
                     trace_rz(sim, hir, target.value(), alpha);
@@ -637,6 +695,11 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
             case GateType::R_Y: {
                 double alpha = node.args[0];
                 for (const auto& target : node.targets) {
+                    if (try_absorb_clifford_axis_rotation(sim, target.value(), alpha,
+                                                          GateType::SQRT_Y, GateType::Y,
+                                                          GateType::SQRT_Y_DAG)) {
+                        continue;
+                    }
                     size_t q = static_cast<size_t>(target.value());
                     sim.inv_state.prepend_H_YZ(q);
                     trace_rz(sim, hir, target.value(), alpha);
@@ -656,9 +719,12 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
 
                     trace_rz(sim, hir, qubit, lambda);
 
-                    sim.inv_state.prepend_H_YZ(q);
-                    trace_rz(sim, hir, qubit, theta);
-                    sim.inv_state.prepend_H_YZ(q);
+                    if (!try_absorb_clifford_axis_rotation(sim, qubit, theta, GateType::SQRT_Y,
+                                                           GateType::Y, GateType::SQRT_Y_DAG)) {
+                        sim.inv_state.prepend_H_YZ(q);
+                        trace_rz(sim, hir, qubit, theta);
+                        sim.inv_state.prepend_H_YZ(q);
+                    }
 
                     trace_rz(sim, hir, qubit, phi);
 

--- a/src/clifft/frontend/frontend.h
+++ b/src/clifft/frontend/frontend.h
@@ -11,7 +11,8 @@
 // 2. For each gate in the circuit:
 //    - Clifford gates: apply to simulator (absorbed into tableau)
 //    - T/TPP gates: emit T_GATE ops with rewound Pauli masks
-//    - SPP and rotation gates: emit PHASE_ROTATION ops for the optimizer
+//    - SPP and non-Clifford rotations: emit PHASE_ROTATION ops for the optimizer
+//    - Canonicalized single-qubit Clifford rotations: absorb into the tableau
 //    - Measurement: extract rewound observable, emit MEASURE
 //    - Classical feedback: extract rewound Pauli, emit CONDITIONAL_PAULI
 // 3. Return HirModule with all emitted operations
@@ -53,7 +54,8 @@ struct InstrumentTraceOptions {
 // This is the main entry point for the Front-End. It:
 // - Absorbs Clifford gates into the tableau
 // - Emits T_GATE ops for T/T_DAG and TPP/TPP_DAG
-// - Emits PHASE_ROTATION ops for SPP/SPP_DAG and rotation gates
+// - Emits PHASE_ROTATION ops for SPP/SPP_DAG and non-Clifford rotations
+// - Absorbs R_X/R_Y/R_Z components within 1e-12 half-turns of a Clifford angle
 // - Emits HeisenbergOps for measurements
 // - Emits HeisenbergOps for classical feedback (CX/CZ with rec targets)
 // - With `instruments` supplied, materializes LEVEL_TRANSITION, LEAKAGE, and

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -2,6 +2,7 @@
 
 #include "clifft/optimizer/commutation.h"
 #include "clifft/util/constants.h"
+#include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <bit>
@@ -456,26 +457,26 @@ void PeepholeFusionPass::run(HirModule& hir) {
                     // Normalize to [0, 2) relative phase range
                     fused = fused - 2.0 * std::floor(fused / 2.0);
 
-                    constexpr double kDemoteEps = 1e-12;
-                    if (std::abs(fused) < kDemoteEps || std::abs(fused - 2.0) < kDemoteEps) {
+                    const auto clifford = classify_clifford_rotation(fused);
+                    if (clifford == CliffordRotation::IDENTITY) {
                         deleted[i] = true;
                         deleted[j] = true;
                         ++cancellations_;
-                    } else if (std::abs(fused - 0.5) < kDemoteEps) {
+                    } else if (clifford == CliffordRotation::SQRT) {
                         // S gate: absorb downstream (phase already in global_weight)
                         deleted[i] = true;
                         deleted[j] = true;
                         apply_virtual_s_downstream(hir, j + 1, destab_i, stab_i, false, false,
                                                    deleted);
                         ++fusions_;
-                    } else if (std::abs(fused - 1.5) < kDemoteEps) {
+                    } else if (clifford == CliffordRotation::SQRT_DAG) {
                         // S_dag gate: absorb downstream (phase already in global_weight)
                         deleted[i] = true;
                         deleted[j] = true;
                         apply_virtual_s_downstream(hir, j + 1, destab_i, stab_i, false, true,
                                                    deleted);
                         ++fusions_;
-                    } else if (std::abs(fused - 0.25) < kDemoteEps) {
+                    } else if (std::abs(fused - 0.25) < kRotationCanonicalizationTolerance) {
                         hir.demote_to_tgate(hir.ops[i], false);
                         if (has_source_map) {
                             auto& dst = hir.source_map[i];
@@ -484,7 +485,7 @@ void PeepholeFusionPass::run(HirModule& hir) {
                         }
                         deleted[j] = true;
                         ++fusions_;
-                    } else if (std::abs(fused - 1.75) < kDemoteEps) {
+                    } else if (std::abs(fused - 1.75) < kRotationCanonicalizationTolerance) {
                         hir.demote_to_tgate(hir.ops[i], /*dagger=*/true);
                         if (has_source_map) {
                             auto& dst = hir.source_map[i];
@@ -524,30 +525,30 @@ void PeepholeFusionPass::run(HirModule& hir) {
             double alpha = hir.ops[i].alpha() * (hir.sign(hir.ops[i]) ? -1.0 : 1.0);
             double a_mod2 = alpha - 2.0 * std::floor(alpha / 2.0);
 
-            constexpr double kDemoteEps = 1e-12;
-            if (std::abs(a_mod2) < kDemoteEps || std::abs(a_mod2 - 2.0) < kDemoteEps) {
+            const auto clifford = classify_clifford_rotation(a_mod2);
+            if (clifford == CliffordRotation::IDENTITY) {
                 deleted[i] = true;
                 ++cancellations_;
                 changed = true;
-            } else if (std::abs(a_mod2 - 0.5) < kDemoteEps) {
+            } else if (clifford == CliffordRotation::SQRT) {
                 // S: absorb downstream (phase already in global_weight)
                 apply_virtual_s_downstream(hir, i + 1, hir.destab_mask(hir.ops[i]),
                                            hir.stab_mask(hir.ops[i]), false, false, deleted);
                 deleted[i] = true;
                 ++fusions_;
                 changed = true;
-            } else if (std::abs(a_mod2 - 1.5) < kDemoteEps) {
+            } else if (clifford == CliffordRotation::SQRT_DAG) {
                 // S_dag: absorb downstream (phase already in global_weight)
                 apply_virtual_s_downstream(hir, i + 1, hir.destab_mask(hir.ops[i]),
                                            hir.stab_mask(hir.ops[i]), false, true, deleted);
                 deleted[i] = true;
                 ++fusions_;
                 changed = true;
-            } else if (std::abs(a_mod2 - 0.25) < kDemoteEps) {
+            } else if (std::abs(a_mod2 - 0.25) < kRotationCanonicalizationTolerance) {
                 hir.demote_to_tgate(hir.ops[i], false);
                 ++fusions_;
                 changed = true;
-            } else if (std::abs(a_mod2 - 1.75) < kDemoteEps) {
+            } else if (std::abs(a_mod2 - 1.75) < kRotationCanonicalizationTolerance) {
                 hir.demote_to_tgate(hir.ops[i], /*dagger=*/true);
                 ++fusions_;
                 changed = true;

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -2,9 +2,11 @@
 
 // Numeric checks that must remain valid under Release -ffast-math.
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <optional>
 
 namespace clifft {
 
@@ -18,6 +20,15 @@ inline constexpr uint32_t kDenseActiveWidthLimit = 60;
 // This is part of Clifft's record-reachability semantics.
 inline constexpr double kMeasurementDustEpsilon = 1e-18;
 
+// Absolute tolerance in half-turn units for replacing a rotation with its
+// canonical Clifford representative. This intentionally absorbs numerical
+// noise from circuit generation and serialization, so it is part of the
+// compiler's approximation policy rather than a floating-point implementation
+// detail.
+inline constexpr double kRotationCanonicalizationTolerance = 1e-12;
+
+enum class CliffordRotation : uint8_t { IDENTITY = 0, SQRT = 1, PAULI = 2, SQRT_DAG = 3 };
+
 // The IEEE 754 bit trick below assumes that layout. Make it explicit.
 static_assert(std::numeric_limits<double>::is_iec559,
               "Clifft probability validation requires IEEE 754 doubles");
@@ -30,6 +41,28 @@ inline bool is_finite_robust(double value) {
     std::memcpy(&bits, &value, sizeof(bits));
     constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
     return (bits & kExpMask) != kExpMask;
+}
+
+// Return the Clifford representative when alpha is within the shared absolute
+// tolerance of a multiple of 0.5 half-turns. Reducing modulo two before any
+// scaling also keeps the calculation finite for every finite binary64 input.
+inline std::optional<CliffordRotation> classify_clifford_rotation(double alpha) {
+    if (!is_finite_robust(alpha)) {
+        return std::nullopt;
+    }
+
+    double reduced = std::fmod(alpha, 2.0);
+    if (reduced < 0.0) {
+        reduced += 2.0;
+    }
+
+    const double nearest_step = std::round(2.0 * reduced);
+    if (std::abs(reduced - 0.5 * nearest_step) >= kRotationCanonicalizationTolerance) {
+        return std::nullopt;
+    }
+
+    const auto residue = static_cast<uint32_t>(nearest_step) & 3U;
+    return static_cast<CliffordRotation>(residue);
 }
 
 // The finite check must precede the comparisons: under -ffast-math the

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -560,14 +560,16 @@ NB_MODULE(_clifft_core, m) {
         },
         nb::arg("circuit"),
         "Trace a parsed circuit through the Clifford front-end to produce the "
-        "Heisenberg IR.");
+        "Heisenberg IR. Single-qubit rotations within 1e-12 half-turns of a "
+        "Clifford angle are canonicalized.");
 
     nb::class_<clifft::HirPass>(m, "HirPass", "Abstract base class for HIR optimization passes.");
 
     nb::class_<clifft::PeepholeFusionPass, clifft::HirPass>(
         m, "PeepholeFusionPass",
         "Symplectic peephole optimization: cancels and fuses T/T-dag gates, "
-        "and removes terminal phases consumed by same-axis measurements.")
+        "canonicalizes rotations within 1e-12 half-turns, and removes terminal "
+        "phases consumed by same-axis measurements.")
         .def(nb::init<>())
         .def_prop_ro("cancellations", &clifft::PeepholeFusionPass::cancellations)
         .def_prop_ro("fusions", &clifft::PeepholeFusionPass::fusions)

--- a/tests/python/test_gate_semantics.py
+++ b/tests/python/test_gate_semantics.py
@@ -143,6 +143,15 @@ def test_absorbed_single_qubit_cliffords() -> None:
     assert_statevectors_equiv(_statevector("H_XY 0"), [0, 1])
 
 
+def test_exact_clifford_rotations_match_named_gates() -> None:
+    _assert_statevectors_equivalent("R_X(0.5) 0", "SQRT_X 0")
+    _assert_statevectors_equivalent("R_X(-0.5) 0", "SQRT_X_DAG 0")
+    _assert_statevectors_equivalent("R_Y(0.5) 0", "SQRT_Y 0")
+    _assert_statevectors_equivalent("R_Y(-0.5) 0", "SQRT_Y_DAG 0")
+    _assert_statevectors_equivalent("H 0\nR_Z(0.5) 0", "H 0\nS 0")
+    _assert_statevectors_equivalent("H 0\nR_Z(1.5) 0", "H 0\nS_DAG 0")
+
+
 def test_mpad_and_inverted_measurements() -> None:
     np.testing.assert_array_equal(_measurements("MPAD 1 0 1 0"), [1, 0, 1, 0])
     np.testing.assert_array_equal(_measurements("MPAD !0 !1"), [1, 0])

--- a/tests/python/test_introspection.py
+++ b/tests/python/test_introspection.py
@@ -16,6 +16,15 @@ import clifft
 class TestHirIntrospection:
     """HIR-level introspection: HeisenbergOp, OpType, iteration."""
 
+    def test_trace_rotation_canonicalization_tolerance(self) -> None:
+        inside = clifft.trace(clifft.parse("R_Z(0.5000000000005) 0"))
+        outside = clifft.trace(clifft.parse("R_Z(0.500000000002) 0"))
+
+        assert inside.num_ops == 0
+        assert outside.num_ops == 1
+        assert outside[0].op_type == clifft.OpType.PHASE_ROTATION
+        assert outside[0].as_dict()["alpha"] == 0.500000000002
+
     def test_source_map_preserves_python_line_provenance(self) -> None:
         hir = clifft.trace(clifft.parse("H 0\nT 0\nM 0"))
 

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -222,14 +222,14 @@ class TestPeepholeProjectiveState:
     """
 
     # Each circuit triggers at least one S absorption: T+T fusion,
-    # T_DAG+T_DAG fusion, rotation fusion to S/S_dag, standalone S-angle
-    # demotion, and absorptions on signed, Y-type, and multi-qubit axes.
+    # T_DAG+T_DAG fusion, rotation fusion to S/S_dag, and absorptions on
+    # signed, Y-type, and multi-qubit axes.
     S_ABSORPTION_CIRCUITS = [
         "H 0\nT 0\nT 0\nH 0",
         "H 0\nT_DAG 0\nT_DAG 0\nH 0",
         "H 0\nR_Z(0.25) 0\nR_Z(0.25) 0\nH 0",
-        "H 0\nR_Z(0.5) 0\nH 0",
-        "H 0\nR_Z(1.5) 0\nH 0",
+        "H 0\nR_Z(0.125) 0\nR_Z(0.375) 0\nH 0",
+        "H 0\nR_Z(0.75) 0\nR_Z(0.75) 0\nH 0",
         "S_DAG 0\nH 0\nT 0\nT 0",
         "S_DAG 0\nH 0\nCX 2 3\nT 0\nCX 3 1\nT 0",
         "H 0\nCX 0 1\nT 1\nT 1\nCX 0 1\nH 0",
@@ -240,7 +240,7 @@ class TestPeepholeProjectiveState:
         # Absorptions that leave rotations needing virtual-frame routing at
         # lowering; these exercise composed physical and planner frames.
         "H 0\nT 0\nT 0\nT 0\nH 0\nT 0",
-        "CX 0 1\nY 1\nH 0\nR_Z(0.5) 0\nX 0",
+        "CX 0 1\nY 1\nH 0\nR_Z(0.25) 0\nR_Z(0.25) 0\nX 0",
         "CX 0 1\nY 1\nH 0\nT_DAG 0\nT_DAG 0\nX 0",
         "S_DAG 0\nH 0\nCX 2 3\nT 0\nCX 3 1\nT 0\nH 1\nT 1",
     ]
@@ -558,10 +558,17 @@ class TestSAbsorptionDifferential:
             "H 0\nH 1\nR_XX(0.25) 0 1\nR_XX(0.25) 0 1\nR_YY(0.25) 0 1"
         )
 
-    def test_phase_rotation_demotion(self) -> None:
-        """PHASE_ROTATION at S/S_dag angles demoted and absorbed.
+    def test_phase_rotation_fusion(self) -> None:
+        """PHASE_ROTATION pairs fuse to S/S_dag and are absorbed.
 
         The two axes exercise both S and S_dag demotion while preserving the
         relative state amplitudes.
         """
-        _assert_absorption_preserves_state("R_Z(0.5) 0\nH 1\nR_Z(1.5) 1")
+        _assert_absorption_preserves_state(
+            "R_Z(0.25) 0\nR_Z(0.25) 0\nH 1\nR_Z(0.75) 1\nR_Z(0.75) 1"
+        )
+
+    @pytest.mark.parametrize("angle", [0.5, 1.5])
+    def test_standalone_multi_qubit_phase_rotation_demotion(self, angle: float) -> None:
+        """Standalone multi-qubit S/S_dag rotations reach peephole absorption."""
+        _assert_absorption_preserves_state(f"R_XX({angle}) 0 1")

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -233,6 +233,21 @@ class TestArbitraryRotations(_StatevectorBackendMixin):
     def test_ry_single_qubit(self) -> None:
         self._check_amplitudes("R_Y(0.3) 0")
 
+    @pytest.mark.parametrize("axis", ["X", "Y", "Z"])
+    @pytest.mark.parametrize(
+        "alpha",
+        [-3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
+    )
+    def test_exact_clifford_rotations(self, axis: str, alpha: float) -> None:
+        self._check_amplitudes(f"H 0\nR_{axis}({alpha}) 0")
+
+    @pytest.mark.parametrize(
+        "angles",
+        ["0.5, -1.0, 1.5", "-2.5, 2.0, -1.5"],
+    )
+    def test_u3_with_exact_clifford_components(self, angles: str) -> None:
+        self._check_amplitudes(f"H 0\nU3({angles}) 0")
+
     def test_u3_gate(self) -> None:
         self._check_amplitudes("U3(0.5, 0.25, 0.125) 0")
 

--- a/tests/python/test_record_probabilities.py
+++ b/tests/python/test_record_probabilities.py
@@ -147,7 +147,7 @@ def test_matches_qiskit_for_random_small_circuits(
     "circuit,num_qubits",
     [
         ("H 0\nR_Z(0.25) 0\nH 0", 1),
-        ("R_X(0.5) 0", 1),
+        ("R_X(0.3) 0", 1),
         ("R_Y(0.3) 0", 1),
         ("U3(0.5, 0.25, 0.125) 0", 1),
         ("H 0\nH 1\nR_ZZ(0.3) 0 1\nH 0\nH 1", 2),

--- a/tests/python/test_statevector_squeeze.py
+++ b/tests/python/test_statevector_squeeze.py
@@ -248,7 +248,7 @@ class TestSqueezeSweep2Expansion:
 
     def test_phase_rotation_bubbles_right(self) -> None:
         """PHASE_ROTATION (from R_Z) should bubble rightward in Sweep 2."""
-        circuit = "H 0\nH 1\nR_Z(0.3) 0\nR_Z(0.5) 1\nM 0\nM 1"
+        circuit = "H 0\nH 1\nR_Z(0.3) 0\nR_Z(0.4) 1\nM 0\nM 1"
         base = clifft.compile(circuit, hir_passes=None)
         squeezed = clifft.compile(circuit, hir_passes=_squeeze_only_pass_manager())
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -6,6 +6,7 @@
 
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/util/numeric.h"
 
 #include "test_helpers.h"
 
@@ -14,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <limits>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -1549,37 +1551,133 @@ TEST_CASE("Frontend: R_Z emits PHASE_ROTATION", "[frontend][rotation]") {
     CHECK(hir.ops[0].alpha() == Catch::Approx(0.25));
 }
 
-TEST_CASE("Frontend: R_X desugars through Hadamard", "[frontend][rotation]") {
-    auto circuit = parse("R_X(0.5) 0");
-    auto hir = trace(circuit);
+TEST_CASE("Frontend: non-Clifford R_X and R_Y emit rotations", "[frontend][rotation]") {
+    for (const char* source : {"R_X(0.3) 0", "R_Y(0.3) 0"}) {
+        CAPTURE(source);
+        auto hir = trace(parse(source));
 
-    REQUIRE(hir.num_ops() == 1);
-    CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
-    CHECK(hir.ops[0].alpha() == Catch::Approx(0.5));
+        REQUIRE(hir.num_ops() == 1);
+        CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+        CHECK(hir.ops[0].alpha() == Catch::Approx(0.3));
+        CHECK(hir.pauli_masks.size() == 1);
+    }
 }
 
-TEST_CASE("Frontend: R_Y desugars through H_YZ", "[frontend][rotation]") {
-    auto circuit = parse("R_Y(0.5) 0");
-    auto hir = trace(circuit);
-
-    REQUIRE(hir.num_ops() == 1);
-    CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
-    CHECK(hir.ops[0].alpha() == Catch::Approx(0.5));
-}
-
-TEST_CASE("Frontend: U3 emits three PHASE_ROTATION ops", "[frontend][rotation]") {
+TEST_CASE("Frontend: U3 absorbs exact Clifford components", "[frontend][rotation]") {
     auto circuit = parse("U3(0.5, 0.25, 0.125) 0");
     auto hir = trace(circuit);
 
-    // U3 = R_Z(phi) * R_Y(theta) * R_Z(lambda) -> 3 rotations
-    REQUIRE(hir.num_ops() == 3);
-    for (size_t i = 0; i < 3; ++i) {
+    // U3 = R_Z(phi) * R_Y(theta) * R_Z(lambda). The R_Y(0.5)
+    // component is absorbed, leaving lambda and phi as rotations.
+    REQUIRE(hir.num_ops() == 2);
+    CHECK(hir.pauli_masks.size() == 2);
+    for (size_t i = 0; i < 2; ++i) {
         CHECK(hir.ops[i].op_type() == OpType::PHASE_ROTATION);
     }
-    // lambda=0.125 first, then theta=0.5, then phi=0.25
+    // lambda=0.125 first, then phi=0.25
     CHECK(hir.ops[0].alpha() == Catch::Approx(0.125));
-    CHECK(hir.ops[1].alpha() == Catch::Approx(0.5));
-    CHECK(hir.ops[2].alpha() == Catch::Approx(0.25));
+    CHECK(hir.ops[1].alpha() == Catch::Approx(0.25));
+}
+
+TEST_CASE("Frontend: U3 absorbs components within the Clifford tolerance", "[frontend][rotation]") {
+    constexpr double delta = 0.5 * kRotationCanonicalizationTolerance;
+    Circuit circuit;
+    circuit.num_qubits = 1;
+    circuit.nodes.push_back(
+        {GateType::U3, {Target::qubit(0)}, {0.5 + delta, -1.0 - delta, 1.5 - delta}, 1});
+    const auto hir = trace(circuit);
+    const auto reference = trace(parse("U3(0.5, -1.0, 1.5) 0"));
+
+    CHECK(hir.num_ops() == 0);
+    CHECK(hir.pauli_masks.size() == 0);
+    REQUIRE(hir.final_tableau.has_value());
+    REQUIRE(reference.final_tableau.has_value());
+    CHECK(*hir.final_tableau == *reference.final_tableau);
+}
+
+TEST_CASE("Frontend: exact Clifford axis rotations match named gates", "[frontend][rotation]") {
+    struct AxisCase {
+        const char* axis;
+        const char* sqrt_gate;
+        const char* pauli_gate;
+        const char* sqrt_dag_gate;
+    };
+    const AxisCase axes[] = {
+        {"X", "SQRT_X", "X", "SQRT_X_DAG"},
+        {"Y", "SQRT_Y", "Y", "SQRT_Y_DAG"},
+        {"Z", "S", "Z", "S_DAG"},
+    };
+
+    struct AngleCase {
+        const char* alpha;
+        int residue;
+    };
+    const AngleCase angles[] = {
+        {"-3.0", 2}, {"-2.5", 3}, {"-2.0", 0}, {"-1.5", 1}, {"-1.0", 2}, {"-0.5", 3}, {"0.0", 0},
+        {"0.5", 1},  {"1.0", 2},  {"1.5", 3},  {"2.0", 0},  {"2.5", 1},  {"3.0", 2},
+    };
+
+    for (const auto& axis : axes) {
+        const char* named_gates[] = {"I", axis.sqrt_gate, axis.pauli_gate, axis.sqrt_dag_gate};
+        for (const auto& angle : angles) {
+            CAPTURE(axis.axis, angle.alpha);
+            const std::string source = "R_" + std::string(axis.axis) + "(" + angle.alpha + ") 0";
+            const std::string reference_source = std::string(named_gates[angle.residue]) + " 0";
+            auto hir = trace(parse(source));
+            const auto reference = trace(parse(reference_source));
+
+            CHECK(hir.num_ops() == 0);
+            CHECK(hir.pauli_masks.size() == 0);
+            REQUIRE(hir.final_tableau.has_value());
+            REQUIRE(reference.final_tableau.has_value());
+            CHECK(*hir.final_tableau == *reference.final_tableau);
+        }
+    }
+}
+
+TEST_CASE("Frontend: Clifford tolerance has an explicit boundary", "[frontend][rotation]") {
+    constexpr double inside = 0.5 + 0.5 * kRotationCanonicalizationTolerance;
+    Circuit inside_circuit;
+    inside_circuit.num_qubits = 1;
+    inside_circuit.nodes.push_back({GateType::R_Z, {Target::qubit(0)}, {inside}, 1});
+    const auto inside_hir = trace(inside_circuit);
+    const auto reference = trace(parse("S 0"));
+
+    CHECK(inside_hir.num_ops() == 0);
+    CHECK(inside_hir.pauli_masks.size() == 0);
+    REQUIRE(inside_hir.final_tableau.has_value());
+    REQUIRE(reference.final_tableau.has_value());
+    CHECK(*inside_hir.final_tableau == *reference.final_tableau);
+
+    constexpr double outside = 0.5 + 2.0 * kRotationCanonicalizationTolerance;
+    Circuit outside_circuit;
+    outside_circuit.num_qubits = 1;
+    outside_circuit.nodes.push_back({GateType::R_Z, {Target::qubit(0)}, {outside}, 1});
+    const auto outside_hir = trace(outside_circuit);
+
+    REQUIRE(outside_hir.num_ops() == 1);
+    CHECK(outside_hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    CHECK(outside_hir.ops[0].alpha() == outside);
+    CHECK(outside_hir.pauli_masks.size() == 1);
+}
+
+TEST_CASE("Frontend: largest finite rotation angle is classified without overflow",
+          "[frontend][rotation]") {
+    const auto reference = trace(parse("I 0"));
+    for (GateType gate : {GateType::R_X, GateType::R_Y, GateType::R_Z}) {
+        CAPTURE(gate_name(gate));
+        Circuit circuit;
+        circuit.num_qubits = 1;
+        circuit.nodes.push_back(
+            {gate, {Target::qubit(0)}, {std::numeric_limits<double>::max()}, 1});
+        const auto hir = trace(circuit);
+
+        CHECK(hir.num_ops() == 0);
+        CHECK(hir.pauli_masks.size() == 0);
+        REQUIRE(hir.final_tableau.has_value());
+        REQUIRE(reference.final_tableau.has_value());
+        CHECK(*hir.final_tableau == *reference.final_tableau);
+    }
 }
 
 TEST_CASE("Frontend: R_ZZ emits PHASE_ROTATION on two-qubit Pauli", "[frontend][rotation]") {
@@ -1624,12 +1722,12 @@ TEST_CASE("Frontend: R_PAULI emits PHASE_ROTATION on arbitrary Pauli", "[fronten
 }
 
 TEST_CASE("Frontend: R_Z global phase accumulation", "[frontend][rotation]") {
-    auto circuit = parse("R_Z(0.5) 0");
+    auto circuit = parse("R_Z(0.25) 0");
     auto hir = trace(circuit);
 
-    // Global phase: e^{-i*0.5*pi/2} = e^{-i*pi/4}
-    double expected_re = std::cos(-0.5 * std::numbers::pi / 2.0);
-    double expected_im = std::sin(-0.5 * std::numbers::pi / 2.0);
+    double expected_re = std::cos(-0.25 * std::numbers::pi / 2.0);
+    double expected_im = std::sin(-0.25 * std::numbers::pi / 2.0);
+    CHECK(hir.num_ops() == 1);
     CHECK(hir.global_weight.real() == Catch::Approx(expected_re).epsilon(1e-12));
     CHECK(hir.global_weight.imag() == Catch::Approx(expected_im).epsilon(1e-12));
 }

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -8,6 +8,7 @@
 #include "clifft/optimizer/statevector_squeeze_pass.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/util/constants.h"
+#include "clifft/util/numeric.h"
 
 #include "test_helpers.h"
 
@@ -535,14 +536,16 @@ TEST_CASE("Peephole: T_dag plus T_dag fusion leaves global_weight unchanged", "[
 
 TEST_CASE("Peephole: PHASE_ROTATION demotes to absorbed S and T gates", "[optimizer]") {
     // 0.5 half-turns = S gate -> absorbed (no ops remain)
-    auto hir_s = hir_from("R_Z(0.5) 0");
+    HirModule hir_s(1, 1);
+    clifft::test::append_phase_rotation(hir_s, 0, Z(0), false, 0.5);
     PeepholeFusionPass pass_s;
     pass_s.run(hir_s);
     REQUIRE(hir_s.ops.empty());
     REQUIRE(pass_s.fusions() == 1);
 
     // 1.5 half-turns = S_dag gate -> absorbed (no ops remain)
-    auto hir_sdag = hir_from("R_Z(1.5) 0");
+    HirModule hir_sdag(1, 1);
+    clifft::test::append_phase_rotation(hir_sdag, 0, Z(0), false, 1.5);
     PeepholeFusionPass pass_sdag;
     pass_sdag.run(hir_sdag);
     REQUIRE(hir_sdag.ops.empty());
@@ -563,6 +566,27 @@ TEST_CASE("Peephole: PHASE_ROTATION demotes to absorbed S and T gates", "[optimi
     REQUIRE(hir_tdag.ops.size() == 1);
     REQUIRE(hir_tdag.ops[0].op_type() == OpType::T_GATE);
     REQUIRE(hir_tdag.ops[0].is_dagger() == true);
+}
+
+TEST_CASE("Peephole: rotation canonicalization uses the shared tolerance", "[optimizer]") {
+    constexpr double inside = 0.5 + 0.5 * kRotationCanonicalizationTolerance;
+    HirModule hir_inside(1, 1);
+    clifft::test::append_phase_rotation(hir_inside, 0, Z(0), false, inside);
+    PeepholeFusionPass inside_pass;
+    inside_pass.run(hir_inside);
+    CHECK(hir_inside.ops.empty());
+    CHECK(inside_pass.fusions() == 1);
+
+    constexpr double outside = 0.5 + 2.0 * kRotationCanonicalizationTolerance;
+    HirModule hir_outside(1, 1);
+    clifft::test::append_phase_rotation(hir_outside, 0, Z(0), false, outside);
+    PeepholeFusionPass outside_pass;
+    outside_pass.run(hir_outside);
+    REQUIRE(hir_outside.ops.size() == 1);
+    CHECK(hir_outside.ops[0].op_type() == OpType::PHASE_ROTATION);
+    CHECK(hir_outside.ops[0].alpha() == outside);
+    CHECK(outside_pass.fusions() == 0);
+    CHECK(outside_pass.cancellations() == 0);
 }
 
 TEST_CASE("Peephole: SPP uses rotation fusion and absorption", "[optimizer]") {


### PR DESCRIPTION
## Summary

- canonicalize finite `R_X`, `R_Y`, and `R_Z` angles within an absolute `1e-12` half-turn tolerance of a Clifford angle during frontend tracing, absorbing the native Clifford directly into the tableau
- use one shared classifier and tolerance in both frontend tracing and HIR peephole canonicalization, eliminating the duplicated local policy
- canonicalize `U3` components independently and exclude absorbed rotations from Pauli-mask capacity estimates
- explicitly document that sub-tolerance deliberate overrotations are treated as their canonical Clifford representative
- cover exact positive and negative periods, inside/outside tolerance boundaries, mixed and all-Clifford `U3`, large finite angles, standalone multi-qubit HIR demotion, and Qiskit Aer statevector equivalence

Closes #367.

## Dependency

This work relies on the projective statevector contract introduced by #369, which permits the frontend to absorb an equivalent Clifford representative without reconstructing the source matrix's scalar phase.

## Compilation snapshot

Compilation-only, one seed at each of the six monitored brickwork points, one worker. The baseline is the parent branch #369; no circuit simulation is included.

| eta | L | T_f/L | compile s, parent -> PR | peak k, parent -> PR | HIR ops, parent -> PR | peak RSS MiB, parent -> PR |
|---:|---:|---:|---:|---:|---:|---:|
| 0.5 | 20 | 8 | 1.176 -> 0.021 | 4 -> 2 | 3,620 -> 3,334 | 79.8 -> 75.9 |
| 0.5 | 20 | 16 | 4.684 -> 0.070 | 4 -> 2 | 7,196 -> 6,604 | 199.3 -> 185.1 |
| 0.5 | 32 | 8 | 7.351 -> 0.110 | 5 -> 3 | 9,124 -> 8,363 | 300.2 -> 275.5 |
| 0.5 | 32 | 16 | 29.459 -> 0.453 | 5 -> 2 | 18,121 -> 16,591 | 1,043.0 -> 955.3 |
| 0.25 | 32 | 8 | 7.523 -> 0.113 | 5 -> 3 | 9,084 -> 8,319 | 297.8 -> 274.2 |
| 1.0 | 32 | 8 | 7.491 -> 0.110 | 5 -> 3 | 9,207 -> 8,459 | 302.4 -> 278.0 |

Across this slice, compile time improves by 55-68x. In a peephole-only ablation, pass time falls from 1.143-29.518 seconds on the parent to 0.034-0.272 milliseconds here. The HIR reduction is modest, but canonicalizing Clifford rotations before HIR prevents them from entering the scanner and lets tracing update the Clifford frame at the source.

## Test plan

- [x] Non-benchmark C++ tests pass: 838 passed
- [x] Python tests pass: 863 passed, 1 skipped
- [x] Qiskit Aer coverage includes 39 exact axis-angle cases and exact/mixed `U3` cases
- [x] Strict documentation build passes
- [x] Documentation examples pass: 32 passed, 7 skipped
- [x] Pre-commit formatting, lint, and type checks pass

## Contributor agreement

- [x] I confirm this contribution is my original work or I have the right to submit it, and I license it under the project Apache-2.0 license.
- [x] I have reviewed the AI-assisted changes and included an `Assisted-by:` git trailer.
