### PR TITLE
docs: publish canonical benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ benchmarks.
 
 ## Why Clifft?
 
+- **Fast on real near-Clifford QEC circuits**: on one pinned CPU core, Clifft
+  0.9 sustained 1.20M attempted shots/s on distance-3 cultivation and 576k on
+  an 85-qubit distillation circuit. See the
+  [reproducible benchmarks](https://github.com/unitaryfoundation/clifft-bench#current-single-core-qec-results).
 - **Stim-compatible format and API**: parse Stim-format circuits with noise,
   detectors, observables, and repeat blocks, plus non-Clifford extensions.
 - **Exact near-Clifford simulation**: simulate localized non-Clifford effects

--- a/docs/development/benchmark-history.md
+++ b/docs/development/benchmark-history.md
@@ -1,41 +1,76 @@
 <!--pytest-codeblocks:skipfile-->
 # Benchmark History
 
-Clifft records benchmark results from its existing C++ Catch2 and Python pytest-benchmark suites on a daily schedule, so maintainers can spot performance drift between releases. The setup is intentionally small: it only records and stores history. It does not gate pull requests, post comments, or alert on regressions.
+Clifft uses two complementary benchmark layers: long reproducible campaigns
+for user-facing performance claims and short scheduled benchmarks for developer
+regression tracking.
 
-## Where to view the charts
+## Campaigns and scheduled benchmarks
+
+| | Reproducible campaigns | Scheduled regression benchmarks |
+|---|---|---|
+| Main question | How do releases and tools compare on application circuits? | Did a focused operation drift over time? |
+| Workloads | Versioned QEC corpus and Quantum Volume matrices | Targeted C++ and Python cases |
+| Runtime | The current QEC campaign uses five samples totaling about 150 seconds per workload, run, and placement | Short enough to run as a daily CI job |
+| Hardware | Named, pinned AWS hardware epochs; fresh boot IDs are recorded | Shared GitHub-hosted runners |
+| Cadence | Infrequent: releases, tool updates, and new hardware epochs | Daily and manual |
+| Output | Raw JSON, derived CSV tables, and reviewed figures | Trend dashboards on `gh-pages` |
+| Best use | Canonical absolute rates and cross-tool or cross-release conclusions | Detecting trends and choosing what to investigate |
+
+The long campaigns live in
+[`clifft-bench`](https://github.com/unitaryfoundation/clifft-bench). They record
+the circuit digest, software lock, host, boot, timed samples, and comparison
+policy. The current results are summarized in the
+[Performance guide](../guide/performance.md).
+
+The scheduled charts are developer telemetry, not a second source of absolute
+performance claims. Shared-runner noise, shorter cases, different units, and a
+different measurement contract mean their values should not be compared
+directly with `clifft-bench` rates.
+
+## Scheduled benchmark dashboards
 
 Each scheduled run appends to a Chart.js viewer hosted on `gh-pages`:
 
-- C++ Catch2 benchmarks: <https://unitaryfoundation.github.io/clifft/bench/cpp/>
-- Python pytest-benchmark suite: <https://unitaryfoundation.github.io/clifft/bench/python/>
+- [C++ Catch2 benchmarks (scalar)](https://unitaryfoundation.github.io/clifft/bench/cpp-scalar/)
+- [C++ Catch2 benchmarks (AVX2)](https://unitaryfoundation.github.io/clifft/bench/cpp-avx2/)
+- [C++ Catch2 benchmarks (AVX-512)](https://unitaryfoundation.github.io/clifft/bench/cpp-avx512/)
+- [Python pytest-benchmark suite](https://unitaryfoundation.github.io/clifft/bench/python/)
 
-The two charts live on the same `gh-pages` branch as the docs site but under their own `/bench/` subpath, so they are not part of the versioned documentation tree.
+ISA-specific dashboards are updated only when the runner exposes the required
+CPU feature. Each viewer's `data.js` contains its complete history.
 
-## What gets recorded
+## What runs and when
 
-Each chart's `data.js` contains the full history as a JS array, easy to skim if you need raw numbers:
+The [`bench.yml`](https://github.com/unitaryfoundation/clifft/blob/main/.github/workflows/bench.yml)
+workflow records:
 
-- C++ Catch2 results come from the sampling benchmarks in [`tests/test_benchmarks.cc`](https://github.com/unitaryfoundation/clifft/blob/main/tests/test_benchmarks.cc) (tagged `[bench]`).
-- Python pytest-benchmark results come from the suites under [`tools/bench/`](https://github.com/unitaryfoundation/clifft/tree/main/tools/bench).
+- C++ sampling cases from
+  [`tests/test_benchmarks.cc`](https://github.com/unitaryfoundation/clifft/blob/main/tests/test_benchmarks.cc),
+  tagged `[bench]` and run in scalar, AVX2, and AVX-512 modes where supported.
+- Python compile and sampling cases under
+  [`tools/bench/`](https://github.com/unitaryfoundation/clifft/tree/main/tools/bench).
 
-## When it runs
+It runs daily at 06:17 UTC and by manual dispatch from **Actions > Benchmark
+history > Run workflow**. It does not run on pull requests or pushes to `main`,
+and it records data without gating, comments, or alerts.
 
-The [`bench.yml`](https://github.com/unitaryfoundation/clifft/blob/main/.github/workflows/bench.yml) workflow runs:
+## Reading the scheduled results
 
-- Daily at 06:17 UTC.
-- On manual dispatch from the **Actions** tab → **Benchmark history** → **Run workflow**.
+- **Runner noise:** GitHub-hosted `ubuntu-24.04` runners share hardware. Trends
+  across many days are more meaningful than isolated spikes.
+- **Different units:** Catch2 plots elapsed time in a reporter-selected unit;
+  lower is better. The Python chart plots iterations per second; higher is
+  better. The charts are not directly comparable.
+- **Investigation workflow:** If a trend looks suspicious, reproduce the
+  relevant suite locally against `main` and the suspect commit with `just
+  bench` for Python or `ctest -R Bench` for C++.
 
-It does not run on pull requests or pushes to `main`.
+## Adding scheduled benchmarks
 
-## Reading the results
-
-A few caveats worth keeping in mind when interpreting the chart:
-
-- **Runner noise.** The workflow uses GitHub-hosted `ubuntu-24.04` runners, which share hardware with other tenants. Expect roughly 5–10% variance run-to-run, more on the smaller fixtures. Trends across many days are meaningful; isolated spikes generally are not.
-- **Two charts, two units.** The C++ chart plots elapsed time per benchmark in whatever unit Catch2's console reporter chose (ns/us/ms/s, picked per case to keep the printed mean readable). The Python chart plots throughput in iterations per second, the default `pytest-benchmark` metric the action records. Lower is better on the C++ chart; higher is better on the Python chart. The two are not directly comparable.
-- **No alerts.** The workflow records data and stops. If you suspect a regression, run the relevant suite locally against `main` and the suspect commit (`just bench` for Python, `ctest -R Bench` for C++).
-
-## Adding new benchmarks
-
-New cases added to [`tests/test_benchmarks.cc`](https://github.com/unitaryfoundation/clifft/blob/main/tests/test_benchmarks.cc) (with the `[bench]` Catch2 tag) or under [`tools/bench/`](https://github.com/unitaryfoundation/clifft/tree/main/tools/bench) are picked up automatically by the next scheduled run; no workflow change is required.
+New `[bench]` cases in
+[`tests/test_benchmarks.cc`](https://github.com/unitaryfoundation/clifft/blob/main/tests/test_benchmarks.cc)
+or new cases under
+[`tools/bench/`](https://github.com/unitaryfoundation/clifft/tree/main/tools/bench)
+are picked up by the next scheduled run without a workflow change. Add
+application-scale or cross-tool workloads to `clifft-bench` instead.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -1,20 +1,53 @@
 # Performance
 
-Clifft targets circuits between pure stabilizer simulation and fully dense
-statevector simulation: large circuits with mostly Clifford structure, localized
-non-Clifford effects, noise, measurements, detectors, and observables.
+Clifft targets the regime between pure stabilizer simulation and fully dense
+statevector simulation: large circuits with mostly Clifford structure and
+localized non-Clifford effects.
 
-The main quantity to watch is the peak active width $k$. Non-Clifford operations
-can increase $k$, while measurements can reduce it. The active state contains
-$2^k$ amplitudes, so both the peak width and the time spent at each width matter.
-Total qubit count and non-Clifford gate count alone are poor performance
-predictors.
+The main quantity to watch is the peak active width $k$. The active state has
+$2^k$ amplitudes, so cost depends on both the peak width and the time spent at
+each width. Total qubit count and non-Clifford gate count alone are poor
+performance predictors.
+
+## Headline CPU results
+
+!!! tip "Clifft is fast on real near-Clifford QEC circuits"
+
+    On one pinned CPU core, Clifft 0.9 sustained 1.20M attempted shots/s on
+    distance-3 cultivation and 576k on an 85-qubit distillation circuit. It
+    exceeded one million attempted shots/s on two workloads in the current
+    eight-circuit campaign.
+
+These are medians over three fresh placements on an AWS `m7a.xlarge` with an
+AMD EPYC 9R14 CPU and Ubuntu 24.04. Each placement used one pinned core. The
+`vs 0.8` column compares the median rate across placements for each release.
+
+| Circuit | Qubits | Peak $k$ | Clifft 0.9 attempted shots/s | vs 0.8 |
+|---|---:|---:|---:|---:|
+| Surface code `d=7, r=7`, $p=10^{-3}$ | 118 | 0 | 484k | +4% |
+| Cultivation `d=3` | 15 | 4 | **1.20M** | +8% |
+| Cultivation `d=5` | 42 | 10 | 182k | +33% |
+| Distillation | 85 | 5 | **576k** | +6% |
+| Coherent surface code `d=3, r=1` | 26 | 4 | **1.88M** | +37% |
+| Coherent surface code `d=3, r=3` | 26 | 7 | 461k | +42% |
+| Coherent surface code `d=5, r=1` | 64 | 12 | 14.6k | +1% |
+| Coherent surface code `d=5, r=5` | 64 | 22 | 7.0 | +10% |
+
+Clifft 0.9 has a higher median than 0.8 on all eight workloads and is faster
+in 23 of the 24 individual placement/workload pairs. Browse the canonical
+[`current-tools-v1` execution](https://github.com/unitaryfoundation/clifft-bench/tree/main/results/current-tools-v1/current-tools-v1-20260824-r1)
+for raw JSON and the complete derived tables.
+
+Sampling throughput counts every attempted shot, including shots discarded by
+detector postselection. The wide coherent `d=5, r=5` case is retained as a
+stress case; its low rate should not be generalized to circuits with the same
+qubit count or peak width.
 
 ## Choosing a simulator
 
 | Regime | Recommended tool | Why |
 |---|---|---|
-| Pure Clifford QEC | Stim | Stim packs stabilizer-frame work across shots and remains the better specialist when the active width is always zero. |
+| Pure Clifford QEC | Stim | Stim packs stabilizer-frame work across shots and is the specialist when active width is always zero. |
 | Low-magic or near-Clifford circuits | Clifft | Clifft is most effective when non-Clifford effects stay localized and measurements repeatedly shrink the active state. |
 | Dense universal circuits | A statevector simulator or Clifft | When $k=n$, Clifft is exact but has the same exponential state-size limit as dense statevector simulation. |
 
@@ -22,123 +55,90 @@ Clifft is not intended to replace Stim for fully Clifford workloads. Its main
 target is the middle regime, where exact non-Clifford effects matter without
 forcing the entire physical system into one dense state.
 
-## Representative CPU results
-
-The following results use the current Clifft sampler at commit
-[`04c4fe6`](https://github.com/unitaryfoundation/clifft/commit/04c4fe662d9b42d06817450096dbb56a541e709d).
-They report median single-threaded CPU performance from 12 balanced process-level
-runs. Sampling throughput counts all attempted shots, including shots rejected by
-detector postselection. The percentage in parentheses is the relative median
-absolute deviation.
-
-| Circuit | Qubits | Peak $k$ | Compile | Attempted shots/s |
-|---|---:|---:|---:|---:|
-| Surface code `d=7, r=7`, $p=10^{-3}$ | 118 | 0 | 12.2 ms | 453k (1.3%) |
-| Cultivation `d=3` | 15 | 4 | 1.38 ms | 1.07M (0.5%) |
-| Cultivation `d=5` | 42 | 10 | 11.3 ms | 125k (3.6%) |
-| Distillation | 85 | 5 | 2.18 ms | 534k (1.2%) |
-| Coherent surface code `d=3, r=1` | 26 | 4 | 0.360 ms | 1.33M (0.9%) |
-| Coherent surface code `d=3, r=3` | 26 | 7 | 0.634 ms | 394k (1.0%) |
-| Coherent surface code `d=5, r=1` | 64 | 12 | 1.24 ms | 14.1k (1.2%) |
-
-The coherent `d=5, r=5` circuit reaches peak width 22. Under the explicit reference
-postselection used here, every attempted shot was discarded and each process
-completed only a handful of shots. It is therefore retained as a setup and API
-guard in the campaign, not reported as a meaningful throughput result.
-
 ## Reading the active-width regimes
 
 ### Active width zero
 
-At active width zero, coefficient-array work disappears, but Clifft still evaluates
-the circuit's sampling actions and symbolic expressions. Stim has an architectural
-advantage in this regime: a Clifford-only engine can pack work from many shots into
-each SIMD instruction, while Clifft retains machinery that also supports
-non-Clifford variants.
+At active width zero, coefficient-array work disappears, but Clifft still
+evaluates sampling actions and symbolic expressions. A Clifford-only engine
+such as Stim can instead pack stabilizer-frame work from many shots into each
+SIMD instruction.
 
 ### Low and moderate active width
 
 Cultivation and distillation are Clifft's main target regime. Their physical
 circuits contain many more qubits than the active state, and measurements can
-remove active coordinates during execution. Clifft therefore performs dense work
-over the smaller $2^k$ active state instead of the full $2^n$ physical state.
+remove active coordinates during execution. Clifft performs dense work over
+the smaller $2^k$ active state instead of the full $2^n$ physical state.
 
-The same peak width does not imply the same throughput. Circuit length, the width
-at each action, measurement and detector work, postselection timing, and the shape
-of active Pauli operations all affect the amount of work per attempted shot.
+The same peak width does not imply the same throughput. Circuit length, width
+at each action, measurement and detector work, postselection timing, and active
+Pauli shape all affect the cost of an attempted shot.
 
 ### Larger active width and the dense limit
 
-As $k$ grows, coefficient-array work dominates and Clifft approaches ordinary
-dense-statevector scaling. A controlled width-12 diagnostic with 512 active
-operations reached 62.9k attempted shots/s on the benchmark host. This diagnostic
-isolates sustained active-state work; it is not intended to represent an application
-workload.
+As $k$ grows, active-state work dominates and Clifft approaches ordinary dense
+statevector scaling. Parallel execution can help wide individual shots, but it
+does not remove the exponential memory limit.
 
-Quantum Volume circuits provide dense execution guards rather than a broad
-cross-simulator claim in this campaign. The current sampler reached 19.5k attempted
-shots/s on the checked QV-10 fixture. QV performance is sensitive to the generated
-circuit's mix of fused, directly vectorized, and scalar operations, so one fixture
-should not be treated as a universal QV scaling result. QV-20 took roughly 0.2
-seconds per shot and completed only four shots per timed process, which is too few
-for a precise rate comparison.
+## Cross-tool and release comparisons
 
-## ISA portability check
+The same single-core QEC campaign compares Clifft 0.9 with SymFT single-shot
+and batched modes. SymFT's fastest applicable mode is faster on seven of the
+eight workloads; Clifft is 1.33x faster on distance-5 cultivation. The winning
+SymFT batch size varies by circuit, so the
+[per-workload table](https://github.com/unitaryfoundation/clifft-bench#current-single-core-qec-results)
+is more useful than one aggregate ranking.
 
-The Linux wheels use an `x86-64-v2` baseline and select ISA-specific kernels at
-runtime. The primary table forced AVX-512 so that its execution target was
-unambiguous. In a separate eight-round forced-AVX2 check, the real QEC workload
-medians ranged from 0.97x to 1.16x their AVX-512 rates. This is a portability guard,
-not evidence that one ISA is universally faster: individual circuits exercise
-different mixtures of specialized and scalar kernels.
+The release-history campaign runs Clifft 0.1 through 0.9 on the same corpus and
+hardware epoch. Clifft 0.9 is faster than 0.1 on all eight workloads, with a
+median per-workload speedup of 1.93x and a range of 1.18x to 16.89x. See the
+[release-history results](https://github.com/unitaryfoundation/clifft-bench#clifft-release-history).
 
-## Methodology
+### Multicore Quantum Volume
 
-The campaign ran on one pinned core of an AMD EPYC 9554P (Zen 4) KVM host. Clifft
-used GCC 13.3, CMake `Release` (`-O3 -DNDEBUG`), an `x86-64-v2` baseline, and
-runtime ISA dispatch. Each timed cell ran in a fresh process with one thread, a
-warmup excluded from timing, and enough shots to target approximately 1.5 seconds.
-The 12 rounds used distinct seeds, and the process schedule was balanced to reduce
-temporal drift.
+![Quantum Volume current-tool latency and Clifft strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082.png)
 
-Each circuit used an explicit noiseless detector and observable reference.
-Postselected circuits used the same detector mask. The benchmark view retained only
-observable 0; QV fixtures without an observable declaration used the final measured
-bit as observable 0. Sampling returned survivor counts rather than raw records, and
-every result was consumed. Compilation and sampling were timed separately; the
-reference calculation was excluded from compilation time.
+On 16 physical cores, Clifft 0.9 has the lowest median single-shot latency of
+the four measured tools at QV20 and QV22. Its paired median QV24 speedup is
+10.17x from 1 to 16 cores. Tool ordering changes with circuit width, as the
+left panel shows.
 
-The QEC circuits come from the
-[Clifft paper corpus at `db7dc9f`](https://github.com/unitaryfoundation/clifft-paper/tree/db7dc9f13a2c2854690e92390c779048a1ac1400/qec_bench).
-The QV fixtures are pinned in the Clifft repository at the measured commit.
+This is a separate exploratory campaign on an AWS `c8i.8xlarge` with three
+deterministic circuit seeds per point. Its latency numbers must not be mixed
+with the single-core QEC throughput table. See the
+[QV methodology and data](https://github.com/unitaryfoundation/clifft-bench/blob/main/docs/qv-multicore.md).
 
-These numbers are representative benchmark points, not performance guarantees.
-Hardware, compiler, ISA, noise model, postselection rate, and circuit structure all
-matter.
+## Measurement scope
 
-## Cross-simulator benchmarks
+The QEC campaign runs each tool version in an isolated pinned environment. A
+fresh process performs setup and warmup, followed by five timed samples that
+total about 150 seconds per workload and placement. Three fresh placements
+reduce the risk that one boot or one point in time determines the current-tool
+comparison. Compilation and sampling are recorded separately, and every result
+is consumed.
 
-The public [clifft-bench](https://github.com/unitaryfoundation/clifft-bench)
-project is developing the canonical, reproducible comparison of Clifft with other
-near-Clifford simulators. Its initial phase is CPU-only and records Clifft and
-SymFT compilation, warmup, correctness, and sampling separately on an immutable
-circuit corpus. Stim comparisons belong on compatible Clifford workloads; GPU
-simulators require a separately scoped hardware comparison. In particular, the
-published Tsim results used GPU hardware and should not be mixed into a CPU-only
-table.
+The circuit corpus, software locks, host identity, boot IDs, raw measurements,
+and derived comparisons live in
+[`clifft-bench`](https://github.com/unitaryfoundation/clifft-bench). Raw JSON is
+authoritative. Absolute values belong to their named hardware epoch and are
+representative measurements, not performance guarantees.
 
-Until that project selects its canonical host and publishes result sets, this page
-focuses on Clifft's own performance model and representative current measurements
-instead of maintaining a second cross-simulator leaderboard.
+## Continuous microbenchmarks
+
+Clifft also runs short C++ and Python benchmarks every day on GitHub-hosted
+runners. Those checks are useful for spotting implementation-level drift, but
+their shared hardware and shorter cases do not make them a source of canonical
+absolute performance numbers. See [Benchmark History](../development/benchmark-history.md)
+for the dashboards and a direct comparison of the two benchmark layers.
 
 ## Historical results
 
-The [original Clifft preprint](https://arxiv.org/abs/2604.27058) and its companion
-repository report the earlier localized-Pauli SVM and include GPU and broad
-Quantum Volume comparisons. Those results remain useful for understanding the
-original method, but they should not be read as measurements of the current
-symbolic-coordinate sampling pipeline.
+The [original Clifft preprint](https://arxiv.org/abs/2604.27058) and its
+companion repository report the earlier localized-Pauli SVM and include GPU and
+broad Quantum Volume comparisons. Those results explain the original method,
+but they are not measurements of the current symbolic-coordinate sampler.
 
 The [symbolic sampling update](../updates/symbolic-sampling.md) gives the
-release-oriented migration history and a matched comparison of the last legacy
-SVM, current Clifft, and SymFT's CPU execution modes.
+migration history and a matched comparison of the last legacy SVM, current
+Clifft, and SymFT's CPU execution modes.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -90,19 +90,31 @@ SymFT batch size varies by circuit, so the
 [per-workload table](https://github.com/unitaryfoundation/clifft-bench#current-single-core-qec-results)
 is more useful than one aggregate ranking.
 
+![QEC workload throughput ratio between Clifft and the fastest measured SymFT mode](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/current-tools-v1-20260824-r1.png)
+
 The release-history campaign runs Clifft 0.1 through 0.9 on the same corpus and
 hardware epoch. Clifft 0.9 is faster than 0.1 on all eight workloads, with a
 median per-workload speedup of 1.93x and a range of 1.18x to 16.89x. See the
 [release-history results](https://github.com/unitaryfoundation/clifft-bench#clifft-release-history).
 
+![Clifft throughput across releases](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/clifft-history-v1-20260825-r1.png)
+
 ### Multicore Quantum Volume
 
-![Quantum Volume current-tool latency and Clifft strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082.png)
+#### Current-tool latency
+
+![Quantum Volume latency by simulator](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082-current-tools.png)
 
 On 16 physical cores, Clifft 0.9 has the lowest median single-shot latency of
-the four measured tools at QV20 and QV22. Its paired median QV24 speedup is
-10.17x from 1 to 16 cores. Tool ordering changes with circuit width, as the
-left panel shows.
+the four measured tools at QV20 and QV22. Tool ordering changes with circuit
+width, so the full curve is more informative than one aggregate ranking.
+
+#### Clifft strong scaling
+
+![Clifft Quantum Volume strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082-clifft-scaling.png)
+
+Clifft's paired median QV24 speedup is 10.17x from 1 to 16 cores. Points show
+paired medians across three deterministic seeds; whiskers show the seed range.
 
 This is a separate exploratory campaign on an AWS `c8i.8xlarge` with three
 deterministic circuit seeds per point. Its latency numbers must not be mixed

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -83,42 +83,57 @@ does not remove the exponential memory limit.
 
 ## Cross-tool and release comparisons
 
-The same single-core QEC campaign compares Clifft 0.9 with SymFT single-shot
-and batched modes. SymFT's fastest applicable mode is faster on seven of the
-eight workloads; Clifft is 1.33x faster on distance-5 cultivation. The winning
-SymFT batch size varies by circuit, so the
+[SymFT](https://arxiv.org/abs/2607.28600) is another CPU simulator targeting
+near-Clifford circuits. The same single-core QEC campaign compares Clifft 0.9
+with the SymFT single-shot backend and batch sizes 32 and 2048 on one pinned
+core. Measuring both modes separates native single-shot performance from the
+additional throughput available by processing independent shots together.
+SymFT's fastest applicable mode is faster on seven of the eight workloads;
+Clifft is 1.33x faster on distance-5 cultivation. The winning SymFT batch size
+varies by circuit, so the
 [per-workload table](https://github.com/unitaryfoundation/clifft-bench#current-single-core-qec-results)
 is more useful than one aggregate ranking.
 
-![QEC workload throughput ratio between Clifft and the fastest measured SymFT mode](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/current-tools-v1-20260824-r1.png)
+![QEC workload throughput ratio between Clifft and the fastest measured SymFT mode](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/current-tools-v1-20260824-r1.png)
 
-The release-history campaign runs Clifft 0.1 through 0.9 on the same corpus and
-hardware epoch. Clifft 0.9 is faster than 0.1 on all eight workloads, with a
-median per-workload speedup of 1.93x and a range of 1.18x to 16.89x. See the
-[release-history results](https://github.com/unitaryfoundation/clifft-bench#clifft-release-history).
+Version 0.8 replaced the localized-Pauli virtual machine with a
+symbolic-coordinate compiler that moves frame and dependency work into
+planning and applies active-Pauli operations directly. Version 0.9 then
+removed global-phase bookkeeping, absorbed more Clifford-valued rotations
+during compilation, and vectorized important active-measurement kernels. The
+release-history campaign runs Clifft 0.1 through 0.9 on the same corpus and
+reference host configuration. Clifft 0.9 is faster than 0.1 on all eight
+workloads, with a median per-workload speedup of 1.93x and a range of 1.18x to
+16.89x. See the [release-history results](https://github.com/unitaryfoundation/clifft-bench#clifft-release-history).
 
-![Clifft throughput across releases](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/clifft-history-v1-20260825-r1.png)
+![Clifft throughput across releases](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/clifft-history-v1-20260825-r1.png)
 
 ### Multicore Quantum Volume
 
-#### Current-tool latency
+Clifft targets near-Clifford circuits, but dense non-Clifford Quantum Volume
+circuits drive the active width to all qubits and require carrying the full
+$2^n$ state vector. This campaign probes that dense limit against Qiskit Aer,
+Qulacs, and qsim, and measures how one wide Clifft shot scales across cores.
 
-![Quantum Volume latency by simulator](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/qv-multicore-v1-2026082-current-tools.png)
+#### Current-tool execution time
 
-On 16 physical cores, Clifft 0.9 has the lowest median single-shot latency of
-the four measured tools at QV20 and QV22. Tool ordering changes with circuit
-width, so the full curve is more informative than one aggregate ranking.
+![Quantum Volume execution time by simulator](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082-current-tools.png)
+
+On 16 physical cores, Clifft 0.9 has the shortest median single-shot execution
+time of the four measured tools at QV20 and QV22. Tool ordering changes with
+circuit width, so the full curve is more informative than one aggregate
+ranking.
 
 #### Clifft strong scaling
 
-![Clifft Quantum Volume strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/qv-multicore-v1-2026082-clifft-scaling.png)
+![Clifft Quantum Volume strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082-clifft-scaling.png)
 
 Clifft's paired median QV24 speedup is 10.17x from 1 to 16 cores. Points show
 paired medians across three deterministic seeds; whiskers show the seed range.
 
 This is a separate exploratory campaign on an AWS `c8i.8xlarge` with three
-deterministic circuit seeds per point. Its latency numbers must not be mixed
-with the single-core QEC throughput table. See the
+deterministic circuit seeds per point. Its execution-time numbers must not be
+mixed with the single-core QEC throughput table. See the
 [QV methodology and data](https://github.com/unitaryfoundation/clifft-bench/blob/main/docs/qv-multicore.md).
 
 ## Measurement scope

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -90,20 +90,20 @@ SymFT batch size varies by circuit, so the
 [per-workload table](https://github.com/unitaryfoundation/clifft-bench#current-single-core-qec-results)
 is more useful than one aggregate ranking.
 
-![QEC workload throughput ratio between Clifft and the fastest measured SymFT mode](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/current-tools-v1-20260824-r1.png)
+![QEC workload throughput ratio between Clifft and the fastest measured SymFT mode](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/current-tools-v1-20260824-r1.png)
 
 The release-history campaign runs Clifft 0.1 through 0.9 on the same corpus and
 hardware epoch. Clifft 0.9 is faster than 0.1 on all eight workloads, with a
 median per-workload speedup of 1.93x and a range of 1.18x to 16.89x. See the
 [release-history results](https://github.com/unitaryfoundation/clifft-bench#clifft-release-history).
 
-![Clifft throughput across releases](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/clifft-history-v1-20260825-r1.png)
+![Clifft throughput across releases](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/clifft-history-v1-20260825-r1.png)
 
 ### Multicore Quantum Volume
 
 #### Current-tool latency
 
-![Quantum Volume latency by simulator](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082-current-tools.png)
+![Quantum Volume latency by simulator](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/qv-multicore-v1-2026082-current-tools.png)
 
 On 16 physical cores, Clifft 0.9 has the lowest median single-shot latency of
 the four measured tools at QV20 and QV22. Tool ordering changes with circuit
@@ -111,7 +111,7 @@ width, so the full curve is more informative than one aggregate ranking.
 
 #### Clifft strong scaling
 
-![Clifft Quantum Volume strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/main/figures/qv-multicore-v1-2026082-clifft-scaling.png)
+![Clifft Quantum Volume strong scaling](https://raw.githubusercontent.com/unitaryfoundation/clifft-bench/8d6a70d47c7f7fa596d87170375c1583dbfca499/figures/qv-multicore-v1-2026082-clifft-scaling.png)
 
 Clifft's paired median QV24 speedup is 10.17x from 1 to 16 cores. Points show
 paired medians across three deterministic seeds; whiskers show the seed range.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,10 @@ print(result.measurements[:5])  # First 5 shots.
 
 <div class="grid cards" markdown>
 
+- **Measured QEC Throughput**
+
+    On one pinned CPU core, Clifft 0.9 sustained 1.20M attempted shots/s on distance-3 cultivation and 576k on an 85-qubit distillation circuit. See [Performance](guide/performance.md) for the reproducible campaign and its scope.
+
 - **Stim-Compatible Format and API**
 
     Parse Stim-format circuits, including noise channels, detectors, observables, and repeat blocks, with extensions for non-Clifford gates. Compile once, then sample many shots through a familiar Python interface.


### PR DESCRIPTION
## Summary

- add a concrete performance highlight to the README and documentation home
- update the Performance guide with the completed QEC, release-history, and multicore Quantum Volume campaigns
- distinguish canonical long-running campaigns from daily regression benchmarks
- correct the scheduled benchmark dashboard links for scalar, AVX2, and AVX-512 results

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `uv run --group docs mkdocs build --strict`
- `git diff --check`