### PR TITLE
perf(compilation): absorb Clifford-valued Pauli rotations

### DIFF
--- a/docs/compiler_ir.json
+++ b/docs/compiler_ir.json
@@ -61,7 +61,7 @@
     "PHASE_ROTATION": {
       "category": "Non-Clifford",
       "summary": "Continuous Z-rotation by angle alpha (half-turns) on a Pauli product.",
-      "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. Global phase differences from the source gate representation are intentionally omitted. R_X, R_Y, and R_Z rotations within the documented 1e-12 half-turn canonicalization tolerance of a Clifford angle, including U3 components, are instead absorbed directly into the Clifford frame and emit no PHASE_ROTATION. Two- and multi-qubit Pauli rotations within that tolerance of an odd integer are likewise absorbed as projective Pauli gates. The peephole pass uses the same tolerance when canonicalizing HIR rotations produced directly or by fusion.",
+      "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. Global phase differences from the source gate representation are intentionally omitted. R_X, R_Y, and R_Z rotations within the documented 1e-12 half-turn canonicalization tolerance of a Clifford angle, including U3 components, are instead absorbed directly into the Clifford frame and emit no PHASE_ROTATION. Two- and multi-qubit Pauli rotations use the same trace-time policy, including square-root Pauli rotations at half-integer angles and projective Pauli gates at odd-integer angles. The peephole pass uses the same tolerance when canonicalizing HIR rotations produced directly or by fusion.",
       "display": [
         "PHASE_ROTATION"
       ]

--- a/docs/compiler_ir.json
+++ b/docs/compiler_ir.json
@@ -61,7 +61,7 @@
     "PHASE_ROTATION": {
       "category": "Non-Clifford",
       "summary": "Continuous Z-rotation by angle alpha (half-turns) on a Pauli product.",
-      "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. Global phase differences from the source gate representation are intentionally omitted. R_X, R_Y, and R_Z rotations within the documented 1e-12 half-turn canonicalization tolerance of a Clifford angle, including U3 components, are instead absorbed directly into the Clifford frame and emit no PHASE_ROTATION. The peephole pass uses the same tolerance when canonicalizing HIR rotations.",
+      "detail": "Applies exp(-i*alpha*pi/2 * P) where P is the rewound Pauli product and alpha is in half-turn units. Global phase differences from the source gate representation are intentionally omitted. R_X, R_Y, and R_Z rotations within the documented 1e-12 half-turn canonicalization tolerance of a Clifford angle, including U3 components, are instead absorbed directly into the Clifford frame and emit no PHASE_ROTATION. Two- and multi-qubit Pauli rotations within that tolerance of an odd integer are likewise absorbed as projective Pauli gates. The peephole pass uses the same tolerance when canonicalizing HIR rotations produced directly or by fusion.",
       "display": [
         "PHASE_ROTATION"
       ]

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -134,6 +134,11 @@ Duplicate target qubits (e.g. `R_XX(0.5) 3 3`) are rejected at parse time.
 The target list uses Stim's Pauli product syntax (e.g. `X0*Y1*Z2`). Maximum
 target count is 64 qubits per instruction.
 
+For two- and multi-qubit Pauli rotations, finite angles within the shared
+`1e-12` half-turn tolerance of an odd integer are projectively Pauli gates and
+are absorbed into the Clifford frame during tracing. The peephole pass applies
+the same rule when fusion produces an odd-integer rotation.
+
 ## Two-Qubit Clifford Gates
 
 | Gate | Notes |

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -43,9 +43,9 @@ whitespace-separated products in one instruction. Prefixing a Pauli term with
 appear only once in each product, which is stricter than Stim for some
 syntactically valid Hermitian products.
 
-The default optimizer absorbs `SPP` and `SPP_DAG` into the Clifford frame, so
-they have no runtime cost. `SPP Z0` and `S 0` represent the same projective
-Clifford operation.
+The frontend absorbs `SPP` and `SPP_DAG` into the Clifford frame during
+tracing, so they have no runtime cost. `SPP Z0` and `S 0` represent the same
+projective Clifford operation.
 
 ## Non-Clifford Extensions
 

--- a/docs/reference/gates.md
+++ b/docs/reference/gates.md
@@ -135,9 +135,10 @@ The target list uses Stim's Pauli product syntax (e.g. `X0*Y1*Z2`). Maximum
 target count is 64 qubits per instruction.
 
 For two- and multi-qubit Pauli rotations, finite angles within the shared
-`1e-12` half-turn tolerance of an odd integer are projectively Pauli gates and
-are absorbed into the Clifford frame during tracing. The peephole pass applies
-the same rule when fusion produces an odd-integer rotation.
+`1e-12` half-turn tolerance of a Clifford angle are absorbed into the Clifford
+frame during tracing. This includes square-root Pauli rotations at half-integer
+angles and projective Pauli gates at odd-integer angles. The peephole pass
+applies the same rule to HIR rotations produced directly or by fusion.
 
 ## Two-Qubit Clifford Gates
 

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -292,6 +292,23 @@ bool try_absorb_clifford_axis_rotation(stim::TableauSimulator<kStimWidth>& sim, 
     return true;
 }
 
+// A Pauli product is a tensor product of commuting single-qubit Paulis. Its
+// sign changes only the omitted global phase of a pi rotation.
+void apply_pauli_product_clifford(stim::TableauSimulator<kStimWidth>& sim,
+                                  const stim::PauliString<kStimWidth>& pauli) {
+    for (uint32_t q = 0; q < sim.inv_state.num_qubits; ++q) {
+        const bool x = pauli.xs[q];
+        const bool z = pauli.zs[q];
+        if (x && z) {
+            apply_single_qubit_clifford(sim, GateType::Y, q);
+        } else if (x) {
+            apply_single_qubit_clifford(sim, GateType::X, q);
+        } else if (z) {
+            apply_single_qubit_clifford(sim, GateType::Z, q);
+        }
+    }
+}
+
 // Trace R_Z(alpha) on a single qubit by extracting its rewound Z axis. The
 // source gate and emitted exponential may differ by a global phase, which is
 // intentionally omitted by the projective state contract.
@@ -312,6 +329,15 @@ void trace_rz(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir, uint32_t 
 // Trace an arbitrary Pauli rotation exp(-i*alpha*pi/2 * P).
 void trace_pauli_rotation(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir,
                           const stim::PauliString<kStimWidth>& obs, double alpha) {
+    const auto rotation = classify_clifford_rotation(alpha);
+    if (rotation == CliffordRotation::IDENTITY) {
+        return;
+    }
+    if (rotation == CliffordRotation::PAULI) {
+        apply_pauli_product_clifford(sim, obs);
+        return;
+    }
+
     stim::PauliString<kStimWidth> rewound = sim.inv_state(obs);
     uint32_t n = sim.inv_state.num_qubits;
     hir.append_phase_rotation(alpha, [&](MutablePauliMaskView slot) {
@@ -409,10 +435,20 @@ size_t count_pauli_masks(const Circuit& circuit) {
             }
             case GateType::R_XX:
             case GateType::R_YY:
-            case GateType::R_ZZ:
-                count += n_targets / 2;
+            case GateType::R_ZZ: {
+                const auto rotation = classify_clifford_rotation(node.args[0]);
+                if (rotation != CliffordRotation::IDENTITY && rotation != CliffordRotation::PAULI) {
+                    count += n_targets / 2;
+                }
                 break;
-            case GateType::R_PAULI:
+            }
+            case GateType::R_PAULI: {
+                const auto rotation = classify_clifford_rotation(node.args[0]);
+                if (rotation != CliffordRotation::IDENTITY && rotation != CliffordRotation::PAULI) {
+                    count += 1;
+                }
+                break;
+            }
             case GateType::SPP:
             case GateType::SPP_DAG:
             case GateType::TPP:

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -10,6 +10,7 @@
 #include <random>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace clifft {
 
@@ -292,21 +293,78 @@ bool try_absorb_clifford_axis_rotation(stim::TableauSimulator<kStimWidth>& sim, 
     return true;
 }
 
-// A Pauli product is a tensor product of commuting single-qubit Paulis. Its
-// sign changes only the omitted global phase of a pi rotation.
-void apply_pauli_product_clifford(stim::TableauSimulator<kStimWidth>& sim,
-                                  const stim::PauliString<kStimWidth>& pauli) {
-    for (uint32_t q = 0; q < sim.inv_state.num_qubits; ++q) {
-        const bool x = pauli.xs[q];
-        const bool z = pauli.zs[q];
-        if (x && z) {
-            apply_single_qubit_clifford(sim, GateType::Y, q);
-        } else if (x) {
-            apply_single_qubit_clifford(sim, GateType::X, q);
-        } else if (z) {
-            apply_single_qubit_clifford(sim, GateType::Z, q);
-        }
+void apply_clifford_pair_rotation(stim::TableauSimulator<kStimWidth>& sim, uint32_t q1, uint32_t q2,
+                                  CliffordRotation rotation, GateType sqrt_gate,
+                                  GateType pauli_gate, GateType sqrt_dag_gate) {
+    switch (rotation) {
+        case CliffordRotation::IDENTITY:
+            break;
+        case CliffordRotation::SQRT:
+            apply_two_qubit_clifford(sim, sqrt_gate, q1, q2);
+            break;
+        case CliffordRotation::PAULI:
+            apply_single_qubit_clifford(sim, pauli_gate, q1);
+            apply_single_qubit_clifford(sim, pauli_gate, q2);
+            break;
+        case CliffordRotation::SQRT_DAG:
+            apply_two_qubit_clifford(sim, sqrt_dag_gate, q1, q2);
+            break;
     }
+}
+
+void apply_sqrt_pauli_product_clifford(stim::TableauSimulator<kStimWidth>& sim,
+                                       const stim::PauliString<kStimWidth>& pauli, bool dagger) {
+    const auto pauli_ref = pauli.ref();
+    const size_t weight = pauli_ref.weight();
+    if (weight == 0) {
+        return;
+    }
+
+    std::vector<stim::GateTarget> targets;
+    targets.reserve(2 * weight - 1);
+    bool first = true;
+    pauli_ref.for_each_active_pauli([&](size_t q) {
+        if (!first) {
+            targets.push_back(stim::GateTarget::combiner());
+        }
+        targets.push_back(stim::GateTarget::pauli_xz(static_cast<uint32_t>(q), pauli.xs[q],
+                                                     pauli.zs[q], first && pauli.sign));
+        first = false;
+    });
+
+    const auto gate = dagger ? stim::GateType::SPP_DAG : stim::GateType::SPP;
+    const stim::CircuitInstruction instruction(gate, {}, targets, {});
+    if (dagger) {
+        sim.do_SPP_DAG(instruction);
+    } else {
+        sim.do_SPP(instruction);
+    }
+}
+
+// Absorb a Clifford-valued rotation around an arbitrary Pauli product. Stim's
+// SPP decomposition accounts for a signed axis; a full Pauli ignores that sign
+// because it changes only the omitted global phase.
+bool try_absorb_clifford_pauli_rotation(stim::TableauSimulator<kStimWidth>& sim,
+                                        const stim::PauliString<kStimWidth>& pauli, double alpha) {
+    const auto rotation = classify_clifford_rotation(alpha);
+    if (!rotation.has_value()) {
+        return false;
+    }
+
+    switch (*rotation) {
+        case CliffordRotation::IDENTITY:
+            break;
+        case CliffordRotation::SQRT:
+            apply_sqrt_pauli_product_clifford(sim, pauli, false);
+            break;
+        case CliffordRotation::PAULI:
+            sim.paulis(pauli);
+            break;
+        case CliffordRotation::SQRT_DAG:
+            apply_sqrt_pauli_product_clifford(sim, pauli, true);
+            break;
+    }
+    return true;
 }
 
 // Trace R_Z(alpha) on a single qubit by extracting its rewound Z axis. The
@@ -329,12 +387,7 @@ void trace_rz(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir, uint32_t 
 // Trace an arbitrary Pauli rotation exp(-i*alpha*pi/2 * P).
 void trace_pauli_rotation(stim::TableauSimulator<kStimWidth>& sim, HirModule& hir,
                           const stim::PauliString<kStimWidth>& obs, double alpha) {
-    const auto rotation = classify_clifford_rotation(alpha);
-    if (rotation == CliffordRotation::IDENTITY) {
-        return;
-    }
-    if (rotation == CliffordRotation::PAULI) {
-        apply_pauli_product_clifford(sim, obs);
+    if (try_absorb_clifford_pauli_rotation(sim, obs, alpha)) {
         return;
     }
 
@@ -436,21 +489,17 @@ size_t count_pauli_masks(const Circuit& circuit) {
             case GateType::R_XX:
             case GateType::R_YY:
             case GateType::R_ZZ: {
-                const auto rotation = classify_clifford_rotation(node.args[0]);
-                if (rotation != CliffordRotation::IDENTITY && rotation != CliffordRotation::PAULI) {
+                if (!classify_clifford_rotation(node.args[0]).has_value()) {
                     count += n_targets / 2;
                 }
                 break;
             }
             case GateType::R_PAULI: {
-                const auto rotation = classify_clifford_rotation(node.args[0]);
-                if (rotation != CliffordRotation::IDENTITY && rotation != CliffordRotation::PAULI) {
+                if (!classify_clifford_rotation(node.args[0]).has_value()) {
                     count += 1;
                 }
                 break;
             }
-            case GateType::SPP:
-            case GateType::SPP_DAG:
             case GateType::TPP:
             case GateType::TPP_DAG:
             case GateType::EXP_VAL:
@@ -748,6 +797,19 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
             case GateType::R_YY:
             case GateType::R_ZZ: {
                 double alpha = node.args[0];
+                const auto clifford_rotation = classify_clifford_rotation(alpha);
+                GateType sqrt_gate = GateType::SQRT_ZZ;
+                GateType pauli_gate = GateType::Z;
+                GateType sqrt_dag_gate = GateType::SQRT_ZZ_DAG;
+                if (node.gate == GateType::R_XX) {
+                    sqrt_gate = GateType::SQRT_XX;
+                    pauli_gate = GateType::X;
+                    sqrt_dag_gate = GateType::SQRT_XX_DAG;
+                } else if (node.gate == GateType::R_YY) {
+                    sqrt_gate = GateType::SQRT_YY;
+                    pauli_gate = GateType::Y;
+                    sqrt_dag_gate = GateType::SQRT_YY_DAG;
+                }
                 for (size_t i = 0; i + 1 < node.targets.size(); i += 2) {
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
@@ -755,6 +817,13 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                         throw std::runtime_error("Duplicate qubit in pair rotation: q" +
                                                  std::to_string(q1));
                     }
+
+                    if (clifford_rotation.has_value()) {
+                        apply_clifford_pair_rotation(sim, q1, q2, *clifford_rotation, sqrt_gate,
+                                                     pauli_gate, sqrt_dag_gate);
+                        continue;
+                    }
+
                     stim::PauliString<kStimWidth> obs(circuit.num_qubits);
                     if (node.gate == GateType::R_XX) {
                         obs.xs[q1] = true;

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -85,6 +85,24 @@ void apply_two_qubit_clifford(stim::TableauSimulator<kStimWidth>& sim, GateType 
         case GateType::SWAP:
             sim.inv_state.prepend_SWAP(a, b);
             return;
+        case GateType::SQRT_XX:
+            sim.inv_state.prepend_SQRT_XX_DAG(a, b);
+            return;
+        case GateType::SQRT_XX_DAG:
+            sim.inv_state.prepend_SQRT_XX(a, b);
+            return;
+        case GateType::SQRT_YY:
+            sim.inv_state.prepend_SQRT_YY_DAG(a, b);
+            return;
+        case GateType::SQRT_YY_DAG:
+            sim.inv_state.prepend_SQRT_YY(a, b);
+            return;
+        case GateType::SQRT_ZZ:
+            sim.inv_state.prepend_SQRT_ZZ_DAG(a, b);
+            return;
+        case GateType::SQRT_ZZ_DAG:
+            sim.inv_state.prepend_SQRT_ZZ(a, b);
+            return;
         default:
             break;
     }
@@ -312,6 +330,28 @@ void apply_clifford_pair_rotation(stim::TableauSimulator<kStimWidth>& sim, uint3
     }
 }
 
+struct PairRotationInfo {
+    GateType sqrt_gate;
+    GateType pauli_gate;
+    GateType sqrt_dag_gate;
+    bool x;
+    bool z;
+};
+
+PairRotationInfo pair_rotation_info(GateType gate) {
+    switch (gate) {
+        case GateType::R_XX:
+            return {GateType::SQRT_XX, GateType::X, GateType::SQRT_XX_DAG, true, false};
+        case GateType::R_YY:
+            return {GateType::SQRT_YY, GateType::Y, GateType::SQRT_YY_DAG, true, true};
+        case GateType::R_ZZ:
+            return {GateType::SQRT_ZZ, GateType::Z, GateType::SQRT_ZZ_DAG, false, true};
+        default:
+            throw std::invalid_argument("Not a pair rotation gate: " +
+                                        std::string(gate_name(gate)));
+    }
+}
+
 void apply_sqrt_pauli_product_clifford(stim::TableauSimulator<kStimWidth>& sim,
                                        const stim::PauliString<kStimWidth>& pauli, bool dagger) {
     const auto pauli_ref = pauli.ref();
@@ -334,11 +374,7 @@ void apply_sqrt_pauli_product_clifford(stim::TableauSimulator<kStimWidth>& sim,
 
     const auto gate = dagger ? stim::GateType::SPP_DAG : stim::GateType::SPP;
     const stim::CircuitInstruction instruction(gate, {}, targets, {});
-    if (dagger) {
-        sim.do_SPP_DAG(instruction);
-    } else {
-        sim.do_SPP(instruction);
-    }
+    sim.do_gate(instruction);
 }
 
 // Absorb a Clifford-valued rotation around an arbitrary Pauli product. Stim's
@@ -500,6 +536,10 @@ size_t count_pauli_masks(const Circuit& circuit) {
                 }
                 break;
             }
+            case GateType::SPP:
+            case GateType::SPP_DAG:
+                // These are absorbed directly into the Clifford frame during tracing.
+                break;
             case GateType::TPP:
             case GateType::TPP_DAG:
             case GateType::EXP_VAL:
@@ -798,18 +838,7 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
             case GateType::R_ZZ: {
                 double alpha = node.args[0];
                 const auto clifford_rotation = classify_clifford_rotation(alpha);
-                GateType sqrt_gate = GateType::SQRT_ZZ;
-                GateType pauli_gate = GateType::Z;
-                GateType sqrt_dag_gate = GateType::SQRT_ZZ_DAG;
-                if (node.gate == GateType::R_XX) {
-                    sqrt_gate = GateType::SQRT_XX;
-                    pauli_gate = GateType::X;
-                    sqrt_dag_gate = GateType::SQRT_XX_DAG;
-                } else if (node.gate == GateType::R_YY) {
-                    sqrt_gate = GateType::SQRT_YY;
-                    pauli_gate = GateType::Y;
-                    sqrt_dag_gate = GateType::SQRT_YY_DAG;
-                }
+                const PairRotationInfo info = pair_rotation_info(node.gate);
                 for (size_t i = 0; i + 1 < node.targets.size(); i += 2) {
                     uint32_t q1 = node.targets[i].value();
                     uint32_t q2 = node.targets[i + 1].value();
@@ -819,24 +848,17 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
                     }
 
                     if (clifford_rotation.has_value()) {
-                        apply_clifford_pair_rotation(sim, q1, q2, *clifford_rotation, sqrt_gate,
-                                                     pauli_gate, sqrt_dag_gate);
+                        apply_clifford_pair_rotation(sim, q1, q2, *clifford_rotation,
+                                                     info.sqrt_gate, info.pauli_gate,
+                                                     info.sqrt_dag_gate);
                         continue;
                     }
 
                     stim::PauliString<kStimWidth> obs(circuit.num_qubits);
-                    if (node.gate == GateType::R_XX) {
-                        obs.xs[q1] = true;
-                        obs.xs[q2] = true;
-                    } else if (node.gate == GateType::R_YY) {
-                        obs.xs[q1] = true;
-                        obs.zs[q1] = true;
-                        obs.xs[q2] = true;
-                        obs.zs[q2] = true;
-                    } else {
-                        obs.zs[q1] = true;
-                        obs.zs[q2] = true;
-                    }
+                    obs.xs[q1] = info.x;
+                    obs.zs[q1] = info.z;
+                    obs.xs[q2] = info.x;
+                    obs.zs[q2] = info.z;
                     trace_pauli_rotation(sim, hir, obs, alpha);
                 }
                 break;

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -128,6 +128,19 @@ void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z
     }
 }
 
+void apply_pauli_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v) {
+    assert(x_v.num_words() == z_v.num_words());
+    assert((tab.num_qubits + 63) / 64 <= x_v.num_words());
+    for (uint32_t q = 0; q < tab.num_qubits; ++q) {
+        if (z_v.bit_get(q)) {
+            tab.xs[q].sign ^= true;
+        }
+        if (x_v.bit_get(q)) {
+            tab.zs[q].sign ^= true;
+        }
+    }
+}
+
 }  // namespace internal
 
 namespace {
@@ -200,6 +213,53 @@ void apply_virtual_s_downstream(HirModule& hir, size_t start_idx, MaskView x_v, 
     // 2. Final Tableau: U_C' = U_C S (requires inverted dagger flag)
     if (hir.final_tableau.has_value()) {
         internal::apply_s_to_tableau(*hir.final_tableau, x_v, z_v, sign_v, is_dagger);
+    }
+}
+
+/// Absorb a virtual Pauli into downstream signs and the final Clifford frame.
+void apply_virtual_pauli_downstream(HirModule& hir, size_t start_idx, MaskView x_v, MaskView z_v,
+                                    const std::vector<uint8_t>& deleted) {
+    auto conjugate_mask = [&](MutablePauliMaskView mask) {
+        if (anti_commute(x_v, z_v, mask.x(), mask.z())) {
+            mask.set_sign(!mask.sign());
+        }
+    };
+
+    for (size_t k = start_idx; k < hir.ops.size(); ++k) {
+        if (deleted[k]) {
+            continue;
+        }
+        auto& op = hir.ops[k];
+        switch (op.op_type()) {
+            case OpType::T_GATE:
+            case OpType::PHASE_ROTATION:
+            case OpType::MEASURE:
+            case OpType::CONDITIONAL_PAULI:
+            case OpType::EXP_VAL:
+                conjugate_mask(hir.mask_at(op));
+                break;
+
+            case OpType::INSTRUMENT: {
+                conjugate_mask(hir.mask_at(op));
+                const auto& site =
+                    hir.instrument_sites[static_cast<uint32_t>(op.instrument_site_idx())];
+                conjugate_mask(hir.pauli_masks.mut_at(site.destination_flip_mask));
+                break;
+            }
+
+            // Pauli-channel signs are physically irrelevant, and these ops
+            // carry no coherent Pauli axis to conjugate.
+            case OpType::NOISE:
+            case OpType::READOUT_NOISE:
+            case OpType::DETECTOR:
+            case OpType::OBSERVABLE:
+            case OpType::NUM_OP_TYPES:
+                break;
+        }
+    }
+
+    if (hir.final_tableau.has_value()) {
+        internal::apply_pauli_to_tableau(*hir.final_tableau, x_v, z_v);
     }
 }
 
@@ -455,6 +515,12 @@ void PeepholeFusionPass::run(HirModule& hir) {
                         apply_virtual_s_downstream(hir, j + 1, destab_i, stab_i, false, true,
                                                    deleted);
                         ++fusions_;
+                    } else if (clifford == CliffordRotation::PAULI) {
+                        // A Pauli rotation is Clifford up to global phase.
+                        deleted[i] = true;
+                        deleted[j] = true;
+                        apply_virtual_pauli_downstream(hir, j + 1, destab_i, stab_i, deleted);
+                        ++fusions_;
                     } else if (std::abs(fused - 0.25) < kRotationCanonicalizationTolerance) {
                         hir.demote_to_tgate(hir.ops[i], false);
                         if (has_source_map) {
@@ -520,6 +586,12 @@ void PeepholeFusionPass::run(HirModule& hir) {
                 // S_dag: absorb downstream.
                 apply_virtual_s_downstream(hir, i + 1, hir.destab_mask(hir.ops[i]),
                                            hir.stab_mask(hir.ops[i]), false, true, deleted);
+                deleted[i] = true;
+                ++fusions_;
+                changed = true;
+            } else if (clifford == CliffordRotation::PAULI) {
+                apply_virtual_pauli_downstream(hir, i + 1, hir.destab_mask(hir.ops[i]),
+                                               hir.stab_mask(hir.ops[i]), deleted);
                 deleted[i] = true;
                 ++fusions_;
                 changed = true;

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -130,14 +130,17 @@ void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z
 
 void apply_pauli_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v) {
     assert(x_v.num_words() == z_v.num_words());
-    assert((tab.num_qubits + 63) / 64 <= x_v.num_words());
-    for (uint32_t q = 0; q < tab.num_qubits; ++q) {
-        if (z_v.bit_get(q)) {
-            tab.xs[q].sign ^= true;
+    const size_t tableau_words = (tab.num_qubits + 63) / 64;
+    assert(tableau_words <= x_v.num_words());
+    const size_t words = std::min({tableau_words, static_cast<size_t>(x_v.num_words()),
+                                   static_cast<size_t>(z_v.num_words())});
+    for (size_t w = 0; w < words; ++w) {
+        uint64_t valid_bits = UINT64_MAX;
+        if (w + 1 == tableau_words && tab.num_qubits % 64 != 0) {
+            valid_bits = (uint64_t{1} << (tab.num_qubits % 64)) - 1;
         }
-        if (x_v.bit_get(q)) {
-            tab.zs[q].sign ^= true;
-        }
+        tab.zs.signs.u64[w] ^= x_v.words[w] & valid_bits;
+        tab.xs.signs.u64[w] ^= z_v.words[w] & valid_bits;
     }
 }
 

--- a/src/clifft/optimizer/peephole.h
+++ b/src/clifft/optimizer/peephole.h
@@ -15,6 +15,9 @@ namespace internal {
 void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v, bool sign_v,
                         bool is_dagger);
 
+/// Compose U_C' = U_C * P into `tab` for the virtual Pauli (x_v, z_v).
+void apply_pauli_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v);
+
 }  // namespace internal
 
 /// Peephole fusion pass: scans the HIR to algebraically cancel or fuse

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -568,10 +568,11 @@ class TestSAbsorptionDifferential:
             "R_Z(0.25) 0\nR_Z(0.25) 0\nH 1\nR_Z(0.75) 1\nR_Z(0.75) 1"
         )
 
-    @pytest.mark.parametrize("angle", [0.5, 1.5])
-    def test_standalone_multi_qubit_phase_rotation_demotion(self, angle: float) -> None:
-        """Standalone multi-qubit S/S_dag rotations reach peephole absorption."""
-        _assert_absorption_preserves_state(f"R_XX({angle}) 0 1")
+    @pytest.mark.parametrize("angles", [(0.2, 0.3), (0.7, 0.8)])
+    def test_fused_multi_qubit_phase_rotation_demotion(self, angles: tuple[float, float]) -> None:
+        """Fused multi-qubit S/S_dag rotations reach peephole absorption."""
+        first, second = angles
+        _assert_absorption_preserves_state(f"R_XX({first}) 0 1\nR_XX({second}) 0 1")
 
 
 class TestPauliRotationAbsorption:

--- a/tests/python/test_peephole_oracle.py
+++ b/tests/python/test_peephole_oracle.py
@@ -572,3 +572,25 @@ class TestSAbsorptionDifferential:
     def test_standalone_multi_qubit_phase_rotation_demotion(self, angle: float) -> None:
         """Standalone multi-qubit S/S_dag rotations reach peephole absorption."""
         _assert_absorption_preserves_state(f"R_XX({angle}) 0 1")
+
+
+class TestPauliRotationAbsorption:
+    """Pauli-valued rotations are folded into the Clifford frame."""
+
+    def test_fused_pauli_residue_preserves_state_ray(self) -> None:
+        circuit = "H 0\nR_Z(0.3) 0\nR_Z(0.7) 0\nR_X(0.2) 0"
+        optimized = _assert_absorption_preserves_state(circuit)
+        assert optimized.peak_active_width == 0
+
+    def test_fused_pauli_residue_preserves_record_probabilities(self) -> None:
+        circuit = "H 0\nR_Z(0.3) 0\nR_Z(0.7) 0\nH 0\nM 0"
+        baseline = clifft.compile(circuit, hir_passes=None)
+        optimized = clifft.compile(circuit, hir_passes=_peephole_pass_manager())
+
+        np.testing.assert_allclose(
+            clifft.record_probabilities(optimized, ["0", "1"]),
+            clifft.record_probabilities(baseline, ["0", "1"]),
+            atol=1e-12,
+        )
+        assert baseline.peak_active_width == 1
+        assert optimized.peak_active_width == 0

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -267,6 +267,18 @@ class TestArbitraryRotations(_StatevectorBackendMixin):
     def test_r_pauli_xyz(self) -> None:
         self._check_amplitudes("R_PAULI(0.1) X0*Y1*Z2")
 
+    @pytest.mark.parametrize(
+        "rotation",
+        [
+            "R_ZZ(1.0) 0 1",
+            "R_XX(-1.0) 0 1",
+            "R_PAULI(3.0) X0*Y1*Z2",
+            "R_Z(0.3) 0\nR_Z(0.7) 0",
+        ],
+    )
+    def test_pauli_valued_rotations(self, rotation: str) -> None:
+        self._check_amplitudes(f"H 0 1 2\n{rotation}\nH 0\nCX 1 2")
+
     def test_rotations_after_cliffords(self) -> None:
         """Rotations after entangling gates should still match."""
         circuit = """

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -274,9 +274,12 @@ class TestArbitraryRotations(_StatevectorBackendMixin):
             "R_XX(-1.0) 0 1",
             "R_PAULI(3.0) X0*Y1*Z2",
             "R_Z(0.3) 0\nR_Z(0.7) 0",
+            "R_ZZ(0.5) 0 1",
+            "R_YY(-0.5) 0 1",
+            "R_PAULI(2.5) X0*Y1*Z2",
         ],
     )
-    def test_pauli_valued_rotations(self, rotation: str) -> None:
+    def test_clifford_valued_pauli_rotations(self, rotation: str) -> None:
         self._check_amplitudes(f"H 0 1 2\n{rotation}\nH 0\nCX 1 2")
 
     def test_rotations_after_cliffords(self) -> None:

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1718,6 +1718,58 @@ TEST_CASE("Frontend: R_PAULI emits PHASE_ROTATION on arbitrary Pauli", "[fronten
     CHECK(hir.stab_mask(hir.ops[0]).bit_get(2));
 }
 
+TEST_CASE("Frontend: Pauli-valued product rotations match named gates", "[frontend][rotation]") {
+    struct RotationCase {
+        const char* source;
+        const char* reference;
+    };
+    const RotationCase cases[] = {
+        {"R_ZZ(1.0) 0 1", "Z 0 1"},
+        {"R_XX(-1.0) 0 1", "X 0 1"},
+        {"R_YY(3.0) 0 1", "Y 0 1"},
+        {"R_PAULI(-3.0) X0*Y1*Z2", "X 0\nY 1\nZ 2"},
+    };
+
+    for (const auto& test_case : cases) {
+        CAPTURE(test_case.source);
+        const HirModule hir = trace(parse(test_case.source));
+        const HirModule reference = trace(parse(test_case.reference));
+
+        CHECK(hir.ops.empty());
+        CHECK(hir.pauli_masks.size() == 0);
+        REQUIRE(hir.final_tableau.has_value());
+        REQUIRE(reference.final_tableau.has_value());
+        CHECK(*hir.final_tableau == *reference.final_tableau);
+    }
+}
+
+TEST_CASE("Frontend: product Pauli canonicalization uses the shared tolerance",
+          "[frontend][rotation]") {
+    constexpr double inside = 1.0 + 0.5 * kRotationCanonicalizationTolerance;
+    Circuit inside_circuit;
+    inside_circuit.num_qubits = 2;
+    inside_circuit.nodes.push_back(
+        {GateType::R_ZZ, {Target::qubit(0), Target::qubit(1)}, {inside}, 1});
+    const HirModule inside_hir = trace(inside_circuit);
+    const HirModule reference = trace(parse("Z 0 1"));
+
+    CHECK(inside_hir.ops.empty());
+    REQUIRE(inside_hir.final_tableau.has_value());
+    REQUIRE(reference.final_tableau.has_value());
+    CHECK(*inside_hir.final_tableau == *reference.final_tableau);
+
+    constexpr double outside = 1.0 + 2.0 * kRotationCanonicalizationTolerance;
+    Circuit outside_circuit;
+    outside_circuit.num_qubits = 2;
+    outside_circuit.nodes.push_back(
+        {GateType::R_ZZ, {Target::qubit(0), Target::qubit(1)}, {outside}, 1});
+    const HirModule outside_hir = trace(outside_circuit);
+
+    REQUIRE(outside_hir.ops.size() == 1);
+    CHECK(outside_hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    CHECK(outside_hir.ops[0].alpha() == outside);
+}
+
 TEST_CASE("Frontend: R_Z omits its source-representation global phase", "[frontend][rotation]") {
     auto circuit = parse("R_Z(0.25) 0");
     auto hir = trace(circuit);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1754,6 +1754,33 @@ TEST_CASE("Frontend: Clifford-valued product rotations match named gates", "[fro
     }
 }
 
+TEST_CASE("Frontend: pair square-root rotations match Pauli-product tracing",
+          "[frontend][rotation]") {
+    struct RotationCase {
+        const char* pair_rotation;
+        const char* pauli_product;
+    };
+    const RotationCase cases[] = {
+        {"R_XX(0.5) 0 1", "SPP X0*X1"}, {"R_XX(-0.5) 0 1", "SPP_DAG X0*X1"},
+        {"R_YY(0.5) 0 1", "SPP Y0*Y1"}, {"R_YY(-0.5) 0 1", "SPP_DAG Y0*Y1"},
+        {"R_ZZ(0.5) 0 1", "SPP Z0*Z1"}, {"R_ZZ(-0.5) 0 1", "SPP_DAG Z0*Z1"},
+    };
+
+    for (const auto& test_case : cases) {
+        CAPTURE(test_case.pair_rotation, test_case.pauli_product);
+        const HirModule pair_hir = trace(parse(test_case.pair_rotation));
+        const HirModule product_hir = trace(parse(test_case.pauli_product));
+
+        CHECK(pair_hir.ops.empty());
+        CHECK(pair_hir.pauli_masks.size() == 0);
+        CHECK(product_hir.ops.empty());
+        CHECK(product_hir.pauli_masks.size() == 0);
+        REQUIRE(pair_hir.final_tableau.has_value());
+        REQUIRE(product_hir.final_tableau.has_value());
+        CHECK(*pair_hir.final_tableau == *product_hir.final_tableau);
+    }
+}
+
 TEST_CASE("Frontend: product Pauli canonicalization uses the shared tolerance",
           "[frontend][rotation]") {
     constexpr double inside = 1.0 + 0.5 * kRotationCanonicalizationTolerance;
@@ -1765,6 +1792,7 @@ TEST_CASE("Frontend: product Pauli canonicalization uses the shared tolerance",
     const HirModule reference = trace(parse("Z 0 1"));
 
     CHECK(inside_hir.ops.empty());
+    CHECK(inside_hir.pauli_masks.size() == 0);
     REQUIRE(inside_hir.final_tableau.has_value());
     REQUIRE(reference.final_tableau.has_value());
     CHECK(*inside_hir.final_tableau == *reference.final_tableau);
@@ -1779,6 +1807,7 @@ TEST_CASE("Frontend: product Pauli canonicalization uses the shared tolerance",
     REQUIRE(outside_hir.ops.size() == 1);
     CHECK(outside_hir.ops[0].op_type() == OpType::PHASE_ROTATION);
     CHECK(outside_hir.ops[0].alpha() == outside);
+    CHECK(outside_hir.pauli_masks.size() == 1);
 
     constexpr double sqrt_inside = 0.5 - 0.5 * kRotationCanonicalizationTolerance;
     Circuit sqrt_inside_circuit;

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -178,21 +178,27 @@ TEST_CASE("Frontend: multiple T gates on different qubits", "[frontend]") {
     REQUIRE(hir.stab_mask(hir.ops[1]) == 0);
 }
 
-TEST_CASE("Frontend: SPP emits signed Pauli rotations", "[frontend]") {
-    auto hir = trace(parse("SPP X0*Y1*Z2\nSPP_DAG !X0"));
+TEST_CASE("Frontend: SPP gates are absorbed as signed Clifford products", "[frontend]") {
+    struct RotationCase {
+        const char* source;
+        const char* reference;
+    };
+    const RotationCase cases[] = {
+        {"SPP X0*Y1*Z2", "H 0\nH_YZ 1\nCX 1 0\nCX 2 0\nS 0\nCX 2 0\nCX 1 0\nH_YZ 1\nH 0"},
+        {"SPP_DAG !X0", "SQRT_X 0"},
+    };
 
-    REQUIRE(hir.num_ops() == 2);
-    CHECK(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
-    CHECK(hir.ops[0].alpha() == Catch::Approx(0.5));
-    CHECK(hir.destab_mask(hir.ops[0]) == (X(0) | X(1)));
-    CHECK(hir.stab_mask(hir.ops[0]) == (Z(1) | Z(2)));
-    CHECK(!hir.sign(hir.ops[0]));
+    for (const auto& test_case : cases) {
+        CAPTURE(test_case.source);
+        const HirModule hir = trace(parse(test_case.source));
+        const HirModule reference = trace(parse(test_case.reference));
 
-    CHECK(hir.ops[1].op_type() == OpType::PHASE_ROTATION);
-    CHECK(hir.ops[1].alpha() == Catch::Approx(-0.5));
-    CHECK(hir.destab_mask(hir.ops[1]) == X(0));
-    CHECK(hir.stab_mask(hir.ops[1]) == 0);
-    CHECK(hir.sign(hir.ops[1]));
+        CHECK(hir.ops.empty());
+        CHECK(hir.pauli_masks.size() == 0);
+        REQUIRE(hir.final_tableau.has_value());
+        REQUIRE(reference.final_tableau.has_value());
+        CHECK(*hir.final_tableau == *reference.final_tableau);
+    }
 }
 
 TEST_CASE("Frontend: TPP emits one T gate per product", "[frontend]") {
@@ -1718,7 +1724,7 @@ TEST_CASE("Frontend: R_PAULI emits PHASE_ROTATION on arbitrary Pauli", "[fronten
     CHECK(hir.stab_mask(hir.ops[0]).bit_get(2));
 }
 
-TEST_CASE("Frontend: Pauli-valued product rotations match named gates", "[frontend][rotation]") {
+TEST_CASE("Frontend: Clifford-valued product rotations match named gates", "[frontend][rotation]") {
     struct RotationCase {
         const char* source;
         const char* reference;
@@ -1728,6 +1734,11 @@ TEST_CASE("Frontend: Pauli-valued product rotations match named gates", "[fronte
         {"R_XX(-1.0) 0 1", "X 0 1"},
         {"R_YY(3.0) 0 1", "Y 0 1"},
         {"R_PAULI(-3.0) X0*Y1*Z2", "X 0\nY 1\nZ 2"},
+        {"R_PAULI(1.0) X0*Z64*Y129", "X 0\nZ 64\nY 129"},
+        {"R_XX(0.5) 0 1", "SQRT_XX 0 1"},
+        {"R_YY(-0.5) 0 1", "SQRT_YY_DAG 0 1"},
+        {"R_ZZ(2.5) 0 1", "SQRT_ZZ 0 1"},
+        {"R_PAULI(0.5) X0*Y1*Z2", "H 0\nH_YZ 1\nCX 1 0\nCX 2 0\nS 0\nCX 2 0\nCX 1 0\nH_YZ 1\nH 0"},
     };
 
     for (const auto& test_case : cases) {
@@ -1768,6 +1779,32 @@ TEST_CASE("Frontend: product Pauli canonicalization uses the shared tolerance",
     REQUIRE(outside_hir.ops.size() == 1);
     CHECK(outside_hir.ops[0].op_type() == OpType::PHASE_ROTATION);
     CHECK(outside_hir.ops[0].alpha() == outside);
+
+    constexpr double sqrt_inside = 0.5 - 0.5 * kRotationCanonicalizationTolerance;
+    Circuit sqrt_inside_circuit;
+    sqrt_inside_circuit.num_qubits = 2;
+    sqrt_inside_circuit.nodes.push_back(
+        {GateType::R_XX, {Target::qubit(0), Target::qubit(1)}, {sqrt_inside}, 1});
+    const HirModule sqrt_inside_hir = trace(sqrt_inside_circuit);
+    const HirModule sqrt_reference = trace(parse("SQRT_XX 0 1"));
+
+    CHECK(sqrt_inside_hir.ops.empty());
+    CHECK(sqrt_inside_hir.pauli_masks.size() == 0);
+    REQUIRE(sqrt_inside_hir.final_tableau.has_value());
+    REQUIRE(sqrt_reference.final_tableau.has_value());
+    CHECK(*sqrt_inside_hir.final_tableau == *sqrt_reference.final_tableau);
+
+    constexpr double sqrt_outside = 0.5 - 2.0 * kRotationCanonicalizationTolerance;
+    Circuit sqrt_outside_circuit;
+    sqrt_outside_circuit.num_qubits = 2;
+    sqrt_outside_circuit.nodes.push_back(
+        {GateType::R_XX, {Target::qubit(0), Target::qubit(1)}, {sqrt_outside}, 1});
+    const HirModule sqrt_outside_hir = trace(sqrt_outside_circuit);
+
+    REQUIRE(sqrt_outside_hir.ops.size() == 1);
+    CHECK(sqrt_outside_hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    CHECK(sqrt_outside_hir.ops[0].alpha() == sqrt_outside);
+    CHECK(sqrt_outside_hir.pauli_masks.size() == 1);
 }
 
 TEST_CASE("Frontend: R_Z omits its source-representation global phase", "[frontend][rotation]") {

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -565,6 +565,131 @@ TEST_CASE("Peephole: rotation canonicalization uses the shared tolerance", "[opt
     CHECK(outside_pass.cancellations() == 0);
 }
 
+TEST_CASE("Peephole: Pauli-valued rotation updates downstream signs and frame", "[optimizer]") {
+    HirModule hir(1, 2);
+    hir.final_tableau.emplace(1);
+    clifft::test::append_phase_rotation(hir, 0, Z(0), false, 1.0);
+    clifft::test::append_measure(hir, X(0), 0, false, MeasRecordIdx{0});
+    const HirModule reference = hir_from("Z 0");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::MEASURE);
+    CHECK(hir.sign(hir.ops[0]));
+    CHECK(pass.fusions() == 1);
+    REQUIRE(hir.final_tableau == reference.final_tableau);
+}
+
+TEST_CASE("Peephole: fused rotations absorb a Pauli residue", "[optimizer]") {
+    HirModule hir(1, 2);
+    hir.final_tableau.emplace(1);
+    clifft::test::append_phase_rotation(hir, 0, Z(0), false, 0.3);
+    clifft::test::append_phase_rotation(hir, 0, Z(0), false, 0.7);
+    const HirModule reference = hir_from("Z 0");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    CHECK(hir.ops.empty());
+    CHECK(pass.fusions() == 1);
+    REQUIRE(hir.final_tableau == reference.final_tableau);
+}
+
+TEST_CASE("Peephole: Pauli absorption composes with an existing Clifford frame", "[optimizer]") {
+    HirModule hir = hir_from("H 0\nR_Z(0.3) 0\nR_Z(0.7) 0");
+    const HirModule reference = hir_from("H 0\nZ 0");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    CHECK(hir.ops.empty());
+    CHECK(pass.fusions() == 1);
+    REQUIRE(hir.final_tableau == reference.final_tableau);
+}
+
+TEST_CASE("Peephole: Pauli residue handles signs periods and tolerance", "[optimizer]") {
+    struct RotationCase {
+        double alpha;
+        bool sign;
+    };
+    const RotationCase cases[] = {
+        {1.0, false},
+        {-1.0, false},
+        {3.0, false},
+        {1.0, true},
+        {1.0 + 0.5 * kRotationCanonicalizationTolerance, false},
+    };
+    const HirModule reference = hir_from("Z 0");
+
+    for (const auto& test_case : cases) {
+        CAPTURE(test_case.alpha, test_case.sign);
+        HirModule hir(1, 1);
+        hir.final_tableau.emplace(1);
+        clifft::test::append_phase_rotation(hir, 0, Z(0), test_case.sign, test_case.alpha);
+
+        PeepholeFusionPass pass;
+        pass.run(hir);
+
+        CHECK(hir.ops.empty());
+        CHECK(pass.fusions() == 1);
+        REQUIRE(hir.final_tableau == reference.final_tableau);
+    }
+
+    constexpr double outside = 1.0 + 2.0 * kRotationCanonicalizationTolerance;
+    HirModule outside_hir(1, 1);
+    outside_hir.final_tableau.emplace(1);
+    clifft::test::append_phase_rotation(outside_hir, 0, Z(0), false, outside);
+    PeepholeFusionPass outside_pass;
+    outside_pass.run(outside_hir);
+
+    REQUIRE(outside_hir.ops.size() == 1);
+    CHECK(outside_hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    CHECK(outside_hir.ops[0].alpha() == outside);
+    CHECK(outside_pass.fusions() == 0);
+}
+
+TEST_CASE("Peephole: Pauli absorption updates instrument masks", "[optimizer]") {
+    HirModule hir(1, 3);
+    clifft::test::append_phase_rotation(hir, 0, Z(0), false, 1.0);
+
+    InstrumentSite site;
+    site.destination_flip_mask =
+        hir.claim_side_mask([](MutablePauliMaskView slot) { slot.x().bit_set(0, true); });
+    hir.instrument_sites.push_back(site);
+    hir.append_instrument(InstrumentSiteIdx{0},
+                          [](MutablePauliMaskView slot) { slot.x().bit_set(0, true); });
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::INSTRUMENT);
+    CHECK(hir.sign(hir.ops[0]));
+    const PauliMaskView flip = hir.pauli_masks.at(hir.instrument_sites[0].destination_flip_mask);
+    CHECK(flip.sign());
+}
+
+TEST_CASE("Peephole: Pauli absorption supports wide multi-word axes", "[optimizer]") {
+    HirModule hir(130, 1);
+    hir.final_tableau.emplace(130);
+    hir.append_phase_rotation(1.0, [](MutablePauliMaskView slot) {
+        slot.x().bit_set(0, true);
+        slot.z().bit_set(64, true);
+        slot.x().bit_set(129, true);
+        slot.z().bit_set(129, true);
+    });
+    const HirModule reference = hir_from("X 0\nZ 64\nY 129");
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    CHECK(hir.ops.empty());
+    CHECK(pass.fusions() == 1);
+    REQUIRE(hir.final_tableau == reference.final_tableau);
+}
+
 TEST_CASE("Peephole: SPP uses rotation fusion and absorption", "[optimizer]") {
     auto hir_spp = hir_from("SPP X0*Y1");
     REQUIRE(hir_spp.ops.size() == 1);

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -690,17 +690,19 @@ TEST_CASE("Peephole: Pauli absorption supports wide multi-word axes", "[optimize
     REQUIRE(hir.final_tableau == reference.final_tableau);
 }
 
-TEST_CASE("Peephole: SPP uses rotation fusion and absorption", "[optimizer]") {
-    auto hir_spp = hir_from("SPP X0*Y1");
-    REQUIRE(hir_spp.ops.size() == 1);
-    REQUIRE(hir_spp.ops[0].op_type() == OpType::PHASE_ROTATION);
+TEST_CASE("Peephole: square-root product rotations use fusion and absorption", "[optimizer]") {
+    HirModule hir_spp(2, 1);
+    hir_spp.final_tableau.emplace(2);
+    clifft::test::append_phase_rotation(hir_spp, 0, X(0) | X(1), false, 0.5);
 
     PeepholeFusionPass pass_spp;
     pass_spp.run(hir_spp);
     REQUIRE(hir_spp.ops.empty());
 
-    auto hir_cancel = hir_from("SPP X0*Y1\nSPP_DAG X0*Y1");
-    REQUIRE(hir_cancel.ops.size() == 2);
+    HirModule hir_cancel(2, 2);
+    hir_cancel.final_tableau.emplace(2);
+    clifft::test::append_phase_rotation(hir_cancel, 0, X(0) | X(1), false, 0.5);
+    clifft::test::append_phase_rotation(hir_cancel, 0, X(0) | X(1), false, -0.5);
 
     PeepholeFusionPass pass_cancel;
     pass_cancel.run(hir_cancel);

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -574,6 +574,9 @@ TEST_CASE("Sampling planner does not activate absorbed Pauli rotations") {
     for (const char* source : {
              "R_ZZ(1.0) 0 1",
              "R_PAULI(-1.0) X0*Y1",
+             "R_ZZ(0.5) 0 1",
+             "R_PAULI(-0.5) X0*Y1",
+             "SPP X0*Y1",
              "R_Z(0.3) 0\nR_Z(0.7) 0",
          }) {
         CAPTURE(source);

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -570,6 +570,25 @@ TEST_CASE("Sampling planner reports the dense active width limit") {
         "sampling planner active width would reach 60, but the dense-state limit is 60");
 }
 
+TEST_CASE("Sampling planner does not activate absorbed Pauli rotations") {
+    for (const char* source : {
+             "R_ZZ(1.0) 0 1",
+             "R_PAULI(-1.0) X0*Y1",
+             "R_Z(0.3) 0\nR_Z(0.7) 0",
+         }) {
+        CAPTURE(source);
+        HirModule hir = clifft::trace(clifft::parse(source));
+        auto passes = clifft::default_hir_pass_manager();
+        passes.run(hir);
+        const SamplingPlan plan = plan_sampling(hir);
+
+        CHECK(hir.ops.empty());
+        CHECK(plan.initial_active_width == 0);
+        CHECK(plan.peak_active_width == 0);
+        CHECK(plan.actions.empty());
+    }
+}
+
 TEST_CASE("Sampling planner output is deterministic") {
     HirModule hir(2, 4);
     hir.num_measurements = 2;

--- a/tests/test_source_map.cc
+++ b/tests/test_source_map.cc
@@ -98,6 +98,14 @@ TEST_CASE("Source map: T plus T_dag cancellation removes both from map", "[sourc
     }
 }
 
+TEST_CASE("Source map: absorbed Pauli residue removes only its source entries", "[source_map]") {
+    auto hir = hir_optimized("R_Z(0.3) 0\nR_Z(0.7) 0\nR_X(0.2) 0");
+
+    REQUIRE(hir.ops.size() == 1);
+    REQUIRE(hir.ops[0].op_type() == OpType::PHASE_ROTATION);
+    REQUIRE(hir.source_map == std::vector<std::vector<uint32_t>>{{3}});
+}
+
 TEST_CASE("Source map: terminal reset phase elimination removes only phase entries",
           "[source_map]") {
     auto hir = hir_optimized(


### PR DESCRIPTION
## Summary

- absorb every Clifford-valued Pauli-product rotation during tracing without emitting HIR operations or reserving Pauli masks
- use native `SQRT_XX`/`SQRT_YY`/`SQRT_ZZ` paths for named pair rotations and Stim's product primitives for arbitrary signed products
- absorb standalone and fused Pauli residues into downstream HIR signs and the final Clifford tableau using word-level sign updates
- preserve instrument side masks and source maps while preventing absorbed rotations from producing plan actions or increasing active width
- document the shared `1e-12` half-turn canonicalization policy for square-root and projective Pauli residues

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `just test` (852/852 C++ tests, including all six long-running benchmarks)
- final native-pair route: 846/846 non-benchmark C++ tests and all focused frontend/optimizer/planner tests
- `uv run pytest tests/python/ -q` (878 passed, 1 skipped)
- `uv run --group docs mkdocs build --strict`
- projective Qiskit Aer comparisons for Pauli and square-root residues on named and arbitrary products
- optimized/unoptimized state-ray and exact record-probability comparisons
- structural regressions for tolerance boundaries, signed and periodic angles, multi-word masks, instrument masks, source maps, and zero active-width promotion

Closes #377
