### PR TITLE
feat(api)!: add intra-shot OpenMP sampling

### DIFF
--- a/.github/scripts/artifact_smoke.py
+++ b/.github/scripts/artifact_smoke.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Smoke-test an installed clifft artifact (wheel or sdist build).
 
-Must be run from the repository root -- the qv10.stim fixture path
-below is relative. The QEMU/SDE wheel-smoke wrapper and the release
-workflow's abi3-verification step both parse this script's stdout:
+The QEMU/SDE wheel-smoke wrapper and the release workflow's abi3-verification
+step both parse this script's stdout:
 they grep for the ``isa=`` line and the trailing ``smoke ok`` line, so
 keep those markers stable.
 """
@@ -15,6 +14,8 @@ import sys
 from pathlib import Path
 
 import clifft
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def parse_python_version(value: str) -> tuple[int, int]:
@@ -34,6 +35,11 @@ def main() -> None:
         metavar="X.Y",
         help="fail unless the running interpreter is exactly this major.minor version",
     )
+    parser.add_argument(
+        "--exercise-intra-shot",
+        action="store_true",
+        help="also run an explicit two-worker intra-shot OpenMP sample",
+    )
     args = parser.parse_args()
 
     if args.expect_python is not None and sys.version_info[:2] != args.expect_python:
@@ -46,9 +52,25 @@ def main() -> None:
     print(f"version={clifft.__version__}  baseline={clifft.CPU_BASELINE}", flush=True)
     print(f"isa={clifft.runtime_isa()}", flush=True)
 
-    symbolic = clifft.compile(Path("tests/fixtures/qv10.stim").read_text())
+    symbolic = clifft.compile((_PROJECT_ROOT / "tests/fixtures/qv10.stim").read_text())
     result = clifft.sample(symbolic, shots=1, seed=280)
     assert result.measurements.shape[0] == 1, result.measurements.shape
+    if args.exercise_intra_shot:
+        threaded = clifft.sample(
+            symbolic,
+            shots=1,
+            seed=280,
+            thread_layout=(1, 2),
+            intra_shot_min_active_width=0,
+        )
+        for serial_values, threaded_values in (
+            (result.measurements, threaded.measurements),
+            (result.detectors, threaded.detectors),
+            (result.observables, threaded.observables),
+        ):
+            assert serial_values.shape == threaded_values.shape
+            assert serial_values.tobytes() == threaded_values.tobytes()
+        print("intra-shot=ok", flush=True)
 
     prog = clifft.compile("H 0\nCX 0 1\nM 0 1")
     ps = clifft.record_probabilities(prog, ["00", "11"])

--- a/.github/scripts/wheel_smoke.sh
+++ b/.github/scripts/wheel_smoke.sh
@@ -18,7 +18,7 @@
 #          the runner's host CPU.
 #
 # Usage:
-#   wheel_smoke.sh <emulator:qemu|sde> <cpu_model> <force_isa|auto> <expected:pass|fail> [expected_isa]
+#   wheel_smoke.sh <emulator:qemu|sde> <cpu_model> <force_isa|auto> <expected:pass|fail> [expected_isa] [intra-shot]
 #
 # Examples:
 #   wheel_smoke.sh qemu Haswell auto   pass  avx2    # auto-detect picks avx2
@@ -28,6 +28,7 @@
 #   wheel_smoke.sh qemu Nehalem avx2   fail          # host lacks avx2 -> clean trap
 #   wheel_smoke.sh sde  skx     auto   pass  avx512  # SDE Skylake-X auto-detect
 #   wheel_smoke.sh sde  skx     avx512 pass  avx512  # SDE force avx512 explicitly
+#   wheel_smoke.sh sde  skx     avx512 pass  avx512 intra-shot  # exercise OpenMP kernels
 #
 # Requires:
 #   - qemu mode: the QEMU_X86_64 env var pointing at the qemu-x86_64
@@ -46,8 +47,8 @@
 
 set -uo pipefail
 
-if [ "$#" -ne 4 ] && [ "$#" -ne 5 ]; then
-    echo "usage: $0 <emulator:qemu|sde> <cpu_model> <force_isa|auto> <expected:pass|fail> [expected_isa]" >&2
+if [ "$#" -lt 4 ] || [ "$#" -gt 6 ]; then
+    echo "usage: $0 <emulator:qemu|sde> <cpu_model> <force_isa|auto> <expected:pass|fail> [expected_isa] [intra-shot]" >&2
     exit 2
 fi
 
@@ -56,6 +57,7 @@ cpu_model="$2"
 force_isa="$3"
 expected="$4"
 expected_isa="${5:-}"
+exercise_intra_shot="${6:-}"
 
 case "$emulator" in
     qemu|sde) ;;
@@ -73,7 +75,19 @@ case "$expected" in
         ;;
 esac
 
+case "$exercise_intra_shot" in
+    ""|intra-shot) ;;
+    *)
+        echo "error: optional smoke mode must be 'intra-shot', got '$exercise_intra_shot'" >&2
+        exit 2
+        ;;
+esac
+
 PYTHON="${PYTHON:-python3}"
+smoke_args=(.github/scripts/artifact_smoke.py)
+if [ "$exercise_intra_shot" = "intra-shot" ]; then
+    smoke_args+=(--exercise-intra-shot)
+fi
 
 if [ "$emulator" = "qemu" ] && ! command -v "${QEMU_X86_64:-qemu-x86_64}" >/dev/null 2>&1; then
     echo "error: ${QEMU_X86_64:-qemu-x86_64} not found" >&2
@@ -93,7 +107,7 @@ if [ "$emulator" = "qemu" ]; then
     if [ "$force_isa" != "auto" ]; then
         qemu_env+=(-E "CLIFFT_FORCE_ISA=$force_isa")
     fi
-    output=$("${QEMU_X86_64:-qemu-x86_64}" -cpu "$cpu_model" "${qemu_env[@]}" "$PYTHON" .github/scripts/artifact_smoke.py 2>&1)
+    output=$("${QEMU_X86_64:-qemu-x86_64}" -cpu "$cpu_model" "${qemu_env[@]}" "$PYTHON" "${smoke_args[@]}" 2>&1)
     exit_code=$?
 else
     # SDE children inherit the environment, so export CLIFFT_FORCE_ISA
@@ -101,7 +115,7 @@ else
     if [ "$force_isa" != "auto" ]; then
         export CLIFFT_FORCE_ISA="$force_isa"
     fi
-    output=$("${SDE64:-sde64}" -"$cpu_model" -- "$PYTHON" .github/scripts/artifact_smoke.py 2>&1)
+    output=$("${SDE64:-sde64}" -"$cpu_model" -- "$PYTHON" "${smoke_args[@]}" 2>&1)
     exit_code=$?
 fi
 echo "$output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
             skbuild-cmake-args: ""
           - label: macOS
             os: macos-latest
-            install-deps: brew install ninja
+            install-deps: brew install ninja libomp
             skbuild-type: Debug
             skbuild-cmake-args: ""
           # MSVC Debug wheels make the Python suite several times slower than

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
       - name: SDE smoke -- Skylake-X (auto-detect)
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx auto pass avx512
       - name: SDE smoke -- Skylake-X + FORCE_ISA=avx512
-        run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512
+        run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512 intra-shot
 
   # Round-trips the packaging pipeline on every pull request: the sdist
   # must be complete and buildable, it must produce a cp312-abi3 wheel,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,8 @@ jobs:
             ${{ inputs.test_version && format('SETUPTOOLS_SCM_PRETEND_VERSION={0}', inputs.test_version) || '' }}
           # Install build dependencies inside the cibuildwheel container
           CIBW_BEFORE_BUILD: pip install setuptools-scm
+          # Apple Clang needs Homebrew's runtime for intra-shot OpenMP kernels.
+          CIBW_BEFORE_ALL_MACOS: brew install libomp
           # Smoke-test: import the built package and audit exported symbols
           CIBW_TEST_COMMAND: >-
             python -c "import clifft; print(clifft.__version__); print(clifft.CPU_BASELINE); print(type(clifft.compile('M 0')).__name__)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,15 @@ jobs:
             python -c "import clifft; print(clifft.__version__); print(clifft.CPU_BASELINE); print(type(clifft.compile('M 0')).__name__)"
             &&
             python {project}/tools/ci/audit_python_exports.py
+          # Test the repaired wheel's bundled runtime, not the source build.
+          CIBW_TEST_COMMAND_MACOS: >-
+            python {project}/.github/scripts/artifact_smoke.py --exercise-intra-shot
+            &&
+            python {project}/tools/ci/audit_python_exports.py
+
+      - name: Audit bundled macOS OpenMP runtime
+        if: matrix.os == 'macos-14'
+        run: python3 tools/ci/audit_macos_wheel.py wheelhouse/*.whl
 
       # QEMU and SDE smoke against the just-built Linux x86_64 wheel.
       # Catches AVX-512 leakage into the AVX-2 dispatch path (would SIGILL
@@ -153,7 +162,7 @@ jobs:
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx auto pass avx512
       - name: SDE smoke -- Skylake-X + FORCE_ISA=avx512
         if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86_64'
-        run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512
+        run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512 intra-shot
 
       # The cp312-abi3 wheel is the only build per platform, so its
       # packaging contract is forward compatibility: it must install and

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -56,8 +56,13 @@ jobs:
             -E "Bench"
 
   asan-ubsan:
+    name: ASan and UBSan OpenMP ${{ matrix.openmp }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        openmp: [ON, OFF]
     env:
       CMAKE_BUILD_TYPE: Debug
       CMAKE_GENERATOR: Ninja
@@ -70,6 +75,10 @@ jobs:
       - name: Install system dependencies
         uses: ./.github/actions/setup-native-tools
 
+      - name: Install OpenMP runtime
+        if: matrix.openmp == 'ON'
+        run: sudo apt-get update && sudo apt-get install -y libomp-dev
+
       # -fno-sanitize-recover=all turns UBSan diagnostics into failures
       # instead of warnings that pass the suite.
       - name: Configure C++ build with ASan and UBSan
@@ -78,7 +87,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
-            -DCLIFFT_OPENMP=OFF \
+            -DCLIFFT_OPENMP=${{ matrix.openmp }} \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g -O1" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -20,7 +20,10 @@ jobs:
       CMAKE_BUILD_TYPE: Debug
       CMAKE_GENERATOR: Ninja
       # TSan flags: compile and link with -fsanitize=thread.
-      TSAN_OPTIONS: "second_deadlock_stack=1"
+      # The runner's libomp is not instrumented. ignore_noninstrumented_modules
+      # avoids runtime-internal false positives while Clifft code remains fully
+      # instrumented; named suppressions keep this scoped when symbols resolve.
+      TSAN_OPTIONS: "suppressions=${{ github.workspace }}/tools/tsan/suppressions.txt second_deadlock_stack=1 ignore_noninstrumented_modules=1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,12 +31,16 @@ jobs:
       - name: Install system dependencies
         uses: ./.github/actions/setup-native-tools
 
+      - name: Install OpenMP runtime
+        run: sudo apt-get update && sudo apt-get install -y libomp-dev
+
       - name: Configure C++ build with TSan
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
+            -DCLIFFT_OPENMP=ON \
             -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread"
@@ -71,6 +78,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
+            -DCLIFFT_OPENMP=OFF \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g -O1" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,45 @@ endif()
 
 message(STATUS "CLIFFT_CPU_BASELINE = ${CLIFFT_CPU_BASELINE}")
 
+set(CLIFFT_OPENMP "AUTO" CACHE STRING
+    "OpenMP intra-shot kernels: OFF, AUTO, or ON")
+set_property(CACHE CLIFFT_OPENMP PROPERTY STRINGS OFF AUTO ON)
+if(NOT CLIFFT_OPENMP STREQUAL "OFF" AND
+   NOT CLIFFT_OPENMP STREQUAL "AUTO" AND
+   NOT CLIFFT_OPENMP STREQUAL "ON")
+    message(FATAL_ERROR "CLIFFT_OPENMP must be one of: OFF, AUTO, ON")
+endif()
+
+set(CLIFFT_OPENMP_ENABLED OFF)
+if(NOT CLIFFT_OPENMP STREQUAL "OFF")
+    if(EMSCRIPTEN)
+        if(CLIFFT_OPENMP STREQUAL "ON")
+            message(FATAL_ERROR "CLIFFT_OPENMP=ON is not supported under Emscripten")
+        endif()
+    else()
+        # Apple Clang does not search Homebrew's libomp prefix by default.
+        if(APPLE AND NOT DEFINED OpenMP_ROOT)
+            execute_process(
+                COMMAND brew --prefix libomp
+                OUTPUT_VARIABLE _CLIFFT_BREW_LIBOMP_PREFIX
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+                RESULT_VARIABLE _CLIFFT_BREW_LIBOMP_RESULT
+            )
+            if(_CLIFFT_BREW_LIBOMP_RESULT EQUAL 0 AND _CLIFFT_BREW_LIBOMP_PREFIX)
+                set(OpenMP_ROOT "${_CLIFFT_BREW_LIBOMP_PREFIX}")
+            endif()
+        endif()
+        find_package(OpenMP QUIET)
+        if(OpenMP_CXX_FOUND)
+            set(CLIFFT_OPENMP_ENABLED ON)
+        elseif(CLIFFT_OPENMP STREQUAL "ON")
+            message(FATAL_ERROR "CLIFFT_OPENMP=ON requested, but OpenMP C++ support was not found")
+        endif()
+    endif()
+endif()
+message(STATUS "CLIFFT_OPENMP = ${CLIFFT_OPENMP} (enabled: ${CLIFFT_OPENMP_ENABLED})")
+
 # If the selected build baseline explicitly guarantees AVX2/FMA, enable those
 # instructions globally so the generic code can also use the same floor.
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -196,6 +235,12 @@ else()
         add_executable(profile_probability tools/profile/profile_probability.cpp)
         target_link_libraries(profile_probability PRIVATE clifft_core)
         target_include_directories(profile_probability PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_BINARY_DIR}/generated
+        )
+        add_executable(profile_sample tools/profile/profile_sample.cpp)
+        target_link_libraries(profile_sample PRIVATE clifft_core)
+        target_include_directories(profile_sample PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/src
             ${CMAKE_CURRENT_BINARY_DIR}/generated
         )

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -56,6 +56,23 @@ Override the default when needed:
 CLIFFT_CPU_BASELINE=generic uv pip install -e .
 ```
 
+### OpenMP support
+
+Optimized intra-shot sampling uses OpenMP when it is available. The CMake
+setting `CLIFFT_OPENMP` defaults to `AUTO`: source builds enable OpenMP when the
+toolchain provides it and otherwise retain the serial and cross-shot paths.
+Use `-DCLIFFT_OPENMP=OFF` to test or require a build without the runtime, or
+`-DCLIFFT_OPENMP=ON` to make configuration fail when OpenMP is unavailable.
+
+Linux GCC installations normally include OpenMP. Apple Clang needs a separate
+runtime; install it with `brew install libomp`. Clifft checks that Homebrew
+prefix automatically, or it can be supplied explicitly:
+
+```bash
+SKBUILD_CMAKE_ARGS="-DCLIFFT_OPENMP=ON -DOpenMP_ROOT=$(brew --prefix libomp)" \
+  uv pip install -e .
+```
+
 ### Runtime kernel dispatch
 
 On supported x86 GNU/Clang builds, the scalar, AVX2, and AVX-512 executor

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -49,4 +49,6 @@ uv run python -c "import clifft; print(clifft.version())"
 - **C++ compiler** with C++20 support (GCC 10+, Clang 12+, or Xcode CLT)
 - **Python** 3.12+
 - **uv** (recommended) — `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- **OpenMP runtime** (optional) — detected automatically; Apple Clang users can
+  install Homebrew `libomp` for intra-shot parallel sampling
 See [Building from Source](../development/building.md) for the full development setup.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -51,4 +51,11 @@ uv run python -c "import clifft; print(clifft.version())"
 - **uv** (recommended) — `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - **OpenMP runtime** (optional) — detected automatically; Apple Clang users can
   install Homebrew `libomp` for intra-shot parallel sampling
+
+OpenMP-enabled Clifft builds load the platform's OpenMP runtime. When combining
+Clifft with packages that bundle another OpenMP runtime, especially on macOS,
+avoid loading multiple runtime implementations into one process. On POSIX
+systems, prefer the `spawn` or `forkserver` multiprocessing start method when
+OpenMP may have initialized before child processes are created.
+
 See [Building from Source](../development/building.md) for the full development setup.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,10 +52,18 @@ uv run python -c "import clifft; print(clifft.version())"
 - **OpenMP runtime** (optional) — detected automatically; Apple Clang users can
   install Homebrew `libomp` for intra-shot parallel sampling
 
-OpenMP-enabled Clifft builds load the platform's OpenMP runtime. When combining
-Clifft with packages that bundle another OpenMP runtime, especially on macOS,
-avoid loading multiple runtime implementations into one process. On POSIX
-systems, prefer the `spawn` or `forkserver` multiprocessing start method when
-OpenMP may have initialized before child processes are created.
+OpenMP-enabled Clifft builds load an OpenMP runtime. Some scientific Python
+packages bundle a different runtime, which can cause conflicts, especially on
+macOS. Leaving Clifft at its default `threads=1` avoids calling its OpenMP
+kernels. If another package has already used its own OpenMP runtime, do not then
+request Clifft intra-shot workers in the same macOS process. Build with
+`CLIFFT_OPENMP=OFF` or run the packages in separate processes when both need
+threaded execution; starting Clifft before the other runtime can also work, but
+process isolation is the robust choice.
+
+On POSIX systems, create process workers before using threaded Clifft sampling,
+or use the `spawn` or `forkserver` start method. Forking after a threaded sample
+and then requesting intra-shot threads in the child can hang in some OpenMP
+runtimes.
 
 See [Building from Source](../development/building.md) for the full development setup.

--- a/docs/guide/importance-sampling.md
+++ b/docs/guide/importance-sampling.md
@@ -331,7 +331,7 @@ postselection. Key observations:
 
 ## API Reference
 
-### `clifft.sample_k(program, shots, k, seed=None, threads=1)`
+### `clifft.sample_k(program, shots, k, seed=None, threads=1, thread_layout=None, intra_shot_min_active_width=None)`
 
 Sample with exactly `k` forced faults per shot. Returns
 a `SampleResult`, just like `clifft.sample()`. Results must be weighted by $P(K=k)$ for correct
@@ -344,7 +344,13 @@ discarded shots.
 Raises `ValueError` if the stratum has zero probability mass (e.g., `k`
 exceeds the number of non-zero-probability sites).
 
-### `clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1)`
+`threads` is the total worker budget. The optional advanced
+`thread_layout=(shot_workers, intra_shot_workers)` override follows the ordinary
+sampling policy described in [Parallel Sampling](simulation.md#parallel-sampling).
+The expert `intra_shot_min_active_width` override defaults to 18 and requires an
+explicit layout.
+
+### `clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1, thread_layout=None, intra_shot_min_active_width=None)`
 
 Sample survivors with exactly `k` forced faults per shot. Returns a
 `SampleResult` whose `.measurements`, `.detectors`, and `.observables`

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -254,17 +254,19 @@ explicit count if the reported hardware concurrency exceeds the available CPU
 quota.
 
 For the fixed-plan symbolic sampler, Clifft automatically chooses one of two
-layouts. It uses cross-shot workers when there are enough shots to occupy the
-budget. For a smaller batch whose peak active width is at least 18, an
-OpenMP-enabled build instead uses the budget within one shot at a time. This
-either-or policy avoids nested thread pools and their affinity and
-oversubscription hazards. Builds without OpenMP always use cross-shot workers.
-`noncomp.sample()` continues to interpret `threads` as cross-shot workers.
-The crossover is a bandwidth-sensitive heuristic measured against pure
-cross-shot scheduling. Use an explicit layout when the crossover on your
-hardware differs.
+ways to use that budget:
 
-The symbolic sampling functions also accept the advanced override
+- With enough shots, it runs several shots at once.
+- With fewer shots and a peak active width of at least 18, an OpenMP-enabled
+  build shares the work within each shot instead.
+
+Clifft does not combine these strategies automatically. Builds without OpenMP
+can only spread work across shots, and `noncomp.sample()` also uses only that
+strategy. The width cutoff is a measured default; advanced users can override
+the layout and cutoff for their hardware.
+
+Most users should use `threads`. The symbolic sampling functions also accept
+the advanced override
 `thread_layout=(shot_workers, intra_shot_workers)`. The override replaces the
 automatic choice, ignores `threads`, and may request a hybrid layout. Both
 counts must be positive, and an intra-shot count above one requires an
@@ -288,13 +290,14 @@ result = clifft.sample(
 )
 ```
 
-Hybrid layouts use ordinary shot workers around OpenMP kernel teams and
-therefore require OpenMP processor binding to be disabled. Clifft rejects a
-requested hybrid layout when `OMP_PROC_BIND` is active, even if the plan is
-below the active-width threshold and would otherwise suppress its intra-shot
-workers. This avoids silently oversubscribing a restricted CPU set and keeps
-validation independent of the program. Pure cross-shot and pure intra-shot
-layouts honor active OpenMP binding.
+In this example, Clifft runs two shots at once and gives each shot up to four
+OpenMP workers once its active width reaches 17. It therefore uses at most eight
+execution threads.
+
+Hybrid layouts combine shot workers with OpenMP teams, so they require OpenMP
+processor binding to be disabled. Clifft rejects a hybrid layout when
+`OMP_PROC_BIND` is active. Pure cross-shot and pure intra-shot layouts can use
+OpenMP binding.
 
 Workers dynamically claim contiguous shot ranges from a shared scheduler.
 With a fixed seed, changing `threads` produces exactly the same result.

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -260,6 +260,9 @@ OpenMP-enabled build instead uses the budget within one shot at a time. This
 either-or policy avoids nested thread pools and their affinity and
 oversubscription hazards. Builds without OpenMP always use cross-shot workers.
 `noncomp.sample()` continues to interpret `threads` as cross-shot workers.
+The crossover is a bandwidth-sensitive heuristic measured against pure
+cross-shot scheduling. Use an explicit layout when the crossover on your
+hardware differs.
 
 The symbolic sampling functions also accept the advanced override
 `thread_layout=(shot_workers, intra_shot_workers)`. The override replaces the
@@ -287,8 +290,10 @@ result = clifft.sample(
 
 Hybrid layouts use ordinary shot workers around OpenMP kernel teams and
 therefore require OpenMP processor binding to be disabled. Clifft rejects a
-hybrid layout when `OMP_PROC_BIND` is active instead of silently
-oversubscribing a restricted CPU set. Pure cross-shot and pure intra-shot
+requested hybrid layout when `OMP_PROC_BIND` is active, even if the plan is
+below the active-width threshold and would otherwise suppress its intra-shot
+workers. This avoids silently oversubscribing a restricted CPU set and keeps
+validation independent of the program. Pure cross-shot and pure intra-shot
 layouts honor active OpenMP binding.
 
 Workers dynamically claim contiguous shot ranges from a shared scheduler.

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -243,15 +243,51 @@ If `seed` is omitted or set to `None`, Clifft uses hardware entropy from the ope
 Each shot derives an independent random stream from the call seed and its shot
 index. Seeded results therefore do not depend on how shots are scheduled.
 
-## Parallel Shots
+## Parallel Sampling
 
 `sample()`, `sample_survivors()`, `sample_k()`, `sample_k_survivors()`, and
-[`noncomp.sample()`](leakage-and-loss.md) accept a `threads` argument. It
-defaults to `1`, so existing calls remain serial. Pass a positive worker count
-to control resource use, or `threads="auto"` to use the implementation-reported
-hardware concurrency. Clifft never creates more workers than shots. In
-containers or processes with CPU-affinity limits, set an explicit count if the
-reported hardware concurrency exceeds the available CPU quota.
+[`noncomp.sample()`](leakage-and-loss.md) accept a `threads` argument. It defaults
+to `1`, so existing calls remain serial. Pass a positive count to set the total
+worker budget, or `threads="auto"` to use the implementation-reported hardware
+concurrency. In containers or processes with CPU-affinity limits, set an
+explicit count if the reported hardware concurrency exceeds the available CPU
+quota.
+
+For the fixed-plan symbolic sampler, Clifft automatically chooses one of two
+layouts. It uses cross-shot workers when there are enough shots to occupy the
+budget. For a smaller batch whose peak active width is at least 18, an
+OpenMP-enabled build instead uses the budget within one shot at a time. This
+either-or policy avoids nested thread pools and their affinity and
+oversubscription hazards. Builds without OpenMP always use cross-shot workers.
+`noncomp.sample()` continues to interpret `threads` as cross-shot workers.
+
+The symbolic sampling functions also accept the advanced override
+`thread_layout=(shot_workers, intra_shot_workers)`. The override replaces the
+automatic choice, ignores `threads`, and may request a hybrid layout. Both
+counts must be positive, and an intra-shot count above one requires an
+OpenMP-enabled build. The active-width threshold still applies within each
+executor. Keep the layout's worker-count product within the CPUs available to
+the process.
+
+Expert callers can change the threshold for an explicit layout with
+`intra_shot_min_active_width`. It defaults to 18 and is resolved before hot
+execution, so changing it does not add policy or allocation work inside a
+kernel:
+
+```python
+result = clifft.sample(
+    program,
+    shots=8,
+    thread_layout=(2, 4),
+    intra_shot_min_active_width=17,
+)
+```
+
+Hybrid layouts use ordinary shot workers around OpenMP kernel teams and
+therefore require OpenMP processor binding to be disabled. Clifft rejects a
+hybrid layout when `OMP_PROC_BIND` is active instead of silently
+oversubscribing a restricted CPU set. Pure cross-shot and pure intra-shot
+layouts honor active OpenMP binding.
 
 Workers dynamically claim contiguous shot ranges from a shared scheduler.
 With a fixed seed, changing `threads` produces exactly the same result.
@@ -259,10 +295,11 @@ With a fixed seed, changing `threads` produces exactly the same result.
 APIs return accepted shots in the same order as the corresponding one-thread
 run.
 
-Each worker owns a separate executor. Its dense coefficient and measurement
-scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,
+Each cross-shot worker owns a separate executor. Its dense coefficient and
+measurement scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,
 plus symbolic state, records, and other executor metadata. Set an explicit
-worker count when memory is more constrained than CPU availability.
+layout when memory is more constrained than CPU availability. Intra-shot
+workers cooperate on one executor and do not replicate this storage.
 Noncomputational workers also own their trajectory continuations and compile
 new continuations independently as their shots encounter jumps.
 
@@ -281,8 +318,8 @@ result = clifft.sample_k_survivors(prog, shots=50_000, k=3, seed=42)
 
 Key API:
 
-- **`clifft.sample_k(program, shots, k, seed=None, threads=1)`** -- Like `sample()`, but forces exactly `k` faults. Only valid for programs without post-selection; post-selected programs must use `sample_k_survivors()`. Returns a `SampleResult` with `.measurements`, `.detectors`, and `.observables`.
-- **`clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1)`** -- Like `sample_survivors()`, but forces exactly `k` faults. Returns a `SampleResult` whose arrays contain only surviving shots plus survivor metadata.
+- **`clifft.sample_k(program, shots, k, seed=None, threads=1, thread_layout=None, intra_shot_min_active_width=None)`** -- Like `sample()`, but forces exactly `k` faults. Only valid for programs without post-selection; post-selected programs must use `sample_k_survivors()`. Returns a `SampleResult` with `.measurements`, `.detectors`, and `.observables`.
+- **`clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1, thread_layout=None, intra_shot_min_active_width=None)`** -- Like `sample_survivors()`, but forces exactly `k` faults. Returns a `SampleResult` whose arrays contain only surviving shots plus survivor metadata.
 - **`program.noise_site_probabilities`** -- 1D NumPy array of per-site fault probabilities, with quantum noise sites followed by readout noise entries. Use this for computing the Poisson-binomial PMF.
 
 See the [Importance Sampling Tutorial](importance-sampling.md) for a complete walkthrough.

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -274,6 +274,8 @@ Expert callers can change the threshold for an explicit layout with
 execution, so changing it does not add policy or allocation work inside a
 kernel:
 
+<!--pytest.mark.skip-->
+
 ```python
 result = clifft.sample(
     program,

--- a/justfile
+++ b/justfile
@@ -128,7 +128,7 @@ profile_build_dir := "build-profile"
 # Build the profiling harnesses (RelWithDebInfo for perf-friendly symbols)
 profile-build:
   cmake -B {{profile_build_dir}} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCLIFFT_BUILD_PROFILER=ON
-  cmake --build {{profile_build_dir}} --target profile_compile profile_probability -j$(nproc)
+  cmake --build {{profile_build_dir}} --target profile_compile profile_probability profile_sample -j$(nproc)
 
 # -------------------------
 # Benchmarking

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -76,6 +76,11 @@ target_link_libraries(clifft_core PRIVATE fast_float)
 find_package(Threads REQUIRED)
 target_link_libraries(clifft_core PUBLIC Threads::Threads)
 
+if(CLIFFT_OPENMP_ENABLED)
+    target_link_libraries(clifft_core PRIVATE OpenMP::OpenMP_CXX)
+    target_compile_definitions(clifft_core PRIVATE CLIFFT_USE_OPENMP)
+endif()
+
 target_compile_features(clifft_core PUBLIC cxx_std_20)
 
 # Code coverage instrumentation (only for Clifft code, not dependencies)

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -27,6 +27,10 @@ PreparedFusedRotationExecution::PreparedFusedRotationExecution(PreparedFusedRota
 #else
     (void)backend;
 #endif
+    assert((sidecar_.storage == nullptr) == (sidecar_.kernel == nullptr) &&
+           "fused sidecar storage and serial kernel must be set together");
+    assert((sidecar_.kernel == nullptr) == (sidecar_.parallel_kernel == nullptr) &&
+           "fused sidecar serial and parallel kernels must be set together");
 }
 
 ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -33,6 +33,15 @@ class PreparedFusedRotationExecution {
         }
     }
 
+    void apply_parallel(State& state, uint32_t workers, uint32_t min_active_width) const noexcept {
+        if (sidecar_.storage != nullptr && sidecar_.parallel_kernel != nullptr) {
+            sidecar_.parallel_kernel(state, rotation_, sidecar_.storage.get(), workers,
+                                     min_active_width);
+        } else {
+            apply_fused_rotation_parallel(state, rotation_, workers, min_active_width);
+        }
+    }
+
   private:
     PreparedFusedRotation rotation_;
     FusedRotationSidecar sidecar_;

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -1,12 +1,14 @@
 #include "clifft/sampling/executor.h"
 
 #include "clifft/util/fault_sampling.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <limits>
 #include <numbers>
 
 namespace clifft::sampling {
@@ -27,6 +29,18 @@ struct MeasurementBranchClassification {
     MeasurementBranchKind kind = MeasurementBranchKind::Random;
     bool clamped_dust = false;
 };
+
+uint32_t resolve_intra_shot_workers(const ExecutablePlan& plan, uint32_t requested_workers,
+                                    uint32_t min_active_width) {
+    if (requested_workers == 0 ||
+        requested_workers > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+        throw std::invalid_argument("sampling executor intra-shot worker count is invalid");
+    }
+    return should_parallelize_intra_shot(plan.peak_active_width(), requested_workers,
+                                         min_active_width)
+               ? requested_workers
+               : 1;
+}
 
 [[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
     MeasurementProbabilities probabilities) noexcept {
@@ -49,10 +63,13 @@ struct MeasurementBranchClassification {
 
 }  // namespace
 
-Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
-    : root_plan_(&plan),
+Executor::Executor(const ExecutablePlan& plan, uint64_t seed, uint32_t intra_shot_workers,
+                   uint32_t intra_shot_min_active_width)
+      : root_plan_(&plan),
       plan_(&plan),
-      state_(plan.peak_active_width_, plan.initial_active_width_),
+      state_(plan.peak_active_width_, plan.initial_active_width_,
+             resolve_intra_shot_workers(plan, intra_shot_workers, intra_shot_min_active_width),
+             intra_shot_min_active_width),
       symbols_(plan.num_symbols_, 0),
       expression_registers_(plan.expression_register_constants_),
       records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_, 0),
@@ -62,7 +79,10 @@ Executor::Executor(const ExecutablePlan& plan, uint64_t seed)
       forced_record_mask_(records_.size(), 0),
       forced_record_values_(records_.size(), 0),
       rng_(seed),
-      backend_(plan.backend_) {
+      backend_(plan.backend_),
+      intra_shot_workers_(
+          resolve_intra_shot_workers(plan, intra_shot_workers, intra_shot_min_active_width)),
+      intra_shot_min_active_width_(intra_shot_min_active_width) {
     previous_presampled_ones_.reserve(plan.presampled_symbols_.size());
 }
 
@@ -195,7 +215,7 @@ ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
 }
 
 void Executor::reset_shot() noexcept {
-    state_.reset();
+    state_.reset_parallel(intra_shot_workers_, intra_shot_min_active_width_);
     // Validation guarantees that every mutable symbol and output is overwritten
     // before use on a completed shot. Only nonfiring noise symbols need restoring.
     for (uint32_t symbol : previous_presampled_ones_) {
@@ -314,31 +334,54 @@ void Executor::assign_forced_quantum_faults() noexcept {
     }
 }
 
-template <ExecutorBackend Backend>
+template <ExecutorBackend Backend, bool Parallel>
 void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     const bool sign = evaluate(action.sign);
     if (action.kernel == DirectRotationKernel::Scalar) {
-        apply_rotation(state_, action.rotation, sign);
+        if constexpr (Parallel) {
+            apply_rotation_parallel(state_, action.rotation, sign, intra_shot_workers_,
+                                    intra_shot_min_active_width_);
+        } else {
+            apply_rotation(state_, action.rotation, sign);
+        }
         return;
     }
     if constexpr (Backend == ExecutorBackend::Avx2) {
-        apply_direct_rotation_avx2(state_, action.rotation, action.kernel, sign);
+        if constexpr (Parallel) {
+            apply_direct_rotation_avx2_parallel(state_, action.rotation, action.kernel, sign,
+                                                intra_shot_workers_, intra_shot_min_active_width_);
+        } else {
+            apply_direct_rotation_avx2(state_, action.rotation, action.kernel, sign);
+        }
     } else if constexpr (Backend == ExecutorBackend::Avx512) {
-        apply_direct_rotation_avx512(state_, action.rotation, action.kernel, sign);
+        if constexpr (Parallel) {
+            apply_direct_rotation_avx512_parallel(state_, action.rotation, action.kernel, sign,
+                                                  intra_shot_workers_,
+                                                  intra_shot_min_active_width_);
+        } else {
+            apply_direct_rotation_avx512(state_, action.rotation, action.kernel, sign);
+        }
     } else {
         assert(false && "scalar executor requires scalar direct-rotation actions");
         apply_rotation(state_, action.rotation, sign);
     }
 }
 
+template <bool Parallel>
 void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->fused_rotations_.size() &&
            "fused rotation action must reference prepared execution");
-    plan_->fused_rotations_[action.rotation_index].apply(state_);
+    if constexpr (Parallel) {
+        plan_->fused_rotations_[action.rotation_index].apply_parallel(state_, intra_shot_workers_,
+                                                                      intra_shot_min_active_width_);
+    } else {
+        plan_->fused_rotations_[action.rotation_index].apply(state_);
+    }
 }
 
+template <bool Parallel>
 void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->dynamic_fused_rotations_.size() &&
@@ -350,12 +393,23 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation&
     }
     assert(variant < rotation.variants.size() &&
            "dynamic fused sign value must select a prepared variant");
-    rotation.variants[variant].apply(state_);
+    if constexpr (Parallel) {
+        rotation.variants[variant].apply_parallel(state_, intra_shot_workers_,
+                                                  intra_shot_min_active_width_);
+    } else {
+        rotation.variants[variant].apply(state_);
+    }
 }
 
+template <bool Parallel>
 void Executor::execute_action(const ExecutablePlan::ExecutePromotion& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    apply_promotion(state_, action.promotion, evaluate(action.sign));
+    if constexpr (Parallel) {
+        apply_promotion_parallel(state_, action.promotion, evaluate(action.sign),
+                                 intra_shot_workers_, intra_shot_min_active_width_);
+    } else {
+        apply_promotion(state_, action.promotion, evaluate(action.sign));
+    }
 }
 
 template <ExecutorBackend Backend, Executor::ShotMode Mode>
@@ -687,7 +741,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteBoundary& action,
     }
 }
 
-template <ExecutorBackend Backend, Executor::ShotMode Mode>
+template <ExecutorBackend Backend, Executor::ShotMode Mode, bool Parallel>
 ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                                        uint32_t begin) noexcept {
     ReplayResult result;
@@ -703,7 +757,12 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                               std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
                     execute_action<Mode>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation>) {
-                    execute_action<Backend>(typed, forced_records, result);
+                    execute_action<Backend, Parallel>(typed, forced_records, result);
+                } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteFusedRotation> ||
+                                     std::is_same_v<T,
+                                                    ExecutablePlan::ExecuteDynamicFusedRotation> ||
+                                     std::is_same_v<T, ExecutablePlan::ExecutePromotion>) {
+                    execute_action<Parallel>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement> ||
                                      std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {
                     execute_action<Backend, Mode>(typed, forced_records, result);
@@ -730,18 +789,38 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
 template <Executor::ShotMode Mode>
 ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forced_records,
                                                    uint32_t begin) noexcept {
+    if (intra_shot_workers_ > 1) {
+        switch (backend_) {
+            case ExecutorBackend::Scalar:
+                return execute_actions<ExecutorBackend::Scalar, Mode, true>(forced_records, begin);
+            case ExecutorBackend::Avx2:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+                return execute_actions<ExecutorBackend::Avx2, Mode, true>(forced_records, begin);
+#else
+                break;
+#endif
+            case ExecutorBackend::Avx512:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+                return execute_actions<ExecutorBackend::Avx512, Mode, true>(forced_records, begin);
+#else
+                break;
+#endif
+        }
+        assert(false && "unhandled sampling executor backend");
+        return {};
+    }
     switch (backend_) {
         case ExecutorBackend::Scalar:
-            return execute_actions<ExecutorBackend::Scalar, Mode>(forced_records, begin);
+            return execute_actions<ExecutorBackend::Scalar, Mode, false>(forced_records, begin);
         case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            return execute_actions<ExecutorBackend::Avx2, Mode>(forced_records, begin);
+            return execute_actions<ExecutorBackend::Avx2, Mode, false>(forced_records, begin);
 #else
             break;
 #endif
         case ExecutorBackend::Avx512:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            return execute_actions<ExecutorBackend::Avx512, Mode>(forced_records, begin);
+            return execute_actions<ExecutorBackend::Avx512, Mode, false>(forced_records, begin);
 #else
             break;
 #endif

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -334,12 +334,12 @@ void Executor::assign_forced_quantum_faults() noexcept {
     }
 }
 
-template <ExecutorBackend Backend, bool Parallel>
+template <ExecutorBackend Backend, Executor::IntraShotMode IntraShot>
 void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     const bool sign = evaluate(action.sign);
     if (action.kernel == DirectRotationKernel::Scalar) {
-        if constexpr (Parallel) {
+        if constexpr (IntraShot == IntraShotMode::OpenMP) {
             apply_rotation_parallel(state_, action.rotation, sign, intra_shot_workers_,
                                     intra_shot_min_active_width_);
         } else {
@@ -348,14 +348,14 @@ void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
         return;
     }
     if constexpr (Backend == ExecutorBackend::Avx2) {
-        if constexpr (Parallel) {
+        if constexpr (IntraShot == IntraShotMode::OpenMP) {
             apply_direct_rotation_avx2_parallel(state_, action.rotation, action.kernel, sign,
                                                 intra_shot_workers_, intra_shot_min_active_width_);
         } else {
             apply_direct_rotation_avx2(state_, action.rotation, action.kernel, sign);
         }
     } else if constexpr (Backend == ExecutorBackend::Avx512) {
-        if constexpr (Parallel) {
+        if constexpr (IntraShot == IntraShotMode::OpenMP) {
             apply_direct_rotation_avx512_parallel(state_, action.rotation, action.kernel, sign,
                                                   intra_shot_workers_,
                                                   intra_shot_min_active_width_);
@@ -368,12 +368,12 @@ void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
     }
 }
 
-template <bool Parallel>
+template <Executor::IntraShotMode IntraShot>
 void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->fused_rotations_.size() &&
            "fused rotation action must reference prepared execution");
-    if constexpr (Parallel) {
+    if constexpr (IntraShot == IntraShotMode::OpenMP) {
         plan_->fused_rotations_[action.rotation_index].apply_parallel(state_, intra_shot_workers_,
                                                                       intra_shot_min_active_width_);
     } else {
@@ -381,7 +381,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action
     }
 }
 
-template <bool Parallel>
+template <Executor::IntraShotMode IntraShot>
 void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.rotation_index < plan_->dynamic_fused_rotations_.size() &&
@@ -393,7 +393,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation&
     }
     assert(variant < rotation.variants.size() &&
            "dynamic fused sign value must select a prepared variant");
-    if constexpr (Parallel) {
+    if constexpr (IntraShot == IntraShotMode::OpenMP) {
         rotation.variants[variant].apply_parallel(state_, intra_shot_workers_,
                                                   intra_shot_min_active_width_);
     } else {
@@ -401,10 +401,10 @@ void Executor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation&
     }
 }
 
-template <bool Parallel>
+template <Executor::IntraShotMode IntraShot>
 void Executor::execute_action(const ExecutablePlan::ExecutePromotion& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    if constexpr (Parallel) {
+    if constexpr (IntraShot == IntraShotMode::OpenMP) {
         apply_promotion_parallel(state_, action.promotion, evaluate(action.sign),
                                  intra_shot_workers_, intra_shot_min_active_width_);
     } else {
@@ -741,7 +741,7 @@ void Executor::execute_action(const ExecutablePlan::ExecuteBoundary& action,
     }
 }
 
-template <ExecutorBackend Backend, Executor::ShotMode Mode, bool Parallel>
+template <ExecutorBackend Backend, Executor::ShotMode Mode, Executor::IntraShotMode IntraShot>
 ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                                        uint32_t begin) noexcept {
     ReplayResult result;
@@ -757,12 +757,12 @@ ReplayResult Executor::execute_actions(std::span<const uint8_t> forced_records,
                               std::is_same_v<T, ExecutablePlan::ExecuteClassicalRecord>) {
                     execute_action<Mode>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation>) {
-                    execute_action<Backend, Parallel>(typed, forced_records, result);
+                    execute_action<Backend, IntraShot>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteFusedRotation> ||
                                      std::is_same_v<T,
                                                     ExecutablePlan::ExecuteDynamicFusedRotation> ||
                                      std::is_same_v<T, ExecutablePlan::ExecutePromotion>) {
-                    execute_action<Parallel>(typed, forced_records, result);
+                    execute_action<IntraShot>(typed, forced_records, result);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement> ||
                                      std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {
                     execute_action<Backend, Mode>(typed, forced_records, result);
@@ -792,16 +792,19 @@ ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forc
     if (intra_shot_workers_ > 1) {
         switch (backend_) {
             case ExecutorBackend::Scalar:
-                return execute_actions<ExecutorBackend::Scalar, Mode, true>(forced_records, begin);
+                return execute_actions<ExecutorBackend::Scalar, Mode, IntraShotMode::OpenMP>(
+                    forced_records, begin);
             case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-                return execute_actions<ExecutorBackend::Avx2, Mode, true>(forced_records, begin);
+                return execute_actions<ExecutorBackend::Avx2, Mode, IntraShotMode::OpenMP>(
+                    forced_records, begin);
 #else
                 break;
 #endif
             case ExecutorBackend::Avx512:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-                return execute_actions<ExecutorBackend::Avx512, Mode, true>(forced_records, begin);
+                return execute_actions<ExecutorBackend::Avx512, Mode, IntraShotMode::OpenMP>(
+                    forced_records, begin);
 #else
                 break;
 #endif
@@ -811,16 +814,19 @@ ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forc
     }
     switch (backend_) {
         case ExecutorBackend::Scalar:
-            return execute_actions<ExecutorBackend::Scalar, Mode, false>(forced_records, begin);
+            return execute_actions<ExecutorBackend::Scalar, Mode, IntraShotMode::Serial>(
+                forced_records, begin);
         case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            return execute_actions<ExecutorBackend::Avx2, Mode, false>(forced_records, begin);
+            return execute_actions<ExecutorBackend::Avx2, Mode, IntraShotMode::Serial>(
+                forced_records, begin);
 #else
             break;
 #endif
         case ExecutorBackend::Avx512:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            return execute_actions<ExecutorBackend::Avx512, Mode, false>(forced_records, begin);
+            return execute_actions<ExecutorBackend::Avx512, Mode, IntraShotMode::Serial>(
+                forced_records, begin);
 #else
             break;
 #endif

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -65,7 +65,7 @@ uint32_t resolve_intra_shot_workers(const ExecutablePlan& plan, uint32_t request
 
 Executor::Executor(const ExecutablePlan& plan, uint64_t seed, uint32_t intra_shot_workers,
                    uint32_t intra_shot_min_active_width)
-      : root_plan_(&plan),
+    : root_plan_(&plan),
       plan_(&plan),
       state_(plan.peak_active_width_, plan.initial_active_width_,
              resolve_intra_shot_workers(plan, intra_shot_workers, intra_shot_min_active_width),

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -2,7 +2,7 @@
 
 #include "clifft/sampling/executable_plan.h"
 #include "clifft/sampling/state.h"
-#include "clifft/util/intra_shot_parallel.h"
+#include "clifft/util/config.h"
 #include "clifft/util/xoshiro.h"
 
 #include <cstddef>

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -2,6 +2,7 @@
 
 #include "clifft/sampling/executable_plan.h"
 #include "clifft/sampling/state.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/xoshiro.h"
 
 #include <cstddef>
@@ -41,7 +42,9 @@ struct ForcedTraceOut {
 // overwrites it.
 class Executor {
   public:
-    explicit Executor(const ExecutablePlan& plan, uint64_t seed = 0);
+    explicit Executor(const ExecutablePlan& plan, uint64_t seed = 0,
+                      uint32_t intra_shot_workers = 1,
+                      uint32_t intra_shot_min_active_width = kDefaultIntraShotMinActiveWidth);
 
     // Replace the deterministic seed with OS entropy before executing shots.
     void reseed_from_entropy() { rng_.seed_from_entropy(); }
@@ -129,16 +132,19 @@ class Executor {
     template <ShotMode Mode>
     [[nodiscard]] ReplayResult execute_actions_for_backend(std::span<const uint8_t> forced_records,
                                                            uint32_t begin = 0) noexcept;
-    template <ExecutorBackend Backend, ShotMode Mode>
+    template <ExecutorBackend Backend, ShotMode Mode, bool Parallel>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records,
                                                uint32_t begin = 0) noexcept;
-    template <ExecutorBackend Backend>
+    template <ExecutorBackend Backend, bool Parallel>
     void execute_action(const ExecutablePlan::ExecuteRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool Parallel>
     void execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool Parallel>
     void execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
+    template <bool Parallel>
     void execute_action(const ExecutablePlan::ExecutePromotion& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <ExecutorBackend Backend, ShotMode Mode>
@@ -221,6 +227,8 @@ class Executor {
 
     // Selected with the root plan and reused by every shot and continuation.
     ExecutorBackend backend_;
+    uint32_t intra_shot_workers_ = 1;
+    uint32_t intra_shot_min_active_width_ = kDefaultIntraShotMinActiveWidth;
 
     // Per-shot control state.
     bool discarded_ = false;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -119,6 +119,11 @@ class Executor {
         ReplayRecords,
     };
 
+    enum class IntraShotMode : uint8_t {
+        Serial,
+        OpenMP,
+    };
+
     void reset_shot() noexcept;
     void assign_presampled_values(std::span<const uint8_t> presampled_values) noexcept;
     void sample_presampled_noise(uint32_t begin, uint32_t end) noexcept;
@@ -132,19 +137,19 @@ class Executor {
     template <ShotMode Mode>
     [[nodiscard]] ReplayResult execute_actions_for_backend(std::span<const uint8_t> forced_records,
                                                            uint32_t begin = 0) noexcept;
-    template <ExecutorBackend Backend, ShotMode Mode, bool Parallel>
+    template <ExecutorBackend Backend, ShotMode Mode, IntraShotMode IntraShot>
     [[nodiscard]] ReplayResult execute_actions(std::span<const uint8_t> forced_records,
                                                uint32_t begin = 0) noexcept;
-    template <ExecutorBackend Backend, bool Parallel>
+    template <ExecutorBackend Backend, IntraShotMode IntraShot>
     void execute_action(const ExecutablePlan::ExecuteRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool Parallel>
+    template <IntraShotMode IntraShot>
     void execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool Parallel>
+    template <IntraShotMode IntraShot>
     void execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
-    template <bool Parallel>
+    template <IntraShotMode IntraShot>
     void execute_action(const ExecutablePlan::ExecutePromotion& action,
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
     template <ExecutorBackend Backend, ShotMode Mode>

--- a/src/clifft/sampling/fused_rotation.cc
+++ b/src/clifft/sampling/fused_rotation.cc
@@ -3,6 +3,7 @@
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/sampling/simd_width.h"
+#include "clifft/util/intra_shot_parallel.h"
 
 #include <algorithm>
 #include <array>
@@ -345,6 +346,73 @@ void apply_fused_rotation_orbits(State& state, const PreparedFusedRotation& rota
     }
 }
 
+template <size_t Dimension>
+void apply_fused_rotation_orbits_parallel(State& state, const PreparedFusedRotation& rotation,
+                                          uint32_t workers) noexcept {
+    static_assert(Dimension == 1 || Dimension == 2 || Dimension == 4);
+    const uint64_t orbit_count = state.size() / Dimension;
+    const size_t matrix_size = Dimension * Dimension;
+    assert(rotation.matrices.size() ==
+               (size_t{1} << rotation.selector_masks.size()) * matrix_size &&
+           "fused rotation matrix table must cover every selector value");
+
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    intra_shot_parallel_ranges(orbit_count, workers, [&](uint64_t begin, uint64_t end) noexcept {
+        for (uint64_t packed = begin; packed < end; ++packed) {
+            // Reinserting zero pivot bits enumerates exactly one representative
+            // from every orbit.
+            uint64_t representative = packed;
+            if constexpr (Dimension >= 2) {
+                representative = insert_zero_bit(representative, rotation.orbit_pivots[0]);
+            }
+            if constexpr (Dimension == 4) {
+                representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+            }
+
+            const size_t selector = selector_index(representative, rotation.selector_masks);
+            const std::complex<double>* const matrix =
+                rotation.matrices.data() + selector * matrix_size;
+
+            // XOR combinations of the orbit basis enumerate every coefficient in
+            // this representative's subspace.
+            std::array<uint64_t, Dimension> indices{};
+            std::array<double, Dimension> input_real{};
+            std::array<double, Dimension> input_imag{};
+            for (size_t column = 0; column < Dimension; ++column) {
+                uint64_t index = representative;
+                if constexpr (Dimension >= 2) {
+                    if ((column & 1U) != 0) {
+                        index ^= rotation.orbit_masks[0];
+                    }
+                }
+                if constexpr (Dimension == 4) {
+                    if ((column & 2U) != 0) {
+                        index ^= rotation.orbit_masks[1];
+                    }
+                }
+                indices[column] = index;
+                input_real[column] = real[index];
+                input_imag[column] = imag[index];
+            }
+
+            for (size_t row = 0; row < Dimension; ++row) {
+                double output_real = 0.0;
+                double output_imag = 0.0;
+                for (size_t column = 0; column < Dimension; ++column) {
+                    const std::complex<double> weight = matrix[row * Dimension + column];
+                    output_real +=
+                        weight.real() * input_real[column] - weight.imag() * input_imag[column];
+                    output_imag +=
+                        weight.real() * input_imag[column] + weight.imag() * input_real[column];
+                }
+                real[indices[row]] = output_real;
+                imag[indices[row]] = output_imag;
+            }
+        }
+    });
+}
+
 }  // namespace
 
 FusedRotationRun prepare_fused_rotation_run(std::span<const PlannedAction> actions) {
@@ -497,6 +565,30 @@ void apply_fused_rotation(State& state, const PreparedFusedRotation& rotation) n
             return;
         case 2:
             apply_fused_rotation_orbits<4>(state, rotation);
+            return;
+        default:
+            assert(false && "fused rotation orbit rank must be at most two");
+            return;
+    }
+}
+
+void apply_fused_rotation_parallel(State& state, const PreparedFusedRotation& rotation,
+                                   uint32_t workers, uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_fused_rotation(state, rotation);
+        return;
+    }
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+    switch (rotation.orbit_rank) {
+        case 0:
+            apply_fused_rotation_orbits_parallel<1>(state, rotation, workers);
+            return;
+        case 1:
+            apply_fused_rotation_orbits_parallel<2>(state, rotation, workers);
+            return;
+        case 2:
+            apply_fused_rotation_orbits_parallel<4>(state, rotation, workers);
             return;
         default:
             assert(false && "fused rotation orbit rank must be at most two");

--- a/src/clifft/sampling/fused_rotation.h
+++ b/src/clifft/sampling/fused_rotation.h
@@ -54,5 +54,7 @@ struct DynamicFusedRotationRun {
 [[nodiscard]] DynamicFusedRotationRun prepare_dynamic_fused_rotation_run(
     std::span<const PlannedAction> actions);
 void apply_fused_rotation(State& state, const PreparedFusedRotation& rotation) noexcept;
+void apply_fused_rotation_parallel(State& state, const PreparedFusedRotation& rotation,
+                                   uint32_t workers, uint32_t min_active_width) noexcept;
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/kernel_dispatch.h
+++ b/src/clifft/sampling/kernel_dispatch.h
@@ -42,12 +42,15 @@ enum class ActiveMeasurementKernel : uint8_t {
     const PreparedMeasurement& measurement, ExecutorBackend backend) noexcept;
 
 using FusedRotationKernel = void (*)(State&, const PreparedFusedRotation&, const void*) noexcept;
+using FusedRotationParallelKernel = void (*)(State&, const PreparedFusedRotation&, const void*,
+                                             uint32_t, uint32_t) noexcept;
 
 // Type-erases optional backend-specific preparation without exposing vector
 // types to the portable executable plan.
 struct FusedRotationSidecar {
     std::shared_ptr<const void> storage;
     FusedRotationKernel kernel = nullptr;
+    FusedRotationParallelKernel parallel_kernel = nullptr;
 };
 
 enum class NewXInstrumentKernel : uint8_t {
@@ -64,6 +67,12 @@ void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
                                 DirectRotationKernel kernel, bool sign) noexcept;
 void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
                                   DirectRotationKernel kernel, bool sign) noexcept;
+void apply_direct_rotation_avx2_parallel(State& state, const PreparedRotation& rotation,
+                                         DirectRotationKernel kernel, bool sign, uint32_t workers,
+                                         uint32_t min_active_width) noexcept;
+void apply_direct_rotation_avx512_parallel(State& state, const PreparedRotation& rotation,
+                                           DirectRotationKernel kernel, bool sign, uint32_t workers,
+                                           uint32_t min_active_width) noexcept;
 
 [[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx2(
     const State& state, const PreparedMeasurement& measurement,

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -1,6 +1,7 @@
 #include "clifft/sampling/kernels.h"
 
 #include "clifft/sampling/indexing.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
@@ -72,6 +73,45 @@ void apply_nondiagonal_rotation(State& state, const PreparedRotation& rotation,
             }
         }
     }
+}
+
+template <bool RealPhase>
+void apply_nondiagonal_rotation_parallel(State& state, const PreparedRotation& rotation,
+                                         double sine, uint32_t workers) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t size = state.size();
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
+    const uint64_t lower_mask = pair_stride - 1;
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+
+    intra_shot_parallel_ranges(size / 2, workers, [&](uint64_t begin, uint64_t end) noexcept {
+        for (uint64_t packed = begin; packed < end; ++packed) {
+            const uint64_t left = (packed & lower_mask) | ((packed & ~lower_mask) << 1);
+            const uint64_t right = left ^ rotation.pauli.x;
+            const double left_real = real[left];
+            const double left_imag = imag[left];
+            const double right_real = real[right];
+            const double right_imag = imag[right];
+            const bool odd_phase = (std::popcount(left & rotation.pauli.z) & 1U) != 0;
+            const double left_sine = odd_phase ? -even_left_sine : even_left_sine;
+            const double right_sine = RealPhase ? left_sine : -left_sine;
+
+            if constexpr (RealPhase) {
+                real[left] = rotation.cosine * left_real + right_sine * right_imag;
+                imag[left] = rotation.cosine * left_imag - right_sine * right_real;
+                real[right] = rotation.cosine * right_real + left_sine * left_imag;
+                imag[right] = rotation.cosine * right_imag - left_sine * left_real;
+            } else {
+                real[left] = rotation.cosine * left_real + right_sine * right_real;
+                imag[left] = rotation.cosine * left_imag + right_sine * right_imag;
+                real[right] = rotation.cosine * right_real + left_sine * left_real;
+                imag[right] = rotation.cosine * right_imag + left_sine * left_imag;
+            }
+        }
+    });
 }
 
 uint64_t diagonal_source(const PreparedMeasurement& measurement, uint64_t packed, bool branch) {
@@ -206,6 +246,41 @@ void apply_rotation(State& state, const PreparedRotation& rotation, bool sign) n
     }
 }
 
+void apply_rotation_parallel(State& state, const PreparedRotation& rotation, bool sign,
+                             uint32_t workers, uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_rotation(state, rotation, sign);
+        return;
+    }
+    assert_descriptor_width(state, rotation.pauli);
+    assert(!rotation.pauli.is_identity() && "identity rotations must be removed during planning");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+
+    double* real = state.real_data();
+    double* imag = state.imag_data();
+    const uint64_t size = state.size();
+    if (rotation.pauli.is_diagonal()) {
+        intra_shot_parallel_ranges(size, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t basis = begin; basis < end; ++basis) {
+                const double eigenvalue =
+                    (std::popcount(basis & rotation.pauli.z) & 1U) != 0 ? -1.0 : 1.0;
+                const double r = real[basis];
+                const double i = imag[basis];
+                const double signed_sine = sine * eigenvalue;
+                real[basis] = rotation.cosine * r + signed_sine * i;
+                imag[basis] = rotation.cosine * i - signed_sine * r;
+            }
+        });
+        return;
+    }
+
+    if (rotation.pauli.even_phase.real() != 0.0) {
+        apply_nondiagonal_rotation_parallel<true>(state, rotation, sine, workers);
+    } else {
+        apply_nondiagonal_rotation_parallel<false>(state, rotation, sine, workers);
+    }
+}
+
 void apply_promotion(State& state, const PreparedPromotion& promotion, bool sign) noexcept {
     assert(state.active_width() < state.max_active_width() &&
            "promotion must fit the sampling state allocation");
@@ -221,6 +296,31 @@ void apply_promotion(State& state, const PreparedPromotion& promotion, bool sign
         real[old_size + basis] = sine * i;
         imag[old_size + basis] = -sine * r;
     }
+    state.set_active_width(state.active_width() + 1);
+}
+
+void apply_promotion_parallel(State& state, const PreparedPromotion& promotion, bool sign,
+                              uint32_t workers, uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_promotion(state, promotion, sign);
+        return;
+    }
+    assert(state.active_width() < state.max_active_width() &&
+           "promotion must fit the sampling state allocation");
+    const double sine = sign ? -promotion.sine : promotion.sine;
+    double* real = state.real_data();
+    double* imag = state.imag_data();
+    const uint64_t old_size = state.size();
+    intra_shot_parallel_ranges(old_size, workers, [&](uint64_t begin, uint64_t end) noexcept {
+        for (uint64_t basis = begin; basis < end; ++basis) {
+            const double r = real[basis];
+            const double i = imag[basis];
+            real[basis] = promotion.cosine * r;
+            imag[basis] = promotion.cosine * i;
+            real[old_size + basis] = sine * i;
+            imag[old_size + basis] = -sine * r;
+        }
+    });
     state.set_active_width(state.active_width() + 1);
 }
 

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -68,6 +68,10 @@ struct MeasurementProbabilities {
 // sign negates the Pauli, equivalently negating the prepared sine.
 void apply_rotation(State& state, const PreparedRotation& rotation, bool sign) noexcept;
 void apply_promotion(State& state, const PreparedPromotion& promotion, bool sign) noexcept;
+void apply_rotation_parallel(State& state, const PreparedRotation& rotation, bool sign,
+                             uint32_t workers, uint32_t min_active_width) noexcept;
+void apply_promotion_parallel(State& state, const PreparedPromotion& promotion, bool sign,
+                              uint32_t workers, uint32_t min_active_width) noexcept;
 
 // Probability evaluation does not mutate the normalized coefficient arrays.
 // Collapse consumes the selected probability so the caller can sample or force

--- a/src/clifft/sampling/kernels_avx2.cc
+++ b/src/clifft/sampling/kernels_avx2.cc
@@ -4,6 +4,7 @@
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/kernel_dispatch.h"
 #include "clifft/sampling/simd_width.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/numeric.h"
 
 #include <array>
@@ -242,6 +243,141 @@ void apply_nondiagonal_rotation_avx2(State& state, const PreparedRotation& rotat
     }
 }
 
+void apply_diagonal_rotation_avx2_parallel(State& state, const PreparedRotation& rotation,
+                                           double sine, uint32_t workers) noexcept {
+    assert(rotation.pauli.is_diagonal() && !rotation.pauli.is_identity() &&
+           rotation.pauli.active_width >= 2 &&
+           "AVX2 diagonal rotation requires at least one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const __m256d cosine = _mm256_set1_pd(rotation.cosine);
+    intra_shot_parallel_ranges(
+        state.size() / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t basis = vector_index * kLanes;
+                const __m256d input_real = _mm256_load_pd(real + basis);
+                const __m256d input_imag = _mm256_load_pd(imag + basis);
+                const __m256d signed_sine = signed_sine_lanes(basis, rotation.pauli.z, sine);
+                const __m256d output_real =
+                    _mm256_fmadd_pd(signed_sine, input_imag, _mm256_mul_pd(cosine, input_real));
+                const __m256d output_imag =
+                    _mm256_fnmadd_pd(signed_sine, input_real, _mm256_mul_pd(cosine, input_imag));
+                _mm256_store_pd(real + basis, output_real);
+                _mm256_store_pd(imag + basis, output_imag);
+            }
+        });
+}
+
+template <bool RealPhase>
+void apply_lane_paired_rotation_avx2_parallel(State& state, const PreparedRotation& rotation,
+                                              double sine, uint32_t workers) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit < kLanes &&
+           rotation.pauli.active_width >= 2 &&
+           "AVX2 lane-paired rotation requires at least one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const __m256d cosine = _mm256_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+
+    intra_shot_parallel_ranges(
+        state.size() / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t basis = vector_index * kLanes;
+                const __m256d input_real = _mm256_load_pd(real + basis);
+                const __m256d input_imag = _mm256_load_pd(imag + basis);
+                const __m256d partner_real = permute_lanes(input_real, permutation);
+                const __m256d partner_imag = permute_lanes(input_imag, permutation);
+                const __m256d basis_sine =
+                    signed_sine_lanes(basis, rotation.pauli.z, sine * base_phase);
+                const __m256d partner_sine =
+                    RealPhase ? basis_sine : _mm256_sub_pd(_mm256_setzero_pd(), basis_sine);
+
+                __m256d output_real;
+                __m256d output_imag;
+                if constexpr (RealPhase) {
+                    output_real = _mm256_fmadd_pd(partner_sine, partner_imag,
+                                                  _mm256_mul_pd(cosine, input_real));
+                    output_imag = _mm256_fnmadd_pd(partner_sine, partner_real,
+                                                   _mm256_mul_pd(cosine, input_imag));
+                } else {
+                    output_real = _mm256_fmadd_pd(partner_sine, partner_real,
+                                                  _mm256_mul_pd(cosine, input_real));
+                    output_imag = _mm256_fmadd_pd(partner_sine, partner_imag,
+                                                  _mm256_mul_pd(cosine, input_imag));
+                }
+                _mm256_store_pd(real + basis, output_real);
+                _mm256_store_pd(imag + basis, output_imag);
+            }
+        });
+}
+
+template <bool RealPhase>
+void apply_nondiagonal_rotation_avx2_parallel(State& state, const PreparedRotation& rotation,
+                                              double sine, uint32_t workers) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit >= kLanes &&
+           "AVX2 non-diagonal rotation requires a high pairing pivot");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
+    const uint64_t lower_mask = pair_stride - 1;
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m256i permutation =
+        _mm256_load_si256(reinterpret_cast<const __m256i*>(kLanePermutations[lane_xor].data()));
+    const __m256d cosine = _mm256_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+
+    intra_shot_parallel_ranges(
+        state.size() / (2 * kLanes), workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t packed = vector_index * kLanes;
+                const uint64_t left = (packed & lower_mask) | ((packed & ~lower_mask) << 1);
+                const uint64_t right_base = (left ^ rotation.pauli.x) & ~(uint64_t{kLanes - 1});
+                const __m256d left_real = _mm256_load_pd(real + left);
+                const __m256d left_imag = _mm256_load_pd(imag + left);
+                const __m256d right_real =
+                    permute_lanes(_mm256_load_pd(real + right_base), permutation);
+                const __m256d right_imag =
+                    permute_lanes(_mm256_load_pd(imag + right_base), permutation);
+                const __m256d left_sine = signed_sine_lanes(left, rotation.pauli.z, even_left_sine);
+
+                __m256d output_left_real;
+                __m256d output_left_imag;
+                __m256d output_right_real;
+                __m256d output_right_imag;
+                if constexpr (RealPhase) {
+                    output_left_real =
+                        _mm256_fmadd_pd(left_sine, right_imag, _mm256_mul_pd(cosine, left_real));
+                    output_left_imag =
+                        _mm256_fnmadd_pd(left_sine, right_real, _mm256_mul_pd(cosine, left_imag));
+                    output_right_real =
+                        _mm256_fmadd_pd(left_sine, left_imag, _mm256_mul_pd(cosine, right_real));
+                    output_right_imag =
+                        _mm256_fnmadd_pd(left_sine, left_real, _mm256_mul_pd(cosine, right_imag));
+                } else {
+                    output_left_real =
+                        _mm256_fnmadd_pd(left_sine, right_real, _mm256_mul_pd(cosine, left_real));
+                    output_left_imag =
+                        _mm256_fnmadd_pd(left_sine, right_imag, _mm256_mul_pd(cosine, left_imag));
+                    output_right_real =
+                        _mm256_fmadd_pd(left_sine, left_real, _mm256_mul_pd(cosine, right_real));
+                    output_right_imag =
+                        _mm256_fmadd_pd(left_sine, left_imag, _mm256_mul_pd(cosine, right_imag));
+                }
+
+                _mm256_store_pd(real + left, output_left_real);
+                _mm256_store_pd(imag + left, output_left_imag);
+                _mm256_store_pd(real + right_base, permute_lanes(output_right_real, permutation));
+                _mm256_store_pd(imag + right_base, permute_lanes(output_right_imag, permutation));
+            }
+        });
+}
+
 void apply_fused_rotation_avx2(State& state, const PreparedFusedRotation& rotation,
                                const void* opaque_sidecar) noexcept {
     const auto& sidecar = *static_cast<const FusedRotationAvx2Sidecar*>(opaque_sidecar);
@@ -368,6 +504,84 @@ void collapse_active_diagonal_measurement_avx2_impl(State& state,
         }
     }
     state.set_active_width(state.active_width() - 1);
+}
+
+void apply_fused_rotation_avx2_parallel(State& state, const PreparedFusedRotation& rotation,
+                                        const void* opaque_sidecar, uint32_t workers,
+                                        uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_fused_rotation_avx2(state, rotation, opaque_sidecar);
+        return;
+    }
+    const auto& sidecar = *static_cast<const FusedRotationAvx2Sidecar*>(opaque_sidecar);
+    assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 2 &&
+           rotation.orbit_pivots[0] < rotation.orbit_pivots[1] &&
+           "AVX2 fused rotation requires ordered high-pivot rank-two orbits");
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+
+    const uint64_t orbit_count = state.size() / kDimension;
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+
+    intra_shot_parallel_ranges(
+        orbit_count / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t packed = vector_index * kLanes;
+                uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
+                representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+                const LaneWeights* const matrix =
+                    sidecar.weights.data() +
+                    selector_index(representative, rotation.selector_masks) * kMatrixSize;
+
+                std::array<__m256d, kDimension> input_real;
+                std::array<__m256d, kDimension> input_imag;
+                for (size_t column = 0; column < kDimension; ++column) {
+                    uint64_t index = representative;
+                    if ((column & 1U) != 0) {
+                        index ^= rotation.orbit_masks[0];
+                    }
+                    if ((column & 2U) != 0) {
+                        index ^= rotation.orbit_masks[1];
+                    }
+                    const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+                    const __m256i permutation = _mm256_load_si256(reinterpret_cast<const __m256i*>(
+                        sidecar.permutations[column].indices.data()));
+                    input_real[column] =
+                        permute_lanes(_mm256_load_pd(real + physical_base), permutation);
+                    input_imag[column] =
+                        permute_lanes(_mm256_load_pd(imag + physical_base), permutation);
+                }
+
+                for (size_t row = 0; row < kDimension; ++row) {
+                    __m256d output_real = _mm256_setzero_pd();
+                    __m256d output_imag = _mm256_setzero_pd();
+                    for (size_t column = 0; column < kDimension; ++column) {
+                        const LaneWeights& weight = matrix[row * kDimension + column];
+                        const __m256d weight_real = _mm256_load_pd(weight.real.data());
+                        const __m256d weight_imag = _mm256_load_pd(weight.imag.data());
+                        output_real = _mm256_fmadd_pd(weight_real, input_real[column], output_real);
+                        output_real =
+                            _mm256_fnmadd_pd(weight_imag, input_imag[column], output_real);
+                        output_imag = _mm256_fmadd_pd(weight_real, input_imag[column], output_imag);
+                        output_imag = _mm256_fmadd_pd(weight_imag, input_real[column], output_imag);
+                    }
+
+                    uint64_t index = representative;
+                    if ((row & 1U) != 0) {
+                        index ^= rotation.orbit_masks[0];
+                    }
+                    if ((row & 2U) != 0) {
+                        index ^= rotation.orbit_masks[1];
+                    }
+                    const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+                    const __m256i permutation = _mm256_load_si256(
+                        reinterpret_cast<const __m256i*>(sidecar.permutations[row].indices.data()));
+                    _mm256_store_pd(real + physical_base, permute_lanes(output_real, permutation));
+                    _mm256_store_pd(imag + physical_base, permute_lanes(output_imag, permutation));
+                }
+            }
+        });
 }
 
 template <bool RealPhase>
@@ -673,6 +887,41 @@ void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
     assert(false && "unknown direct rotation kernel");
 }
 
+void apply_direct_rotation_avx2_parallel(State& state, const PreparedRotation& rotation,
+                                         DirectRotationKernel kernel, bool sign, uint32_t workers,
+                                         uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_direct_rotation_avx2(state, rotation, kernel, sign);
+        return;
+    }
+    assert(state.active_width() == rotation.pauli.active_width &&
+           "AVX2 rotation width must match the active state");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+    switch (kernel) {
+        case DirectRotationKernel::Diagonal:
+            apply_diagonal_rotation_avx2_parallel(state, rotation, sine, workers);
+            return;
+        case DirectRotationKernel::HighPivot:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_nondiagonal_rotation_avx2_parallel<true>(state, rotation, sine, workers);
+            } else {
+                apply_nondiagonal_rotation_avx2_parallel<false>(state, rotation, sine, workers);
+            }
+            return;
+        case DirectRotationKernel::LanePaired:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_lane_paired_rotation_avx2_parallel<true>(state, rotation, sine, workers);
+            } else {
+                apply_lane_paired_rotation_avx2_parallel<false>(state, rotation, sine, workers);
+            }
+            return;
+        case DirectRotationKernel::Scalar:
+            assert(false && "scalar rotations must not enter the AVX2 kernel");
+            return;
+    }
+    assert(false && "unknown direct rotation kernel");
+}
+
 FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(const PreparedFusedRotation& rotation) {
     if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 2 ||
         rotation.orbit_pivots[0] >= rotation.orbit_pivots[1]) {
@@ -709,7 +958,8 @@ FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(const PreparedFusedRota
         }
     }
 
-    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx2};
+    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx2,
+                                apply_fused_rotation_avx2_parallel};
 }
 
 void apply_new_x_instrument_no_fire_avx2(State& state, double factor_zero, double factor_one,

--- a/src/clifft/sampling/kernels_avx512.cc
+++ b/src/clifft/sampling/kernels_avx512.cc
@@ -4,6 +4,7 @@
 #include "clifft/sampling/indexing.h"
 #include "clifft/sampling/kernel_dispatch.h"
 #include "clifft/sampling/simd_width.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/numeric.h"
 
 #include <array>
@@ -241,6 +242,141 @@ void apply_nondiagonal_rotation_avx512(State& state, const PreparedRotation& rot
     }
 }
 
+void apply_diagonal_rotation_avx512_parallel(State& state, const PreparedRotation& rotation,
+                                             double sine, uint32_t workers) noexcept {
+    assert(rotation.pauli.is_diagonal() && !rotation.pauli.is_identity() &&
+           rotation.pauli.active_width >= 3 &&
+           "AVX-512 diagonal rotation requires at least one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const __m512d cosine = _mm512_set1_pd(rotation.cosine);
+    intra_shot_parallel_ranges(
+        state.size() / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t basis = vector_index * kLanes;
+                const __m512d input_real = _mm512_load_pd(real + basis);
+                const __m512d input_imag = _mm512_load_pd(imag + basis);
+                const __m512d signed_sine = signed_sine_lanes(basis, rotation.pauli.z, sine);
+                const __m512d output_real =
+                    _mm512_fmadd_pd(signed_sine, input_imag, _mm512_mul_pd(cosine, input_real));
+                const __m512d output_imag =
+                    _mm512_fnmadd_pd(signed_sine, input_real, _mm512_mul_pd(cosine, input_imag));
+                _mm512_store_pd(real + basis, output_real);
+                _mm512_store_pd(imag + basis, output_imag);
+            }
+        });
+}
+
+template <bool RealPhase>
+void apply_lane_paired_rotation_avx512_parallel(State& state, const PreparedRotation& rotation,
+                                                double sine, uint32_t workers) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit < kLanes &&
+           rotation.pauli.active_width >= 3 &&
+           "AVX-512 lane-paired rotation requires one vector block");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const __m512d cosine = _mm512_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+
+    intra_shot_parallel_ranges(
+        state.size() / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t basis = vector_index * kLanes;
+                const __m512d input_real = _mm512_load_pd(real + basis);
+                const __m512d input_imag = _mm512_load_pd(imag + basis);
+                const __m512d partner_real = _mm512_permutexvar_pd(permutation, input_real);
+                const __m512d partner_imag = _mm512_permutexvar_pd(permutation, input_imag);
+                const __m512d basis_sine =
+                    signed_sine_lanes(basis, rotation.pauli.z, sine * base_phase);
+                const __m512d partner_sine =
+                    RealPhase ? basis_sine : _mm512_sub_pd(_mm512_setzero_pd(), basis_sine);
+
+                __m512d output_real;
+                __m512d output_imag;
+                if constexpr (RealPhase) {
+                    output_real = _mm512_fmadd_pd(partner_sine, partner_imag,
+                                                  _mm512_mul_pd(cosine, input_real));
+                    output_imag = _mm512_fnmadd_pd(partner_sine, partner_real,
+                                                   _mm512_mul_pd(cosine, input_imag));
+                } else {
+                    output_real = _mm512_fmadd_pd(partner_sine, partner_real,
+                                                  _mm512_mul_pd(cosine, input_real));
+                    output_imag = _mm512_fmadd_pd(partner_sine, partner_imag,
+                                                  _mm512_mul_pd(cosine, input_imag));
+                }
+                _mm512_store_pd(real + basis, output_real);
+                _mm512_store_pd(imag + basis, output_imag);
+            }
+        });
+}
+
+template <bool RealPhase>
+void apply_nondiagonal_rotation_avx512_parallel(State& state, const PreparedRotation& rotation,
+                                                double sine, uint32_t workers) noexcept {
+    assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit >= kLanes &&
+           "AVX-512 non-diagonal rotation requires a high pairing pivot");
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
+    const uint64_t lower_mask = pair_stride - 1;
+    const uint64_t lane_xor = rotation.pauli.x & (kLanes - 1);
+    const __m512i permutation = _mm512_load_si512(kLanePermutations[lane_xor].data());
+    const __m512d cosine = _mm512_set1_pd(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+
+    intra_shot_parallel_ranges(
+        state.size() / (2 * kLanes), workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t packed = vector_index * kLanes;
+                const uint64_t left = (packed & lower_mask) | ((packed & ~lower_mask) << 1);
+                const uint64_t right_base = (left ^ rotation.pauli.x) & ~(uint64_t{kLanes - 1});
+                const __m512d left_real = _mm512_load_pd(real + left);
+                const __m512d left_imag = _mm512_load_pd(imag + left);
+                const __m512d right_real =
+                    _mm512_permutexvar_pd(permutation, _mm512_load_pd(real + right_base));
+                const __m512d right_imag =
+                    _mm512_permutexvar_pd(permutation, _mm512_load_pd(imag + right_base));
+                const __m512d left_sine = signed_sine_lanes(left, rotation.pauli.z, even_left_sine);
+
+                __m512d output_left_real;
+                __m512d output_left_imag;
+                __m512d output_right_real;
+                __m512d output_right_imag;
+                if constexpr (RealPhase) {
+                    output_left_real =
+                        _mm512_fmadd_pd(left_sine, right_imag, _mm512_mul_pd(cosine, left_real));
+                    output_left_imag =
+                        _mm512_fnmadd_pd(left_sine, right_real, _mm512_mul_pd(cosine, left_imag));
+                    output_right_real =
+                        _mm512_fmadd_pd(left_sine, left_imag, _mm512_mul_pd(cosine, right_real));
+                    output_right_imag =
+                        _mm512_fnmadd_pd(left_sine, left_real, _mm512_mul_pd(cosine, right_imag));
+                } else {
+                    output_left_real =
+                        _mm512_fnmadd_pd(left_sine, right_real, _mm512_mul_pd(cosine, left_real));
+                    output_left_imag =
+                        _mm512_fnmadd_pd(left_sine, right_imag, _mm512_mul_pd(cosine, left_imag));
+                    output_right_real =
+                        _mm512_fmadd_pd(left_sine, left_real, _mm512_mul_pd(cosine, right_real));
+                    output_right_imag =
+                        _mm512_fmadd_pd(left_sine, left_imag, _mm512_mul_pd(cosine, right_imag));
+                }
+
+                _mm512_store_pd(real + left, output_left_real);
+                _mm512_store_pd(imag + left, output_left_imag);
+                _mm512_store_pd(real + right_base,
+                                _mm512_permutexvar_pd(permutation, output_right_real));
+                _mm512_store_pd(imag + right_base,
+                                _mm512_permutexvar_pd(permutation, output_right_imag));
+            }
+        });
+}
+
 // Fused matrices vary with representative parity. The sidecar expands those
 // choices by lane so the hot loop can traverse eight independent orbits without
 // gathers or selector branches.
@@ -371,6 +507,86 @@ void collapse_active_diagonal_measurement_avx512_impl(State& state,
         }
     }
     state.set_active_width(state.active_width() - 1);
+}
+
+void apply_fused_rotation_avx512_parallel(State& state, const PreparedFusedRotation& rotation,
+                                          const void* opaque_sidecar, uint32_t workers,
+                                          uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_fused_rotation_avx512(state, rotation, opaque_sidecar);
+        return;
+    }
+    const auto& sidecar = *static_cast<const FusedRotationAvx512Sidecar*>(opaque_sidecar);
+    assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 3 &&
+           rotation.orbit_pivots[0] < rotation.orbit_pivots[1] &&
+           "AVX-512 fused rotation requires ordered high-pivot rank-two orbits");
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+
+    const uint64_t orbit_count = state.size() / kDimension;
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+
+    intra_shot_parallel_ranges(
+        orbit_count / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+            for (uint64_t vector_index = begin; vector_index < end; ++vector_index) {
+                const uint64_t packed = vector_index * kLanes;
+                uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
+                representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+                const LaneWeights* const matrix =
+                    sidecar.weights.data() +
+                    selector_index(representative, rotation.selector_masks) * kMatrixSize;
+
+                std::array<__m512d, kDimension> input_real;
+                std::array<__m512d, kDimension> input_imag;
+                for (size_t column = 0; column < kDimension; ++column) {
+                    uint64_t index = representative;
+                    if ((column & 1U) != 0) {
+                        index ^= rotation.orbit_masks[0];
+                    }
+                    if ((column & 2U) != 0) {
+                        index ^= rotation.orbit_masks[1];
+                    }
+                    const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+                    const __m512i permutation =
+                        _mm512_load_si512(sidecar.permutations[column].indices.data());
+                    input_real[column] =
+                        _mm512_permutexvar_pd(permutation, _mm512_load_pd(real + physical_base));
+                    input_imag[column] =
+                        _mm512_permutexvar_pd(permutation, _mm512_load_pd(imag + physical_base));
+                }
+
+                for (size_t row = 0; row < kDimension; ++row) {
+                    __m512d output_real = _mm512_setzero_pd();
+                    __m512d output_imag = _mm512_setzero_pd();
+                    for (size_t column = 0; column < kDimension; ++column) {
+                        const LaneWeights& weight = matrix[row * kDimension + column];
+                        const __m512d weight_real = _mm512_load_pd(weight.real.data());
+                        const __m512d weight_imag = _mm512_load_pd(weight.imag.data());
+                        output_real = _mm512_fmadd_pd(weight_real, input_real[column], output_real);
+                        output_real =
+                            _mm512_fnmadd_pd(weight_imag, input_imag[column], output_real);
+                        output_imag = _mm512_fmadd_pd(weight_real, input_imag[column], output_imag);
+                        output_imag = _mm512_fmadd_pd(weight_imag, input_real[column], output_imag);
+                    }
+
+                    uint64_t index = representative;
+                    if ((row & 1U) != 0) {
+                        index ^= rotation.orbit_masks[0];
+                    }
+                    if ((row & 2U) != 0) {
+                        index ^= rotation.orbit_masks[1];
+                    }
+                    const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+                    const __m512i permutation =
+                        _mm512_load_si512(sidecar.permutations[row].indices.data());
+                    _mm512_store_pd(real + physical_base,
+                                    _mm512_permutexvar_pd(permutation, output_real));
+                    _mm512_store_pd(imag + physical_base,
+                                    _mm512_permutexvar_pd(permutation, output_imag));
+                }
+            }
+        });
 }
 
 template <bool RealPhase>
@@ -681,6 +897,41 @@ void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation
     assert(false && "unknown direct rotation kernel");
 }
 
+void apply_direct_rotation_avx512_parallel(State& state, const PreparedRotation& rotation,
+                                           DirectRotationKernel kernel, bool sign, uint32_t workers,
+                                           uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_direct_rotation_avx512(state, rotation, kernel, sign);
+        return;
+    }
+    assert(state.active_width() == rotation.pauli.active_width &&
+           "AVX-512 rotation width must match the active state");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+    switch (kernel) {
+        case DirectRotationKernel::Diagonal:
+            apply_diagonal_rotation_avx512_parallel(state, rotation, sine, workers);
+            return;
+        case DirectRotationKernel::HighPivot:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_nondiagonal_rotation_avx512_parallel<true>(state, rotation, sine, workers);
+            } else {
+                apply_nondiagonal_rotation_avx512_parallel<false>(state, rotation, sine, workers);
+            }
+            return;
+        case DirectRotationKernel::LanePaired:
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_lane_paired_rotation_avx512_parallel<true>(state, rotation, sine, workers);
+            } else {
+                apply_lane_paired_rotation_avx512_parallel<false>(state, rotation, sine, workers);
+            }
+            return;
+        case DirectRotationKernel::Scalar:
+            assert(false && "scalar rotations must not enter the AVX-512 kernel");
+            return;
+    }
+    assert(false && "unknown direct rotation kernel");
+}
+
 // Host-specific preparation transposes selector matrices into lane-major
 // weights once, keeping both allocation and selector expansion out of shots.
 FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRotation& rotation) {
@@ -721,7 +972,8 @@ FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(const PreparedFusedRo
         }
     }
 
-    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx512};
+    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_avx512,
+                                apply_fused_rotation_avx512_parallel};
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -2,6 +2,7 @@
 
 #include "clifft/sampling/executor.h"
 #include "clifft/util/fault_sampling.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/shot_parallel.h"
 #include "clifft/util/shot_seed.h"
 
@@ -21,15 +22,19 @@ void reseed_executor_for_shot(Executor& executor, const SeedRoot& root, uint32_t
 }
 
 struct SamplingWorker {
-    explicit SamplingWorker(const ExecutablePlan& plan) : executor(plan) {}
+    SamplingWorker(const ExecutablePlan& plan, uint32_t intra_shot_workers,
+                   uint32_t intra_shot_min_active_width)
+        : executor(plan, 0, intra_shot_workers, intra_shot_min_active_width) {}
 
     Executor executor;
 };
 
 struct ConditionedSamplingWorker {
     ConditionedSamplingWorker(const ExecutablePlan& plan, std::span<const double> probabilities,
-                              uint32_t k)
-        : executor(plan), fault_sampler(probabilities, k) {}
+                              uint32_t k, uint32_t intra_shot_workers,
+                              uint32_t intra_shot_min_active_width)
+        : executor(plan, 0, intra_shot_workers, intra_shot_min_active_width),
+          fault_sampler(probabilities, k) {}
 
     Executor executor;
     KFaultSampler fault_sampler;
@@ -44,8 +49,10 @@ struct SurvivorCounts {
 };
 
 struct SurvivorWorker {
-    explicit SurvivorWorker(const ExecutablePlan& plan)
-        : executor(plan), counts(plan.num_observables()) {}
+    SurvivorWorker(const ExecutablePlan& plan, uint32_t intra_shot_workers,
+                   uint32_t intra_shot_min_active_width)
+        : executor(plan, 0, intra_shot_workers, intra_shot_min_active_width),
+          counts(plan.num_observables()) {}
 
     Executor executor;
     SurvivorCounts counts;
@@ -53,13 +60,56 @@ struct SurvivorWorker {
 
 struct ConditionedSurvivorWorker {
     ConditionedSurvivorWorker(const ExecutablePlan& plan, std::span<const double> probabilities,
-                              uint32_t k)
-        : executor(plan), fault_sampler(probabilities, k), counts(plan.num_observables()) {}
+                              uint32_t k, uint32_t intra_shot_workers,
+                              uint32_t intra_shot_min_active_width)
+        : executor(plan, 0, intra_shot_workers, intra_shot_min_active_width),
+          fault_sampler(probabilities, k),
+          counts(plan.num_observables()) {}
 
     Executor executor;
     KFaultSampler fault_sampler;
     SurvivorCounts counts;
 };
+
+ThreadLayout resolve_thread_layout(const ExecutablePlan& plan, uint32_t shots,
+                                   uint32_t requested_threads,
+                                   std::optional<ThreadLayout> override) {
+    if (override.has_value()) {
+        if (override->shot_workers == 0 || override->intra_shot_workers == 0) {
+            throw std::invalid_argument("thread_layout worker counts must be positive");
+        }
+        if (override->intra_shot_workers > 1 && !intra_shot_parallelism_available()) {
+            throw std::invalid_argument(
+                "thread_layout intra-shot workers require an OpenMP-enabled build");
+        }
+        if (override->intra_shot_workers > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+            throw std::invalid_argument("thread_layout intra-shot worker count is too large");
+        }
+        override->shot_workers = std::min(override->shot_workers, shots);
+        if (!should_parallelize_intra_shot(plan.peak_active_width(), override->intra_shot_workers,
+                                           override->intra_shot_min_active_width)) {
+            override->intra_shot_workers = 1;
+        }
+        if (override->shot_workers > 1 && override->intra_shot_workers > 1 &&
+            openmp_process_binding_active()) {
+            throw std::invalid_argument("hybrid thread_layout requires OMP_PROC_BIND=false");
+        }
+        return *override;
+    }
+
+    const uint32_t budget = resolve_thread_budget(requested_threads);
+    if (shots != 0 && shots < budget &&
+        should_parallelize_intra_shot(plan.peak_active_width(), budget,
+                                      kDefaultIntraShotMinActiveWidth)) {
+        if (budget > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+            throw std::invalid_argument("intra-shot thread budget is too large");
+        }
+        return {.shot_workers = 1,
+                .intra_shot_workers = budget,
+                .intra_shot_min_active_width = kDefaultIntraShotMinActiveWidth};
+    }
+    return {.shot_workers = std::min(shots, budget), .intra_shot_workers = 1};
+}
 
 template <typename T>
 void compact_survivor_rows(std::vector<T>& values, std::span<const uint8_t> survived, size_t stride,
@@ -82,7 +132,7 @@ void compact_survivor_rows(std::vector<T>& values, std::span<const uint8_t> surv
 
 template <typename MakeWorker, typename RunShot>
 SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
-                                 std::optional<uint64_t> seed, uint32_t threads,
+                                 std::optional<uint64_t> seed, ThreadLayout thread_layout,
                                  MakeWorker&& make_worker, RunShot&& run_shot) {
     auto checked_size = [shots](size_t stride) {
         if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
@@ -102,7 +152,7 @@ SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
 
     const SeedRoot root = make_seed_root(shots, seed);
     (void)run_shot_ranges(
-        shots, threads, std::forward<MakeWorker>(make_worker),
+        shots, thread_layout.shot_workers, std::forward<MakeWorker>(make_worker),
         [&](auto& worker_handle, ShotRange range) {
             auto& worker = *worker_handle;
             Executor& executor = worker.executor;
@@ -129,7 +179,7 @@ SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
 template <typename MakeWorker, typename RunShot>
 SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_t shots,
                                              std::optional<uint64_t> seed, bool keep_records,
-                                             uint32_t threads, MakeWorker&& make_worker,
+                                             ThreadLayout thread_layout, MakeWorker&& make_worker,
                                              RunShot&& run_shot) {
     SamplingSurvivorResult result;
     result.total_shots = shots;
@@ -152,7 +202,7 @@ SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_
     std::vector<uint8_t> survived(keep_records ? shots : 0, 0);
     const SeedRoot root = make_seed_root(shots, seed);
     auto workers = run_shot_ranges(
-        shots, threads, std::forward<MakeWorker>(make_worker),
+        shots, thread_layout.shot_workers, std::forward<MakeWorker>(make_worker),
         [&](auto& worker_handle, ShotRange range) {
             auto& worker = *worker_handle;
             Executor& executor = worker.executor;
@@ -210,7 +260,7 @@ SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_
 }  // namespace
 
 SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed,
-                      uint32_t threads) {
+                      uint32_t threads, std::optional<ThreadLayout> thread_layout) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "fixed-plan sampling does not support instrument traps; use the trajectory driver");
@@ -224,20 +274,26 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
             "fixed-row sampling does not support postselection; use sample_survivors");
     }
 
+    const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
     return sample_fixed_rows(
-        plan, shots, seed, threads,
-        [&](uint32_t) { return std::make_unique<SamplingWorker>(plan); },
+        plan, shots, seed, resolved,
+        [&](uint32_t) {
+            return std::make_unique<SamplingWorker>(plan, resolved.intra_shot_workers,
+                                                    resolved.intra_shot_min_active_width);
+        },
         [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
 }
 
 std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
-                                    std::optional<uint64_t> seed, uint32_t threads) {
-    return sample(plan, shots, seed, threads).measurements;
+                                    std::optional<uint64_t> seed, uint32_t threads,
+                                    std::optional<ThreadLayout> thread_layout) {
+    return sample(plan, shots, seed, threads, thread_layout).measurements;
 }
 
 SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
                                         std::optional<uint64_t> seed, bool keep_records,
-                                        uint32_t threads) {
+                                        uint32_t threads,
+                                        std::optional<ThreadLayout> thread_layout) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "survivor sampling does not support instrument traps; use the trajectory driver");
@@ -247,14 +303,19 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
             "survivor sampling requires a distribution for every presampled symbol");
     }
 
+    const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
     return sample_surviving_rows(
-        plan, shots, seed, keep_records, threads,
-        [&](uint32_t) { return std::make_unique<SurvivorWorker>(plan); },
+        plan, shots, seed, keep_records, resolved,
+        [&](uint32_t) {
+            return std::make_unique<SurvivorWorker>(plan, resolved.intra_shot_workers,
+                                                    resolved.intra_shot_min_active_width);
+        },
         [](SurvivorWorker& worker) noexcept { worker.executor.run_shot(); });
 }
 
 SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
-                        std::optional<uint64_t> seed, uint32_t threads) {
+                        std::optional<uint64_t> seed, uint32_t threads,
+                        std::optional<ThreadLayout> thread_layout) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "forced-fault sampling does not support instrument traps or trajectory drivers");
@@ -268,17 +329,23 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
             "fixed-row forced-fault sampling does not support postselection; use "
             "sample_k_survivors");
     }
+    const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
     if (shots == 0) {
         return sample_fixed_rows(
-            plan, shots, seed, threads,
-            [&](uint32_t) { return std::make_unique<SamplingWorker>(plan); },
+            plan, shots, seed, resolved,
+            [&](uint32_t) {
+                return std::make_unique<SamplingWorker>(plan, resolved.intra_shot_workers,
+                                                        resolved.intra_shot_min_active_width);
+            },
             [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
     }
     const std::vector<double> probabilities = plan.noise_site_probabilities();
     return sample_fixed_rows(
-        plan, shots, seed, threads,
+        plan, shots, seed, resolved,
         [&](uint32_t) {
-            return std::make_unique<ConditionedSamplingWorker>(plan, probabilities, k);
+            return std::make_unique<ConditionedSamplingWorker>(
+                plan, probabilities, k, resolved.intra_shot_workers,
+                resolved.intra_shot_min_active_width);
         },
         [](ConditionedSamplingWorker& worker) noexcept {
             worker.executor.run_shot(worker.fault_sampler);
@@ -287,7 +354,8 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
 
 SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
                                           std::optional<uint64_t> seed, bool keep_records,
-                                          uint32_t threads) {
+                                          uint32_t threads,
+                                          std::optional<ThreadLayout> thread_layout) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "forced-fault survivor sampling does not support instrument traps or trajectory "
@@ -297,17 +365,23 @@ SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t s
         throw std::invalid_argument(
             "forced-fault survivor sampling requires a distribution for every presampled symbol");
     }
+    const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
     if (shots == 0) {
         return sample_surviving_rows(
-            plan, shots, seed, keep_records, threads,
-            [&](uint32_t) { return std::make_unique<SurvivorWorker>(plan); },
+            plan, shots, seed, keep_records, resolved,
+            [&](uint32_t) {
+                return std::make_unique<SurvivorWorker>(plan, resolved.intra_shot_workers,
+                                                        resolved.intra_shot_min_active_width);
+            },
             [](SurvivorWorker& worker) noexcept { worker.executor.run_shot(); });
     }
     const std::vector<double> probabilities = plan.noise_site_probabilities();
     return sample_surviving_rows(
-        plan, shots, seed, keep_records, threads,
+        plan, shots, seed, keep_records, resolved,
         [&](uint32_t) {
-            return std::make_unique<ConditionedSurvivorWorker>(plan, probabilities, k);
+            return std::make_unique<ConditionedSurvivorWorker>(
+                plan, probabilities, k, resolved.intra_shot_workers,
+                resolved.intra_shot_min_active_width);
         },
         [](ConditionedSurvivorWorker& worker) noexcept {
             worker.executor.run_shot(worker.fault_sampler);

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -86,13 +86,13 @@ ThreadLayout resolve_thread_layout(const ExecutablePlan& plan, uint32_t shots,
             throw std::invalid_argument("thread_layout intra-shot worker count is too large");
         }
         override->shot_workers = std::min(override->shot_workers, shots);
-        if (!should_parallelize_intra_shot(plan.peak_active_width(), override->intra_shot_workers,
-                                           override->intra_shot_min_active_width)) {
-            override->intra_shot_workers = 1;
-        }
         if (override->shot_workers > 1 && override->intra_shot_workers > 1 &&
             openmp_process_binding_active()) {
             throw std::invalid_argument("hybrid thread_layout requires OMP_PROC_BIND=false");
+        }
+        if (!should_parallelize_intra_shot(plan.peak_active_width(), override->intra_shot_workers,
+                                           override->intra_shot_min_active_width)) {
+            override->intra_shot_workers = 1;
         }
         return *override;
     }

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clifft/sampling/executable_plan.h"
+#include "clifft/util/intra_shot_parallel.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -35,16 +36,28 @@ struct SamplingSurvivorResult {
     std::vector<double> exp_vals;
 };
 
+// Explicitly partitions sampling workers across independent shots and the
+// coefficient kernels within each shot. When supplied, this layout overrides
+// the automatic policy selected by threads, whose value is then ignored. The
+// minimum active width is evaluated during executor setup and at coefficient
+// actions; it does not introduce work inside coefficient loops.
+struct ThreadLayout {
+    uint32_t shot_workers = 1;
+    uint32_t intra_shot_workers = 1;
+    uint32_t intra_shot_min_active_width = kDefaultIntraShotMinActiveWidth;
+};
+
 // Samples a fixed number of shots into row-major visible-record storage. The
 // plan and executor are prepared once, and all output is allocated before the
 // first shot enters hot execution. Plans with presampled symbols are rejected
 // until their sampling distribution is part of the executable contract.
-// threads=0 selects the implementation-reported hardware concurrency; the
-// public Python API spells this as threads="auto". Explicit worker counts are
-// capped at the number of shots.
-[[nodiscard]] std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
-                                                  std::optional<uint64_t> seed = std::nullopt,
-                                                  uint32_t threads = 1);
+// threads is a total worker budget. threads=0 selects the implementation-
+// reported hardware concurrency; the public Python API spells this as
+// threads="auto". Automatic scheduling uses either cross-shot or intra-shot
+// workers, not a hybrid layout.
+[[nodiscard]] std::vector<uint8_t> sample_records(
+    const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed = std::nullopt,
+    uint32_t threads = 1, std::optional<ThreadLayout> thread_layout = std::nullopt);
 
 // Replays each row-major visible record and returns its joint log probability.
 // Unreachable records map to the lowest finite double because release builds
@@ -57,21 +70,22 @@ struct SamplingSurvivorResult {
 
 [[nodiscard]] SamplingResult sample(const ExecutablePlan& plan, uint32_t shots,
                                     std::optional<uint64_t> seed = std::nullopt,
-                                    uint32_t threads = 1);
+                                    uint32_t threads = 1,
+                                    std::optional<ThreadLayout> thread_layout = std::nullopt);
 
-[[nodiscard]] SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
-                                                      std::optional<uint64_t> seed = std::nullopt,
-                                                      bool keep_records = false,
-                                                      uint32_t threads = 1);
+[[nodiscard]] SamplingSurvivorResult sample_survivors(
+    const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed = std::nullopt,
+    bool keep_records = false, uint32_t threads = 1,
+    std::optional<ThreadLayout> thread_layout = std::nullopt);
 
 [[nodiscard]] SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
                                       std::optional<uint64_t> seed = std::nullopt,
-                                      uint32_t threads = 1);
+                                      uint32_t threads = 1,
+                                      std::optional<ThreadLayout> thread_layout = std::nullopt);
 
-[[nodiscard]] SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots,
-                                                        uint32_t k,
-                                                        std::optional<uint64_t> seed = std::nullopt,
-                                                        bool keep_records = false,
-                                                        uint32_t threads = 1);
+[[nodiscard]] SamplingSurvivorResult sample_k_survivors(
+    const ExecutablePlan& plan, uint32_t shots, uint32_t k,
+    std::optional<uint64_t> seed = std::nullopt, bool keep_records = false, uint32_t threads = 1,
+    std::optional<ThreadLayout> thread_layout = std::nullopt);
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "clifft/sampling/executable_plan.h"
-#include "clifft/util/intra_shot_parallel.h"
+#include "clifft/util/config.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/src/clifft/sampling/state.cc
+++ b/src/clifft/sampling/state.cc
@@ -1,6 +1,7 @@
 #include "clifft/sampling/state.h"
 
 #include "clifft/util/intra_shot_parallel.h"
+#include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <cassert>

--- a/src/clifft/sampling/state.cc
+++ b/src/clifft/sampling/state.cc
@@ -1,6 +1,6 @@
 #include "clifft/sampling/state.h"
 
-#include "clifft/util/numeric.h"
+#include "clifft/util/intra_shot_parallel.h"
 
 #include <algorithm>
 #include <cassert>
@@ -23,7 +23,8 @@ uint64_t round_array_stride(uint64_t entries) {
 
 }  // namespace
 
-State::State(uint32_t max_active_width, uint32_t initial_active_width)
+State::State(uint32_t max_active_width, uint32_t initial_active_width,
+             uint32_t initialization_workers, uint32_t intra_shot_min_active_width)
     : initial_active_width_(initial_active_width),
       active_width_(initial_active_width),
       max_active_width_(max_active_width) {
@@ -48,7 +49,19 @@ State::State(uint32_t max_active_width, uint32_t initial_active_width)
     imag_ = real_ + coefficient_stride_;
     scratch_real_ = imag_ + coefficient_stride_;
     scratch_imag_ = scratch_real_ + scratch_stride_;
-    reset();
+    if (should_parallelize_intra_shot(max_active_width_, initialization_workers,
+                                      intra_shot_min_active_width)) {
+        // Matching each worker's future coefficient range here lets the OS
+        // place physical pages by first touch without changing allocation.
+        intra_shot_parallel_ranges(coefficient_stride_, initialization_workers,
+                                   [&](uint64_t begin, uint64_t end) noexcept {
+                                       std::fill(real_ + begin, real_ + end, 0.0);
+                                       std::fill(imag_ + begin, imag_ + end, 0.0);
+                                   });
+        real_[0] = 1.0;
+    } else {
+        reset();
+    }
 }
 
 State::~State() {
@@ -74,6 +87,20 @@ void State::reset() noexcept {
     // each newly active range, and measurement scratch is overwritten on use.
     std::fill_n(real_, static_cast<size_t>(size()), 0.0);
     std::fill_n(imag_, static_cast<size_t>(size()), 0.0);
+    real_[0] = 1.0;
+}
+
+void State::reset_parallel(uint32_t workers, uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(initial_active_width_, workers, min_active_width)) {
+        reset();
+        return;
+    }
+    assert(!allocation_.empty() && "cannot reset a moved-from sampling state");
+    active_width_ = initial_active_width_;
+    intra_shot_parallel_ranges(size(), workers, [&](uint64_t begin, uint64_t end) noexcept {
+        std::fill(real_ + begin, real_ + end, 0.0);
+        std::fill(imag_ + begin, imag_ + end, 0.0);
+    });
     real_[0] = 1.0;
 }
 

--- a/src/clifft/sampling/state.h
+++ b/src/clifft/sampling/state.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "clifft/util/intra_shot_parallel.h"
+#include "clifft/util/config.h"
 #include "clifft/util/page_allocation.h"
 
 #include <cstddef>

--- a/src/clifft/sampling/state.h
+++ b/src/clifft/sampling/state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/page_allocation.h"
 
 #include <cstddef>
@@ -15,7 +16,9 @@ class State {
   public:
     // Immediately allocates all coefficient and temporary storage required by
     // max_active_width, even when initial_active_width is smaller.
-    explicit State(uint32_t max_active_width, uint32_t initial_active_width = 0);
+    explicit State(uint32_t max_active_width, uint32_t initial_active_width = 0,
+                   uint32_t initialization_workers = 1,
+                   uint32_t intra_shot_min_active_width = kDefaultIntraShotMinActiveWidth);
     ~State();
 
     State(const State&) = delete;
@@ -26,6 +29,7 @@ class State {
     // Restore the configured initial width and |0...0> coefficients.
     // The allocation and all array addresses remain unchanged.
     void reset() noexcept;
+    void reset_parallel(uint32_t workers, uint32_t min_active_width) noexcept;
 
     // A continuation boundary may require a wider dense state than the plan
     // that began the shot. Grow without changing live coefficients or the

--- a/src/clifft/util/config.h
+++ b/src/clifft/util/config.h
@@ -14,4 +14,8 @@ constexpr uint32_t kMaxTargetsPerInstruction = 1'000'000;
 // Maximum total AST nodes after REPEAT unrolling (defense against OOM).
 constexpr size_t kMaxUnrolledOps = 10'000'000;
 
+// Wide coefficient traversals can amortize OpenMP team startup. Expert
+// thread layouts may override this default without rebuilding Clifft.
+inline constexpr uint32_t kDefaultIntraShotMinActiveWidth = 18;
+
 }  // namespace clifft

--- a/src/clifft/util/intra_shot_parallel.h
+++ b/src/clifft/util/intra_shot_parallel.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#if defined(CLIFFT_USE_OPENMP)
+#include <omp.h>
+#endif
+
+namespace clifft {
+
+#if defined(__GNUC__) || defined(__clang__)
+#define CLIFFT_INTRA_SHOT_INLINE [[gnu::always_inline, gnu::flatten]] inline
+#elif defined(_MSC_VER)
+#define CLIFFT_INTRA_SHOT_INLINE __forceinline
+#else
+#define CLIFFT_INTRA_SHOT_INLINE inline
+#endif
+
+inline constexpr uint32_t kDefaultIntraShotMinActiveWidth = 18;
+
+[[nodiscard]] inline constexpr bool intra_shot_parallelism_available() noexcept {
+#if defined(CLIFFT_USE_OPENMP)
+    return true;
+#else
+    return false;
+#endif
+}
+
+[[nodiscard]] inline constexpr bool should_parallelize_intra_shot(
+    uint32_t active_width, uint32_t workers, uint32_t min_active_width) noexcept {
+    return intra_shot_parallelism_available() && workers > 1 && active_width >= min_active_width;
+}
+
+[[nodiscard]] inline bool openmp_process_binding_active() noexcept {
+#if defined(CLIFFT_USE_OPENMP) && defined(_OPENMP) && _OPENMP >= 201307
+    return omp_get_proc_bind() != omp_proc_bind_false;
+#else
+    return false;
+#endif
+}
+
+// OpenMP owns the team lifetime, while explicit contiguous ranges keep every
+// kernel's coefficient traversal deterministic and independent of runtime
+// scheduling policy.
+template <typename Kernel>
+CLIFFT_INTRA_SHOT_INLINE void intra_shot_parallel_ranges(uint64_t count, uint32_t workers,
+                                                         Kernel&& kernel) noexcept {
+#if defined(CLIFFT_USE_OPENMP)
+    const int requested_team_size =
+        static_cast<int>(workers > static_cast<uint32_t>(std::numeric_limits<int>::max())
+                             ? std::numeric_limits<int>::max()
+                             : workers);
+#pragma omp parallel num_threads(requested_team_size)
+    {
+        const uint64_t team_size = static_cast<uint64_t>(omp_get_num_threads());
+        const uint64_t thread = static_cast<uint64_t>(omp_get_thread_num());
+        const uint64_t range_size = count / team_size;
+        const uint64_t extra = count % team_size;
+        const uint64_t begin = thread * range_size + (thread < extra ? thread : extra);
+        const uint64_t end = begin + range_size + (thread < extra ? 1 : 0);
+        kernel(begin, end);
+    }
+#else
+    static_cast<void>(workers);
+    kernel(0, count);
+#endif
+}
+
+#undef CLIFFT_INTRA_SHOT_INLINE
+
+}  // namespace clifft

--- a/src/clifft/util/intra_shot_parallel.h
+++ b/src/clifft/util/intra_shot_parallel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "clifft/util/config.h"
+
 #include <cstdint>
 #include <limits>
 
@@ -10,16 +12,14 @@
 namespace clifft {
 
 #if defined(__GNUC__) || defined(__clang__)
-#define CLIFFT_INTRA_SHOT_INLINE [[gnu::always_inline, gnu::flatten]] inline
+#define CLIFFT_INTRA_SHOT_INLINE [[gnu::always_inline, gnu::flatten]] static inline
 #elif defined(_MSC_VER)
-#define CLIFFT_INTRA_SHOT_INLINE __forceinline
+#define CLIFFT_INTRA_SHOT_INLINE static __forceinline
 #else
-#define CLIFFT_INTRA_SHOT_INLINE inline
+#define CLIFFT_INTRA_SHOT_INLINE static inline
 #endif
 
-inline constexpr uint32_t kDefaultIntraShotMinActiveWidth = 18;
-
-[[nodiscard]] inline constexpr bool intra_shot_parallelism_available() noexcept {
+[[nodiscard]] static constexpr bool intra_shot_parallelism_available() noexcept {
 #if defined(CLIFFT_USE_OPENMP)
     return true;
 #else
@@ -27,12 +27,12 @@ inline constexpr uint32_t kDefaultIntraShotMinActiveWidth = 18;
 #endif
 }
 
-[[nodiscard]] inline constexpr bool should_parallelize_intra_shot(
+[[nodiscard]] static constexpr bool should_parallelize_intra_shot(
     uint32_t active_width, uint32_t workers, uint32_t min_active_width) noexcept {
     return intra_shot_parallelism_available() && workers > 1 && active_width >= min_active_width;
 }
 
-[[nodiscard]] inline bool openmp_process_binding_active() noexcept {
+[[nodiscard]] static inline bool openmp_process_binding_active() noexcept {
 #if defined(CLIFFT_USE_OPENMP) && defined(_OPENMP) && _OPENMP >= 201307
     return omp_get_proc_bind() != omp_proc_bind_false;
 #else

--- a/src/clifft/util/shot_parallel.h
+++ b/src/clifft/util/shot_parallel.h
@@ -6,12 +6,15 @@
 // allocate those contexts up front; trajectory samplers may grow them only at
 // explicit continuation boundaries.
 
+#include "clifft/util/intra_shot_parallel.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <thread>
 #include <type_traits>
@@ -25,25 +28,26 @@ struct ShotRange {
 };
 
 // requested_threads == 0 selects the implementation-reported hardware
-// concurrency. A shot batch never creates more workers than shots, and
-// environments without native threads use the serial implementation.
-inline uint32_t resolve_shot_worker_count(uint32_t shots, uint32_t requested_threads) noexcept {
-    if (shots == 0) {
-        return 0;
-    }
+// concurrency. Environments without native threads use a serial budget.
+inline uint32_t resolve_thread_budget(uint32_t requested_threads) noexcept {
 #if defined(__EMSCRIPTEN__)
     (void)requested_threads;
     return 1;
 #else
-    uint32_t workers = requested_threads;
-    if (workers == 0) {
-        workers = std::thread::hardware_concurrency();
-        if (workers == 0) {
-            workers = 1;
+    if (requested_threads == 0) {
+        const uint32_t concurrency = std::thread::hardware_concurrency();
+        if (concurrency != 0) {
+            return concurrency;
         }
+        return 1;
     }
-    return std::min(workers, shots);
+    return requested_threads;
 #endif
+}
+
+// A shot batch never creates more cross-shot workers than shots.
+inline uint32_t resolve_shot_worker_count(uint32_t shots, uint32_t requested_threads) noexcept {
+    return std::min(resolve_thread_budget(requested_threads), shots);
 }
 
 inline uint32_t shot_chunk_size(uint32_t shots, uint32_t workers) noexcept {
@@ -107,35 +111,44 @@ auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWorker&& ma
         }
     };
 
-    // std::jthread is unavailable on some of the minimum compiler and standard
-    // library versions we support. This lifetime helper ensures every std::thread
-    // is joined, including when constructing a later thread throws after earlier
-    // workers have started.
-    struct JoiningThreads {
-        std::vector<std::thread>& threads;
+    if (openmp_process_binding_active()) {
+#if defined(CLIFFT_USE_OPENMP)
+        const int omp_worker_count = static_cast<int>(std::min<uint32_t>(
+            worker_count, static_cast<uint32_t>(std::numeric_limits<int>::max())));
+#pragma omp parallel num_threads(omp_worker_count)
+        { worker_loop(static_cast<uint32_t>(omp_get_thread_num())); }
+#endif
+    } else {
+        // std::jthread is unavailable on some of the minimum compiler and standard
+        // library versions we support. This lifetime helper ensures every std::thread
+        // is joined, including when constructing a later thread throws after earlier
+        // workers have started.
+        struct JoiningThreads {
+            std::vector<std::thread>& threads;
 
-        ~JoiningThreads() {
-            for (std::thread& thread : threads) {
-                if (thread.joinable()) {
-                    thread.join();
+            ~JoiningThreads() {
+                for (std::thread& thread : threads) {
+                    if (thread.joinable()) {
+                        thread.join();
+                    }
                 }
             }
-        }
-    };
+        };
 
-    std::vector<std::thread> threads;
-    threads.reserve(worker_count - 1);
-    {
-        JoiningThreads joining{threads};
-        try {
-            for (uint32_t worker = 1; worker < worker_count; ++worker) {
-                threads.emplace_back(worker_loop, worker);
+        std::vector<std::thread> threads;
+        threads.reserve(worker_count - 1);
+        {
+            JoiningThreads joining{threads};
+            try {
+                for (uint32_t worker = 1; worker < worker_count; ++worker) {
+                    threads.emplace_back(worker_loop, worker);
+                }
+            } catch (...) {
+                cancelled.store(true, std::memory_order_relaxed);
+                throw;
             }
-        } catch (...) {
-            cancelled.store(true, std::memory_order_relaxed);
-            throw;
+            worker_loop(0);
         }
-        worker_loop(0);
     }
     if (first_error != nullptr) {
         std::rethrow_exception(first_error);

--- a/src/clifft/util/shot_parallel.h
+++ b/src/clifft/util/shot_parallel.h
@@ -62,9 +62,11 @@ inline uint32_t shot_chunk_size(uint32_t shots, uint32_t workers) noexcept {
 // run_range(worker_handle, range) may execute concurrently for different
 // handles. If it throws, remaining work is cancelled, all threads are joined,
 // and the first exception is rethrown on the calling thread.
+// Internal linkage keeps the target-local OpenMP configuration from changing a
+// shared template definition in consumers that do not inherit the core define.
 template <typename MakeWorker, typename RunRange>
-auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWorker&& make_worker,
-                     RunRange&& run_range) {
+static auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWorker&& make_worker,
+                            RunRange&& run_range) {
     using WorkerHandle = std::remove_cvref_t<std::invoke_result_t<MakeWorker, uint32_t>>;
     const uint32_t worker_count = resolve_shot_worker_count(shots, requested_threads);
     std::vector<WorkerHandle> workers;

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -27,10 +27,12 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
+#include <nanobind/stl/tuple.h>
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 #include <span>
 #include <stdexcept>
+#include <tuple>
 #include <variant>
 
 namespace nb = nanobind;
@@ -51,6 +53,35 @@ uint32_t parse_thread_option(const ThreadOption& option) {
         throw std::invalid_argument("threads must be a positive integer or 'auto'");
     }
     return static_cast<uint32_t>(count);
+}
+
+std::optional<clifft::sampling::ThreadLayout> parse_thread_layout(
+    const std::optional<std::tuple<int64_t, int64_t>>& option,
+    std::optional<int64_t> min_active_width) {
+    if (!option.has_value()) {
+        if (min_active_width.has_value()) {
+            throw std::invalid_argument(
+                "intra_shot_min_active_width requires an explicit thread_layout");
+        }
+        return std::nullopt;
+    }
+    const auto [shot_workers, intra_shot_workers] = *option;
+    if (shot_workers <= 0 || intra_shot_workers <= 0 ||
+        static_cast<uint64_t>(shot_workers) > std::numeric_limits<uint32_t>::max() ||
+        static_cast<uint64_t>(intra_shot_workers) > std::numeric_limits<uint32_t>::max()) {
+        throw std::invalid_argument("thread_layout must contain two positive worker counts");
+    }
+    if (min_active_width.has_value() &&
+        (*min_active_width < 0 ||
+         static_cast<uint64_t>(*min_active_width) > std::numeric_limits<uint32_t>::max())) {
+        throw std::invalid_argument("intra_shot_min_active_width must be non-negative");
+    }
+    return clifft::sampling::ThreadLayout{
+        .shot_workers = static_cast<uint32_t>(shot_workers),
+        .intra_shot_workers = static_cast<uint32_t>(intra_shot_workers),
+        .intra_shot_min_active_width = min_active_width.has_value()
+                                           ? static_cast<uint32_t>(*min_active_width)
+                                           : clifft::kDefaultIntraShotMinActiveWidth};
 }
 
 // Zero-copy transfer: move a std::vector into a numpy array via capsule ownership.
@@ -746,7 +777,9 @@ NB_MODULE(_clifft_core, m) {
     m.def(
         "sample",
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
-           std::optional<uint64_t> seed, const ThreadOption& thread_option) {
+           std::optional<uint64_t> seed, const ThreadOption& thread_option,
+           const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
+           std::optional<int64_t> intra_shot_min_active_width) {
             if (program.has_postselection()) {
                 throw nb::value_error(
                     "sample() cannot be used with post-selected programs because it "
@@ -754,10 +787,12 @@ NB_MODULE(_clifft_core, m) {
                     "Use sample_survivors(program, shots, keep_records=True) instead.");
             }
             const uint32_t threads = parse_thread_option(thread_option);
+            const auto thread_layout =
+                parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
             clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                result = clifft::sampling::sample(program, shots, seed, threads);
+                result = clifft::sampling::sample(program, shots, seed, threads, thread_layout);
             }
 
             auto meas_arr = vec_to_numpy(std::move(result.measurements),
@@ -773,20 +808,27 @@ NB_MODULE(_clifft_core, m) {
                                             nb::none(), nb::none(), ev_arr);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
-        nb::arg("threads") = int64_t{1},
+        nb::arg("threads") = int64_t{1}, nb::arg("thread_layout") = nb::none(),
+        nb::arg("intra_shot_min_active_width") = nb::none(),
         "Run a compiled program and return a SampleResult.\n\n"
         "Raises ValueError for post-selected programs because fixed-row output\n"
         "cannot represent discarded shots. Use sample_survivors() instead.\n\n"
         "If seed is None (default), uses hardware entropy. threads is a positive\n"
-        "worker count or 'auto' to use the implementation-reported hardware\n"
-        "concurrency; it defaults to 1.\n\n"
+        "total worker budget or 'auto' to use the implementation-reported hardware\n"
+        "concurrency; it defaults to 1. Automatic scheduling uses either cross-shot\n"
+        "or intra-shot workers. thread_layout=(shot_workers, intra_shot_workers)\n"
+        "overrides that choice and ignores threads; intra-shot counts above 1\n"
+        "require OpenMP support. intra_shot_min_active_width overrides the\n"
+        "default threshold of 18 for an explicit layout.\n\n"
         "Returns a SampleResult with .measurements, .detectors, .observables attributes.\n"
         "Supports tuple unpacking: m, d, o = clifft.sample(prog, shots)");
 
     m.def(
         "sample_k",
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
-           std::optional<uint64_t> seed, const ThreadOption& thread_option) {
+           std::optional<uint64_t> seed, const ThreadOption& thread_option,
+           const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
+           std::optional<int64_t> intra_shot_min_active_width) {
             if (program.has_postselection()) {
                 throw nb::value_error(
                     "sample_k() cannot be used with post-selected programs because it "
@@ -794,10 +836,13 @@ NB_MODULE(_clifft_core, m) {
                     "Use sample_k_survivors(program, shots, k, keep_records=True) instead.");
             }
             const uint32_t threads = parse_thread_option(thread_option);
+            const auto thread_layout =
+                parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
             clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                result = clifft::sampling::sample_k(program, shots, k, seed, threads);
+                result =
+                    clifft::sampling::sample_k(program, shots, k, seed, threads, thread_layout);
             }
 
             auto meas_arr = vec_to_numpy(std::move(result.measurements),
@@ -813,7 +858,8 @@ NB_MODULE(_clifft_core, m) {
                                             nb::none(), nb::none(), ev_arr);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
-        nb::arg("threads") = int64_t{1},
+        nb::arg("threads") = int64_t{1}, nb::arg("thread_layout") = nb::none(),
+        nb::arg("intra_shot_min_active_width") = nb::none(),
         "Sample with exactly k forced faults per shot (importance sampling).\n\n"
         "Sites are drawn from the exact conditional Poisson-Binomial\n"
         "distribution. Results are conditioned on K=k and must be combined\n"
@@ -826,9 +872,11 @@ NB_MODULE(_clifft_core, m) {
         "Raises ValueError if the k-fault stratum has zero probability mass\n"
         "(e.g. k exceeds the number of non-zero-probability sites).\n\n"
         "When all site probabilities are equal, an O(k) Fisher-Yates\n"
-        "sampler is used automatically. threads is a positive worker count\n"
+        "sampler is used automatically. threads is a positive total worker budget\n"
         "or 'auto' to use the implementation-reported hardware concurrency;\n"
-        "it defaults to 1.\n\n"
+        "it defaults to 1. thread_layout=(shot_workers, intra_shot_workers)\n"
+        "overrides automatic scheduling. intra_shot_min_active_width overrides\n"
+        "the default threshold of 18 for an explicit layout.\n\n"
         "Returns a SampleResult with .measurements, .detectors, .observables attributes.\n"
         "Supports tuple unpacking: m, d, o = clifft.sample_k(prog, shots, k)");
 
@@ -862,20 +910,25 @@ NB_MODULE(_clifft_core, m) {
 
     m.def(
         "sample_k_survivors",
-        [make_survivor_result](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
-                               uint32_t k, std::optional<uint64_t> seed, bool keep_records,
-                               const ThreadOption& thread_option) {
+        [make_survivor_result](
+            const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
+            std::optional<uint64_t> seed, bool keep_records, const ThreadOption& thread_option,
+            const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
+            std::optional<int64_t> intra_shot_min_active_width) {
             const uint32_t threads = parse_thread_option(thread_option);
+            const auto thread_layout =
+                parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
             clifft::sampling::SamplingSurvivorResult result;
             {
                 nb::gil_scoped_release release;
                 result = clifft::sampling::sample_k_survivors(program, shots, k, seed, keep_records,
-                                                              threads);
+                                                              threads, thread_layout);
             }
             return make_survivor_result(std::move(result), program, keep_records);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
+        nb::arg("thread_layout") = nb::none(), nb::arg("intra_shot_min_active_width") = nb::none(),
         "Sample survivors with exactly k forced faults per shot.\n\n"
         "Results are conditioned on K=k. To estimate the overall logical\n"
         "error rate across strata, weight numerator and denominator\n"
@@ -883,8 +936,11 @@ NB_MODULE(_clifft_core, m) {
         "  p_fail = sum(P(K=k)*logical_errors_k/shots_k)\n"
         "         / sum(P(K=k)*passed_k/shots_k)\n\n"
         "Raises ValueError if the k-fault stratum has zero probability mass.\n"
-        "threads is a positive worker count or 'auto' to use the\n"
-        "implementation-reported hardware concurrency; it defaults to 1.\n\n"
+        "threads is a positive total worker budget or 'auto' to use the\n"
+        "implementation-reported hardware concurrency; it defaults to 1.\n"
+        "thread_layout=(shot_workers, intra_shot_workers) overrides automatic\n"
+        "scheduling. intra_shot_min_active_width overrides the default threshold\n"
+        "of 18 for an explicit layout.\n\n"
         "Returns a SampleResult. Survivor metadata is always populated via\n"
         ".total_shots, .passed_shots, .discards, .logical_errors, and\n"
         ".observable_ones. Per-shot record arrays\n"
@@ -893,24 +949,32 @@ NB_MODULE(_clifft_core, m) {
 
     m.def(
         "sample_survivors",
-        [make_survivor_result](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
-                               std::optional<uint64_t> seed, bool keep_records,
-                               const ThreadOption& thread_option) {
+        [make_survivor_result](
+            const clifft::sampling::ExecutablePlan& program, uint32_t shots,
+            std::optional<uint64_t> seed, bool keep_records, const ThreadOption& thread_option,
+            const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
+            std::optional<int64_t> intra_shot_min_active_width) {
             const uint32_t threads = parse_thread_option(thread_option);
+            const auto thread_layout =
+                parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
             clifft::sampling::SamplingSurvivorResult result;
             {
                 nb::gil_scoped_release release;
-                result =
-                    clifft::sampling::sample_survivors(program, shots, seed, keep_records, threads);
+                result = clifft::sampling::sample_survivors(program, shots, seed, keep_records,
+                                                            threads, thread_layout);
             }
             return make_survivor_result(std::move(result), program, keep_records);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
+        nb::arg("thread_layout") = nb::none(), nb::arg("intra_shot_min_active_width") = nb::none(),
         "Sample shots and return results only for surviving (non-discarded) shots.\n\n"
         "If seed is None (default), uses hardware entropy. threads is a positive\n"
-        "worker count or 'auto' to use the implementation-reported hardware\n"
-        "concurrency; it defaults to 1.\n\n"
+        "total worker budget or 'auto' to use the implementation-reported hardware\n"
+        "concurrency; it defaults to 1. thread_layout=(shot_workers,\n"
+        "intra_shot_workers) overrides automatic scheduling.\n"
+        "intra_shot_min_active_width overrides the default threshold of 18 for\n"
+        "an explicit layout.\n\n"
         "Returns a SampleResult. Survivor metadata is always populated via\n"
         ".total_shots, .passed_shots, .discards, .logical_errors, and\n"
         ".observable_ones. Per-shot record arrays\n"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,14 @@ if(CLIFFT_X86_RUNTIME_DISPATCH)
     target_compile_definitions(clifft_tests PRIVATE CLIFFT_TESTS_HAVE_X86_KERNELS)
 endif()
 
+if(CLIFFT_OPENMP_ENABLED)
+    target_link_libraries(clifft_tests PRIVATE OpenMP::OpenMP_CXX)
+    target_compile_definitions(clifft_tests PRIVATE
+        CLIFFT_TESTS_HAVE_OPENMP
+        CLIFFT_USE_OPENMP
+    )
+endif()
+
 # Code coverage instrumentation for test executable
 if(CLIFFT_COVERAGE)
     target_compile_options(clifft_tests PRIVATE --coverage)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,3 +71,22 @@ endif()
 
 # Auto-discover Catch2 tests for CTest integration
 catch_discover_tests(clifft_tests)
+
+if(CLIFFT_OPENMP_ENABLED)
+    # These cases need an explicit environment because processor binding and a
+    # runtime-limited team are otherwise host-dependent and easy to miss in CI.
+    add_test(NAME clifft_openmp_bound_layout_validation
+        COMMAND clifft_tests "Sampling thread layouts validate explicit worker counts")
+    set_tests_properties(clifft_openmp_bound_layout_validation PROPERTIES
+        ENVIRONMENT "OMP_PROC_BIND=spread;OMP_PLACES=cores")
+
+    add_test(NAME clifft_openmp_limited_fixed_rows
+        COMMAND clifft_tests "Threaded fixed-row sampling preserves seeded shot order")
+    set_tests_properties(clifft_openmp_limited_fixed_rows PROPERTIES
+        ENVIRONMENT "OMP_PROC_BIND=spread;OMP_PLACES=cores;OMP_THREAD_LIMIT=1")
+
+    add_test(NAME clifft_openmp_bound_trajectory
+        COMMAND clifft_tests "trajectory: worker counts preserve seeded rows and sidecars")
+    set_tests_properties(clifft_openmp_bound_trajectory PROPERTIES
+        ENVIRONMENT "OMP_PROC_BIND=spread;OMP_PLACES=cores")
+endif()

--- a/tests/python/test_openmp_coexistence.py
+++ b/tests/python/test_openmp_coexistence.py
@@ -1,0 +1,95 @@
+"""Smoke tests for Clifft alongside another OpenMP-using extension."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_COEXISTENCE_SCRIPT = r"""
+import sys
+
+
+def run_aer():
+    from qiskit import QuantumCircuit
+    from qiskit_aer import AerSimulator
+
+    circuit = QuantumCircuit(12)
+    circuit.h(range(12))
+    circuit.save_statevector()
+    simulator = AerSimulator(
+        method="statevector",
+        max_parallel_threads=2,
+        statevector_parallel_threshold=1,
+    )
+    assert simulator.run(circuit, shots=1).result().success
+
+
+def run_clifft(threaded):
+    import clifft
+
+    program = clifft.compile("H 0\nT 0\nM 0")
+    options = {"threads": 1}
+    if threaded:
+        options = {
+            "thread_layout": (1, 2),
+            "intra_shot_min_active_width": 0,
+        }
+    try:
+        result = clifft.sample(
+            program,
+            1,
+            seed=1,
+            **options,
+        )
+    except ValueError as exc:
+        if "OpenMP-enabled build" in str(exc):
+            raise SystemExit(77) from exc
+        raise
+    assert result.measurements.shape == (1, 1)
+
+
+threaded = sys.argv[2] == "threaded"
+if sys.argv[1] == "aer-first":
+    run_aer()
+    run_clifft(threaded)
+else:
+    run_clifft(threaded)
+    run_aer()
+"""
+
+
+@pytest.mark.parametrize(
+    ("order", "threaded"),
+    [
+        ("aer-first", False),
+        pytest.param(
+            "aer-first",
+            True,
+            marks=pytest.mark.xfail(
+                condition=sys.platform == "darwin",
+                reason="Aer-first intra-shot OpenMP can load conflicting runtimes on macOS",
+                strict=False,
+            ),
+        ),
+        ("clifft-first", True),
+    ],
+)
+def test_qiskit_aer_and_clifft_openmp_coexistence(order: str, threaded: bool) -> None:
+    """Serial use and the supported threaded order coexist with Qiskit Aer."""
+    environment = os.environ.copy()
+    environment["OMP_NUM_THREADS"] = "2"
+    mode = "threaded" if threaded else "serial"
+    completed = subprocess.run(
+        [sys.executable, "-c", _COEXISTENCE_SCRIPT, order, mode],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+        timeout=30,
+    )
+    if completed.returncode == 77:
+        pytest.skip("Clifft was built without OpenMP")
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -158,6 +158,60 @@ class TestSample:
         with pytest.raises((TypeError, ValueError), match="threads|incompatible"):
             sampling_api.sample(prog, 1, threads=threads)
 
+    def test_sample_thread_layout_preserves_seeded_rows(self, sampling_api: Any) -> None:
+        """An explicit layout is a thin override of automatic worker selection."""
+        prog = sampling_api.compile(
+            "H 0 1\nT 0\nM 0 1\nDETECTOR rec[-2] rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]"
+        )
+        serial = sampling_api.sample(prog, 257, seed=12346, threads=1)
+        threaded = sampling_api.sample(prog, 257, seed=12346, threads="auto", thread_layout=(2, 1))
+        np.testing.assert_array_equal(threaded.measurements, serial.measurements)
+        np.testing.assert_array_equal(threaded.detectors, serial.detectors)
+        np.testing.assert_array_equal(threaded.observables, serial.observables)
+
+    def test_sample_runtime_intra_shot_threshold_preserves_seeded_rows(
+        self, sampling_api: Any
+    ) -> None:
+        """Expert layouts can lower the kernel crossover without rebuilding."""
+        prog = sampling_api.compile("H 0 1\nT 0\nM 0 1")
+        serial = sampling_api.sample(prog, 31, seed=12347, threads=1)
+        threaded = sampling_api.sample(
+            prog,
+            31,
+            seed=12347,
+            thread_layout=(1, 2),
+            intra_shot_min_active_width=0,
+        )
+        np.testing.assert_array_equal(threaded.measurements, serial.measurements)
+
+    @pytest.mark.parametrize(
+        ("thread_layout", "min_active_width"),
+        [(None, 0), ((1, 1), -1), ((1, 1), 2**40), ((1, 1), 1.5)],
+    )
+    def test_sample_rejects_invalid_runtime_intra_shot_threshold(
+        self, sampling_api: Any, thread_layout: Any, min_active_width: Any
+    ) -> None:
+        """The expert threshold is bounded and requires an explicit layout."""
+        prog = sampling_api.compile("M 0")
+        with pytest.raises(
+            (TypeError, ValueError), match="intra_shot_min_active_width|incompatible"
+        ):
+            sampling_api.sample(
+                prog,
+                1,
+                thread_layout=thread_layout,
+                intra_shot_min_active_width=min_active_width,
+            )
+
+    @pytest.mark.parametrize("thread_layout", [(0, 1), (1, 0), (1,), "auto", (1, 1.5)])
+    def test_sample_rejects_invalid_thread_layout(
+        self, sampling_api: Any, thread_layout: Any
+    ) -> None:
+        """Explicit layouts require two positive integral worker counts."""
+        prog = sampling_api.compile("M 0")
+        with pytest.raises((TypeError, ValueError), match="thread_layout|incompatible"):
+            sampling_api.sample(prog, 1, thread_layout=thread_layout)
+
     def test_sample_different_seeds(self, sampling_api: Any) -> None:
         """Different seeds produce different results."""
         prog = sampling_api.compile("H 0\nM 0")

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -3,6 +3,7 @@
 #include "clifft/sampling/kernels.h"
 #include "clifft/util/runtime_isa.h"
 
+#include <algorithm>
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -197,6 +198,13 @@ TEST_CASE("Dynamic fused rotation matches scalar across affine sign values") {
             const std::array values = {first_value, second_value};
             Executor executor(executable);
             executor.run_shot(values);
+
+#if defined(CLIFFT_TESTS_HAVE_OPENMP)
+            Executor parallel_executor(executable, 0, 4, 0);
+            parallel_executor.run_shot(values);
+            REQUIRE(std::ranges::equal(parallel_executor.state().real(), executor.state().real()));
+            REQUIRE(std::ranges::equal(parallel_executor.state().imag(), executor.state().imag()));
+#endif
 
             State expected(6, 6);
             for (const RotateActivePauli& rotation : rotations) {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -4,6 +4,7 @@
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
 #include "clifft/sampling/state_queries.h"
+#include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
@@ -24,6 +25,7 @@
 #include <optional>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -1358,15 +1360,23 @@ TEST_CASE("Sampling thread layouts validate explicit worker counts") {
                         "thread_layout worker counts must be positive");
 
 #if defined(CLIFFT_TESTS_HAVE_OPENMP)
-    const clifft::sampling::ThreadLayout hybrid{
-        .shot_workers = 2, .intra_shot_workers = 2, .intra_shot_min_active_width = 0};
+    const std::array hybrid_layouts{
+        clifft::sampling::ThreadLayout{
+            .shot_workers = 2, .intra_shot_workers = 2, .intra_shot_min_active_width = 0},
+        clifft::sampling::ThreadLayout{
+            .shot_workers = 2, .intra_shot_workers = 2, .intra_shot_min_active_width = 18},
+    };
     if (clifft::openmp_process_binding_active()) {
-        REQUIRE_THROWS_WITH(clifft::sampling::sample(executable, 7, uint64_t{12}, 1, hybrid),
-                            "hybrid thread_layout requires OMP_PROC_BIND=false");
+        for (const clifft::sampling::ThreadLayout hybrid : hybrid_layouts) {
+            REQUIRE_THROWS_WITH(clifft::sampling::sample(executable, 7, uint64_t{12}, 1, hybrid),
+                                "hybrid thread_layout requires OMP_PROC_BIND=false");
+        }
     } else {
-        const clifft::sampling::SamplingResult result =
-            clifft::sampling::sample(executable, 7, uint64_t{12}, 1, hybrid);
-        REQUIRE(result.measurements.size() == 7);
+        for (const clifft::sampling::ThreadLayout hybrid : hybrid_layouts) {
+            const clifft::sampling::SamplingResult result =
+                clifft::sampling::sample(executable, 7, uint64_t{12}, 1, hybrid);
+            REQUIRE(result.measurements.size() == 7);
+        }
     }
 #else
     REQUIRE_THROWS_WITH(
@@ -1379,8 +1389,34 @@ TEST_CASE("Sampling thread layouts validate explicit worker counts") {
 }
 
 #if defined(CLIFFT_TESTS_HAVE_OPENMP)
-TEST_CASE("Intra-shot rotation kernels preserve serial coefficients") {
+TEST_CASE("Automatic intra-shot sampling preserves seeded results") {
     constexpr uint32_t width = 18;
+    std::string circuit;
+    for (uint32_t qubit = 0; qubit < width; ++qubit) {
+        circuit.append("H ").append(std::to_string(qubit)).append("\n");
+        circuit.append("T ").append(std::to_string(qubit)).append("\n");
+    }
+    circuit.append("M");
+    for (uint32_t qubit = 0; qubit < width; ++qubit) {
+        circuit.append(" ").append(std::to_string(qubit));
+    }
+    circuit.append("\n");
+
+    const ExecutablePlan executable(plan_from(circuit));
+    REQUIRE(executable.peak_active_width() == width);
+    const clifft::sampling::SamplingResult serial =
+        clifft::sampling::sample(executable, 2, uint64_t{9184}, 1);
+    const clifft::sampling::SamplingResult automatic =
+        clifft::sampling::sample(executable, 2, uint64_t{9184}, 4);
+
+    REQUIRE(automatic.measurements == serial.measurements);
+    REQUIRE(automatic.detectors == serial.detectors);
+    REQUIRE(automatic.observables == serial.observables);
+    REQUIRE(automatic.exp_vals == serial.exp_vals);
+}
+
+TEST_CASE("Intra-shot rotation and promotion kernels preserve serial coefficients") {
+    constexpr uint32_t width = 19;
     SamplingPlan plan;
     plan.num_qubits = width;
     plan.peak_active_width = width;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1350,6 +1350,93 @@ TEST_CASE("Threaded fixed-row sampling preserves seeded shot order") {
     }
 }
 
+TEST_CASE("Sampling thread layouts validate explicit worker counts") {
+    const ExecutablePlan executable(plan_from("H 0\nM 0\n"));
+    REQUIRE_THROWS_WITH(clifft::sampling::sample(executable, 1, uint64_t{11}, 1,
+                                                 clifft::sampling::ThreadLayout{
+                                                     .shot_workers = 0, .intra_shot_workers = 1}),
+                        "thread_layout worker counts must be positive");
+
+#if defined(CLIFFT_TESTS_HAVE_OPENMP)
+    const clifft::sampling::ThreadLayout hybrid{
+        .shot_workers = 2, .intra_shot_workers = 2, .intra_shot_min_active_width = 0};
+    if (clifft::openmp_process_binding_active()) {
+        REQUIRE_THROWS_WITH(clifft::sampling::sample(executable, 7, uint64_t{12}, 1, hybrid),
+                            "hybrid thread_layout requires OMP_PROC_BIND=false");
+    } else {
+        const clifft::sampling::SamplingResult result =
+            clifft::sampling::sample(executable, 7, uint64_t{12}, 1, hybrid);
+        REQUIRE(result.measurements.size() == 7);
+    }
+#else
+    REQUIRE_THROWS_WITH(
+        clifft::sampling::sample(
+            executable, 1, uint64_t{12}, 1,
+            clifft::sampling::ThreadLayout{
+                .shot_workers = 1, .intra_shot_workers = 2, .intra_shot_min_active_width = 0}),
+        "thread_layout intra-shot workers require an OpenMP-enabled build");
+#endif
+}
+
+#if defined(CLIFFT_TESTS_HAVE_OPENMP)
+TEST_CASE("Intra-shot rotation kernels preserve serial coefficients") {
+    constexpr uint32_t width = 18;
+    SamplingPlan plan;
+    plan.num_qubits = width;
+    plan.peak_active_width = width;
+    for (uint32_t active = 0; active < width; ++active) {
+        plan.actions.push_back(
+            PlannedAction{active, active + 1, PromoteDormantRotation{0.25, AffineBool(false)}});
+    }
+    constexpr std::array<ActivePauli, 8> paulis{{
+        {0x15555, 0x2aaaa},
+        {0x2a9c3, 0x13179},
+        {0, 0x3ffff},
+        {0x3ff00, 0x00ff3},
+        {0x2c71d, 0x19ac6},
+        {0x00003, 0x2c5a1},
+        {0x20000, 0x15555},
+        {0x31b6d, 0x0e493},
+    }};
+    for (const ActivePauli pauli : paulis) {
+        plan.actions.push_back(
+            PlannedAction{width, width, RotateActivePauli{pauli, 0.125, AffineBool(false)}});
+    }
+
+    const ExecutablePlan executable(plan);
+    Executor serial(executable, 17, 1);
+    Executor parallel(executable, 17, 4);
+    serial.run_shot();
+    parallel.run_shot();
+
+    REQUIRE(parallel.state().active_width() == serial.state().active_width());
+    REQUIRE(std::ranges::equal(parallel.state().real(), serial.state().real()));
+    REQUIRE(std::ranges::equal(parallel.state().imag(), serial.state().imag()));
+}
+
+TEST_CASE("Intra-shot active-width threshold is configurable") {
+    constexpr uint32_t width = 17;
+    SamplingPlan plan;
+    plan.num_qubits = width;
+    plan.peak_active_width = width;
+    for (uint32_t active = 0; active < width; ++active) {
+        plan.actions.push_back(
+            PlannedAction{active, active + 1, PromoteDormantRotation{0.25, AffineBool(false)}});
+    }
+    plan.actions.push_back(PlannedAction{
+        width, width, RotateActivePauli{ActivePauli{0x15555, 0x1aaaa}, 0.125, AffineBool(false)}});
+
+    const ExecutablePlan executable(plan);
+    Executor serial(executable, 19, 1, width);
+    Executor parallel(executable, 19, 4, width);
+    serial.run_shot();
+    parallel.run_shot();
+
+    REQUIRE(std::ranges::equal(parallel.state().real(), serial.state().real()));
+    REQUIRE(std::ranges::equal(parallel.state().imag(), serial.state().imag()));
+}
+#endif
+
 TEST_CASE("Threaded survivor sampling preserves seeded survivors and records") {
     const std::array<uint8_t, 1> postselection{1};
     const ExecutablePlan executable(

--- a/tools/ci/audit_macos_wheel.py
+++ b/tools/ci/audit_macos_wheel.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Verify that a repaired macOS wheel carries and loads its OpenMP runtime."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def _wheel_members(wheel: Path) -> tuple[str, list[str]]:
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+    extensions = [
+        name
+        for name in names
+        if Path(name).name.startswith("_clifft_core") and name.endswith(".so")
+    ]
+    if len(extensions) != 1:
+        raise RuntimeError(f"expected one _clifft_core extension, found {extensions}")
+    bundled_libomp = [
+        name for name in names if "libomp" in Path(name).name.lower() and name.endswith(".dylib")
+    ]
+    if not bundled_libomp:
+        raise RuntimeError("wheel does not contain a bundled libomp dylib")
+    return extensions[0], bundled_libomp
+
+
+def _dependencies(binary: Path) -> list[str]:
+    completed = subprocess.run(
+        ["otool", "-L", str(binary)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        line.strip().split(" (compatibility version", maxsplit=1)[0]
+        for line in completed.stdout.splitlines()[1:]
+        if line.strip()
+    ]
+
+
+def audit(wheel: Path) -> None:
+    extension_member, libomp_members = _wheel_members(wheel)
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        with zipfile.ZipFile(wheel) as archive:
+            extension = Path(archive.extract(extension_member, root))
+        dependencies = _dependencies(extension)
+
+    libomp_dependencies = [
+        dependency for dependency in dependencies if "libomp" in Path(dependency).name.lower()
+    ]
+    if not libomp_dependencies:
+        raise RuntimeError("_clifft_core does not declare a libomp dependency")
+    if any(not dependency.startswith("@loader_path/") for dependency in libomp_dependencies):
+        raise RuntimeError(f"libomp dependency is not wheel-relative: {libomp_dependencies}")
+
+    bundled_names = {Path(member).name for member in libomp_members}
+    referenced_names = {Path(dependency).name for dependency in libomp_dependencies}
+    if not referenced_names <= bundled_names:
+        raise RuntimeError(
+            f"referenced libomp is not bundled: references={referenced_names}, "
+            f"bundled={bundled_names}"
+        )
+
+    forbidden_prefixes = ("/opt/homebrew/", "/usr/local/")
+    external = [
+        dependency for dependency in dependencies if dependency.startswith(forbidden_prefixes)
+    ]
+    if external:
+        raise RuntimeError(f"extension retains build-machine dependencies: {external}")
+
+    print(f"wheel: {wheel}")
+    print(f"extension: {extension_member}")
+    print(f"bundled libomp: {', '.join(libomp_members)}")
+    print(f"libomp load command: {', '.join(libomp_dependencies)}")
+    print("macOS wheel OpenMP audit passed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args()
+    audit(args.wheel.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -1,12 +1,14 @@
-# Compilation and Probability Profiling Tools
+# Native Profiling Tools
 
-Two native C++ harnesses isolate production compile and strong-simulation
-costs for `perf` or another sampling profiler:
+Three native C++ harnesses isolate production compile, sampling, and
+strong-simulation costs for `perf` or another sampling profiler:
 
 - `profile_compile` repeatedly runs parse, trace and HIR optimization,
   coordinate planning, and executable-plan preparation.
 - `profile_probability` compiles a unitary circuit and repeatedly queries
   `clifft::basis_probabilities()` over a batch of bitstrings.
+- `profile_sample` compiles a circuit once and repeatedly samples it through
+  the public C++ path.
 
 ## Build
 
@@ -17,7 +19,7 @@ the optimized code paths used for profiling.
 cmake -B build-profile \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCLIFFT_BUILD_PROFILER=ON
-cmake --build build-profile --target profile_compile profile_probability -j$(nproc)
+cmake --build build-profile --target profile_compile profile_probability profile_sample -j$(nproc)
 ```
 
 The equivalent build command is `just profile-build`.
@@ -46,6 +48,33 @@ CLIFFT_COMPILE_ITERATIONS=200 \
 | `CLIFFT_CLIFFORD_DEPTH` | 5000 | Clifford gates in the generated circuit |
 | `CLIFFT_T_GATES` | 0 | T gates appended to the generated circuit |
 | `CLIFFT_POSTSELECT_ALL` | unset | Mark every detector for postselection |
+
+## Sampling
+
+`profile_sample` keeps parsing and compilation outside the measured interval.
+Executor construction, state initialization, hot execution, and result
+collection remain inside it, matching the end-to-end cost of repeated calls to
+the public sampling API.
+
+```bash
+CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim \
+  CLIFFT_PROFILE_SHOTS=1 \
+  CLIFFT_PROFILE_THREADS=1 \
+  ./build-profile/profile_sample
+```
+
+| Variable | Default | Description |
+|---|---:|---|
+| `CLIFFT_CIRCUIT_FILE` | required | Input `.stim` file |
+| `CLIFFT_PROFILE_SHOTS` | 1 | Shots per measured sample call |
+| `CLIFFT_PROFILE_THREADS` | 1 | Total worker budget; `0` selects auto |
+| `CLIFFT_PROFILE_SHOT_WORKERS` | unset | Explicit cross-shot workers; set with intra-shot workers |
+| `CLIFFT_PROFILE_INTRA_SHOT_WORKERS` | unset | Explicit per-shot workers; set with shot workers |
+| `CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH` | 18 | Expert kernel threshold; requires an explicit layout |
+| `CLIFFT_PROFILE_WARMUPS` | 2 | Untimed sample calls |
+| `CLIFFT_PROFILE_REPETITIONS` | 20 | Timed sample calls |
+| `CLIFFT_PROFILE_GENERATED_WIDTH` | unset | Generate a rotation-heavy circuit of this width instead of loading a file |
+| `CLIFFT_PROFILE_GENERATED_DEPTH` | 20 | Layers in the generated circuit |
 
 ## Probability queries
 

--- a/tools/profile/profile_sample.cpp
+++ b/tools/profile/profile_sample.cpp
@@ -99,7 +99,7 @@ void summarize(std::vector<double> samples_ms, int shots) {
     const double sum = std::accumulate(samples_ms.begin(), samples_ms.end(), 0.0);
     const double mean = sum / static_cast<double>(samples_ms.size());
     const double median = samples_ms[samples_ms.size() / 2];
-    const double p95 = samples_ms[(samples_ms.size() * 95) / 100];
+    const double p95 = samples_ms[(samples_ms.size() * 95 - 1) / 100];
 
     std::cout << "Sampling distribution:\n";
     std::cout << "  min:    " << samples_ms.front() << " ms\n";

--- a/tools/profile/profile_sample.cpp
+++ b/tools/profile/profile_sample.cpp
@@ -1,0 +1,223 @@
+// Clifft sampling profiler
+//
+// Compiles a circuit once, then repeatedly samples it through the public C++
+// path. This keeps compilation and file IO outside the measured interval while
+// retaining executor construction, state initialization, and result collection.
+//
+// See tools/profile/README.md for build instructions.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/sampling/sampler.h"
+
+#include <algorithm>
+#include <bit>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kDefaultShots = 1;
+constexpr int kDefaultThreads = 1;
+constexpr int kDefaultWarmups = 2;
+constexpr int kDefaultRepetitions = 20;
+constexpr int kDefaultGeneratedDepth = 20;
+constexpr uint64_t kSeed = 42;
+
+int get_env_int(const char* name, int default_value) {
+    const char* value = std::getenv(name);
+    return value == nullptr ? default_value : std::stoi(value);
+}
+
+std::string read_file(const std::string& path) {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        std::cerr << "Error: cannot open file: " << path << "\n";
+        std::exit(1);
+    }
+    std::ostringstream contents;
+    contents << file.rdbuf();
+    return contents.str();
+}
+
+std::string generate_circuit(int width, int depth) {
+    std::ostringstream circuit;
+    for (int layer = 0; layer < depth; ++layer) {
+        for (int qubit = 0; qubit < width; ++qubit) {
+            const double offset = static_cast<double>((layer * width + qubit) % 17) / 1000.0;
+            circuit << "U3(" << 0.123 + offset << ',' << 0.234 + offset << ',' << -0.345 - offset
+                    << ") " << qubit << '\n';
+        }
+        for (int qubit = layer & 1; qubit + 1 < width; qubit += 2) {
+            circuit << "CX " << qubit << ' ' << qubit + 1 << '\n';
+        }
+    }
+    circuit << "M";
+    for (int qubit = 0; qubit < width; ++qubit) {
+        circuit << ' ' << qubit;
+    }
+    circuit << '\n';
+    return circuit.str();
+}
+
+uint64_t mix(uint64_t checksum, uint64_t value) {
+    checksum ^= value + 0x9e3779b97f4a7c15ULL + (checksum << 6) + (checksum >> 2);
+    return checksum;
+}
+
+uint64_t checksum_result(const clifft::sampling::SamplingResult& result) {
+    uint64_t checksum = 0;
+    for (uint8_t value : result.measurements) {
+        checksum = mix(checksum, value);
+    }
+    for (uint8_t value : result.detectors) {
+        checksum = mix(checksum, value);
+    }
+    for (uint8_t value : result.observables) {
+        checksum = mix(checksum, value);
+    }
+    for (double value : result.exp_vals) {
+        checksum = mix(checksum, std::bit_cast<uint64_t>(value));
+    }
+    return checksum;
+}
+
+void summarize(std::vector<double> samples_ms, int shots) {
+    std::sort(samples_ms.begin(), samples_ms.end());
+    const double sum = std::accumulate(samples_ms.begin(), samples_ms.end(), 0.0);
+    const double mean = sum / static_cast<double>(samples_ms.size());
+    const double median = samples_ms[samples_ms.size() / 2];
+    const double p95 = samples_ms[(samples_ms.size() * 95) / 100];
+
+    std::cout << "Sampling distribution:\n";
+    std::cout << "  min:    " << samples_ms.front() << " ms\n";
+    std::cout << "  median: " << median << " ms\n";
+    std::cout << "  mean:   " << mean << " ms\n";
+    std::cout << "  p95:    " << p95 << " ms\n";
+    std::cout << "  max:    " << samples_ms.back() << " ms\n";
+    std::cout << "  median per shot: " << median / static_cast<double>(shots) << " ms\n";
+}
+
+}  // namespace
+
+int main() {
+    const char* circuit_file = std::getenv("CLIFFT_CIRCUIT_FILE");
+    const int shots = get_env_int("CLIFFT_PROFILE_SHOTS", kDefaultShots);
+    const int threads = get_env_int("CLIFFT_PROFILE_THREADS", kDefaultThreads);
+    const int warmups = get_env_int("CLIFFT_PROFILE_WARMUPS", kDefaultWarmups);
+    const int repetitions = get_env_int("CLIFFT_PROFILE_REPETITIONS", kDefaultRepetitions);
+    const int generated_width = get_env_int("CLIFFT_PROFILE_GENERATED_WIDTH", 0);
+    const int generated_depth =
+        get_env_int("CLIFFT_PROFILE_GENERATED_DEPTH", kDefaultGeneratedDepth);
+    const char* shot_workers_value = std::getenv("CLIFFT_PROFILE_SHOT_WORKERS");
+    const char* intra_workers_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_WORKERS");
+    const char* min_active_width_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH");
+    const bool has_layout = shot_workers_value != nullptr || intra_workers_value != nullptr;
+    const int shot_workers = get_env_int("CLIFFT_PROFILE_SHOT_WORKERS", 0);
+    const int intra_shot_workers = get_env_int("CLIFFT_PROFILE_INTRA_SHOT_WORKERS", 0);
+    const int intra_shot_min_active_width =
+        get_env_int("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH",
+                    static_cast<int>(clifft::kDefaultIntraShotMinActiveWidth));
+    if (shots < 1 || threads < 0 || warmups < 0 || repetitions < 1) {
+        std::cerr << "Error: shots and repetitions must be positive; threads and warmups must be "
+                     "non-negative\n";
+        return 1;
+    }
+    if ((circuit_file == nullptr || std::string(circuit_file).empty()) && generated_width < 1) {
+        std::cerr << "Error: set CLIFFT_CIRCUIT_FILE or CLIFFT_PROFILE_GENERATED_WIDTH\n";
+        return 1;
+    }
+    if (generated_width < 0 || generated_depth < 1) {
+        std::cerr << "Error: generated width must be non-negative and depth must be positive\n";
+        return 1;
+    }
+    if (has_layout && (shot_workers < 1 || intra_shot_workers < 1)) {
+        std::cerr << "Error: set both layout worker counts to positive values\n";
+        return 1;
+    }
+    if (min_active_width_value != nullptr && !has_layout) {
+        std::cerr << "Error: the intra-shot minimum active width requires an explicit layout\n";
+        return 1;
+    }
+    if (intra_shot_min_active_width < 0) {
+        std::cerr << "Error: the intra-shot minimum active width must be non-negative\n";
+        return 1;
+    }
+
+    std::cout << "Clifft Sampling Profiler\n";
+    std::cout << "========================\n";
+    if (circuit_file != nullptr && !std::string(circuit_file).empty()) {
+        std::cout << "Circuit:     " << circuit_file << "\n";
+    } else {
+        std::cout << "Circuit:     generated width " << generated_width << ", depth "
+                  << generated_depth << "\n";
+    }
+    std::cout << "Shots:       " << shots << "\n";
+    std::cout << "Threads:     " << threads << "\n";
+    if (has_layout) {
+        std::cout << "Layout:      " << shot_workers << " shot x " << intra_shot_workers
+                  << " intra-shot\n";
+        std::cout << "Min width:   " << intra_shot_min_active_width << "\n";
+    }
+    std::cout << "Warmups:     " << warmups << "\n";
+    std::cout << "Repetitions: " << repetitions << "\n\n";
+
+    const std::string circuit_text = circuit_file != nullptr && !std::string(circuit_file).empty()
+                                         ? read_file(circuit_file)
+                                         : generate_circuit(generated_width, generated_depth);
+    clifft::Circuit circuit = clifft::parse(circuit_text);
+    clifft::HirModule hir = clifft::trace(circuit);
+    auto pass_manager = clifft::default_hir_pass_manager();
+    pass_manager.run(hir);
+    clifft::sampling::SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+
+    std::cout << "Plan: " << hir.num_qubits << " qubits, peak active width "
+              << plan.peak_active_width << ", " << plan.actions.size() << " actions\n\n";
+    clifft::sampling::ExecutablePlan program(plan);
+    const std::optional<clifft::sampling::ThreadLayout> thread_layout =
+        has_layout
+            ? std::optional<clifft::sampling::ThreadLayout>{{.shot_workers = static_cast<uint32_t>(
+                                                                 shot_workers),
+                                                             .intra_shot_workers =
+                                                                 static_cast<uint32_t>(
+                                                                     intra_shot_workers),
+                                                             .intra_shot_min_active_width =
+                                                                 static_cast<uint32_t>(
+                                                                     intra_shot_min_active_width)}}
+            : std::nullopt;
+
+    uint64_t checksum = 0;
+    for (int iteration = 0; iteration < warmups; ++iteration) {
+        checksum = mix(checksum, checksum_result(clifft::sampling::sample(
+                                     program, static_cast<uint32_t>(shots), kSeed + iteration,
+                                     static_cast<uint32_t>(threads), thread_layout)));
+    }
+
+    std::vector<double> samples_ms;
+    samples_ms.reserve(static_cast<size_t>(repetitions));
+    for (int iteration = 0; iteration < repetitions; ++iteration) {
+        const auto start = std::chrono::steady_clock::now();
+        auto result = clifft::sampling::sample(program, static_cast<uint32_t>(shots),
+                                               kSeed + warmups + iteration,
+                                               static_cast<uint32_t>(threads), thread_layout);
+        const auto end = std::chrono::steady_clock::now();
+        samples_ms.push_back(std::chrono::duration<double, std::milli>(end - start).count());
+        checksum = mix(checksum, checksum_result(result));
+    }
+
+    summarize(samples_ms, shots);
+    std::cout << "Checksum: " << checksum << "\n";
+    return 0;
+}

--- a/tools/tsan/suppressions.txt
+++ b/tools/tsan/suppressions.txt
@@ -1,0 +1,15 @@
+# OpenMP runtimes maintain internal worker pools and barriers in uninstrumented
+# code. Suppress only their runtime frames so races in Clifft kernels remain
+# visible to ThreadSanitizer.
+
+# LLVM libomp
+race:__kmp_resume_64
+race:__kmp_suspend_64
+race:__kmp_launch_monitor
+race:__kmp_create_worker
+race:__kmp_set_num_threads
+race:__kmp_internal_end_atexit
+
+# GCC libgomp
+race:gomp_team_start
+race:gomp_thread_start


### PR DESCRIPTION
## Summary

Closes #312.

- restore OpenMP acceleration for wide scalar, AVX2, AVX-512, fused-rotation, and promotion coefficient passes, including parallel first-touch initialization
- treat threads as a total worker budget: automatic scheduling uses cross-shot workers when shots fill the budget, or one intra-shot team for undersubscribed workloads with peak active width at least 18
- add the expert thread_layout=(shot_workers, intra_shot_workers) override and runtime intra_shot_min_active_width threshold
- retain explicit hybrid layouts, reject them when OpenMP processor binding is active, and use an OpenMP team for pure cross-shot work under binding so affinity is honored
- add AUTO/OFF/ON OpenMP build support, macOS libomp setup, sanitizer handling, a sampling profiler, tests, and documentation

The automatic policy deliberately remains either-or and does not select a hybrid layout. Builds without OpenMP continue to use the existing cross-shot path.

## Performance

Measured on the 8-vCPU AMD EPYC development VM with the QV20 fixture:

- one shot: 217.3 ms median with one worker versus 68.2 ms with eight intra-shot workers, a 3.2x speedup with identical checksums
- eight shots: explicit 2x4 took 430 ms median versus automatic 8x1 at 549 ms, demonstrating why the expert override remains useful
- QV10 at 100 shots remained approximately 5 ms with OpenMP enabled and disabled

## Breaking change

The threads argument is now a total sampling worker budget and can select intra-shot execution for wide, undersubscribed fixed-plan workloads. Use thread_layout=(shot_workers, 1) to force the previous cross-shot-only behavior.

## Test plan

- [x] C++ tests pass with OpenMP ON: 849 test cases and 476,252 assertions
- [x] C++ tests pass with OpenMP OFF: 847 test cases and 476,246 assertions
- [x] Python tests pass: 830 tests
- [x] Doc examples pass: 32 passed and 8 environment-dependent examples skipped
- [x] Processor-bound hybrid rejection and pure cross-shot affinity paths tested
- [x] Pre-commit checks pass

## Contributor agreement

- [ ] I confirm this contribution is my original work or I have the right to submit it, and I license it under the Apache-2.0 license.
- [x] This contribution was AI-assisted, the generated code was reviewed, and the commits include Assisted-by trailers.