### PR TITLE
feat(hip): add retained sampling and experimental Python workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         run: cmake --build build-hip --target clifft_hip_tests --parallel 2
 
       - name: Run GPU-free HIP conformance tests
-        run: ctest --test-dir build-hip --output-on-failure -R HIP
+        run: ctest --test-dir build-hip --output-on-failure --no-tests=error -R HIP
       - name: Build editable HIP Python package
         env:
           CMAKE_ARGS: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install Python binding build dependencies
+        run: uv sync --frozen --only-group dev --no-install-project
+
       - name: Configure gfx942 HIP build
         run: |
           cmake -S . -B build-hip -G Ninja \
@@ -115,6 +124,20 @@ jobs:
 
       - name: Run GPU-free HIP conformance tests
         run: ctest --test-dir build-hip --output-on-failure -R HIP
+
+      - name: Configure gfx942 HIP Python extension
+        run: |
+          cmake -S . -B build-python-hip -G Ninja \
+            -DSKBUILD=ON \
+            -DPython_EXECUTABLE=${{ github.workspace }}/.venv/bin/python \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCLIFFT_ENABLE_HIP=ON \
+            -DCMAKE_HIP_ARCHITECTURES=gfx942 \
+            -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+            -DCMAKE_HIP_COMPILER_ROCM_ROOT=/opt/rocm
+
+      - name: Compile optional HIP Python extension
+        run: cmake --build build-python-hip --target _clifft_hip --parallel 2
 
   build-and-test:
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,20 +124,19 @@ jobs:
 
       - name: Run GPU-free HIP conformance tests
         run: ctest --test-dir build-hip --output-on-failure -R HIP
-
-      - name: Configure gfx942 HIP Python extension
-        run: |
-          cmake -S . -B build-python-hip -G Ninja \
-            -DSKBUILD=ON \
-            -DPython_EXECUTABLE="$GITHUB_WORKSPACE/.venv/bin/python" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCLIFFT_ENABLE_HIP=ON \
-            -DCMAKE_HIP_ARCHITECTURES=gfx942 \
-            -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+      - name: Build editable HIP Python package
+        env:
+          CMAKE_ARGS: >-
+            -DCMAKE_BUILD_TYPE=Release
+            -DCLIFFT_ENABLE_HIP=ON
+            -DCMAKE_HIP_ARCHITECTURES=gfx942
+            -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++
             -DCMAKE_HIP_COMPILER_ROCM_ROOT=/opt/rocm
+          CMAKE_BUILD_PARALLEL_LEVEL: "2"
+        run: uv pip install --editable .
 
-      - name: Compile optional HIP Python extension
-        run: cmake --build build-python-hip --target _clifft_hip --parallel 2
+      - name: Run GPU-free HIP Python boundary tests
+        run: uv run --no-sync pytest tests/python/test_experimental_hip.py -v
 
   build-and-test:
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           cmake -S . -B build-python-hip -G Ninja \
             -DSKBUILD=ON \
-            -DPython_EXECUTABLE=${{ github.workspace }}/.venv/bin/python \
+            -DPython_EXECUTABLE="$GITHUB_WORKSPACE/.venv/bin/python" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCLIFFT_ENABLE_HIP=ON \
             -DCMAKE_HIP_ARCHITECTURES=gfx942 \

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # C++ / CMake build artifacts
 /build/
 /build-hip/
+/build-python-hip/
 /build-wasm/
 build-coverage/
 build-profile/

--- a/docs/development/hip-backend.md
+++ b/docs/development/hip-backend.md
@@ -19,6 +19,10 @@ pairings, active-width transitions, expressions, and noise distributions. The
 device therefore executes the plan without performing topology planning or
 allocating storage in its dispatch loop.
 
+CPU and HIP lowering share only execution-ready Pauli preparation and result
+containers. Their executable layouts, mutable state, dispatch order, and
+workspace ownership remain backend-specific.
+
 ## Building for gfx942
 
 HIP support is off by default. Enable it explicitly and select the target GPU:
@@ -53,13 +57,15 @@ coefficient, scratch, symbol, record, and output storage before kernel launch.
 It is intentionally restricted to peak active width `k <= 4`, where serial
 coefficient work per shot is small.
 
-`sampling::hip::Sampler` uploads an executable once and owns a reusable,
-precision-specific workspace. Large requests are divided into bounded batches;
+`sampling::hip::Sampler` uploads an executable once and owns scalar result
+metadata plus a reusable, precision-specific workspace; it does not retain a
+duplicate host executable. Large requests are divided into bounded batches;
 the kernel receives the global shot offset so changing the batch size does not
 change a seeded shot's random stream. The free C++ sampling functions remain
-convenience wrappers that construct a temporary sampler. Aggregate-only
-survivor sampling downloads survival flags and observables, but omits record,
-detector, and expectation-value transfers that its caller does not consume.
+convenience wrappers that construct a temporary sampler. Aggregate-only survivor
+sampling downloads survival flags and observables, but omits record, detector,
+and expectation-value transfers that its caller does not consume. Overlapping
+calls on one retained sampler are rejected by the backend.
 
 This tier supports both coefficient formats in one backend:
 

--- a/docs/development/hip-backend.md
+++ b/docs/development/hip-backend.md
@@ -53,6 +53,12 @@ coefficient, scratch, symbol, record, and output storage before kernel launch.
 It is intentionally restricted to peak active width `k <= 4`, where serial
 coefficient work per shot is small.
 
+`sampling::hip::Sampler` uploads an executable once and owns a reusable,
+precision-specific workspace. Large requests are divided into bounded batches;
+the kernel receives the global shot offset so changing the batch size does not
+change a seeded shot's random stream. The free C++ sampling functions remain
+convenience wrappers that construct a temporary sampler.
+
 This tier supports both coefficient formats in one backend:
 
 - FP64 coefficients are the default.
@@ -81,9 +87,10 @@ new `SamplingAction` without handling it in the HIP lowering also fails during
 this build.
 
 When HIP is enabled, the ROCm CI job additionally compiles the device code for
-`gfx942` and links the HIP conformance test executable. Tests for zero-shot
-requests and input validation run without a device. Tests that launch kernels
-report as skipped when no AMD GPU is visible.
+`gfx942`, links the HIP conformance test executable, and builds the optional
+Python extension. Tests for zero-shot requests and input validation run without
+a device. Tests that launch kernels report as skipped when no AMD GPU is
+visible.
 
 This compile-only coverage does not establish that kernels launch or produce
 correct results on a GPU.
@@ -121,10 +128,12 @@ the same seed, including when a request is divided into different batch sizes.
 ## Next Work
 
 - Run the complete conformance suite on MI300X hardware.
-- Retain uploaded programs and reusable work buffers across sampling calls.
-- Process large requests in bounded shot batches and aggregate results on the
-  device when full rows are not requested.
+- Aggregate survivor statistics on the device when full rows are not
+  requested.
 - Add a cooperative thread-block path using on-chip shared memory through
   approximately `k = 10`, including the cultivation distance-5 fixture.
 - Evaluate a global-memory path for larger active widths after the cooperative
   path is validated.
+
+See [HIP Kernel Development](hip-kernel-development.md) for the experimental
+Python workflow, source map, and extension checklist.

--- a/docs/development/hip-backend.md
+++ b/docs/development/hip-backend.md
@@ -87,12 +87,13 @@ new `SamplingAction` without handling it in the HIP lowering also fails during
 this build.
 
 When HIP is enabled, the ROCm CI job additionally compiles the device code for
-`gfx942`, links the HIP conformance test executable, and builds the optional
-Python extension. Tests for zero-shot requests and input validation run without
-a device. Tests that launch kernels report as skipped when no AMD GPU is
+`gfx942`, runs the GPU-free HIP conformance cases, and installs the optional
+Python extension through the editable developer workflow. The Python boundary
+test passes shared HIR from `_clifft_core` into `_clifft_hip` and inspects the
+lowered program. Tests that launch kernels report as skipped when no AMD GPU is
 visible.
 
-This compile-only coverage does not establish that kernels launch or produce
+This GPU-free coverage does not establish that kernels launch or produce
 correct results on a GPU.
 
 ## Tests That Run on an AMD GPU

--- a/docs/development/hip-backend.md
+++ b/docs/development/hip-backend.md
@@ -57,7 +57,9 @@ coefficient work per shot is small.
 precision-specific workspace. Large requests are divided into bounded batches;
 the kernel receives the global shot offset so changing the batch size does not
 change a seeded shot's random stream. The free C++ sampling functions remain
-convenience wrappers that construct a temporary sampler.
+convenience wrappers that construct a temporary sampler. Aggregate-only
+survivor sampling downloads survival flags and observables, but omits record,
+detector, and expectation-value transfers that its caller does not consume.
 
 This tier supports both coefficient formats in one backend:
 

--- a/docs/development/hip-kernel-development.md
+++ b/docs/development/hip-kernel-development.md
@@ -17,7 +17,8 @@ CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx942" \
     uv pip install -e .
 ```
 
-The exe.dev compiler selection can be added to the same command:
+On hosts where the HIP compiler is installed under `/usr`, add its location to
+the same command:
 
 ```bash
 CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON \
@@ -62,7 +63,8 @@ branch = sampler.replay_shot([0])
 `Program` is an immutable host lowering and can be inspected without a GPU.
 `Sampler` selects FP32 or FP64 coefficient evolution, uploads the program, and
 allocates its bounded workspace on the device current at construction. It is
-synchronous and should be reused for repeated calls. Its
+synchronous and should be reused for repeated calls, but calls on one sampler
+must not overlap. Its
 `allocated_device_bytes` and `max_batch_shots` properties make memory
 experiments visible without exposing raw buffers.
 

--- a/docs/development/hip-kernel-development.md
+++ b/docs/development/hip-kernel-development.md
@@ -106,7 +106,9 @@ private serialization for the HIP interpreter, not another semantic IR.
 `Sampler` owns one uploaded program and one precision-specific workspace.
 Allocation is complete before a batch enters the kernel. A request larger than
 `max_batch_shots` reuses that workspace, and each launch receives both its
-local row count and global shot offset.
+local row count and global shot offset. Aggregate-only survivor requests skip
+unused record, detector, and expectation-value downloads; device-side survivor
+aggregation remains a separate execution-path extension.
 
 A cooperative path should add a separate kernel and typed launcher, then
 dispatch by peak active width. It should not add topology work to the device:

--- a/docs/development/hip-kernel-development.md
+++ b/docs/development/hip-kernel-development.md
@@ -1,0 +1,169 @@
+<!--pytest-codeblocks:skipfile-->
+
+# HIP Kernel Development
+
+This guide is the handoff point for extending the experimental AMD backend.
+The backend is intentionally private below `SamplingPlan`: changes to its
+packed actions, workspace, and kernels do not define a cross-backend ABI.
+
+## Build a Developer Installation
+
+The ordinary Python package always contains `clifft.experimental.hip`, but its
+native extension is built only when HIP is explicitly enabled. On a ROCm host,
+install an editable developer build with:
+
+```bash
+CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx942" \
+    uv pip install -e .
+```
+
+The exe.dev compiler selection can be added to the same command:
+
+```bash
+CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON \
+    -DCMAKE_HIP_ARCHITECTURES=gfx942 \
+    -DCMAKE_HIP_COMPILER=/usr/bin/clang++-17 \
+    -DCMAKE_HIP_COMPILER_ROCM_ROOT=/usr" \
+    uv pip install -e .
+```
+
+For C++ iteration, use the standalone build documented in
+[Experimental HIP Sampling Backend](hip-backend.md). Both paths compile device
+code offline; only kernel-launch tests require a visible GPU.
+
+## Python Iteration Loop
+
+The Python facade uses the same HIR optimization and `SamplingPlan` boundary as
+the CPU backend:
+
+```python
+from clifft.experimental import hip
+
+print(hip.backend_info())
+
+program = hip.compile("""
+    H 0
+    T 0
+    H 0
+    M 0
+    OBSERVABLE_INCLUDE(0) rec[-1]
+""")
+print(program.inspect())
+
+sampler = hip.Sampler(
+    program,
+    precision="fp64",
+    max_batch_shots=16_384,
+)
+result = sampler.sample(100_000, seed=1234, block_size=256)
+branch = sampler.replay_shot([0])
+```
+
+`Program` is an immutable host lowering and can be inspected without a GPU.
+`Sampler` selects FP32 or FP64 coefficient evolution, uploads the program, and
+allocates its bounded workspace on the device current at construction. It is
+synchronous and should be reused for repeated calls. Its
+`allocated_device_bytes` and `max_batch_shots` properties make memory
+experiments visible without exposing raw buffers.
+
+## Source Map
+
+| Change | Primary location | Contract |
+| --- | --- | --- |
+| Support a `SamplingAction` | `src/clifft/sampling/hip/executable.cc` | Exhaustive lowering from the shared plan |
+| Change a packed action | `src/clifft/sampling/hip/device_program.h` | Private host/device descriptor |
+| Change coefficient evolution | Device half of `src/clifft/sampling/hip/sampler.hip` | FP32 and FP64 interpreter templates |
+| Change per-shot memory layout | `Sampler::Impl` and `coefficient_elements_per_shot` in `sampler.hip` | Retained device and host workspace |
+| Change launch or batching | Host half of `sampler.hip` | Global shot indices and synchronous batches |
+| Change the Python experiment | `src/python/clifft/experimental/hip.py` | Thin wrapper over `_clifft_hip` |
+| Add conformance cases | `tests/test_hip_sampler.cc` and `tests/python/utils_hip.py` | CPU oracle, replay, and distributions |
+
+The `__HIP_DEVICE_COMPILE__` boundary in `sampler.hip` separates device
+interpretation from host ownership and collection. Kernel templates must keep
+device-visible explicit instantiations when their launchers are hidden from the
+device pass.
+
+## Add or Change an Action
+
+1. Add explicit lowering for the existing `SamplingAction` alternative in
+   `Executable::lower_action`. The dependent static assertion makes an
+   unhandled alternative fail in ordinary CPU builds.
+2. Put only execution-ready fields in `detail::Action`. Pauli geometry,
+   coordinate changes, and symbolic dependencies belong in planning or
+   lowering, not in the kernel.
+3. Implement the tag in the interpreter switch for both coefficient types.
+4. Add host-only packing assertions to `test_hip_executable.cc`.
+5. Add forced-replay or deterministic hardware coverage before relying on a
+   statistical comparison.
+
+Do not create a second name for an existing sampling action. The device tag is
+private serialization for the HIP interpreter, not another semantic IR.
+
+## Change the Workspace or Add an Execution Tier
+
+`Sampler` owns one uploaded program and one precision-specific workspace.
+Allocation is complete before a batch enters the kernel. A request larger than
+`max_batch_shots` reuses that workspace, and each launch receives both its
+local row count and global shot offset.
+
+A cooperative path should add a separate kernel and typed launcher, then
+dispatch by peak active width. It should not add topology work to the device:
+the packed executable already carries pairings, Pauli phases, expressions, and
+active-width transitions. Keep the current thread-per-shot path as the small
+width reference while the cooperative path uses on-chip shared memory through
+approximately `k = 10`.
+
+When changing batching or launch geometry, preserve these invariants:
+
+- no allocation inside a kernel or ordinary dispatch loop;
+- the RNG uses the global shot index, so batch size cannot change seeded rows;
+- coefficient arithmetic follows the selected precision;
+- reductions, normalization, statistics, replay likelihoods, and expectation
+  values remain FP64; and
+- the CPU `ExecutablePlan` remains the semantic oracle.
+
+## Add Another AMD Architecture
+
+The interpreter has no `gfx942` semantic branch. Select another target at
+build time:
+
+```bash
+cmake -S . -B build-hip -G Ninja \
+    -DCLIFFT_ENABLE_HIP=ON \
+    -DCMAKE_HIP_ARCHITECTURES=gfx950
+```
+
+A development binary may contain more than one target:
+
+```bash
+cmake -S . -B build-hip -G Ninja \
+    -DCLIFFT_ENABLE_HIP=ON \
+    -DCMAKE_HIP_ARCHITECTURES="gfx942;gfx950"
+```
+
+Add architecture-specific launch traits only after measurement shows a real
+difference, such as block size, shared-memory capacity, or wavefront tuning.
+Do not duplicate the action format or interpreter solely to name another GPU.
+
+## Conformance Workflow
+
+The C++ suite is the canonical backend conformance layer:
+
+```bash
+cmake --build build-hip --target clifft_tests clifft_hip_tests -j
+ctest --test-dir build-hip --output-on-failure -R HIP
+```
+
+The Python suite provides quick developer probes:
+
+```bash
+uv run pytest tests/python/test_experimental_hip.py -v
+```
+
+`tests/python/utils_hip.py` provides exact repeatability, full-row
+distribution, and forced-record probability helpers. Prefer forced replay for
+small branching circuits because it probes every reachable branch and its
+likelihood. Use joint-distribution comparisons for noise and other stochastic
+behavior, with both precision modes parameterized. Add later measurements,
+detectors, observables, and expectation values after non-diagonal operations so
+tests observe the evolved state rather than only the first sampled outcome.

--- a/docs/development/hip-kernel-development.md
+++ b/docs/development/hip-kernel-development.md
@@ -63,21 +63,22 @@ branch = sampler.replay_shot([0])
 `Program` is an immutable host lowering and can be inspected without a GPU.
 `Sampler` selects FP32 or FP64 coefficient evolution, uploads the program, and
 allocates its bounded workspace on the device current at construction. It is
-synchronous and should be reused for repeated calls, but calls on one sampler
-must not overlap. Its
-`allocated_device_bytes` and `max_batch_shots` properties make memory
-experiments visible without exposing raw buffers.
+synchronous and should be reused for repeated calls. Overlapping calls on one
+sampler are rejected; use a separate sampler per caller. Its
+`allocated_device_bytes` and `max_batch_shots` properties make memory experiments
+visible without exposing raw buffers.
 
 ## Source Map
 
 | Change | Primary location | Contract |
 | --- | --- | --- |
-| Support a `SamplingAction` | `src/clifft/sampling/hip/executable.cc` | Exhaustive lowering from the shared plan |
+| Support a `SamplingAction` | `src/clifft/sampling/hip/executable_plan.cc` | Exhaustive lowering from the shared plan |
+| Change shared Pauli preparation | `src/clifft/sampling/pauli_preparation.h` | Execution-ready geometry consumed by CPU and HIP lowering |
 | Change a packed action | `src/clifft/sampling/hip/device_program.h` | Private host/device descriptor |
 | Change coefficient evolution | Device half of `src/clifft/sampling/hip/sampler.hip` | FP32 and FP64 interpreter templates |
-| Change per-shot memory layout | `Sampler::Impl` and `coefficient_elements_per_shot` in `sampler.hip` | Retained device and host workspace |
+| Change per-shot memory layout | `coefficient_elements_per_shot` in `device_program.h` and `Sampler::Impl` in `sampler.hip` | Shared host/device sizing and retained workspace |
 | Change launch or batching | Host half of `sampler.hip` | Global shot indices and synchronous batches |
-| Change the Python experiment | `src/python/clifft/experimental/hip.py` | Thin wrapper over `_clifft_hip` |
+| Change the Python experiment | `src/python/clifft/experimental/hip.py` | Typed optional facade over `_clifft_hip` |
 | Add conformance cases | `tests/test_hip_sampler.cc` and `tests/python/utils_hip.py` | CPU oracle, replay, and distributions |
 
 The `__HIP_DEVICE_COMPILE__` boundary in `sampler.hip` separates device
@@ -88,13 +89,13 @@ device pass.
 ## Add or Change an Action
 
 1. Add explicit lowering for the existing `SamplingAction` alternative in
-   `Executable::lower_action`. The dependent static assertion makes an
+   `ExecutablePlan::lower_action`. The dependent static assertion makes an
    unhandled alternative fail in ordinary CPU builds.
 2. Put only execution-ready fields in `detail::Action`. Pauli geometry,
    coordinate changes, and symbolic dependencies belong in planning or
    lowering, not in the kernel.
 3. Implement the tag in the interpreter switch for both coefficient types.
-4. Add host-only packing assertions to `test_hip_executable.cc`.
+4. Add host-only packing assertions to `test_hip_executable_plan.cc`.
 5. Add forced-replay or deterministic hardware coverage before relying on a
    statistical comparison.
 
@@ -103,11 +104,12 @@ private serialization for the HIP interpreter, not another semantic IR.
 
 ## Change the Workspace or Add an Execution Tier
 
-`Sampler` owns one uploaded program and one precision-specific workspace.
+`Sampler` owns one uploaded program, scalar result-layout metadata, and one
+precision-specific workspace. It does not retain a duplicate host executable.
 Allocation is complete before a batch enters the kernel. A request larger than
-`max_batch_shots` reuses that workspace, and each launch receives both its
-local row count and global shot offset. Aggregate-only survivor requests skip
-unused record, detector, and expectation-value downloads; device-side survivor
+`max_batch_shots` reuses that workspace, and each launch receives both its local
+row count and global shot offset. Aggregate-only survivor requests skip unused
+record, detector, and expectation-value downloads; device-side survivor
 aggregation remains a separate execution-path extension.
 
 A cooperative path should add a separate kernel and typed launcher, then

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - Building from Source: development/building.md
     - Experimental:
       - HIP Sampling Backend: development/hip-backend.md
+      - HIP Kernel Development: development/hip-kernel-development.md
     - Testing Strategy: development/testing.md
     - Benchmark History: development/benchmark-history.md
     - Releasing: development/releasing.md

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(clifft_core STATIC
     sampling/inspection_format.cc
     sampling/planner.cc
     sampling/planner_frame.cc
+    sampling/pauli_preparation.cc
     sampling/kernel_dispatch.cc
     sampling/executable_plan.cc
     sampling/executable_plan_inspection.cc

--- a/src/clifft/sampling/hip/device_program.h
+++ b/src/clifft/sampling/hip/device_program.h
@@ -28,6 +28,20 @@ enum class ActionTag : uint8_t {
 inline constexpr uint8_t kPostselected = 1U << 0;
 inline constexpr uint8_t kAbsentActiveProjection = 1U << 1;
 
+inline constexpr uint64_t coefficient_state_capacity(uint32_t peak_active_width) {
+    return uint64_t{1} << peak_active_width;
+}
+
+inline constexpr uint64_t coefficient_scratch_capacity(uint32_t peak_active_width) {
+    const uint64_t capacity = coefficient_state_capacity(peak_active_width);
+    return capacity > 1 ? capacity >> 1 : 1;
+}
+
+inline constexpr uint64_t coefficient_elements_per_shot(uint32_t peak_active_width) {
+    return 2 * coefficient_state_capacity(peak_active_width) +
+           2 * coefficient_scratch_capacity(peak_active_width);
+}
+
 struct Expression {
     uint32_t term_begin = 0;
     uint32_t term_count = 0;

--- a/src/clifft/sampling/hip/executable_plan.cc
+++ b/src/clifft/sampling/hip/executable_plan.cc
@@ -3,6 +3,7 @@
 #include "clifft/sampling/kernels.h"
 
 #include <limits>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -26,6 +27,32 @@ void flatten_pauli(detail::Action& action, const PreparedPauli& pauli) {
     action.phase_imag = static_cast<int8_t>(pauli.even_phase.imag());
     action.x = pauli.x;
     action.z = pauli.z;
+}
+
+const char* action_tag_name(detail::ActionTag tag) {
+    switch (tag) {
+        case detail::ActionTag::RotateActivePauli:
+            return "RotateActivePauli";
+        case detail::ActionTag::PromoteDormantRotation:
+            return "PromoteDormantRotation";
+        case detail::ActionTag::MeasureActivePauli:
+            return "MeasureActivePauli";
+        case detail::ActionTag::MeasureDormantRandom:
+            return "MeasureDormantRandom";
+        case detail::ActionTag::RecordClassical:
+            return "RecordClassical";
+        case detail::ActionTag::DefineSymbol:
+            return "DefineSymbol";
+        case detail::ActionTag::ApplyReadoutNoise:
+            return "ApplyReadoutNoise";
+        case detail::ActionTag::WriteDetector:
+            return "WriteDetector";
+        case detail::ActionTag::WriteObservable:
+            return "WriteObservable";
+        case detail::ActionTag::WriteExpectationValue:
+            return "WriteExpectationValue";
+    }
+    return "Unknown";
 }
 
 }  // namespace
@@ -80,6 +107,33 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
     for (const PlannedAction& action : plan.actions) {
         actions_.push_back(lower_action(action));
     }
+}
+
+size_t ExecutablePlan::packed_bytes() const {
+    return actions_.size() * sizeof(detail::Action) +
+           expressions_.size() * sizeof(detail::Expression) +
+           expression_terms_.size() * sizeof(uint32_t) +
+           noise_sites_.size() * sizeof(detail::NoiseSite) +
+           noise_outcomes_.size() * sizeof(detail::NoiseOutcome);
+}
+
+std::string ExecutablePlan::inspect() const {
+    std::ostringstream output;
+    output << "HIP executable: actions=" << actions_.size()
+           << " peak_active_width=" << peak_active_width_ << " packed_bytes=" << packed_bytes()
+           << '\n';
+    output << "storage: symbols=" << num_symbols_ << " records=" << num_records()
+           << " detectors=" << num_detectors_ << " observables=" << num_observables_
+           << " exp_vals=" << num_exp_vals_ << '\n';
+    for (size_t index = 0; index < actions_.size(); ++index) {
+        const detail::Action& action = actions_[index];
+        output << index << ": " << action_tag_name(action.tag)
+               << " active_before=" << action.active_before << " expression=" << action.expression
+               << " x=" << action.x << " z=" << action.z << " index0=" << action.index0
+               << " index1=" << action.index1 << " index2=" << action.index2
+               << " flags=" << static_cast<uint32_t>(action.flags) << '\n';
+    }
+    return output.str();
 }
 
 uint32_t ExecutablePlan::append_expression(const AffineBool& expression) {

--- a/src/clifft/sampling/hip/executable_plan.cc
+++ b/src/clifft/sampling/hip/executable_plan.cc
@@ -1,6 +1,6 @@
 #include "clifft/sampling/hip/executable_plan.h"
 
-#include "clifft/sampling/kernels.h"
+#include "clifft/sampling/pauli_preparation.h"
 
 #include <limits>
 #include <sstream>

--- a/src/clifft/sampling/hip/executable_plan.h
+++ b/src/clifft/sampling/hip/executable_plan.h
@@ -3,8 +3,10 @@
 #include "clifft/sampling/hip/device_program.h"
 #include "clifft/sampling/plan.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace clifft::sampling::hip {
@@ -29,6 +31,9 @@ class ExecutablePlan {
     [[nodiscard]] uint32_t num_observables() const { return num_observables_; }
     [[nodiscard]] uint32_t num_exp_vals() const { return num_exp_vals_; }
     [[nodiscard]] bool has_postselection() const { return has_postselection_; }
+    [[nodiscard]] uint32_t num_actions() const { return static_cast<uint32_t>(actions_.size()); }
+    [[nodiscard]] size_t packed_bytes() const;
+    [[nodiscard]] std::string inspect() const;
 
     [[nodiscard]] std::span<const detail::Action> actions() const { return actions_; }
     [[nodiscard]] std::span<const detail::Expression> expressions() const { return expressions_; }

--- a/src/clifft/sampling/hip/sampler.h
+++ b/src/clifft/sampling/hip/sampler.h
@@ -39,6 +39,7 @@ struct ReplayResult {
 
 // Owns one uploaded executable and a precision-specific reusable workspace.
 // The object is synchronous and bound to the device current at construction.
+// Calls on one instance must not overlap; use a separate Sampler per caller.
 class Sampler {
   public:
     explicit Sampler(const ExecutablePlan& executable,

--- a/src/clifft/sampling/hip/sampler.h
+++ b/src/clifft/sampling/hip/sampler.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "clifft/sampling/hip/executable_plan.h"
-#include "clifft/sampling/sampler.h"
+#include "clifft/sampling/results.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/src/clifft/sampling/hip/sampler.h
+++ b/src/clifft/sampling/hip/sampler.h
@@ -3,7 +3,9 @@
 #include "clifft/sampling/hip/executable_plan.h"
 #include "clifft/sampling/sampler.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <span>
 #include <string>
@@ -15,10 +17,14 @@ enum class CoefficientPrecision : uint8_t {
     FP32,
 };
 
+inline constexpr uint32_t kDefaultBlockSize = 256;
+inline constexpr uint32_t kDefaultMaxBatchShots = 65536;
+
 struct SamplingOptions {
     std::optional<uint64_t> seed = std::nullopt;
     CoefficientPrecision coefficient_precision = CoefficientPrecision::FP64;
-    uint32_t block_size = 256;
+    uint32_t block_size = kDefaultBlockSize;
+    uint32_t max_batch_shots = kDefaultMaxBatchShots;
 };
 
 struct ReplayResult {
@@ -30,6 +36,36 @@ struct ReplayResult {
 
 [[nodiscard]] bool is_available() noexcept;
 [[nodiscard]] std::string backend_info();
+
+// Owns one uploaded executable and a precision-specific reusable workspace.
+// The object is synchronous and bound to the device current at construction.
+class Sampler {
+  public:
+    explicit Sampler(const ExecutablePlan& executable,
+                     CoefficientPrecision coefficient_precision = CoefficientPrecision::FP64,
+                     uint32_t max_batch_shots = kDefaultMaxBatchShots);
+    ~Sampler();
+
+    Sampler(const Sampler&) = delete;
+    Sampler& operator=(const Sampler&) = delete;
+    Sampler(Sampler&&) noexcept;
+    Sampler& operator=(Sampler&&) noexcept;
+
+    [[nodiscard]] SamplingResult sample(uint32_t shots, std::optional<uint64_t> seed = std::nullopt,
+                                        uint32_t block_size = kDefaultBlockSize);
+    [[nodiscard]] SamplingSurvivorResult sample_survivors(
+        uint32_t shots, bool keep_records = false, std::optional<uint64_t> seed = std::nullopt,
+        uint32_t block_size = kDefaultBlockSize);
+    [[nodiscard]] ReplayResult replay_shot(std::span<const uint8_t> forced_records);
+
+    [[nodiscard]] CoefficientPrecision coefficient_precision() const;
+    [[nodiscard]] uint32_t max_batch_shots() const;
+    [[nodiscard]] size_t allocated_device_bytes() const;
+
+  private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
 
 [[nodiscard]] SamplingResult sample(const ExecutablePlan& executable, uint32_t shots,
                                     const SamplingOptions& options = {});

--- a/src/clifft/sampling/hip/sampler.h
+++ b/src/clifft/sampling/hip/sampler.h
@@ -39,7 +39,7 @@ struct ReplayResult {
 
 // Owns one uploaded executable and a precision-specific reusable workspace.
 // The object is synchronous and bound to the device current at construction.
-// Calls on one instance must not overlap; use a separate Sampler per caller.
+// Overlapping calls are rejected; use a separate Sampler per caller.
 class Sampler {
   public:
     explicit Sampler(const ExecutablePlan& executable,
@@ -62,6 +62,11 @@ class Sampler {
     [[nodiscard]] CoefficientPrecision coefficient_precision() const;
     [[nodiscard]] uint32_t max_batch_shots() const;
     [[nodiscard]] size_t allocated_device_bytes() const;
+    [[nodiscard]] uint32_t num_visible_records() const;
+    [[nodiscard]] uint32_t num_records() const;
+    [[nodiscard]] uint32_t num_detectors() const;
+    [[nodiscard]] uint32_t num_observables() const;
+    [[nodiscard]] uint32_t num_exp_vals() const;
 
   private:
     class Impl;

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -691,6 +691,12 @@ void validate_replay_input(const ExecutablePlan& executable,
 
 class Sampler::Impl {
   public:
+    enum class DownloadMode : uint8_t {
+        FullRows,
+        SurvivorCounts,
+        Replay,
+    };
+
     Impl(const ExecutablePlan& source, CoefficientPrecision selected_precision,
          uint32_t selected_max_batch_shots)
         : executable(source),
@@ -721,7 +727,7 @@ class Sampler::Impl {
           host_survived(max_batch) {}
 
     void run_batch(detail::SeedRoot root, uint64_t shot_offset, uint32_t shots,
-                   uint32_t block_size) {
+                   uint32_t block_size, DownloadMode download_mode) {
         if (shots > max_batch) {
             throw std::invalid_argument("HIP batch exceeds retained workspace capacity");
         }
@@ -730,7 +736,7 @@ class Sampler::Impl {
         } else {
             launch<double, false>(root, shot_offset, shots, block_size, fp64_coefficients.data());
         }
-        download_rows(shots, false);
+        download_rows(shots, download_mode);
     }
 
     void run_replay(std::span<const uint8_t> input) {
@@ -741,7 +747,7 @@ class Sampler::Impl {
         } else {
             launch<double, true>(empty_root, 0, 1, 1, fp64_coefficients.data());
         }
-        download_rows(1, true);
+        download_rows(1, DownloadMode::Replay);
     }
 
     [[nodiscard]] size_t allocated_device_bytes() const {
@@ -797,21 +803,23 @@ class Sampler::Impl {
         check_hip(hipDeviceSynchronize(), "kernel execution");
     }
 
-    void download_rows(uint32_t shots, bool replay) {
-        records.download(
-            std::span(host_records)
-                .first(checked_elements(shots, executable.num_records(), "record result")));
-        detectors.download(
-            std::span(host_detectors)
-                .first(checked_elements(shots, executable.num_detectors(), "detector result")));
+    void download_rows(uint32_t shots, DownloadMode mode) {
+        if (mode != DownloadMode::SurvivorCounts) {
+            records.download(
+                std::span(host_records)
+                    .first(checked_elements(shots, executable.num_records(), "record result")));
+            detectors.download(
+                std::span(host_detectors)
+                    .first(checked_elements(shots, executable.num_detectors(), "detector result")));
+            exp_vals.download(
+                std::span(host_exp_vals)
+                    .first(checked_elements(shots, executable.num_exp_vals(), "expectation result")));
+        }
         observables.download(
             std::span(host_observables)
                 .first(checked_elements(shots, executable.num_observables(), "observable result")));
-        exp_vals.download(
-            std::span(host_exp_vals)
-                .first(checked_elements(shots, executable.num_exp_vals(), "expectation result")));
         survived.download(std::span(host_survived).first(shots));
-        if (replay) {
+        if (mode == DownloadMode::Replay) {
             log_probabilities.download(std::span(&host_log_probability, 1));
             reachable.download(std::span(&host_reachable, 1));
         }
@@ -873,7 +881,8 @@ SamplingResult Sampler::sample(uint32_t shots, std::optional<uint64_t> seed, uin
     const detail::SeedRoot device_root{{root.w[0], root.w[1], root.w[2], root.w[3]}};
     for (uint32_t offset = 0; offset < shots;) {
         const uint32_t batch = std::min(impl_->max_batch, shots - offset);
-        impl_->run_batch(device_root, offset, batch, block_size);
+        impl_->run_batch(device_root, offset, batch, block_size,
+                         Impl::DownloadMode::FullRows);
         for (uint32_t local_shot = 0; local_shot < batch; ++local_shot) {
             if (impl_->executable.num_visible_records() != 0) {
                 std::copy_n(
@@ -935,7 +944,9 @@ SamplingSurvivorResult Sampler::sample_survivors(uint32_t shots, bool keep_recor
     const detail::SeedRoot device_root{{root.w[0], root.w[1], root.w[2], root.w[3]}};
     for (uint32_t offset = 0; offset < shots;) {
         const uint32_t batch = std::min(impl_->max_batch, shots - offset);
-        impl_->run_batch(device_root, offset, batch, block_size);
+        impl_->run_batch(device_root, offset, batch, block_size,
+                         keep_records ? Impl::DownloadMode::FullRows
+                                      : Impl::DownloadMode::SurvivorCounts);
         for (uint32_t local_shot = 0; local_shot < batch; ++local_shot) {
             if (impl_->host_survived[local_shot] == 0) {
                 continue;

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -352,9 +352,9 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_
         return;
     }
 
-    const uint64_t capacity = uint64_t{1} << program.peak_active_width;
-    const uint64_t scratch_capacity = capacity > 1 ? capacity >> 1 : 1;
-    const uint64_t coefficient_stride = 2 * capacity + 2 * scratch_capacity;
+    const uint64_t capacity = coefficient_state_capacity(program.peak_active_width);
+    const uint64_t scratch_capacity = coefficient_scratch_capacity(program.peak_active_width);
+    const uint64_t coefficient_stride = coefficient_elements_per_shot(program.peak_active_width);
     Coefficient* real = coefficient_storage + static_cast<uint64_t>(shot) * coefficient_stride;
     Coefficient* imag = real + capacity;
     Coefficient* scratch_real = imag + capacity;
@@ -599,6 +599,13 @@ class DeviceBuffer {
     [[nodiscard]] size_t bytes() const { return count_ * sizeof(T); }
 
     void download(std::span<T> destination) const {
+        if (destination.size() != count_) {
+            throw std::invalid_argument("HIP download destination must match the device buffer");
+        }
+        download_prefix(destination);
+    }
+
+    void download_prefix(std::span<T> destination) const {
         if (destination.size() > count_) {
             throw std::invalid_argument("HIP download destination exceeds the device buffer");
         }
@@ -703,7 +710,7 @@ class Sampler::Impl {
           program(executable),
           precision(selected_precision),
           max_batch(selected_max_batch_shots),
-          coefficient_stride(coefficient_elements_per_shot(executable)),
+          coefficient_stride(detail::coefficient_elements_per_shot(executable.peak_active_width())),
           fp32_coefficients(selected_precision == CoefficientPrecision::FP32
                                 ? checked_elements(max_batch, coefficient_stride, "coefficient")
                                 : 0),
@@ -782,12 +789,6 @@ class Sampler::Impl {
     uint8_t host_reachable = 0;
 
   private:
-    static uint64_t coefficient_elements_per_shot(const ExecutablePlan& executable) {
-        const uint64_t state_capacity = uint64_t{1} << executable.peak_active_width();
-        const uint64_t scratch_capacity = state_capacity > 1 ? state_capacity >> 1 : 1;
-        return 2 * state_capacity + 2 * scratch_capacity;
-    }
-
     template <typename Coefficient, bool Replay>
     void launch(detail::SeedRoot root, uint64_t shot_offset, uint32_t shots, uint32_t block_size,
                 Coefficient* coefficient_storage) {
@@ -805,20 +806,20 @@ class Sampler::Impl {
 
     void download_rows(uint32_t shots, DownloadMode mode) {
         if (mode != DownloadMode::SurvivorCounts) {
-            records.download(
+            records.download_prefix(
                 std::span(host_records)
                     .first(checked_elements(shots, executable.num_records(), "record result")));
-            detectors.download(
+            detectors.download_prefix(
                 std::span(host_detectors)
                     .first(checked_elements(shots, executable.num_detectors(), "detector result")));
-            exp_vals.download(
+            exp_vals.download_prefix(
                 std::span(host_exp_vals)
                     .first(checked_elements(shots, executable.num_exp_vals(), "expectation result")));
         }
-        observables.download(
+        observables.download_prefix(
             std::span(host_observables)
                 .first(checked_elements(shots, executable.num_observables(), "observable result")));
-        survived.download(std::span(host_survived).first(shots));
+        survived.download_prefix(std::span(host_survived).first(shots));
         if (mode == DownloadMode::Replay) {
             log_probabilities.download(std::span(&host_log_probability, 1));
             reachable.download(std::span(&host_reachable, 1));

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -339,12 +339,13 @@ __device__ __forceinline__ void sample_noise(const ProgramView& program, Xoshiro
 }
 
 template <typename Coefficient, bool Replay>
-__global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint32_t shots,
-                                Coefficient* coefficient_storage, uint8_t* symbol_storage,
-                                uint8_t* record_storage, const uint8_t* forced_record_storage,
-                                uint8_t* detector_storage, uint8_t* observable_storage,
-                                double* exp_val_storage, double* log_probability_storage,
-                                uint8_t* reachable_storage, uint8_t* survived) {
+__global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_t shot_offset,
+                                uint32_t shots, Coefficient* coefficient_storage,
+                                uint8_t* symbol_storage, uint8_t* record_storage,
+                                const uint8_t* forced_record_storage, uint8_t* detector_storage,
+                                uint8_t* observable_storage, double* exp_val_storage,
+                                double* log_probability_storage, uint8_t* reachable_storage,
+                                uint8_t* survived) {
     const uint64_t shot =
         static_cast<uint64_t>(blockIdx.x) * static_cast<uint64_t>(blockDim.x) + threadIdx.x;
     if (shot >= shots) {
@@ -404,7 +405,7 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint32_
         exp_vals[exp_val] = 0.0;
     }
 
-    Xoshiro256PlusPlus rng = shot_rng(seed_root, shot);
+    Xoshiro256PlusPlus rng = shot_rng(seed_root, shot_offset + shot);
     if constexpr (!Replay) {
         sample_noise(program, rng, symbols);
     }
@@ -496,18 +497,22 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint32_
 // The host launcher is intentionally hidden from the HIP device pass below.
 // Keep explicit device-visible instantiations here so the offload bundle owns
 // kernels instead of only host registration stubs.
-template __global__ void interpret_shots<float, false>(
-    ProgramView, SeedRoot, uint32_t, float*, uint8_t*, uint8_t*, const uint8_t*, uint8_t*,
-    uint8_t*, double*, double*, uint8_t*, uint8_t*);
-template __global__ void interpret_shots<double, false>(
-    ProgramView, SeedRoot, uint32_t, double*, uint8_t*, uint8_t*, const uint8_t*, uint8_t*,
-    uint8_t*, double*, double*, uint8_t*, uint8_t*);
-template __global__ void interpret_shots<float, true>(
-    ProgramView, SeedRoot, uint32_t, float*, uint8_t*, uint8_t*, const uint8_t*, uint8_t*,
-    uint8_t*, double*, double*, uint8_t*, uint8_t*);
-template __global__ void interpret_shots<double, true>(
-    ProgramView, SeedRoot, uint32_t, double*, uint8_t*, uint8_t*, const uint8_t*, uint8_t*,
-    uint8_t*, double*, double*, uint8_t*, uint8_t*);
+template __global__ void interpret_shots<float, false>(ProgramView, SeedRoot, uint64_t, uint32_t,
+                                                       float*, uint8_t*, uint8_t*, const uint8_t*,
+                                                       uint8_t*, uint8_t*, double*, double*,
+                                                       uint8_t*, uint8_t*);
+template __global__ void interpret_shots<double, false>(ProgramView, SeedRoot, uint64_t, uint32_t,
+                                                        double*, uint8_t*, uint8_t*, const uint8_t*,
+                                                        uint8_t*, uint8_t*, double*, double*,
+                                                        uint8_t*, uint8_t*);
+template __global__ void interpret_shots<float, true>(ProgramView, SeedRoot, uint64_t, uint32_t,
+                                                      float*, uint8_t*, uint8_t*, const uint8_t*,
+                                                      uint8_t*, uint8_t*, double*, double*,
+                                                      uint8_t*, uint8_t*);
+template __global__ void interpret_shots<double, true>(ProgramView, SeedRoot, uint64_t, uint32_t,
+                                                       double*, uint8_t*, uint8_t*, const uint8_t*,
+                                                       uint8_t*, uint8_t*, double*, double*,
+                                                       uint8_t*, uint8_t*);
 
 }  // namespace
 
@@ -591,15 +596,26 @@ class DeviceBuffer {
 
     [[nodiscard]] T* data() { return data_; }
     [[nodiscard]] const T* data() const { return data_; }
+    [[nodiscard]] size_t bytes() const { return count_ * sizeof(T); }
 
     void download(std::span<T> destination) const {
-        if (destination.size() != count_) {
-            throw std::invalid_argument("HIP download destination has the wrong size");
+        if (destination.size() > count_) {
+            throw std::invalid_argument("HIP download destination exceeds the device buffer");
         }
         if (!destination.empty()) {
             check_hip(hipMemcpy(destination.data(), data_, destination.size_bytes(),
                                 hipMemcpyDeviceToHost),
                       "result download");
+        }
+    }
+
+    void upload(std::span<const T> source) {
+        if (source.size() > count_) {
+            throw std::invalid_argument("HIP upload source exceeds the device buffer");
+        }
+        if (!source.empty()) {
+            check_hip(hipMemcpy(data_, source.data(), source.size_bytes(), hipMemcpyHostToDevice),
+                      "input upload");
         }
     }
 
@@ -637,116 +653,170 @@ struct UploadedProgram {
     DeviceBuffer<detail::NoiseSite> noise_sites;
     DeviceBuffer<detail::NoiseOutcome> noise_outcomes;
     detail::ProgramView view;
+
+    [[nodiscard]] size_t bytes() const {
+        return actions.bytes() + expressions.bytes() + expression_terms.bytes() +
+               noise_sites.bytes() + noise_outcomes.bytes();
+    }
 };
 
-struct Rows {
-    std::vector<uint8_t> records;
-    std::vector<uint8_t> detectors;
-    std::vector<uint8_t> observables;
-    std::vector<double> exp_vals;
-    std::vector<double> log_probabilities;
-    std::vector<uint8_t> reachable;
-    std::vector<uint8_t> survived;
-};
-
-template <typename Coefficient, bool Replay>
-Rows run_device(const ExecutablePlan& executable, uint32_t shots, const SamplingOptions& options,
-                std::span<const uint8_t> forced_record_input = {}) {
-    UploadedProgram program(executable);
-    const uint64_t capacity = uint64_t{1} << executable.peak_active_width();
-    const uint64_t scratch_capacity = capacity > 1 ? capacity >> 1 : 1;
-    const uint64_t coefficient_stride = 2 * capacity + 2 * scratch_capacity;
-
-    DeviceBuffer<Coefficient> coefficients(
-        checked_elements(shots, coefficient_stride, "coefficient"));
-    DeviceBuffer<uint8_t> symbols(checked_elements(shots, executable.num_symbols(), "symbol"));
-    DeviceBuffer<uint8_t> records(checked_elements(shots, executable.num_records(), "record"));
-    DeviceBuffer<uint8_t> forced_records(forced_record_input);
-    DeviceBuffer<uint8_t> detectors(
-        checked_elements(shots, executable.num_detectors(), "detector"));
-    DeviceBuffer<uint8_t> observables(
-        checked_elements(shots, executable.num_observables(), "observable"));
-    DeviceBuffer<double> exp_vals(
-        checked_elements(shots, executable.num_exp_vals(), "expectation"));
-    DeviceBuffer<double> log_probabilities(Replay ? shots : 0);
-    DeviceBuffer<uint8_t> reachable(Replay ? shots : 0);
-    DeviceBuffer<uint8_t> survived(shots);
-
-    const SeedRoot root = Replay ? SeedRoot{} : make_seed_root(shots, options.seed);
-    const detail::SeedRoot device_root{{root.w[0], root.w[1], root.w[2], root.w[3]}};
-    const uint32_t blocks = static_cast<uint32_t>(
-        (static_cast<uint64_t>(shots) + options.block_size - 1) / options.block_size);
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(detail::interpret_shots<Coefficient, Replay>), dim3(blocks),
-                       dim3(options.block_size), 0, 0, program.view, device_root, shots,
-                       coefficients.data(), symbols.data(), records.data(), forced_records.data(),
-                       detectors.data(), observables.data(), exp_vals.data(),
-                       log_probabilities.data(), reachable.data(), survived.data());
-    check_hip(hipGetLastError(), "kernel launch");
-    check_hip(hipDeviceSynchronize(), "kernel execution");
-
-    Rows rows;
-    rows.records.resize(checked_elements(shots, executable.num_records(), "record result"));
-    rows.detectors.resize(checked_elements(shots, executable.num_detectors(), "detector result"));
-    rows.observables.resize(
-        checked_elements(shots, executable.num_observables(), "observable result"));
-    rows.exp_vals.resize(checked_elements(shots, executable.num_exp_vals(), "expectation result"));
-    if constexpr (Replay) {
-        rows.log_probabilities.resize(shots);
-        rows.reachable.resize(shots);
-    }
-    rows.survived.resize(shots);
-    records.download(rows.records);
-    detectors.download(rows.detectors);
-    observables.download(rows.observables);
-    exp_vals.download(rows.exp_vals);
-    if constexpr (Replay) {
-        log_probabilities.download(rows.log_probabilities);
-        reachable.download(rows.reachable);
-    }
-    survived.download(rows.survived);
-    return rows;
-}
-
-Rows execute(const ExecutablePlan& executable, uint32_t shots, const SamplingOptions& options) {
-    if (options.coefficient_precision == CoefficientPrecision::FP32) {
-        return run_device<float, false>(executable, shots, options);
-    }
-    return run_device<double, false>(executable, shots, options);
-}
-
-Rows execute_replay(const ExecutablePlan& executable, std::span<const uint8_t> forced_records,
-                    CoefficientPrecision coefficient_precision) {
-    const SamplingOptions options{.coefficient_precision = coefficient_precision, .block_size = 1};
-    if (coefficient_precision == CoefficientPrecision::FP32) {
-        return run_device<float, true>(executable, 1, options, forced_records);
-    }
-    return run_device<double, true>(executable, 1, options, forced_records);
-}
-
-void validate_options(const SamplingOptions& options) {
-    if (options.block_size == 0 || options.block_size > 1024) {
+void validate_block_size(uint32_t block_size) {
+    if (block_size == 0 || block_size > 1024) {
         throw std::invalid_argument("HIP block size must be between 1 and 1024");
     }
 }
 
-template <typename T>
-void compact_rows(std::vector<T>& values, std::span<const uint8_t> survived, size_t stride,
-                  uint32_t passed_shots) {
-    size_t destination = 0;
-    for (size_t shot = 0; shot < survived.size(); ++shot) {
-        if (survived[shot] == 0) {
-            continue;
-        }
-        if (destination != shot && stride != 0) {
-            std::copy_n(values.begin() + shot * stride, stride,
-                        values.begin() + destination * stride);
-        }
-        ++destination;
+void validate_max_batch_shots(uint32_t max_batch_shots) {
+    if (max_batch_shots == 0) {
+        throw std::invalid_argument("HIP max_batch_shots must be positive");
     }
-    values.resize(static_cast<size_t>(passed_shots) * stride);
+}
+
+void validate_replay_input(const ExecutablePlan& executable,
+                           std::span<const uint8_t> forced_records) {
+    if (forced_records.size() != executable.num_records()) {
+        throw std::invalid_argument(
+            "HIP replay requires one forced value for every visible and hidden record");
+    }
+    if (!std::all_of(forced_records.begin(), forced_records.end(),
+                     [](uint8_t value) { return value <= 1; })) {
+        throw std::invalid_argument("HIP replay record bytes must be Boolean");
+    }
+    if (!executable.noise_sites().empty()) {
+        throw std::invalid_argument("HIP replay does not support presampled noise");
+    }
 }
 
 }  // namespace
+
+class Sampler::Impl {
+  public:
+    Impl(const ExecutablePlan& source, CoefficientPrecision selected_precision,
+         uint32_t selected_max_batch_shots)
+        : executable(source),
+          program(executable),
+          precision(selected_precision),
+          max_batch(selected_max_batch_shots),
+          coefficient_stride(coefficient_elements_per_shot(executable)),
+          fp32_coefficients(selected_precision == CoefficientPrecision::FP32
+                                ? checked_elements(max_batch, coefficient_stride, "coefficient")
+                                : 0),
+          fp64_coefficients(selected_precision == CoefficientPrecision::FP64
+                                ? checked_elements(max_batch, coefficient_stride, "coefficient")
+                                : 0),
+          symbols(checked_elements(max_batch, executable.num_symbols(), "symbol")),
+          records(checked_elements(max_batch, executable.num_records(), "record")),
+          forced_records(executable.num_records()),
+          detectors(checked_elements(max_batch, executable.num_detectors(), "detector")),
+          observables(checked_elements(max_batch, executable.num_observables(), "observable")),
+          exp_vals(checked_elements(max_batch, executable.num_exp_vals(), "expectation")),
+          log_probabilities(1),
+          reachable(1),
+          survived(max_batch),
+          host_records(checked_elements(max_batch, executable.num_records(), "host record")),
+          host_detectors(checked_elements(max_batch, executable.num_detectors(), "host detector")),
+          host_observables(
+              checked_elements(max_batch, executable.num_observables(), "host observable")),
+          host_exp_vals(checked_elements(max_batch, executable.num_exp_vals(), "host expectation")),
+          host_survived(max_batch) {}
+
+    void run_batch(detail::SeedRoot root, uint64_t shot_offset, uint32_t shots,
+                   uint32_t block_size) {
+        if (shots > max_batch) {
+            throw std::invalid_argument("HIP batch exceeds retained workspace capacity");
+        }
+        if (precision == CoefficientPrecision::FP32) {
+            launch<float, false>(root, shot_offset, shots, block_size, fp32_coefficients.data());
+        } else {
+            launch<double, false>(root, shot_offset, shots, block_size, fp64_coefficients.data());
+        }
+        download_rows(shots, false);
+    }
+
+    void run_replay(std::span<const uint8_t> input) {
+        forced_records.upload(input);
+        const detail::SeedRoot empty_root{};
+        if (precision == CoefficientPrecision::FP32) {
+            launch<float, true>(empty_root, 0, 1, 1, fp32_coefficients.data());
+        } else {
+            launch<double, true>(empty_root, 0, 1, 1, fp64_coefficients.data());
+        }
+        download_rows(1, true);
+    }
+
+    [[nodiscard]] size_t allocated_device_bytes() const {
+        return program.bytes() + fp32_coefficients.bytes() + fp64_coefficients.bytes() +
+               symbols.bytes() + records.bytes() + forced_records.bytes() + detectors.bytes() +
+               observables.bytes() + exp_vals.bytes() + log_probabilities.bytes() +
+               reachable.bytes() + survived.bytes();
+    }
+
+    ExecutablePlan executable;
+    UploadedProgram program;
+    CoefficientPrecision precision;
+    uint32_t max_batch;
+    uint64_t coefficient_stride;
+    DeviceBuffer<float> fp32_coefficients;
+    DeviceBuffer<double> fp64_coefficients;
+    DeviceBuffer<uint8_t> symbols;
+    DeviceBuffer<uint8_t> records;
+    DeviceBuffer<uint8_t> forced_records;
+    DeviceBuffer<uint8_t> detectors;
+    DeviceBuffer<uint8_t> observables;
+    DeviceBuffer<double> exp_vals;
+    DeviceBuffer<double> log_probabilities;
+    DeviceBuffer<uint8_t> reachable;
+    DeviceBuffer<uint8_t> survived;
+    std::vector<uint8_t> host_records;
+    std::vector<uint8_t> host_detectors;
+    std::vector<uint8_t> host_observables;
+    std::vector<double> host_exp_vals;
+    std::vector<uint8_t> host_survived;
+    double host_log_probability = 0.0;
+    uint8_t host_reachable = 0;
+
+  private:
+    static uint64_t coefficient_elements_per_shot(const ExecutablePlan& executable) {
+        const uint64_t state_capacity = uint64_t{1} << executable.peak_active_width();
+        const uint64_t scratch_capacity = state_capacity > 1 ? state_capacity >> 1 : 1;
+        return 2 * state_capacity + 2 * scratch_capacity;
+    }
+
+    template <typename Coefficient, bool Replay>
+    void launch(detail::SeedRoot root, uint64_t shot_offset, uint32_t shots, uint32_t block_size,
+                Coefficient* coefficient_storage) {
+        const uint32_t blocks =
+            static_cast<uint32_t>((static_cast<uint64_t>(shots) + block_size - 1) / block_size);
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(detail::interpret_shots<Coefficient, Replay>),
+                           dim3(blocks), dim3(block_size), 0, 0, program.view, root, shot_offset,
+                           shots, coefficient_storage, symbols.data(), records.data(),
+                           forced_records.data(), detectors.data(), observables.data(),
+                           exp_vals.data(), log_probabilities.data(), reachable.data(),
+                           survived.data());
+        check_hip(hipGetLastError(), "kernel launch");
+        check_hip(hipDeviceSynchronize(), "kernel execution");
+    }
+
+    void download_rows(uint32_t shots, bool replay) {
+        records.download(
+            std::span(host_records)
+                .first(checked_elements(shots, executable.num_records(), "record result")));
+        detectors.download(
+            std::span(host_detectors)
+                .first(checked_elements(shots, executable.num_detectors(), "detector result")));
+        observables.download(
+            std::span(host_observables)
+                .first(checked_elements(shots, executable.num_observables(), "observable result")));
+        exp_vals.download(
+            std::span(host_exp_vals)
+                .first(checked_elements(shots, executable.num_exp_vals(), "expectation result")));
+        survived.download(std::span(host_survived).first(shots));
+        if (replay) {
+            log_probabilities.download(std::span(&host_log_probability, 1));
+            reachable.download(std::span(&host_reachable, 1));
+        }
+    }
+};
 
 bool is_available() noexcept {
     int device_count = 0;
@@ -770,10 +840,19 @@ std::string backend_info() {
     return output.str();
 }
 
-SamplingResult sample(const ExecutablePlan& executable, uint32_t shots,
-                      const SamplingOptions& options) {
-    validate_options(options);
-    if (executable.has_postselection()) {
+Sampler::Sampler(const ExecutablePlan& executable, CoefficientPrecision coefficient_precision,
+                 uint32_t max_batch_shots) {
+    validate_max_batch_shots(max_batch_shots);
+    impl_ = std::make_unique<Impl>(executable, coefficient_precision, max_batch_shots);
+}
+
+Sampler::~Sampler() = default;
+Sampler::Sampler(Sampler&&) noexcept = default;
+Sampler& Sampler::operator=(Sampler&&) noexcept = default;
+
+SamplingResult Sampler::sample(uint32_t shots, std::optional<uint64_t> seed, uint32_t block_size) {
+    validate_block_size(block_size);
+    if (impl_->executable.has_postselection()) {
         throw std::invalid_argument(
             "HIP fixed-row sampling does not support postselection; use sample_survivors");
     }
@@ -781,97 +860,214 @@ SamplingResult sample(const ExecutablePlan& executable, uint32_t shots,
     if (shots == 0) {
         return result;
     }
-    Rows rows = execute(executable, shots, options);
     result.measurements.resize(
-        checked_elements(shots, executable.num_visible_records(), "measurement result"));
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        std::copy_n(rows.records.begin() + static_cast<size_t>(shot) * executable.num_records(),
-                    executable.num_visible_records(),
-                    result.measurements.begin() +
-                        static_cast<size_t>(shot) * executable.num_visible_records());
+        checked_elements(shots, impl_->executable.num_visible_records(), "measurement result"));
+    result.detectors.resize(
+        checked_elements(shots, impl_->executable.num_detectors(), "detector result"));
+    result.observables.resize(
+        checked_elements(shots, impl_->executable.num_observables(), "observable result"));
+    result.exp_vals.resize(
+        checked_elements(shots, impl_->executable.num_exp_vals(), "expectation result"));
+
+    const SeedRoot root = make_seed_root(shots, seed);
+    const detail::SeedRoot device_root{{root.w[0], root.w[1], root.w[2], root.w[3]}};
+    for (uint32_t offset = 0; offset < shots;) {
+        const uint32_t batch = std::min(impl_->max_batch, shots - offset);
+        impl_->run_batch(device_root, offset, batch, block_size);
+        for (uint32_t local_shot = 0; local_shot < batch; ++local_shot) {
+            if (impl_->executable.num_visible_records() != 0) {
+                std::copy_n(
+                    impl_->host_records.begin() +
+                        static_cast<size_t>(local_shot) * impl_->executable.num_records(),
+                    impl_->executable.num_visible_records(),
+                    result.measurements.begin() + static_cast<size_t>(offset + local_shot) *
+                                                      impl_->executable.num_visible_records());
+            }
+        }
+        if (impl_->executable.num_detectors() != 0) {
+            std::copy_n(
+                impl_->host_detectors.begin(),
+                checked_elements(batch, impl_->executable.num_detectors(), "detector batch"),
+                result.detectors.begin() +
+                    static_cast<size_t>(offset) * impl_->executable.num_detectors());
+        }
+        if (impl_->executable.num_observables() != 0) {
+            std::copy_n(
+                impl_->host_observables.begin(),
+                checked_elements(batch, impl_->executable.num_observables(), "observable batch"),
+                result.observables.begin() +
+                    static_cast<size_t>(offset) * impl_->executable.num_observables());
+        }
+        if (impl_->executable.num_exp_vals() != 0) {
+            std::copy_n(
+                impl_->host_exp_vals.begin(),
+                checked_elements(batch, impl_->executable.num_exp_vals(), "expectation batch"),
+                result.exp_vals.begin() +
+                    static_cast<size_t>(offset) * impl_->executable.num_exp_vals());
+        }
+        offset += batch;
     }
-    result.detectors = std::move(rows.detectors);
-    result.observables = std::move(rows.observables);
-    result.exp_vals = std::move(rows.exp_vals);
     return result;
 }
 
-SamplingSurvivorResult sample_survivors(const ExecutablePlan& executable, uint32_t shots,
-                                        bool keep_records, const SamplingOptions& options) {
-    validate_options(options);
+SamplingSurvivorResult Sampler::sample_survivors(uint32_t shots, bool keep_records,
+                                                 std::optional<uint64_t> seed,
+                                                 uint32_t block_size) {
+    validate_block_size(block_size);
     SamplingSurvivorResult result;
     result.total_shots = shots;
     if (shots == 0) {
         return result;
     }
-    result.observable_ones.resize(executable.num_observables(), 0);
-    Rows rows = execute(executable, shots, options);
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        if (rows.survived[shot] == 0) {
-            continue;
-        }
-        ++result.passed_shots;
-        bool logical_error = false;
-        for (uint32_t observable = 0; observable < executable.num_observables(); ++observable) {
-            const bool value =
-                rows.observables[static_cast<size_t>(shot) * executable.num_observables() +
-                                 observable] != 0;
-            result.observable_ones[observable] += static_cast<uint64_t>(value);
-            logical_error |= value;
-        }
-        result.logical_errors += static_cast<uint32_t>(logical_error);
-    }
-    if (!keep_records) {
-        return result;
+    result.observable_ones.resize(impl_->executable.num_observables(), 0);
+    if (keep_records) {
+        result.measurements.resize(checked_elements(shots, impl_->executable.num_visible_records(),
+                                                    "survivor measurement result"));
+        result.detectors.resize(
+            checked_elements(shots, impl_->executable.num_detectors(), "survivor detector result"));
+        result.observables.resize(checked_elements(shots, impl_->executable.num_observables(),
+                                                   "survivor observable result"));
+        result.exp_vals.resize(checked_elements(shots, impl_->executable.num_exp_vals(),
+                                                "survivor expectation result"));
     }
 
-    result.measurements.resize(
-        checked_elements(shots, executable.num_visible_records(), "measurement result"));
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        std::copy_n(rows.records.begin() + static_cast<size_t>(shot) * executable.num_records(),
-                    executable.num_visible_records(),
+    const SeedRoot root = make_seed_root(shots, seed);
+    const detail::SeedRoot device_root{{root.w[0], root.w[1], root.w[2], root.w[3]}};
+    for (uint32_t offset = 0; offset < shots;) {
+        const uint32_t batch = std::min(impl_->max_batch, shots - offset);
+        impl_->run_batch(device_root, offset, batch, block_size);
+        for (uint32_t local_shot = 0; local_shot < batch; ++local_shot) {
+            if (impl_->host_survived[local_shot] == 0) {
+                continue;
+            }
+            const uint32_t destination = result.passed_shots++;
+            bool logical_error = false;
+            for (uint32_t observable = 0; observable < impl_->executable.num_observables();
+                 ++observable) {
+                const bool value = impl_->host_observables[static_cast<size_t>(local_shot) *
+                                                               impl_->executable.num_observables() +
+                                                           observable] != 0;
+                result.observable_ones[observable] += static_cast<uint64_t>(value);
+                logical_error |= value;
+            }
+            result.logical_errors += static_cast<uint32_t>(logical_error);
+            if (!keep_records) {
+                continue;
+            }
+            if (impl_->executable.num_visible_records() != 0) {
+                std::copy_n(
+                    impl_->host_records.begin() +
+                        static_cast<size_t>(local_shot) * impl_->executable.num_records(),
+                    impl_->executable.num_visible_records(),
                     result.measurements.begin() +
-                        static_cast<size_t>(shot) * executable.num_visible_records());
+                        static_cast<size_t>(destination) * impl_->executable.num_visible_records());
+            }
+            if (impl_->executable.num_detectors() != 0) {
+                std::copy_n(impl_->host_detectors.begin() +
+                                static_cast<size_t>(local_shot) * impl_->executable.num_detectors(),
+                            impl_->executable.num_detectors(),
+                            result.detectors.begin() + static_cast<size_t>(destination) *
+                                                           impl_->executable.num_detectors());
+            }
+            if (impl_->executable.num_observables() != 0) {
+                std::copy_n(
+                    impl_->host_observables.begin() +
+                        static_cast<size_t>(local_shot) * impl_->executable.num_observables(),
+                    impl_->executable.num_observables(),
+                    result.observables.begin() +
+                        static_cast<size_t>(destination) * impl_->executable.num_observables());
+            }
+            if (impl_->executable.num_exp_vals() != 0) {
+                std::copy_n(impl_->host_exp_vals.begin() +
+                                static_cast<size_t>(local_shot) * impl_->executable.num_exp_vals(),
+                            impl_->executable.num_exp_vals(),
+                            result.exp_vals.begin() + static_cast<size_t>(destination) *
+                                                          impl_->executable.num_exp_vals());
+            }
+        }
+        offset += batch;
     }
-    compact_rows(result.measurements, rows.survived, executable.num_visible_records(),
-                 result.passed_shots);
-    compact_rows(rows.detectors, rows.survived, executable.num_detectors(), result.passed_shots);
-    compact_rows(rows.observables, rows.survived, executable.num_observables(),
-                 result.passed_shots);
-    compact_rows(rows.exp_vals, rows.survived, executable.num_exp_vals(), result.passed_shots);
-    result.detectors = std::move(rows.detectors);
-    result.observables = std::move(rows.observables);
-    result.exp_vals = std::move(rows.exp_vals);
+    if (keep_records) {
+        result.measurements.resize(static_cast<size_t>(result.passed_shots) *
+                                   impl_->executable.num_visible_records());
+        result.detectors.resize(static_cast<size_t>(result.passed_shots) *
+                                impl_->executable.num_detectors());
+        result.observables.resize(static_cast<size_t>(result.passed_shots) *
+                                  impl_->executable.num_observables());
+        result.exp_vals.resize(static_cast<size_t>(result.passed_shots) *
+                               impl_->executable.num_exp_vals());
+    }
     return result;
 }
 
-ReplayResult replay_shot(const ExecutablePlan& executable, std::span<const uint8_t> forced_records,
-                         CoefficientPrecision coefficient_precision) {
-    if (forced_records.size() != executable.num_records()) {
-        throw std::invalid_argument(
-            "HIP replay requires one forced value for every visible and hidden record");
-    }
-    if (!std::all_of(forced_records.begin(), forced_records.end(),
-                     [](uint8_t value) { return value <= 1; })) {
-        throw std::invalid_argument("HIP replay record bytes must be Boolean");
-    }
-    if (!executable.noise_sites().empty()) {
-        throw std::invalid_argument("HIP replay does not support presampled noise");
-    }
-    Rows rows = execute_replay(executable, forced_records, coefficient_precision);
+ReplayResult Sampler::replay_shot(std::span<const uint8_t> forced_records) {
+    validate_replay_input(impl_->executable, forced_records);
+    impl_->run_replay(forced_records);
     ReplayResult result;
-    result.reachable = rows.reachable[0] != 0;
-    result.survived = rows.survived[0] != 0;
-    result.log_probability = rows.log_probabilities[0];
+    result.reachable = impl_->host_reachable != 0;
+    result.survived = impl_->host_survived[0] != 0;
+    result.log_probability = impl_->host_log_probability;
     if (!result.reachable || !result.survived) {
         return result;
     }
-    result.outputs.measurements.assign(rows.records.begin(),
-                                       rows.records.begin() + executable.num_visible_records());
-    result.outputs.detectors = std::move(rows.detectors);
-    result.outputs.observables = std::move(rows.observables);
-    result.outputs.exp_vals = std::move(rows.exp_vals);
+    result.outputs.measurements.assign(
+        impl_->host_records.begin(),
+        impl_->host_records.begin() + impl_->executable.num_visible_records());
+    result.outputs.detectors.assign(
+        impl_->host_detectors.begin(),
+        impl_->host_detectors.begin() + impl_->executable.num_detectors());
+    result.outputs.observables.assign(
+        impl_->host_observables.begin(),
+        impl_->host_observables.begin() + impl_->executable.num_observables());
+    result.outputs.exp_vals.assign(impl_->host_exp_vals.begin(),
+                                   impl_->host_exp_vals.begin() + impl_->executable.num_exp_vals());
     return result;
+}
+
+CoefficientPrecision Sampler::coefficient_precision() const {
+    return impl_->precision;
+}
+
+uint32_t Sampler::max_batch_shots() const {
+    return impl_->max_batch;
+}
+
+size_t Sampler::allocated_device_bytes() const {
+    return impl_->allocated_device_bytes();
+}
+
+SamplingResult sample(const ExecutablePlan& executable, uint32_t shots,
+                      const SamplingOptions& options) {
+    validate_block_size(options.block_size);
+    validate_max_batch_shots(options.max_batch_shots);
+    if (executable.has_postselection()) {
+        throw std::invalid_argument(
+            "HIP fixed-row sampling does not support postselection; use sample_survivors");
+    }
+    if (shots == 0) {
+        return {};
+    }
+    Sampler sampler(executable, options.coefficient_precision, options.max_batch_shots);
+    return sampler.sample(shots, options.seed, options.block_size);
+}
+
+SamplingSurvivorResult sample_survivors(const ExecutablePlan& executable, uint32_t shots,
+                                        bool keep_records, const SamplingOptions& options) {
+    validate_block_size(options.block_size);
+    validate_max_batch_shots(options.max_batch_shots);
+    if (shots == 0) {
+        return {.total_shots = 0};
+    }
+    Sampler sampler(executable, options.coefficient_precision, options.max_batch_shots);
+    return sampler.sample_survivors(shots, keep_records, options.seed, options.block_size);
+}
+
+ReplayResult replay_shot(const ExecutablePlan& executable,
+                         std::span<const uint8_t> forced_records,
+                         CoefficientPrecision coefficient_precision) {
+    validate_replay_input(executable, forced_records);
+    Sampler sampler(executable, coefficient_precision, 1);
+    return sampler.replay_shot(forced_records);
 }
 
 }  // namespace clifft::sampling::hip

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -525,6 +525,7 @@ template __global__ void interpret_shots<double, true>(ProgramView, SeedRoot, ui
 #include "clifft/util/shot_seed.h"
 
 #include <algorithm>
+#include <atomic>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -535,6 +536,23 @@ template __global__ void interpret_shots<double, true>(ProgramView, SeedRoot, ui
 namespace clifft::sampling::hip {
 
 namespace {
+
+class BusyGuard {
+  public:
+    explicit BusyGuard(std::atomic_flag& busy) : busy_(busy) {
+        if (busy_.test_and_set(std::memory_order_acquire)) {
+            throw std::runtime_error("calls on one HIP Sampler instance must not overlap");
+        }
+    }
+
+    ~BusyGuard() { busy_.clear(std::memory_order_release); }
+
+    BusyGuard(const BusyGuard&) = delete;
+    BusyGuard& operator=(const BusyGuard&) = delete;
+
+  private:
+    std::atomic_flag& busy_;
+};
 
 void check_hip(hipError_t error, const char* operation) {
     if (error != hipSuccess) {
@@ -637,7 +655,9 @@ struct UploadedProgram {
           expressions(executable.expressions()),
           expression_terms(executable.expression_terms()),
           noise_sites(executable.noise_sites()),
-          noise_outcomes(executable.noise_outcomes()) {
+          noise_outcomes(executable.noise_outcomes()),
+          num_visible_records(executable.num_visible_records()),
+          has_postselection(executable.has_postselection()) {
         view.actions = actions.data();
         view.expressions = expressions.data();
         view.expression_terms = expression_terms.data();
@@ -660,6 +680,8 @@ struct UploadedProgram {
     DeviceBuffer<detail::NoiseSite> noise_sites;
     DeviceBuffer<detail::NoiseOutcome> noise_outcomes;
     detail::ProgramView view;
+    uint32_t num_visible_records;
+    bool has_postselection;
 
     [[nodiscard]] size_t bytes() const {
         return actions.bytes() + expressions.bytes() + expression_terms.bytes() +
@@ -679,9 +701,9 @@ void validate_max_batch_shots(uint32_t max_batch_shots) {
     }
 }
 
-void validate_replay_input(const ExecutablePlan& executable,
+void validate_replay_input(uint32_t num_records, uint32_t noise_site_count,
                            std::span<const uint8_t> forced_records) {
-    if (forced_records.size() != executable.num_records()) {
+    if (forced_records.size() != num_records) {
         throw std::invalid_argument(
             "HIP replay requires one forced value for every visible and hidden record");
     }
@@ -689,9 +711,15 @@ void validate_replay_input(const ExecutablePlan& executable,
                      [](uint8_t value) { return value <= 1; })) {
         throw std::invalid_argument("HIP replay record bytes must be Boolean");
     }
-    if (!executable.noise_sites().empty()) {
+    if (noise_site_count != 0) {
         throw std::invalid_argument("HIP replay does not support presampled noise");
     }
+}
+
+void validate_replay_input(const ExecutablePlan& executable,
+                           std::span<const uint8_t> forced_records) {
+    validate_replay_input(executable.num_records(),
+                          static_cast<uint32_t>(executable.noise_sites().size()), forced_records);
 }
 
 }  // namespace
@@ -706,31 +734,30 @@ class Sampler::Impl {
 
     Impl(const ExecutablePlan& source, CoefficientPrecision selected_precision,
          uint32_t selected_max_batch_shots)
-        : executable(source),
-          program(executable),
+        : program(source),
           precision(selected_precision),
           max_batch(selected_max_batch_shots),
-          coefficient_stride(detail::coefficient_elements_per_shot(executable.peak_active_width())),
+          coefficient_stride(detail::coefficient_elements_per_shot(source.peak_active_width())),
           fp32_coefficients(selected_precision == CoefficientPrecision::FP32
                                 ? checked_elements(max_batch, coefficient_stride, "coefficient")
                                 : 0),
           fp64_coefficients(selected_precision == CoefficientPrecision::FP64
                                 ? checked_elements(max_batch, coefficient_stride, "coefficient")
                                 : 0),
-          symbols(checked_elements(max_batch, executable.num_symbols(), "symbol")),
-          records(checked_elements(max_batch, executable.num_records(), "record")),
-          forced_records(executable.num_records()),
-          detectors(checked_elements(max_batch, executable.num_detectors(), "detector")),
-          observables(checked_elements(max_batch, executable.num_observables(), "observable")),
-          exp_vals(checked_elements(max_batch, executable.num_exp_vals(), "expectation")),
+          symbols(checked_elements(max_batch, source.num_symbols(), "symbol")),
+          records(checked_elements(max_batch, source.num_records(), "record")),
+          forced_records(source.num_records()),
+          detectors(checked_elements(max_batch, source.num_detectors(), "detector")),
+          observables(checked_elements(max_batch, source.num_observables(), "observable")),
+          exp_vals(checked_elements(max_batch, source.num_exp_vals(), "expectation")),
           log_probabilities(1),
           reachable(1),
           survived(max_batch),
-          host_records(checked_elements(max_batch, executable.num_records(), "host record")),
-          host_detectors(checked_elements(max_batch, executable.num_detectors(), "host detector")),
+          host_records(checked_elements(max_batch, source.num_records(), "host record")),
+          host_detectors(checked_elements(max_batch, source.num_detectors(), "host detector")),
           host_observables(
-              checked_elements(max_batch, executable.num_observables(), "host observable")),
-          host_exp_vals(checked_elements(max_batch, executable.num_exp_vals(), "host expectation")),
+              checked_elements(max_batch, source.num_observables(), "host observable")),
+          host_exp_vals(checked_elements(max_batch, source.num_exp_vals(), "host expectation")),
           host_survived(max_batch) {}
 
     void run_batch(detail::SeedRoot root, uint64_t shot_offset, uint32_t shots,
@@ -764,7 +791,12 @@ class Sampler::Impl {
                reachable.bytes() + survived.bytes();
     }
 
-    ExecutablePlan executable;
+    [[nodiscard]] uint32_t num_visible_records() const { return program.num_visible_records; }
+    [[nodiscard]] uint32_t num_records() const { return program.view.num_records; }
+    [[nodiscard]] uint32_t num_detectors() const { return program.view.num_detectors; }
+    [[nodiscard]] uint32_t num_observables() const { return program.view.num_observables; }
+    [[nodiscard]] uint32_t num_exp_vals() const { return program.view.num_exp_vals; }
+
     UploadedProgram program;
     CoefficientPrecision precision;
     uint32_t max_batch;
@@ -787,6 +819,7 @@ class Sampler::Impl {
     std::vector<uint8_t> host_survived;
     double host_log_probability = 0.0;
     uint8_t host_reachable = 0;
+    std::atomic_flag busy = ATOMIC_FLAG_INIT;
 
   private:
     template <typename Coefficient, bool Replay>
@@ -808,17 +841,17 @@ class Sampler::Impl {
         if (mode != DownloadMode::SurvivorCounts) {
             records.download_prefix(
                 std::span(host_records)
-                    .first(checked_elements(shots, executable.num_records(), "record result")));
+                    .first(checked_elements(shots, program.view.num_records, "record result")));
             detectors.download_prefix(
                 std::span(host_detectors)
-                    .first(checked_elements(shots, executable.num_detectors(), "detector result")));
+                    .first(checked_elements(shots, program.view.num_detectors, "detector result")));
             exp_vals.download_prefix(
                 std::span(host_exp_vals)
-                    .first(checked_elements(shots, executable.num_exp_vals(), "expectation result")));
+                    .first(checked_elements(shots, program.view.num_exp_vals, "expectation result")));
         }
         observables.download_prefix(
             std::span(host_observables)
-                .first(checked_elements(shots, executable.num_observables(), "observable result")));
+                .first(checked_elements(shots, program.view.num_observables, "observable result")));
         survived.download_prefix(std::span(host_survived).first(shots));
         if (mode == DownloadMode::Replay) {
             log_probabilities.download(std::span(&host_log_probability, 1));
@@ -860,8 +893,9 @@ Sampler::Sampler(Sampler&&) noexcept = default;
 Sampler& Sampler::operator=(Sampler&&) noexcept = default;
 
 SamplingResult Sampler::sample(uint32_t shots, std::optional<uint64_t> seed, uint32_t block_size) {
+    BusyGuard guard(impl_->busy);
     validate_block_size(block_size);
-    if (impl_->executable.has_postselection()) {
+    if (impl_->program.has_postselection) {
         throw std::invalid_argument(
             "HIP fixed-row sampling does not support postselection; use sample_survivors");
     }
@@ -870,13 +904,13 @@ SamplingResult Sampler::sample(uint32_t shots, std::optional<uint64_t> seed, uin
         return result;
     }
     result.measurements.resize(
-        checked_elements(shots, impl_->executable.num_visible_records(), "measurement result"));
+        checked_elements(shots, impl_->num_visible_records(), "measurement result"));
     result.detectors.resize(
-        checked_elements(shots, impl_->executable.num_detectors(), "detector result"));
+        checked_elements(shots, impl_->num_detectors(), "detector result"));
     result.observables.resize(
-        checked_elements(shots, impl_->executable.num_observables(), "observable result"));
+        checked_elements(shots, impl_->num_observables(), "observable result"));
     result.exp_vals.resize(
-        checked_elements(shots, impl_->executable.num_exp_vals(), "expectation result"));
+        checked_elements(shots, impl_->num_exp_vals(), "expectation result"));
 
     const SeedRoot root = make_seed_root(shots, seed);
     const detail::SeedRoot device_root{{root.w[0], root.w[1], root.w[2], root.w[3]}};
@@ -885,35 +919,35 @@ SamplingResult Sampler::sample(uint32_t shots, std::optional<uint64_t> seed, uin
         impl_->run_batch(device_root, offset, batch, block_size,
                          Impl::DownloadMode::FullRows);
         for (uint32_t local_shot = 0; local_shot < batch; ++local_shot) {
-            if (impl_->executable.num_visible_records() != 0) {
+            if (impl_->num_visible_records() != 0) {
                 std::copy_n(
                     impl_->host_records.begin() +
-                        static_cast<size_t>(local_shot) * impl_->executable.num_records(),
-                    impl_->executable.num_visible_records(),
+                        static_cast<size_t>(local_shot) * impl_->num_records(),
+                    impl_->num_visible_records(),
                     result.measurements.begin() + static_cast<size_t>(offset + local_shot) *
-                                                      impl_->executable.num_visible_records());
+                                                      impl_->num_visible_records());
             }
         }
-        if (impl_->executable.num_detectors() != 0) {
+        if (impl_->num_detectors() != 0) {
             std::copy_n(
                 impl_->host_detectors.begin(),
-                checked_elements(batch, impl_->executable.num_detectors(), "detector batch"),
+                checked_elements(batch, impl_->num_detectors(), "detector batch"),
                 result.detectors.begin() +
-                    static_cast<size_t>(offset) * impl_->executable.num_detectors());
+                    static_cast<size_t>(offset) * impl_->num_detectors());
         }
-        if (impl_->executable.num_observables() != 0) {
+        if (impl_->num_observables() != 0) {
             std::copy_n(
                 impl_->host_observables.begin(),
-                checked_elements(batch, impl_->executable.num_observables(), "observable batch"),
+                checked_elements(batch, impl_->num_observables(), "observable batch"),
                 result.observables.begin() +
-                    static_cast<size_t>(offset) * impl_->executable.num_observables());
+                    static_cast<size_t>(offset) * impl_->num_observables());
         }
-        if (impl_->executable.num_exp_vals() != 0) {
+        if (impl_->num_exp_vals() != 0) {
             std::copy_n(
                 impl_->host_exp_vals.begin(),
-                checked_elements(batch, impl_->executable.num_exp_vals(), "expectation batch"),
+                checked_elements(batch, impl_->num_exp_vals(), "expectation batch"),
                 result.exp_vals.begin() +
-                    static_cast<size_t>(offset) * impl_->executable.num_exp_vals());
+                    static_cast<size_t>(offset) * impl_->num_exp_vals());
         }
         offset += batch;
     }
@@ -923,21 +957,22 @@ SamplingResult Sampler::sample(uint32_t shots, std::optional<uint64_t> seed, uin
 SamplingSurvivorResult Sampler::sample_survivors(uint32_t shots, bool keep_records,
                                                  std::optional<uint64_t> seed,
                                                  uint32_t block_size) {
+    BusyGuard guard(impl_->busy);
     validate_block_size(block_size);
     SamplingSurvivorResult result;
     result.total_shots = shots;
     if (shots == 0) {
         return result;
     }
-    result.observable_ones.resize(impl_->executable.num_observables(), 0);
+    result.observable_ones.resize(impl_->num_observables(), 0);
     if (keep_records) {
-        result.measurements.resize(checked_elements(shots, impl_->executable.num_visible_records(),
+        result.measurements.resize(checked_elements(shots, impl_->num_visible_records(),
                                                     "survivor measurement result"));
         result.detectors.resize(
-            checked_elements(shots, impl_->executable.num_detectors(), "survivor detector result"));
-        result.observables.resize(checked_elements(shots, impl_->executable.num_observables(),
+            checked_elements(shots, impl_->num_detectors(), "survivor detector result"));
+        result.observables.resize(checked_elements(shots, impl_->num_observables(),
                                                    "survivor observable result"));
-        result.exp_vals.resize(checked_elements(shots, impl_->executable.num_exp_vals(),
+        result.exp_vals.resize(checked_elements(shots, impl_->num_exp_vals(),
                                                 "survivor expectation result"));
     }
 
@@ -954,10 +989,9 @@ SamplingSurvivorResult Sampler::sample_survivors(uint32_t shots, bool keep_recor
             }
             const uint32_t destination = result.passed_shots++;
             bool logical_error = false;
-            for (uint32_t observable = 0; observable < impl_->executable.num_observables();
-                 ++observable) {
+            for (uint32_t observable = 0; observable < impl_->num_observables(); ++observable) {
                 const bool value = impl_->host_observables[static_cast<size_t>(local_shot) *
-                                                               impl_->executable.num_observables() +
+                                                               impl_->num_observables() +
                                                            observable] != 0;
                 result.observable_ones[observable] += static_cast<uint64_t>(value);
                 logical_error |= value;
@@ -966,54 +1000,56 @@ SamplingSurvivorResult Sampler::sample_survivors(uint32_t shots, bool keep_recor
             if (!keep_records) {
                 continue;
             }
-            if (impl_->executable.num_visible_records() != 0) {
+            if (impl_->num_visible_records() != 0) {
                 std::copy_n(
                     impl_->host_records.begin() +
-                        static_cast<size_t>(local_shot) * impl_->executable.num_records(),
-                    impl_->executable.num_visible_records(),
+                        static_cast<size_t>(local_shot) * impl_->num_records(),
+                    impl_->num_visible_records(),
                     result.measurements.begin() +
-                        static_cast<size_t>(destination) * impl_->executable.num_visible_records());
+                        static_cast<size_t>(destination) * impl_->num_visible_records());
             }
-            if (impl_->executable.num_detectors() != 0) {
+            if (impl_->num_detectors() != 0) {
                 std::copy_n(impl_->host_detectors.begin() +
-                                static_cast<size_t>(local_shot) * impl_->executable.num_detectors(),
-                            impl_->executable.num_detectors(),
+                                static_cast<size_t>(local_shot) * impl_->num_detectors(),
+                            impl_->num_detectors(),
                             result.detectors.begin() + static_cast<size_t>(destination) *
-                                                           impl_->executable.num_detectors());
+                                                           impl_->num_detectors());
             }
-            if (impl_->executable.num_observables() != 0) {
+            if (impl_->num_observables() != 0) {
                 std::copy_n(
                     impl_->host_observables.begin() +
-                        static_cast<size_t>(local_shot) * impl_->executable.num_observables(),
-                    impl_->executable.num_observables(),
+                        static_cast<size_t>(local_shot) * impl_->num_observables(),
+                    impl_->num_observables(),
                     result.observables.begin() +
-                        static_cast<size_t>(destination) * impl_->executable.num_observables());
+                        static_cast<size_t>(destination) * impl_->num_observables());
             }
-            if (impl_->executable.num_exp_vals() != 0) {
+            if (impl_->num_exp_vals() != 0) {
                 std::copy_n(impl_->host_exp_vals.begin() +
-                                static_cast<size_t>(local_shot) * impl_->executable.num_exp_vals(),
-                            impl_->executable.num_exp_vals(),
+                                static_cast<size_t>(local_shot) * impl_->num_exp_vals(),
+                            impl_->num_exp_vals(),
                             result.exp_vals.begin() + static_cast<size_t>(destination) *
-                                                          impl_->executable.num_exp_vals());
+                                                          impl_->num_exp_vals());
             }
         }
         offset += batch;
     }
     if (keep_records) {
         result.measurements.resize(static_cast<size_t>(result.passed_shots) *
-                                   impl_->executable.num_visible_records());
+                                   impl_->num_visible_records());
         result.detectors.resize(static_cast<size_t>(result.passed_shots) *
-                                impl_->executable.num_detectors());
+                                impl_->num_detectors());
         result.observables.resize(static_cast<size_t>(result.passed_shots) *
-                                  impl_->executable.num_observables());
+                                  impl_->num_observables());
         result.exp_vals.resize(static_cast<size_t>(result.passed_shots) *
-                               impl_->executable.num_exp_vals());
+                               impl_->num_exp_vals());
     }
     return result;
 }
 
 ReplayResult Sampler::replay_shot(std::span<const uint8_t> forced_records) {
-    validate_replay_input(impl_->executable, forced_records);
+    BusyGuard guard(impl_->busy);
+    validate_replay_input(impl_->num_records(), impl_->program.view.noise_site_count,
+                          forced_records);
     impl_->run_replay(forced_records);
     ReplayResult result;
     result.reachable = impl_->host_reachable != 0;
@@ -1024,15 +1060,15 @@ ReplayResult Sampler::replay_shot(std::span<const uint8_t> forced_records) {
     }
     result.outputs.measurements.assign(
         impl_->host_records.begin(),
-        impl_->host_records.begin() + impl_->executable.num_visible_records());
+        impl_->host_records.begin() + impl_->num_visible_records());
     result.outputs.detectors.assign(
         impl_->host_detectors.begin(),
-        impl_->host_detectors.begin() + impl_->executable.num_detectors());
+        impl_->host_detectors.begin() + impl_->num_detectors());
     result.outputs.observables.assign(
         impl_->host_observables.begin(),
-        impl_->host_observables.begin() + impl_->executable.num_observables());
+        impl_->host_observables.begin() + impl_->num_observables());
     result.outputs.exp_vals.assign(impl_->host_exp_vals.begin(),
-                                   impl_->host_exp_vals.begin() + impl_->executable.num_exp_vals());
+                                   impl_->host_exp_vals.begin() + impl_->num_exp_vals());
     return result;
 }
 
@@ -1046,6 +1082,26 @@ uint32_t Sampler::max_batch_shots() const {
 
 size_t Sampler::allocated_device_bytes() const {
     return impl_->allocated_device_bytes();
+}
+
+uint32_t Sampler::num_visible_records() const {
+    return impl_->num_visible_records();
+}
+
+uint32_t Sampler::num_records() const {
+    return impl_->num_records();
+}
+
+uint32_t Sampler::num_detectors() const {
+    return impl_->num_detectors();
+}
+
+uint32_t Sampler::num_observables() const {
+    return impl_->num_observables();
+}
+
+uint32_t Sampler::num_exp_vals() const {
+    return impl_->num_exp_vals();
 }
 
 SamplingResult sample(const ExecutablePlan& executable, uint32_t shots,

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -1047,7 +1047,8 @@ SamplingResult sample(const ExecutablePlan& executable, uint32_t shots,
     if (shots == 0) {
         return {};
     }
-    Sampler sampler(executable, options.coefficient_precision, options.max_batch_shots);
+    Sampler sampler(executable, options.coefficient_precision,
+                    std::min(shots, options.max_batch_shots));
     return sampler.sample(shots, options.seed, options.block_size);
 }
 
@@ -1058,7 +1059,8 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& executable, uint32
     if (shots == 0) {
         return {.total_shots = 0};
     }
-    Sampler sampler(executable, options.coefficient_precision, options.max_batch_shots);
+    Sampler sampler(executable, options.coefficient_precision,
+                    std::min(shots, options.max_batch_shots));
     return sampler.sample_survivors(shots, keep_records, options.seed, options.block_size);
 }
 

--- a/src/clifft/sampling/kernels.cc
+++ b/src/clifft/sampling/kernels.cc
@@ -9,23 +9,12 @@
 #include <cassert>
 #include <cmath>
 #include <complex>
-#include <numbers>
-#include <stdexcept>
-#include <string>
 
 namespace clifft::sampling {
 
 namespace {
 
 constexpr double kInvSqrt2 = 0.707106781186547524400844362104849039;
-
-uint64_t width_mask(uint32_t active_width) {
-    if (active_width >= kDenseActiveWidthLimit) {
-        throw std::invalid_argument("prepared Pauli active width must be below " +
-                                    std::to_string(kDenseActiveWidthLimit));
-    }
-    return active_width == 0 ? 0 : (uint64_t{1} << active_width) - 1;
-}
 
 void assert_descriptor_width(const State& state, const PreparedPauli& pauli) {
     assert(state.active_width() == pauli.active_width &&
@@ -142,59 +131,6 @@ std::complex<double> compact_nondiagonal(const State& state, const PreparedMeasu
 }
 
 }  // namespace
-
-PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width) {
-    const uint64_t valid_bits = width_mask(active_width);
-    if ((pauli.x & ~valid_bits) != 0 || (pauli.z & ~valid_bits) != 0) {
-        throw std::invalid_argument("prepared Pauli has bits outside its active width");
-    }
-
-    static constexpr std::complex<double> kIPowers[4] = {
-        {1.0, 0.0}, {0.0, 1.0}, {-1.0, 0.0}, {0.0, -1.0}};
-    const uint32_t overlap = std::popcount(pauli.x & pauli.z);
-    return PreparedPauli{.active_width = active_width,
-                         .x = pauli.x,
-                         .z = pauli.z,
-                         .pairing_bit = std::bit_floor(pauli.x),
-                         .even_phase = kIPowers[overlap & 3U]};
-}
-
-PreparedRotation prepare_rotation(ActivePauli pauli, uint32_t active_width, double half_turns) {
-    if (!is_finite_robust(half_turns)) {
-        throw std::invalid_argument("prepared rotation angle must be finite");
-    }
-    if (pauli.is_identity()) {
-        throw std::invalid_argument("cannot prepare an identity rotation");
-    }
-    const double angle = std::numbers::pi * half_turns / 2.0;
-    return PreparedRotation{prepare_pauli(pauli, active_width), std::cos(angle), std::sin(angle)};
-}
-
-PreparedPromotion prepare_promotion(double half_turns) {
-    if (!is_finite_robust(half_turns)) {
-        throw std::invalid_argument("prepared promotion angle must be finite");
-    }
-    const double angle = std::numbers::pi * half_turns / 2.0;
-    return PreparedPromotion{std::cos(angle), std::sin(angle)};
-}
-
-PreparedMeasurement prepare_measurement(ActivePauli pauli, uint32_t active_width, uint32_t pivot) {
-    PreparedPauli prepared = prepare_pauli(pauli, active_width);
-    if (active_width == 0 || prepared.is_identity()) {
-        throw std::invalid_argument("cannot prepare an active identity measurement");
-    }
-    if (pivot >= active_width) {
-        throw std::invalid_argument("prepared measurement pivot is outside its active width");
-    }
-    const uint64_t pivot_bit = uint64_t{1} << pivot;
-    const bool pivot_is_valid =
-        prepared.x != 0 ? (prepared.x & pivot_bit) != 0 : (prepared.z & pivot_bit) != 0;
-    if (!pivot_is_valid) {
-        throw std::invalid_argument("prepared measurement pivot is outside Pauli support");
-    }
-    return PreparedMeasurement{prepared, pivot, uint64_t{1} << (active_width - 1),
-                               prepared.z & ~pivot_bit};
-}
 
 double expectation_value(const State& state, const PreparedPauli& pauli) noexcept {
     assert_descriptor_width(state, pauli);

--- a/src/clifft/sampling/kernels.h
+++ b/src/clifft/sampling/kernels.h
@@ -1,49 +1,14 @@
 #pragma once
 
-#include "clifft/sampling/plan.h"
+#include "clifft/sampling/pauli_preparation.h"
 #include "clifft/sampling/state.h"
 
-#include <complex>
 #include <cstdint>
 
 namespace clifft::sampling {
 
-// Portable descriptors and scalar kernel entry points used by CPU execution.
-// ISA-specific selection and implementations stay outside this header.
-
-// Describes a Pauli operation to apply to the state vector. Its masks and
-// precomputed index values identify affected coefficients without referring to
-// the State's storage.
-struct PreparedPauli {
-    uint32_t active_width = 0;
-    uint64_t x = 0;
-    uint64_t z = 0;
-    // Highest set X bit. It selects the pair stride and half-space for a
-    // non-diagonal Pauli, and is zero only when the Pauli is diagonal.
-    uint64_t pairing_bit = 0;
-    std::complex<double> even_phase = {1.0, 0.0};
-
-    [[nodiscard]] bool is_identity() const { return x == 0 && z == 0; }
-    [[nodiscard]] bool is_diagonal() const { return x == 0; }
-};
-
-struct PreparedRotation {
-    PreparedPauli pauli;
-    double cosine = 1.0;
-    double sine = 0.0;
-};
-
-struct PreparedPromotion {
-    double cosine = 1.0;
-    double sine = 0.0;
-};
-
-struct PreparedMeasurement {
-    PreparedPauli pauli;
-    uint32_t pivot = 0;
-    uint64_t output_size = 0;
-    uint64_t z_without_pivot = 0;
-};
+// Portable scalar kernel entry points used by CPU execution. ISA-specific
+// selection and implementations stay outside this header.
 
 struct MeasurementProbabilities {
     double zero = 0.0;
@@ -52,13 +17,6 @@ struct MeasurementProbabilities {
     [[nodiscard]] double total() const { return zero + one; }
     [[nodiscard]] double for_branch(bool branch) const { return branch ? one : zero; }
 };
-
-[[nodiscard]] PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width);
-[[nodiscard]] PreparedRotation prepare_rotation(ActivePauli pauli, uint32_t active_width,
-                                                double half_turns);
-[[nodiscard]] PreparedPromotion prepare_promotion(double half_turns);
-[[nodiscard]] PreparedMeasurement prepare_measurement(ActivePauli pauli, uint32_t active_width,
-                                                      uint32_t pivot);
 
 // Computes <P> on normalized active-coordinate coefficients without mutating
 // the state.

--- a/src/clifft/sampling/pauli_preparation.cc
+++ b/src/clifft/sampling/pauli_preparation.cc
@@ -1,0 +1,79 @@
+#include "clifft/sampling/pauli_preparation.h"
+
+#include "clifft/util/numeric.h"
+
+#include <bit>
+#include <cmath>
+#include <complex>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+
+namespace clifft::sampling {
+
+namespace {
+
+uint64_t width_mask(uint32_t active_width) {
+    if (active_width >= kDenseActiveWidthLimit) {
+        throw std::invalid_argument("prepared Pauli active width must be below " +
+                                    std::to_string(kDenseActiveWidthLimit));
+    }
+    return active_width == 0 ? 0 : (uint64_t{1} << active_width) - 1;
+}
+
+}  // namespace
+
+PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width) {
+    const uint64_t valid_bits = width_mask(active_width);
+    if ((pauli.x & ~valid_bits) != 0 || (pauli.z & ~valid_bits) != 0) {
+        throw std::invalid_argument("prepared Pauli has bits outside its active width");
+    }
+
+    static constexpr std::complex<double> kIPowers[4] = {
+        {1.0, 0.0}, {0.0, 1.0}, {-1.0, 0.0}, {0.0, -1.0}};
+    const uint32_t overlap = std::popcount(pauli.x & pauli.z);
+    return PreparedPauli{.active_width = active_width,
+                         .x = pauli.x,
+                         .z = pauli.z,
+                         .pairing_bit = std::bit_floor(pauli.x),
+                         .even_phase = kIPowers[overlap & 3U]};
+}
+
+PreparedRotation prepare_rotation(ActivePauli pauli, uint32_t active_width, double half_turns) {
+    if (!is_finite_robust(half_turns)) {
+        throw std::invalid_argument("prepared rotation angle must be finite");
+    }
+    if (pauli.is_identity()) {
+        throw std::invalid_argument("cannot prepare an identity rotation");
+    }
+    const double angle = std::numbers::pi * half_turns / 2.0;
+    return PreparedRotation{prepare_pauli(pauli, active_width), std::cos(angle), std::sin(angle)};
+}
+
+PreparedPromotion prepare_promotion(double half_turns) {
+    if (!is_finite_robust(half_turns)) {
+        throw std::invalid_argument("prepared promotion angle must be finite");
+    }
+    const double angle = std::numbers::pi * half_turns / 2.0;
+    return PreparedPromotion{std::cos(angle), std::sin(angle)};
+}
+
+PreparedMeasurement prepare_measurement(ActivePauli pauli, uint32_t active_width, uint32_t pivot) {
+    PreparedPauli prepared = prepare_pauli(pauli, active_width);
+    if (active_width == 0 || prepared.is_identity()) {
+        throw std::invalid_argument("cannot prepare an active identity measurement");
+    }
+    if (pivot >= active_width) {
+        throw std::invalid_argument("prepared measurement pivot is outside its active width");
+    }
+    const uint64_t pivot_bit = uint64_t{1} << pivot;
+    const bool pivot_is_valid =
+        prepared.x != 0 ? (prepared.x & pivot_bit) != 0 : (prepared.z & pivot_bit) != 0;
+    if (!pivot_is_valid) {
+        throw std::invalid_argument("prepared measurement pivot is outside Pauli support");
+    }
+    return PreparedMeasurement{prepared, pivot, uint64_t{1} << (active_width - 1),
+                               prepared.z & ~pivot_bit};
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/pauli_preparation.h
+++ b/src/clifft/sampling/pauli_preparation.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "clifft/sampling/plan.h"
+
+#include <complex>
+#include <cstdint>
+
+namespace clifft::sampling {
+
+// Execution-ready Pauli geometry shared by CPU and device lowering.
+struct PreparedPauli {
+    uint32_t active_width = 0;
+    uint64_t x = 0;
+    uint64_t z = 0;
+    // Highest set X bit. It selects the pair stride and half-space for a
+    // non-diagonal Pauli, and is zero only when the Pauli is diagonal.
+    uint64_t pairing_bit = 0;
+    std::complex<double> even_phase = {1.0, 0.0};
+
+    [[nodiscard]] bool is_identity() const { return x == 0 && z == 0; }
+    [[nodiscard]] bool is_diagonal() const { return x == 0; }
+};
+
+struct PreparedRotation {
+    PreparedPauli pauli;
+    double cosine = 1.0;
+    double sine = 0.0;
+};
+
+struct PreparedPromotion {
+    double cosine = 1.0;
+    double sine = 0.0;
+};
+
+struct PreparedMeasurement {
+    PreparedPauli pauli;
+    uint32_t pivot = 0;
+    uint64_t output_size = 0;
+    uint64_t z_without_pivot = 0;
+};
+
+[[nodiscard]] PreparedPauli prepare_pauli(ActivePauli pauli, uint32_t active_width);
+[[nodiscard]] PreparedRotation prepare_rotation(ActivePauli pauli, uint32_t active_width,
+                                                double half_turns);
+[[nodiscard]] PreparedPromotion prepare_promotion(double half_turns);
+[[nodiscard]] PreparedMeasurement prepare_measurement(ActivePauli pauli, uint32_t active_width,
+                                                      uint32_t pivot);
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/results.h
+++ b/src/clifft/sampling/results.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace clifft::sampling {
+
+// Backend-neutral row-major outputs from ordinary sampling.
+struct SamplingResult {
+    std::vector<uint8_t> measurements;
+    std::vector<uint8_t> detectors;
+    std::vector<uint8_t> observables;
+    std::vector<double> exp_vals;
+};
+
+// Backend-neutral outputs from postselected survivor sampling.
+struct SamplingSurvivorResult {
+    uint32_t total_shots = 0;
+    uint32_t passed_shots = 0;
+    uint32_t logical_errors = 0;
+    std::vector<uint64_t> observable_ones;
+    std::vector<uint8_t> measurements;
+    std::vector<uint8_t> detectors;
+    std::vector<uint8_t> observables;
+    std::vector<double> exp_vals;
+};
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/results.h"
 #include "clifft/util/config.h"
 
 #include <cstddef>
@@ -16,25 +17,6 @@ namespace clifft::sampling {
 // Planning produces semantic actions, lowering prepares fixed CPU descriptors,
 // Executor owns mutable state for one shot, and the functions below drive
 // repeated shots and collect their outputs.
-
-// Collected row-major outputs from ordinary or fixed-fault-count sampling.
-struct SamplingResult {
-    std::vector<uint8_t> measurements;
-    std::vector<uint8_t> detectors;
-    std::vector<uint8_t> observables;
-    std::vector<double> exp_vals;
-};
-
-struct SamplingSurvivorResult {
-    uint32_t total_shots = 0;
-    uint32_t passed_shots = 0;
-    uint32_t logical_errors = 0;
-    std::vector<uint64_t> observable_ones;
-    std::vector<uint8_t> measurements;
-    std::vector<uint8_t> detectors;
-    std::vector<uint8_t> observables;
-    std::vector<double> exp_vals;
-};
 
 // Explicitly partitions sampling workers across independent shots and the
 // coefficient kernels within each shot. When supplied, this layout overrides

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -54,6 +54,24 @@ install(TARGETS _clifft_core
     LIBRARY DESTINATION clifft
     RUNTIME DESTINATION clifft)
 
+if(CLIFFT_ENABLE_HIP)
+    # Keep ROCm out of the ordinary extension and wheels. The pure-Python
+    # experimental facade discovers this module only in an explicit HIP build.
+    nanobind_add_module(
+        _clifft_hip
+        STABLE_ABI
+        hip_bindings.cc
+    )
+    target_link_libraries(_clifft_hip PRIVATE clifft_hip_backend)
+    if(UNIX AND NOT APPLE)
+        target_link_options(_clifft_hip PRIVATE
+            "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/clifft_hip.lds")
+    endif()
+    install(TARGETS _clifft_hip
+        LIBRARY DESTINATION clifft
+        RUNTIME DESTINATION clifft)
+endif()
+
 # Generate type stubs for the C++ extension at install time so that type
 # checkers (mypy, pyright) can see the full API.  INSTALL_TIME runs stubgen
 # after the .so is in its final location, which is required for import.

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -739,6 +739,24 @@ NB_MODULE(_clifft_core, m) {
         "    expected_observables: Optional noiseless reference parities for observables.\n");
 
     m.def(
+        "_prepare_hir_for_lowering",
+        [](const std::string& stim_text, std::vector<uint8_t> expected_detectors,
+           std::vector<uint8_t> expected_observables, bool normalize_syndromes,
+           clifft::HirPassManager* hir_passes) {
+            clifft::HirModule hir;
+            {
+                nb::gil_scoped_release release;
+                hir = prepare_hir_for_lowering(stim_text, normalize_syndromes, hir_passes,
+                                               expected_detectors, expected_observables);
+            }
+            return nb::make_tuple(std::move(hir), std::move(expected_detectors),
+                                  std::move(expected_observables));
+        },
+        nb::arg("stim_text"), nb::arg("expected_detectors") = std::vector<uint8_t>{},
+        nb::arg("expected_observables") = std::vector<uint8_t>{},
+        nb::arg("normalize_syndromes") = false, nb::arg("hir_passes") = nb::none());
+
+    m.def(
         "compile",
         [](const std::string& stim_text, std::vector<uint8_t> postselection_mask,
            std::vector<uint8_t> expected_detectors, std::vector<uint8_t> expected_observables,

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -10,11 +10,16 @@ dimension is `2^k`.
 # ruff: noqa: E402
 from __future__ import annotations
 
+import importlib
 from collections.abc import Sequence
-from typing import Protocol, TypeAlias, cast
+from types import ModuleType
+from typing import TYPE_CHECKING, Protocol, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import clifft.experimental as experimental
 
 from clifft._build_config import CPU_BASELINE
 from clifft._cpu_check import ensure_supported_cpu
@@ -363,4 +368,10 @@ __all__ = [
 
 __version__ = version()
 
-from clifft import experimental
+
+def __getattr__(name: str) -> ModuleType:
+    if name == "experimental":
+        module = importlib.import_module("clifft.experimental")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -345,6 +345,7 @@ __all__ = [
     "compile",
     "compute_reference_syndrome",
     "default_hir_pass_manager",
+    "experimental",
     "get_statevector",
     "lower",
     "noncomp",
@@ -361,3 +362,5 @@ __all__ = [
 ]
 
 __version__ = version()
+
+from clifft import experimental

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -61,6 +61,9 @@ from clifft._clifft_core import (
     version,
 )
 from clifft._clifft_core import (
+    _prepare_hir_for_lowering as _prepare_hir_for_lowering,
+)
+from clifft._clifft_core import (
     compile as _compile_core,
 )
 from clifft._sample_result import SampleResult

--- a/src/python/clifft/experimental/__init__.py
+++ b/src/python/clifft/experimental/__init__.py
@@ -1,5 +1,21 @@
 """Experimental APIs that may change without compatibility guarantees."""
 
-from clifft.experimental import hip
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import clifft.experimental.hip as hip
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name == "hip":
+        module = importlib.import_module("clifft.experimental.hip")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["hip"]

--- a/src/python/clifft/experimental/__init__.py
+++ b/src/python/clifft/experimental/__init__.py
@@ -1,0 +1,5 @@
+"""Experimental APIs that may change without compatibility guarantees."""
+
+from clifft.experimental import hip
+
+__all__ = ["hip"]

--- a/src/python/clifft/experimental/hip.py
+++ b/src/python/clifft/experimental/hip.py
@@ -9,13 +9,13 @@ from types import ModuleType
 from typing import Any, Literal, cast
 
 from clifft import (
+    _DEFAULT_PASSES,
     HirModule,
     HirPassManager,
     SampleResult,
-    compute_reference_syndrome,
+    _DefaultPasses,
+    _prepare_hir_for_lowering,
     default_hir_pass_manager,
-    parse,
-    trace,
 )
 
 Precision = Literal["fp64", "fp32"]
@@ -86,6 +86,11 @@ class Program:
         return cast(int, self._native.num_measurements)
 
     @property
+    def num_records(self) -> int:
+        """Return the visible plus hidden record width required by replay."""
+        return cast(int, self._native.num_records)
+
+    @property
     def num_detectors(self) -> int:
         return cast(int, self._native.num_detectors)
 
@@ -115,13 +120,6 @@ class Program:
         )
 
 
-class _DefaultPasses:
-    pass
-
-
-_DEFAULT_PASSES = _DefaultPasses()
-
-
 def lower(
     hir: HirModule,
     postselection_mask: list[int] | None = None,
@@ -149,20 +147,18 @@ def compile(
     hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
 ) -> Program:
     """Compile Stim text through the shared HIR and SamplingPlan pipeline."""
-    detectors = expected_detectors if expected_detectors is not None else []
-    observables = expected_observables if expected_observables is not None else []
-    if normalize_syndromes and (detectors or observables):
-        raise ValueError("expected parities cannot be supplied when normalize_syndromes=True")
-
-    hir = trace(parse(stim_text))
     if isinstance(hir_passes, _DefaultPasses):
         hir_passes = default_hir_pass_manager()
-    if hir_passes is not None:
-        hir_passes.run(hir)
-    if normalize_syndromes:
-        reference = compute_reference_syndrome(hir)
-        detectors = cast(list[int], reference["detectors"])
-        observables = cast(list[int], reference["observables"])
+    prepared = _prepare_hir_for_lowering(
+        stim_text,
+        expected_detectors if expected_detectors is not None else [],
+        expected_observables if expected_observables is not None else [],
+        normalize_syndromes,
+        hir_passes,
+    )
+    hir = cast(HirModule, prepared[0])
+    detectors = cast(list[int], prepared[1])
+    observables = cast(list[int], prepared[2])
     return lower(hir, postselection_mask, detectors, observables)
 
 

--- a/src/python/clifft/experimental/hip.py
+++ b/src/python/clifft/experimental/hip.py
@@ -177,7 +177,10 @@ class ReplayResult:
 
 
 class Sampler:
-    """A synchronous sampler with one uploaded program and retained workspace."""
+    """A synchronous sampler with one uploaded program and retained workspace.
+
+    Calls on one instance must not overlap. Use a separate sampler per caller.
+    """
 
     __slots__ = ("_native", "program")
 

--- a/src/python/clifft/experimental/hip.py
+++ b/src/python/clifft/experimental/hip.py
@@ -189,15 +189,15 @@ class Sampler:
         program: Program,
         *,
         precision: Precision = "fp64",
-        max_batch_shots: int = 65_536,
+        max_batch_shots: int | None = None,
     ) -> None:
         native = _require_native()
         self.program = program
-        self._native = native.Sampler(
-            program._native,
-            _precision_value(precision),
-            max_batch_shots,
-        )
+        native_precision = _precision_value(precision)
+        if max_batch_shots is None:
+            self._native = native.Sampler(program._native, native_precision)
+        else:
+            self._native = native.Sampler(program._native, native_precision, max_batch_shots)
 
     @property
     def precision(self) -> Precision:
@@ -219,9 +219,11 @@ class Sampler:
         shots: int,
         *,
         seed: int | None = None,
-        block_size: int = 256,
+        block_size: int | None = None,
     ) -> SampleResult:
         """Sample fixed rows while reusing the retained device workspace."""
+        if block_size is None:
+            return cast(SampleResult, self._native.sample(shots, seed))
         return cast(SampleResult, self._native.sample(shots, seed, block_size))
 
     def sample_survivors(
@@ -230,9 +232,14 @@ class Sampler:
         *,
         keep_records: bool = False,
         seed: int | None = None,
-        block_size: int = 256,
+        block_size: int | None = None,
     ) -> SampleResult:
         """Sample and retain only shots that pass postselection."""
+        if block_size is None:
+            return cast(
+                SampleResult,
+                self._native.sample_survivors(shots, keep_records, seed),
+            )
         return cast(
             SampleResult,
             self._native.sample_survivors(shots, keep_records, seed, block_size),

--- a/src/python/clifft/experimental/hip.py
+++ b/src/python/clifft/experimental/hip.py
@@ -1,0 +1,259 @@
+"""Developer-facing access to Clifft's optional AMD HIP sampling backend."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any, Literal, cast
+
+from clifft import (
+    HirModule,
+    HirPassManager,
+    SampleResult,
+    compute_reference_syndrome,
+    default_hir_pass_manager,
+    parse,
+    trace,
+)
+
+Precision = Literal["fp64", "fp32"]
+
+_NATIVE_NAME = "clifft._clifft_hip"
+_NATIVE_SPEC = importlib.util.find_spec(_NATIVE_NAME)
+_native: ModuleType | None = None
+_native_error: ImportError | None = None
+if _NATIVE_SPEC is not None:
+    try:
+        _native = importlib.import_module(_NATIVE_NAME)
+    except ImportError as error:
+        _native_error = error
+
+
+def is_built() -> bool:
+    """Return whether this Clifft installation contains the HIP extension."""
+    return _NATIVE_SPEC is not None
+
+
+def is_available() -> bool:
+    """Return whether the extension loaded and can see an AMD GPU."""
+    return _native is not None and bool(_native.is_available())
+
+
+def backend_info() -> str:
+    """Describe the optional extension and any devices visible to HIP."""
+    if _NATIVE_SPEC is None:
+        return "HIP backend not built; rebuild Clifft with CLIFFT_ENABLE_HIP=ON"
+    if _native is None:
+        return f"HIP extension failed to load: {_native_error}"
+    return cast(str, _native.backend_info())
+
+
+def _require_native() -> ModuleType:
+    if _native is None:
+        raise RuntimeError(backend_info())
+    return _native
+
+
+def _precision_value(precision: Precision) -> Any:
+    native = _require_native()
+    if precision == "fp64":
+        return native.CoefficientPrecision.FP64
+    if precision == "fp32":
+        return native.CoefficientPrecision.FP32
+    raise ValueError("precision must be 'fp64' or 'fp32'")
+
+
+class Program:
+    """An immutable, backend-private lowering of a SamplingPlan."""
+
+    __slots__ = ("_native",)
+
+    def __init__(self, native: Any) -> None:
+        self._native = native
+
+    @property
+    def peak_active_width(self) -> int:
+        return cast(int, self._native.peak_active_width)
+
+    @property
+    def num_actions(self) -> int:
+        return cast(int, self._native.num_actions)
+
+    @property
+    def num_measurements(self) -> int:
+        return cast(int, self._native.num_measurements)
+
+    @property
+    def num_detectors(self) -> int:
+        return cast(int, self._native.num_detectors)
+
+    @property
+    def num_observables(self) -> int:
+        return cast(int, self._native.num_observables)
+
+    @property
+    def num_exp_vals(self) -> int:
+        return cast(int, self._native.num_exp_vals)
+
+    @property
+    def has_postselection(self) -> bool:
+        return cast(bool, self._native.has_postselection)
+
+    @property
+    def packed_bytes(self) -> int:
+        return cast(int, self._native.packed_bytes)
+
+    def inspect(self) -> str:
+        """Return diagnostic text for the packed executable."""
+        return cast(str, self._native.inspect())
+
+    def __repr__(self) -> str:
+        return (
+            f"Program({self.num_actions} actions, " f"peak_active_width={self.peak_active_width})"
+        )
+
+
+class _DefaultPasses:
+    pass
+
+
+_DEFAULT_PASSES = _DefaultPasses()
+
+
+def lower(
+    hir: HirModule,
+    postselection_mask: list[int] | None = None,
+    expected_detectors: list[int] | None = None,
+    expected_observables: list[int] | None = None,
+) -> Program:
+    """Lower optimized HIR into the experimental HIP executable format."""
+    native = _require_native()
+    return Program(
+        native.lower(
+            hir,
+            postselection_mask if postselection_mask is not None else [],
+            expected_detectors if expected_detectors is not None else [],
+            expected_observables if expected_observables is not None else [],
+        )
+    )
+
+
+def compile(
+    stim_text: str,
+    postselection_mask: list[int] | None = None,
+    expected_detectors: list[int] | None = None,
+    expected_observables: list[int] | None = None,
+    normalize_syndromes: bool = False,
+    hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+) -> Program:
+    """Compile Stim text through the shared HIR and SamplingPlan pipeline."""
+    detectors = expected_detectors if expected_detectors is not None else []
+    observables = expected_observables if expected_observables is not None else []
+    if normalize_syndromes and (detectors or observables):
+        raise ValueError("expected parities cannot be supplied when normalize_syndromes=True")
+
+    hir = trace(parse(stim_text))
+    if isinstance(hir_passes, _DefaultPasses):
+        hir_passes = default_hir_pass_manager()
+    if hir_passes is not None:
+        hir_passes.run(hir)
+    if normalize_syndromes:
+        reference = compute_reference_syndrome(hir)
+        detectors = cast(list[int], reference["detectors"])
+        observables = cast(list[int], reference["observables"])
+    return lower(hir, postselection_mask, detectors, observables)
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Result of one forced-record path through the HIP interpreter."""
+
+    reachable: bool
+    survived: bool
+    log_probability: float
+    outputs: SampleResult
+
+
+class Sampler:
+    """A synchronous sampler with one uploaded program and retained workspace."""
+
+    __slots__ = ("_native", "program")
+
+    def __init__(
+        self,
+        program: Program,
+        *,
+        precision: Precision = "fp64",
+        max_batch_shots: int = 65_536,
+    ) -> None:
+        native = _require_native()
+        self.program = program
+        self._native = native.Sampler(
+            program._native,
+            _precision_value(precision),
+            max_batch_shots,
+        )
+
+    @property
+    def precision(self) -> Precision:
+        native = _require_native()
+        if self._native.coefficient_precision == native.CoefficientPrecision.FP32:
+            return "fp32"
+        return "fp64"
+
+    @property
+    def max_batch_shots(self) -> int:
+        return cast(int, self._native.max_batch_shots)
+
+    @property
+    def allocated_device_bytes(self) -> int:
+        return cast(int, self._native.allocated_device_bytes)
+
+    def sample(
+        self,
+        shots: int,
+        *,
+        seed: int | None = None,
+        block_size: int = 256,
+    ) -> SampleResult:
+        """Sample fixed rows while reusing the retained device workspace."""
+        return cast(SampleResult, self._native.sample(shots, seed, block_size))
+
+    def sample_survivors(
+        self,
+        shots: int,
+        *,
+        keep_records: bool = False,
+        seed: int | None = None,
+        block_size: int = 256,
+    ) -> SampleResult:
+        """Sample and retain only shots that pass postselection."""
+        return cast(
+            SampleResult,
+            self._native.sample_survivors(shots, keep_records, seed, block_size),
+        )
+
+    def replay_shot(self, forced_records: list[int]) -> ReplayResult:
+        """Force every record value to probe one measurement branch exactly."""
+        result = self._native.replay_shot(forced_records)
+        return ReplayResult(
+            reachable=cast(bool, result["reachable"]),
+            survived=cast(bool, result["survived"]),
+            log_probability=cast(float, result["log_probability"]),
+            outputs=cast(SampleResult, result["outputs"]),
+        )
+
+
+__all__ = [
+    "Precision",
+    "Program",
+    "ReplayResult",
+    "Sampler",
+    "backend_info",
+    "compile",
+    "is_available",
+    "is_built",
+    "lower",
+]

--- a/src/python/clifft/noncomp.py
+++ b/src/python/clifft/noncomp.py
@@ -35,7 +35,7 @@ from typing import Callable, Iterator, Literal
 import numpy as np
 import numpy.typing as npt
 
-from clifft import _clifft_core
+import clifft._clifft_core as _clifft_core
 from clifft._clifft_core import Circuit
 
 __all__ = [

--- a/src/python/clifft_hip.lds
+++ b/src/python/clifft_hip.lds
@@ -1,0 +1,6 @@
+{
+    global:
+        PyInit__clifft_hip;
+    local:
+        *;
+};

--- a/src/python/hip_bindings.cc
+++ b/src/python/hip_bindings.cc
@@ -3,7 +3,6 @@
 #include "clifft/sampling/hip/sampler.h"
 #include "clifft/sampling/planner.h"
 
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -12,7 +11,6 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -20,23 +18,6 @@
 namespace nb = nanobind;
 
 namespace {
-
-class BusyGuard {
-  public:
-    explicit BusyGuard(std::atomic_flag& busy) : busy_(busy) {
-        if (busy_.test_and_set(std::memory_order_acquire)) {
-            throw std::runtime_error("calls on one HIP Sampler instance must not overlap");
-        }
-    }
-
-    ~BusyGuard() { busy_.clear(std::memory_order_release); }
-
-    BusyGuard(const BusyGuard&) = delete;
-    BusyGuard& operator=(const BusyGuard&) = delete;
-
-  private:
-    std::atomic_flag& busy_;
-};
 
 template <typename T>
 nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> values,
@@ -49,28 +30,27 @@ nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> values,
 }
 
 nb::object rows_to_python(clifft::sampling::SamplingResult result, uint32_t rows,
-                          const clifft::sampling::hip::ExecutablePlan& program) {
+                          const clifft::sampling::hip::Sampler& sampler) {
     auto measurements =
-        vec_to_numpy(std::move(result.measurements), {rows, program.num_visible_records()});
-    auto detectors = vec_to_numpy(std::move(result.detectors), {rows, program.num_detectors()});
+        vec_to_numpy(std::move(result.measurements), {rows, sampler.num_visible_records()});
+    auto detectors = vec_to_numpy(std::move(result.detectors), {rows, sampler.num_detectors()});
     auto observables =
-        vec_to_numpy(std::move(result.observables), {rows, program.num_observables()});
-    auto exp_vals = vec_to_numpy(std::move(result.exp_vals), {rows, program.num_exp_vals()});
+        vec_to_numpy(std::move(result.observables), {rows, sampler.num_observables()});
+    auto exp_vals = vec_to_numpy(std::move(result.exp_vals), {rows, sampler.num_exp_vals()});
     nb::object cls = nb::module_::import_("clifft._sample_result").attr("SampleResult");
     return cls(measurements, detectors, observables, nb::none(), nb::none(), nb::none(), nb::none(),
                exp_vals);
 }
 
 nb::object survivors_to_python(clifft::sampling::SamplingSurvivorResult result,
-                               const clifft::sampling::hip::ExecutablePlan& program,
-                               bool keep_records) {
+                               const clifft::sampling::hip::Sampler& sampler, bool keep_records) {
     const uint32_t rows = keep_records ? result.passed_shots : 0;
     auto measurements =
-        vec_to_numpy(std::move(result.measurements), {rows, program.num_visible_records()});
-    auto detectors = vec_to_numpy(std::move(result.detectors), {rows, program.num_detectors()});
+        vec_to_numpy(std::move(result.measurements), {rows, sampler.num_visible_records()});
+    auto detectors = vec_to_numpy(std::move(result.detectors), {rows, sampler.num_detectors()});
     auto observables =
-        vec_to_numpy(std::move(result.observables), {rows, program.num_observables()});
-    auto exp_vals = vec_to_numpy(std::move(result.exp_vals), {rows, program.num_exp_vals()});
+        vec_to_numpy(std::move(result.observables), {rows, sampler.num_observables()});
+    auto exp_vals = vec_to_numpy(std::move(result.exp_vals), {rows, sampler.num_exp_vals()});
     const size_t observable_count = result.observable_ones.size();
     auto observable_ones = vec_to_numpy(std::move(result.observable_ones), {observable_count});
     nb::object cls = nb::module_::import_("clifft._sample_result").attr("SampleResult");
@@ -78,23 +58,12 @@ nb::object survivors_to_python(clifft::sampling::SamplingSurvivorResult result,
                result.logical_errors, observable_ones, exp_vals);
 }
 
-struct BoundSampler {
-    BoundSampler(const clifft::sampling::hip::ExecutablePlan& source,
-                 clifft::sampling::hip::CoefficientPrecision precision, uint32_t max_batch_shots)
-        : program(source), sampler(program, precision, max_batch_shots) {}
-
-    clifft::sampling::hip::ExecutablePlan program;
-    clifft::sampling::hip::Sampler sampler;
-    // The GIL is released during device execution, so protect the retained
-    // workspace independently of Python thread scheduling.
-    std::atomic_flag busy = ATOMIC_FLAG_INIT;
-};
-
 }  // namespace
 
 NB_MODULE(_clifft_hip, module) {
     using clifft::sampling::hip::CoefficientPrecision;
     using clifft::sampling::hip::ExecutablePlan;
+    using clifft::sampling::hip::Sampler;
 
     module.doc() = "Experimental Clifft HIP backend";
 
@@ -131,54 +100,49 @@ NB_MODULE(_clifft_hip, module) {
         nb::arg("expected_detectors") = std::vector<uint8_t>{},
         nb::arg("expected_observables") = std::vector<uint8_t>{});
 
-    nb::class_<BoundSampler>(module, "Sampler")
+    nb::class_<Sampler>(module, "Sampler")
         .def(nb::init<const ExecutablePlan&, CoefficientPrecision, uint32_t>(), nb::arg("program"),
              nb::arg("coefficient_precision") = CoefficientPrecision::FP64,
              nb::arg("max_batch_shots") = clifft::sampling::hip::kDefaultMaxBatchShots)
-        .def_prop_ro(
-            "coefficient_precision",
-            [](const BoundSampler& bound) { return bound.sampler.coefficient_precision(); })
+        .def_prop_ro("coefficient_precision",
+                     [](const Sampler& sampler) { return sampler.coefficient_precision(); })
         .def_prop_ro("max_batch_shots",
-                     [](const BoundSampler& bound) { return bound.sampler.max_batch_shots(); })
-        .def_prop_ro(
-            "allocated_device_bytes",
-            [](const BoundSampler& bound) { return bound.sampler.allocated_device_bytes(); })
+                     [](const Sampler& sampler) { return sampler.max_batch_shots(); })
+        .def_prop_ro("allocated_device_bytes",
+                     [](const Sampler& sampler) { return sampler.allocated_device_bytes(); })
         .def(
             "sample",
-            [](BoundSampler& bound, uint32_t shots, std::optional<uint64_t> seed,
+            [](Sampler& sampler, uint32_t shots, std::optional<uint64_t> seed,
                uint32_t block_size) {
-                BusyGuard guard(bound.busy);
                 clifft::sampling::SamplingResult result;
                 {
                     nb::gil_scoped_release release;
-                    result = bound.sampler.sample(shots, seed, block_size);
+                    result = sampler.sample(shots, seed, block_size);
                 }
-                return rows_to_python(std::move(result), shots, bound.program);
+                return rows_to_python(std::move(result), shots, sampler);
             },
             nb::arg("shots"), nb::arg("seed") = nb::none(),
             nb::arg("block_size") = clifft::sampling::hip::kDefaultBlockSize)
         .def(
             "sample_survivors",
-            [](BoundSampler& bound, uint32_t shots, bool keep_records, std::optional<uint64_t> seed,
+            [](Sampler& sampler, uint32_t shots, bool keep_records, std::optional<uint64_t> seed,
                uint32_t block_size) {
-                BusyGuard guard(bound.busy);
                 clifft::sampling::SamplingSurvivorResult result;
                 {
                     nb::gil_scoped_release release;
-                    result = bound.sampler.sample_survivors(shots, keep_records, seed, block_size);
+                    result = sampler.sample_survivors(shots, keep_records, seed, block_size);
                 }
-                return survivors_to_python(std::move(result), bound.program, keep_records);
+                return survivors_to_python(std::move(result), sampler, keep_records);
             },
             nb::arg("shots"), nb::arg("keep_records") = false, nb::arg("seed") = nb::none(),
             nb::arg("block_size") = clifft::sampling::hip::kDefaultBlockSize)
         .def(
             "replay_shot",
-            [](BoundSampler& bound, std::vector<uint8_t> forced_records) {
-                BusyGuard guard(bound.busy);
+            [](Sampler& sampler, std::vector<uint8_t> forced_records) {
                 clifft::sampling::hip::ReplayResult result;
                 {
                     nb::gil_scoped_release release;
-                    result = bound.sampler.replay_shot(forced_records);
+                    result = sampler.replay_shot(forced_records);
                 }
                 nb::dict output;
                 output["reachable"] = result.reachable;
@@ -186,7 +150,7 @@ NB_MODULE(_clifft_hip, module) {
                 output["log_probability"] = result.log_probability;
                 output["outputs"] =
                     rows_to_python(std::move(result.outputs),
-                                   result.reachable && result.survived ? 1 : 0, bound.program);
+                                   result.reachable && result.survived ? 1 : 0, sampler);
                 return output;
             },
             nb::arg("forced_records"));

--- a/src/python/hip_bindings.cc
+++ b/src/python/hip_bindings.cc
@@ -3,6 +3,7 @@
 #include "clifft/sampling/hip/sampler.h"
 #include "clifft/sampling/planner.h"
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -11,6 +12,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -18,6 +20,23 @@
 namespace nb = nanobind;
 
 namespace {
+
+class BusyGuard {
+  public:
+    explicit BusyGuard(std::atomic_flag& busy) : busy_(busy) {
+        if (busy_.test_and_set(std::memory_order_acquire)) {
+            throw std::runtime_error("calls on one HIP Sampler instance must not overlap");
+        }
+    }
+
+    ~BusyGuard() { busy_.clear(std::memory_order_release); }
+
+    BusyGuard(const BusyGuard&) = delete;
+    BusyGuard& operator=(const BusyGuard&) = delete;
+
+  private:
+    std::atomic_flag& busy_;
+};
 
 template <typename T>
 nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> values,
@@ -66,6 +85,9 @@ struct BoundSampler {
 
     clifft::sampling::hip::ExecutablePlan program;
     clifft::sampling::hip::Sampler sampler;
+    // The GIL is released during device execution, so protect the retained
+    // workspace independently of Python thread scheduling.
+    std::atomic_flag busy = ATOMIC_FLAG_INIT;
 };
 
 }  // namespace
@@ -124,6 +146,7 @@ NB_MODULE(_clifft_hip, module) {
             "sample",
             [](BoundSampler& bound, uint32_t shots, std::optional<uint64_t> seed,
                uint32_t block_size) {
+                BusyGuard guard(bound.busy);
                 clifft::sampling::SamplingResult result;
                 {
                     nb::gil_scoped_release release;
@@ -137,6 +160,7 @@ NB_MODULE(_clifft_hip, module) {
             "sample_survivors",
             [](BoundSampler& bound, uint32_t shots, bool keep_records, std::optional<uint64_t> seed,
                uint32_t block_size) {
+                BusyGuard guard(bound.busy);
                 clifft::sampling::SamplingSurvivorResult result;
                 {
                     nb::gil_scoped_release release;
@@ -149,6 +173,7 @@ NB_MODULE(_clifft_hip, module) {
         .def(
             "replay_shot",
             [](BoundSampler& bound, std::vector<uint8_t> forced_records) {
+                BusyGuard guard(bound.busy);
                 clifft::sampling::hip::ReplayResult result;
                 {
                     nb::gil_scoped_release release;

--- a/src/python/hip_bindings.cc
+++ b/src/python/hip_bindings.cc
@@ -1,0 +1,170 @@
+#include "clifft/frontend/hir.h"
+#include "clifft/sampling/hip/executable_plan.h"
+#include "clifft/sampling/hip/sampler.h"
+#include "clifft/sampling/planner.h"
+
+#include <cstdint>
+#include <memory>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace nb = nanobind;
+
+namespace {
+
+template <typename T>
+nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> values,
+                                                     std::initializer_list<size_t> shape) {
+    auto owner_ptr = std::make_unique<std::vector<T>>(std::move(values));
+    T* data = owner_ptr->data();
+    nb::capsule owner(owner_ptr.release(),
+                      [](void* pointer) noexcept { delete static_cast<std::vector<T>*>(pointer); });
+    return nb::ndarray<nb::numpy, T, nb::c_contig>(data, shape, owner);
+}
+
+nb::object rows_to_python(clifft::sampling::SamplingResult result, uint32_t rows,
+                          const clifft::sampling::hip::ExecutablePlan& program) {
+    auto measurements =
+        vec_to_numpy(std::move(result.measurements), {rows, program.num_visible_records()});
+    auto detectors = vec_to_numpy(std::move(result.detectors), {rows, program.num_detectors()});
+    auto observables =
+        vec_to_numpy(std::move(result.observables), {rows, program.num_observables()});
+    auto exp_vals = vec_to_numpy(std::move(result.exp_vals), {rows, program.num_exp_vals()});
+    nb::object cls = nb::module_::import_("clifft._sample_result").attr("SampleResult");
+    return cls(measurements, detectors, observables, nb::none(), nb::none(), nb::none(), nb::none(),
+               exp_vals);
+}
+
+nb::object survivors_to_python(clifft::sampling::SamplingSurvivorResult result,
+                               const clifft::sampling::hip::ExecutablePlan& program,
+                               bool keep_records) {
+    const uint32_t rows = keep_records ? result.passed_shots : 0;
+    auto measurements =
+        vec_to_numpy(std::move(result.measurements), {rows, program.num_visible_records()});
+    auto detectors = vec_to_numpy(std::move(result.detectors), {rows, program.num_detectors()});
+    auto observables =
+        vec_to_numpy(std::move(result.observables), {rows, program.num_observables()});
+    auto exp_vals = vec_to_numpy(std::move(result.exp_vals), {rows, program.num_exp_vals()});
+    const size_t observable_count = result.observable_ones.size();
+    auto observable_ones = vec_to_numpy(std::move(result.observable_ones), {observable_count});
+    nb::object cls = nb::module_::import_("clifft._sample_result").attr("SampleResult");
+    return cls(measurements, detectors, observables, result.total_shots, result.passed_shots,
+               result.logical_errors, observable_ones, exp_vals);
+}
+
+struct BoundSampler {
+    BoundSampler(const clifft::sampling::hip::ExecutablePlan& source,
+                 clifft::sampling::hip::CoefficientPrecision precision, uint32_t max_batch_shots)
+        : program(source), sampler(program, precision, max_batch_shots) {}
+
+    clifft::sampling::hip::ExecutablePlan program;
+    clifft::sampling::hip::Sampler sampler;
+};
+
+}  // namespace
+
+NB_MODULE(_clifft_hip, module) {
+    using clifft::sampling::hip::CoefficientPrecision;
+    using clifft::sampling::hip::ExecutablePlan;
+
+    module.doc() = "Experimental Clifft HIP backend";
+
+    nb::enum_<CoefficientPrecision>(module, "CoefficientPrecision")
+        .value("FP64", CoefficientPrecision::FP64)
+        .value("FP32", CoefficientPrecision::FP32);
+
+    nb::class_<ExecutablePlan>(module, "Program")
+        .def_prop_ro("peak_active_width", &ExecutablePlan::peak_active_width)
+        .def_prop_ro("num_actions", &ExecutablePlan::num_actions)
+        .def_prop_ro("num_measurements", &ExecutablePlan::num_visible_records)
+        .def_prop_ro("num_detectors", &ExecutablePlan::num_detectors)
+        .def_prop_ro("num_observables", &ExecutablePlan::num_observables)
+        .def_prop_ro("num_exp_vals", &ExecutablePlan::num_exp_vals)
+        .def_prop_ro("has_postselection", &ExecutablePlan::has_postselection)
+        .def_prop_ro("packed_bytes", &ExecutablePlan::packed_bytes)
+        .def("inspect", &ExecutablePlan::inspect)
+        .def("__repr__", [](const ExecutablePlan& program) {
+            return "Program(" + std::to_string(program.num_actions()) +
+                   " actions, peak_active_width=" + std::to_string(program.peak_active_width()) +
+                   ")";
+        });
+
+    module.def(
+        "lower",
+        [](const clifft::HirModule& hir, std::vector<uint8_t> postselection_mask,
+           std::vector<uint8_t> expected_detectors, std::vector<uint8_t> expected_observables) {
+            nb::gil_scoped_release release;
+            return ExecutablePlan(clifft::sampling::plan_sampling(
+                hir, {postselection_mask, expected_detectors, expected_observables}));
+        },
+        nb::arg("hir"), nb::arg("postselection_mask") = std::vector<uint8_t>{},
+        nb::arg("expected_detectors") = std::vector<uint8_t>{},
+        nb::arg("expected_observables") = std::vector<uint8_t>{});
+
+    nb::class_<BoundSampler>(module, "Sampler")
+        .def(nb::init<const ExecutablePlan&, CoefficientPrecision, uint32_t>(), nb::arg("program"),
+             nb::arg("coefficient_precision") = CoefficientPrecision::FP64,
+             nb::arg("max_batch_shots") = clifft::sampling::hip::kDefaultMaxBatchShots)
+        .def_prop_ro(
+            "coefficient_precision",
+            [](const BoundSampler& bound) { return bound.sampler.coefficient_precision(); })
+        .def_prop_ro("max_batch_shots",
+                     [](const BoundSampler& bound) { return bound.sampler.max_batch_shots(); })
+        .def_prop_ro(
+            "allocated_device_bytes",
+            [](const BoundSampler& bound) { return bound.sampler.allocated_device_bytes(); })
+        .def(
+            "sample",
+            [](BoundSampler& bound, uint32_t shots, std::optional<uint64_t> seed,
+               uint32_t block_size) {
+                clifft::sampling::SamplingResult result;
+                {
+                    nb::gil_scoped_release release;
+                    result = bound.sampler.sample(shots, seed, block_size);
+                }
+                return rows_to_python(std::move(result), shots, bound.program);
+            },
+            nb::arg("shots"), nb::arg("seed") = nb::none(),
+            nb::arg("block_size") = clifft::sampling::hip::kDefaultBlockSize)
+        .def(
+            "sample_survivors",
+            [](BoundSampler& bound, uint32_t shots, bool keep_records, std::optional<uint64_t> seed,
+               uint32_t block_size) {
+                clifft::sampling::SamplingSurvivorResult result;
+                {
+                    nb::gil_scoped_release release;
+                    result = bound.sampler.sample_survivors(shots, keep_records, seed, block_size);
+                }
+                return survivors_to_python(std::move(result), bound.program, keep_records);
+            },
+            nb::arg("shots"), nb::arg("keep_records") = false, nb::arg("seed") = nb::none(),
+            nb::arg("block_size") = clifft::sampling::hip::kDefaultBlockSize)
+        .def(
+            "replay_shot",
+            [](BoundSampler& bound, std::vector<uint8_t> forced_records) {
+                clifft::sampling::hip::ReplayResult result;
+                {
+                    nb::gil_scoped_release release;
+                    result = bound.sampler.replay_shot(forced_records);
+                }
+                nb::dict output;
+                output["reachable"] = result.reachable;
+                output["survived"] = result.survived;
+                output["log_probability"] = result.log_probability;
+                output["outputs"] =
+                    rows_to_python(std::move(result.outputs),
+                                   result.reachable && result.survived ? 1 : 0, bound.program);
+                return output;
+            },
+            nb::arg("forced_records"));
+
+    module.def("is_available", &clifft::sampling::hip::is_available);
+    module.def("backend_info", &clifft::sampling::hip::backend_info);
+}

--- a/src/python/hip_bindings.cc
+++ b/src/python/hip_bindings.cc
@@ -106,6 +106,7 @@ NB_MODULE(_clifft_hip, module) {
         .def_prop_ro("peak_active_width", &ExecutablePlan::peak_active_width)
         .def_prop_ro("num_actions", &ExecutablePlan::num_actions)
         .def_prop_ro("num_measurements", &ExecutablePlan::num_visible_records)
+        .def_prop_ro("num_records", &ExecutablePlan::num_records)
         .def_prop_ro("num_detectors", &ExecutablePlan::num_detectors)
         .def_prop_ro("num_observables", &ExecutablePlan::num_observables)
         .def_prop_ro("num_exp_vals", &ExecutablePlan::num_exp_vals)

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/inspection_format.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner_frame.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/pauli_preparation.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/kernel_dispatch.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan_builder.cc

--- a/tests/python/test_experimental_hip.py
+++ b/tests/python/test_experimental_hip.py
@@ -49,14 +49,17 @@ def test_hip_python_forced_replay_probes_each_branch(
     tolerance: float,
 ) -> None:
     require_hip_device()
-    circuit = "H 0\nT 0\nM 0\nEXP_VAL Z0\nOBSERVABLE_INCLUDE(0) rec[-1]"
+    circuit = "H 0\nR 0\nH 0\nT 0\nM 0\nEXP_VAL Z0\nOBSERVABLE_INCLUDE(0) rec[-1]"
     cpu_program = clifft.compile(circuit)
-    sampler = hip.Sampler(hip.compile(circuit), precision=precision, max_batch_shots=1)
+    hip_program = hip.compile(circuit)
+    sampler = hip.Sampler(hip_program, precision=precision, max_batch_shots=1)
+
+    assert hip_program.num_measurements == 1
+    assert hip_program.num_records == 2
 
     assert_forced_record_probabilities(
         cpu_program,
         sampler,
-        1,
         absolute_tolerance=tolerance,
     )
 

--- a/tests/python/test_experimental_hip.py
+++ b/tests/python/test_experimental_hip.py
@@ -1,0 +1,55 @@
+"""Developer-facing examples and boundary tests for the experimental HIP API."""
+
+from __future__ import annotations
+
+import pytest
+from utils_hip import assert_forced_record_probabilities, assert_repeatable
+
+import clifft
+from clifft.experimental import hip
+
+
+def test_hip_facade_explains_when_native_extension_is_absent() -> None:
+    if hip.is_built():
+        program = hip.compile("H 0\nT 0\nM 0")
+        assert program.num_actions > 0
+        assert "HIP executable" in program.inspect()
+        return
+
+    assert not hip.is_available()
+    assert "CLIFFT_ENABLE_HIP=ON" in hip.backend_info()
+    with pytest.raises(RuntimeError, match="CLIFFT_ENABLE_HIP"):
+        hip.compile("M 0")
+
+
+@pytest.mark.skipif(not hip.is_available(), reason="requires an AMD GPU visible to HIP")
+@pytest.mark.parametrize("precision", ["fp64", "fp32"])
+def test_hip_python_sampler_reuses_bounded_workspace(precision: hip.Precision) -> None:
+    program = hip.compile("H 0\nT 0\nH 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
+    sampler = hip.Sampler(program, precision=precision, max_batch_shots=7)
+
+    assert sampler.precision == precision
+    assert sampler.max_batch_shots == 7
+    assert sampler.allocated_device_bytes > 0
+    assert_repeatable(sampler, 257, 1234)
+
+
+@pytest.mark.skipif(not hip.is_available(), reason="requires an AMD GPU visible to HIP")
+@pytest.mark.parametrize(
+    ("precision", "tolerance"),
+    [("fp64", 1e-12), ("fp32", 2e-5)],
+)
+def test_hip_python_forced_replay_probes_each_branch(
+    precision: hip.Precision,
+    tolerance: float,
+) -> None:
+    circuit = "H 0\nT 0\nM 0\nEXP_VAL Z0\nOBSERVABLE_INCLUDE(0) rec[-1]"
+    cpu_program = clifft.compile(circuit)
+    sampler = hip.Sampler(hip.compile(circuit), precision=precision, max_batch_shots=1)
+
+    assert_forced_record_probabilities(
+        cpu_program,
+        sampler,
+        1,
+        absolute_tolerance=tolerance,
+    )

--- a/tests/python/test_experimental_hip.py
+++ b/tests/python/test_experimental_hip.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
-from utils_hip import assert_forced_record_probabilities, assert_repeatable
+from utils_hip import (
+    assert_distribution_matches,
+    assert_forced_record_probabilities,
+    assert_repeatable,
+    require_hip_device,
+)
 
 import clifft
 from clifft.experimental import hip
@@ -22,9 +28,9 @@ def test_hip_facade_explains_when_native_extension_is_absent() -> None:
         hip.compile("M 0")
 
 
-@pytest.mark.skipif(not hip.is_available(), reason="requires an AMD GPU visible to HIP")
 @pytest.mark.parametrize("precision", ["fp64", "fp32"])
 def test_hip_python_sampler_reuses_bounded_workspace(precision: hip.Precision) -> None:
+    require_hip_device()
     program = hip.compile("H 0\nT 0\nH 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]")
     sampler = hip.Sampler(program, precision=precision, max_batch_shots=7)
 
@@ -34,7 +40,6 @@ def test_hip_python_sampler_reuses_bounded_workspace(precision: hip.Precision) -
     assert_repeatable(sampler, 257, 1234)
 
 
-@pytest.mark.skipif(not hip.is_available(), reason="requires an AMD GPU visible to HIP")
 @pytest.mark.parametrize(
     ("precision", "tolerance"),
     [("fp64", 1e-12), ("fp32", 2e-5)],
@@ -43,6 +48,7 @@ def test_hip_python_forced_replay_probes_each_branch(
     precision: hip.Precision,
     tolerance: float,
 ) -> None:
+    require_hip_device()
     circuit = "H 0\nT 0\nM 0\nEXP_VAL Z0\nOBSERVABLE_INCLUDE(0) rec[-1]"
     cpu_program = clifft.compile(circuit)
     sampler = hip.Sampler(hip.compile(circuit), precision=precision, max_batch_shots=1)
@@ -53,3 +59,25 @@ def test_hip_python_forced_replay_probes_each_branch(
         1,
         absolute_tolerance=tolerance,
     )
+
+
+@pytest.mark.parametrize("precision", ["fp64", "fp32"])
+def test_hip_python_matches_cpu_joint_distribution(precision: hip.Precision) -> None:
+    require_hip_device()
+    circuit = """\
+H 0
+T 0
+H 0
+CX 0 1
+PAULI_CHANNEL_1(0.1, 0.2, 0.05) 1
+M 0 1
+DETECTOR rec[-1] rec[-2]
+OBSERVABLE_INCLUDE(0) rec[-1]
+"""
+    shots = 20_000
+    cpu = clifft.sample(clifft.compile(circuit), shots, seed=41)
+    gpu = hip.Sampler(hip.compile(circuit), precision=precision).sample(shots, seed=42)
+    cpu_rows = np.concatenate((cpu.measurements, cpu.detectors, cpu.observables), axis=1)
+    gpu_rows = np.concatenate((gpu.measurements, gpu.detectors, gpu.observables), axis=1)
+
+    assert_distribution_matches(cpu_rows, gpu_rows)

--- a/tests/python/test_sampling_integration.py
+++ b/tests/python/test_sampling_integration.py
@@ -18,8 +18,13 @@ _RUNTIME_DISPATCH_BUILD = platform.machine().lower() in {"amd64", "x86_64"} and 
 
 
 def test_experimental_namespace_reports_optional_hip_build() -> None:
-    assert clifft.experimental.hip.is_built() in {True, False}
-    assert clifft.experimental.hip.backend_info()
+    built = clifft.experimental.hip.is_built()
+    info = clifft.experimental.hip.backend_info()
+
+    if built:
+        assert info.startswith("HIP ")
+    else:
+        assert info == "HIP backend not built; rebuild Clifft with CLIFFT_ENABLE_HIP=ON"
 
 
 @pytest.mark.skipif(

--- a/tests/python/test_sampling_integration.py
+++ b/tests/python/test_sampling_integration.py
@@ -1,6 +1,5 @@
 """Integration and boundary tests for the public sampling API."""
 
-import importlib.util
 import os
 import platform
 import subprocess
@@ -18,8 +17,9 @@ _RUNTIME_DISPATCH_BUILD = platform.machine().lower() in {"amd64", "x86_64"} and 
 )
 
 
-def test_transition_only_experimental_module_is_absent() -> None:
-    assert importlib.util.find_spec("clifft.experimental") is None
+def test_experimental_namespace_reports_optional_hip_build() -> None:
+    assert clifft.experimental.hip.is_built() in {True, False}
+    assert clifft.experimental.hip.backend_info()
 
 
 @pytest.mark.skipif(

--- a/tests/python/test_sampling_integration.py
+++ b/tests/python/test_sampling_integration.py
@@ -27,6 +27,23 @@ def test_experimental_namespace_reports_optional_hip_build() -> None:
         assert info == "HIP backend not built; rebuild Clifft with CLIFFT_ENABLE_HIP=ON"
 
 
+def test_import_clifft_does_not_eagerly_load_experimental_hip() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import clifft; "
+            "print('clifft.experimental' in sys.modules); "
+            "print('clifft._clifft_hip' in sys.modules)",
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    assert completed.stdout.splitlines() == ["False", "False"]
+
+
 @pytest.mark.skipif(
     not _RUNTIME_DISPATCH_BUILD,
     reason="CLIFFT_FORCE_ISA is ignored when runtime dispatch is not compiled",

--- a/tests/python/utils_hip.py
+++ b/tests/python/utils_hip.py
@@ -65,11 +65,12 @@ def assert_distribution_matches(
 def assert_forced_record_probabilities(
     cpu_program: clifft.Program,
     hip_sampler: hip.Sampler,
-    num_records: int,
     *,
     absolute_tolerance: float,
 ) -> None:
     """Enumerate every small record branch and compare reachability and probability."""
+    num_records = hip_sampler.program.num_records
+    assert num_records == cpu_program.num_measurements + cpu_program.num_hidden_measurements
     records = np.asarray(list(itertools.product((0, 1), repeat=num_records)), dtype=np.uint8)
     cpu_log_probabilities = clifft.record_probabilities(cpu_program, records, return_log=True)
     for record, log_probability in zip(records, cpu_log_probabilities, strict=True):

--- a/tests/python/utils_hip.py
+++ b/tests/python/utils_hip.py
@@ -1,0 +1,82 @@
+"""Reusable CPU-oracle checks for experimental HIP kernel development."""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+import clifft
+from clifft.experimental import hip
+
+
+def require_hip_device() -> None:
+    """Skip the current test when no AMD device is visible."""
+    if not hip.is_available():
+        pytest.skip("requires an AMD GPU visible to HIP")
+
+
+def assert_same_rows(left: clifft.SampleResult, right: clifft.SampleResult) -> None:
+    """Compare all fixed-row outputs exactly."""
+    np.testing.assert_array_equal(left.measurements, right.measurements)
+    np.testing.assert_array_equal(left.detectors, right.detectors)
+    np.testing.assert_array_equal(left.observables, right.observables)
+    np.testing.assert_array_equal(left.exp_vals, right.exp_vals)
+
+
+def assert_repeatable(sampler: hip.Sampler, shots: int, seed: int) -> None:
+    """Check that retained execution and batching preserve seeded rows."""
+    assert_same_rows(sampler.sample(shots, seed=seed), sampler.sample(shots, seed=seed))
+
+
+def assert_distribution_matches(
+    cpu_rows: npt.NDArray[np.uint8],
+    hip_rows: npt.NDArray[np.uint8],
+    *,
+    sigma: float = 6.0,
+    absolute_floor: float = 1e-3,
+) -> None:
+    """Compare complete empirical row distributions with two-sample tolerances."""
+    if cpu_rows.ndim != 2 or hip_rows.ndim != 2 or cpu_rows.shape[1] != hip_rows.shape[1]:
+        raise ValueError("row arrays must be 2D with the same number of columns")
+    if cpu_rows.shape[0] == 0 or hip_rows.shape[0] == 0:
+        raise ValueError("distribution comparisons require non-empty samples")
+
+    width = cpu_rows.shape[1]
+    if width > 63:
+        raise ValueError("distribution helper supports at most 63 output bits")
+    powers = np.left_shift(np.uint64(1), np.arange(width, dtype=np.uint64))
+    cpu_keys = cpu_rows.astype(np.uint64) @ powers
+    hip_keys = hip_rows.astype(np.uint64) @ powers
+    for key in np.union1d(cpu_keys, hip_keys):
+        cpu_probability = float(np.mean(cpu_keys == key))
+        hip_probability = float(np.mean(hip_keys == key))
+        variance = (
+            cpu_probability
+            * (1.0 - cpu_probability)
+            * (1.0 / cpu_rows.shape[0] + 1.0 / hip_rows.shape[0])
+        )
+        tolerance = sigma * np.sqrt(variance) + absolute_floor
+        assert hip_probability == pytest.approx(cpu_probability, abs=tolerance)
+
+
+def assert_forced_record_probabilities(
+    cpu_program: clifft.Program,
+    hip_sampler: hip.Sampler,
+    num_records: int,
+    *,
+    absolute_tolerance: float,
+) -> None:
+    """Enumerate every small record branch and compare reachability and probability."""
+    records = np.asarray(list(itertools.product((0, 1), repeat=num_records)), dtype=np.uint8)
+    cpu_probabilities = clifft.record_probabilities(cpu_program, records)
+    for record, probability in zip(records, cpu_probabilities, strict=True):
+        replay = hip_sampler.replay_shot(record.tolist())
+        assert replay.reachable == (probability > 0.0)
+        if replay.reachable:
+            assert replay.log_probability == pytest.approx(
+                np.log(probability), abs=absolute_tolerance
+            )
+            np.testing.assert_array_equal(replay.outputs.measurements, record[np.newaxis, :])

--- a/tests/python/utils_hip.py
+++ b/tests/python/utils_hip.py
@@ -71,12 +71,10 @@ def assert_forced_record_probabilities(
 ) -> None:
     """Enumerate every small record branch and compare reachability and probability."""
     records = np.asarray(list(itertools.product((0, 1), repeat=num_records)), dtype=np.uint8)
-    cpu_probabilities = clifft.record_probabilities(cpu_program, records)
-    for record, probability in zip(records, cpu_probabilities, strict=True):
+    cpu_log_probabilities = clifft.record_probabilities(cpu_program, records, return_log=True)
+    for record, log_probability in zip(records, cpu_log_probabilities, strict=True):
         replay = hip_sampler.replay_shot(record.tolist())
-        assert replay.reachable == (probability > 0.0)
+        assert replay.reachable == np.isfinite(log_probability)
         if replay.reachable:
-            assert replay.log_probability == pytest.approx(
-                np.log(probability), abs=absolute_tolerance
-            )
+            assert replay.log_probability == pytest.approx(log_probability, abs=absolute_tolerance)
             np.testing.assert_array_equal(replay.outputs.measurements, record[np.newaxis, :])

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -7,6 +7,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <string>
 #include <string_view>
 #include <variant>
 
@@ -52,6 +53,20 @@ TEST_CASE("HIP executable lowers existing sampling action names") {
     REQUIRE(executable.actions()[3].tag == ActionTag::WriteExpectationValue);
     REQUIRE(executable.actions()[4].tag == ActionTag::WriteObservable);
     REQUIRE(executable.num_exp_vals() == 1);
+}
+
+TEST_CASE("HIP executable inspection identifies packed modification points") {
+    using Catch::Matchers::ContainsSubstring;
+
+    const ExecutablePlan executable(plan_from("H 0\nT 0\nM 0\nDETECTOR rec[-1]\n"));
+    const std::string diagnostic = executable.inspect();
+
+    REQUIRE(executable.num_actions() == executable.actions().size());
+    REQUIRE(executable.packed_bytes() >= executable.actions().size_bytes());
+    REQUIRE_THAT(diagnostic, ContainsSubstring("HIP executable: actions="));
+    REQUIRE_THAT(diagnostic, ContainsSubstring("PromoteDormantRotation"));
+    REQUIRE_THAT(diagnostic, ContainsSubstring("MeasureActivePauli"));
+    REQUIRE_THAT(diagnostic, ContainsSubstring("WriteDetector"));
 }
 
 TEST_CASE("HIP executable packs affine terms and categorical noise") {

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -34,6 +34,15 @@ TEST_CASE("HIP sampling has an independent random stream domain") {
     STATIC_REQUIRE(clifft::kHipSamplingExecutorDomain != clifft::kSamplingExecutorDomain);
 }
 
+TEST_CASE("HIP device layout sizes coefficient workspace consistently") {
+    STATIC_REQUIRE(clifft::sampling::hip::detail::coefficient_state_capacity(0) == 1);
+    STATIC_REQUIRE(clifft::sampling::hip::detail::coefficient_scratch_capacity(0) == 1);
+    STATIC_REQUIRE(clifft::sampling::hip::detail::coefficient_elements_per_shot(0) == 4);
+    STATIC_REQUIRE(clifft::sampling::hip::detail::coefficient_state_capacity(4) == 16);
+    STATIC_REQUIRE(clifft::sampling::hip::detail::coefficient_scratch_capacity(4) == 8);
+    STATIC_REQUIRE(clifft::sampling::hip::detail::coefficient_elements_per_shot(4) == 48);
+}
+
 TEST_CASE("HIP executable lowers existing sampling action names") {
     const SamplingPlan plan = plan_from(R"(
         H 0

--- a/tests/test_hip_sampler.cc
+++ b/tests/test_hip_sampler.cc
@@ -21,6 +21,7 @@ using clifft::sampling::SamplingPlan;
 using clifft::sampling::SamplingResult;
 using clifft::sampling::SamplingSurvivorResult;
 using clifft::sampling::hip::CoefficientPrecision;
+using clifft::sampling::hip::Sampler;
 using clifft::sampling::hip::SamplingOptions;
 using CpuExecutablePlan = clifft::sampling::ExecutablePlan;
 using HipExecutablePlan = clifft::sampling::hip::ExecutablePlan;
@@ -67,9 +68,12 @@ TEST_CASE("HIP sampler zero shots does not require a device") {
 
     const SamplingOptions invalid_low{.block_size = 0};
     const SamplingOptions invalid_high{.block_size = 1025};
+    const SamplingOptions invalid_batch{.max_batch_shots = 0};
     REQUIRE_THROWS_AS(clifft::sampling::hip::sample(executable, 0, invalid_low),
                       std::invalid_argument);
     REQUIRE_THROWS_AS(clifft::sampling::hip::sample_survivors(executable, 0, false, invalid_high),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(clifft::sampling::hip::sample(executable, 0, invalid_batch),
                       std::invalid_argument);
 }
 
@@ -157,6 +161,80 @@ TEST_CASE("HIP sampler is repeatable within each coefficient precision") {
         const SamplingResult first = clifft::sampling::hip::sample(executable, 4096, options);
         const SamplingResult second = clifft::sampling::hip::sample(executable, 4096, options);
         require_same_rows(first, second);
+    }
+}
+
+TEST_CASE("HIP retained sampler preserves seeded rows across bounded batches") {
+    require_hip_device();
+    const HipExecutablePlan executable(plan_from(R"(
+        H 0
+        T 0
+        H 0
+        M 0
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )"));
+
+    constexpr uint32_t kShots = 257;
+    for (const CoefficientPrecision precision :
+         {CoefficientPrecision::FP64, CoefficientPrecision::FP32}) {
+        Sampler sampler(executable, precision, 7);
+        REQUIRE(sampler.coefficient_precision() == precision);
+        REQUIRE(sampler.max_batch_shots() == 7);
+        REQUIRE(sampler.allocated_device_bytes() > 0);
+        const size_t allocated_bytes = sampler.allocated_device_bytes();
+
+        const SamplingResult batched = sampler.sample(kShots, uint64_t{1234}, 64);
+        const SamplingResult repeated = sampler.sample(kShots, uint64_t{1234}, 64);
+        const SamplingResult single_batch =
+            clifft::sampling::hip::sample(executable, kShots,
+                                          {.seed = uint64_t{1234},
+                                           .coefficient_precision = precision,
+                                           .block_size = 64,
+                                           .max_batch_shots = kShots});
+
+        require_same_rows(batched, repeated);
+        require_same_rows(batched, single_batch);
+        REQUIRE(sampler.allocated_device_bytes() == allocated_bytes);
+    }
+}
+
+TEST_CASE("HIP retained sampler preserves survivor order across bounded batches") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        H 0
+        M 0
+        DETECTOR rec[-1]
+        H 1
+        M 1
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )"));
+    const std::array<uint8_t, 1> postselection{1};
+    clifft::sampling::SamplingPlanOptions plan_options;
+    plan_options.postselection_mask = postselection;
+    const HipExecutablePlan executable(clifft::sampling::plan_sampling(hir, plan_options));
+    require_hip_device();
+
+    constexpr uint32_t kShots = 263;
+    for (const CoefficientPrecision precision :
+         {CoefficientPrecision::FP64, CoefficientPrecision::FP32}) {
+        Sampler sampler(executable, precision, 5);
+        const SamplingSurvivorResult batched =
+            sampler.sample_survivors(kShots, true, uint64_t{91}, 32);
+        const SamplingSurvivorResult single_batch =
+            clifft::sampling::hip::sample_survivors(executable, kShots, true,
+                                                    {.seed = uint64_t{91},
+                                                     .coefficient_precision = precision,
+                                                     .block_size = 32,
+                                                     .max_batch_shots = kShots});
+
+        REQUIRE(batched.total_shots == single_batch.total_shots);
+        REQUIRE(batched.passed_shots == single_batch.passed_shots);
+        REQUIRE(batched.logical_errors == single_batch.logical_errors);
+        REQUIRE(batched.observable_ones == single_batch.observable_ones);
+        REQUIRE(batched.measurements == single_batch.measurements);
+        REQUIRE(batched.detectors == single_batch.detectors);
+        REQUIRE(batched.observables == single_batch.observables);
+        REQUIRE(batched.exp_vals == single_batch.exp_vals);
     }
 }
 


### PR DESCRIPTION
Retain uploaded HIP programs and precision-specific bounded workspaces across
calls, preserving global-shot RNG streams and survivor ordering across batches.
Reject overlapping sampler calls while keeping ROCm out of the ordinary Python
extension.

Expose compilation, plan inspection, FP32 and FP64 sampling, survivor sampling,
and forced replay through `clifft.experimental.hip`. Add GPU-free conformance
and packaging coverage plus developer documentation for lowering, packed data,
coefficient evolution, workspace layout, launch policy, and GPU targets.

Assisted-by: Codex (GPT-5) <noreply@openai.com>
