### PR TITLE
feat(compilation): add native Clifford algebra

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 add_library(clifft_core STATIC
     circuit/parser.cc
+    tableau/pauli_string.cc
+    tableau/tableau.cc
     frontend/frontend.cc
     optimizer/hir_pass_manager.cc
     optimizer/drop_non_unitary_pass.cc

--- a/src/clifft/tableau/pauli_string.cc
+++ b/src/clifft/tableau/pauli_string.cc
@@ -1,0 +1,115 @@
+#include "clifft/tableau/pauli_string.h"
+
+#include <bit>
+#include <cassert>
+#include <stdexcept>
+
+namespace clifft {
+
+namespace {
+
+uint8_t y_phase(MaskView x, MaskView z) {
+    uint32_t count = 0;
+    assert(x.num_words() == z.num_words());
+    for (uint32_t w = 0; w < x.num_words(); ++w) {
+        count += std::popcount(x.words[w] & z.words[w]);
+    }
+    return static_cast<uint8_t>(count & 3U);
+}
+
+bool symplectic_parity(PauliStringView first, PauliStringView second) {
+    assert(first.num_qubits() == second.num_qubits());
+    bool parity = false;
+    for (uint32_t w = 0; w < first.x().num_words(); ++w) {
+        parity ^= (std::popcount((first.x().words[w] & second.z().words[w]) ^
+                                 (first.z().words[w] & second.x().words[w])) &
+                   1U) != 0;
+    }
+    return parity;
+}
+
+}  // namespace
+
+bool PauliStringView::is_hermitian() const {
+    const uint8_t delta = (phase_ - y_phase(x_, z_)) & 3U;
+    return delta == 0 || delta == 2;
+}
+
+bool PauliStringView::sign() const {
+    const uint8_t delta = (phase_ - y_phase(x_, z_)) & 3U;
+    assert((delta == 0 || delta == 2) && "PauliStringView::sign requires a Hermitian Pauli");
+    return delta == 2;
+}
+
+bool PauliStringView::commutes(PauliStringView other) const {
+    return !symplectic_parity(*this, other);
+}
+
+PauliString::PauliString(uint32_t num_qubits)
+    : num_qubits_(num_qubits), x_((num_qubits + 63) / 64, 0), z_(x_.size(), 0) {}
+
+PauliString PauliString::from_text(std::string_view text) {
+    if (text.empty() || (text.front() != '+' && text.front() != '-')) {
+        throw std::invalid_argument("Pauli text must start with a sign");
+    }
+
+    PauliString result(static_cast<uint32_t>(text.size() - 1));
+    for (uint32_t q = 0; q < result.num_qubits(); ++q) {
+        switch (text[q + 1]) {
+            case '_':
+            case 'I':
+                break;
+            case 'X':
+                result.set_pauli(q, true, false);
+                break;
+            case 'Y':
+                result.set_pauli(q, true, true);
+                break;
+            case 'Z':
+                result.set_pauli(q, false, true);
+                break;
+            default:
+                throw std::invalid_argument("Invalid Pauli character");
+        }
+    }
+    result.set_sign(text.front() == '-');
+    return result;
+}
+
+void PauliString::set_pauli(uint32_t qubit, bool x_value, bool z_value) {
+    assert(qubit < num_qubits_);
+    mut_x().bit_set(qubit, x_value);
+    mut_z().bit_set(qubit, z_value);
+}
+
+void PauliString::set_sign(bool sign_value) {
+    phase_ = (y_phase(x(), z()) + (sign_value ? 2U : 0U)) & 3U;
+}
+
+void PauliString::right_multiply(PauliStringView other) {
+    assert(num_qubits_ == other.num_qubits());
+    bool crossing_parity = false;
+    for (uint32_t w = 0; w < x().num_words(); ++w) {
+        crossing_parity ^= (std::popcount(z_[w] & other.x().words[w]) & 1U) != 0;
+    }
+    phase_ = (phase_ + other.phase() + (crossing_parity ? 2U : 0U)) & 3U;
+    mut_x().xor_with(other.x());
+    mut_z().xor_with(other.z());
+    clear_padding();
+}
+
+bool PauliString::operator==(const PauliString& other) const {
+    return num_qubits_ == other.num_qubits_ && phase_ == other.phase_ && x_ == other.x_ &&
+           z_ == other.z_;
+}
+
+void PauliString::clear_padding() {
+    if (num_qubits_ == 0 || num_qubits_ % 64 == 0) {
+        return;
+    }
+    const uint64_t valid = (uint64_t{1} << (num_qubits_ % 64)) - 1;
+    x_.back() &= valid;
+    z_.back() &= valid;
+}
+
+}  // namespace clifft

--- a/src/clifft/tableau/pauli_string.h
+++ b/src/clifft/tableau/pauli_string.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// Runtime-width Pauli strings used by the native Clifford tableau.
+
+#include "clifft/util/mask_view.h"
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace clifft {
+
+class PauliStringView {
+  public:
+    PauliStringView(MaskView x, MaskView z, uint8_t phase, uint32_t num_qubits)
+        : x_(x), z_(z), phase_(phase & 3U), num_qubits_(num_qubits) {}
+
+    [[nodiscard]] MaskView x() const { return x_; }
+    [[nodiscard]] MaskView z() const { return z_; }
+    [[nodiscard]] uint8_t phase() const { return phase_; }
+    [[nodiscard]] uint32_t num_qubits() const { return num_qubits_; }
+    [[nodiscard]] bool sign() const;
+    [[nodiscard]] bool is_hermitian() const;
+    [[nodiscard]] bool commutes(PauliStringView other) const;
+
+  private:
+    MaskView x_;
+    MaskView z_;
+    uint8_t phase_;
+    uint32_t num_qubits_;
+};
+
+class PauliString {
+  public:
+    explicit PauliString(uint32_t num_qubits = 0);
+
+    [[nodiscard]] static PauliString from_text(std::string_view text);
+
+    [[nodiscard]] uint32_t num_qubits() const { return num_qubits_; }
+    [[nodiscard]] MaskView x() const { return MaskView{x_}; }
+    [[nodiscard]] MaskView z() const { return MaskView{z_}; }
+    [[nodiscard]] MutableMaskView mut_x() { return MutableMaskView{x_}; }
+    [[nodiscard]] MutableMaskView mut_z() { return MutableMaskView{z_}; }
+    [[nodiscard]] uint8_t phase() const { return phase_; }
+    [[nodiscard]] bool sign() const { return view().sign(); }
+    [[nodiscard]] bool is_hermitian() const { return view().is_hermitian(); }
+    [[nodiscard]] PauliStringView view() const {
+        return PauliStringView{x(), z(), phase_, num_qubits_};
+    }
+
+    void set_pauli(uint32_t qubit, bool x, bool z);
+    void set_phase(uint8_t phase) { phase_ = phase & 3U; }
+    void add_phase(uint8_t phase) { phase_ = (phase_ + phase) & 3U; }
+    void set_sign(bool sign);
+    void negate() { add_phase(2); }
+    void right_multiply(PauliStringView other);
+
+    [[nodiscard]] bool operator==(const PauliString& other) const;
+
+  private:
+    void clear_padding();
+
+    uint32_t num_qubits_;
+    std::vector<uint64_t> x_;
+    std::vector<uint64_t> z_;
+    uint8_t phase_ = 0;
+};
+
+}  // namespace clifft

--- a/src/clifft/tableau/tableau.cc
+++ b/src/clifft/tableau/tableau.cc
@@ -1,0 +1,342 @@
+#include "clifft/tableau/tableau.h"
+
+#include <array>
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
+namespace clifft {
+
+namespace {
+
+uint32_t row_index(bool z, uint32_t qubit, uint32_t num_qubits) {
+    return (z ? num_qubits : 0) + qubit;
+}
+
+}  // namespace
+
+Tableau::Tableau(uint32_t num_qubits)
+    : num_qubits_(num_qubits),
+      num_words_((num_qubits + 63) / 64),
+      x_rows_(static_cast<size_t>(2) * num_qubits * num_words_, 0),
+      z_rows_(x_rows_.size(), 0),
+      phases_(static_cast<size_t>(2) * num_qubits, 0) {
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        x_rows_[static_cast<size_t>(q) * num_words_ + q / 64] |= uint64_t{1} << (q % 64);
+        z_rows_[static_cast<size_t>(num_qubits_ + q) * num_words_ + q / 64] |= uint64_t{1}
+                                                                               << (q % 64);
+    }
+}
+
+Tableau Tableau::from_rows(std::initializer_list<std::string_view> rows) {
+    if (rows.size() % 2 != 0) {
+        throw std::invalid_argument("A tableau requires one X and one Z row per qubit");
+    }
+    Tableau result(static_cast<uint32_t>(rows.size() / 2));
+    uint32_t q = 0;
+    for (auto it = rows.begin(); it != rows.end();) {
+        const PauliString x = PauliString::from_text(*it++);
+        const PauliString z = PauliString::from_text(*it++);
+        if (x.num_qubits() != result.num_qubits() || z.num_qubits() != result.num_qubits()) {
+            throw std::invalid_argument("Tableau row width mismatch");
+        }
+        result.set_row(row_index(false, q, result.num_qubits()), x.view());
+        result.set_row(row_index(true, q, result.num_qubits()), z.view());
+        ++q;
+    }
+    return result;
+}
+
+Tableau Tableau::from_named_gate(GateType gate) {
+    switch (gate) {
+        case GateType::H:
+            return from_rows({"+Z", "+X"});
+        case GateType::S:
+            return from_rows({"+Y", "+Z"});
+        case GateType::S_DAG:
+            return from_rows({"-Y", "+Z"});
+        case GateType::X:
+            return from_rows({"+X", "-Z"});
+        case GateType::Y:
+            return from_rows({"-X", "-Z"});
+        case GateType::Z:
+            return from_rows({"-X", "+Z"});
+        case GateType::SQRT_X:
+            return from_rows({"+X", "-Y"});
+        case GateType::SQRT_X_DAG:
+            return from_rows({"+X", "+Y"});
+        case GateType::SQRT_Y:
+            return from_rows({"-Z", "+X"});
+        case GateType::SQRT_Y_DAG:
+            return from_rows({"+Z", "-X"});
+        case GateType::H_XY:
+            return from_rows({"+Y", "-Z"});
+        case GateType::H_YZ:
+            return from_rows({"-X", "+Y"});
+        case GateType::H_NXY:
+            return from_rows({"-Y", "-Z"});
+        case GateType::H_NXZ:
+            return from_rows({"-Z", "-X"});
+        case GateType::H_NYZ:
+            return from_rows({"-X", "-Y"});
+        case GateType::C_XYZ:
+            return from_rows({"+Y", "+X"});
+        case GateType::C_ZYX:
+            return from_rows({"+Z", "+Y"});
+        case GateType::C_NXYZ:
+            return from_rows({"-Y", "-X"});
+        case GateType::C_NZYX:
+            return from_rows({"-Z", "-Y"});
+        case GateType::C_XNYZ:
+            return from_rows({"-Y", "+X"});
+        case GateType::C_XYNZ:
+            return from_rows({"+Y", "-X"});
+        case GateType::C_ZNYX:
+            return from_rows({"+Z", "-Y"});
+        case GateType::C_ZYNX:
+            return from_rows({"-Z", "+Y"});
+        case GateType::I:
+            return Tableau(1);
+        case GateType::CX:
+            return from_rows({"+XX", "+Z_", "+_X", "+ZZ"});
+        case GateType::CY:
+            return from_rows({"+XY", "+Z_", "+ZX", "+ZZ"});
+        case GateType::CZ:
+            return from_rows({"+XZ", "+Z_", "+ZX", "+_Z"});
+        case GateType::SWAP:
+            return from_rows({"+_X", "+_Z", "+X_", "+Z_"});
+        case GateType::ISWAP:
+            return from_rows({"+ZY", "+_Z", "+YZ", "+Z_"});
+        case GateType::ISWAP_DAG:
+            return from_rows({"-ZY", "+_Z", "-YZ", "+Z_"});
+        case GateType::SQRT_XX:
+            return from_rows({"+X_", "-YX", "+_X", "-XY"});
+        case GateType::SQRT_XX_DAG:
+            return from_rows({"+X_", "+YX", "+_X", "+XY"});
+        case GateType::SQRT_YY:
+            return from_rows({"-ZY", "+XY", "-YZ", "+YX"});
+        case GateType::SQRT_YY_DAG:
+            return from_rows({"+ZY", "-XY", "+YZ", "-YX"});
+        case GateType::SQRT_ZZ:
+            return from_rows({"+YZ", "+Z_", "+ZY", "+_Z"});
+        case GateType::SQRT_ZZ_DAG:
+            return from_rows({"-YZ", "+Z_", "-ZY", "+_Z"});
+        case GateType::CXSWAP:
+            return from_rows({"+XX", "+_Z", "+X_", "+ZZ"});
+        case GateType::CZSWAP:
+            return from_rows({"+ZX", "+_Z", "+XZ", "+Z_"});
+        case GateType::SWAPCX:
+            return from_rows({"+_X", "+ZZ", "+XX", "+Z_"});
+        case GateType::XCX:
+            return from_rows({"+X_", "+ZX", "+_X", "+XZ"});
+        case GateType::XCY:
+            return from_rows({"+X_", "+ZY", "+XX", "+XZ"});
+        case GateType::XCZ:
+            return from_rows({"+X_", "+ZZ", "+XX", "+_Z"});
+        case GateType::YCX:
+            return from_rows({"+XX", "+ZX", "+_X", "+YZ"});
+        case GateType::YCY:
+            return from_rows({"+XY", "+ZY", "+YX", "+YZ"});
+        case GateType::YCZ:
+            return from_rows({"+XZ", "+ZZ", "+YX", "+_Z"});
+        case GateType::II:
+            return Tableau(2);
+        default:
+            throw std::invalid_argument("Gate does not have a fixed Clifford tableau: " +
+                                        std::string(gate_name(gate)));
+    }
+}
+
+Tableau Tableau::from_pauli_rotation(PauliStringView axis, bool dagger) {
+    if (!axis.is_hermitian()) {
+        throw std::invalid_argument("Pauli rotation axis must be Hermitian");
+    }
+    Tableau result(axis.num_qubits());
+    Tableau identity(axis.num_qubits());
+    for (uint32_t q = 0; q < axis.num_qubits(); ++q) {
+        for (bool z_generator : {false, true}) {
+            const uint32_t index = row_index(z_generator, q, axis.num_qubits());
+            const PauliStringView generator = identity.row(index);
+            if (axis.commutes(generator)) {
+                continue;
+            }
+            PauliString mapped(axis.num_qubits());
+            mapped.set_phase(axis.phase());
+            mapped.mut_x().xor_with(axis.x());
+            mapped.mut_z().xor_with(axis.z());
+            mapped.right_multiply(generator);
+            mapped.add_phase(dagger ? 1 : 3);
+            result.set_row(index, mapped.view());
+        }
+    }
+    return result;
+}
+
+PauliStringView Tableau::row(uint32_t index) const {
+    assert(index < 2 * num_qubits_);
+    const size_t offset = static_cast<size_t>(index) * num_words_;
+    return PauliStringView{MaskView{std::span<const uint64_t>(x_rows_).subspan(offset, num_words_)},
+                           MaskView{std::span<const uint64_t>(z_rows_).subspan(offset, num_words_)},
+                           phases_[index], num_qubits_};
+}
+
+PauliStringView Tableau::x_output(uint32_t qubit) const {
+    assert(qubit < num_qubits_);
+    return row(row_index(false, qubit, num_qubits_));
+}
+
+PauliStringView Tableau::z_output(uint32_t qubit) const {
+    assert(qubit < num_qubits_);
+    return row(row_index(true, qubit, num_qubits_));
+}
+
+PauliString Tableau::y_output(uint32_t qubit) const {
+    PauliString input(num_qubits_);
+    input.set_pauli(qubit, true, true);
+    input.set_sign(false);
+    return apply(input.view());
+}
+
+void Tableau::set_row(uint32_t index, PauliStringView value) {
+    assert(index < 2 * num_qubits_);
+    assert(value.num_qubits() == num_qubits_);
+    const size_t offset = static_cast<size_t>(index) * num_words_;
+    for (uint32_t w = 0; w < num_words_; ++w) {
+        x_rows_[offset + w] = value.x().words[w];
+        z_rows_[offset + w] = value.z().words[w];
+    }
+    phases_[index] = value.phase();
+}
+
+PauliString Tableau::apply(PauliStringView input) const {
+    assert(input.num_qubits() == num_qubits_);
+    PauliString result(num_qubits_);
+    result.set_phase(input.phase());
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        if (input.x().bit_get(q)) {
+            result.right_multiply(x_output(q));
+        }
+    }
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        if (input.z().bit_get(q)) {
+            result.right_multiply(z_output(q));
+        }
+    }
+    return result;
+}
+
+Tableau Tableau::then(const Tableau& next) const {
+    if (num_qubits_ != next.num_qubits_) {
+        throw std::invalid_argument("Cannot compose tableaus with different widths");
+    }
+    Tableau result(num_qubits_);
+    for (uint32_t row_i = 0; row_i < 2 * num_qubits_; ++row_i) {
+        const PauliString mapped = next.apply(row(row_i));
+        result.set_row(row_i, mapped.view());
+    }
+    return result;
+}
+
+Tableau Tableau::inverse() const {
+    Tableau result(num_qubits_);
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        PauliString inverse_x(num_qubits_);
+        PauliString inverse_z(num_qubits_);
+        for (uint32_t k = 0; k < num_qubits_; ++k) {
+            inverse_x.set_pauli(k, z_output(k).z().bit_get(q), x_output(k).z().bit_get(q));
+            inverse_z.set_pauli(k, z_output(k).x().bit_get(q), x_output(k).x().bit_get(q));
+        }
+        inverse_x.set_sign(false);
+        inverse_z.set_sign(false);
+        if (apply(inverse_x.view()).sign()) {
+            inverse_x.negate();
+        }
+        if (apply(inverse_z.view()).sign()) {
+            inverse_z.negate();
+        }
+        result.set_row(row_index(false, q, num_qubits_), inverse_x.view());
+        result.set_row(row_index(true, q, num_qubits_), inverse_z.view());
+    }
+    return result;
+}
+
+void Tableau::append_local(const Tableau& gate, std::span<const uint32_t> targets) {
+    if (gate.num_qubits() != targets.size()) {
+        throw std::invalid_argument("Gate tableau width does not match target count");
+    }
+    for (uint32_t target : targets) {
+        if (target >= num_qubits_) {
+            throw std::invalid_argument("Gate target is outside the tableau");
+        }
+    }
+
+    for (uint32_t row_i = 0; row_i < 2 * num_qubits_; ++row_i) {
+        const PauliStringView old = row(row_i);
+        PauliString local(gate.num_qubits());
+        for (uint32_t local_q = 0; local_q < targets.size(); ++local_q) {
+            local.set_pauli(local_q, old.x().bit_get(targets[local_q]),
+                            old.z().bit_get(targets[local_q]));
+        }
+        local.set_sign(false);
+        const PauliString mapped = gate.apply(local.view());
+
+        PauliString replacement(num_qubits_);
+        replacement.set_phase(old.phase());
+        replacement.mut_x().xor_with(old.x());
+        replacement.mut_z().xor_with(old.z());
+        replacement.add_phase((4U - local.phase() + mapped.phase()) & 3U);
+        for (uint32_t local_q = 0; local_q < targets.size(); ++local_q) {
+            replacement.set_pauli(targets[local_q], mapped.x().bit_get(local_q),
+                                  mapped.z().bit_get(local_q));
+        }
+        set_row(row_i, replacement.view());
+    }
+}
+
+void Tableau::prepend_local(const Tableau& gate, std::span<const uint32_t> targets) {
+    if (gate.num_qubits() != targets.size()) {
+        throw std::invalid_argument("Gate tableau width does not match target count");
+    }
+    for (uint32_t target : targets) {
+        if (target >= num_qubits_) {
+            throw std::invalid_argument("Gate target is outside the tableau");
+        }
+    }
+
+    std::vector<PauliString> replacements;
+    replacements.reserve(2 * targets.size());
+    for (bool z_generator : {false, true}) {
+        for (uint32_t local_q = 0; local_q < targets.size(); ++local_q) {
+            const PauliStringView gate_row =
+                z_generator ? gate.z_output(local_q) : gate.x_output(local_q);
+            PauliString scattered(num_qubits_);
+            scattered.set_phase(gate_row.phase());
+            for (uint32_t k = 0; k < targets.size(); ++k) {
+                scattered.set_pauli(targets[k], gate_row.x().bit_get(k), gate_row.z().bit_get(k));
+            }
+            replacements.push_back(apply(scattered.view()));
+        }
+    }
+    size_t replacement = 0;
+    for (bool z_generator : {false, true}) {
+        for (uint32_t target : targets) {
+            set_row(row_index(z_generator, target, num_qubits_),
+                    replacements[replacement++].view());
+        }
+    }
+}
+
+void Tableau::append_named_gate(GateType gate, std::span<const uint32_t> targets) {
+    append_local(from_named_gate(gate), targets);
+}
+
+void Tableau::prepend_named_gate(GateType gate, std::span<const uint32_t> targets) {
+    prepend_local(from_named_gate(gate), targets);
+}
+
+bool Tableau::operator==(const Tableau& other) const {
+    return num_qubits_ == other.num_qubits_ && x_rows_ == other.x_rows_ &&
+           z_rows_ == other.z_rows_ && phases_ == other.phases_;
+}
+
+}  // namespace clifft

--- a/src/clifft/tableau/tableau.h
+++ b/src/clifft/tableau/tableau.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// Native runtime-width Clifford tableau.
+
+#include "clifft/circuit/gate_data.h"
+#include "clifft/tableau/pauli_string.h"
+
+#include <cstdint>
+#include <initializer_list>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace clifft {
+
+class Tableau {
+  public:
+    explicit Tableau(uint32_t num_qubits = 0);
+
+    [[nodiscard]] static Tableau from_named_gate(GateType gate);
+    [[nodiscard]] static Tableau from_pauli_rotation(PauliStringView axis, bool dagger);
+
+    [[nodiscard]] uint32_t num_qubits() const { return num_qubits_; }
+    [[nodiscard]] PauliStringView x_output(uint32_t qubit) const;
+    [[nodiscard]] PauliStringView z_output(uint32_t qubit) const;
+    [[nodiscard]] PauliString y_output(uint32_t qubit) const;
+    [[nodiscard]] PauliString apply(PauliStringView input) const;
+    [[nodiscard]] Tableau then(const Tableau& next) const;
+    [[nodiscard]] Tableau inverse() const;
+
+    void append_local(const Tableau& gate, std::span<const uint32_t> targets);
+    void prepend_local(const Tableau& gate, std::span<const uint32_t> targets);
+    void append_named_gate(GateType gate, std::span<const uint32_t> targets);
+    void prepend_named_gate(GateType gate, std::span<const uint32_t> targets);
+
+    [[nodiscard]] bool operator==(const Tableau& other) const;
+
+  private:
+    [[nodiscard]] static Tableau from_rows(std::initializer_list<std::string_view> rows);
+    [[nodiscard]] PauliStringView row(uint32_t index) const;
+    void set_row(uint32_t index, PauliStringView value);
+
+    uint32_t num_qubits_;
+    uint32_t num_words_;
+    std::vector<uint64_t> x_rows_;
+    std::vector<uint64_t> z_rows_;
+    std::vector<uint8_t> phases_;
+};
+
+}  // namespace clifft

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(clifft_tests
     test_page_allocation.cc
     test_parser.cc
     test_stim_contract.cc
+    test_tableau.cc
     test_hir.cc
     test_frontend.cc
     test_frontend_instruments.cc

--- a/tests/test_tableau.cc
+++ b/tests/test_tableau.cc
@@ -1,0 +1,268 @@
+#include "clifft/tableau/tableau.h"
+
+#include "stim.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <random>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct GateCase {
+    clifft::GateType gate;
+    std::string_view name;
+    uint32_t arity;
+};
+
+constexpr std::array kNamedCliffords{
+    GateCase{clifft::GateType::H, "H", 1},
+    GateCase{clifft::GateType::S, "S", 1},
+    GateCase{clifft::GateType::S_DAG, "S_DAG", 1},
+    GateCase{clifft::GateType::X, "X", 1},
+    GateCase{clifft::GateType::Y, "Y", 1},
+    GateCase{clifft::GateType::Z, "Z", 1},
+    GateCase{clifft::GateType::SQRT_X, "SQRT_X", 1},
+    GateCase{clifft::GateType::SQRT_X_DAG, "SQRT_X_DAG", 1},
+    GateCase{clifft::GateType::SQRT_Y, "SQRT_Y", 1},
+    GateCase{clifft::GateType::SQRT_Y_DAG, "SQRT_Y_DAG", 1},
+    GateCase{clifft::GateType::H_XY, "H_XY", 1},
+    GateCase{clifft::GateType::H_YZ, "H_YZ", 1},
+    GateCase{clifft::GateType::H_NXY, "H_NXY", 1},
+    GateCase{clifft::GateType::H_NXZ, "H_NXZ", 1},
+    GateCase{clifft::GateType::H_NYZ, "H_NYZ", 1},
+    GateCase{clifft::GateType::C_XYZ, "C_XYZ", 1},
+    GateCase{clifft::GateType::C_ZYX, "C_ZYX", 1},
+    GateCase{clifft::GateType::C_NXYZ, "C_NXYZ", 1},
+    GateCase{clifft::GateType::C_NZYX, "C_NZYX", 1},
+    GateCase{clifft::GateType::C_XNYZ, "C_XNYZ", 1},
+    GateCase{clifft::GateType::C_XYNZ, "C_XYNZ", 1},
+    GateCase{clifft::GateType::C_ZNYX, "C_ZNYX", 1},
+    GateCase{clifft::GateType::C_ZYNX, "C_ZYNX", 1},
+    GateCase{clifft::GateType::CX, "CX", 2},
+    GateCase{clifft::GateType::CY, "CY", 2},
+    GateCase{clifft::GateType::CZ, "CZ", 2},
+    GateCase{clifft::GateType::SWAP, "SWAP", 2},
+    GateCase{clifft::GateType::ISWAP, "ISWAP", 2},
+    GateCase{clifft::GateType::ISWAP_DAG, "ISWAP_DAG", 2},
+    GateCase{clifft::GateType::SQRT_XX, "SQRT_XX", 2},
+    GateCase{clifft::GateType::SQRT_XX_DAG, "SQRT_XX_DAG", 2},
+    GateCase{clifft::GateType::SQRT_YY, "SQRT_YY", 2},
+    GateCase{clifft::GateType::SQRT_YY_DAG, "SQRT_YY_DAG", 2},
+    GateCase{clifft::GateType::SQRT_ZZ, "SQRT_ZZ", 2},
+    GateCase{clifft::GateType::SQRT_ZZ_DAG, "SQRT_ZZ_DAG", 2},
+    GateCase{clifft::GateType::CXSWAP, "CXSWAP", 2},
+    GateCase{clifft::GateType::CZSWAP, "CZSWAP", 2},
+    GateCase{clifft::GateType::SWAPCX, "SWAPCX", 2},
+    GateCase{clifft::GateType::XCX, "XCX", 2},
+    GateCase{clifft::GateType::XCY, "XCY", 2},
+    GateCase{clifft::GateType::XCZ, "XCZ", 2},
+    GateCase{clifft::GateType::YCX, "YCX", 2},
+    GateCase{clifft::GateType::YCY, "YCY", 2},
+    GateCase{clifft::GateType::YCZ, "YCZ", 2},
+};
+
+template <typename StimPauli>
+void check_pauli(clifft::PauliStringView actual, const StimPauli& expected) {
+    REQUIRE(actual.is_hermitian());
+    CHECK(actual.sign() == expected.sign);
+    for (uint32_t q = 0; q < actual.num_qubits(); ++q) {
+        CHECK(actual.x().bit_get(q) == expected.xs[q]);
+        CHECK(actual.z().bit_get(q) == expected.zs[q]);
+    }
+    if (actual.num_qubits() % 64 != 0 && actual.num_qubits() != 0) {
+        const uint64_t padding = ~((uint64_t{1} << (actual.num_qubits() % 64)) - 1);
+        CHECK((actual.x().words.back() & padding) == 0);
+        CHECK((actual.z().words.back() & padding) == 0);
+    }
+}
+
+void check_tableau(const clifft::Tableau& actual, const stim::Tableau<64>& expected) {
+    REQUIRE(actual.num_qubits() == expected.num_qubits);
+    for (uint32_t q = 0; q < actual.num_qubits(); ++q) {
+        check_pauli(actual.x_output(q), expected.xs[q]);
+        check_pauli(actual.z_output(q), expected.zs[q]);
+    }
+}
+
+stim::Tableau<64> stim_pauli_rotation(clifft::PauliStringView axis, bool dagger) {
+    std::mt19937_64 rng(0);
+    stim::TableauSimulator<64> simulator(std::move(rng), axis.num_qubits());
+    std::vector<stim::GateTarget> targets;
+    bool first = true;
+    for (uint32_t q = 0; q < axis.num_qubits(); ++q) {
+        if (!axis.x().bit_get(q) && !axis.z().bit_get(q)) {
+            continue;
+        }
+        if (!first) {
+            targets.push_back(stim::GateTarget::combiner());
+        }
+        targets.push_back(stim::GateTarget::pauli_xz(q, axis.x().bit_get(q), axis.z().bit_get(q),
+                                                     first && axis.sign()));
+        first = false;
+    }
+    if (!targets.empty()) {
+        const stim::CircuitInstruction instruction(
+            dagger ? stim::GateType::SPP_DAG : stim::GateType::SPP, {}, targets, {});
+        simulator.do_gate(instruction);
+    }
+    return simulator.inv_state.inverse();
+}
+
+}  // namespace
+
+TEST_CASE("Native Pauli phase convention preserves Hermitian signs", "[tableau]") {
+    const clifft::PauliString x = clifft::PauliString::from_text("+X");
+    const clifft::PauliString y = clifft::PauliString::from_text("+Y");
+    const clifft::PauliString negative_y = clifft::PauliString::from_text("-Y");
+    CHECK(x.phase() == 0);
+    CHECK(y.phase() == 1);
+    CHECK_FALSE(y.sign());
+    CHECK(negative_y.phase() == 3);
+    CHECK(negative_y.sign());
+
+    clifft::PauliString product = x;
+    product.right_multiply(y.view());
+    CHECK(product.is_hermitian() == false);
+    product.right_multiply(x.view());
+    CHECK(product == negative_y);
+}
+
+TEST_CASE("Native named Clifford cases cover fixed gate metadata", "[tableau]") {
+    constexpr size_t gate_count = static_cast<size_t>(clifft::GateType::UNKNOWN);
+    std::array<bool, gate_count> covered{};
+
+    for (const GateCase& gate : kNamedCliffords) {
+        CAPTURE(gate.name);
+        const size_t index = static_cast<size_t>(gate.gate);
+        REQUIRE(index < covered.size());
+        CHECK(clifft::is_clifford(gate.gate));
+        const clifft::GateArity arity = clifft::gate_arity(gate.gate);
+        CHECK((arity == clifft::GateArity::SINGLE || arity == clifft::GateArity::PAIR));
+        CHECK(gate.arity == (arity == clifft::GateArity::SINGLE ? 1U : 2U));
+        CHECK_FALSE(covered[index]);
+        covered[index] = true;
+    }
+
+    for (size_t index = 0; index < covered.size(); ++index) {
+        const auto gate = static_cast<clifft::GateType>(index);
+        const clifft::GateArity arity = clifft::gate_arity(gate);
+        if (!clifft::is_clifford(gate) ||
+            (arity != clifft::GateArity::SINGLE && arity != clifft::GateArity::PAIR)) {
+            continue;
+        }
+        CAPTURE(clifft::gate_name(gate));
+        CHECK(covered[index]);
+    }
+}
+
+TEST_CASE("Native named Clifford rows match Stim", "[tableau]") {
+    for (const GateCase& gate : kNamedCliffords) {
+        CAPTURE(gate.name);
+        const clifft::Tableau actual = clifft::Tableau::from_named_gate(gate.gate);
+        const stim::Tableau<64> expected = stim::GATE_DATA.at(gate.name).tableau<64>();
+        check_tableau(actual, expected);
+        check_tableau(actual.inverse(), expected.inverse());
+    }
+}
+
+TEST_CASE("Native local composition matches Stim across mask words", "[tableau]") {
+    constexpr std::array<uint32_t, 8> widths{0, 1, 63, 64, 65, 127, 128, 129};
+    for (uint32_t width : widths) {
+        CAPTURE(width);
+        clifft::Tableau appended(width);
+        clifft::Tableau prepended(width);
+        stim::Tableau<64> expected_appended(width);
+        stim::Tableau<64> expected_prepended(width);
+        std::mt19937_64 rng(0x6c6f63616cULL + width);
+
+        for (uint32_t step = 0; step < 80 && width != 0; ++step) {
+            const GateCase& gate = kNamedCliffords[rng() % kNamedCliffords.size()];
+            if (gate.arity > width) {
+                continue;
+            }
+            const uint32_t first = static_cast<uint32_t>(rng() % width);
+            uint32_t second = first;
+            while (gate.arity == 2 && second == first) {
+                second = static_cast<uint32_t>(rng() % width);
+            }
+            const std::array<uint32_t, 2> native_targets{first, second};
+            const auto native_span = std::span(native_targets).first(gate.arity);
+            std::vector<size_t> stim_targets{first};
+            if (gate.arity == 2) {
+                stim_targets.push_back(second);
+            }
+            const stim::Tableau<64> stim_gate = stim::GATE_DATA.at(gate.name).tableau<64>();
+
+            appended.append_named_gate(gate.gate, native_span);
+            prepended.prepend_named_gate(gate.gate, native_span);
+            expected_appended.inplace_scatter_append(stim_gate, stim_targets);
+            expected_prepended.inplace_scatter_prepend(stim_gate, stim_targets);
+        }
+
+        check_tableau(appended, expected_appended);
+        check_tableau(prepended, expected_prepended);
+        check_tableau(appended.inverse(), expected_appended.inverse());
+        check_tableau(prepended.inverse(), expected_prepended.inverse());
+    }
+}
+
+TEST_CASE("Native tableau application and composition match Stim", "[tableau]") {
+    constexpr uint32_t width = 65;
+    clifft::Tableau first(width);
+    clifft::Tableau second(width);
+    stim::Tableau<64> expected_first(width);
+    stim::Tableau<64> expected_second(width);
+
+    const std::array<uint32_t, 2> native_pair{0, 64};
+    const std::vector<size_t> stim_first{0};
+    const std::vector<size_t> stim_second{64};
+    const std::vector<size_t> stim_pair{0, 64};
+    first.append_named_gate(clifft::GateType::H, std::span(native_pair).first<1>());
+    first.append_named_gate(clifft::GateType::CX, native_pair);
+    second.append_named_gate(clifft::GateType::S, std::span(native_pair).last<1>());
+    second.append_named_gate(clifft::GateType::CY, native_pair);
+    expected_first.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<64>(), stim_first);
+    expected_first.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<64>(), stim_pair);
+    expected_second.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<64>(), stim_second);
+    expected_second.inplace_scatter_append(stim::GATE_DATA.at("CY").tableau<64>(), stim_pair);
+
+    check_tableau(first.then(second), expected_first.then(expected_second));
+
+    std::mt19937_64 rng(0x6170706c79ULL);
+    for (uint32_t sample = 0; sample < 100; ++sample) {
+        clifft::PauliString input(width);
+        stim::PauliString<64> expected_input(width);
+        for (uint32_t q = 0; q < width; ++q) {
+            const uint32_t pauli = static_cast<uint32_t>(rng() & 3U);
+            input.set_pauli(q, (pauli & 1U) != 0, (pauli & 2U) != 0);
+            expected_input.xs[q] = (pauli & 1U) != 0;
+            expected_input.zs[q] = (pauli & 2U) != 0;
+        }
+        input.set_sign((rng() & 1U) != 0);
+        expected_input.sign = input.sign();
+        check_pauli(first.apply(input.view()).view(), expected_first(expected_input));
+    }
+}
+
+TEST_CASE("Native Pauli rotations match Stim across mask words", "[tableau]") {
+    constexpr uint32_t width = 129;
+    constexpr std::array<uint32_t, 5> qubits{0, 63, 64, 127, 128};
+    for (bool sign : {false, true}) {
+        for (bool dagger : {false, true}) {
+            clifft::PauliString axis(width);
+            for (uint32_t k = 0; k < qubits.size(); ++k) {
+                const uint32_t pauli = k % 3;
+                axis.set_pauli(qubits[k], pauli != 2, pauli != 0);
+            }
+            axis.set_sign(sign);
+            CAPTURE(sign, dagger);
+            check_tableau(clifft::Tableau::from_pauli_rotation(axis.view(), dagger),
+                          stim_pauli_rotation(axis.view(), dagger));
+        }
+    }
+}


### PR DESCRIPTION
Introduce runtime-width native Pauli strings and tableaus with gate construction, application, composition, inversion, and local updates. Keep production behavior on Stim while differential tests validate every named Clifford and packed-word boundary.

Part of #385.

Assisted-by: Codex (GPT-5) <noreply@openai.com>