### PR TITLE
fix(sampling): conjugate the inverse-frame expansion in basis probabilities

### DIFF
--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -237,6 +237,9 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
     // the base string toward the requested virtual basis by applying the unique
     // generator for each still-set pivot bit, accumulating the Pauli phases on
     // the way. Any residual bit means the basis state is outside the support.
+    // The result is the expansion coefficient <basis|U_C^dagger|x>, with the
+    // base-string coefficient chosen real positive; callers forming the Born
+    // amplitude <x|U_C|...> must conjugate it.
     mask_copy_to(residual, basis);
     mask_xor_with(residual, basis_mask_view(base));
     mask_copy_to(current, basis_mask_view(base));
@@ -477,7 +480,9 @@ std::vector<double> basis_probabilities_from_factored_state(
                 // Dormant |0> axes do not contribute a Z-frame sign.
                 const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
                 double sign = sign_bit ? -1.0 : 1.0;
-                amp += coefficient_at(active_index) * sign * coeff;
+                // The walk yields the expansion coefficient <y|U_C^dagger|x>;
+                // the Born amplitude sums v_i against its conjugate <x|U_C|y>.
+                amp += coefficient_at(active_index) * sign * std::conj(coeff);
             }
         } else {
             // Fast path: every dormant column is a pivot, so dormant
@@ -545,7 +550,9 @@ std::vector<double> basis_probabilities_from_factored_state(
                                       : ((current.words[0] ^ state_px.words[0]) & active_mask);
                 const bool sign_bit = (std::popcount(active_index & active_z_mask) & 1U) != 0;
                 const double sign = sign_bit ? -1.0 : 1.0;
-                total += coefficient_at(active_index) * sign * amp;
+                // amp tracks the walked coefficient <y|U_C^dagger|x>; the Born
+                // amplitude sums v_i against its conjugate <x|U_C|y>.
+                total += coefficient_at(active_index) * sign * std::conj(amp);
             }
             amp = total;
         }

--- a/tests/python/test_basis_probabilities.py
+++ b/tests/python/test_basis_probabilities.py
@@ -232,6 +232,53 @@ def test_probabilities_match_dense_statevector_for_small_circuit(
     )
 
 
+@pytest.mark.parametrize(
+    "circuit,bitstrings",
+    [
+        ("H 0\nS 0\nT 0\nH 0", ["0", "1"]),
+        ("H 0\nS 0\nT 0\nH 0\nCX 0 1", ["00", "11"]),
+    ],
+)
+def test_probabilities_conjugate_complex_clifford_frames(
+    circuit: str, bitstrings: list[str], basis_probabilities_api: Any
+) -> None:
+    # The frame H*S*H combines both active coordinates into each outcome with
+    # relatively imaginary weights. The query expands the state through the
+    # inverse frame, and forgetting to conjugate that expansion inverts the
+    # interference, swapping the two outcome weights.
+    prog = basis_probabilities_api.compile(circuit)
+    probs = basis_probabilities_api.basis_probabilities(prog, bitstrings)
+
+    np.testing.assert_allclose(
+        probs, [(2.0 - math.sqrt(2.0)) / 4.0, (2.0 + math.sqrt(2.0)) / 4.0], atol=1e-12
+    )
+    np.testing.assert_allclose(
+        np.abs(clifft.get_statevector(prog)) ** 2,
+        basis_probabilities_api.basis_probabilities(
+            prog, [format(i, f"0{prog.num_qubits}b")[::-1] for i in range(1 << prog.num_qubits)]
+        ),
+        atol=1e-12,
+    )
+
+
+# The pinned seeds include generator outputs whose outcome amplitudes combine
+# several active coordinates with complex relative weights; broad sweeps with
+# only a few seeds can miss that interference pattern entirely.
+@pytest.mark.parametrize("num_qubits,seed", [(2, 12), (4, 95), (3, 7), (4, 21)])
+def test_probabilities_match_statevector_for_random_circuits(
+    num_qubits: int, seed: int, basis_probabilities_api: Any
+) -> None:
+    circuit = random_dense_clifford_t_circuit(num_qubits, depth=18, seed=seed)
+    prog = basis_probabilities_api.compile(circuit)
+    bitstrings = [format(i, f"0{prog.num_qubits}b")[::-1] for i in range(1 << prog.num_qubits)]
+
+    np.testing.assert_allclose(
+        basis_probabilities_api.basis_probabilities(prog, bitstrings),
+        np.abs(clifft.get_statevector(prog)) ** 2,
+        atol=1e-12,
+    )
+
+
 @pytest.mark.parametrize("num_qubits,seed", [(2, 101), (3, 202), (4, 303)])
 def test_probabilities_match_qiskit_for_random_small_circuits(
     num_qubits: int, seed: int, basis_probabilities_api: Any

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -491,6 +491,34 @@ TEST_CASE("Sampling basis probabilities reject nonunitary plans") {
     REQUIRE_THAT(probabilities[1], Catch::Matchers::WithinAbs(0.5, 1e-12));
 }
 
+TEST_CASE("Sampling basis probabilities conjugate a complex Clifford frame") {
+    // The frame H*S*H mixes the two active coordinates with weights (1 +- i)/2
+    // while the T rotation leaves them relatively imaginary. The query expands
+    // the state through the inverse frame, so dropping the conjugate of that
+    // expansion inverts the interference and swaps the outcome weights.
+    const double p_low = (2.0 - std::numbers::sqrt2) / 4.0;
+    const double p_high = (2.0 + std::numbers::sqrt2) / 4.0;
+
+    SECTION("every dormant column is a pivot") {
+        const ExecutablePlan executable(plan_from("H 0\nS 0\nT 0\nH 0\n"));
+        const std::vector<double> probabilities =
+            clifft::sampling::basis_probabilities(executable, std::array<uint64_t, 2>{0, 1}, 2, 1);
+        REQUIRE_THAT(probabilities[0], Catch::Matchers::WithinAbs(p_low, 1e-12));
+        REQUIRE_THAT(probabilities[1], Catch::Matchers::WithinAbs(p_high, 1e-12));
+    }
+
+    SECTION("a free dormant column disables the gray-code walk") {
+        // The trailing CX correlates the dormant qubit with the active
+        // coordinate, so the dormant column has no X pivot and the query takes
+        // the explicit per-index walk instead of the gray-code path.
+        const ExecutablePlan executable(plan_from("H 0\nS 0\nT 0\nH 0\nCX 0 1\n"));
+        const std::vector<double> probabilities =
+            clifft::sampling::basis_probabilities(executable, std::array<uint64_t, 2>{0, 3}, 2, 1);
+        REQUIRE_THAT(probabilities[0], Catch::Matchers::WithinAbs(p_low, 1e-12));
+        REQUIRE_THAT(probabilities[1], Catch::Matchers::WithinAbs(p_high, 1e-12));
+    }
+}
+
 TEST_CASE("Sampling statevectors reject nonunitary and oversized plans") {
     const ExecutablePlan measured(plan_from("H 0\nM 0\n"));
     REQUIRE_THROWS_AS(clifft::sampling::get_statevector(measured), std::invalid_argument);


### PR DESCRIPTION
## Summary

- conjugate the inverse-frame stabilizer expansion when forming the Born amplitude in `basis_probabilities`, on both the gray-code walk and the free-dormant-column fallback
- document the direction convention of `BoundStabilizerAmplitudeQuery::amplitude` so future callers know the conjugation is theirs to apply
- add analytic regression tests on both walk paths plus pinned random circuits that detect the inverted interference against statevector moduli

## Root cause

The query expands `U_C^dagger |x>` over the active coordinates and summed those expansion coefficients directly against the active state. The Born amplitude `<x| U_C P (|phi> x |0>)` needs the conjugate of each coefficient, exactly as the formula in `docs/theory/basis_probabilities.md` (`<x|U_C|y(i)>`) states. For the issue's reproduction the correct amplitude is `(1+i)(cos(pi/8) - sin(pi/8))/2` giving `P(0) = (2 - sqrt(2))/4 = 0.1464...`, while the unconjugated sum yields `(1-i)(cos(pi/8) + sin(pi/8))/2` giving `0.8536...` -- the apparent "reversal" is specific to the one-qubit case; in general the interference is inverted, not permuted.

The error is only observable when two or more active coordinates combine into one outcome with complex relative weight, which is why real-mixing frames and the existing pinned Qiskit seeds never caught it (about 4% of short random 1-3 qubit Clifford+T circuits trigger it).

## Provenance

Wheel bisect of the reproduction across the feature's history (requested in the issue): the behavior is present at the feature's birth commit a44ab2aa (#60, `probabilities()`), at the last SVM-backend commit before the symbolic-coordinate rewrite, at 7420b8c2 (#275), and on current main with an identical failure set. It is a day-one bug carried through every rewrite of the query, not a regression from the projective-statevector series (#369, #372, #378) or any other refactor.

A sweep of the other query surfaces against an independent dense reference found no sibling issues: `get_statevector` (projective, 180+ circuits), `EXP_VAL` (60/60), `record_probabilities` (50/50, separate replay path), sampling distributions, near-Clifford canonicalization, and SPP/TPP products are all clean. The stabilizer-amplitude machinery has a single caller, so no other consumer inherits the bug.

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files`
- C++ Debug: 843/843 non-benchmark tests pass; the new test's two sections were verified (via temporary instrumentation) to exercise the gray-code and fallback walks respectively, and both fail without the fix
- Python (Debug extension): 870 passed, including the new analytic and pinned-seed differential tests; pinned seeds (2, 12) and (4, 95) reproduce the mismatch without the fix
- independent randomized differential (`basis_probabilities` vs `|get_statevector|^2`, 300 random 1-3 qubit Clifford+T circuits): 12/300 mismatched before the fix, 0/300 after

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
