### PR TITLE
perf(compilation): restore native Clifford scaling

### DIFF
--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -50,12 +50,6 @@ Pauli pauli_from_mask(const HirModule& hir, PauliMaskHandle handle) {
     return result;
 }
 
-Pauli single_x(uint32_t num_qubits, uint32_t q) {
-    Pauli result(num_qubits);
-    result.set_pauli(q, true, false);
-    return result;
-}
-
 struct ResolvedPauli {
     Pauli body;
     AffineBool sign;
@@ -278,7 +272,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
 
         const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
         define_symbol(plan, branch, SymbolKind::Branch, action_index);
-        Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, *dormant_pivot));
+        Pauli correction(coordinates.current_to_initial().x_output(*dormant_pivot));
         correction.set_sign(false);
         symbolic_frame.apply(correction, AffineBool::symbol(branch));
         const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);
@@ -314,7 +308,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
 
     const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     define_symbol(plan, branch, SymbolKind::Branch, action_index);
-    Pauli correction = coordinates.to_initial(single_x(plan.num_qubits, active_width - 1));
+    Pauli correction(coordinates.current_to_initial().x_output(active_width - 1));
     correction.set_sign(false);
     symbolic_frame.apply(correction, AffineBool::symbol(branch));
     const AffineBool outcome = resolved.sign ^ AffineBool::symbol(branch);

--- a/src/clifft/sampling/planner_frame.cc
+++ b/src/clifft/sampling/planner_frame.cc
@@ -39,12 +39,28 @@ bool anticommutes(const PlannerPauli& left, const PlannerPauli& right) {
 }
 
 bool has_x_below(const PlannerPauli& pauli, uint32_t end) {
-    for (uint32_t q = 0; q < end; ++q) {
-        if (pauli.x().bit_get(q)) {
+    const uint32_t complete_words = end / 64;
+    for (uint32_t w = 0; w < complete_words; ++w) {
+        if (pauli.x().words[w] != 0) {
             return true;
         }
     }
-    return false;
+    const uint32_t tail = end % 64;
+    return tail != 0 && (pauli.x().words[complete_words] & ((uint64_t{1} << tail) - 1)) != 0;
+}
+
+template <typename Callback>
+void for_each_set_bit(MaskView mask, uint32_t end, Callback&& callback) {
+    for (uint32_t w = 0; w < mask.num_words() && 64 * w < end; ++w) {
+        uint64_t pending = mask.words[w];
+        if (64 * (w + 1) > end && end % 64 != 0) {
+            pending &= (uint64_t{1} << (end % 64)) - 1;
+        }
+        while (pending != 0) {
+            callback(64 * w + std::countr_zero(pending));
+            pending &= pending - 1;
+        }
+    }
 }
 
 size_t validated_words_per_row(uint32_t num_qubits, uint32_t num_symbols) {
@@ -125,21 +141,17 @@ void CoordinateFrame::promote_dormant(const PlannerPauli& promoted, uint32_t act
     // generator that anticommutes with the promoted Pauli acquires the old
     // pivot stabilizer, preserving the same symplectic basis as the generic
     // frame composition without materializing its identity rows.
-    for (uint32_t q = 0; q < n; ++q) {
+    for_each_set_bit(promoted.z(), n, [&](uint32_t q) {
         if (q == dormant_pivot) {
-            continue;
+            return;
         }
-        if (promoted.z().bit_get(q)) {
-            PlannerPauli row(current_to_initial_.x_output(q));
-            row.right_multiply(pivot_stabilizer.view());
-            current_to_initial_.set_x_output(q, row.view());
+        current_to_initial_.right_multiply_x_output(q, pivot_stabilizer.view());
+    });
+    for_each_set_bit(promoted.x(), n, [&](uint32_t q) {
+        if (q != dormant_pivot) {
+            current_to_initial_.right_multiply_z_output(q, pivot_stabilizer.view());
         }
-        if (promoted.x().bit_get(q)) {
-            PlannerPauli row(current_to_initial_.z_output(q));
-            row.right_multiply(pivot_stabilizer.view());
-            current_to_initial_.set_z_output(q, row.view());
-        }
-    }
+    });
 
     for (uint32_t q = dormant_pivot; q > active_width; --q) {
         current_to_initial_.set_x_output(q, current_to_initial_.x_output(q - 1));
@@ -154,25 +166,23 @@ void CoordinateFrame::measure_dormant(const PlannerPauli& measured, uint32_t dor
     assert(measured.num_qubits() == n && dormant_pivot < n);
 
     PlannerPauli mapped_measured = to_initial(measured);
-    PlannerPauli pivot_stabilizer(current_to_initial_.z_output(dormant_pivot));
+    // Avoid an allocation per measurement: updates skip the pivot Z row, which is copied into X
+    // before the final write overwrites that source row.
+    const PauliStringView pivot_stabilizer = current_to_initial_.z_output(dormant_pivot);
     invalidate_reverse_cache();
 
-    for (uint32_t q = 0; q < n; ++q) {
+    for_each_set_bit(measured.z(), n, [&](uint32_t q) {
         if (q == dormant_pivot) {
-            continue;
+            return;
         }
-        if (measured.z().bit_get(q)) {
-            PlannerPauli row(current_to_initial_.x_output(q));
-            row.right_multiply(pivot_stabilizer.view());
-            current_to_initial_.set_x_output(q, row.view());
+        current_to_initial_.right_multiply_x_output(q, pivot_stabilizer);
+    });
+    for_each_set_bit(measured.x(), n, [&](uint32_t q) {
+        if (q != dormant_pivot) {
+            current_to_initial_.right_multiply_z_output(q, pivot_stabilizer);
         }
-        if (measured.x().bit_get(q)) {
-            PlannerPauli row(current_to_initial_.z_output(q));
-            row.right_multiply(pivot_stabilizer.view());
-            current_to_initial_.set_z_output(q, row.view());
-        }
-    }
-    current_to_initial_.set_x_output(dormant_pivot, pivot_stabilizer.view());
+    });
+    current_to_initial_.set_x_output(dormant_pivot, pivot_stabilizer);
     current_to_initial_.set_z_output(dormant_pivot, mapped_measured.view());
 }
 
@@ -187,29 +197,18 @@ void CoordinateFrame::measure_active(const PlannerPauli& measured, uint32_t acti
                                           : current_to_initial_.z_output(pivot));
     invalidate_reverse_cache();
 
-    for (uint32_t q = 0; q < active_width; ++q) {
-        if (q == pivot) {
-            continue;
-        }
-        if (diagonal) {
-            if (measured.z().bit_get(q)) {
-                PlannerPauli row(current_to_initial_.x_output(q));
-                row.right_multiply(pivot_conjugate.view());
-                current_to_initial_.set_x_output(q, row.view());
+    if (!diagonal) {
+        for_each_set_bit(measured.x(), active_width, [&](uint32_t q) {
+            if (q != pivot) {
+                current_to_initial_.right_multiply_z_output(q, pivot_conjugate.view());
             }
-        } else {
-            if (measured.x().bit_get(q)) {
-                PlannerPauli row(current_to_initial_.z_output(q));
-                row.right_multiply(pivot_conjugate.view());
-                current_to_initial_.set_z_output(q, row.view());
-            }
-            if (measured.z().bit_get(q)) {
-                PlannerPauli row(current_to_initial_.x_output(q));
-                row.right_multiply(pivot_conjugate.view());
-                current_to_initial_.set_x_output(q, row.view());
-            }
-        }
+        });
     }
+    for_each_set_bit(measured.z(), active_width, [&](uint32_t q) {
+        if (q != pivot) {
+            current_to_initial_.right_multiply_x_output(q, pivot_conjugate.view());
+        }
+    });
 
     for (uint32_t q = pivot; q + 1 < active_width; ++q) {
         current_to_initial_.set_x_output(q, current_to_initial_.x_output(q + 1));

--- a/src/clifft/tableau/tableau.cc
+++ b/src/clifft/tableau/tableau.cc
@@ -1,6 +1,7 @@
 #include "clifft/tableau/tableau.h"
 
 #include <array>
+#include <bit>
 #include <cassert>
 #include <stdexcept>
 #include <string>
@@ -11,6 +12,28 @@ namespace {
 
 uint32_t row_index(bool z, uint32_t qubit, uint32_t num_qubits) {
     return (z ? num_qubits : 0) + qubit;
+}
+
+void right_multiply_generator(PauliString& pauli, uint32_t qubit, bool z_generator) {
+    const bool old_x = pauli.x().bit_get(qubit);
+    const bool old_z = pauli.z().bit_get(qubit);
+    if (!z_generator && old_z) {
+        pauli.add_phase(2);
+    }
+    pauli.set_pauli(qubit, old_x ^ !z_generator, old_z ^ z_generator);
+}
+
+void right_multiply_masks(MutableMaskView x, MutableMaskView z, uint8_t& phase,
+                          PauliStringView value, uint8_t phase_delta = 0) {
+    assert(x.num_words() == value.x().num_words());
+    assert(z.num_words() == value.z().num_words());
+    bool crossing_parity = false;
+    for (uint32_t w = 0; w < x.num_words(); ++w) {
+        crossing_parity ^= (std::popcount(z.words[w] & value.x().words[w]) & 1U) != 0;
+    }
+    phase = (phase + value.phase() + phase_delta + (crossing_parity ? 2U : 0U)) & 3U;
+    x.xor_with(value.x());
+    z.xor_with(value.z());
 }
 
 }  // namespace
@@ -47,104 +70,117 @@ Tableau Tableau::from_rows(std::initializer_list<std::string_view> rows) {
     return result;
 }
 
-Tableau Tableau::from_named_gate(GateType gate) {
+const Tableau& Tableau::named_gate_tableau(GateType gate) {
+// Parsing fixed row literals for every circuit operation needlessly makes gate lookup allocate.
+#define CLIFFT_RETURN_CACHED_TABLEAU(...)                       \
+    do {                                                        \
+        static const Tableau result = from_rows({__VA_ARGS__}); \
+        return result;                                          \
+    } while (false)
+
     switch (gate) {
         case GateType::H:
-            return from_rows({"+Z", "+X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Z", "+X");
         case GateType::S:
-            return from_rows({"+Y", "+Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Y", "+Z");
         case GateType::S_DAG:
-            return from_rows({"-Y", "+Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Y", "+Z");
         case GateType::X:
-            return from_rows({"+X", "-Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X", "-Z");
         case GateType::Y:
-            return from_rows({"-X", "-Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-X", "-Z");
         case GateType::Z:
-            return from_rows({"-X", "+Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-X", "+Z");
         case GateType::SQRT_X:
-            return from_rows({"+X", "-Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X", "-Y");
         case GateType::SQRT_X_DAG:
-            return from_rows({"+X", "+Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X", "+Y");
         case GateType::SQRT_Y:
-            return from_rows({"-Z", "+X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Z", "+X");
         case GateType::SQRT_Y_DAG:
-            return from_rows({"+Z", "-X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Z", "-X");
         case GateType::H_XY:
-            return from_rows({"+Y", "-Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Y", "-Z");
         case GateType::H_YZ:
-            return from_rows({"-X", "+Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-X", "+Y");
         case GateType::H_NXY:
-            return from_rows({"-Y", "-Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Y", "-Z");
         case GateType::H_NXZ:
-            return from_rows({"-Z", "-X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Z", "-X");
         case GateType::H_NYZ:
-            return from_rows({"-X", "-Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-X", "-Y");
         case GateType::C_XYZ:
-            return from_rows({"+Y", "+X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Y", "+X");
         case GateType::C_ZYX:
-            return from_rows({"+Z", "+Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Z", "+Y");
         case GateType::C_NXYZ:
-            return from_rows({"-Y", "-X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Y", "-X");
         case GateType::C_NZYX:
-            return from_rows({"-Z", "-Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Z", "-Y");
         case GateType::C_XNYZ:
-            return from_rows({"-Y", "+X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Y", "+X");
         case GateType::C_XYNZ:
-            return from_rows({"+Y", "-X"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Y", "-X");
         case GateType::C_ZNYX:
-            return from_rows({"+Z", "-Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+Z", "-Y");
         case GateType::C_ZYNX:
-            return from_rows({"-Z", "+Y"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-Z", "+Y");
         case GateType::I:
-            return Tableau(1);
+            CLIFFT_RETURN_CACHED_TABLEAU("+X", "+Z");
         case GateType::CX:
-            return from_rows({"+XX", "+Z_", "+_X", "+ZZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XX", "+Z_", "+_X", "+ZZ");
         case GateType::CY:
-            return from_rows({"+XY", "+Z_", "+ZX", "+ZZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XY", "+Z_", "+ZX", "+ZZ");
         case GateType::CZ:
-            return from_rows({"+XZ", "+Z_", "+ZX", "+_Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XZ", "+Z_", "+ZX", "+_Z");
         case GateType::SWAP:
-            return from_rows({"+_X", "+_Z", "+X_", "+Z_"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+_X", "+_Z", "+X_", "+Z_");
         case GateType::ISWAP:
-            return from_rows({"+ZY", "+_Z", "+YZ", "+Z_"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+ZY", "+_Z", "+YZ", "+Z_");
         case GateType::ISWAP_DAG:
-            return from_rows({"-ZY", "+_Z", "-YZ", "+Z_"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-ZY", "+_Z", "-YZ", "+Z_");
         case GateType::SQRT_XX:
-            return from_rows({"+X_", "-YX", "+_X", "-XY"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X_", "-YX", "+_X", "-XY");
         case GateType::SQRT_XX_DAG:
-            return from_rows({"+X_", "+YX", "+_X", "+XY"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X_", "+YX", "+_X", "+XY");
         case GateType::SQRT_YY:
-            return from_rows({"-ZY", "+XY", "-YZ", "+YX"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-ZY", "+XY", "-YZ", "+YX");
         case GateType::SQRT_YY_DAG:
-            return from_rows({"+ZY", "-XY", "+YZ", "-YX"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+ZY", "-XY", "+YZ", "-YX");
         case GateType::SQRT_ZZ:
-            return from_rows({"+YZ", "+Z_", "+ZY", "+_Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+YZ", "+Z_", "+ZY", "+_Z");
         case GateType::SQRT_ZZ_DAG:
-            return from_rows({"-YZ", "+Z_", "-ZY", "+_Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("-YZ", "+Z_", "-ZY", "+_Z");
         case GateType::CXSWAP:
-            return from_rows({"+XX", "+_Z", "+X_", "+ZZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XX", "+_Z", "+X_", "+ZZ");
         case GateType::CZSWAP:
-            return from_rows({"+ZX", "+_Z", "+XZ", "+Z_"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+ZX", "+_Z", "+XZ", "+Z_");
         case GateType::SWAPCX:
-            return from_rows({"+_X", "+ZZ", "+XX", "+Z_"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+_X", "+ZZ", "+XX", "+Z_");
         case GateType::XCX:
-            return from_rows({"+X_", "+ZX", "+_X", "+XZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X_", "+ZX", "+_X", "+XZ");
         case GateType::XCY:
-            return from_rows({"+X_", "+ZY", "+XX", "+XZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X_", "+ZY", "+XX", "+XZ");
         case GateType::XCZ:
-            return from_rows({"+X_", "+ZZ", "+XX", "+_Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+X_", "+ZZ", "+XX", "+_Z");
         case GateType::YCX:
-            return from_rows({"+XX", "+ZX", "+_X", "+YZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XX", "+ZX", "+_X", "+YZ");
         case GateType::YCY:
-            return from_rows({"+XY", "+ZY", "+YX", "+YZ"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XY", "+ZY", "+YX", "+YZ");
         case GateType::YCZ:
-            return from_rows({"+XZ", "+ZZ", "+YX", "+_Z"});
+            CLIFFT_RETURN_CACHED_TABLEAU("+XZ", "+ZZ", "+YX", "+_Z");
         case GateType::II:
-            return Tableau(2);
+            CLIFFT_RETURN_CACHED_TABLEAU("+X_", "+Z_", "+_X", "+_Z");
         default:
             throw std::invalid_argument("Gate does not have a fixed Clifford tableau: " +
                                         std::string(gate_name(gate)));
     }
+
+#undef CLIFFT_RETURN_CACHED_TABLEAU
+}
+
+Tableau Tableau::from_named_gate(GateType gate) {
+    return named_gate_tableau(gate);
 }
 
 Tableau Tableau::from_pauli_rotation(PauliStringView axis, bool dagger) {
@@ -152,19 +188,18 @@ Tableau Tableau::from_pauli_rotation(PauliStringView axis, bool dagger) {
         throw std::invalid_argument("Pauli rotation axis must be Hermitian");
     }
     Tableau result(axis.num_qubits());
-    Tableau identity(axis.num_qubits());
     for (uint32_t q = 0; q < axis.num_qubits(); ++q) {
         for (bool z_generator : {false, true}) {
             const uint32_t index = row_index(z_generator, q, axis.num_qubits());
-            const PauliStringView generator = identity.row(index);
-            if (axis.commutes(generator)) {
+            const bool anticommutes = z_generator ? axis.x().bit_get(q) : axis.z().bit_get(q);
+            if (!anticommutes) {
                 continue;
             }
             PauliString mapped(axis.num_qubits());
             mapped.set_phase(axis.phase());
             mapped.mut_x().xor_with(axis.x());
             mapped.mut_z().xor_with(axis.z());
-            mapped.right_multiply(generator);
+            right_multiply_generator(mapped, q, z_generator);
             mapped.add_phase(dagger ? 1 : 3);
             result.set_row(index, mapped.view());
         }
@@ -200,6 +235,16 @@ void Tableau::set_z_output(uint32_t qubit, PauliStringView value) {
     set_row(row_index(true, qubit, num_qubits_), value);
 }
 
+void Tableau::right_multiply_x_output(uint32_t qubit, PauliStringView value) {
+    assert(qubit < num_qubits_);
+    right_multiply_row_by_pauli(row_index(false, qubit, num_qubits_), value);
+}
+
+void Tableau::right_multiply_z_output(uint32_t qubit, PauliStringView value) {
+    assert(qubit < num_qubits_);
+    right_multiply_row_by_pauli(row_index(true, qubit, num_qubits_), value);
+}
+
 bool Tableau::satisfies_invariants() const {
     for (uint32_t q = 0; q < num_qubits_; ++q) {
         if (!x_output(q).is_hermitian() || !z_output(q).is_hermitian()) {
@@ -233,18 +278,48 @@ void Tableau::set_row(uint32_t index, PauliStringView value) {
     phases_[index] = value.phase();
 }
 
+void Tableau::right_multiply_row(uint32_t destination, uint32_t source, uint8_t phase_delta) {
+    assert(destination < 2 * num_qubits_);
+    assert(source < 2 * num_qubits_);
+    assert(destination != source);
+    right_multiply_row_by_pauli(destination, row(source), phase_delta);
+}
+
+void Tableau::right_multiply_row_by_pauli(uint32_t destination, PauliStringView value,
+                                          uint8_t phase_delta) {
+    assert(destination < 2 * num_qubits_);
+    assert(value.num_qubits() == num_qubits_);
+    const size_t destination_offset = static_cast<size_t>(destination) * num_words_;
+    right_multiply_masks(
+        MutableMaskView{std::span<uint64_t>(x_rows_).subspan(destination_offset, num_words_)},
+        MutableMaskView{std::span<uint64_t>(z_rows_).subspan(destination_offset, num_words_)},
+        phases_[destination], value, phase_delta);
+}
+
 PauliString Tableau::apply(PauliStringView input) const {
     assert(input.num_qubits() == num_qubits_);
     PauliString result(num_qubits_);
     result.set_phase(input.phase());
-    for (uint32_t q = 0; q < num_qubits_; ++q) {
-        if (input.x().bit_get(q)) {
+    for (uint32_t w = 0; w < num_words_; ++w) {
+        uint64_t pending = input.x().words[w];
+        if (w + 1 == num_words_ && num_qubits_ % 64 != 0) {
+            pending &= (uint64_t{1} << (num_qubits_ % 64)) - 1;
+        }
+        while (pending != 0) {
+            const uint32_t q = 64 * w + std::countr_zero(pending);
             result.right_multiply(x_output(q));
+            pending &= pending - 1;
         }
     }
-    for (uint32_t q = 0; q < num_qubits_; ++q) {
-        if (input.z().bit_get(q)) {
+    for (uint32_t w = 0; w < num_words_; ++w) {
+        uint64_t pending = input.z().words[w];
+        if (w + 1 == num_words_ && num_qubits_ % 64 != 0) {
+            pending &= (uint64_t{1} << (num_qubits_ % 64)) - 1;
+        }
+        while (pending != 0) {
+            const uint32_t q = 64 * w + std::countr_zero(pending);
             result.right_multiply(z_output(q));
+            pending &= pending - 1;
         }
     }
     return result;
@@ -328,35 +403,118 @@ void Tableau::prepend_local(const Tableau& gate, std::span<const uint32_t> targe
         }
     }
 
-    std::vector<PauliString> replacements;
-    replacements.reserve(2 * targets.size());
+    const size_t replacement_count = 2 * targets.size();
+    const size_t scratch_words = replacement_count * num_words_;
+    if (prepend_scratch_x_.size() < scratch_words) {
+        prepend_scratch_x_.resize(scratch_words);
+        prepend_scratch_z_.resize(scratch_words);
+    }
+    if (prepend_scratch_phases_.size() < replacement_count) {
+        prepend_scratch_phases_.resize(replacement_count);
+    }
+
+    size_t replacement = 0;
     for (bool z_generator : {false, true}) {
         for (uint32_t local_q = 0; local_q < targets.size(); ++local_q) {
             const PauliStringView gate_row =
                 z_generator ? gate.z_output(local_q) : gate.x_output(local_q);
-            PauliString scattered(num_qubits_);
-            scattered.set_phase(gate_row.phase());
+            const size_t offset = replacement * num_words_;
+            MutableMaskView mapped_x{
+                std::span<uint64_t>(prepend_scratch_x_).subspan(offset, num_words_)};
+            MutableMaskView mapped_z{
+                std::span<uint64_t>(prepend_scratch_z_).subspan(offset, num_words_)};
+            mapped_x.zero_out();
+            mapped_z.zero_out();
+            prepend_scratch_phases_[replacement] = gate_row.phase();
             for (uint32_t k = 0; k < targets.size(); ++k) {
-                scattered.set_pauli(targets[k], gate_row.x().bit_get(k), gate_row.z().bit_get(k));
+                if (gate_row.x().bit_get(k)) {
+                    right_multiply_masks(mapped_x, mapped_z, prepend_scratch_phases_[replacement],
+                                         x_output(targets[k]));
+                }
             }
-            replacements.push_back(apply(scattered.view()));
+            for (uint32_t k = 0; k < targets.size(); ++k) {
+                if (gate_row.z().bit_get(k)) {
+                    right_multiply_masks(mapped_x, mapped_z, prepend_scratch_phases_[replacement],
+                                         z_output(targets[k]));
+                }
+            }
+            ++replacement;
         }
     }
-    size_t replacement = 0;
+    replacement = 0;
     for (bool z_generator : {false, true}) {
         for (uint32_t target : targets) {
-            set_row(row_index(z_generator, target, num_qubits_),
-                    replacements[replacement++].view());
+            const size_t offset = replacement * num_words_;
+            set_row(
+                row_index(z_generator, target, num_qubits_),
+                PauliStringView{
+                    MaskView{
+                        std::span<const uint64_t>(prepend_scratch_x_).subspan(offset, num_words_)},
+                    MaskView{
+                        std::span<const uint64_t>(prepend_scratch_z_).subspan(offset, num_words_)},
+                    prepend_scratch_phases_[replacement], num_qubits_});
+            ++replacement;
         }
     }
 }
 
 void Tableau::append_named_gate(GateType gate, std::span<const uint32_t> targets) {
-    append_local(from_named_gate(gate), targets);
+    append_local(named_gate_tableau(gate), targets);
 }
 
 void Tableau::prepend_named_gate(GateType gate, std::span<const uint32_t> targets) {
-    prepend_local(from_named_gate(gate), targets);
+    const Tableau& gate_tableau = named_gate_tableau(gate);
+    if (gate_tableau.num_qubits() != targets.size()) {
+        throw std::invalid_argument("Gate tableau width does not match target count");
+    }
+    for (uint32_t target : targets) {
+        if (target >= num_qubits_) {
+            throw std::invalid_argument("Gate target is outside the tableau");
+        }
+    }
+
+    // Common traced gates have row-local updates that avoid generic composition scratch.
+    switch (gate) {
+        case GateType::I:
+        case GateType::II:
+            return;
+        case GateType::H: {
+            const uint32_t x_index = row_index(false, targets[0], num_qubits_);
+            const uint32_t z_index = row_index(true, targets[0], num_qubits_);
+            const size_t x_offset = static_cast<size_t>(x_index) * num_words_;
+            const size_t z_offset = static_cast<size_t>(z_index) * num_words_;
+            for (uint32_t w = 0; w < num_words_; ++w) {
+                std::swap(x_rows_[x_offset + w], x_rows_[z_offset + w]);
+                std::swap(z_rows_[x_offset + w], z_rows_[z_offset + w]);
+            }
+            std::swap(phases_[x_index], phases_[z_index]);
+            return;
+        }
+        case GateType::S:
+        case GateType::S_DAG:
+            right_multiply_row(row_index(false, targets[0], num_qubits_),
+                               row_index(true, targets[0], num_qubits_),
+                               gate == GateType::S ? 1U : 3U);
+            return;
+        case GateType::X:
+            phases_[row_index(true, targets[0], num_qubits_)] ^= 2U;
+            return;
+        case GateType::Y:
+            phases_[row_index(false, targets[0], num_qubits_)] ^= 2U;
+            phases_[row_index(true, targets[0], num_qubits_)] ^= 2U;
+            return;
+        case GateType::Z:
+            phases_[row_index(false, targets[0], num_qubits_)] ^= 2U;
+            return;
+        case GateType::CX:
+            right_multiply_row(row_index(false, targets[0], num_qubits_),
+                               row_index(false, targets[1], num_qubits_));
+            right_multiply_row(row_index(true, targets[1], num_qubits_),
+                               row_index(true, targets[0], num_qubits_));
+            return;
+        default:
+            prepend_local(gate_tableau, targets);
+    }
 }
 
 void Tableau::prepend_pauli(PauliStringView axis) {
@@ -378,11 +536,11 @@ void Tableau::prepend_pauli_rotation(PauliStringView axis, bool dagger) {
         throw std::invalid_argument("Pauli rotation axis does not match the tableau");
     }
     const PauliString mapped_axis = apply(axis);
-    Tableau identity(num_qubits_);
     for (uint32_t q = 0; q < num_qubits_; ++q) {
         for (bool z_generator : {false, true}) {
             const uint32_t index = row_index(z_generator, q, num_qubits_);
-            if (axis.commutes(identity.row(index))) {
+            const bool anticommutes = z_generator ? axis.x().bit_get(q) : axis.z().bit_get(q);
+            if (!anticommutes) {
                 continue;
             }
             PauliString mapped = mapped_axis;

--- a/src/clifft/tableau/tableau.h
+++ b/src/clifft/tableau/tableau.h
@@ -31,6 +31,8 @@ class Tableau {
 
     void set_x_output(uint32_t qubit, PauliStringView value);
     void set_z_output(uint32_t qubit, PauliStringView value);
+    void right_multiply_x_output(uint32_t qubit, PauliStringView value);
+    void right_multiply_z_output(uint32_t qubit, PauliStringView value);
 
     void append_local(const Tableau& gate, std::span<const uint32_t> targets);
     void prepend_local(const Tableau& gate, std::span<const uint32_t> targets);
@@ -49,14 +51,21 @@ class Tableau {
 
   private:
     [[nodiscard]] static Tableau from_rows(std::initializer_list<std::string_view> rows);
+    [[nodiscard]] static const Tableau& named_gate_tableau(GateType gate);
     [[nodiscard]] PauliStringView row(uint32_t index) const;
     void set_row(uint32_t index, PauliStringView value);
+    void right_multiply_row_by_pauli(uint32_t destination, PauliStringView value,
+                                     uint8_t phase_delta = 0);
+    void right_multiply_row(uint32_t destination, uint32_t source, uint8_t phase_delta = 0);
 
     uint32_t num_qubits_;
     uint32_t num_words_;
     std::vector<uint64_t> x_rows_;
     std::vector<uint64_t> z_rows_;
     std::vector<uint8_t> phases_;
+    std::vector<uint64_t> prepend_scratch_x_;
+    std::vector<uint64_t> prepend_scratch_z_;
+    std::vector<uint8_t> prepend_scratch_phases_;
 };
 
 }  // namespace clifft


### PR DESCRIPTION
Cache fixed gate tableaus, compose sparse rows directly, and reuse prepend scratch storage. Apply the same packed set-bit and in-place row updates in planner coordinate changes, restoring native Clifford compile-time scaling.

Part of #385.

Assisted-by: Codex (GPT-5) <noreply@openai.com>