### PR TITLE
perf(sampling): vectorize active measurement kernels

### DIFF
--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -51,6 +51,8 @@ std::string_view active_measurement_kernel_name(ActiveMeasurementKernel kernel) 
     switch (kernel) {
         case ActiveMeasurementKernel::Scalar:
             return "scalar";
+        case ActiveMeasurementKernel::HighPivot:
+            return "high_pivot";
         case ActiveMeasurementKernel::LanePaired:
             return "lane_paired";
     }

--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -51,6 +51,8 @@ std::string_view active_measurement_kernel_name(ActiveMeasurementKernel kernel) 
     switch (kernel) {
         case ActiveMeasurementKernel::Scalar:
             return "scalar";
+        case ActiveMeasurementKernel::Diagonal:
+            return "diagonal";
         case ActiveMeasurementKernel::HighPivot:
             return "high_pivot";
         case ActiveMeasurementKernel::LanePaired:

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -367,9 +367,10 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
             return measurement_probabilities(state_, action.measurement);
         }
         if constexpr (Backend == ExecutorBackend::Avx2) {
-            return active_measurement_probabilities_avx2(state_, action.measurement);
+            return active_measurement_probabilities_avx2(state_, action.measurement, action.kernel);
         } else if constexpr (Backend == ExecutorBackend::Avx512) {
-            return active_measurement_probabilities_avx512(state_, action.measurement);
+            return active_measurement_probabilities_avx512(state_, action.measurement,
+                                                           action.kernel);
         } else {
             assert(false && "scalar executor requires scalar active-measurement actions");
             return measurement_probabilities(state_, action.measurement);
@@ -401,9 +402,11 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
     if (action.kernel == ActiveMeasurementKernel::Scalar) {
         collapse_measurement(state_, action.measurement, branch, branch_probability);
     } else if constexpr (Backend == ExecutorBackend::Avx2) {
-        collapse_active_measurement_avx2(state_, action.measurement, branch, branch_probability);
+        collapse_active_measurement_avx2(state_, action.measurement, action.kernel, branch,
+                                         branch_probability);
     } else if constexpr (Backend == ExecutorBackend::Avx512) {
-        collapse_active_measurement_avx512(state_, action.measurement, branch, branch_probability);
+        collapse_active_measurement_avx512(state_, action.measurement, action.kernel, branch,
+                                           branch_probability);
     } else {
         assert(false && "scalar executor requires scalar active-measurement actions");
         collapse_measurement(state_, action.measurement, branch, branch_probability);

--- a/src/clifft/sampling/kernel_dispatch.cc
+++ b/src/clifft/sampling/kernel_dispatch.cc
@@ -17,13 +17,12 @@ ActiveMeasurementKernel select_active_measurement(const PreparedMeasurement& mea
     if (measurement.pauli.active_width < min_active_width) {
         return ActiveMeasurementKernel::Scalar;
     }
+    const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
     if (measurement.pauli.is_diagonal()) {
-        const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
         // Removing the lowest measured coordinate preserves packed output order.
         return (measurement.pauli.z & (pivot_bit - 1)) == 0 ? ActiveMeasurementKernel::Diagonal
                                                             : ActiveMeasurementKernel::Scalar;
     }
-    const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
     if (measurement.pauli.pairing_bit == pivot_bit && pivot_bit >= vector_lanes) {
         return ActiveMeasurementKernel::HighPivot;
     }

--- a/src/clifft/sampling/kernel_dispatch.cc
+++ b/src/clifft/sampling/kernel_dispatch.cc
@@ -14,11 +14,17 @@ constexpr uint32_t kMinProfitableAvx512MeasurementWidth = 4;
 ActiveMeasurementKernel select_active_measurement(const PreparedMeasurement& measurement,
                                                   uint64_t vector_lanes, uint32_t lane_index_bits,
                                                   uint32_t min_active_width) noexcept {
-    if (measurement.pauli.is_diagonal() || measurement.pauli.x >= vector_lanes ||
-        measurement.pivot >= lane_index_bits || measurement.pauli.active_width < min_active_width) {
+    if (measurement.pauli.is_diagonal() || measurement.pauli.active_width < min_active_width) {
         return ActiveMeasurementKernel::Scalar;
     }
-    return ActiveMeasurementKernel::LanePaired;
+    const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
+    if (measurement.pauli.pairing_bit == pivot_bit && pivot_bit >= vector_lanes) {
+        return ActiveMeasurementKernel::HighPivot;
+    }
+    if (measurement.pauli.x < vector_lanes && measurement.pivot < lane_index_bits) {
+        return ActiveMeasurementKernel::LanePaired;
+    }
+    return ActiveMeasurementKernel::Scalar;
 }
 
 constexpr uint64_t kNoExcludedPairingBit = 0;

--- a/src/clifft/sampling/kernel_dispatch.cc
+++ b/src/clifft/sampling/kernel_dispatch.cc
@@ -14,8 +14,14 @@ constexpr uint32_t kMinProfitableAvx512MeasurementWidth = 4;
 ActiveMeasurementKernel select_active_measurement(const PreparedMeasurement& measurement,
                                                   uint64_t vector_lanes, uint32_t lane_index_bits,
                                                   uint32_t min_active_width) noexcept {
-    if (measurement.pauli.is_diagonal() || measurement.pauli.active_width < min_active_width) {
+    if (measurement.pauli.active_width < min_active_width) {
         return ActiveMeasurementKernel::Scalar;
+    }
+    if (measurement.pauli.is_diagonal()) {
+        const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
+        // Removing the lowest measured coordinate preserves packed output order.
+        return (measurement.pauli.z & (pivot_bit - 1)) == 0 ? ActiveMeasurementKernel::Diagonal
+                                                            : ActiveMeasurementKernel::Scalar;
     }
     const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
     if (measurement.pauli.pairing_bit == pivot_bit && pivot_bit >= vector_lanes) {

--- a/src/clifft/sampling/kernel_dispatch.h
+++ b/src/clifft/sampling/kernel_dispatch.h
@@ -33,6 +33,7 @@ enum class DirectRotationKernel : uint8_t {
 
 enum class ActiveMeasurementKernel : uint8_t {
     Scalar,
+    HighPivot,
     LanePaired,
 };
 
@@ -64,13 +65,17 @@ void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation
                                   DirectRotationKernel kernel, bool sign) noexcept;
 
 [[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx2(
-    const State& state, const PreparedMeasurement& measurement) noexcept;
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept;
 void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& measurement,
-                                      bool branch, double branch_probability) noexcept;
+                                      ActiveMeasurementKernel kernel, bool branch,
+                                      double branch_probability) noexcept;
 [[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx512(
-    const State& state, const PreparedMeasurement& measurement) noexcept;
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept;
 void collapse_active_measurement_avx512(State& state, const PreparedMeasurement& measurement,
-                                        bool branch, double branch_probability) noexcept;
+                                        ActiveMeasurementKernel kernel, bool branch,
+                                        double branch_probability) noexcept;
 
 [[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(
     const PreparedFusedRotation& rotation);

--- a/src/clifft/sampling/kernel_dispatch.h
+++ b/src/clifft/sampling/kernel_dispatch.h
@@ -33,6 +33,7 @@ enum class DirectRotationKernel : uint8_t {
 
 enum class ActiveMeasurementKernel : uint8_t {
     Scalar,
+    Diagonal,
     HighPivot,
     LanePaired,
 };

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -44,6 +44,24 @@ constexpr std::array<LanePermutationIndices, kLanes> make_lane_permutations() {
     return result;
 }
 
+constexpr std::array<std::array<LanePermutationIndices, 2>, kLanes>
+make_diagonal_compaction_permutations() {
+    std::array<std::array<LanePermutationIndices, 2>, kLanes> result{};
+    for (size_t z = 1; z < kLanes; ++z) {
+        for (size_t parity = 0; parity < 2; ++parity) {
+            size_t destination = 0;
+            for (size_t lane = 0; lane < kLanes; ++lane) {
+                if ((std::popcount(z & lane) & 1U) == parity) {
+                    result[z][parity][2 * destination] = static_cast<int32_t>(2 * lane);
+                    result[z][parity][2 * destination + 1] = static_cast<int32_t>(2 * lane + 1);
+                    ++destination;
+                }
+            }
+        }
+    }
+    return result;
+}
+
 constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
     std::array<LaneSigns, kLanes> result{};
     for (size_t z = 0; z < kLanes; ++z) {
@@ -56,6 +74,8 @@ constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
 
 alignas(32) constexpr auto kLanePermutations = make_lane_permutations();
 alignas(32) constexpr auto kLaneParitySigns = make_lane_parity_signs();
+alignas(32) constexpr auto kDiagonalCompactionPermutations =
+    make_diagonal_compaction_permutations();
 
 alignas(32) constexpr std::array<LanePermutationIndices, 2> kMeasurementCompactionPermutations = {{
     {0, 1, 4, 5, 0, 0, 0, 0},
@@ -288,6 +308,68 @@ void apply_fused_rotation_avx2(State& state, const PreparedFusedRotation& rotati
     }
 }
 
+MeasurementProbabilities active_diagonal_measurement_probabilities_avx2_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    __m256d zero_sum = _mm256_setzero_pd();
+    __m256d one_sum = _mm256_setzero_pd();
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m256d input_real = _mm256_load_pd(real + basis);
+        const __m256d input_imag = _mm256_load_pd(imag + basis);
+        const __m256d norm =
+            _mm256_fmadd_pd(input_real, input_real, _mm256_mul_pd(input_imag, input_imag));
+        const __m256d parity = signed_sine_lanes(basis, measurement.pauli.z, 1.0);
+        const __m256d zero_mask = _mm256_cmp_pd(parity, _mm256_setzero_pd(), _CMP_GT_OQ);
+        zero_sum = _mm256_add_pd(zero_sum, _mm256_and_pd(zero_mask, norm));
+        one_sum = _mm256_add_pd(one_sum, _mm256_andnot_pd(zero_mask, norm));
+    }
+    return MeasurementProbabilities{reduce_add(zero_sum), reduce_add(one_sum)};
+}
+
+void collapse_active_diagonal_measurement_avx2_impl(State& state,
+                                                    const PreparedMeasurement& measurement,
+                                                    bool branch,
+                                                    double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
+    const __m256d scale = _mm256_set1_pd(1.0 / std::sqrt(branch_probability));
+    assert((measurement.pauli.z & (pivot_bit - 1)) == 0 &&
+           "AVX2 diagonal compaction requires the lowest measured pivot");
+
+    if (measurement.pivot >= 2) {
+        for (uint64_t packed = 0; packed < measurement.output_size; packed += kLanes) {
+            const uint64_t source0 = insert_zero_bit(packed, measurement.pivot);
+            const bool other_parity =
+                (std::popcount(source0 & measurement.z_without_pivot) & 1U) != 0;
+            const uint64_t source = source0 | (branch != other_parity ? pivot_bit : 0);
+            const __m256d selected_real = _mm256_load_pd(real + source);
+            const __m256d selected_imag = _mm256_load_pd(imag + source);
+            _mm256_store_pd(real + packed, _mm256_mul_pd(scale, selected_real));
+            _mm256_store_pd(imag + packed, _mm256_mul_pd(scale, selected_imag));
+        }
+    } else {
+        const uint64_t lane_z = measurement.pauli.z & (kLanes - 1);
+        for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+            const bool high_parity = (std::popcount(basis & measurement.pauli.z) & 1U) != 0;
+            const size_t selected_lane_parity = static_cast<size_t>(branch != high_parity);
+            const __m256i compaction = _mm256_load_si256(reinterpret_cast<const __m256i*>(
+                kDiagonalCompactionPermutations[lane_z][selected_lane_parity].data()));
+            const __m128d selected_real =
+                _mm256_castpd256_pd128(permute_lanes(_mm256_load_pd(real + basis), compaction));
+            const __m128d selected_imag =
+                _mm256_castpd256_pd128(permute_lanes(_mm256_load_pd(imag + basis), compaction));
+            _mm_storeu_pd(real + basis / 2,
+                          _mm_mul_pd(_mm256_castpd256_pd128(scale), selected_real));
+            _mm_storeu_pd(imag + basis / 2,
+                          _mm_mul_pd(_mm256_castpd256_pd128(scale), selected_imag));
+        }
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 template <bool RealPhase>
 MeasurementProbabilities active_measurement_probabilities_avx2_impl(
     const State& state, const PreparedMeasurement& measurement) noexcept {
@@ -494,9 +576,15 @@ MeasurementProbabilities active_measurement_probabilities_avx2(
     const State& state, const PreparedMeasurement& measurement,
     ActiveMeasurementKernel kernel) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 2 &&
-           kernel != ActiveMeasurementKernel::Scalar &&
-           "AVX2 active measurement requires a vectorized pairing");
+           measurement.pauli.active_width >= 2 && kernel != ActiveMeasurementKernel::Scalar &&
+           "AVX2 active measurement requires a profitable vector width");
+    if (kernel == ActiveMeasurementKernel::Diagonal) {
+        assert(measurement.pauli.is_diagonal() &&
+               "AVX2 diagonal measurement requires a diagonal Pauli");
+        return active_diagonal_measurement_probabilities_avx2_impl(state, measurement);
+    }
+    assert(!measurement.pauli.is_diagonal() &&
+           "AVX2 paired measurement requires a non-diagonal Pauli");
     if (kernel == ActiveMeasurementKernel::HighPivot) {
         assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
                measurement.pauli.pairing_bit >= kLanes &&
@@ -519,10 +607,18 @@ void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& m
                                       ActiveMeasurementKernel kernel, bool branch,
                                       double branch_probability) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 2 &&
-           kernel != ActiveMeasurementKernel::Scalar && is_finite_robust(branch_probability) &&
-           branch_probability > 0.0 &&
-           "AVX2 active measurement requires a positive-probability vectorized pairing");
+           measurement.pauli.active_width >= 2 && kernel != ActiveMeasurementKernel::Scalar &&
+           is_finite_robust(branch_probability) && branch_probability > 0.0 &&
+           "AVX2 active measurement requires a positive-probability vector width");
+    if (kernel == ActiveMeasurementKernel::Diagonal) {
+        assert(measurement.pauli.is_diagonal() &&
+               "AVX2 diagonal measurement requires a diagonal Pauli");
+        collapse_active_diagonal_measurement_avx2_impl(state, measurement, branch,
+                                                       branch_probability);
+        return;
+    }
+    assert(!measurement.pauli.is_diagonal() &&
+           "AVX2 paired measurement requires a non-diagonal Pauli");
     if (kernel == ActiveMeasurementKernel::HighPivot) {
         assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
                measurement.pauli.pairing_bit >= kLanes &&

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -341,6 +341,60 @@ MeasurementProbabilities active_measurement_probabilities_avx2_impl(
 }
 
 template <bool RealPhase>
+MeasurementProbabilities active_measurement_probabilities_high_pivot_avx2_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    const uint64_t pair_stride = measurement.pauli.pairing_bit;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const double base_coefficient =
+        RealPhase ? measurement.pauli.even_phase.real() : -measurement.pauli.even_phase.imag();
+    __m256d zero_sum = _mm256_setzero_pd();
+    __m256d one_sum = _mm256_setzero_pd();
+
+    for (uint64_t block = 0; block < state.size(); block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; offset += kLanes) {
+            const uint64_t left = block + offset;
+            const uint64_t right_base = (left ^ measurement.pauli.x) & ~(uint64_t{kLanes - 1});
+            const __m256d left_real = _mm256_load_pd(real + left);
+            const __m256d left_imag = _mm256_load_pd(imag + left);
+            const __m256d right_real =
+                permute_lanes(_mm256_load_pd(real + right_base), permutation);
+            const __m256d right_imag =
+                permute_lanes(_mm256_load_pd(imag + right_base), permutation);
+            const __m256d coefficient =
+                signed_sine_lanes(left, measurement.pauli.z, base_coefficient);
+
+            __m256d zero_real;
+            __m256d zero_imag;
+            __m256d one_real;
+            __m256d one_imag;
+            if constexpr (RealPhase) {
+                zero_real = _mm256_fmadd_pd(coefficient, right_real, left_real);
+                zero_imag = _mm256_fmadd_pd(coefficient, right_imag, left_imag);
+                one_real = _mm256_fnmadd_pd(coefficient, right_real, left_real);
+                one_imag = _mm256_fnmadd_pd(coefficient, right_imag, left_imag);
+            } else {
+                zero_real = _mm256_fnmadd_pd(coefficient, right_imag, left_real);
+                zero_imag = _mm256_fmadd_pd(coefficient, right_real, left_imag);
+                one_real = _mm256_fmadd_pd(coefficient, right_imag, left_real);
+                one_imag = _mm256_fnmadd_pd(coefficient, right_real, left_imag);
+            }
+            const __m256d zero_norm =
+                _mm256_fmadd_pd(zero_real, zero_real, _mm256_mul_pd(zero_imag, zero_imag));
+            const __m256d one_norm =
+                _mm256_fmadd_pd(one_real, one_real, _mm256_mul_pd(one_imag, one_imag));
+            zero_sum = _mm256_add_pd(zero_sum, zero_norm);
+            one_sum = _mm256_add_pd(one_sum, one_norm);
+        }
+    }
+    return MeasurementProbabilities{0.5 * reduce_add(zero_sum), 0.5 * reduce_add(one_sum)};
+}
+
+template <bool RealPhase>
 void collapse_active_measurement_avx2_impl(State& state, const PreparedMeasurement& measurement,
                                            bool branch, double branch_probability) noexcept {
     double* const real = state.real_data();
@@ -384,14 +438,77 @@ void collapse_active_measurement_avx2_impl(State& state, const PreparedMeasureme
     state.set_active_width(state.active_width() - 1);
 }
 
+template <bool RealPhase>
+void collapse_active_measurement_high_pivot_avx2_impl(State& state,
+                                                      const PreparedMeasurement& measurement,
+                                                      bool branch,
+                                                      double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = measurement.pauli.pairing_bit;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const double eigenvalue = branch ? -1.0 : 1.0;
+    const double base_coefficient = eigenvalue * (RealPhase ? measurement.pauli.even_phase.real()
+                                                            : -measurement.pauli.even_phase.imag());
+    const __m256d scale = _mm256_set1_pd(kInvSqrt2 / std::sqrt(branch_probability));
+
+    // A highest-bit pivot splits each pair period into contiguous source
+    // halves. Loading both halves before writing their compacted destination
+    // keeps forward traversal safe without scratch storage.
+    for (uint64_t block = 0; block < state.size(); block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; offset += kLanes) {
+            const uint64_t left = block + offset;
+            const uint64_t right_base = (left ^ measurement.pauli.x) & ~(uint64_t{kLanes - 1});
+            const __m256d left_real = _mm256_load_pd(real + left);
+            const __m256d left_imag = _mm256_load_pd(imag + left);
+            const __m256d right_real =
+                permute_lanes(_mm256_load_pd(real + right_base), permutation);
+            const __m256d right_imag =
+                permute_lanes(_mm256_load_pd(imag + right_base), permutation);
+            const __m256d coefficient =
+                signed_sine_lanes(left, measurement.pauli.z, base_coefficient);
+
+            __m256d output_real;
+            __m256d output_imag;
+            if constexpr (RealPhase) {
+                output_real = _mm256_fmadd_pd(coefficient, right_real, left_real);
+                output_imag = _mm256_fmadd_pd(coefficient, right_imag, left_imag);
+            } else {
+                output_real = _mm256_fnmadd_pd(coefficient, right_imag, left_real);
+                output_imag = _mm256_fmadd_pd(coefficient, right_real, left_imag);
+            }
+            const uint64_t destination = block / 2 + offset;
+            _mm256_store_pd(real + destination, _mm256_mul_pd(scale, output_real));
+            _mm256_store_pd(imag + destination, _mm256_mul_pd(scale, output_imag));
+        }
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 }  // namespace
 
 MeasurementProbabilities active_measurement_probabilities_avx2(
-    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
-           measurement.pivot < 2 && measurement.pauli.active_width >= 2 &&
-           "AVX2 active measurement requires a low-lane Pauli pairing");
+           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 2 &&
+           kernel != ActiveMeasurementKernel::Scalar &&
+           "AVX2 active measurement requires a vectorized pairing");
+    if (kernel == ActiveMeasurementKernel::HighPivot) {
+        assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
+               measurement.pauli.pairing_bit >= kLanes &&
+               "AVX2 high-pivot measurement requires the highest X bit");
+        if (measurement.pauli.even_phase.real() != 0.0) {
+            return active_measurement_probabilities_high_pivot_avx2_impl<true>(state, measurement);
+        }
+        return active_measurement_probabilities_high_pivot_avx2_impl<false>(state, measurement);
+    }
+    assert(kernel == ActiveMeasurementKernel::LanePaired && measurement.pauli.x < kLanes &&
+           measurement.pivot < 2 &&
+           "AVX2 lane-paired measurement requires a low-lane Pauli pairing");
     if (measurement.pauli.even_phase.real() != 0.0) {
         return active_measurement_probabilities_avx2_impl<true>(state, measurement);
     }
@@ -399,12 +516,29 @@ MeasurementProbabilities active_measurement_probabilities_avx2(
 }
 
 void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& measurement,
-                                      bool branch, double branch_probability) noexcept {
+                                      ActiveMeasurementKernel kernel, bool branch,
+                                      double branch_probability) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
-           measurement.pivot < 2 && measurement.pauli.active_width >= 2 &&
-           is_finite_robust(branch_probability) && branch_probability > 0.0 &&
-           "AVX2 active measurement requires a positive-probability low-lane pairing");
+           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 2 &&
+           kernel != ActiveMeasurementKernel::Scalar && is_finite_robust(branch_probability) &&
+           branch_probability > 0.0 &&
+           "AVX2 active measurement requires a positive-probability vectorized pairing");
+    if (kernel == ActiveMeasurementKernel::HighPivot) {
+        assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
+               measurement.pauli.pairing_bit >= kLanes &&
+               "AVX2 high-pivot measurement requires the highest X bit");
+        if (measurement.pauli.even_phase.real() != 0.0) {
+            collapse_active_measurement_high_pivot_avx2_impl<true>(state, measurement, branch,
+                                                                   branch_probability);
+        } else {
+            collapse_active_measurement_high_pivot_avx2_impl<false>(state, measurement, branch,
+                                                                    branch_probability);
+        }
+        return;
+    }
+    assert(kernel == ActiveMeasurementKernel::LanePaired && measurement.pauli.x < kLanes &&
+           measurement.pivot < 2 &&
+           "AVX2 lane-paired measurement requires a low-lane Pauli pairing");
     if (measurement.pauli.even_phase.real() != 0.0) {
         collapse_active_measurement_avx2_impl<true>(state, measurement, branch, branch_probability);
     } else {

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -55,6 +55,21 @@ constexpr std::array<LaneIndices, kLanes> make_lane_permutations() {
     return result;
 }
 
+constexpr std::array<std::array<LaneIndices, 2>, kLanes> make_diagonal_compaction_permutations() {
+    std::array<std::array<LaneIndices, 2>, kLanes> result{};
+    for (size_t z = 1; z < kLanes; ++z) {
+        for (size_t parity = 0; parity < 2; ++parity) {
+            size_t destination = 0;
+            for (size_t lane = 0; lane < kLanes; ++lane) {
+                if ((std::popcount(z & lane) & 1U) == parity) {
+                    result[z][parity][destination++] = lane;
+                }
+            }
+        }
+    }
+    return result;
+}
+
 constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
     std::array<LaneSigns, kLanes> result{};
     for (size_t z = 0; z < kLanes; ++z) {
@@ -67,6 +82,8 @@ constexpr std::array<LaneSigns, kLanes> make_lane_parity_signs() {
 
 alignas(64) constexpr auto kLanePermutations = make_lane_permutations();
 alignas(64) constexpr auto kLaneParitySigns = make_lane_parity_signs();
+alignas(64) constexpr auto kDiagonalCompactionPermutations =
+    make_diagonal_compaction_permutations();
 
 struct alignas(64) LanePermutation {
     std::array<uint64_t, kLanes> indices{};
@@ -294,6 +311,68 @@ void apply_fused_rotation_avx512(State& state, const PreparedFusedRotation& rota
     }
 }
 
+MeasurementProbabilities active_diagonal_measurement_probabilities_avx512_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    __m512d zero_sum = _mm512_setzero_pd();
+    __m512d one_sum = _mm512_setzero_pd();
+
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const __m512d input_real = _mm512_load_pd(real + basis);
+        const __m512d input_imag = _mm512_load_pd(imag + basis);
+        const __m512d norm =
+            _mm512_fmadd_pd(input_real, input_real, _mm512_mul_pd(input_imag, input_imag));
+        const __m512d parity = signed_sine_lanes(basis, measurement.pauli.z, 1.0);
+        const __mmask8 zero_mask = _mm512_cmp_pd_mask(parity, _mm512_setzero_pd(), _CMP_GT_OQ);
+        zero_sum = _mm512_mask_add_pd(zero_sum, zero_mask, zero_sum, norm);
+        one_sum = _mm512_mask_add_pd(one_sum, static_cast<__mmask8>(~zero_mask), one_sum, norm);
+    }
+    return MeasurementProbabilities{_mm512_reduce_add_pd(zero_sum), _mm512_reduce_add_pd(one_sum)};
+}
+
+void collapse_active_diagonal_measurement_avx512_impl(State& state,
+                                                      const PreparedMeasurement& measurement,
+                                                      bool branch,
+                                                      double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
+    const __m512d scale = _mm512_set1_pd(1.0 / std::sqrt(branch_probability));
+    assert((measurement.pauli.z & (pivot_bit - 1)) == 0 &&
+           "AVX-512 diagonal compaction requires the lowest measured pivot");
+
+    if (measurement.pivot >= 3) {
+        for (uint64_t packed = 0; packed < measurement.output_size; packed += kLanes) {
+            const uint64_t source0 = insert_zero_bit(packed, measurement.pivot);
+            const bool other_parity =
+                (std::popcount(source0 & measurement.z_without_pivot) & 1U) != 0;
+            const uint64_t source = source0 | (branch != other_parity ? pivot_bit : 0);
+            const __m512d selected_real = _mm512_load_pd(real + source);
+            const __m512d selected_imag = _mm512_load_pd(imag + source);
+            _mm512_store_pd(real + packed, _mm512_mul_pd(scale, selected_real));
+            _mm512_store_pd(imag + packed, _mm512_mul_pd(scale, selected_imag));
+        }
+    } else {
+        const uint64_t lane_z = measurement.pauli.z & (kLanes - 1);
+        for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+            const bool high_parity = (std::popcount(basis & measurement.pauli.z) & 1U) != 0;
+            const size_t selected_lane_parity = static_cast<size_t>(branch != high_parity);
+            const __m512i compaction = _mm512_load_si512(
+                kDiagonalCompactionPermutations[lane_z][selected_lane_parity].data());
+            const __m256d selected_real = _mm512_castpd512_pd256(
+                _mm512_permutexvar_pd(compaction, _mm512_load_pd(real + basis)));
+            const __m256d selected_imag = _mm512_castpd512_pd256(
+                _mm512_permutexvar_pd(compaction, _mm512_load_pd(imag + basis)));
+            _mm256_storeu_pd(real + basis / 2,
+                             _mm256_mul_pd(_mm512_castpd512_pd256(scale), selected_real));
+            _mm256_storeu_pd(imag + basis / 2,
+                             _mm256_mul_pd(_mm512_castpd512_pd256(scale), selected_imag));
+        }
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 template <bool RealPhase>
 MeasurementProbabilities active_measurement_probabilities_avx512_impl(
     const State& state, const PreparedMeasurement& measurement) noexcept {
@@ -501,9 +580,15 @@ MeasurementProbabilities active_measurement_probabilities_avx512(
     const State& state, const PreparedMeasurement& measurement,
     ActiveMeasurementKernel kernel) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 3 &&
-           kernel != ActiveMeasurementKernel::Scalar &&
-           "AVX-512 active measurement requires a vectorized pairing");
+           measurement.pauli.active_width >= 4 && kernel != ActiveMeasurementKernel::Scalar &&
+           "AVX-512 active measurement requires a profitable vector width");
+    if (kernel == ActiveMeasurementKernel::Diagonal) {
+        assert(measurement.pauli.is_diagonal() &&
+               "AVX-512 diagonal measurement requires a diagonal Pauli");
+        return active_diagonal_measurement_probabilities_avx512_impl(state, measurement);
+    }
+    assert(!measurement.pauli.is_diagonal() &&
+           "AVX-512 paired measurement requires a non-diagonal Pauli");
     if (kernel == ActiveMeasurementKernel::HighPivot) {
         assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
                measurement.pauli.pairing_bit >= kLanes &&
@@ -527,10 +612,18 @@ void collapse_active_measurement_avx512(State& state, const PreparedMeasurement&
                                         ActiveMeasurementKernel kernel, bool branch,
                                         double branch_probability) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 3 &&
-           kernel != ActiveMeasurementKernel::Scalar && is_finite_robust(branch_probability) &&
-           branch_probability > 0.0 &&
-           "AVX-512 active measurement requires a positive-probability vectorized pairing");
+           measurement.pauli.active_width >= 4 && kernel != ActiveMeasurementKernel::Scalar &&
+           is_finite_robust(branch_probability) && branch_probability > 0.0 &&
+           "AVX-512 active measurement requires a positive-probability vector width");
+    if (kernel == ActiveMeasurementKernel::Diagonal) {
+        assert(measurement.pauli.is_diagonal() &&
+               "AVX-512 diagonal measurement requires a diagonal Pauli");
+        collapse_active_diagonal_measurement_avx512_impl(state, measurement, branch,
+                                                         branch_probability);
+        return;
+    }
+    assert(!measurement.pauli.is_diagonal() &&
+           "AVX-512 paired measurement requires a non-diagonal Pauli");
     if (kernel == ActiveMeasurementKernel::HighPivot) {
         assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
                measurement.pauli.pairing_bit >= kLanes &&

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -347,6 +347,60 @@ MeasurementProbabilities active_measurement_probabilities_avx512_impl(
 }
 
 template <bool RealPhase>
+MeasurementProbabilities active_measurement_probabilities_high_pivot_avx512_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    const uint64_t pair_stride = measurement.pauli.pairing_bit;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const double base_coefficient =
+        RealPhase ? measurement.pauli.even_phase.real() : -measurement.pauli.even_phase.imag();
+    __m512d zero_sum = _mm512_setzero_pd();
+    __m512d one_sum = _mm512_setzero_pd();
+
+    for (uint64_t block = 0; block < state.size(); block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; offset += kLanes) {
+            const uint64_t left = block + offset;
+            const uint64_t right_base = (left ^ measurement.pauli.x) & ~(uint64_t{kLanes - 1});
+            const __m512d left_real = _mm512_load_pd(real + left);
+            const __m512d left_imag = _mm512_load_pd(imag + left);
+            const __m512d right_real =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(real + right_base));
+            const __m512d right_imag =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(imag + right_base));
+            const __m512d coefficient =
+                signed_sine_lanes(left, measurement.pauli.z, base_coefficient);
+
+            __m512d zero_real;
+            __m512d zero_imag;
+            __m512d one_real;
+            __m512d one_imag;
+            if constexpr (RealPhase) {
+                zero_real = _mm512_fmadd_pd(coefficient, right_real, left_real);
+                zero_imag = _mm512_fmadd_pd(coefficient, right_imag, left_imag);
+                one_real = _mm512_fnmadd_pd(coefficient, right_real, left_real);
+                one_imag = _mm512_fnmadd_pd(coefficient, right_imag, left_imag);
+            } else {
+                zero_real = _mm512_fnmadd_pd(coefficient, right_imag, left_real);
+                zero_imag = _mm512_fmadd_pd(coefficient, right_real, left_imag);
+                one_real = _mm512_fmadd_pd(coefficient, right_imag, left_real);
+                one_imag = _mm512_fnmadd_pd(coefficient, right_real, left_imag);
+            }
+            const __m512d zero_norm =
+                _mm512_fmadd_pd(zero_real, zero_real, _mm512_mul_pd(zero_imag, zero_imag));
+            const __m512d one_norm =
+                _mm512_fmadd_pd(one_real, one_real, _mm512_mul_pd(one_imag, one_imag));
+            zero_sum = _mm512_add_pd(zero_sum, zero_norm);
+            one_sum = _mm512_add_pd(one_sum, one_norm);
+        }
+    }
+    return MeasurementProbabilities{0.5 * _mm512_reduce_add_pd(zero_sum),
+                                    0.5 * _mm512_reduce_add_pd(one_sum)};
+}
+
+template <bool RealPhase>
 void collapse_active_measurement_avx512_impl(State& state, const PreparedMeasurement& measurement,
                                              bool branch, double branch_probability) noexcept {
     double* const real = state.real_data();
@@ -392,14 +446,77 @@ void collapse_active_measurement_avx512_impl(State& state, const PreparedMeasure
     state.set_active_width(state.active_width() - 1);
 }
 
+template <bool RealPhase>
+void collapse_active_measurement_high_pivot_avx512_impl(State& state,
+                                                        const PreparedMeasurement& measurement,
+                                                        bool branch,
+                                                        double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = measurement.pauli.pairing_bit;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lane_xor = measurement.pauli.x & (kLanes - 1);
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const double eigenvalue = branch ? -1.0 : 1.0;
+    const double base_coefficient = eigenvalue * (RealPhase ? measurement.pauli.even_phase.real()
+                                                            : -measurement.pauli.even_phase.imag());
+    const __m512d scale = _mm512_set1_pd(kInvSqrt2 / std::sqrt(branch_probability));
+
+    // A highest-bit pivot splits each pair period into contiguous source
+    // halves. Loading both halves before writing their compacted destination
+    // keeps forward traversal safe without scratch storage.
+    for (uint64_t block = 0; block < state.size(); block += pair_period) {
+        for (uint64_t offset = 0; offset < pair_stride; offset += kLanes) {
+            const uint64_t left = block + offset;
+            const uint64_t right_base = (left ^ measurement.pauli.x) & ~(uint64_t{kLanes - 1});
+            const __m512d left_real = _mm512_load_pd(real + left);
+            const __m512d left_imag = _mm512_load_pd(imag + left);
+            const __m512d right_real =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(real + right_base));
+            const __m512d right_imag =
+                _mm512_permutexvar_pd(permutation, _mm512_load_pd(imag + right_base));
+            const __m512d coefficient =
+                signed_sine_lanes(left, measurement.pauli.z, base_coefficient);
+
+            __m512d output_real;
+            __m512d output_imag;
+            if constexpr (RealPhase) {
+                output_real = _mm512_fmadd_pd(coefficient, right_real, left_real);
+                output_imag = _mm512_fmadd_pd(coefficient, right_imag, left_imag);
+            } else {
+                output_real = _mm512_fnmadd_pd(coefficient, right_imag, left_real);
+                output_imag = _mm512_fmadd_pd(coefficient, right_real, left_imag);
+            }
+            const uint64_t destination = block / 2 + offset;
+            _mm512_store_pd(real + destination, _mm512_mul_pd(scale, output_real));
+            _mm512_store_pd(imag + destination, _mm512_mul_pd(scale, output_imag));
+        }
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 }  // namespace
 
 MeasurementProbabilities active_measurement_probabilities_avx512(
-    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
-           measurement.pivot < 3 && measurement.pauli.active_width >= 3 &&
-           "AVX-512 active measurement requires a low-lane Pauli pairing");
+           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 3 &&
+           kernel != ActiveMeasurementKernel::Scalar &&
+           "AVX-512 active measurement requires a vectorized pairing");
+    if (kernel == ActiveMeasurementKernel::HighPivot) {
+        assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
+               measurement.pauli.pairing_bit >= kLanes &&
+               "AVX-512 high-pivot measurement requires the highest X bit");
+        if (measurement.pauli.even_phase.real() != 0.0) {
+            return active_measurement_probabilities_high_pivot_avx512_impl<true>(state,
+                                                                                 measurement);
+        }
+        return active_measurement_probabilities_high_pivot_avx512_impl<false>(state, measurement);
+    }
+    assert(kernel == ActiveMeasurementKernel::LanePaired && measurement.pauli.x < kLanes &&
+           measurement.pivot < 3 &&
+           "AVX-512 lane-paired measurement requires a low-lane Pauli pairing");
     if (measurement.pauli.even_phase.real() != 0.0) {
         return active_measurement_probabilities_avx512_impl<true>(state, measurement);
     }
@@ -407,12 +524,29 @@ MeasurementProbabilities active_measurement_probabilities_avx512(
 }
 
 void collapse_active_measurement_avx512(State& state, const PreparedMeasurement& measurement,
-                                        bool branch, double branch_probability) noexcept {
+                                        ActiveMeasurementKernel kernel, bool branch,
+                                        double branch_probability) noexcept {
     assert(state.active_width() == measurement.pauli.active_width &&
-           !measurement.pauli.is_diagonal() && measurement.pauli.x < kLanes &&
-           measurement.pivot < 3 && measurement.pauli.active_width >= 3 &&
-           is_finite_robust(branch_probability) && branch_probability > 0.0 &&
-           "AVX-512 active measurement requires a positive-probability low-lane pairing");
+           !measurement.pauli.is_diagonal() && measurement.pauli.active_width >= 3 &&
+           kernel != ActiveMeasurementKernel::Scalar && is_finite_robust(branch_probability) &&
+           branch_probability > 0.0 &&
+           "AVX-512 active measurement requires a positive-probability vectorized pairing");
+    if (kernel == ActiveMeasurementKernel::HighPivot) {
+        assert(measurement.pauli.pairing_bit == (uint64_t{1} << measurement.pivot) &&
+               measurement.pauli.pairing_bit >= kLanes &&
+               "AVX-512 high-pivot measurement requires the highest X bit");
+        if (measurement.pauli.even_phase.real() != 0.0) {
+            collapse_active_measurement_high_pivot_avx512_impl<true>(state, measurement, branch,
+                                                                     branch_probability);
+        } else {
+            collapse_active_measurement_high_pivot_avx512_impl<false>(state, measurement, branch,
+                                                                      branch_probability);
+        }
+        return;
+    }
+    assert(kernel == ActiveMeasurementKernel::LanePaired && measurement.pauli.x < kLanes &&
+           measurement.pivot < 3 &&
+           "AVX-512 lane-paired measurement requires a low-lane Pauli pairing");
     if (measurement.pauli.even_phase.real() != 0.0) {
         collapse_active_measurement_avx512_impl<true>(state, measurement, branch,
                                                       branch_probability);

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -85,10 +85,10 @@ std::optional<uint32_t> first_x_at_or_above(const Pauli& pauli, uint32_t begin) 
     return std::nullopt;
 }
 
-std::optional<uint32_t> first_x_below(const Pauli& pauli, uint32_t end) {
-    for (uint32_t q = 0; q < end; ++q) {
-        if (pauli.xs[q]) {
-            return q;
+std::optional<uint32_t> last_x_below(const Pauli& pauli, uint32_t end) {
+    for (uint32_t q = end; q > 0; --q) {
+        if (pauli.xs[q - 1]) {
+            return q - 1;
         }
     }
     return std::nullopt;
@@ -303,7 +303,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
         return resolved.sign;
     }
 
-    std::optional<uint32_t> pivot = first_x_below(resolved.body, active_width);
+    std::optional<uint32_t> pivot = last_x_below(resolved.body, active_width);
     if (!pivot.has_value()) {
         pivot = first_z_below(resolved.body, active_width);
     }

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -389,14 +389,15 @@ TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b001, 0b110}, 3, 0) == ActiveMeasurementKernel::Scalar);
     REQUIRE(select({0b001, 0b1110}, 4, 0) == ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b111, 0b101000}, 6, 2) == ActiveMeasurementKernel::LanePaired);
-    REQUIRE(select({0b1000, 0b0111}, 4, 3) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b1000, 0b0111}, 4, 3) == ActiveMeasurementKernel::HighPivot);
     REQUIRE(select({0b01, 0b10}, 2, 0, ExecutorBackend::Avx2) ==
             ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b01, 0b110}, 3, 0, ExecutorBackend::Avx2) ==
             ActiveMeasurementKernel::LanePaired);
     REQUIRE(select({0b10, 0b101}, 3, 1, ExecutorBackend::Avx2) ==
             ActiveMeasurementKernel::LanePaired);
-    REQUIRE(select({0b100, 0b011}, 3, 2, ExecutorBackend::Avx2) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0b100, 0b011}, 3, 2, ExecutorBackend::Avx2) ==
+            ActiveMeasurementKernel::HighPivot);
     REQUIRE(select({0b01, 0b110}, 3, 0, ExecutorBackend::Scalar) ==
             ActiveMeasurementKernel::Scalar);
 }
@@ -536,7 +537,7 @@ TEST_CASE("Sampling kernels measurements match dense projectors for every small 
 }
 
 #if defined(CLIFFT_TESTS_HAVE_X86_KERNELS)
-TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
+TEST_CASE("Active measurement SIMD matches scalar Pauli compaction") {
     const RuntimeIsa runtime_isa = clifft::internal::runtime_isa();
     if (runtime_isa != RuntimeIsa::Avx2 && runtime_isa != RuntimeIsa::Avx512) {
         return;
@@ -544,26 +545,21 @@ TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
     const ExecutorBackend backend =
         runtime_isa == RuntimeIsa::Avx512 ? ExecutorBackend::Avx512 : ExecutorBackend::Avx2;
 
-    const uint64_t vector_lanes = runtime_isa == RuntimeIsa::Avx512 ? 8 : 4;
-    const uint32_t lane_index_bits = runtime_isa == RuntimeIsa::Avx512 ? 3 : 2;
     const uint32_t min_profitable_width = runtime_isa == RuntimeIsa::Avx512 ? 4 : 2;
     for (uint32_t active_width = min_profitable_width; active_width <= 6; ++active_width) {
         const uint64_t z_limit = uint64_t{1} << active_width;
         const std::vector<std::complex<double>> input = deterministic_state(active_width);
-        for (uint64_t x = 1; x < vector_lanes; ++x) {
+        for (uint64_t x = 1; x < z_limit; ++x) {
             for (uint64_t z = 0; z < z_limit; ++z) {
                 for (uint32_t pivot : valid_measurement_pivots(x, z, active_width)) {
-                    if (pivot >= lane_index_bits || (x & (uint64_t{1} << pivot)) == 0) {
-                        continue;
-                    }
                     CAPTURE(active_width, x, z, pivot);
                     const PreparedMeasurement measurement =
                         prepare_measurement({x, z}, active_width, pivot);
                     const ActiveMeasurementKernel selected =
                         resolve_active_measurement_kernel(measurement, backend);
-                    REQUIRE(selected == (active_width >= min_profitable_width
-                                             ? ActiveMeasurementKernel::LanePaired
-                                             : ActiveMeasurementKernel::Scalar));
+                    if (selected == ActiveMeasurementKernel::Scalar) {
+                        continue;
+                    }
 
                     State scalar_probability_state(active_width, active_width);
                     load_state(scalar_probability_state, input);
@@ -575,9 +571,9 @@ TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
                     const MeasurementProbabilities actual =
                         runtime_isa == RuntimeIsa::Avx512
                             ? active_measurement_probabilities_avx512(vector_probability_state,
-                                                                      measurement)
+                                                                      measurement, selected)
                             : active_measurement_probabilities_avx2(vector_probability_state,
-                                                                    measurement);
+                                                                    measurement, selected);
                     REQUIRE_THAT(actual.zero,
                                  Catch::Matchers::WithinAbs(expected.zero, kTolerance));
                     REQUIRE_THAT(actual.one, Catch::Matchers::WithinAbs(expected.one, kTolerance));
@@ -591,11 +587,11 @@ TEST_CASE("Active measurement SIMD matches scalar low-lane Pauli compaction") {
                         State vector_state(active_width, active_width);
                         load_state(vector_state, input);
                         if (runtime_isa == RuntimeIsa::Avx512) {
-                            collapse_active_measurement_avx512(vector_state, measurement, branch,
-                                                               actual.for_branch(branch));
+                            collapse_active_measurement_avx512(vector_state, measurement, selected,
+                                                               branch, actual.for_branch(branch));
                         } else {
-                            collapse_active_measurement_avx2(vector_state, measurement, branch,
-                                                             actual.for_branch(branch));
+                            collapse_active_measurement_avx2(vector_state, measurement, selected,
+                                                             branch, actual.for_branch(branch));
                         }
 
                         require_vectors_close(coefficients(vector_state),

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -545,6 +545,8 @@ TEST_CASE("Active measurement SIMD matches scalar Pauli compaction") {
     const ExecutorBackend backend =
         runtime_isa == RuntimeIsa::Avx512 ? ExecutorBackend::Avx512 : ExecutorBackend::Avx2;
 
+    const uint64_t vector_lanes = runtime_isa == RuntimeIsa::Avx512 ? 8 : 4;
+    const uint32_t lane_index_bits = runtime_isa == RuntimeIsa::Avx512 ? 3 : 2;
     const uint32_t min_profitable_width = runtime_isa == RuntimeIsa::Avx512 ? 4 : 2;
     for (uint32_t active_width = min_profitable_width; active_width <= 6; ++active_width) {
         const uint64_t z_limit = uint64_t{1} << active_width;
@@ -557,7 +559,15 @@ TEST_CASE("Active measurement SIMD matches scalar Pauli compaction") {
                         prepare_measurement({x, z}, active_width, pivot);
                     const ActiveMeasurementKernel selected =
                         resolve_active_measurement_kernel(measurement, backend);
-                    if (selected == ActiveMeasurementKernel::Scalar) {
+                    const uint64_t pivot_bit = uint64_t{1} << pivot;
+                    ActiveMeasurementKernel expected_kernel = ActiveMeasurementKernel::Scalar;
+                    if (std::bit_floor(x) == pivot_bit && pivot_bit >= vector_lanes) {
+                        expected_kernel = ActiveMeasurementKernel::HighPivot;
+                    } else if (x < vector_lanes && pivot < lane_index_bits) {
+                        expected_kernel = ActiveMeasurementKernel::LanePaired;
+                    }
+                    REQUIRE(selected == expected_kernel);
+                    if (expected_kernel == ActiveMeasurementKernel::Scalar) {
                         continue;
                     }
 

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -603,6 +603,70 @@ TEST_CASE("Active measurement SIMD matches scalar Pauli compaction") {
         }
     }
 }
+
+TEST_CASE("Diagonal active measurement SIMD matches scalar compaction") {
+    const RuntimeIsa runtime_isa = clifft::internal::runtime_isa();
+    if (runtime_isa != RuntimeIsa::Avx2 && runtime_isa != RuntimeIsa::Avx512) {
+        return;
+    }
+    const ExecutorBackend backend =
+        runtime_isa == RuntimeIsa::Avx512 ? ExecutorBackend::Avx512 : ExecutorBackend::Avx2;
+    const uint32_t min_profitable_width = runtime_isa == RuntimeIsa::Avx512 ? 4 : 2;
+    for (uint32_t active_width = min_profitable_width; active_width <= 6; ++active_width) {
+        const uint64_t z_limit = uint64_t{1} << active_width;
+        const std::vector<std::complex<double>> input = deterministic_state(active_width);
+        for (uint64_t z = 1; z < z_limit; ++z) {
+            for (uint32_t pivot : valid_measurement_pivots(0, z, active_width)) {
+                CAPTURE(active_width, z, pivot);
+                const PreparedMeasurement measurement =
+                    prepare_measurement({0, z}, active_width, pivot);
+                const uint64_t pivot_bit = uint64_t{1} << pivot;
+                const bool has_lower_z = (z & (pivot_bit - 1)) != 0;
+                const ActiveMeasurementKernel selected =
+                    resolve_active_measurement_kernel(measurement, backend);
+                REQUIRE(selected == (has_lower_z ? ActiveMeasurementKernel::Scalar
+                                                 : ActiveMeasurementKernel::Diagonal));
+                if (has_lower_z) {
+                    continue;
+                }
+
+                State scalar_probability_state(active_width, active_width);
+                load_state(scalar_probability_state, input);
+                const MeasurementProbabilities expected =
+                    measurement_probabilities(scalar_probability_state, measurement);
+
+                State vector_probability_state(active_width, active_width);
+                load_state(vector_probability_state, input);
+                const MeasurementProbabilities actual =
+                    runtime_isa == RuntimeIsa::Avx512
+                        ? active_measurement_probabilities_avx512(vector_probability_state,
+                                                                  measurement, selected)
+                        : active_measurement_probabilities_avx2(vector_probability_state,
+                                                                measurement, selected);
+                REQUIRE_THAT(actual.zero, Catch::Matchers::WithinAbs(expected.zero, kTolerance));
+                REQUIRE_THAT(actual.one, Catch::Matchers::WithinAbs(expected.one, kTolerance));
+
+                for (bool branch : {false, true}) {
+                    State scalar_state(active_width, active_width);
+                    load_state(scalar_state, input);
+                    collapse_measurement(scalar_state, measurement, branch,
+                                         expected.for_branch(branch));
+
+                    State vector_state(active_width, active_width);
+                    load_state(vector_state, input);
+                    if (runtime_isa == RuntimeIsa::Avx512) {
+                        collapse_active_measurement_avx512(vector_state, measurement, selected,
+                                                           branch, actual.for_branch(branch));
+                    } else {
+                        collapse_active_measurement_avx2(vector_state, measurement, selected,
+                                                         branch, actual.for_branch(branch));
+                    }
+                    require_vectors_close(coefficients(vector_state), coefficients(scalar_state));
+                }
+            }
+        }
+    }
+}
 #endif
 
 TEST_CASE("Sampling instrument kernels match dense projectors without compacting") {

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
@@ -390,6 +391,9 @@ TEST_CASE("Sampling planner correlates arbitrary repeated active measurements") 
             const SamplingPlan plan = plan_sampling(hir);
 
             const auto& first = action_as<MeasureActivePauli>(plan, 2);
+            if (first.pauli.x != 0) {
+                REQUIRE(first.active_pivot == 63U - std::countl_zero(first.pauli.x));
+            }
             const auto& repeated = action_as<RecordClassical>(plan, 3);
             REQUIRE(repeated.outcome == first.outcome);
         }

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -56,9 +56,9 @@ void require_same_coordinate_map(const CoordinateFrame& direct, const Coordinate
 
 std::optional<uint32_t> active_measurement_pivot(const PlannerPauli& measured,
                                                  uint32_t active_width) {
-    for (uint32_t q = 0; q < active_width; ++q) {
-        if (measured.xs[q]) {
-            return q;
+    for (uint32_t q = active_width; q > 0; --q) {
+        if (measured.xs[q - 1]) {
+            return q - 1;
         }
     }
     for (uint32_t q = 0; q < active_width; ++q) {


### PR DESCRIPTION
## Summary

- choose the highest active X coordinate as the measurement pivot and use contiguous-half AVX2/AVX-512 probability and collapse kernels when profitable
- vectorize diagonal active-measurement probability scans and collapse compaction when the compiler-selected pivot is the lowest measured Z coordinate
- retain scalar and lane-paired fallbacks for narrow or incompatible shapes, and expose the selected kernel through plan inspection

Closes #346.

## Performance

Pinned single-core CPU medians from GCC 13 release wheels built with the x86-64-v2 baseline:

| Workload | ISA | Baseline | This PR | Change |
| --- | --- | ---: | ---: | ---: |
| QV10, 20,000 shots | AVX-512 | 1.0321 s | 0.9594 s | 7.0% faster |
| Cultivation d5, 50,000 shots | AVX-512 | 1.1570 s | 0.8221 s | 28.9% faster |
| QV10, 20,000 shots | AVX2 | 1.0627 s | 1.0299 s | 3.1% faster |
| Cultivation d5, 50,000 shots | AVX2 | 1.3525 s | 0.9124 s | 32.5% faster |
| QV20, 10 shots | AVX-512 | 1.8684 s | 1.8684 s | neutral |

The isolated highest-pivot probability-and-collapse kernel measured 3.94x faster on AVX2 and 4.44x faster on AVX-512. QV20 has substantial VM run-to-run variance; a reversed-order confirmation produced the neutral medians above.

## Testing

- forced AVX-512 non-benchmark suite: 841 test cases, 1,052,587 assertions
- forced AVX2 non-benchmark suite: 841 test cases, 1,006,567 assertions
- exhaustive diagonal scalar-versus-SIMD probability and collapse comparison under both backends
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
