### PR TITLE
ci: give package-smoke its own ccache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,12 +377,13 @@ jobs:
       - name: Install ninja and ccache
         uses: ./.github/actions/setup-native-tools
 
-      # Same key as release-cpp-smoke (Release build, same CPU baseline),
-      # so this job reuses that job's ccache instead of building cold.
+      # Distinct key from release-cpp-smoke: both jobs save timestamped
+      # entries and restores take the newest prefix match, so a shared
+      # prefix lets each job clobber the other's warm objects.
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-Release-${{ env.CLIFFT_CPU_BASELINE }}
+          key: ${{ runner.os }}-ccache-package-Release-${{ env.CLIFFT_CPU_BASELINE }}
           # Caches saved from PR runs are scoped to the PR ref and cannot be
           # reused elsewhere; saving only on main limits repo cache eviction.
           save: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

Follow-up from measuring PR-time cache behavior: `package-smoke` shared `release-cpp-smoke`'s ccache key prefix. The ccache action saves timestamp-suffixed entries and restores the newest prefix match, so the two jobs clobber each other — after tonight's main run the newest `Release-x86-64-v2` entry was package-smoke's 5MB wheel-objects cache, which release-cpp-smoke would restore on the next PR and compile the C++ suite nearly cold (observed: 125s builds). A dedicated key gives each job a stable warm cache.

Also noted while measuring, no action needed: the main-only 3.14 suite's first run spent 11m48s source-building `stim==1.15.0` (no cp314 wheel on PyPI); the built wheel is now in the uv cache saved on main, so that cost recurs only when the locked stim version changes.

## Test plan

Three-line key/comment change; actionlint and YAML parse clean. Cache effect is measurable on the next few main pushes and PRs — I'll report the warm `release-cpp-smoke`/`package-smoke` durations.

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's [Apache-2.0 license](../LICENSE).
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.