### PR TITLE
feat(compilation): migrate Stim consumers

### DIFF
--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -20,7 +20,7 @@ namespace clifft {
 namespace {
 
 using BasisMask = std::vector<uint64_t>;
-using StabilizerRow = stim::PauliString<kStimWidth>;
+using StabilizerRow = PauliString;
 
 [[nodiscard]] MaskView basis_mask_view(const BasisMask& mask) {
     return MaskView{std::span<const uint64_t>(mask)};
@@ -93,8 +93,8 @@ void mask_xor_with(MutableMaskView dst, MaskView src) {
 }
 
 [[nodiscard]] uint64_t valid_word_mask(uint32_t n, size_t words, size_t word) {
-    // Stim simd_bits may contain padding above num_qubits. Word-level scans must
-    // mask those bits or they can create spurious Y phases and Z parities.
+    // Keep word-level scans explicit about the logical width so high padding
+    // bits can never create spurious Y phases or Z parities.
     const uint32_t used_bits = n % 64;
     if (word + 1 != words || used_bits == 0) {
         return ~uint64_t{0};
@@ -106,7 +106,7 @@ void mask_xor_with(MutableMaskView dst, MaskView src) {
     BasisMask mask = zero_basis_mask(n);
     const size_t words = mask.size();
     for (size_t w = 0; w < words; ++w) {
-        mask[w] = p.xs.u64[w] & valid_word_mask(n, words, w);
+        mask[w] = p.x().words[w] & valid_word_mask(n, words, w);
     }
     return mask;
 }
@@ -128,7 +128,7 @@ void mask_xor_with(MutableMaskView dst, MaskView src) {
     uint32_t count = 0;
     const size_t words = basis_word_count(n);
     for (size_t w = 0; w < words; ++w) {
-        count += std::popcount(p.xs.u64[w] & p.zs.u64[w] & valid_word_mask(n, words, w));
+        count += std::popcount(p.x().words[w] & p.z().words[w] & valid_word_mask(n, words, w));
     }
     return count;
 }
@@ -142,7 +142,7 @@ void mask_xor_with(MutableMaskView dst, MaskView src) {
     const size_t words = basis_word_count(n);
     for (size_t w = 0; w < words; ++w) {
         const uint64_t valid = valid_word_mask(n, words, w);
-        z_basis_parity ^= (std::popcount(p.zs.u64[w] & basis.words[w] & valid) & 1U) != 0;
+        z_basis_parity ^= (std::popcount(p.z().words[w] & basis.words[w] & valid) & 1U) != 0;
     }
     if (z_basis_parity) {
         phase_idx += 2;
@@ -152,14 +152,14 @@ void mask_xor_with(MutableMaskView dst, MaskView src) {
 
 void multiply_row_by(StabilizerRow& dst, BasisMask& dst_sign_mask, const StabilizerRow& src,
                      const BasisMask& src_sign_mask) {
-    dst.ref() *= src;
+    dst.right_multiply(src.view());
     mask_xor_with(dst_sign_mask, src_sign_mask);
 }
 
 [[nodiscard]] bool row_has_any_z(const StabilizerRow& p, uint32_t n) {
     const size_t words = basis_word_count(n);
     for (size_t w = 0; w < words; ++w) {
-        if ((p.zs.u64[w] & valid_word_mask(n, words, w)) != 0) {
+        if ((p.z().words[w] & valid_word_mask(n, words, w)) != 0) {
             return true;
         }
     }
@@ -206,10 +206,10 @@ struct StabilizerAmplitudeStructure {
         query.x_signs.reserve(x_rows.size());
 
         for (size_t i = 0; i < x_rows.size(); ++i) {
-            query.x_signs.push_back(dynamic_sign(static_cast<bool>(x_rows[i].sign),
-                                                 basis_mask_view(x_sign_masks[i]), physical_basis)
-                                        ? 1U
-                                        : 0U);
+            query.x_signs.push_back(
+                dynamic_sign(x_rows[i].sign(), basis_mask_view(x_sign_masks[i]), physical_basis)
+                    ? 1U
+                    : 0U);
         }
 
         for (const auto& term : base_terms) {
@@ -262,7 +262,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
 }
 
 [[nodiscard]] StabilizerAmplitudeStructure make_stabilizer_amplitude_structure(
-    uint32_t n, const stim::Tableau<kStimWidth>& inv_tableau, uint32_t active_k) {
+    uint32_t n, const Tableau& inv_tableau, uint32_t active_k) {
     std::vector<StabilizerRow> rows;
     std::vector<BasisMask> sign_masks;
     rows.reserve(n);
@@ -272,7 +272,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
     // queried physical bitstring x: the q-th stabilizer has sign x_q. Store that
     // dependence as a sign mask so the row-reduction structure can be reused.
     for (uint32_t q = 0; q < n; ++q) {
-        rows.emplace_back(inv_tableau.zs[q]);
+        rows.emplace_back(inv_tableau.z_output(q));
         sign_masks.push_back(zero_basis_mask(n));
         mutable_basis_mask_view(sign_masks.back()).bit_set(q, true);
     }
@@ -301,7 +301,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
         auto rank_row = rows.begin() + static_cast<std::ptrdiff_t>(rank_x);
         auto rank_sign = sign_masks.begin() + static_cast<std::ptrdiff_t>(rank_x);
         for (auto it = rank_row; it != rows.end(); ++it) {
-            if (it->xs[col]) {
+            if (it->x().bit_get(col)) {
                 pivot = it;
                 pivot_sign = sign_masks.begin() + (it - rows.begin());
                 break;
@@ -314,7 +314,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
         std::iter_swap(rank_row, pivot);
         std::iter_swap(rank_sign, pivot_sign);
         for (size_t r = 0; r < rows.size(); ++r) {
-            if (r != rank_x && rows[r].xs[col]) {
+            if (r != rank_x && rows[r].x().bit_get(col)) {
                 multiply_row_by(rows[r], sign_masks[r], rows[rank_x], sign_masks[rank_x]);
             }
         }
@@ -337,7 +337,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
         auto rank_row = z_rows.begin() + static_cast<std::ptrdiff_t>(rank_z);
         auto rank_sign = z_sign_masks.begin() + static_cast<std::ptrdiff_t>(rank_z);
         for (auto it = rank_row; it != z_rows.end(); ++it) {
-            if (it->zs[col]) {
+            if (it->z().bit_get(col)) {
                 pivot = it;
                 pivot_sign = z_sign_masks.begin() + (it - z_rows.begin());
                 break;
@@ -350,13 +350,12 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
         std::iter_swap(rank_row, pivot);
         std::iter_swap(rank_sign, pivot_sign);
         for (size_t r = 0; r < z_rows.size(); ++r) {
-            if (r != rank_z && z_rows[r].zs[col]) {
+            if (r != rank_z && z_rows[r].z().bit_get(col)) {
                 multiply_row_by(z_rows[r], z_sign_masks[r], z_rows[rank_z], z_sign_masks[rank_z]);
             }
         }
-        base_terms.push_back(DynamicSignTerm{.bit = col,
-                                             .static_sign = static_cast<bool>(z_rows[rank_z].sign),
-                                             .sign_mask = z_sign_masks[rank_z]});
+        base_terms.push_back(DynamicSignTerm{
+            .bit = col, .static_sign = z_rows[rank_z].sign(), .sign_mask = z_sign_masks[rank_z]});
         ++rank_z;
     }
 
@@ -366,9 +365,8 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
     // inconsistent tableau metadata or a reduction bug.
     for (size_t r = rank_z; r < z_rows.size(); ++r) {
         if (!row_has_any_z(z_rows[r], n)) {
-            identity_constraints.push_back(
-                IdentityConstraint{.static_sign = static_cast<bool>(z_rows[r].sign),
-                                   .sign_mask = std::move(z_sign_masks[r])});
+            identity_constraints.push_back(IdentityConstraint{
+                .static_sign = z_rows[r].sign(), .sign_mask = std::move(z_sign_masks[r])});
         }
     }
 
@@ -410,14 +408,13 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
 
 template <typename CoefficientAt>
 std::vector<double> basis_probabilities_from_factored_state(
-    uint32_t n, uint32_t active_width, uint64_t active_size,
-    const stim::Tableau<kStimWidth>& final_tableau, MaskView state_px, uint64_t active_z_mask,
-    CoefficientAt coefficient_at, std::span<const uint64_t> basis_masks, size_t num_basis_masks,
-    size_t words_per_basis_mask) {
+    uint32_t n, uint32_t active_width, uint64_t active_size, const Tableau& final_tableau,
+    MaskView state_px, uint64_t active_z_mask, CoefficientAt coefficient_at,
+    std::span<const uint64_t> basis_masks, size_t num_basis_masks, size_t words_per_basis_mask) {
     // The factored state is U_C * P * (|phi>_A x |0>_D). The inverse tableau
     // lets the batch query evaluator reuse stabilizers of U_C^dagger |x> for
     // every requested physical bitstring x.
-    stim::Tableau<kStimWidth> inv_tableau = final_tableau.inverse(false);
+    Tableau inv_tableau = final_tableau.inverse();
 
     const size_t expected_words = basis_word_count(n);
     if (words_per_basis_mask != expected_words) {
@@ -568,7 +565,7 @@ namespace sampling {
 std::vector<double> basis_probabilities(const ExecutablePlan& plan,
                                         std::span<const uint64_t> basis_masks,
                                         size_t num_basis_masks, size_t words_per_basis_mask) {
-    const stim::Tableau<kStimWidth>* final_tableau = plan.final_state_tableau();
+    const Tableau* final_tableau = plan.final_state_tableau();
     if (final_tableau == nullptr) {
         throw std::invalid_argument(
             "basis_probabilities() requires pure-state evolution: measurements, feedback, "

--- a/src/clifft/api/statevector.cc
+++ b/src/clifft/api/statevector.cc
@@ -2,11 +2,13 @@
 #include "clifft/sampling/state_queries.h"
 #include "clifft/sampling/state_query_limits.h"
 
+#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <span>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -14,38 +16,104 @@
 namespace clifft {
 namespace {
 
-std::complex<double> exact_clifford_factor(std::complex<float> factor, double support_magnitude) {
-    if (factor == std::complex<float>{0.0F, 0.0F}) {
-        return {0.0, 0.0};
-    }
-
-    // Stim canonicalizes a stabilizer state to a uniform magnitude times one
-    // of {1, -1, i, -i}. Recover those exact classes before multiplying the
-    // double-precision active state instead of preserving float rounding in
-    // the public result.
-    assert((factor.real() == 0.0F) != (factor.imag() == 0.0F));
-    if (factor.real() > 0.0F) {
-        return {support_magnitude, 0.0};
-    }
-    if (factor.real() < 0.0F) {
-        return {-support_magnitude, 0.0};
-    }
-    return factor.imag() > 0.0F ? std::complex<double>{0.0, support_magnitude}
-                                : std::complex<double>{0.0, -support_magnitude};
-}
-
 void validate_statevector_size(uint32_t num_qubits) {
     if (num_qubits > sampling::kMaxExpandedStatevectorQubits) {
-        throw std::runtime_error(
-            "Statevector expansion limited to 10 qubits (dense U_C matrix is 4^n)");
+        throw std::runtime_error("Statevector expansion limited to 10 qubits");
     }
+}
+
+[[nodiscard]] std::complex<double> i_pow(uint8_t phase) {
+    switch (phase & 3U) {
+        case 0:
+            return {1.0, 0.0};
+        case 1:
+            return {0.0, 1.0};
+        case 2:
+            return {-1.0, 0.0};
+        default:
+            return {0.0, -1.0};
+    }
+}
+
+void apply_pauli(PauliStringView pauli, std::span<const std::complex<double>> input,
+                 std::span<std::complex<double>> output) {
+    assert(input.size() == output.size());
+    const uint64_t x = pauli.x().words.empty() ? 0 : pauli.x().words[0];
+    const uint64_t z = pauli.z().words.empty() ? 0 : pauli.z().words[0];
+    const std::complex<double> phase = i_pow(pauli.phase());
+    for (uint64_t basis = 0; basis < input.size(); ++basis) {
+        const double z_sign = (std::popcount(basis & z) & 1U) != 0 ? -1.0 : 1.0;
+        output[basis ^ x] = phase * z_sign * input[basis];
+    }
+}
+
+std::vector<std::complex<double>> zero_state_image(const Tableau& tableau) {
+    const uint64_t dimension = uint64_t{1} << tableau.num_qubits();
+    std::vector<std::complex<double>> state(dimension);
+    std::vector<std::complex<double>> transformed(dimension);
+
+    // At least one computational basis vector has nonzero overlap with the
+    // stabilizer state. The first survivor fixes a deterministic global phase
+    // with its first nonzero amplitude positive real.
+    for (uint64_t seed = 0; seed < dimension; ++seed) {
+        std::ranges::fill(state, std::complex<double>{0.0, 0.0});
+        state[seed] = {1.0, 0.0};
+        bool survives = true;
+        for (uint32_t q = 0; q < tableau.num_qubits(); ++q) {
+            apply_pauli(tableau.z_output(q), state, transformed);
+            double norm = 0.0;
+            for (uint64_t basis = 0; basis < dimension; ++basis) {
+                state[basis] += transformed[basis];
+                norm += std::norm(state[basis]);
+            }
+            if (norm == 0.0) {
+                survives = false;
+                break;
+            }
+            const double scale = 1.0 / std::sqrt(norm);
+            for (auto& amplitude : state) {
+                amplitude *= scale;
+            }
+        }
+        if (survives) {
+            return state;
+        }
+    }
+    throw std::logic_error("Clifford tableau has no stabilized state");
+}
+
+std::vector<std::complex<double>> apply_tableau(const Tableau& tableau,
+                                                std::span<const std::complex<double>> input) {
+    const uint64_t dimension = uint64_t{1} << tableau.num_qubits();
+    assert(input.size() == dimension);
+    const std::vector<std::complex<double>> zero_image = zero_state_image(tableau);
+    std::vector<std::complex<double>> column(dimension);
+    std::vector<std::complex<double>> output(dimension);
+    for (uint64_t basis = 0; basis < dimension; ++basis) {
+        if (input[basis] == std::complex<double>{0.0, 0.0}) {
+            continue;
+        }
+        PauliString virtual_x(tableau.num_qubits());
+        for (uint32_t q = 0; q < tableau.num_qubits(); ++q) {
+            if (((basis >> q) & 1U) != 0) {
+                virtual_x.set_pauli(q, true, false);
+            }
+        }
+        const PauliString physical_x = tableau.apply(virtual_x.view());
+        apply_pauli(physical_x.view(), zero_image, column);
+        for (uint64_t row = 0; row < dimension; ++row) {
+            output[row] += column[row] * input[basis];
+        }
+    }
+    return output;
 }
 
 template <typename CoefficientAt>
-std::vector<std::complex<double>> expand_factored_state(
-    uint32_t num_qubits, uint32_t active_width, uint64_t active_size, uint64_t pauli_x,
-    uint64_t pauli_z, const stim::Tableau<kStimWidth>* final_tableau,
-    CoefficientAt coefficient_at) {
+std::vector<std::complex<double>> expand_factored_state(uint32_t num_qubits, uint32_t active_width,
+                                                        uint64_t active_size, uint64_t pauli_x,
+                                                        uint64_t pauli_z,
+                                                        const Tableau* final_tableau,
+                                                        CoefficientAt coefficient_at) {
     validate_statevector_size(num_qubits);
     const uint64_t dimension = uint64_t{1} << num_qubits;
     assert(active_width <= num_qubits && "active width exceeds physical qubit count");
@@ -67,23 +135,7 @@ std::vector<std::complex<double>> expand_factored_state(
     if (final_tableau == nullptr) {
         physical = std::move(framed);
     } else {
-        physical.assign(dimension, {0.0, 0.0});
-        const auto unitary = final_tableau->to_flat_unitary_matrix(true);
-        for (uint64_t row = 0; row < dimension; ++row) {
-            uint64_t support = 0;
-            for (uint64_t col = 0; col < dimension; ++col) {
-                support += unitary[row * dimension + col] != std::complex<float>{0.0F, 0.0F};
-            }
-            assert(support != 0 && "Clifford unitary row has empty support");
-            const double support_magnitude = 1.0 / std::sqrt(static_cast<double>(support));
-            std::complex<double> amplitude{0.0, 0.0};
-            for (uint64_t col = 0; col < dimension; ++col) {
-                amplitude +=
-                    exact_clifford_factor(unitary[row * dimension + col], support_magnitude) *
-                    framed[col];
-            }
-            physical[row] = amplitude;
-        }
+        physical = apply_tableau(*final_tableau, framed);
     }
 
     return physical;
@@ -94,7 +146,7 @@ std::vector<std::complex<double>> expand_factored_state(
 namespace sampling {
 
 std::vector<std::complex<double>> get_statevector(const ExecutablePlan& plan) {
-    const stim::Tableau<kStimWidth>* final_tableau = plan.final_state_tableau();
+    const Tableau* final_tableau = plan.final_state_tableau();
     if (final_tableau == nullptr) {
         throw std::invalid_argument(
             "get_statevector() requires pure-state unitary evolution: measurements, feedback, "

--- a/src/clifft/frontend/frontend.cc
+++ b/src/clifft/frontend/frontend.cc
@@ -2,9 +2,6 @@
 
 #include "clifft/tableau/tableau.h"
 #include "clifft/util/numeric.h"
-#include "clifft/util/stim_mask.h"
-
-#include "stim.h"
 
 #include <array>
 #include <cmath>
@@ -399,21 +396,6 @@ PauliString build_pauli_string(const std::vector<Target>& targets, uint32_t num_
     }
     observable.set_sign(false);
     return observable;
-}
-
-stim::Tableau<kStimWidth> to_stim_tableau(const Tableau& source) {
-    stim::Tableau<kStimWidth> result(source.num_qubits());
-    for (uint32_t q = 0; q < source.num_qubits(); ++q) {
-        const PauliStringView x = source.x_output(q);
-        const PauliStringView z = source.z_output(q);
-        mask_view_to_stim(x.x(), source.num_qubits(), result.xs[q].xs);
-        mask_view_to_stim(x.z(), source.num_qubits(), result.xs[q].zs);
-        mask_view_to_stim(z.x(), source.num_qubits(), result.zs[q].xs);
-        mask_view_to_stim(z.z(), source.num_qubits(), result.zs[q].zs);
-        result.xs[q].sign = x.sign();
-        result.zs[q].sign = z.sign();
-    }
-    return result;
 }
 
 /// Conservative upper bound on the number of noise channel masks the
@@ -1290,7 +1272,7 @@ HirModule trace(const Circuit& circuit, const InstrumentTraceOptions* instrument
     }
 
     hir.num_hidden_measurements = hidden_meas_idx - circuit.num_measurements;
-    hir.final_tableau = to_stim_tableau(inverse.inverse());
+    hir.final_tableau = inverse.inverse();
 
     return hir;
 }

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -11,12 +11,10 @@
 // HeisenbergOp by an opaque PauliMaskHandle. Variable-sized payloads (noise
 // channels, detector/observable target lists) live in side-tables on HirModule.
 
+#include "clifft/tableau/tableau.h"
 #include "clifft/util/config.h"
 #include "clifft/util/mask_view.h"
 #include "clifft/util/pauli_arena.h"
-#include "clifft/util/stim_mask.h"
-
-#include "stim.h"
 
 #include <algorithm>
 #include <cassert>
@@ -462,7 +460,7 @@ struct HirModule {
     /// invalidated the map for that op.
     std::vector<std::vector<uint32_t>> source_map;
 
-    std::optional<stim::Tableau<kStimWidth>> final_tableau;
+    std::optional<Tableau> final_tableau;
 
     // Hidden measurement slot trace() assigned to the requested node's
     // reset (set when InstrumentTraceOptions::forced_traceout_node names a

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -74,74 +74,20 @@ inline void conjugate_pauli_by_S(MaskView x_p, MaskView z_p, bool sign_p, Mutabl
 
 namespace internal {
 
-void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v, bool sign_v,
-                        bool is_dagger) {
-    // Map P_virt forward through U_C to get P_phys in O(n^2), then
-    // conjugate all physical rows by P_phys in O(n^2).
-    const size_t words = std::min<size_t>((tab.num_qubits + 63) / 64, x_v.num_words());
-
-    stim::PauliString<kStimWidth> p_virt(tab.num_qubits);
-    for (size_t w = 0; w < words; ++w) {
-        p_virt.xs.u64[w] = x_v.words[w];
-        p_virt.zs.u64[w] = z_v.words[w];
-    }
-    p_virt.sign = sign_v;
-
-    stim::PauliString<kStimWidth> p_phys = tab(p_virt);
-
-    std::vector<uint64_t> px_phys(words, 0);
-    std::vector<uint64_t> pz_phys(words, 0);
-    for (size_t w = 0; w < words; ++w) {
-        px_phys[w] = p_phys.xs.u64[w];
-        pz_phys[w] = p_phys.zs.u64[w];
-    }
-    bool psign_phys = p_phys.sign;
-    MaskView px_view{std::span<const uint64_t>(px_phys)};
-    MaskView pz_view{std::span<const uint64_t>(pz_phys)};
-
-    std::vector<uint64_t> q_x(words, 0);
-    std::vector<uint64_t> q_z(words, 0);
-    MutableMaskView qx_view{std::span<uint64_t>(q_x)};
-    MutableMaskView qz_view{std::span<uint64_t>(q_z)};
-
-    // Tableau generators: S_P X_q S_P^dag, so pass !is_dagger
-    for (size_t q = 0; q < tab.num_qubits; ++q) {
-        auto apply_to_ps = [&](stim::PauliStringRef<kStimWidth> row) {
-            for (size_t w = 0; w < words; ++w) {
-                q_x[w] = row.xs.u64[w];
-                q_z[w] = row.zs.u64[w];
-            }
-            bool q_sign = row.sign;
-
-            conjugate_pauli_by_S(px_view, pz_view, psign_phys, qx_view, qz_view, q_sign,
-                                 !is_dagger);
-
-            for (size_t w = 0; w < words; ++w) {
-                row.xs.u64[w] = q_x[w];
-                row.zs.u64[w] = q_z[w];
-            }
-            row.sign = q_sign;
-        };
-
-        apply_to_ps(tab.xs[q]);
-        apply_to_ps(tab.zs[q]);
-    }
+void apply_s_to_tableau(Tableau& tab, MaskView x_v, MaskView z_v, bool sign_v, bool is_dagger) {
+    PauliString axis(tab.num_qubits());
+    axis.mut_x().xor_with(x_v);
+    axis.mut_z().xor_with(z_v);
+    axis.set_sign(sign_v);
+    tab.prepend_pauli_rotation(axis.view(), is_dagger);
 }
 
-void apply_pauli_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v) {
-    assert(x_v.num_words() == z_v.num_words());
-    const size_t tableau_words = (tab.num_qubits + 63) / 64;
-    assert(tableau_words <= x_v.num_words());
-    const size_t words = std::min({tableau_words, static_cast<size_t>(x_v.num_words()),
-                                   static_cast<size_t>(z_v.num_words())});
-    for (size_t w = 0; w < words; ++w) {
-        uint64_t valid_bits = UINT64_MAX;
-        if (w + 1 == tableau_words && tab.num_qubits % 64 != 0) {
-            valid_bits = (uint64_t{1} << (tab.num_qubits % 64)) - 1;
-        }
-        tab.zs.signs.u64[w] ^= x_v.words[w] & valid_bits;
-        tab.xs.signs.u64[w] ^= z_v.words[w] & valid_bits;
-    }
+void apply_pauli_to_tableau(Tableau& tab, MaskView x_v, MaskView z_v) {
+    PauliString axis(tab.num_qubits());
+    axis.mut_x().xor_with(x_v);
+    axis.mut_z().xor_with(z_v);
+    axis.set_sign(false);
+    tab.prepend_pauli(axis.view());
 }
 
 }  // namespace internal

--- a/src/clifft/optimizer/peephole.h
+++ b/src/clifft/optimizer/peephole.h
@@ -2,7 +2,6 @@
 
 #include "clifft/optimizer/hir_pass.h"
 #include "clifft/util/mask_view.h"
-#include "clifft/util/stim_mask.h"
 
 #include <cstddef>
 
@@ -12,11 +11,10 @@ namespace internal {
 
 /// Compose U_C' = U_C * S_P into `tab` for the S/S_dag rotation on the
 /// virtual Pauli (x_v, z_v, sign_v), updating only the symplectic action.
-void apply_s_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v, bool sign_v,
-                        bool is_dagger);
+void apply_s_to_tableau(Tableau& tab, MaskView x_v, MaskView z_v, bool sign_v, bool is_dagger);
 
 /// Compose U_C' = U_C * P into `tab` for the virtual Pauli (x_v, z_v).
-void apply_pauli_to_tableau(stim::Tableau<kStimWidth>& tab, MaskView x_v, MaskView z_v);
+void apply_pauli_to_tableau(Tableau& tab, MaskView x_v, MaskView z_v);
 
 }  // namespace internal
 

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -75,7 +75,7 @@ class ExecutablePlan {
     [[nodiscard]] bool supports_final_state_queries() const { return final_tableau_.has_value(); }
     // Exact final-state queries need the coordinate-to-physical map, but
     // ordinary execution must not depend on or mutate it.
-    [[nodiscard]] const stim::Tableau<kStimWidth>* final_state_tableau() const noexcept {
+    [[nodiscard]] const Tableau* final_state_tableau() const noexcept {
         return final_tableau_ ? &*final_tableau_ : nullptr;
     }
     [[nodiscard]] uint32_t num_instrument_sites() const {
@@ -331,7 +331,7 @@ class ExecutablePlan {
     ExecutorBackend backend_ = ExecutorBackend::Scalar;
     uint32_t num_readout_noise_sites_ = 0;
     uint32_t initial_noise_end_ = 0;
-    std::optional<stim::Tableau<kStimWidth>> final_tableau_;
+    std::optional<Tableau> final_tableau_;
 
     // Affine register initialization and reverse symbol dependencies.
 

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -379,7 +379,7 @@ void SamplingPlan::validate() const {
     if (total_records > std::numeric_limits<uint32_t>::max()) {
         invalid_plan("record count exceeds uint32 range");
     }
-    if (final_tableau.has_value() && final_tableau->num_qubits != num_qubits) {
+    if (final_tableau.has_value() && final_tableau->num_qubits() != num_qubits) {
         invalid_plan("final tableau width does not match the qubit count");
     }
     if (source_map.has_value() && !source_map->is_valid_for(actions.size())) {

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -19,8 +19,8 @@
 // SymFT: Universal Fault-Tolerant Quantum Circuit Simulation via Symbolic
 // Clifford--Pauli Frames and Stabilizer Coordinates, arXiv:2607.28600.
 
+#include "clifft/tableau/tableau.h"
 #include "clifft/util/numeric.h"
-#include "clifft/util/stim_mask.h"
 
 #include <array>
 #include <cstdint>
@@ -345,7 +345,7 @@ struct SamplingPlan {
     // Present only for pure-state plans eligible for exact final-state
     // queries. It maps the final stabilizer coordinates used by the action
     // stream into physical qubits and is never read by ordinary dispatch.
-    std::optional<stim::Tableau<kStimWidth>> final_tableau;
+    std::optional<Tableau> final_tableau;
 
     std::vector<SymbolInfo> symbols;
     std::vector<PresampledNoiseSite> presampled_noise_sites;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -3,9 +3,6 @@
 #include "clifft/sampling/planner_frame.h"
 #include "clifft/util/hir_introspection.h"
 #include "clifft/util/numeric.h"
-#include "clifft/util/stim_mask.h"
-
-#include "stim.h"
 
 #include <algorithm>
 #include <cmath>
@@ -29,31 +26,33 @@ using internal::SymbolicPauliFrame;
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
-    mask_view_to_stim(hir.destab_mask(op), hir.num_qubits, result.xs);
-    mask_view_to_stim(hir.stab_mask(op), hir.num_qubits, result.zs);
+    result.mut_x().xor_with(hir.destab_mask(op));
+    result.mut_z().xor_with(hir.stab_mask(op));
+    result.set_sign(false);
     return result;
 }
 
 Pauli noise_pauli_from_hir(const HirModule& hir, PauliMaskHandle handle) {
     Pauli result(hir.num_qubits);
     const PauliMaskView mask = hir.noise_channel_masks.at(handle);
-    mask_view_to_stim(mask.x(), hir.num_qubits, result.xs);
-    mask_view_to_stim(mask.z(), hir.num_qubits, result.zs);
+    result.mut_x().xor_with(mask.x());
+    result.mut_z().xor_with(mask.z());
+    result.set_sign(false);
     return result;
 }
 
 Pauli pauli_from_mask(const HirModule& hir, PauliMaskHandle handle) {
     Pauli result(hir.num_qubits);
     const PauliMaskView mask = hir.pauli_masks.at(handle);
-    mask_view_to_stim(mask.x(), hir.num_qubits, result.xs);
-    mask_view_to_stim(mask.z(), hir.num_qubits, result.zs);
-    result.sign = false;
+    result.mut_x().xor_with(mask.x());
+    result.mut_z().xor_with(mask.z());
+    result.set_sign(false);
     return result;
 }
 
 Pauli single_x(uint32_t num_qubits, uint32_t q) {
     Pauli result(num_qubits);
-    result.xs[q] = true;
+    result.set_pauli(q, true, false);
     return result;
 }
 
@@ -67,14 +66,14 @@ ResolvedPauli resolve_pauli(const Pauli& initial_body, const AffineBool& initial
     AffineBool sign = initial_sign;
     sign ^= symbolic_frame.sign_for(initial_body);
     Pauli body = coordinates.to_current(initial_body);
-    sign ^= static_cast<bool>(body.sign);
-    body.sign = false;
+    sign ^= body.sign();
+    body.set_sign(false);
     return ResolvedPauli{std::move(body), std::move(sign)};
 }
 
 std::optional<uint32_t> first_x_at_or_above(const Pauli& pauli, uint32_t begin) {
-    for (uint32_t q = begin; q < pauli.num_qubits; ++q) {
-        if (pauli.xs[q]) {
+    for (uint32_t q = begin; q < pauli.num_qubits(); ++q) {
+        if (pauli.x().bit_get(q)) {
             return q;
         }
     }
@@ -83,7 +82,7 @@ std::optional<uint32_t> first_x_at_or_above(const Pauli& pauli, uint32_t begin) 
 
 std::optional<uint32_t> last_x_below(const Pauli& pauli, uint32_t end) {
     for (uint32_t q = end; q > 0; --q) {
-        if (pauli.xs[q - 1]) {
+        if (pauli.x().bit_get(q - 1)) {
             return q - 1;
         }
     }
@@ -92,7 +91,7 @@ std::optional<uint32_t> last_x_below(const Pauli& pauli, uint32_t end) {
 
 std::optional<uint32_t> first_z_below(const Pauli& pauli, uint32_t end) {
     for (uint32_t q = 0; q < end; ++q) {
-        if (pauli.zs[q]) {
+        if (pauli.z().bit_get(q)) {
             return q;
         }
     }
@@ -102,8 +101,8 @@ std::optional<uint32_t> first_z_below(const Pauli& pauli, uint32_t end) {
 ActivePauli active_projection(const Pauli& pauli, uint32_t active_width) {
     ActivePauli result;
     for (uint32_t q = 0; q < active_width; ++q) {
-        result.x |= static_cast<uint64_t>(pauli.xs[q]) << q;
-        result.z |= static_cast<uint64_t>(pauli.zs[q]) << q;
+        result.x |= static_cast<uint64_t>(pauli.x().bit_get(q)) << q;
+        result.z |= static_cast<uint64_t>(pauli.z().bit_get(q)) << q;
     }
     return result;
 }
@@ -280,7 +279,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
         define_symbol(plan, branch, SymbolKind::Branch, action_index);
         Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, *dormant_pivot));
-        correction.sign = false;
+        correction.set_sign(false);
         symbolic_frame.apply(correction, AffineBool::symbol(branch));
         const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
         append_action(plan,
@@ -306,17 +305,17 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
         throw std::logic_error("sampling planner could not select an active measurement pivot");
     }
 
-    Pauli active_body(resolved.body.num_qubits);
+    Pauli active_body(resolved.body.num_qubits());
     for (uint32_t q = 0; q < active_width; ++q) {
-        active_body.xs[q] = resolved.body.xs[q];
-        active_body.zs[q] = resolved.body.zs[q];
+        active_body.set_pauli(q, resolved.body.x().bit_get(q), resolved.body.z().bit_get(q));
     }
+    active_body.set_sign(false);
     coordinates.measure_active(active_body, active_width, *pivot);
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     define_symbol(plan, branch, SymbolKind::Branch, action_index);
     Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, active_width - 1));
-    correction.sign = false;
+    correction.set_sign(false);
     symbolic_frame.apply(correction, AffineBool::symbol(branch));
     const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
     append_action(plan,

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -4,7 +4,6 @@
 #include <bit>
 #include <cassert>
 #include <limits>
-#include <numeric>
 #include <stdexcept>
 #include <utility>
 
@@ -12,21 +11,15 @@ namespace clifft::sampling::internal {
 
 namespace {
 
-std::vector<size_t> identity_indices(size_t size) {
-    std::vector<size_t> result(size);
-    std::iota(result.begin(), result.end(), size_t{0});
-    return result;
-}
-
 PlannerPauli single_x(uint32_t num_qubits, uint32_t q) {
     PlannerPauli result(num_qubits);
-    result.xs[q] = true;
+    result.set_pauli(q, true, false);
     return result;
 }
 
 PlannerPauli single_z(uint32_t num_qubits, uint32_t q) {
     PlannerPauli result(num_qubits);
-    result.zs[q] = true;
+    result.set_pauli(q, false, true);
     return result;
 }
 
@@ -35,49 +28,23 @@ PlannerPauli positive_body_xor(const PlannerPauli& left, const PlannerPauli& rig
     // are disjoint. Overlapping supports could contribute a phase that this
     // body-only helper intentionally does not compute.
     PlannerPauli result(left);
-    result.xs ^= right.xs;
-    result.zs ^= right.zs;
-    result.sign = false;
+    result.mut_x().xor_with(right.x());
+    result.mut_z().xor_with(right.z());
+    result.set_sign(false);
     return result;
 }
 
 bool anticommutes(const PlannerPauli& left, const PlannerPauli& right) {
-    return !left.ref().commutes(right.ref());
+    return !left.view().commutes(right.view());
 }
 
 bool has_x_below(const PlannerPauli& pauli, uint32_t end) {
     for (uint32_t q = 0; q < end; ++q) {
-        if (pauli.xs[q]) {
+        if (pauli.x().bit_get(q)) {
             return true;
         }
     }
     return false;
-}
-
-void evaluate_generator_into(stim::PauliStringRef<kStimWidth> destination,
-                             const stim::PauliStringRef<kStimWidth>& generator,
-                             const PlannerTableau& map) {
-    // Planner basis changes are sparse. Writing directly into tableau-owned
-    // rows avoids the owning Pauli allocation that Stim's generic composition
-    // performs for every X and Z generator.
-    destination.xs.clear();
-    destination.zs.clear();
-    destination.sign = generator.sign;
-    generator.for_each_active_pauli([&](size_t q) {
-        const bool x = generator.xs[q];
-        const bool z = generator.zs[q];
-        if (x && z) {
-            uint8_t log_i = 1;
-            log_i += destination.inplace_right_mul_returning_log_i_scalar(map.xs[q]);
-            log_i += destination.inplace_right_mul_returning_log_i_scalar(map.zs[q]);
-            assert((log_i & 1) == 0);
-            destination.sign ^= (log_i & 2) != 0;
-        } else if (x) {
-            destination *= map.xs[q];
-        } else {
-            destination *= map.zs[q];
-        }
-    });
 }
 
 size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
@@ -87,56 +54,56 @@ size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
 
 }  // namespace
 
-CoordinateFrame::CoordinateFrame(uint32_t num_qubits)
-    : current_to_initial_(num_qubits), indices_(identity_indices(num_qubits)) {}
+CoordinateFrame::CoordinateFrame(uint32_t num_qubits) : current_to_initial_(num_qubits) {}
 
 PlannerPauli CoordinateFrame::to_current(const PlannerPauli& initial) {
     if (initial_to_current_.has_value()) {
-        return initial_to_current_->scatter_eval(initial.ref(), indices_);
+        return initial_to_current_->apply(initial.view());
     }
 
     // Inverting an n-qubit tableau evaluates 2n generator rows. Use the same
     // number of direct lookups as a conservative structural break-even before
     // materializing the inverse for a lookup-heavy basis interval.
     const uint64_t direct_lookup_limit =
-        std::max<uint64_t>(1, 2 * static_cast<uint64_t>(initial.num_qubits));
+        std::max<uint64_t>(1, 2 * static_cast<uint64_t>(initial.num_qubits()));
     if (direct_reverse_lookups_ >= direct_lookup_limit) {
         initial_to_current_.emplace(current_to_initial_.inverse());
-        return initial_to_current_->scatter_eval(initial.ref(), indices_);
+        return initial_to_current_->apply(initial.view());
     }
     ++direct_reverse_lookups_;
 
-    PlannerPauli current(initial.num_qubits);
-    for (uint32_t q = 0; q < initial.num_qubits; ++q) {
+    PlannerPauli current(initial.num_qubits());
+    for (uint32_t q = 0; q < initial.num_qubits(); ++q) {
         // Coordinates in a symplectic basis are selected by commuting with its
         // opposite generator: Z generators select X and vice versa.
-        current.xs[q] = !initial.ref().commutes(current_to_initial_.zs[q]);
-        current.zs[q] = !initial.ref().commutes(current_to_initial_.xs[q]);
+        current.set_pauli(q, !initial.view().commutes(current_to_initial_.z_output(q)),
+                          !initial.view().commutes(current_to_initial_.x_output(q)));
     }
+    current.set_sign(false);
 
     // Generator signs affect the sign, but not the symplectic coordinates. A
     // forward evaluation recovers that phase without materializing an inverse.
-    const PlannerPauli round_trip = current_to_initial_.scatter_eval(current.ref(), indices_);
-    assert(round_trip.xs == initial.xs);
-    assert(round_trip.zs == initial.zs);
-    current.sign = static_cast<bool>(round_trip.sign) ^ static_cast<bool>(initial.sign);
+    const PlannerPauli round_trip = current_to_initial_.apply(current.view());
+    assert(round_trip.x().words == initial.x().words);
+    assert(round_trip.z().words == initial.z().words);
+    current.set_sign(round_trip.sign() ^ initial.sign());
     return current;
 }
 
 PlannerPauli CoordinateFrame::to_initial(const PlannerPauli& current) const {
-    return current_to_initial_.scatter_eval(current.ref(), indices_);
+    return current_to_initial_.apply(current.view());
 }
 
 void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordinates) {
     invalidate_reverse_cache();
     PlannerTableau previous(std::move(current_to_initial_));
-    assert(new_basis_in_old_coordinates.num_qubits == previous.num_qubits);
-    current_to_initial_ = PlannerTableau(new_basis_in_old_coordinates.num_qubits);
-    for (size_t q = 0; q < new_basis_in_old_coordinates.num_qubits; ++q) {
-        evaluate_generator_into(current_to_initial_.xs[q], new_basis_in_old_coordinates.xs[q],
-                                previous);
-        evaluate_generator_into(current_to_initial_.zs[q], new_basis_in_old_coordinates.zs[q],
-                                previous);
+    assert(new_basis_in_old_coordinates.num_qubits() == previous.num_qubits());
+    current_to_initial_ = PlannerTableau(new_basis_in_old_coordinates.num_qubits());
+    for (uint32_t q = 0; q < new_basis_in_old_coordinates.num_qubits(); ++q) {
+        const PlannerPauli x = previous.apply(new_basis_in_old_coordinates.x_output(q));
+        const PlannerPauli z = previous.apply(new_basis_in_old_coordinates.z_output(q));
+        current_to_initial_.set_x_output(q, x.view());
+        current_to_initial_.set_z_output(q, z.view());
     }
     assert(current_to_initial_.satisfies_invariants());
 }
@@ -146,12 +113,12 @@ void CoordinateFrame::change_basis(const PlannerTableau& new_basis_in_old_coordi
 // tests validate them instead of rescanning the tableau after every event.
 void CoordinateFrame::promote_dormant(const PlannerPauli& promoted, uint32_t active_width,
                                       uint32_t dormant_pivot) {
-    const uint32_t n = static_cast<uint32_t>(current_to_initial_.num_qubits);
-    assert(promoted.num_qubits == n && active_width < n && dormant_pivot >= active_width &&
+    const uint32_t n = current_to_initial_.num_qubits();
+    assert(promoted.num_qubits() == n && active_width < n && dormant_pivot >= active_width &&
            dormant_pivot < n);
 
     PlannerPauli mapped_promoted = to_initial(promoted);
-    PlannerPauli pivot_stabilizer(current_to_initial_.zs[dormant_pivot]);
+    PlannerPauli pivot_stabilizer(current_to_initial_.z_output(dormant_pivot));
     invalidate_reverse_cache();
 
     // The new promoted pair replaces the selected dormant pair. Every other
@@ -162,54 +129,62 @@ void CoordinateFrame::promote_dormant(const PlannerPauli& promoted, uint32_t act
         if (q == dormant_pivot) {
             continue;
         }
-        if (promoted.zs[q]) {
-            current_to_initial_.xs[q] *= pivot_stabilizer;
+        if (promoted.z().bit_get(q)) {
+            PlannerPauli row(current_to_initial_.x_output(q));
+            row.right_multiply(pivot_stabilizer.view());
+            current_to_initial_.set_x_output(q, row.view());
         }
-        if (promoted.xs[q]) {
-            current_to_initial_.zs[q] *= pivot_stabilizer;
+        if (promoted.x().bit_get(q)) {
+            PlannerPauli row(current_to_initial_.z_output(q));
+            row.right_multiply(pivot_stabilizer.view());
+            current_to_initial_.set_z_output(q, row.view());
         }
     }
 
     for (uint32_t q = dormant_pivot; q > active_width; --q) {
-        current_to_initial_.xs[q] = current_to_initial_.xs[q - 1];
-        current_to_initial_.zs[q] = current_to_initial_.zs[q - 1];
+        current_to_initial_.set_x_output(q, current_to_initial_.x_output(q - 1));
+        current_to_initial_.set_z_output(q, current_to_initial_.z_output(q - 1));
     }
-    current_to_initial_.xs[active_width] = mapped_promoted;
-    current_to_initial_.zs[active_width] = pivot_stabilizer;
+    current_to_initial_.set_x_output(active_width, mapped_promoted.view());
+    current_to_initial_.set_z_output(active_width, pivot_stabilizer.view());
 }
 
 void CoordinateFrame::measure_dormant(const PlannerPauli& measured, uint32_t dormant_pivot) {
-    const uint32_t n = static_cast<uint32_t>(current_to_initial_.num_qubits);
-    assert(measured.num_qubits == n && dormant_pivot < n);
+    const uint32_t n = current_to_initial_.num_qubits();
+    assert(measured.num_qubits() == n && dormant_pivot < n);
 
     PlannerPauli mapped_measured = to_initial(measured);
-    PlannerPauli pivot_stabilizer(current_to_initial_.zs[dormant_pivot]);
+    PlannerPauli pivot_stabilizer(current_to_initial_.z_output(dormant_pivot));
     invalidate_reverse_cache();
 
     for (uint32_t q = 0; q < n; ++q) {
         if (q == dormant_pivot) {
             continue;
         }
-        if (measured.zs[q]) {
-            current_to_initial_.xs[q] *= pivot_stabilizer;
+        if (measured.z().bit_get(q)) {
+            PlannerPauli row(current_to_initial_.x_output(q));
+            row.right_multiply(pivot_stabilizer.view());
+            current_to_initial_.set_x_output(q, row.view());
         }
-        if (measured.xs[q]) {
-            current_to_initial_.zs[q] *= pivot_stabilizer;
+        if (measured.x().bit_get(q)) {
+            PlannerPauli row(current_to_initial_.z_output(q));
+            row.right_multiply(pivot_stabilizer.view());
+            current_to_initial_.set_z_output(q, row.view());
         }
     }
-    current_to_initial_.xs[dormant_pivot] = pivot_stabilizer;
-    current_to_initial_.zs[dormant_pivot] = mapped_measured;
+    current_to_initial_.set_x_output(dormant_pivot, pivot_stabilizer.view());
+    current_to_initial_.set_z_output(dormant_pivot, mapped_measured.view());
 }
 
 void CoordinateFrame::measure_active(const PlannerPauli& measured, uint32_t active_width,
                                      uint32_t pivot) {
-    assert(measured.num_qubits == current_to_initial_.num_qubits && active_width > 0 &&
-           active_width <= current_to_initial_.num_qubits && pivot < active_width);
+    assert(measured.num_qubits() == current_to_initial_.num_qubits() && active_width > 0 &&
+           active_width <= current_to_initial_.num_qubits() && pivot < active_width);
 
     const bool diagonal = !has_x_below(measured, active_width);
     PlannerPauli mapped_measured = to_initial(measured);
-    PlannerPauli pivot_conjugate(diagonal ? current_to_initial_.xs[pivot]
-                                          : current_to_initial_.zs[pivot]);
+    PlannerPauli pivot_conjugate(diagonal ? current_to_initial_.x_output(pivot)
+                                          : current_to_initial_.z_output(pivot));
     invalidate_reverse_cache();
 
     for (uint32_t q = 0; q < active_width; ++q) {
@@ -217,25 +192,31 @@ void CoordinateFrame::measure_active(const PlannerPauli& measured, uint32_t acti
             continue;
         }
         if (diagonal) {
-            if (measured.zs[q]) {
-                current_to_initial_.xs[q] *= pivot_conjugate;
+            if (measured.z().bit_get(q)) {
+                PlannerPauli row(current_to_initial_.x_output(q));
+                row.right_multiply(pivot_conjugate.view());
+                current_to_initial_.set_x_output(q, row.view());
             }
         } else {
-            if (measured.xs[q]) {
-                current_to_initial_.zs[q] *= pivot_conjugate;
+            if (measured.x().bit_get(q)) {
+                PlannerPauli row(current_to_initial_.z_output(q));
+                row.right_multiply(pivot_conjugate.view());
+                current_to_initial_.set_z_output(q, row.view());
             }
-            if (measured.zs[q]) {
-                current_to_initial_.xs[q] *= pivot_conjugate;
+            if (measured.z().bit_get(q)) {
+                PlannerPauli row(current_to_initial_.x_output(q));
+                row.right_multiply(pivot_conjugate.view());
+                current_to_initial_.set_x_output(q, row.view());
             }
         }
     }
 
     for (uint32_t q = pivot; q + 1 < active_width; ++q) {
-        current_to_initial_.xs[q] = current_to_initial_.xs[q + 1];
-        current_to_initial_.zs[q] = current_to_initial_.zs[q + 1];
+        current_to_initial_.set_x_output(q, current_to_initial_.x_output(q + 1));
+        current_to_initial_.set_z_output(q, current_to_initial_.z_output(q + 1));
     }
-    current_to_initial_.xs[active_width - 1] = pivot_conjugate;
-    current_to_initial_.zs[active_width - 1] = mapped_measured;
+    current_to_initial_.set_x_output(active_width - 1, pivot_conjugate.view());
+    current_to_initial_.set_z_output(active_width - 1, mapped_measured.view());
 }
 
 void CoordinateFrame::invalidate_reverse_cache() {
@@ -275,7 +256,7 @@ SymbolicPauliFrame::SymbolicPauliFrame(uint32_t num_qubits, uint32_t num_symbols
 }
 
 void SymbolicPauliFrame::apply(const PlannerPauli& correction, const AffineBool& condition) {
-    assert(correction.num_qubits == num_qubits_ &&
+    assert(correction.num_qubits() == num_qubits_ &&
            "symbolic Pauli correction width must match the planner frame");
 
     // Noise corrections are usually one- or two-qubit Paulis. Iterating their
@@ -284,8 +265,8 @@ void SymbolicPauliFrame::apply(const PlannerPauli& correction, const AffineBool&
     const uint32_t tail_bits = num_qubits_ % 64;
     const uint64_t last_word_mask = tail_bits == 0 ? ~uint64_t{0} : (uint64_t{1} << tail_bits) - 1;
     for (size_t word = 0; word < num_words; ++word) {
-        const uint64_t x_bits = correction.xs.u64[word];
-        const uint64_t z_bits = correction.zs.u64[word];
+        const uint64_t x_bits = correction.x().words[word];
+        const uint64_t z_bits = correction.z().words[word];
         uint64_t support = x_bits | z_bits;
         if (word + 1 == num_words) {
             support &= last_word_mask;
@@ -306,16 +287,16 @@ void SymbolicPauliFrame::apply(const PlannerPauli& correction, const AffineBool&
 }
 
 AffineBool SymbolicPauliFrame::sign_for(const PlannerPauli& observable) {
-    assert(observable.num_qubits == num_qubits_ &&
+    assert(observable.num_qubits() == num_qubits_ &&
            "symbolic Pauli observable width must match the planner frame");
     std::ranges::fill(scratch_, uint64_t{0});
     bool constant = false;
     for (uint32_t q = 0; q < num_qubits_; ++q) {
-        if (observable.xs[q]) {
+        if (observable.x().bit_get(q)) {
             xor_row(scratch_, z_row(q));
             constant ^= z_constants_[q] != 0;
         }
-        if (observable.zs[q]) {
+        if (observable.z().bit_get(q)) {
             xor_row(scratch_, x_row(q));
             constant ^= x_constants_[q] != 0;
         }
@@ -385,7 +366,7 @@ void SymbolicPauliFrame::xor_condition(std::span<uint64_t> row, uint8_t& constan
 
 PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted, uint32_t active_width,
                                        uint32_t dormant_pivot) {
-    const uint32_t n = static_cast<uint32_t>(promoted.num_qubits);
+    const uint32_t n = promoted.num_qubits();
     PlannerTableau frame(n);
     const PlannerPauli old_stabilizer = single_z(n, dormant_pivot);
 
@@ -406,12 +387,12 @@ PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted, uint32_t ac
         if (anticommutes(z, promoted)) {
             z = positive_body_xor(z, old_stabilizer);
         }
-        frame.xs[q] = x;
-        frame.zs[q] = z;
+        frame.set_x_output(q, x.view());
+        frame.set_z_output(q, z.view());
     }
 
-    frame.xs[active_width] = promoted;
-    frame.zs[active_width] = old_stabilizer;
+    frame.set_x_output(active_width, promoted.view());
+    frame.set_z_output(active_width, old_stabilizer.view());
 
     uint32_t new_q = active_width + 1;
     for (uint32_t old_q = active_width; old_q < n; ++old_q) {
@@ -426,8 +407,8 @@ PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted, uint32_t ac
         if (anticommutes(z, promoted)) {
             z = positive_body_xor(z, old_stabilizer);
         }
-        frame.xs[new_q] = x;
-        frame.zs[new_q] = z;
+        frame.set_x_output(new_q, x.view());
+        frame.set_z_output(new_q, z.view());
         ++new_q;
     }
 
@@ -438,7 +419,7 @@ PlannerTableau dormant_promotion_frame(const PlannerPauli& promoted, uint32_t ac
 }
 
 PlannerTableau dormant_measurement_frame(const PlannerPauli& measured, uint32_t dormant_pivot) {
-    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
+    const uint32_t n = measured.num_qubits();
     PlannerTableau frame(n);
     const PlannerPauli old_stabilizer = single_z(n, dormant_pivot);
 
@@ -460,12 +441,12 @@ PlannerTableau dormant_measurement_frame(const PlannerPauli& measured, uint32_t 
         if (anticommutes(z, measured)) {
             z = positive_body_xor(z, old_stabilizer);
         }
-        frame.xs[q] = x;
-        frame.zs[q] = z;
+        frame.set_x_output(q, x.view());
+        frame.set_z_output(q, z.view());
     }
 
-    frame.xs[dormant_pivot] = old_stabilizer;
-    frame.zs[dormant_pivot] = measured;
+    frame.set_x_output(dormant_pivot, old_stabilizer.view());
+    frame.set_z_output(dormant_pivot, measured.view());
 
     if (!frame.satisfies_invariants()) {
         throw std::logic_error("sampling planner produced an invalid dormant measurement frame");
@@ -475,7 +456,7 @@ PlannerTableau dormant_measurement_frame(const PlannerPauli& measured, uint32_t 
 
 PlannerTableau active_measurement_frame(const PlannerPauli& measured, uint32_t active_width,
                                         uint32_t pivot) {
-    const uint32_t n = static_cast<uint32_t>(measured.num_qubits);
+    const uint32_t n = measured.num_qubits();
     PlannerTableau frame(n);
     const bool diagonal = !has_x_below(measured, active_width);
     const PlannerPauli pivot_x = single_x(n, pivot);
@@ -488,8 +469,8 @@ PlannerTableau active_measurement_frame(const PlannerPauli& measured, uint32_t a
     // Moving the measured Pauli to the last active Z generator gives the
     // direct measurement kernel one coordinate to remove. The cumulative
     // frame maps later operations into the remaining packed coordinates.
-    frame.zs[active_width - 1] = measured;
-    frame.xs[active_width - 1] = diagonal ? pivot_x : pivot_z;
+    frame.set_z_output(active_width - 1, measured.view());
+    frame.set_x_output(active_width - 1, diagonal ? pivot_x.view() : pivot_z.view());
 
     uint32_t new_q = 0;
     for (uint32_t old_q = 0; old_q < active_width; ++old_q) {
@@ -499,19 +480,19 @@ PlannerTableau active_measurement_frame(const PlannerPauli& measured, uint32_t a
         PlannerPauli x = single_x(n, old_q);
         PlannerPauli z = single_z(n, old_q);
         if (diagonal) {
-            if (measured.zs[old_q]) {
+            if (measured.z().bit_get(old_q)) {
                 x = positive_body_xor(x, pivot_x);
             }
         } else {
-            if (measured.xs[old_q]) {
+            if (measured.x().bit_get(old_q)) {
                 z = positive_body_xor(z, pivot_z);
             }
-            if (measured.zs[old_q]) {
+            if (measured.z().bit_get(old_q)) {
                 x = positive_body_xor(x, pivot_z);
             }
         }
-        frame.xs[new_q] = x;
-        frame.zs[new_q] = z;
+        frame.set_x_output(new_q, x.view());
+        frame.set_z_output(new_q, z.view());
         ++new_q;
     }
 

--- a/src/clifft/sampling/planner_frame.h
+++ b/src/clifft/sampling/planner_frame.h
@@ -2,8 +2,6 @@
 
 #include "clifft/sampling/plan.h"
 
-#include "stim.h"
-
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -12,8 +10,8 @@
 
 namespace clifft::sampling::internal {
 
-using PlannerPauli = stim::PauliString<kStimWidth>;
-using PlannerTableau = stim::Tableau<kStimWidth>;
+using PlannerPauli = PauliString;
+using PlannerTableau = Tableau;
 
 // Tracks the cumulative relationship between physical HIR coordinates and the
 // packed stabilizer coordinates selected while planning.
@@ -47,8 +45,6 @@ class CoordinateFrame {
     PlannerTableau current_to_initial_;
     std::optional<PlannerTableau> initial_to_current_;
     uint64_t direct_reverse_lookups_ = 0;
-    std::vector<size_t> indices_;
-
     void invalidate_reverse_cache();
 };
 

--- a/src/clifft/tableau/pauli_string.cc
+++ b/src/clifft/tableau/pauli_string.cc
@@ -48,6 +48,12 @@ bool PauliStringView::commutes(PauliStringView other) const {
 PauliString::PauliString(uint32_t num_qubits)
     : num_qubits_(num_qubits), x_((num_qubits + 63) / 64, 0), z_(x_.size(), 0) {}
 
+PauliString::PauliString(PauliStringView source) : PauliString(source.num_qubits()) {
+    mut_x().xor_with(source.x());
+    mut_z().xor_with(source.z());
+    set_phase(source.phase());
+}
+
 PauliString PauliString::from_text(std::string_view text) {
     if (text.empty() || (text.front() != '+' && text.front() != '-')) {
         throw std::invalid_argument("Pauli text must start with a sign");

--- a/src/clifft/tableau/pauli_string.h
+++ b/src/clifft/tableau/pauli_string.h
@@ -33,6 +33,7 @@ class PauliStringView {
 class PauliString {
   public:
     explicit PauliString(uint32_t num_qubits = 0);
+    explicit PauliString(PauliStringView source);
 
     [[nodiscard]] static PauliString from_text(std::string_view text);
 

--- a/src/clifft/tableau/tableau.cc
+++ b/src/clifft/tableau/tableau.cc
@@ -190,6 +190,31 @@ PauliStringView Tableau::z_output(uint32_t qubit) const {
     return row(row_index(true, qubit, num_qubits_));
 }
 
+void Tableau::set_x_output(uint32_t qubit, PauliStringView value) {
+    assert(qubit < num_qubits_);
+    set_row(row_index(false, qubit, num_qubits_), value);
+}
+
+void Tableau::set_z_output(uint32_t qubit, PauliStringView value) {
+    assert(qubit < num_qubits_);
+    set_row(row_index(true, qubit, num_qubits_), value);
+}
+
+bool Tableau::satisfies_invariants() const {
+    for (uint32_t q = 0; q < num_qubits_; ++q) {
+        if (!x_output(q).is_hermitian() || !z_output(q).is_hermitian()) {
+            return false;
+        }
+        for (uint32_t other = 0; other < num_qubits_; ++other) {
+            if (!x_output(q).commutes(x_output(other)) || !z_output(q).commutes(z_output(other)) ||
+                (x_output(q).commutes(z_output(other)) == (q == other))) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 PauliString Tableau::y_output(uint32_t qubit) const {
     PauliString input(num_qubits_);
     input.set_pauli(qubit, true, true);

--- a/src/clifft/tableau/tableau.h
+++ b/src/clifft/tableau/tableau.h
@@ -27,11 +27,21 @@ class Tableau {
     [[nodiscard]] PauliString apply(PauliStringView input) const;
     [[nodiscard]] Tableau then(const Tableau& next) const;
     [[nodiscard]] Tableau inverse() const;
+    [[nodiscard]] bool satisfies_invariants() const;
+
+    void set_x_output(uint32_t qubit, PauliStringView value);
+    void set_z_output(uint32_t qubit, PauliStringView value);
 
     void append_local(const Tableau& gate, std::span<const uint32_t> targets);
     void prepend_local(const Tableau& gate, std::span<const uint32_t> targets);
     void append_named_gate(GateType gate, std::span<const uint32_t> targets);
     void prepend_named_gate(GateType gate, std::span<const uint32_t> targets);
+    void append_named_gate(GateType gate, std::initializer_list<uint32_t> targets) {
+        append_named_gate(gate, std::span<const uint32_t>{targets.begin(), targets.size()});
+    }
+    void prepend_named_gate(GateType gate, std::initializer_list<uint32_t> targets) {
+        prepend_named_gate(gate, std::span<const uint32_t>{targets.begin(), targets.size()});
+    }
     void prepend_pauli(PauliStringView axis);
     void prepend_pauli_rotation(PauliStringView axis, bool dagger);
 

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -180,6 +180,21 @@ inline DenseMatrix dense_tableau_matrix(const stim::Tableau<kStimWidth>& tab) {
     return m;
 }
 
+inline DenseMatrix dense_tableau_matrix(const Tableau& tab) {
+    stim::Tableau<kStimWidth> oracle(tab.num_qubits());
+    for (uint32_t q = 0; q < tab.num_qubits(); ++q) {
+        const PauliStringView x = tab.x_output(q);
+        const PauliStringView z = tab.z_output(q);
+        mask_view_to_stim(x.x(), tab.num_qubits(), oracle.xs[q].xs);
+        mask_view_to_stim(x.z(), tab.num_qubits(), oracle.xs[q].zs);
+        mask_view_to_stim(z.x(), tab.num_qubits(), oracle.zs[q].xs);
+        mask_view_to_stim(z.z(), tab.num_qubits(), oracle.zs[q].zs);
+        oracle.xs[q].sign = x.sign();
+        oracle.zs[q].sign = z.sign();
+    }
+    return dense_tableau_matrix(oracle);
+}
+
 inline DenseMatrix dense_matmul(const DenseMatrix& a, const DenseMatrix& b, uint64_t dim) {
     DenseMatrix r(dim * dim, {0.0, 0.0});
     for (uint64_t i = 0; i < dim; ++i) {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -573,18 +573,18 @@ TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
 
 TEST_CASE("Sampling plan validates exact-query metadata") {
     SamplingPlan unitary = valid_rotation_plan();
-    unitary.final_tableau = stim::Tableau<clifft::kStimWidth>(1);
+    unitary.final_tableau = clifft::Tableau(1);
     REQUIRE_NOTHROW(unitary.validate());
     REQUIRE(unitary.inspect().find("final_state_queries=1") != std::string::npos);
 
     SECTION("tableau width") {
-        unitary.final_tableau = stim::Tableau<clifft::kStimWidth>(2);
+        unitary.final_tableau = clifft::Tableau(2);
         REQUIRE_THROWS_AS(unitary.validate(), std::invalid_argument);
     }
 
     SECTION("nonunitary action stream") {
         SamplingPlan measured = valid_dormant_measurement_plan();
-        measured.final_tableau = stim::Tableau<clifft::kStimWidth>(1);
+        measured.final_tableau = clifft::Tableau(1);
         REQUIRE_THROWS_AS(measured.validate(), std::invalid_argument);
     }
 }

--- a/tests/test_sampling_planner_frame.cc
+++ b/tests/test_sampling_planner_frame.cc
@@ -22,20 +22,18 @@ namespace {
 PlannerPauli signed_pauli(uint32_t num_qubits, uint32_t body, bool sign) {
     PlannerPauli result(num_qubits);
     for (uint32_t q = 0; q < num_qubits; ++q) {
-        result.xs[q] = (body >> q) & 1U;
-        result.zs[q] = (body >> (q + num_qubits)) & 1U;
+        result.set_pauli(q, (body >> q) & 1U, (body >> (q + num_qubits)) & 1U);
     }
-    result.sign = sign;
+    result.set_sign(sign);
     return result;
 }
 
 PlannerTableau nontrivial_basis(uint32_t num_qubits) {
     PlannerTableau result(num_qubits);
-    result.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
+    result.append_named_gate(clifft::GateType::H, {0});
     if (num_qubits > 1) {
-        result.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<clifft::kStimWidth>(), {1});
-        result.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(),
-                                      {0, num_qubits - 1});
+        result.append_named_gate(clifft::GateType::S, {1});
+        result.append_named_gate(clifft::GateType::CX, {0, num_qubits - 1});
     }
     return result;
 }
@@ -45,11 +43,11 @@ void require_same_coordinate_map(const CoordinateFrame& direct, const Coordinate
     for (uint32_t q = 0; q < num_qubits; ++q) {
         CAPTURE(q);
         PlannerPauli x(num_qubits);
-        x.xs[q] = true;
+        x.set_pauli(q, true, false);
         REQUIRE(direct.to_initial(x) == generic.to_initial(x));
 
         PlannerPauli z(num_qubits);
-        z.zs[q] = true;
+        z.set_pauli(q, false, true);
         REQUIRE(direct.to_initial(z) == generic.to_initial(z));
     }
 }
@@ -57,12 +55,12 @@ void require_same_coordinate_map(const CoordinateFrame& direct, const Coordinate
 std::optional<uint32_t> active_measurement_pivot(const PlannerPauli& measured,
                                                  uint32_t active_width) {
     for (uint32_t q = active_width; q > 0; --q) {
-        if (measured.xs[q - 1]) {
+        if (measured.x().bit_get(q - 1)) {
             return q - 1;
         }
     }
     for (uint32_t q = 0; q < active_width; ++q) {
-        if (measured.zs[q]) {
+        if (measured.z().bit_get(q)) {
             return q;
         }
     }
@@ -74,20 +72,20 @@ std::optional<uint32_t> active_measurement_pivot(const PlannerPauli& measured,
 TEST_CASE("Planner coordinate frame round trips composed basis changes") {
     CoordinateFrame coordinates(3);
     PlannerTableau first(3);
-    first.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
+    first.append_named_gate(clifft::GateType::H, {0});
     PlannerTableau second(3);
-    second.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(), {0, 1});
+    second.append_named_gate(clifft::GateType::CX, {0, 1});
 
     PlannerPauli initial(3);
-    initial.xs[0] = true;
-    initial.zs[1] = true;
-    initial.sign = true;
+    initial.set_pauli(0, true, false);
+    initial.set_pauli(1, false, true);
+    initial.set_sign(true);
 
     coordinates.change_basis(first);
     const PlannerPauli after_first = coordinates.to_current(initial);
-    REQUIRE(after_first.xs[0] == false);
-    REQUIRE(after_first.zs[0] == true);
-    REQUIRE(after_first.zs[1] == true);
+    REQUIRE(after_first.x().bit_get(0) == false);
+    REQUIRE(after_first.z().bit_get(0) == true);
+    REQUIRE(after_first.z().bit_get(1) == true);
     REQUIRE(coordinates.to_initial(after_first) == initial);
 
     coordinates.change_basis(second);
@@ -99,20 +97,17 @@ TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis")
     constexpr uint32_t kNumQubits = 3;
     CoordinateFrame coordinates(kNumQubits);
     PlannerTableau cumulative(kNumQubits);
-    const std::vector<size_t> indices{0, 1, 2};
-
     const auto require_matches_inverse = [&] {
         const PlannerTableau inverse = cumulative.inverse();
         for (uint32_t body = 0; body < 1U << (2 * kNumQubits); ++body) {
             for (bool sign : {false, true}) {
                 PlannerPauli initial(kNumQubits);
                 for (uint32_t q = 0; q < kNumQubits; ++q) {
-                    initial.xs[q] = (body >> q) & 1U;
-                    initial.zs[q] = (body >> (q + kNumQubits)) & 1U;
+                    initial.set_pauli(q, (body >> q) & 1U, (body >> (q + kNumQubits)) & 1U);
                 }
-                initial.sign = sign;
+                initial.set_sign(sign);
 
-                const PlannerPauli expected = inverse.scatter_eval(initial.ref(), indices);
+                const PlannerPauli expected = inverse.apply(initial.view());
                 const PlannerPauli actual = coordinates.to_current(initial);
                 REQUIRE(actual == expected);
                 REQUIRE(coordinates.to_initial(actual) == initial);
@@ -124,32 +119,32 @@ TEST_CASE("Planner coordinate frame matches explicit inverse for signed Paulis")
     for (const auto& [gate, targets] : std::vector<std::pair<const char*, std::vector<size_t>>>{
              {"H", {0}}, {"S", {1}}, {"CX", {0, 1}}, {"SQRT_X", {2}}, {"CZ", {1, 2}}}) {
         PlannerTableau change(kNumQubits);
-        change.inplace_scatter_append(stim::GATE_DATA.at(gate).tableau<clifft::kStimWidth>(),
-                                      targets);
+        std::vector<uint32_t> native_targets(targets.begin(), targets.end());
+        change.append_named_gate(clifft::parse_gate_name(gate), native_targets);
         coordinates.change_basis(change);
         cumulative = change.then(cumulative);
         require_matches_inverse();
     }
 
     PlannerPauli promoted(kNumQubits);
-    promoted.zs[0] = true;
-    promoted.xs[2] = true;
+    promoted.set_pauli(0, false, true);
+    promoted.set_pauli(2, true, false);
     const PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 2);
     coordinates.promote_dormant(promoted, 1, 2);
     cumulative = promotion.then(cumulative);
     require_matches_inverse();
 
     PlannerPauli active(kNumQubits);
-    active.xs[0] = true;
-    active.zs[1] = true;
+    active.set_pauli(0, true, false);
+    active.set_pauli(1, false, true);
     const PlannerTableau removal = active_measurement_frame(active, 2, 0);
     coordinates.measure_active(active, 2, 0);
     cumulative = removal.then(cumulative);
     require_matches_inverse();
 
     PlannerPauli dormant(kNumQubits);
-    dormant.zs[0] = true;
-    dormant.xs[2] = true;
+    dormant.set_pauli(0, false, true);
+    dormant.set_pauli(2, true, false);
     const PlannerTableau replacement = dormant_measurement_frame(dormant, 2);
     coordinates.measure_dormant(dormant, 2);
     cumulative = replacement.then(cumulative);
@@ -165,9 +160,9 @@ TEST_CASE("Planner structured coordinate updates match generic frames") {
             for (uint32_t body = 0; body < 1U << (2 * kNumQubits); ++body) {
                 for (bool sign : {false, true}) {
                     const PlannerPauli promoted = signed_pauli(kNumQubits, body, sign);
-                    bool is_selected_pivot = promoted.xs[dormant_pivot];
+                    bool is_selected_pivot = promoted.x().bit_get(dormant_pivot);
                     for (uint32_t q = active_width; q < dormant_pivot; ++q) {
-                        is_selected_pivot &= !promoted.xs[q];
+                        is_selected_pivot &= !promoted.x().bit_get(q);
                     }
                     if (!is_selected_pivot) {
                         continue;
@@ -191,7 +186,7 @@ TEST_CASE("Planner structured coordinate updates match generic frames") {
         for (uint32_t body = 0; body < 1U << (2 * kNumQubits); ++body) {
             for (bool sign : {false, true}) {
                 const PlannerPauli measured = signed_pauli(kNumQubits, body, sign);
-                if (!measured.xs[dormant_pivot]) {
+                if (!measured.x().bit_get(dormant_pivot)) {
                     continue;
                 }
                 CAPTURE(dormant_pivot, body, sign);
@@ -213,10 +208,10 @@ TEST_CASE("Planner structured coordinate updates match generic frames") {
             for (bool sign : {false, true}) {
                 PlannerPauli measured(kNumQubits);
                 for (uint32_t q = 0; q < active_width; ++q) {
-                    measured.xs[q] = (active_body >> q) & 1U;
-                    measured.zs[q] = (active_body >> (q + active_width)) & 1U;
+                    measured.set_pauli(q, (active_body >> q) & 1U,
+                                       (active_body >> (q + active_width)) & 1U);
                 }
-                measured.sign = sign;
+                measured.set_sign(sign);
                 const std::optional<uint32_t> pivot =
                     active_measurement_pivot(measured, active_width);
                 REQUIRE(pivot.has_value());
@@ -238,11 +233,6 @@ TEST_CASE("Planner coordinate frame matches inverse across packed words") {
     constexpr uint32_t kNumQubits = 70;
     CoordinateFrame coordinates(kNumQubits);
     PlannerTableau cumulative(kNumQubits);
-    std::vector<size_t> indices(kNumQubits);
-    for (uint32_t q = 0; q < kNumQubits; ++q) {
-        indices[q] = q;
-    }
-
     uint64_t random_state = 0x9e3779b97f4a7c15ULL;
     const auto next_bits = [&] {
         random_state ^= random_state << 13;
@@ -261,16 +251,13 @@ TEST_CASE("Planner coordinate frame matches inverse across packed words") {
                     x_bits = next_bits();
                     z_bits = next_bits();
                 }
-                initial.xs[q] = (x_bits >> (q & 63U)) & 1U;
-                initial.zs[q] = (z_bits >> (q & 63U)) & 1U;
+                initial.set_pauli(q, (x_bits >> (q & 63U)) & 1U, (z_bits >> (q & 63U)) & 1U);
             }
-            initial.xs[63] = (sample & 1U) != 0;
-            initial.zs[63] = (sample & 2U) != 0;
-            initial.xs[64] = (sample & 4U) != 0;
-            initial.zs[64] = (sample & 8U) != 0;
-            initial.sign = (sample & 16U) != 0;
+            initial.set_pauli(63, (sample & 1U) != 0, (sample & 2U) != 0);
+            initial.set_pauli(64, (sample & 4U) != 0, (sample & 8U) != 0);
+            initial.set_sign((sample & 16U) != 0);
 
-            const PlannerPauli expected = inverse.scatter_eval(initial.ref(), indices);
+            const PlannerPauli expected = inverse.apply(initial.view());
             const PlannerPauli actual = coordinates.to_current(initial);
             REQUIRE(actual == expected);
             REQUIRE(coordinates.to_initial(actual) == initial);
@@ -284,43 +271,43 @@ TEST_CASE("Planner coordinate frame matches inverse across packed words") {
     };
 
     PlannerTableau gates(kNumQubits);
-    gates.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {64});
-    gates.inplace_scatter_append(stim::GATE_DATA.at("CX").tableau<clifft::kStimWidth>(), {0, 64});
-    gates.inplace_scatter_append(stim::GATE_DATA.at("S").tableau<clifft::kStimWidth>(), {69});
-    gates.inplace_scatter_append(stim::GATE_DATA.at("CZ").tableau<clifft::kStimWidth>(), {64, 69});
+    gates.append_named_gate(clifft::GateType::H, {64});
+    gates.append_named_gate(clifft::GateType::CX, {0, 64});
+    gates.append_named_gate(clifft::GateType::S, {69});
+    gates.append_named_gate(clifft::GateType::CZ, {64, 69});
     apply_change(gates);
 
     PlannerPauli promoted(kNumQubits);
-    promoted.zs[0] = true;
-    promoted.xs[69] = true;
-    promoted.sign = true;
+    promoted.set_pauli(0, false, true);
+    promoted.set_pauli(69, true, false);
+    promoted.set_sign(true);
     PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 69);
     coordinates.promote_dormant(promoted, 1, 69);
     cumulative = promotion.then(cumulative);
     require_matches_inverse();
 
     PlannerPauli active(kNumQubits);
-    active.xs[0] = true;
-    active.zs[64] = true;
-    active.sign = true;
+    active.set_pauli(0, true, false);
+    active.set_pauli(64, false, true);
+    active.set_sign(true);
     PlannerTableau active_removal = active_measurement_frame(active, 65, 0);
     coordinates.measure_active(active, 65, 0);
     cumulative = active_removal.then(cumulative);
     require_matches_inverse();
 
     PlannerPauli diagonal(kNumQubits);
-    diagonal.zs[3] = true;
-    diagonal.zs[63] = true;
-    diagonal.sign = true;
+    diagonal.set_pauli(3, false, true);
+    diagonal.set_pauli(63, false, true);
+    diagonal.set_sign(true);
     PlannerTableau diagonal_removal = active_measurement_frame(diagonal, 64, 3);
     coordinates.measure_active(diagonal, 64, 3);
     cumulative = diagonal_removal.then(cumulative);
     require_matches_inverse();
 
     PlannerPauli dormant(kNumQubits);
-    dormant.zs[0] = true;
-    dormant.xs[69] = true;
-    dormant.sign = true;
+    dormant.set_pauli(0, false, true);
+    dormant.set_pauli(69, true, false);
+    dormant.set_sign(true);
     PlannerTableau dormant_replacement = dormant_measurement_frame(dormant, 69);
     coordinates.measure_dormant(dormant, 69);
     cumulative = dormant_replacement.then(cumulative);
@@ -331,8 +318,8 @@ TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
     constexpr uint32_t kNumQubits = 3;
     CoordinateFrame coordinates(kNumQubits);
     PlannerPauli initial(kNumQubits);
-    initial.xs[0] = true;
-    initial.zs[2] = true;
+    initial.set_pauli(0, true, false);
+    initial.set_pauli(2, false, true);
 
     for (uint32_t lookup = 0; lookup < 2 * kNumQubits; ++lookup) {
         REQUIRE(coordinates.to_current(initial) == initial);
@@ -342,11 +329,10 @@ TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
     REQUIRE(coordinates.has_cached_inverse_for_testing());
 
     PlannerTableau change(kNumQubits);
-    change.inplace_scatter_append(stim::GATE_DATA.at("H").tableau<clifft::kStimWidth>(), {0});
+    change.append_named_gate(clifft::GateType::H, {0});
     coordinates.change_basis(change);
     REQUIRE_FALSE(coordinates.has_cached_inverse_for_testing());
-    REQUIRE(coordinates.to_current(initial) ==
-            change.inverse().scatter_eval(initial.ref(), {0, 1, 2}));
+    REQUIRE(coordinates.to_current(initial) == change.inverse().apply(initial.view()));
 
     for (uint32_t lookup = 0; lookup < 2 * kNumQubits; ++lookup) {
         static_cast<void>(coordinates.to_current(initial));
@@ -354,14 +340,14 @@ TEST_CASE("Planner coordinate frame caches repeated reverse lookups") {
     REQUIRE(coordinates.has_cached_inverse_for_testing());
 
     PlannerPauli promoted(kNumQubits);
-    promoted.zs[0] = true;
-    promoted.xs[2] = true;
-    promoted.sign = true;
+    promoted.set_pauli(0, false, true);
+    promoted.set_pauli(2, true, false);
+    promoted.set_sign(true);
     const PlannerTableau promotion = dormant_promotion_frame(promoted, 1, 2);
     coordinates.promote_dormant(promoted, 1, 2);
     REQUIRE_FALSE(coordinates.has_cached_inverse_for_testing());
     REQUIRE(coordinates.to_current(initial) ==
-            promotion.then(change).inverse().scatter_eval(initial.ref(), {0, 1, 2}));
+            promotion.then(change).inverse().apply(initial.view()));
 }
 
 TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
@@ -369,20 +355,19 @@ TEST_CASE("Planner symbolic frame composes affine Pauli corrections") {
     const AffineBool wide_condition(true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});
 
     PlannerPauli x_correction(2);
-    x_correction.xs[0] = true;
+    x_correction.set_pauli(0, true, false);
     frame.apply(x_correction, wide_condition);
 
     PlannerPauli z_observable(2);
-    z_observable.zs[0] = true;
+    z_observable.set_pauli(0, false, true);
     REQUIRE(frame.sign_for(z_observable) == wide_condition);
 
     PlannerPauli z_correction(2);
-    z_correction.zs[0] = true;
+    z_correction.set_pauli(0, false, true);
     frame.apply(z_correction, AffineBool::symbol(SymbolId{1}));
 
     PlannerPauli y_observable(2);
-    y_observable.xs[0] = true;
-    y_observable.zs[0] = true;
+    y_observable.set_pauli(0, true, true);
     REQUIRE(frame.sign_for(y_observable) == (wide_condition ^ AffineBool::symbol(SymbolId{1})));
 
     frame.apply(x_correction, wide_condition);
@@ -396,90 +381,85 @@ TEST_CASE("Planner symbolic frame applies sparse corrections across packed words
     const AffineBool condition(true, {SymbolId{0}, SymbolId{64}, SymbolId{129}});
 
     PlannerPauli correction(kNumQubits);
-    correction.xs[0] = true;
-    correction.zs[1] = true;
-    correction.xs[63] = true;
-    correction.zs[63] = true;
-    correction.xs[64] = true;
-    correction.zs[65] = true;
-    correction.xs[69] = true;
-    correction.zs[69] = true;
+    correction.set_pauli(0, true, false);
+    correction.set_pauli(1, false, true);
+    correction.set_pauli(63, true, true);
+    correction.set_pauli(64, true, false);
+    correction.set_pauli(65, false, true);
+    correction.set_pauli(69, true, true);
     frame.apply(correction, condition);
 
     for (uint32_t q : {0U, 63U, 64U, 69U}) {
         PlannerPauli observable(kNumQubits);
-        observable.zs[q] = true;
+        observable.set_pauli(q, false, true);
         REQUIRE(frame.sign_for(observable) == condition);
     }
     for (uint32_t q : {1U, 63U, 65U, 69U}) {
         PlannerPauli observable(kNumQubits);
-        observable.xs[q] = true;
+        observable.set_pauli(q, true, false);
         REQUIRE(frame.sign_for(observable) == condition);
     }
 
     PlannerPauli unaffected(kNumQubits);
-    unaffected.xs[62] = true;
-    unaffected.zs[68] = true;
+    unaffected.set_pauli(62, true, false);
+    unaffected.set_pauli(68, false, true);
     REQUIRE(frame.sign_for(unaffected) == AffineBool(false));
 
     frame.apply(correction, condition);
     PlannerPauli cancelled(kNumQubits);
-    cancelled.xs[69] = true;
-    cancelled.zs[69] = true;
+    cancelled.set_pauli(69, true, true);
     REQUIRE(frame.sign_for(cancelled) == AffineBool(false));
 }
 
 TEST_CASE("Planner symbolic frame rejects unknown symbols") {
     SymbolicPauliFrame frame(1, 1);
     PlannerPauli correction(1);
-    correction.xs[0] = true;
+    correction.set_pauli(0, true, false);
 
     REQUIRE_THROWS_AS(frame.apply(correction, AffineBool::symbol(SymbolId{1})), std::logic_error);
 }
 
-TEST_CASE("Planner symbolic frame masks active Pauli padding") {
+TEST_CASE("Planner symbolic frame handles partial final words") {
     constexpr uint32_t kNumQubits = 65;
     SymbolicPauliFrame frame(kNumQubits, 1);
     PlannerPauli correction(kNumQubits);
-    correction.xs[64] = true;
-    correction.xs.u64[1] |= uint64_t{1} << 5;
+    correction.set_pauli(64, true, false);
 
     REQUIRE_NOTHROW(frame.apply(correction, AffineBool::symbol(SymbolId{0})));
 
     PlannerPauli observable(kNumQubits);
-    observable.zs[64] = true;
+    observable.set_pauli(64, false, true);
     REQUIRE(frame.sign_for(observable) == AffineBool::symbol(SymbolId{0}));
 }
 
 TEST_CASE("Planner promotion frame localizes the promoted observable") {
     PlannerPauli promoted(3);
-    promoted.zs[0] = true;
-    promoted.xs[2] = true;
+    promoted.set_pauli(0, false, true);
+    promoted.set_pauli(2, true, false);
 
     const PlannerTableau frame = dormant_promotion_frame(promoted, 1, 2);
     REQUIRE(frame.satisfies_invariants());
-    REQUIRE(frame.xs[1] == promoted);
+    REQUIRE(clifft::PauliString(frame.x_output(1)) == promoted);
 
     const PlannerTableau old_to_new = frame.inverse();
-    const PlannerPauli localized =
-        old_to_new.scatter_eval(promoted.ref(), std::vector<size_t>{0, 1, 2});
+    const PlannerPauli localized = old_to_new.apply(promoted.view());
     PlannerPauli expected(3);
-    expected.xs[1] = true;
+    expected.set_pauli(1, true, false);
     REQUIRE(localized == expected);
 }
 
 TEST_CASE("Planner measurement frames install the selected observables") {
     PlannerPauli dormant(3);
-    dormant.zs[0] = true;
-    dormant.xs[2] = true;
+    dormant.set_pauli(0, false, true);
+    dormant.set_pauli(2, true, false);
     const PlannerTableau dormant_frame = dormant_measurement_frame(dormant, 2);
     REQUIRE(dormant_frame.satisfies_invariants());
-    REQUIRE(dormant_frame.zs[2] == dormant);
+    REQUIRE(clifft::PauliString(dormant_frame.z_output(2)) == dormant);
 
     PlannerPauli active(3);
-    active.xs[0] = true;
-    active.zs[1] = true;
+    active.set_pauli(0, true, false);
+    active.set_pauli(1, false, true);
     const PlannerTableau active_frame = active_measurement_frame(active, 2, 0);
     REQUIRE(active_frame.satisfies_invariants());
-    REQUIRE(active_frame.zs[1] == active);
+    REQUIRE(clifft::PauliString(active_frame.z_output(1)) == active);
 }


### PR DESCRIPTION
Move HIR, optimization, planning, exact state queries, and executable metadata onto the native Clifford types while retaining Stim as an independent test oracle.

Part of #385.

Assisted-by: Codex (GPT-5) <noreply@openai.com>