### PR TITLE
feat(sampling): add packed cross-shot execution

### DIFF
--- a/docs/guide/importance-sampling.md
+++ b/docs/guide/importance-sampling.md
@@ -331,7 +331,7 @@ postselection. Key observations:
 
 ## API Reference
 
-### `clifft.sample_k(program, shots, k, seed=None, threads=1, thread_layout=None, intra_shot_min_active_width=None)`
+### `clifft.sample_k(program, shots, k, seed=None, threads=1, thread_layout=None, intra_shot_min_active_width=None, batch_size="auto")`
 
 Sample with exactly `k` forced faults per shot. Returns
 a `SampleResult`, just like `clifft.sample()`. Results must be weighted by $P(K=k)$ for correct
@@ -348,9 +348,12 @@ exceeds the number of non-zero-probability sites).
 `thread_layout=(shot_workers, intra_shot_workers)` override follows the ordinary
 sampling policy described in [Parallel Sampling](simulation.md#parallel-sampling).
 The expert `intra_shot_min_active_width` override defaults to 18 and requires an
-explicit layout.
+explicit layout. `batch_size` follows the packed cross-shot policy described in
+[Parallel Sampling](simulation.md#parallel-sampling): `"auto"` selects an
+adaptive capacity, `1` forces scalar execution, and a positive integer caps and
+forces the packed capacity.
 
-### `clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1, thread_layout=None, intra_shot_min_active_width=None)`
+### `clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1, thread_layout=None, intra_shot_min_active_width=None, batch_size="auto")`
 
 Sample survivors with exactly `k` forced faults per shot. Returns a
 `SampleResult` whose `.measurements`, `.detectors`, and `.observables`

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -265,6 +265,27 @@ can only spread work across shots, and `noncomp.sample()` also uses only that
 strategy. The width cutoff is a measured default; advanced users can override
 the layout and cutoff for their hardware.
 
+Within each cross-shot worker, the symbolic sampler normally processes shots
+in an adaptive packed batch. Classical symbols, expression results, records,
+detectors, and observables are bit-packed across the batch, while each live
+shot retains its own dense active state and random stream. The automatic
+capacity is bounded by the worker's shot count, a maximum of 512 lanes, and a
+768 KiB dense-state footprint budget. Automatic mode currently selects packing
+only for noiseless peak-active-width-zero plans with at least 64 shots per
+worker. Benchmarks show that per-lane noise sampling and action-major traversal
+of dense states still favor the scalar executor, so noisy and active-state
+plans conservatively fall back to it.
+
+The four fixed-plan sampling functions accept `batch_size="auto"` by default.
+Use `batch_size=1` to force the scalar executor when comparing profiles, or a
+positive integer to cap and force packed capacity. A final partial batch is
+handled automatically; explicit capacities are limited to 2048 lanes. Packed
+batching is currently CPU-only and cannot be combined with an intra-shot worker
+count above one. Transition instruments,
+traps, continuations, record replay, and externally supplied presampled-symbol
+execution remain on their existing scalar paths; `noncomp.sample()` is
+unchanged.
+
 Most users should use `threads`. The symbolic sampling functions also accept
 the advanced override
 `thread_layout=(shot_workers, intra_shot_workers)`. The override replaces the
@@ -305,11 +326,13 @@ With a fixed seed, changing `threads` produces exactly the same result.
 APIs return accepted shots in the same order as the corresponding one-thread
 run.
 
-Each cross-shot worker owns a separate executor. Its dense coefficient and
-measurement scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,
-plus symbolic state, records, and other executor metadata. Set an explicit
-layout when memory is more constrained than CPU availability. Intra-shot
-workers cooperate on one executor and do not replicate this storage.
+Each cross-shot worker owns a separate scalar or packed executor. Each retained
+lane's dense coefficient and measurement scratch storage uses roughly
+$24 \times 2^k$ bytes at peak active width $k$, plus packed symbolic state,
+records, and other executor metadata. Automatic batching limits the aggregate
+dense-state allocation per worker as described above. Set an explicit layout
+or batch size when memory is more constrained than CPU availability. Intra-shot
+workers cooperate on one scalar executor and do not replicate this storage.
 Noncomputational workers also own their trajectory continuations and compile
 new continuations independently as their shots encounter jumps.
 
@@ -328,8 +351,8 @@ result = clifft.sample_k_survivors(prog, shots=50_000, k=3, seed=42)
 
 Key API:
 
-- **`clifft.sample_k(program, shots, k, seed=None, threads=1, thread_layout=None, intra_shot_min_active_width=None)`** -- Like `sample()`, but forces exactly `k` faults. Only valid for programs without post-selection; post-selected programs must use `sample_k_survivors()`. Returns a `SampleResult` with `.measurements`, `.detectors`, and `.observables`.
-- **`clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1, thread_layout=None, intra_shot_min_active_width=None)`** -- Like `sample_survivors()`, but forces exactly `k` faults. Returns a `SampleResult` whose arrays contain only surviving shots plus survivor metadata.
+- **`clifft.sample_k(program, shots, k, seed=None, threads=1, thread_layout=None, intra_shot_min_active_width=None, batch_size="auto")`** -- Like `sample()`, but forces exactly `k` faults. Only valid for programs without post-selection; post-selected programs must use `sample_k_survivors()`. Returns a `SampleResult` with `.measurements`, `.detectors`, and `.observables`.
+- **`clifft.sample_k_survivors(program, shots, k, seed=None, keep_records=False, threads=1, thread_layout=None, intra_shot_min_active_width=None, batch_size="auto")`** -- Like `sample_survivors()`, but forces exactly `k` faults. Returns a `SampleResult` whose arrays contain only surviving shots plus survivor metadata.
 - **`program.noise_site_probabilities`** -- 1D NumPy array of per-site fault probabilities, with quantum noise sites followed by readout noise entries. Use this for computing the Poisson-binomial PMF.
 
 See the [Importance Sampling Tutorial](importance-sampling.md) for a complete walkthrough.

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(clifft_core STATIC
     sampling/planner.cc
     sampling/planner_frame.cc
     sampling/pauli_preparation.cc
+    sampling/batch_bits.cc
+    sampling/batch_executor.cc
     sampling/kernel_dispatch.cc
     sampling/executable_plan.cc
     sampling/executable_plan_inspection.cc

--- a/src/clifft/sampling/batch_bits.cc
+++ b/src/clifft/sampling/batch_bits.cc
@@ -1,0 +1,158 @@
+#include "clifft/sampling/batch_bits.h"
+
+#include <algorithm>
+#include <bit>
+#include <limits>
+#include <stdexcept>
+
+namespace clifft::sampling {
+
+namespace {
+
+uint64_t compress_bits_portable(uint64_t bits, uint64_t keep) noexcept {
+    uint64_t output = 0;
+    uint64_t destination = 1;
+    while (keep != 0) {
+        const uint64_t source = keep & (~keep + 1);
+        if ((bits & source) != 0) {
+            output |= destination;
+        }
+        keep &= keep - 1;
+        destination <<= 1;
+    }
+    return output;
+}
+
+}  // namespace
+
+size_t packed_word_count(uint32_t lanes) noexcept {
+    return (static_cast<size_t>(lanes) + 63) / 64;
+}
+
+uint64_t low_lane_mask(uint32_t bits) noexcept {
+    if (bits == 0) {
+        return 0;
+    }
+    if (bits >= 64) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return (uint64_t{1} << bits) - 1;
+}
+
+void fill_low_lane_mask(std::span<uint64_t> output, uint32_t lanes) noexcept {
+    const size_t live_words = packed_word_count(lanes);
+    for (size_t word = 0; word < live_words; ++word) {
+        const uint32_t remaining = lanes - static_cast<uint32_t>(word * 64);
+        output[word] = low_lane_mask(remaining);
+    }
+    std::fill(output.begin() + static_cast<std::ptrdiff_t>(live_words), output.end(), uint64_t{0});
+}
+
+uint32_t count_lane_bits(std::span<const uint64_t> bits, uint32_t lanes) noexcept {
+    const size_t live_words = packed_word_count(lanes);
+    uint32_t count = 0;
+    for (size_t word = 0; word < live_words; ++word) {
+        const uint32_t remaining = lanes - static_cast<uint32_t>(word * 64);
+        count += static_cast<uint32_t>(std::popcount(bits[word] & low_lane_mask(remaining)));
+    }
+    return count;
+}
+
+PackedBitColumns::PackedBitColumns(size_t columns, uint32_t lane_capacity)
+    : columns_(columns),
+      lane_capacity_(lane_capacity),
+      word_capacity_(packed_word_count(lane_capacity)) {
+    if (columns_ != 0 && word_capacity_ > std::numeric_limits<size_t>::max() / columns_) {
+        throw std::length_error("packed batch bit-column allocation exceeds size_t range");
+    }
+    words_.resize(columns_ * word_capacity_, 0);
+}
+
+std::span<uint64_t> PackedBitColumns::column(size_t column_index) noexcept {
+    assert(column_index < columns_ && "packed bit column index must be in range");
+    return std::span<uint64_t>(words_).subspan(column_index * word_capacity_, word_capacity_);
+}
+
+std::span<const uint64_t> PackedBitColumns::column(size_t column_index) const noexcept {
+    assert(column_index < columns_ && "packed bit column index must be in range");
+    return std::span<const uint64_t>(words_).subspan(column_index * word_capacity_, word_capacity_);
+}
+
+bool PackedBitColumns::bit(size_t column_index, uint32_t lane) const noexcept {
+    assert(lane < lane_capacity_ && "packed bit lane must be in range");
+    return ((column(column_index)[lane >> 6] >> (lane & 63)) & uint64_t{1}) != 0;
+}
+
+void PackedBitColumns::set_bit(size_t column_index, uint32_t lane) noexcept {
+    assert(lane < lane_capacity_ && "packed bit lane must be in range");
+    column(column_index)[lane >> 6] |= uint64_t{1} << (lane & 63);
+}
+
+void PackedBitColumns::clear() noexcept {
+    std::ranges::fill(words_, uint64_t{0});
+}
+
+void PackedBitColumns::assign(size_t column_index, std::span<const uint64_t> source,
+                              std::span<const uint64_t> live_mask) noexcept {
+    assert(source.size() >= word_capacity_ && live_mask.size() >= word_capacity_ &&
+           "packed assignment inputs must cover the fixed word capacity");
+    std::span<uint64_t> destination = column(column_index);
+    for (size_t word = 0; word < word_capacity_; ++word) {
+        destination[word] = source[word] & live_mask[word];
+    }
+}
+
+void PackedBitColumns::assign_xor(size_t column_index, std::span<const uint64_t> left,
+                                  std::span<const uint64_t> right,
+                                  std::span<const uint64_t> live_mask) noexcept {
+    assert(left.size() >= word_capacity_ && right.size() >= word_capacity_ &&
+           live_mask.size() >= word_capacity_ &&
+           "packed XOR assignment inputs must cover the fixed word capacity");
+    std::span<uint64_t> destination = column(column_index);
+    for (size_t word = 0; word < word_capacity_; ++word) {
+        destination[word] = (left[word] ^ right[word]) & live_mask[word];
+    }
+}
+
+void PackedBitColumns::xor_into(size_t column_index, std::span<const uint64_t> source) noexcept {
+    assert(source.size() >= word_capacity_ &&
+           "packed XOR input must cover the fixed word capacity");
+    std::span<uint64_t> destination = column(column_index);
+    for (size_t word = 0; word < word_capacity_; ++word) {
+        destination[word] ^= source[word];
+    }
+}
+
+void PackedBitColumns::compact(std::span<const uint64_t> keep_mask, uint32_t old_lanes,
+                               uint32_t new_lanes, std::span<uint64_t> scratch) noexcept {
+    assert(old_lanes <= lane_capacity_ && new_lanes <= old_lanes &&
+           keep_mask.size() >= word_capacity_ && scratch.size() >= word_capacity_ &&
+           count_lane_bits(keep_mask, old_lanes) == new_lanes &&
+           "packed compaction inputs must describe the retained lanes");
+    const size_t old_words = packed_word_count(old_lanes);
+    for (size_t column_index = 0; column_index < columns_; ++column_index) {
+        std::ranges::fill(scratch, uint64_t{0});
+        const std::span<const uint64_t> source = column(column_index);
+        uint32_t destination_bit = 0;
+        for (size_t source_word = 0; source_word < old_words; ++source_word) {
+            const uint32_t remaining = old_lanes - static_cast<uint32_t>(source_word * 64);
+            const uint64_t keep = keep_mask[source_word] & low_lane_mask(remaining);
+            const uint32_t kept = static_cast<uint32_t>(std::popcount(keep));
+            if (kept == 0) {
+                continue;
+            }
+            const uint64_t compressed = compress_bits_portable(source[source_word], keep);
+            const size_t destination_word = destination_bit >> 6;
+            const uint32_t shift = destination_bit & 63;
+            scratch[destination_word] |= compressed << shift;
+            if (shift != 0 && kept > 64 - shift) {
+                scratch[destination_word + 1] |= compressed >> (64 - shift);
+            }
+            destination_bit += kept;
+        }
+        assert(destination_bit == new_lanes && "packed compaction must retain every live lane");
+        std::ranges::copy(scratch, column(column_index).begin());
+    }
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/batch_bits.h
+++ b/src/clifft/sampling/batch_bits.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace clifft::sampling {
+
+// Fixed-capacity symbol-major bit columns used by packed cross-shot execution.
+// Construction owns all allocation; hot operations only overwrite existing
+// words. Column c and lane s live at words_[c * word_capacity_ + s / 64].
+class PackedBitColumns {
+  public:
+    PackedBitColumns() = default;
+    PackedBitColumns(size_t columns, uint32_t lane_capacity);
+
+    [[nodiscard]] size_t num_columns() const noexcept { return columns_; }
+    [[nodiscard]] uint32_t lane_capacity() const noexcept { return lane_capacity_; }
+    [[nodiscard]] size_t word_capacity() const noexcept { return word_capacity_; }
+
+    [[nodiscard]] std::span<uint64_t> column(size_t column) noexcept;
+    [[nodiscard]] std::span<const uint64_t> column(size_t column) const noexcept;
+
+    [[nodiscard]] bool bit(size_t column, uint32_t lane) const noexcept;
+    void set_bit(size_t column, uint32_t lane) noexcept;
+    void clear() noexcept;
+
+    // Replace a column with bits, restricting padding and rejected lanes to
+    // zero. Source and live_mask must cover the fixed word capacity.
+    void assign(size_t column, std::span<const uint64_t> source,
+                std::span<const uint64_t> live_mask) noexcept;
+    void assign_xor(size_t column, std::span<const uint64_t> left, std::span<const uint64_t> right,
+                    std::span<const uint64_t> live_mask) noexcept;
+    void xor_into(size_t column, std::span<const uint64_t> source) noexcept;
+
+    // Stable-compacts every column using keep_mask. scratch is one fixed-size
+    // word row prepared by the owning executor before dispatch.
+    void compact(std::span<const uint64_t> keep_mask, uint32_t old_lanes, uint32_t new_lanes,
+                 std::span<uint64_t> scratch) noexcept;
+
+  private:
+    size_t columns_ = 0;
+    uint32_t lane_capacity_ = 0;
+    size_t word_capacity_ = 0;
+    std::vector<uint64_t> words_;
+};
+
+[[nodiscard]] size_t packed_word_count(uint32_t lanes) noexcept;
+[[nodiscard]] uint64_t low_lane_mask(uint32_t bits) noexcept;
+void fill_low_lane_mask(std::span<uint64_t> output, uint32_t lanes) noexcept;
+[[nodiscard]] uint32_t count_lane_bits(std::span<const uint64_t> bits, uint32_t lanes) noexcept;
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/batch_executor.cc
+++ b/src/clifft/sampling/batch_executor.cc
@@ -1,0 +1,689 @@
+#include "clifft/sampling/batch_executor.h"
+
+#include "clifft/util/fault_sampling.h"
+#include "clifft/util/noise_sampling.h"
+#include "clifft/util/numeric.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace clifft::sampling {
+
+namespace {
+
+enum class MeasurementBranchKind : uint8_t {
+    Random,
+    DeterministicZero,
+    DeterministicOne,
+};
+
+struct MeasurementBranchClassification {
+    MeasurementBranchKind kind = MeasurementBranchKind::Random;
+    bool clamped_dust = false;
+};
+
+[[nodiscard]] MeasurementBranchClassification classify_measurement_branch(
+    MeasurementProbabilities probabilities) noexcept {
+    const double total = probabilities.total();
+    assert(is_finite_robust(probabilities.zero) && probabilities.zero >= 0.0 &&
+           is_finite_robust(probabilities.one) && probabilities.one >= 0.0 &&
+           is_finite_robust(total) && total > 0.0 &&
+           "measurement probabilities must be finite, nonnegative, and nonzero");
+    const double epsilon = kMeasurementDustEpsilon * total;
+    if (probabilities.one <= epsilon) {
+        return {.kind = MeasurementBranchKind::DeterministicZero,
+                .clamped_dust = probabilities.one > 0.0};
+    }
+    if (probabilities.zero <= epsilon) {
+        return {.kind = MeasurementBranchKind::DeterministicOne,
+                .clamped_dust = probabilities.zero > 0.0};
+    }
+    return {.kind = MeasurementBranchKind::Random};
+}
+
+[[nodiscard]] const ExecutablePlan* validate_batch_plan(const ExecutablePlan& plan) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument("packed sampling does not support instrument continuations");
+    }
+    return &plan;
+}
+
+[[nodiscard]] size_t checked_product(size_t left, size_t right, const char* description) {
+    if (left != 0 && right > std::numeric_limits<size_t>::max() / left) {
+        throw std::length_error(std::string("packed batch ") + description +
+                                " allocation exceeds size_t range");
+    }
+    return left * right;
+}
+
+}  // namespace
+
+uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots, uint32_t shot_workers,
+                                uint32_t intra_shot_workers,
+                                std::optional<uint32_t> requested_batch_size) {
+    if (requested_batch_size.has_value() && *requested_batch_size == 0) {
+        throw std::invalid_argument("batch_size must be a positive integer or 'auto'");
+    }
+    if (shots == 0 || shot_workers == 0 || plan.has_instruments()) {
+        return 1;
+    }
+    if (intra_shot_workers > 1) {
+        if (requested_batch_size.has_value() && *requested_batch_size > 1) {
+            throw std::invalid_argument(
+                "packed batch_size is incompatible with intra-shot workers");
+        }
+        return 1;
+    }
+#if defined(__EMSCRIPTEN__)
+    if (requested_batch_size.has_value() && *requested_batch_size > 1) {
+        throw std::invalid_argument("packed batch_size is unavailable in WebAssembly builds");
+    }
+    return 1;
+#else
+    const uint32_t worker_shots =
+        static_cast<uint32_t>((static_cast<uint64_t>(shots) + shot_workers - 1) / shot_workers);
+    if (requested_batch_size.has_value()) {
+        return std::max(uint32_t{1},
+                        std::min({*requested_batch_size, worker_shots, kMaxExplicitBatchShots}));
+    }
+    if (worker_shots < kDefaultMinAutoBatchShots) {
+        return 1;
+    }
+    // Dense action-major lane traversal and per-lane fault presampling do not
+    // yet beat the shot-major executor reliably. Keep those plans scalar until
+    // a benchmark-supported crossover is available; explicit capacities remain
+    // useful for profiling and correctness coverage of the complete executor.
+    if (plan.peak_active_width() != 0 || plan.num_presampled_symbols() != 0 ||
+        plan.has_readout_noise()) {
+        return 1;
+    }
+    const size_t state_bytes = State::allocation_bytes_for(plan.peak_active_width());
+    const size_t footprint_capacity = std::max<size_t>(1, kDefaultBatchStateBudget / state_bytes);
+    return static_cast<uint32_t>(
+        std::min<size_t>({worker_shots, kDefaultMaxAutoBatchShots, footprint_capacity}));
+#endif
+}
+
+BatchExecutor::BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity)
+    : plan_(validate_batch_plan(plan)),
+      lane_capacity_(lane_capacity),
+      word_capacity_(packed_word_count(lane_capacity)),
+      state_bytes_per_lane_(State::allocation_bytes_for(plan.peak_active_width_)),
+      state_storage_(checked_product(state_bytes_per_lane_, lane_capacity, "state")),
+      state_slots_(lane_capacity),
+      rngs_(lane_capacity),
+      shot_indices_(lane_capacity),
+      symbols_(plan.num_symbols_, lane_capacity),
+      expression_registers_(plan.expression_register_constants_.size(), lane_capacity),
+      records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_,
+               lane_capacity),
+      detectors_(plan.num_detectors_, lane_capacity),
+      observables_(plan.num_observables_, lane_capacity),
+      forced_readout_(plan.num_readout_noise_sites_, lane_capacity),
+      exp_vals_(checked_product(plan.num_exp_vals_, lane_capacity, "expectation"), 0.0),
+      live_words_(word_capacity_, 0),
+      scratch_words_(word_capacity_, 0),
+      compaction_scratch_(word_capacity_, 0) {
+    if (lane_capacity_ == 0) {
+        throw std::invalid_argument("packed sampling lane capacity must be positive");
+    }
+    states_.reserve(lane_capacity_);
+    auto* storage = static_cast<std::byte*>(state_storage_.data());
+    for (uint32_t lane = 0; lane < lane_capacity_; ++lane) {
+        states_.push_back(State::from_borrowed_storage(
+            plan.peak_active_width_, plan.initial_active_width_,
+            storage + static_cast<size_t>(lane) * state_bytes_per_lane_, state_bytes_per_lane_));
+    }
+}
+
+void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_t shots) noexcept {
+    fixed_fault_mode_ = false;
+    reset_batch(root, first_shot, shots);
+    sample_presampled_noise();
+    [[maybe_unused]] bool executed = false;
+    switch (plan_->backend_) {
+        case ExecutorBackend::Scalar:
+            execute_actions<ExecutorBackend::Scalar>();
+            executed = true;
+            break;
+        case ExecutorBackend::Avx2:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+            execute_actions<ExecutorBackend::Avx2>();
+            executed = true;
+            break;
+#else
+            break;
+#endif
+        case ExecutorBackend::Avx512:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+            execute_actions<ExecutorBackend::Avx512>();
+            executed = true;
+            break;
+#else
+            break;
+#endif
+    }
+    assert(executed && "unhandled packed sampling executor backend");
+    finalize_live_lanes();
+}
+
+void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_t shots,
+                              KFaultSampler& fault_sampler) noexcept {
+    fixed_fault_mode_ = true;
+    reset_batch(root, first_shot, shots);
+    assign_forced_faults(fault_sampler);
+    [[maybe_unused]] bool executed = false;
+    switch (plan_->backend_) {
+        case ExecutorBackend::Scalar:
+            execute_actions<ExecutorBackend::Scalar>();
+            executed = true;
+            break;
+        case ExecutorBackend::Avx2:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+            execute_actions<ExecutorBackend::Avx2>();
+            executed = true;
+            break;
+#else
+            break;
+#endif
+        case ExecutorBackend::Avx512:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+            execute_actions<ExecutorBackend::Avx512>();
+            executed = true;
+            break;
+#else
+            break;
+#endif
+    }
+    assert(executed && "unhandled packed sampling executor backend");
+    finalize_live_lanes();
+}
+
+void BatchExecutor::reset_batch(const SeedRoot& root, uint32_t first_shot,
+                                uint32_t shots) noexcept {
+    assert(shots <= lane_capacity_ && "packed batch must fit retained capacity");
+    attempted_shots_ = shots;
+    active_lanes_ = shots;
+    live_count_ = shots;
+    fill_low_lane_mask(live_words_, shots);
+    symbols_.clear();
+    expression_registers_.clear();
+    records_.clear();
+    detectors_.clear();
+    observables_.clear();
+    forced_readout_.clear();
+    std::ranges::fill(exp_vals_, 0.0);
+    for (uint32_t lane = 0; lane < shots; ++lane) {
+        state_slots_[lane] = lane;
+        states_[lane].reset();
+        shot_indices_[lane] = first_shot + lane;
+        const std::array<uint64_t, 4> words =
+            derive_state(root, shot_indices_[lane], kSamplingExecutorDomain);
+        rngs_[lane].seed_full(words[0], words[1], words[2], words[3]);
+    }
+    initialize_expression_registers();
+}
+
+void BatchExecutor::initialize_expression_registers() noexcept {
+    for (size_t expression = 0; expression < plan_->expression_register_constants_.size();
+         ++expression) {
+        if (plan_->expression_register_constants_[expression] != 0) {
+            expression_registers_.assign(expression, live_words_, live_words_);
+        }
+    }
+}
+
+void BatchExecutor::sample_presampled_noise() noexcept {
+    const uint32_t end = static_cast<uint32_t>(plan_->noise_sites_.size());
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        uint32_t first_candidate = 0;
+        while (first_candidate < end) {
+            const double current_hazard =
+                first_candidate == 0 ? 0.0 : plan_->noise_hazards_[first_candidate - 1];
+            if (current_hazard >= plan_->noise_hazards_[end - 1]) {
+                break;
+            }
+            const uint32_t site = sample_next_noise_site(plan_->noise_hazards_, first_candidate,
+                                                         rngs_[lane].next_double());
+            if (site == kNoNoiseSite || site >= end) {
+                break;
+            }
+            activate_noise_site(lane, site);
+            first_candidate = site + 1;
+        }
+    }
+    for (uint32_t symbol : plan_->presampled_symbols_) {
+        propagate_symbol(symbol);
+    }
+}
+
+void BatchExecutor::assign_forced_faults(KFaultSampler& fault_sampler) noexcept {
+    assert(fault_sampler.num_sites() ==
+               plan_->noise_sites_.size() + plan_->num_readout_noise_sites_ &&
+           "conditioned batch sampler must cover every fault site");
+    const uint32_t quantum_sites = static_cast<uint32_t>(plan_->noise_sites_.size());
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        const std::span<const uint32_t> selected =
+            fault_sampler.sample([&]() noexcept { return rngs_[lane].next_double(); });
+        for (uint32_t site : selected) {
+            if (site < quantum_sites) {
+                activate_noise_site(lane, site);
+            } else {
+                forced_readout_.set_bit(site - quantum_sites, lane);
+            }
+        }
+    }
+    for (uint32_t symbol : plan_->presampled_symbols_) {
+        propagate_symbol(symbol);
+    }
+}
+
+void BatchExecutor::activate_noise_site(uint32_t lane, uint32_t site_index) noexcept {
+    assert(site_index < plan_->noise_sites_.size() && "noise site must be prepared");
+    const ExecutablePlan::PreparedNoiseSite& site = plan_->noise_sites_[site_index];
+    const uint32_t outcome_end = site.outcome_begin + site.outcome_count;
+    assert(site.outcome_count > 0 && outcome_end <= plan_->noise_outcomes_.size() &&
+           "firing noise site must contain prepared outcomes");
+    uint32_t outcome_index = site.outcome_begin;
+    if (site.outcome_count > 1) {
+        const double execution_probability =
+            plan_->noise_outcomes_[outcome_end - 1].cumulative_probability;
+        const double draw = rngs_[lane].next_double() * execution_probability;
+        while (draw >= plan_->noise_outcomes_[outcome_index].cumulative_probability) {
+            ++outcome_index;
+            assert(outcome_index < outcome_end && "channel draw must select a prepared outcome");
+        }
+    }
+    const uint32_t symbol = plan_->noise_outcomes_[outcome_index].symbol;
+    assert(!symbols_.bit(symbol, lane) && "noise site must define a fresh lane symbol");
+    symbols_.set_bit(symbol, lane);
+}
+
+void BatchExecutor::propagate_symbol(uint32_t symbol) noexcept {
+    const std::span<const uint64_t> values = symbols_.column(symbol);
+    for (uint32_t register_id : plan_->expression_dependencies_.dependent_registers(symbol)) {
+        expression_registers_.xor_into(register_id, values);
+    }
+}
+
+void BatchExecutor::assign_symbol(uint32_t symbol, std::span<const uint64_t> values) noexcept {
+    symbols_.assign(symbol, values, live_words_);
+    propagate_symbol(symbol);
+}
+
+template <ExecutorBackend Backend>
+void BatchExecutor::execute_actions() noexcept {
+    for (size_t action_index = 0; action_index < plan_->actions_.size(); ++action_index) {
+        const ExecutablePlan::Action& action = plan_->actions_[action_index];
+        std::visit(
+            [&](const auto& typed) noexcept {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation> ||
+                              std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement>) {
+                    execute_action<Backend>(typed, action_index);
+                } else {
+                    execute_action(typed, action_index);
+                }
+            },
+            action);
+        if (live_count_ == 0) {
+            return;
+        }
+    }
+}
+
+template <ExecutorBackend Backend>
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteRotation& action, size_t) noexcept {
+    const std::span<const uint64_t> signs = evaluate(action.sign);
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (!is_live(lane)) {
+            continue;
+        }
+        const bool sign = lane_bit(signs, lane);
+        if (action.kernel == DirectRotationKernel::Scalar) {
+            apply_rotation(state(lane), action.rotation, sign);
+        } else if constexpr (Backend == ExecutorBackend::Avx2) {
+            apply_direct_rotation_avx2(state(lane), action.rotation, action.kernel, sign);
+        } else if constexpr (Backend == ExecutorBackend::Avx512) {
+            apply_direct_rotation_avx512(state(lane), action.rotation, action.kernel, sign);
+        } else {
+            assert(false && "scalar batch executor requires scalar rotation actions");
+        }
+    }
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
+                                   size_t) noexcept {
+    assert(action.rotation_index < plan_->fused_rotations_.size() &&
+           "fused rotation action must reference prepared execution");
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (is_live(lane)) {
+            plan_->fused_rotations_[action.rotation_index].apply(state(lane));
+        }
+    }
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
+                                   size_t) noexcept {
+    assert(action.rotation_index < plan_->dynamic_fused_rotations_.size() &&
+           "dynamic fused rotation action must reference prepared execution");
+    const auto& rotation = plan_->dynamic_fused_rotations_[action.rotation_index];
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (!is_live(lane)) {
+            continue;
+        }
+        uint32_t variant = 0;
+        for (size_t basis = 0; basis < rotation.sign_basis.size(); ++basis) {
+            variant |= static_cast<uint32_t>(lane_bit(evaluate(rotation.sign_basis[basis]), lane))
+                       << basis;
+        }
+        assert(variant < rotation.variants.size() && "dynamic sign must select a prepared variant");
+        rotation.variants[variant].apply(state(lane));
+    }
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecutePromotion& action,
+                                   size_t) noexcept {
+    const std::span<const uint64_t> signs = evaluate(action.sign);
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (is_live(lane)) {
+            apply_promotion(state(lane), action.promotion, lane_bit(signs, lane));
+        }
+    }
+}
+
+template <ExecutorBackend Backend>
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
+                                   size_t) noexcept {
+    const std::span<const uint64_t> corrections = evaluate(action.correction);
+    std::ranges::fill(scratch_words_, uint64_t{0});
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (!is_live(lane)) {
+            continue;
+        }
+        const MeasurementProbabilities probabilities = [&]() noexcept {
+            if (action.kernel == ActiveMeasurementKernel::Scalar) {
+                return measurement_probabilities(state(lane), action.measurement);
+            }
+            if constexpr (Backend == ExecutorBackend::Avx2) {
+                return active_measurement_probabilities_avx2(state(lane), action.measurement,
+                                                             action.kernel);
+            } else if constexpr (Backend == ExecutorBackend::Avx512) {
+                return active_measurement_probabilities_avx512(state(lane), action.measurement,
+                                                               action.kernel);
+            } else {
+                assert(false && "scalar batch executor requires scalar measurement actions");
+                return measurement_probabilities(state(lane), action.measurement);
+            }
+        }();
+        const bool branch = sample_active_branch(lane, probabilities);
+        if (branch) {
+            scratch_words_[lane >> 6] |= uint64_t{1} << (lane & 63);
+        }
+        const double branch_probability = probabilities.for_branch(branch);
+        if (action.kernel == ActiveMeasurementKernel::Scalar) {
+            collapse_measurement(state(lane), action.measurement, branch, branch_probability);
+        } else if constexpr (Backend == ExecutorBackend::Avx2) {
+            collapse_active_measurement_avx2(state(lane), action.measurement, action.kernel, branch,
+                                             branch_probability);
+        } else if constexpr (Backend == ExecutorBackend::Avx512) {
+            collapse_active_measurement_avx512(state(lane), action.measurement, action.kernel,
+                                               branch, branch_probability);
+        }
+    }
+    assign_symbol(action.branch, scratch_words_);
+    records_.assign_xor(action.record, scratch_words_, corrections, live_words_);
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
+                                   size_t) noexcept {
+    const std::span<const uint64_t> corrections = evaluate(action.correction);
+    std::ranges::fill(scratch_words_, uint64_t{0});
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (is_live(lane) && rngs_[lane].next_double() >= 0.5) {
+            scratch_words_[lane >> 6] |= uint64_t{1} << (lane & 63);
+        }
+    }
+    assign_symbol(action.branch, scratch_words_);
+    records_.assign_xor(action.record, scratch_words_, corrections, live_words_);
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
+                                   size_t) noexcept {
+    records_.assign(action.record, evaluate(action.outcome), live_words_);
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
+                                   size_t) noexcept {
+    assign_symbol(action.symbol, evaluate(action.value));
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
+                                   size_t) noexcept {
+    const std::span<const uint64_t> sources = evaluate(action.source);
+    std::ranges::fill(scratch_words_, uint64_t{0});
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (!is_live(lane)) {
+            continue;
+        }
+        const bool source = lane_bit(sources, lane);
+        const bool flip =
+            fixed_fault_mode_ ? forced_readout_.bit(action.site, lane) : [&]() noexcept {
+                const double probability =
+                    source ? action.prob_one_to_zero : action.prob_zero_to_one;
+                return probability >= 1.0 ||
+                       (probability > 0.0 && rngs_[lane].next_double() < probability);
+            }();
+        if (flip) {
+            scratch_words_[lane >> 6] |= uint64_t{1} << (lane & 63);
+        }
+    }
+    assign_symbol(action.flip, scratch_words_);
+    records_.assign_xor(action.record, sources, scratch_words_, live_words_);
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action,
+                                   size_t action_index) noexcept {
+    const std::span<const uint64_t> outcomes = evaluate(action.outcome);
+    detectors_.assign(action.detector, outcomes, live_words_);
+    if (!action.postselected) {
+        return;
+    }
+    uint32_t rejected = 0;
+    for (size_t word = 0; word < word_capacity_; ++word) {
+        const uint64_t dead = outcomes[word] & live_words_[word];
+        rejected += static_cast<uint32_t>(std::popcount(dead));
+        live_words_[word] &= ~dead;
+    }
+    live_count_ -= rejected;
+    if (should_compact(action_index)) {
+        compact_live_lanes();
+    }
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteObservable& action,
+                                   size_t) noexcept {
+    observables_.assign(action.observable, evaluate(action.outcome), live_words_);
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
+                                   size_t) noexcept {
+    assert(action.exp_val < plan_->num_exp_vals_ &&
+           "expectation action must reference preallocated storage");
+    double* output = exp_vals_.data() + static_cast<size_t>(action.exp_val) * lane_capacity_;
+    const std::span<const uint64_t> signs = evaluate(action.sign);
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (!is_live(lane)) {
+            continue;
+        }
+        if (!action.active_projection.has_value()) {
+            output[lane] = 0.0;
+        } else {
+            const double value = expectation_value(state(lane), *action.active_projection);
+            output[lane] = lane_bit(signs, lane) ? -value : value;
+        }
+    }
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteInstrument&, size_t) noexcept {
+    assert(false && "instrument actions must remain on the scalar trajectory executor");
+}
+
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteBoundary&, size_t) noexcept {
+    assert(false && "continuation boundaries must remain on the scalar trajectory executor");
+}
+
+std::span<const uint64_t> BatchExecutor::evaluate(
+    ExecutablePlan::PreparedExpression expression) const noexcept {
+    assert(expression.register_id < expression_registers_.num_columns() &&
+           "prepared expression must reference a packed register");
+    return expression_registers_.column(expression.register_id);
+}
+
+bool BatchExecutor::lane_bit(std::span<const uint64_t> bits, uint32_t lane) const noexcept {
+    assert(bits.size() >= word_capacity_ && lane < active_lanes_ &&
+           "packed expression lookup must reference an active lane");
+    return ((bits[lane >> 6] >> (lane & 63)) & uint64_t{1}) != 0;
+}
+
+bool BatchExecutor::is_live(uint32_t lane) const noexcept {
+    assert(lane < active_lanes_ && "live lookup must reference the current lane span");
+    return ((live_words_[lane >> 6] >> (lane & 63)) & uint64_t{1}) != 0;
+}
+
+State& BatchExecutor::state(uint32_t lane) noexcept {
+    assert(lane < active_lanes_ && state_slots_[lane] < states_.size() &&
+           "batch lane must map to retained state storage");
+    return states_[state_slots_[lane]];
+}
+
+const State& BatchExecutor::state(uint32_t lane) const noexcept {
+    assert(lane < active_lanes_ && state_slots_[lane] < states_.size() &&
+           "batch lane must map to retained state storage");
+    return states_[state_slots_[lane]];
+}
+
+bool BatchExecutor::sample_active_branch(uint32_t lane,
+                                         MeasurementProbabilities probabilities) noexcept {
+    const MeasurementBranchClassification classification =
+        classify_measurement_branch(probabilities);
+    switch (classification.kind) {
+        case MeasurementBranchKind::Random:
+            return rngs_[lane].next_double() * probabilities.total() >= probabilities.zero;
+        case MeasurementBranchKind::DeterministicZero:
+            dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
+            return false;
+        case MeasurementBranchKind::DeterministicOne:
+            dust_clamps_ += static_cast<uint64_t>(classification.clamped_dust);
+            return true;
+    }
+    assert(false && "unhandled measurement branch classification");
+    return false;
+}
+
+bool BatchExecutor::should_compact(size_t action_index) const noexcept {
+    if (live_count_ == 0 || live_count_ == active_lanes_) {
+        return false;
+    }
+    const uint64_t remaining_actions = plan_->actions_.size() - action_index - 1;
+    if (remaining_actions == 0) {
+        return false;
+    }
+    const uint64_t old_words = packed_word_count(active_lanes_);
+    const uint64_t new_words = packed_word_count(live_count_);
+    const uint64_t dead_lanes = active_lanes_ - live_count_;
+    const uint64_t bit_columns = symbols_.num_columns() + expression_registers_.num_columns() +
+                                 records_.num_columns() + detectors_.num_columns() +
+                                 observables_.num_columns() + forced_readout_.num_columns();
+    const uint64_t carry_cost =
+        dead_lanes * remaining_actions + (old_words - new_words) * remaining_actions * 8;
+    const uint64_t compact_cost = bit_columns * old_words +
+                                  static_cast<uint64_t>(plan_->num_exp_vals_) * live_count_ +
+                                  static_cast<uint64_t>(live_count_) * 3;
+    return carry_cost > compact_cost;
+}
+
+void BatchExecutor::compact_live_lanes() noexcept {
+    if (live_count_ == active_lanes_) {
+        return;
+    }
+    if (live_count_ == 0) {
+        active_lanes_ = 0;
+        std::ranges::fill(live_words_, uint64_t{0});
+        ++compactions_;
+        return;
+    }
+    const uint32_t old_lanes = active_lanes_;
+    symbols_.compact(live_words_, old_lanes, live_count_, compaction_scratch_);
+    expression_registers_.compact(live_words_, old_lanes, live_count_, compaction_scratch_);
+    records_.compact(live_words_, old_lanes, live_count_, compaction_scratch_);
+    detectors_.compact(live_words_, old_lanes, live_count_, compaction_scratch_);
+    observables_.compact(live_words_, old_lanes, live_count_, compaction_scratch_);
+    forced_readout_.compact(live_words_, old_lanes, live_count_, compaction_scratch_);
+
+    uint32_t destination = 0;
+    for (uint32_t source = 0; source < old_lanes; ++source) {
+        if (!is_live(source)) {
+            continue;
+        }
+        if (destination != source) {
+            state_slots_[destination] = state_slots_[source];
+            rngs_[destination] = rngs_[source];
+            shot_indices_[destination] = shot_indices_[source];
+            for (uint32_t exp_val = 0; exp_val < plan_->num_exp_vals_; ++exp_val) {
+                exp_vals_[static_cast<size_t>(exp_val) * lane_capacity_ + destination] =
+                    exp_vals_[static_cast<size_t>(exp_val) * lane_capacity_ + source];
+            }
+        }
+        ++destination;
+    }
+    assert(destination == live_count_ && "lane compaction must retain every live context");
+    active_lanes_ = live_count_;
+    fill_low_lane_mask(live_words_, active_lanes_);
+    ++compactions_;
+}
+
+void BatchExecutor::finalize_live_lanes() noexcept {
+    if (live_count_ != active_lanes_) {
+        compact_live_lanes();
+    }
+}
+
+uint32_t BatchExecutor::shot_index(uint32_t lane) const noexcept {
+    assert(lane < live_count_ && active_lanes_ == live_count_ &&
+           "batch outputs require finalized live lanes");
+    return shot_indices_[lane];
+}
+
+bool BatchExecutor::measurement(uint32_t lane, uint32_t record) const noexcept {
+    assert(lane < live_count_ && record < plan_->num_visible_records_ &&
+           "measurement output must be visible and live");
+    return records_.bit(record, lane);
+}
+
+bool BatchExecutor::detector(uint32_t lane, uint32_t detector_index) const noexcept {
+    assert(lane < live_count_ && detector_index < plan_->num_detectors_ &&
+           "detector output must be live and in range");
+    return detectors_.bit(detector_index, lane);
+}
+
+bool BatchExecutor::observable(uint32_t lane, uint32_t observable_index) const noexcept {
+    assert(lane < live_count_ && observable_index < plan_->num_observables_ &&
+           "observable output must be live and in range");
+    return observables_.bit(observable_index, lane);
+}
+
+double BatchExecutor::exp_val(uint32_t lane, uint32_t exp_val_index) const noexcept {
+    assert(lane < live_count_ && exp_val_index < plan_->num_exp_vals_ &&
+           "expectation output must be live and in range");
+    return exp_vals_[static_cast<size_t>(exp_val_index) * lane_capacity_ + lane];
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/batch_executor.h
+++ b/src/clifft/sampling/batch_executor.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include "clifft/sampling/batch_bits.h"
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/util/page_allocation.h"
+#include "clifft/util/shot_seed.h"
+#include "clifft/util/xoshiro.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace clifft {
+class KFaultSampler;
+}
+
+namespace clifft::sampling {
+
+inline constexpr uint32_t kDefaultMaxAutoBatchShots = 512;
+inline constexpr uint32_t kMaxExplicitBatchShots = 2048;
+inline constexpr size_t kDefaultBatchStateBudget = 768 * 1024;
+inline constexpr uint32_t kDefaultMinAutoBatchShots = 64;
+
+// Resolve one worker's retained lane capacity. requested_batch_size is empty
+// for conservative automatic selection, one for the scalar path, or an
+// explicit packed capacity. Validation and allocation happen before dispatch.
+[[nodiscard]] uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots,
+                                              uint32_t shot_workers, uint32_t intra_shot_workers,
+                                              std::optional<uint32_t> requested_batch_size);
+
+// Single-threaded packed executor for fixed plans. It traverses one immutable
+// action stream for every lane while retaining the existing contiguous State
+// kernels for each live shot. Instruments and continuation boundaries remain
+// on Executor and are rejected before construction.
+class BatchExecutor {
+  public:
+    BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity);
+
+    BatchExecutor(const BatchExecutor&) = delete;
+    BatchExecutor& operator=(const BatchExecutor&) = delete;
+    BatchExecutor(BatchExecutor&&) = delete;
+    BatchExecutor& operator=(BatchExecutor&&) = delete;
+
+    void run_batch(const SeedRoot& root, uint32_t first_shot, uint32_t shots) noexcept;
+    void run_batch(const SeedRoot& root, uint32_t first_shot, uint32_t shots,
+                   KFaultSampler& fault_sampler) noexcept;
+
+    [[nodiscard]] uint32_t lane_capacity() const noexcept { return lane_capacity_; }
+    [[nodiscard]] uint32_t attempted_shots() const noexcept { return attempted_shots_; }
+    [[nodiscard]] uint32_t surviving_shots() const noexcept { return live_count_; }
+    [[nodiscard]] uint32_t shot_index(uint32_t lane) const noexcept;
+    [[nodiscard]] bool measurement(uint32_t lane, uint32_t record) const noexcept;
+    [[nodiscard]] bool detector(uint32_t lane, uint32_t detector) const noexcept;
+    [[nodiscard]] bool observable(uint32_t lane, uint32_t observable) const noexcept;
+    [[nodiscard]] double exp_val(uint32_t lane, uint32_t exp_val) const noexcept;
+    [[nodiscard]] uint64_t dust_clamps() const noexcept { return dust_clamps_; }
+    [[nodiscard]] uint64_t compactions() const noexcept { return compactions_; }
+
+  private:
+    void reset_batch(const SeedRoot& root, uint32_t first_shot, uint32_t shots) noexcept;
+    void sample_presampled_noise() noexcept;
+    void assign_forced_faults(KFaultSampler& fault_sampler) noexcept;
+    void activate_noise_site(uint32_t lane, uint32_t site) noexcept;
+    void initialize_expression_registers() noexcept;
+    void propagate_symbol(uint32_t symbol) noexcept;
+    void assign_symbol(uint32_t symbol, std::span<const uint64_t> values) noexcept;
+
+    template <ExecutorBackend Backend>
+    void execute_actions() noexcept;
+    template <ExecutorBackend Backend>
+    void execute_action(const ExecutablePlan::ExecuteRotation& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteDynamicFusedRotation& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecutePromotion& action,
+                        size_t action_index) noexcept;
+    template <ExecutorBackend Backend>
+    void execute_action(const ExecutablePlan::ExecuteActiveMeasurement& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteDetector& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteObservable& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteExpectation& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteInstrument& action,
+                        size_t action_index) noexcept;
+    void execute_action(const ExecutablePlan::ExecuteBoundary& action,
+                        size_t action_index) noexcept;
+
+    [[nodiscard]] std::span<const uint64_t> evaluate(
+        ExecutablePlan::PreparedExpression expression) const noexcept;
+    [[nodiscard]] bool lane_bit(std::span<const uint64_t> bits, uint32_t lane) const noexcept;
+    [[nodiscard]] bool is_live(uint32_t lane) const noexcept;
+    [[nodiscard]] State& state(uint32_t lane) noexcept;
+    [[nodiscard]] const State& state(uint32_t lane) const noexcept;
+    [[nodiscard]] bool sample_active_branch(uint32_t lane,
+                                            MeasurementProbabilities probabilities) noexcept;
+    [[nodiscard]] bool should_compact(size_t action_index) const noexcept;
+    void compact_live_lanes() noexcept;
+    void finalize_live_lanes() noexcept;
+
+    const ExecutablePlan* plan_;
+    uint32_t lane_capacity_ = 0;
+    size_t word_capacity_ = 0;
+    size_t state_bytes_per_lane_ = 0;
+
+    // One allocation contains every lane's shot-major coefficient and scratch
+    // block. State facades borrow their corresponding aligned slices.
+    PageAlignedAllocation state_storage_;
+    std::vector<State> states_;
+    std::vector<uint32_t> state_slots_;
+    std::vector<Xoshiro256PlusPlus> rngs_;
+    std::vector<uint32_t> shot_indices_;
+
+    PackedBitColumns symbols_;
+    PackedBitColumns expression_registers_;
+    PackedBitColumns records_;
+    PackedBitColumns detectors_;
+    PackedBitColumns observables_;
+    PackedBitColumns forced_readout_;
+    std::vector<double> exp_vals_;
+
+    std::vector<uint64_t> live_words_;
+    std::vector<uint64_t> scratch_words_;
+    std::vector<uint64_t> compaction_scratch_;
+
+    uint32_t attempted_shots_ = 0;
+    uint32_t active_lanes_ = 0;
+    uint32_t live_count_ = 0;
+    bool fixed_fault_mode_ = false;
+    uint64_t dust_clamps_ = 0;
+    uint64_t compactions_ = 0;
+};
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -16,6 +16,7 @@
 namespace clifft::sampling {
 
 class Executor;
+class BatchExecutor;
 class ExecutablePlanBuilder;
 
 // Owns one portable fused descriptor and the optional sidecar prepared by the
@@ -100,6 +101,7 @@ class ExecutablePlan {
 
   private:
     friend class Executor;
+    friend class BatchExecutor;
     friend class ExecutablePlanBuilder;
 
     // To keep actions compact, register_id refers to expression details in the

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/sampler.h"
 
+#include "clifft/sampling/batch_executor.h"
 #include "clifft/sampling/executor.h"
 #include "clifft/util/fault_sampling.h"
 #include "clifft/util/intra_shot_parallel.h"
@@ -67,6 +68,43 @@ struct ConditionedSurvivorWorker {
           counts(plan.num_observables()) {}
 
     Executor executor;
+    KFaultSampler fault_sampler;
+    SurvivorCounts counts;
+};
+
+struct BatchSamplingWorker {
+    BatchSamplingWorker(const ExecutablePlan& plan, uint32_t capacity) : executor(plan, capacity) {}
+
+    BatchExecutor executor;
+};
+
+struct ConditionedBatchSamplingWorker {
+    ConditionedBatchSamplingWorker(const ExecutablePlan& plan,
+                                   std::span<const double> probabilities, uint32_t k,
+                                   uint32_t capacity)
+        : executor(plan, capacity), fault_sampler(probabilities, k) {}
+
+    BatchExecutor executor;
+    KFaultSampler fault_sampler;
+};
+
+struct BatchSurvivorWorker {
+    BatchSurvivorWorker(const ExecutablePlan& plan, uint32_t capacity)
+        : executor(plan, capacity), counts(plan.num_observables()) {}
+
+    BatchExecutor executor;
+    SurvivorCounts counts;
+};
+
+struct ConditionedBatchSurvivorWorker {
+    ConditionedBatchSurvivorWorker(const ExecutablePlan& plan,
+                                   std::span<const double> probabilities, uint32_t k,
+                                   uint32_t capacity)
+        : executor(plan, capacity),
+          fault_sampler(probabilities, k),
+          counts(plan.num_observables()) {}
+
+    BatchExecutor executor;
     KFaultSampler fault_sampler;
     SurvivorCounts counts;
 };
@@ -176,6 +214,68 @@ SamplingResult sample_fixed_rows(const ExecutablePlan& plan, uint32_t shots,
     return result;
 }
 
+template <typename MakeWorker, typename RunBatch>
+SamplingResult sample_fixed_batches(const ExecutablePlan& plan, uint32_t shots,
+                                    std::optional<uint64_t> seed, ThreadLayout thread_layout,
+                                    uint32_t batch_capacity, MakeWorker&& make_worker,
+                                    RunBatch&& run_batch) {
+    auto checked_size = [shots](size_t stride) {
+        if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
+            throw std::length_error("sampling output size exceeds size_t range");
+        }
+        return static_cast<size_t>(shots) * stride;
+    };
+
+    SamplingResult result;
+    result.measurements.resize(checked_size(plan.num_visible_records()));
+    result.detectors.resize(checked_size(plan.num_detectors()));
+    result.observables.resize(checked_size(plan.num_observables()));
+    result.exp_vals.resize(checked_size(plan.num_exp_vals()));
+    if (shots == 0) {
+        return result;
+    }
+
+    const SeedRoot root = make_seed_root(shots, seed);
+    (void)run_shot_ranges(
+        shots, thread_layout.shot_workers, std::forward<MakeWorker>(make_worker),
+        [&](auto& worker_handle, ShotRange range) {
+            auto& worker = *worker_handle;
+            BatchExecutor& executor = worker.executor;
+            for (uint32_t offset = range.begin; offset < range.end;) {
+                const uint32_t batch = std::min(batch_capacity, range.end - offset);
+                run_batch(worker, root, offset, batch);
+                assert(executor.surviving_shots() == batch &&
+                       "fixed-row batch must retain every shot");
+                for (uint32_t lane = 0; lane < batch; ++lane) {
+                    const uint32_t shot = executor.shot_index(lane);
+                    for (uint32_t record = 0; record < plan.num_visible_records(); ++record) {
+                        result.measurements[static_cast<size_t>(shot) * plan.num_visible_records() +
+                                            record] =
+                            static_cast<uint8_t>(executor.measurement(lane, record));
+                    }
+                    for (uint32_t detector = 0; detector < plan.num_detectors(); ++detector) {
+                        result.detectors[static_cast<size_t>(shot) * plan.num_detectors() +
+                                         detector] =
+                            static_cast<uint8_t>(executor.detector(lane, detector));
+                    }
+                    for (uint32_t observable = 0; observable < plan.num_observables();
+                         ++observable) {
+                        result.observables[static_cast<size_t>(shot) * plan.num_observables() +
+                                           observable] =
+                            static_cast<uint8_t>(executor.observable(lane, observable));
+                    }
+                    for (uint32_t exp_val = 0; exp_val < plan.num_exp_vals(); ++exp_val) {
+                        result.exp_vals[static_cast<size_t>(shot) * plan.num_exp_vals() + exp_val] =
+                            executor.exp_val(lane, exp_val);
+                    }
+                }
+                offset += batch;
+            }
+        },
+        batch_capacity);
+    return result;
+}
+
 template <typename MakeWorker, typename RunShot>
 SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_t shots,
                                              std::optional<uint64_t> seed, bool keep_records,
@@ -257,10 +357,104 @@ SamplingSurvivorResult sample_surviving_rows(const ExecutablePlan& plan, uint32_
     return result;
 }
 
+template <typename MakeWorker, typename RunBatch>
+SamplingSurvivorResult sample_surviving_batches(const ExecutablePlan& plan, uint32_t shots,
+                                                std::optional<uint64_t> seed, bool keep_records,
+                                                ThreadLayout thread_layout, uint32_t batch_capacity,
+                                                MakeWorker&& make_worker, RunBatch&& run_batch) {
+    SamplingSurvivorResult result;
+    result.total_shots = shots;
+    if (shots == 0) {
+        return result;
+    }
+    result.observable_ones.resize(plan.num_observables(), 0);
+    if (keep_records) {
+        auto checked_reserve = [shots](size_t stride) {
+            if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
+                throw std::length_error("survivor output size exceeds size_t range");
+            }
+            return static_cast<size_t>(shots) * stride;
+        };
+        result.measurements.resize(checked_reserve(plan.num_visible_records()));
+        result.detectors.resize(checked_reserve(plan.num_detectors()));
+        result.observables.resize(checked_reserve(plan.num_observables()));
+        result.exp_vals.resize(checked_reserve(plan.num_exp_vals()));
+    }
+    std::vector<uint8_t> survived(keep_records ? shots : 0, 0);
+    const SeedRoot root = make_seed_root(shots, seed);
+    auto workers = run_shot_ranges(
+        shots, thread_layout.shot_workers, std::forward<MakeWorker>(make_worker),
+        [&](auto& worker_handle, ShotRange range) {
+            auto& worker = *worker_handle;
+            BatchExecutor& executor = worker.executor;
+            SurvivorCounts& counts = worker.counts;
+            for (uint32_t offset = range.begin; offset < range.end;) {
+                const uint32_t batch = std::min(batch_capacity, range.end - offset);
+                run_batch(worker, root, offset, batch);
+                for (uint32_t lane = 0; lane < executor.surviving_shots(); ++lane) {
+                    ++counts.passed_shots;
+                    bool logical_error = false;
+                    for (uint32_t observable = 0; observable < plan.num_observables();
+                         ++observable) {
+                        const bool value = executor.observable(lane, observable);
+                        counts.observable_ones[observable] += static_cast<uint64_t>(value);
+                        logical_error |= value;
+                    }
+                    counts.logical_errors += static_cast<uint32_t>(logical_error);
+                    if (!keep_records) {
+                        continue;
+                    }
+                    const uint32_t shot = executor.shot_index(lane);
+                    survived[shot] = 1;
+                    for (uint32_t record = 0; record < plan.num_visible_records(); ++record) {
+                        result.measurements[static_cast<size_t>(shot) * plan.num_visible_records() +
+                                            record] =
+                            static_cast<uint8_t>(executor.measurement(lane, record));
+                    }
+                    for (uint32_t detector = 0; detector < plan.num_detectors(); ++detector) {
+                        result.detectors[static_cast<size_t>(shot) * plan.num_detectors() +
+                                         detector] =
+                            static_cast<uint8_t>(executor.detector(lane, detector));
+                    }
+                    for (uint32_t observable = 0; observable < plan.num_observables();
+                         ++observable) {
+                        result.observables[static_cast<size_t>(shot) * plan.num_observables() +
+                                           observable] =
+                            static_cast<uint8_t>(executor.observable(lane, observable));
+                    }
+                    for (uint32_t exp_val = 0; exp_val < plan.num_exp_vals(); ++exp_val) {
+                        result.exp_vals[static_cast<size_t>(shot) * plan.num_exp_vals() + exp_val] =
+                            executor.exp_val(lane, exp_val);
+                    }
+                }
+                offset += batch;
+            }
+        },
+        batch_capacity);
+    for (const auto& worker : workers) {
+        result.passed_shots += worker->counts.passed_shots;
+        result.logical_errors += worker->counts.logical_errors;
+        for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
+            result.observable_ones[observable] += worker->counts.observable_ones[observable];
+        }
+    }
+    if (keep_records) {
+        compact_survivor_rows(result.measurements, survived, plan.num_visible_records(),
+                              result.passed_shots);
+        compact_survivor_rows(result.detectors, survived, plan.num_detectors(),
+                              result.passed_shots);
+        compact_survivor_rows(result.observables, survived, plan.num_observables(),
+                              result.passed_shots);
+        compact_survivor_rows(result.exp_vals, survived, plan.num_exp_vals(), result.passed_shots);
+    }
+    return result;
+}
+
 }  // namespace
 
 SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed,
-                      uint32_t threads, std::optional<ThreadLayout> thread_layout) {
+                      uint32_t threads, std::optional<ThreadLayout> thread_layout,
+                      std::optional<uint32_t> batch_size) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "fixed-plan sampling does not support instrument traps; use the trajectory driver");
@@ -275,6 +469,15 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
     }
 
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
+    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
+                                                           resolved.intra_shot_workers, batch_size);
+    if (batch_capacity > 1) {
+        return sample_fixed_batches(
+            plan, shots, seed, resolved, batch_capacity,
+            [&](uint32_t) { return std::make_unique<BatchSamplingWorker>(plan, batch_capacity); },
+            [](BatchSamplingWorker& worker, const SeedRoot& root, uint32_t first_shot,
+               uint32_t batch) noexcept { worker.executor.run_batch(root, first_shot, batch); });
+    }
     return sample_fixed_rows(
         plan, shots, seed, resolved,
         [&](uint32_t) {
@@ -286,14 +489,15 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
 
 std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
                                     std::optional<uint64_t> seed, uint32_t threads,
-                                    std::optional<ThreadLayout> thread_layout) {
-    return sample(plan, shots, seed, threads, thread_layout).measurements;
+                                    std::optional<ThreadLayout> thread_layout,
+                                    std::optional<uint32_t> batch_size) {
+    return sample(plan, shots, seed, threads, thread_layout, batch_size).measurements;
 }
 
 SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t shots,
                                         std::optional<uint64_t> seed, bool keep_records,
-                                        uint32_t threads,
-                                        std::optional<ThreadLayout> thread_layout) {
+                                        uint32_t threads, std::optional<ThreadLayout> thread_layout,
+                                        std::optional<uint32_t> batch_size) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "survivor sampling does not support instrument traps; use the trajectory driver");
@@ -304,6 +508,15 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
     }
 
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
+    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
+                                                           resolved.intra_shot_workers, batch_size);
+    if (batch_capacity > 1) {
+        return sample_surviving_batches(
+            plan, shots, seed, keep_records, resolved, batch_capacity,
+            [&](uint32_t) { return std::make_unique<BatchSurvivorWorker>(plan, batch_capacity); },
+            [](BatchSurvivorWorker& worker, const SeedRoot& root, uint32_t first_shot,
+               uint32_t batch) noexcept { worker.executor.run_batch(root, first_shot, batch); });
+    }
     return sample_surviving_rows(
         plan, shots, seed, keep_records, resolved,
         [&](uint32_t) {
@@ -315,7 +528,8 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
 
 SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
                         std::optional<uint64_t> seed, uint32_t threads,
-                        std::optional<ThreadLayout> thread_layout) {
+                        std::optional<ThreadLayout> thread_layout,
+                        std::optional<uint32_t> batch_size) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "forced-fault sampling does not support instrument traps or trajectory drivers");
@@ -330,6 +544,8 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
             "sample_k_survivors");
     }
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
+    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
+                                                           resolved.intra_shot_workers, batch_size);
     if (shots == 0) {
         return sample_fixed_rows(
             plan, shots, seed, resolved,
@@ -340,6 +556,18 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
             [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
     }
     const std::vector<double> probabilities = plan.noise_site_probabilities();
+    if (batch_capacity > 1) {
+        return sample_fixed_batches(
+            plan, shots, seed, resolved, batch_capacity,
+            [&](uint32_t) {
+                return std::make_unique<ConditionedBatchSamplingWorker>(plan, probabilities, k,
+                                                                        batch_capacity);
+            },
+            [](ConditionedBatchSamplingWorker& worker, const SeedRoot& root, uint32_t first_shot,
+               uint32_t batch) noexcept {
+                worker.executor.run_batch(root, first_shot, batch, worker.fault_sampler);
+            });
+    }
     return sample_fixed_rows(
         plan, shots, seed, resolved,
         [&](uint32_t) {
@@ -355,7 +583,8 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
 SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
                                           std::optional<uint64_t> seed, bool keep_records,
                                           uint32_t threads,
-                                          std::optional<ThreadLayout> thread_layout) {
+                                          std::optional<ThreadLayout> thread_layout,
+                                          std::optional<uint32_t> batch_size) {
     if (plan.has_instruments()) {
         throw std::invalid_argument(
             "forced-fault survivor sampling does not support instrument traps or trajectory "
@@ -366,6 +595,8 @@ SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t s
             "forced-fault survivor sampling requires a distribution for every presampled symbol");
     }
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
+    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
+                                                           resolved.intra_shot_workers, batch_size);
     if (shots == 0) {
         return sample_surviving_rows(
             plan, shots, seed, keep_records, resolved,
@@ -376,6 +607,18 @@ SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t s
             [](SurvivorWorker& worker) noexcept { worker.executor.run_shot(); });
     }
     const std::vector<double> probabilities = plan.noise_site_probabilities();
+    if (batch_capacity > 1) {
+        return sample_surviving_batches(
+            plan, shots, seed, keep_records, resolved, batch_capacity,
+            [&](uint32_t) {
+                return std::make_unique<ConditionedBatchSurvivorWorker>(plan, probabilities, k,
+                                                                        batch_capacity);
+            },
+            [](ConditionedBatchSurvivorWorker& worker, const SeedRoot& root, uint32_t first_shot,
+               uint32_t batch) noexcept {
+                worker.executor.run_batch(root, first_shot, batch, worker.fault_sampler);
+            });
+    }
     return sample_surviving_rows(
         plan, shots, seed, keep_records, resolved,
         [&](uint32_t) {

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -15,8 +15,8 @@ namespace clifft::sampling {
 // Sampling pipeline:
 //   optimized HirModule -> SamplingPlan -> ExecutablePlan -> Executor -> results
 // Planning produces semantic actions, lowering prepares fixed CPU descriptors,
-// Executor owns mutable state for one shot, and the functions below drive
-// repeated shots and collect their outputs.
+// Executor owns mutable state for one shot, BatchExecutor owns a packed lane
+// group, and the functions below select a prepared path and collect outputs.
 
 // Explicitly partitions sampling workers across independent shots and the
 // coefficient kernels within each shot. When supplied, this layout overrides
@@ -36,10 +36,12 @@ struct ThreadLayout {
 // threads is a total worker budget. threads=0 selects the implementation-
 // reported hardware concurrency; the public Python API spells this as
 // threads="auto". Automatic scheduling uses either cross-shot or intra-shot
-// workers, not a hybrid layout.
+// workers, not a hybrid layout. batch_size is empty for adaptive selection,
+// one for scalar execution, or an explicit packed lane-capacity limit.
 [[nodiscard]] std::vector<uint8_t> sample_records(
     const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed = std::nullopt,
-    uint32_t threads = 1, std::optional<ThreadLayout> thread_layout = std::nullopt);
+    uint32_t threads = 1, std::optional<ThreadLayout> thread_layout = std::nullopt,
+    std::optional<uint32_t> batch_size = std::nullopt);
 
 // Replays each row-major visible record and returns its joint log probability.
 // Unreachable records map to the lowest finite double because release builds
@@ -53,21 +55,25 @@ struct ThreadLayout {
 [[nodiscard]] SamplingResult sample(const ExecutablePlan& plan, uint32_t shots,
                                     std::optional<uint64_t> seed = std::nullopt,
                                     uint32_t threads = 1,
-                                    std::optional<ThreadLayout> thread_layout = std::nullopt);
+                                    std::optional<ThreadLayout> thread_layout = std::nullopt,
+                                    std::optional<uint32_t> batch_size = std::nullopt);
 
 [[nodiscard]] SamplingSurvivorResult sample_survivors(
     const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed = std::nullopt,
     bool keep_records = false, uint32_t threads = 1,
-    std::optional<ThreadLayout> thread_layout = std::nullopt);
+    std::optional<ThreadLayout> thread_layout = std::nullopt,
+    std::optional<uint32_t> batch_size = std::nullopt);
 
 [[nodiscard]] SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
                                       std::optional<uint64_t> seed = std::nullopt,
                                       uint32_t threads = 1,
-                                      std::optional<ThreadLayout> thread_layout = std::nullopt);
+                                      std::optional<ThreadLayout> thread_layout = std::nullopt,
+                                      std::optional<uint32_t> batch_size = std::nullopt);
 
 [[nodiscard]] SamplingSurvivorResult sample_k_survivors(
     const ExecutablePlan& plan, uint32_t shots, uint32_t k,
     std::optional<uint64_t> seed = std::nullopt, bool keep_records = false, uint32_t threads = 1,
-    std::optional<ThreadLayout> thread_layout = std::nullopt);
+    std::optional<ThreadLayout> thread_layout = std::nullopt,
+    std::optional<uint32_t> batch_size = std::nullopt);
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/state.cc
+++ b/src/clifft/sampling/state.cc
@@ -22,17 +22,39 @@ uint64_t round_array_stride(uint64_t entries) {
                     (entries + kDoublesPerAlignment - 1) & ~(kDoublesPerAlignment - 1));
 }
 
+size_t state_allocation_bytes(uint32_t max_active_width) {
+    if (max_active_width >= kDenseActiveWidthLimit) {
+        throw std::invalid_argument("sampling state maximum active width must be below " +
+                                    std::to_string(kDenseActiveWidthLimit));
+    }
+    const uint64_t capacity = uint64_t{1} << max_active_width;
+    const uint64_t coefficient_stride = round_array_stride(capacity);
+    const uint64_t scratch_capacity = std::max(uint64_t{1}, capacity >> 1);
+    const uint64_t scratch_stride = round_array_stride(scratch_capacity);
+    const uint64_t allocated_doubles = 2 * coefficient_stride + 2 * scratch_stride;
+    if (allocated_doubles > std::numeric_limits<size_t>::max() / sizeof(double)) {
+        throw std::length_error("sampling state allocation exceeds addressable memory");
+    }
+    return static_cast<size_t>(allocated_doubles) * sizeof(double);
+}
+
 }  // namespace
+
+size_t State::allocation_bytes_for(uint32_t max_active_width) {
+    return state_allocation_bytes(max_active_width);
+}
+
+State State::from_borrowed_storage(uint32_t max_active_width, uint32_t initial_active_width,
+                                   void* storage, size_t storage_bytes) {
+    return State(max_active_width, initial_active_width, storage, storage_bytes);
+}
 
 State::State(uint32_t max_active_width, uint32_t initial_active_width,
              uint32_t initialization_workers, uint32_t intra_shot_min_active_width)
     : initial_active_width_(initial_active_width),
       active_width_(initial_active_width),
       max_active_width_(max_active_width) {
-    if (max_active_width >= kDenseActiveWidthLimit) {
-        throw std::invalid_argument("sampling state maximum active width must be below " +
-                                    std::to_string(kDenseActiveWidthLimit));
-    }
+    const size_t allocation_bytes = state_allocation_bytes(max_active_width);
     if (initial_active_width > max_active_width) {
         throw std::invalid_argument("sampling state initial active width exceeds its maximum");
     }
@@ -40,16 +62,8 @@ State::State(uint32_t max_active_width, uint32_t initial_active_width,
     coefficient_stride_ = round_array_stride(capacity_);
     const uint64_t scratch_capacity = std::max(uint64_t{1}, capacity_ >> 1);
     scratch_stride_ = round_array_stride(scratch_capacity);
-    const uint64_t allocated_doubles = 2 * coefficient_stride_ + 2 * scratch_stride_;
-    if (allocated_doubles > std::numeric_limits<size_t>::max() / sizeof(double)) {
-        throw std::length_error("sampling state allocation exceeds addressable memory");
-    }
-    const size_t allocation_bytes = static_cast<size_t>(allocated_doubles) * sizeof(double);
     allocation_ = PageAlignedAllocation(allocation_bytes);
-    real_ = static_cast<double*>(allocation_.data());
-    imag_ = real_ + coefficient_stride_;
-    scratch_real_ = imag_ + coefficient_stride_;
-    scratch_imag_ = scratch_real_ + scratch_stride_;
+    bind_storage(allocation_.data(), allocation_.size());
     if (should_parallelize_intra_shot(max_active_width_, initialization_workers,
                                       intra_shot_min_active_width)) {
         // Matching each worker's future coefficient range here lets the OS
@@ -63,6 +77,34 @@ State::State(uint32_t max_active_width, uint32_t initial_active_width,
     } else {
         reset();
     }
+}
+
+State::State(uint32_t max_active_width, uint32_t initial_active_width, void* storage,
+             size_t storage_bytes)
+    : initial_active_width_(initial_active_width),
+      active_width_(initial_active_width),
+      max_active_width_(max_active_width) {
+    const size_t required_bytes = state_allocation_bytes(max_active_width);
+    if (initial_active_width > max_active_width) {
+        throw std::invalid_argument("sampling state initial active width exceeds its maximum");
+    }
+    if (storage == nullptr || storage_bytes < required_bytes) {
+        throw std::invalid_argument("borrowed sampling state storage is too small");
+    }
+    capacity_ = uint64_t{1} << max_active_width;
+    coefficient_stride_ = round_array_stride(capacity_);
+    const uint64_t scratch_capacity = std::max(uint64_t{1}, capacity_ >> 1);
+    scratch_stride_ = round_array_stride(scratch_capacity);
+    bind_storage(storage, storage_bytes);
+    reset();
+}
+
+void State::bind_storage(void* storage, size_t storage_bytes) {
+    real_ = static_cast<double*>(storage);
+    imag_ = real_ + coefficient_stride_;
+    scratch_real_ = imag_ + coefficient_stride_;
+    scratch_imag_ = scratch_real_ + scratch_stride_;
+    storage_bytes_ = storage_bytes;
 }
 
 State::~State() {
@@ -82,7 +124,7 @@ State& State::operator=(State&& other) noexcept {
 }
 
 void State::reset() noexcept {
-    assert(!allocation_.empty() && "cannot reset a moved-from sampling state");
+    assert(real_ != nullptr && "cannot reset a moved-from sampling state");
     active_width_ = initial_active_width_;
     // Only the live prefix is observable. Promotions overwrite both halves of
     // each newly active range, and measurement scratch is overwritten on use.
@@ -96,7 +138,7 @@ void State::reset_parallel(uint32_t workers, uint32_t min_active_width) noexcept
         reset();
         return;
     }
-    assert(!allocation_.empty() && "cannot reset a moved-from sampling state");
+    assert(real_ != nullptr && "cannot reset a moved-from sampling state");
     active_width_ = initial_active_width_;
     intra_shot_parallel_ranges(size(), workers, [&](uint64_t begin, uint64_t end) noexcept {
         std::fill(real_ + begin, real_ + end, 0.0);
@@ -140,6 +182,7 @@ void State::ensure_capacity(uint32_t max_active_width) {
     capacity_ = new_capacity;
     coefficient_stride_ = new_coefficient_stride;
     scratch_stride_ = new_scratch_stride;
+    storage_bytes_ = allocation_.size();
     max_active_width_ = max_active_width;
 }
 
@@ -154,6 +197,7 @@ void State::release() noexcept {
     imag_ = nullptr;
     scratch_real_ = nullptr;
     scratch_imag_ = nullptr;
+    storage_bytes_ = 0;
 }
 
 void State::move_from(State&& other) noexcept {
@@ -165,6 +209,7 @@ void State::move_from(State&& other) noexcept {
     capacity_ = std::exchange(other.capacity_, 0);
     coefficient_stride_ = std::exchange(other.coefficient_stride_, 0);
     scratch_stride_ = std::exchange(other.scratch_stride_, 0);
+    storage_bytes_ = std::exchange(other.storage_bytes_, 0);
     initial_active_width_ = std::exchange(other.initial_active_width_, 0);
     active_width_ = std::exchange(other.active_width_, 0);
     max_active_width_ = std::exchange(other.max_active_width_, 0);

--- a/src/clifft/sampling/state.h
+++ b/src/clifft/sampling/state.h
@@ -9,11 +9,17 @@
 
 namespace clifft::sampling {
 
+class BatchExecutor;
+
 // Holds one shot's normalized state-vector coefficients for direct-Pauli
 // execution. The same allocation contains temporary arrays used while
 // collapsing a non-diagonal measurement.
 class State {
   public:
+    // Exact allocation size used by capacity planning. This includes both
+    // coefficient arrays, measurement scratch, and per-array alignment.
+    [[nodiscard]] static size_t allocation_bytes_for(uint32_t max_active_width);
+
     // Immediately allocates all coefficient and temporary storage required by
     // max_active_width, even when initial_active_width is smaller.
     explicit State(uint32_t max_active_width, uint32_t initial_active_width = 0,
@@ -42,6 +48,7 @@ class State {
     [[nodiscard]] uint32_t max_active_width() const { return max_active_width_; }
     [[nodiscard]] uint64_t size() const { return uint64_t{1} << active_width_; }
     [[nodiscard]] uint64_t capacity() const { return capacity_; }
+    [[nodiscard]] size_t allocation_bytes() const { return storage_bytes_; }
 
     [[nodiscard]] std::span<double> real() { return {real_, static_cast<size_t>(size())}; }
     [[nodiscard]] std::span<const double> real() const {
@@ -66,6 +73,16 @@ class State {
     void set_active_width(uint32_t width) noexcept;
 
   private:
+    friend class BatchExecutor;
+
+    // One batch allocation avoids charging the page-size minimum to every
+    // narrow lane. The owning BatchExecutor outlives all borrowed facades.
+    [[nodiscard]] static State from_borrowed_storage(uint32_t max_active_width,
+                                                     uint32_t initial_active_width, void* storage,
+                                                     size_t storage_bytes);
+    State(uint32_t max_active_width, uint32_t initial_active_width, void* storage,
+          size_t storage_bytes);
+    void bind_storage(void* storage, size_t storage_bytes);
     void release() noexcept;
     void move_from(State&& other) noexcept;
 
@@ -77,6 +94,7 @@ class State {
     uint64_t capacity_ = 0;
     uint64_t coefficient_stride_ = 0;
     uint64_t scratch_stride_ = 0;
+    size_t storage_bytes_ = 0;
     uint32_t initial_active_width_ = 0;
     uint32_t active_width_ = 0;
     uint32_t max_active_width_ = 0;

--- a/src/clifft/util/shot_parallel.h
+++ b/src/clifft/util/shot_parallel.h
@@ -50,12 +50,14 @@ inline uint32_t resolve_shot_worker_count(uint32_t shots, uint32_t requested_thr
     return std::min(resolve_thread_budget(requested_threads), shots);
 }
 
-inline uint32_t shot_chunk_size(uint32_t shots, uint32_t workers) noexcept {
+inline uint32_t shot_chunk_size(uint32_t shots, uint32_t workers,
+                                uint32_t minimum_chunk_size = 1) noexcept {
     assert(workers != 0 && "shot chunking requires at least one worker");
     constexpr uint64_t kTargetChunksPerWorker = 8;
     const uint64_t target_chunks = static_cast<uint64_t>(workers) * kTargetChunksPerWorker;
-    return static_cast<uint32_t>(
-        std::max<uint64_t>(1, (static_cast<uint64_t>(shots) + target_chunks - 1) / target_chunks));
+    return static_cast<uint32_t>(std::max<uint64_t>(
+        minimum_chunk_size,
+        std::max<uint64_t>(1, (static_cast<uint64_t>(shots) + target_chunks - 1) / target_chunks)));
 }
 
 // make_worker(index) runs for every worker before any range is dispatched.
@@ -66,7 +68,7 @@ inline uint32_t shot_chunk_size(uint32_t shots, uint32_t workers) noexcept {
 // shared template definition in consumers that do not inherit the core define.
 template <typename MakeWorker, typename RunRange>
 static auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWorker&& make_worker,
-                            RunRange&& run_range) {
+                            RunRange&& run_range, uint32_t minimum_chunk_size = 1) {
     using WorkerHandle = std::remove_cvref_t<std::invoke_result_t<MakeWorker, uint32_t>>;
     const uint32_t worker_count = resolve_shot_worker_count(shots, requested_threads);
     std::vector<WorkerHandle> workers;
@@ -85,7 +87,7 @@ static auto run_shot_ranges(uint32_t shots, uint32_t requested_threads, MakeWork
 #if defined(__EMSCRIPTEN__)
     std::invoke(run_range, workers[0], ShotRange{0, shots});
 #else
-    const uint32_t chunk_size = shot_chunk_size(shots, worker_count);
+    const uint32_t chunk_size = shot_chunk_size(shots, worker_count, minimum_chunk_size);
     std::atomic<uint64_t> next_shot{0};
     std::atomic<bool> cancelled{false};
     std::exception_ptr first_error;

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -40,6 +40,7 @@ namespace nb = nanobind;
 namespace {
 
 using ThreadOption = std::variant<int64_t, std::string>;
+using BatchSizeOption = std::variant<int64_t, std::string>;
 
 uint32_t parse_thread_option(const ThreadOption& option) {
     if (const auto* name = std::get_if<std::string>(&option)) {
@@ -51,6 +52,20 @@ uint32_t parse_thread_option(const ThreadOption& option) {
     const int64_t count = std::get<int64_t>(option);
     if (count <= 0 || static_cast<uint64_t>(count) > std::numeric_limits<uint32_t>::max()) {
         throw std::invalid_argument("threads must be a positive integer or 'auto'");
+    }
+    return static_cast<uint32_t>(count);
+}
+
+std::optional<uint32_t> parse_batch_size_option(const BatchSizeOption& option) {
+    if (const auto* name = std::get_if<std::string>(&option)) {
+        if (*name == "auto") {
+            return std::nullopt;
+        }
+        throw std::invalid_argument("batch_size must be a positive integer or 'auto'");
+    }
+    const int64_t count = std::get<int64_t>(option);
+    if (count <= 0 || static_cast<uint64_t>(count) > std::numeric_limits<uint32_t>::max()) {
+        throw std::invalid_argument("batch_size must be a positive integer or 'auto'");
     }
     return static_cast<uint32_t>(count);
 }
@@ -797,7 +812,8 @@ NB_MODULE(_clifft_core, m) {
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots,
            std::optional<uint64_t> seed, const ThreadOption& thread_option,
            const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
-           std::optional<int64_t> intra_shot_min_active_width) {
+           std::optional<int64_t> intra_shot_min_active_width,
+           const BatchSizeOption& batch_size_option) {
             if (program.has_postselection()) {
                 throw nb::value_error(
                     "sample() cannot be used with post-selected programs because it "
@@ -807,10 +823,12 @@ NB_MODULE(_clifft_core, m) {
             const uint32_t threads = parse_thread_option(thread_option);
             const auto thread_layout =
                 parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
+            const auto batch_size = parse_batch_size_option(batch_size_option);
             clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                result = clifft::sampling::sample(program, shots, seed, threads, thread_layout);
+                result = clifft::sampling::sample(program, shots, seed, threads, thread_layout,
+                                                  batch_size);
             }
 
             auto meas_arr = vec_to_numpy(std::move(result.measurements),
@@ -828,6 +846,7 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("threads") = int64_t{1}, nb::arg("thread_layout") = nb::none(),
         nb::arg("intra_shot_min_active_width") = nb::none(),
+        nb::arg("batch_size") = std::string("auto"),
         "Run a compiled program and return a SampleResult.\n\n"
         "Raises ValueError for post-selected programs because fixed-row output\n"
         "cannot represent discarded shots. Use sample_survivors() instead.\n\n"
@@ -837,7 +856,10 @@ NB_MODULE(_clifft_core, m) {
         "or intra-shot workers. thread_layout=(shot_workers, intra_shot_workers)\n"
         "overrides that choice and ignores threads; intra-shot counts above 1\n"
         "require OpenMP support. intra_shot_min_active_width overrides the\n"
-        "default threshold of 18 for an explicit layout.\n\n"
+        "default threshold of 18 for an explicit layout. batch_size='auto'\n"
+        "selects an adaptive cross-shot batch, 1 forces scalar execution, and\n"
+        "a larger integer caps the lanes retained by each shot worker. Packed\n"
+        "batching cannot be combined with intra-shot workers.\n\n"
         "Returns a SampleResult with .measurements, .detectors, .observables attributes.\n"
         "Supports tuple unpacking: m, d, o = clifft.sample(prog, shots)");
 
@@ -846,7 +868,8 @@ NB_MODULE(_clifft_core, m) {
         [](const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
            std::optional<uint64_t> seed, const ThreadOption& thread_option,
            const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
-           std::optional<int64_t> intra_shot_min_active_width) {
+           std::optional<int64_t> intra_shot_min_active_width,
+           const BatchSizeOption& batch_size_option) {
             if (program.has_postselection()) {
                 throw nb::value_error(
                     "sample_k() cannot be used with post-selected programs because it "
@@ -856,11 +879,12 @@ NB_MODULE(_clifft_core, m) {
             const uint32_t threads = parse_thread_option(thread_option);
             const auto thread_layout =
                 parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
+            const auto batch_size = parse_batch_size_option(batch_size_option);
             clifft::sampling::SamplingResult result;
             {
                 nb::gil_scoped_release release;
-                result =
-                    clifft::sampling::sample_k(program, shots, k, seed, threads, thread_layout);
+                result = clifft::sampling::sample_k(program, shots, k, seed, threads, thread_layout,
+                                                    batch_size);
             }
 
             auto meas_arr = vec_to_numpy(std::move(result.measurements),
@@ -878,6 +902,7 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
         nb::arg("threads") = int64_t{1}, nb::arg("thread_layout") = nb::none(),
         nb::arg("intra_shot_min_active_width") = nb::none(),
+        nb::arg("batch_size") = std::string("auto"),
         "Sample with exactly k forced faults per shot (importance sampling).\n\n"
         "Sites are drawn from the exact conditional Poisson-Binomial\n"
         "distribution. Results are conditioned on K=k and must be combined\n"
@@ -894,7 +919,10 @@ NB_MODULE(_clifft_core, m) {
         "or 'auto' to use the implementation-reported hardware concurrency;\n"
         "it defaults to 1. thread_layout=(shot_workers, intra_shot_workers)\n"
         "overrides automatic scheduling. intra_shot_min_active_width overrides\n"
-        "the default threshold of 18 for an explicit layout.\n\n"
+        "the default threshold of 18 for an explicit layout. batch_size='auto'\n"
+        "selects an adaptive cross-shot batch, 1 forces scalar execution, and\n"
+        "a larger integer caps the lanes retained by each shot worker. Packed\n"
+        "batching cannot be combined with intra-shot workers.\n\n"
         "Returns a SampleResult with .measurements, .detectors, .observables attributes.\n"
         "Supports tuple unpacking: m, d, o = clifft.sample_k(prog, shots, k)");
 
@@ -932,21 +960,24 @@ NB_MODULE(_clifft_core, m) {
             const clifft::sampling::ExecutablePlan& program, uint32_t shots, uint32_t k,
             std::optional<uint64_t> seed, bool keep_records, const ThreadOption& thread_option,
             const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
-            std::optional<int64_t> intra_shot_min_active_width) {
+            std::optional<int64_t> intra_shot_min_active_width,
+            const BatchSizeOption& batch_size_option) {
             const uint32_t threads = parse_thread_option(thread_option);
             const auto thread_layout =
                 parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
+            const auto batch_size = parse_batch_size_option(batch_size_option);
             clifft::sampling::SamplingSurvivorResult result;
             {
                 nb::gil_scoped_release release;
                 result = clifft::sampling::sample_k_survivors(program, shots, k, seed, keep_records,
-                                                              threads, thread_layout);
+                                                              threads, thread_layout, batch_size);
             }
             return make_survivor_result(std::move(result), program, keep_records);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("k"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
         nb::arg("thread_layout") = nb::none(), nb::arg("intra_shot_min_active_width") = nb::none(),
+        nb::arg("batch_size") = std::string("auto"),
         "Sample survivors with exactly k forced faults per shot.\n\n"
         "Results are conditioned on K=k. To estimate the overall logical\n"
         "error rate across strata, weight numerator and denominator\n"
@@ -958,7 +989,10 @@ NB_MODULE(_clifft_core, m) {
         "implementation-reported hardware concurrency; it defaults to 1.\n"
         "thread_layout=(shot_workers, intra_shot_workers) overrides automatic\n"
         "scheduling. intra_shot_min_active_width overrides the default threshold\n"
-        "of 18 for an explicit layout.\n\n"
+        "of 18 for an explicit layout. batch_size='auto' selects an adaptive\n"
+        "cross-shot batch, 1 forces scalar execution, and a larger integer caps\n"
+        "the lanes retained by each shot worker. Packed batching cannot be\n"
+        "combined with intra-shot workers.\n\n"
         "Returns a SampleResult. Survivor metadata is always populated via\n"
         ".total_shots, .passed_shots, .discards, .logical_errors, and\n"
         ".observable_ones. Per-shot record arrays\n"
@@ -971,28 +1005,34 @@ NB_MODULE(_clifft_core, m) {
             const clifft::sampling::ExecutablePlan& program, uint32_t shots,
             std::optional<uint64_t> seed, bool keep_records, const ThreadOption& thread_option,
             const std::optional<std::tuple<int64_t, int64_t>>& thread_layout_option,
-            std::optional<int64_t> intra_shot_min_active_width) {
+            std::optional<int64_t> intra_shot_min_active_width,
+            const BatchSizeOption& batch_size_option) {
             const uint32_t threads = parse_thread_option(thread_option);
             const auto thread_layout =
                 parse_thread_layout(thread_layout_option, intra_shot_min_active_width);
+            const auto batch_size = parse_batch_size_option(batch_size_option);
             clifft::sampling::SamplingSurvivorResult result;
             {
                 nb::gil_scoped_release release;
                 result = clifft::sampling::sample_survivors(program, shots, seed, keep_records,
-                                                            threads, thread_layout);
+                                                            threads, thread_layout, batch_size);
             }
             return make_survivor_result(std::move(result), program, keep_records);
         },
         nb::arg("program"), nb::arg("shots"), nb::arg("seed") = nb::none(),
         nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
         nb::arg("thread_layout") = nb::none(), nb::arg("intra_shot_min_active_width") = nb::none(),
+        nb::arg("batch_size") = std::string("auto"),
         "Sample shots and return results only for surviving (non-discarded) shots.\n\n"
         "If seed is None (default), uses hardware entropy. threads is a positive\n"
         "total worker budget or 'auto' to use the implementation-reported hardware\n"
         "concurrency; it defaults to 1. thread_layout=(shot_workers,\n"
         "intra_shot_workers) overrides automatic scheduling.\n"
         "intra_shot_min_active_width overrides the default threshold of 18 for\n"
-        "an explicit layout.\n\n"
+        "an explicit layout. batch_size='auto' selects an adaptive cross-shot\n"
+        "batch, 1 forces scalar execution, and a larger integer caps the lanes\n"
+        "retained by each shot worker. Packed batching cannot be combined with\n"
+        "intra-shot workers.\n\n"
         "Returns a SampleResult. Survivor metadata is always populated via\n"
         ".total_shots, .passed_shots, .discards, .logical_errors, and\n"
         ".observable_ones. Per-shot record arrays\n"

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/planner_frame.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/pauli_preparation.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/batch_bits.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/batch_executor.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/kernel_dispatch.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/executable_plan_builder.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ include(Catch)
 add_executable(clifft_tests
     test_benchmarks.cc
     test_bitmask.cc
+    test_batch_bits.cc
+    test_batch_executor.cc
     test_mask_view.cc
     test_page_allocation.cc
     test_parser.cc

--- a/tests/python/test_importance_sampling.py
+++ b/tests/python/test_importance_sampling.py
@@ -160,6 +160,13 @@ class TestSampleK(_ImportanceBackendMixin):
         threaded = self.sampling_api.sample_k(prog, shots=257, k=1, seed=99, threads="auto")
         np.testing.assert_array_equal(threaded.measurements, serial.measurements)
 
+    @pytest.mark.parametrize("batch_size", [2, 63, 64, 65, "auto"])
+    def test_batch_size_preserves_seeded_rows(self, batch_size: Any) -> None:
+        prog = self.compile("X_ERROR(0.1) 0 1 2\nM 0 1 2")
+        scalar = self.sampling_api.sample_k(prog, shots=257, k=1, seed=991, batch_size=1)
+        packed = self.sampling_api.sample_k(prog, shots=257, k=1, seed=991, batch_size=batch_size)
+        np.testing.assert_array_equal(packed.measurements, scalar.measurements)
+
     def test_readout_noise_forcing(self) -> None:
         """k=1 with only readout noise should flip every shot."""
         prog = self.compile(
@@ -230,6 +237,32 @@ class TestSampleKSurvivors(_ImportanceBackendMixin):
         np.testing.assert_array_equal(threaded.measurements, serial.measurements)
         np.testing.assert_array_equal(threaded.detectors, serial.detectors)
         np.testing.assert_array_equal(threaded.observables, serial.observables)
+
+    @pytest.mark.parametrize("batch_size", [2, 63, 64, 65, "auto"])
+    def test_batch_size_preserves_seeded_survivors(self, batch_size: Any) -> None:
+        prog = self.sampling_api.compile(
+            "X_ERROR(0.1) 0 1 2\nM 0 1 2\nEXP_VAL Z0\n"
+            "DETECTOR rec[-3]\nOBSERVABLE_INCLUDE(0) rec[-1]",
+            postselection_mask=[1],
+        )
+        scalar = self.sampling_api.sample_k_survivors(
+            prog, shots=257, k=1, seed=1001, keep_records=True, batch_size=1
+        )
+        packed = self.sampling_api.sample_k_survivors(
+            prog,
+            shots=257,
+            k=1,
+            seed=1001,
+            keep_records=True,
+            batch_size=batch_size,
+        )
+        assert packed.passed_shots == scalar.passed_shots
+        assert packed.logical_errors == scalar.logical_errors
+        np.testing.assert_array_equal(packed.observable_ones, scalar.observable_ones)
+        np.testing.assert_array_equal(packed.measurements, scalar.measurements)
+        np.testing.assert_array_equal(packed.detectors, scalar.detectors)
+        np.testing.assert_array_equal(packed.observables, scalar.observables)
+        np.testing.assert_array_equal(packed.exp_vals, scalar.exp_vals)
 
 
 class TestImportanceSamplingEndToEnd(_ImportanceBackendMixin):

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -151,6 +151,38 @@ class TestSample:
         np.testing.assert_array_equal(threaded.detectors, serial.detectors)
         np.testing.assert_array_equal(threaded.observables, serial.observables)
 
+    @pytest.mark.parametrize("batch_size", [2, 63, 64, 65, "auto"])
+    def test_sample_batch_size_preserves_seeded_rows(
+        self, sampling_api: Any, batch_size: Any
+    ) -> None:
+        prog = sampling_api.compile(
+            "X_ERROR(0.125) 0\nH 0 1\nT 0\nM 0 1\n"
+            "DETECTOR rec[-2] rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\nEXP_VAL Z0"
+        )
+        scalar = sampling_api.sample(prog, 257, seed=8123, batch_size=1)
+        packed = sampling_api.sample(prog, 257, seed=8123, batch_size=batch_size)
+        np.testing.assert_array_equal(packed.measurements, scalar.measurements)
+        np.testing.assert_array_equal(packed.detectors, scalar.detectors)
+        np.testing.assert_array_equal(packed.observables, scalar.observables)
+        np.testing.assert_array_equal(packed.exp_vals, scalar.exp_vals)
+
+    @pytest.mark.parametrize("batch_size", [0, -1, "all", 1.5, 2**40])
+    def test_sample_rejects_invalid_batch_size(self, sampling_api: Any, batch_size: Any) -> None:
+        prog = sampling_api.compile("M 0")
+        with pytest.raises((TypeError, ValueError), match="batch_size|incompatible"):
+            sampling_api.sample(prog, 1, batch_size=batch_size)
+
+    def test_sample_rejects_packed_intra_shot_layout(self, sampling_api: Any) -> None:
+        prog = sampling_api.compile("H 0\nT 0\nM 0")
+        with pytest.raises((ValueError, RuntimeError), match="batch_size|intra-shot|OpenMP"):
+            sampling_api.sample(
+                prog,
+                2,
+                thread_layout=(1, 2),
+                intra_shot_min_active_width=0,
+                batch_size=2,
+            )
+
     @pytest.mark.parametrize("threads", [0, -1, "all", 1.5])
     def test_sample_rejects_invalid_threads(self, sampling_api: Any, threads: Any) -> None:
         """Only positive integers and the auto sentinel are accepted."""
@@ -921,6 +953,27 @@ class TestSampleSurvivors:
         np.testing.assert_array_equal(threaded.measurements, serial.measurements)
         np.testing.assert_array_equal(threaded.detectors, serial.detectors)
         np.testing.assert_array_equal(threaded.observables, serial.observables)
+
+    @pytest.mark.parametrize("batch_size", [2, 63, 64, 65, "auto"])
+    def test_batch_size_preserves_survivor_rows(self, sampling_api: Any, batch_size: Any) -> None:
+        prog = sampling_api.compile(
+            "H 0\nM 0\nEXP_VAL Z0\nDETECTOR rec[-1]\nH 1\nT 1\n"
+            "EXP_VAL X1\nM 1\nOBSERVABLE_INCLUDE(0) rec[-1]",
+            postselection_mask=[1],
+        )
+        scalar = sampling_api.sample_survivors(
+            prog, 257, seed=54322, keep_records=True, batch_size=1
+        )
+        packed = sampling_api.sample_survivors(
+            prog, 257, seed=54322, keep_records=True, batch_size=batch_size
+        )
+        assert packed.passed_shots == scalar.passed_shots
+        assert packed.logical_errors == scalar.logical_errors
+        np.testing.assert_array_equal(packed.observable_ones, scalar.observable_ones)
+        np.testing.assert_array_equal(packed.measurements, scalar.measurements)
+        np.testing.assert_array_equal(packed.detectors, scalar.detectors)
+        np.testing.assert_array_equal(packed.observables, scalar.observables)
+        np.testing.assert_array_equal(packed.exp_vals, scalar.exp_vals)
 
     def test_no_postselection_all_pass(self, sampling_api: Any) -> None:
         """Without postselection, all shots pass."""

--- a/tests/test_batch_bits.cc
+++ b/tests/test_batch_bits.cc
@@ -1,0 +1,65 @@
+#include "clifft/sampling/batch_bits.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <vector>
+
+using clifft::sampling::fill_low_lane_mask;
+using clifft::sampling::packed_word_count;
+using clifft::sampling::PackedBitColumns;
+
+TEST_CASE("Packed batch columns preserve lane boundaries") {
+    for (uint32_t lanes : std::array<uint32_t, 7>{1, 2, 63, 64, 65, 127, 128}) {
+        PackedBitColumns columns(3, lanes);
+        columns.set_bit(0, 0);
+        columns.set_bit(1, lanes - 1);
+        for (uint32_t lane = 0; lane < lanes; ++lane) {
+            if ((lane % 3) == 1) {
+                columns.set_bit(2, lane);
+            }
+        }
+        CAPTURE(lanes);
+        REQUIRE(columns.bit(0, 0));
+        REQUIRE(columns.bit(1, lanes - 1));
+        for (uint32_t lane = 0; lane < lanes; ++lane) {
+            REQUIRE(columns.bit(2, lane) == ((lane % 3) == 1));
+        }
+    }
+}
+
+TEST_CASE("Packed batch columns compact every sidecar stably") {
+    constexpr uint32_t lanes = 130;
+    PackedBitColumns columns(4, lanes);
+    std::vector<uint64_t> keep(packed_word_count(lanes), 0);
+    std::vector<uint32_t> sources;
+    for (uint32_t lane = 0; lane < lanes; ++lane) {
+        if ((lane % 5) != 1 && lane != 64) {
+            keep[lane >> 6] |= uint64_t{1} << (lane & 63);
+            sources.push_back(lane);
+        }
+        for (size_t column = 0; column < columns.num_columns(); ++column) {
+            if (((lane * 7 + static_cast<uint32_t>(column)) % 11) < 4) {
+                columns.set_bit(column, lane);
+            }
+        }
+    }
+
+    std::vector<uint64_t> scratch(packed_word_count(lanes), 0);
+    columns.compact(keep, lanes, static_cast<uint32_t>(sources.size()), scratch);
+    for (size_t column = 0; column < columns.num_columns(); ++column) {
+        for (uint32_t destination = 0; destination < sources.size(); ++destination) {
+            CAPTURE(column, destination, sources[destination]);
+            REQUIRE(columns.bit(column, destination) ==
+                    (((sources[destination] * 7 + static_cast<uint32_t>(column)) % 11) < 4));
+        }
+    }
+}
+
+TEST_CASE("Packed batch low masks clear padding") {
+    std::vector<uint64_t> words(3, ~uint64_t{0});
+    fill_low_lane_mask(words, 65);
+    REQUIRE(words[0] == ~uint64_t{0});
+    REQUIRE(words[1] == 1);
+    REQUIRE(words[2] == 0);
+}

--- a/tests/test_batch_executor.cc
+++ b/tests/test_batch_executor.cc
@@ -1,0 +1,167 @@
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/sampling/batch_executor.h"
+#include "clifft/sampling/executor.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/util/fault_sampling.h"
+#include "clifft/util/shot_seed.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+using clifft::derive_state;
+using clifft::KFaultSampler;
+using clifft::make_seed_root;
+using clifft::SeedRoot;
+using clifft::sampling::BatchExecutor;
+using clifft::sampling::ExecutablePlan;
+using clifft::sampling::Executor;
+using clifft::sampling::resolve_batch_capacity;
+
+namespace {
+
+void seed_executor(Executor& executor, const SeedRoot& root, uint32_t shot) {
+    const std::array<uint64_t, 4> words = derive_state(root, shot, clifft::kSamplingExecutorDomain);
+    executor.reseed_full(words[0], words[1], words[2], words[3]);
+}
+
+ExecutablePlan compile_batch_test_plan(
+    std::optional<std::span<const uint8_t>> postselection = std::nullopt) {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        X_ERROR(0.125) 0
+        H 0
+        T 0
+        M 0
+        H 1
+        M(0.25) 1
+        EXP_VAL Z1
+        DETECTOR rec[-2] rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        H 2
+        T 2
+        EXP_VAL X2
+        M 2
+    )"));
+    clifft::sampling::SamplingPlanOptions options;
+    if (postselection.has_value()) {
+        options.postselection_mask = *postselection;
+    }
+    return ExecutablePlan(clifft::sampling::plan_sampling(hir, options));
+}
+
+void compare_lane_outputs(const BatchExecutor& batch, uint32_t lane, const Executor& scalar,
+                          const ExecutablePlan& plan) {
+    for (uint32_t record = 0; record < plan.num_visible_records(); ++record) {
+        CAPTURE(lane, record);
+        REQUIRE(batch.measurement(lane, record) == (scalar.visible_records()[record] != 0));
+    }
+    for (uint32_t detector = 0; detector < plan.num_detectors(); ++detector) {
+        CAPTURE(lane, detector);
+        REQUIRE(batch.detector(lane, detector) == (scalar.detectors()[detector] != 0));
+    }
+    for (uint32_t observable = 0; observable < plan.num_observables(); ++observable) {
+        CAPTURE(lane, observable);
+        REQUIRE(batch.observable(lane, observable) == (scalar.observables()[observable] != 0));
+    }
+    for (uint32_t exp_val = 0; exp_val < plan.num_exp_vals(); ++exp_val) {
+        CAPTURE(lane, exp_val);
+        REQUIRE(batch.exp_val(lane, exp_val) == scalar.exp_vals()[exp_val]);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("Packed executor preserves seeded fixed-plan rows") {
+    constexpr uint32_t shots = 65;
+    const ExecutablePlan plan = compile_batch_test_plan();
+    const SeedRoot root = make_seed_root(shots, uint64_t{9183});
+    BatchExecutor batch(plan, shots);
+    batch.run_batch(root, 0, shots);
+    REQUIRE(batch.surviving_shots() == shots);
+
+    Executor scalar(plan);
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        seed_executor(scalar, root, shot);
+        scalar.run_shot();
+        REQUIRE(batch.shot_index(shot) == shot);
+        compare_lane_outputs(batch, shot, scalar, plan);
+    }
+}
+
+TEST_CASE("Packed executor compacts seeded survivor sidecars") {
+    constexpr uint32_t shots = 129;
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan plan = compile_batch_test_plan(postselection);
+    const SeedRoot root = make_seed_root(shots, uint64_t{9184});
+    BatchExecutor batch(plan, shots);
+    batch.run_batch(root, 0, shots);
+
+    Executor scalar(plan);
+    uint32_t lane = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        seed_executor(scalar, root, shot);
+        scalar.run_shot();
+        if (scalar.discarded()) {
+            continue;
+        }
+        REQUIRE(lane < batch.surviving_shots());
+        REQUIRE(batch.shot_index(lane) == shot);
+        compare_lane_outputs(batch, lane, scalar, plan);
+        ++lane;
+    }
+    REQUIRE(lane == batch.surviving_shots());
+}
+
+TEST_CASE("Packed executor preserves fixed-fault rows") {
+    constexpr uint32_t shots = 67;
+    const ExecutablePlan plan = compile_batch_test_plan();
+    const SeedRoot root = make_seed_root(shots, uint64_t{9185});
+    const std::vector<double> probabilities = plan.noise_site_probabilities();
+    KFaultSampler batch_faults(probabilities, 1);
+    BatchExecutor batch(plan, shots);
+    batch.run_batch(root, 0, shots, batch_faults);
+
+    KFaultSampler scalar_faults(probabilities, 1);
+    Executor scalar(plan);
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        seed_executor(scalar, root, shot);
+        scalar.run_shot(scalar_faults);
+        REQUIRE(batch.shot_index(shot) == shot);
+        compare_lane_outputs(batch, shot, scalar, plan);
+    }
+}
+
+TEST_CASE("Packed capacity policy bounds worker state footprint") {
+    const ExecutablePlan narrow(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse("H 0 1\nM 0 1\n"))));
+    REQUIRE(resolve_batch_capacity(narrow, 4096, 1, 1, std::nullopt) == 512);
+    REQUIRE(resolve_batch_capacity(narrow, 1024, 4, 1, std::nullopt) == 256);
+    REQUIRE(resolve_batch_capacity(narrow, 63, 1, 1, std::nullopt) == 1);
+    REQUIRE(resolve_batch_capacity(narrow, 63, 1, 1, uint32_t{65}) == 63);
+    REQUIRE(resolve_batch_capacity(narrow, 4096, 1, 1, uint32_t{4096}) == 2048);
+    REQUIRE(resolve_batch_capacity(narrow, 4096, 1, 1, uint32_t{1}) == 1);
+    REQUIRE_THROWS_WITH(resolve_batch_capacity(narrow, 4096, 1, 2, uint32_t{2}),
+                        "packed batch_size is incompatible with intra-shot workers");
+
+    std::string circuit;
+    for (uint32_t qubit = 0; qubit < 12; ++qubit) {
+        circuit.append("H ")
+            .append(std::to_string(qubit))
+            .append("\nT ")
+            .append(std::to_string(qubit))
+            .append("\n");
+    }
+    const ExecutablePlan wide(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse(circuit))));
+    REQUIRE(wide.peak_active_width() == 12);
+    REQUIRE(resolve_batch_capacity(wide, 4096, 1, 1, std::nullopt) == 1);
+
+    const ExecutablePlan noisy = compile_batch_test_plan();
+    REQUIRE(resolve_batch_capacity(noisy, 4096, 1, 1, std::nullopt) == 1);
+    REQUIRE(resolve_batch_capacity(noisy, 4096, 1, 1, uint32_t{65}) == 65);
+}

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -15,6 +15,7 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
 #include <numeric>
+#include <optional>
 #include <vector>
 
 using Catch::Matchers::WithinAbs;
@@ -570,6 +571,51 @@ TEST_CASE("Threaded conditioned sampling preserves seeded rows and survivors") {
     REQUIRE(survivor_threaded.detectors == survivor_serial.detectors);
     REQUIRE(survivor_threaded.observables == survivor_serial.observables);
     REQUIRE(survivor_threaded.exp_vals == survivor_serial.exp_vals);
+}
+
+TEST_CASE("Explicit batch capacities preserve conditioned rows and survivors") {
+    auto fixed = compile_circuit(R"(
+        X_ERROR(0.1) 0 1 2
+        M 0 1 2
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        EXP_VAL Z2
+    )");
+    const clifft::sampling::SamplingResult fixed_scalar =
+        clifft::sampling::sample_k(fixed, 257, 1, 481, 1, std::nullopt, uint32_t{1});
+
+    const std::array<uint8_t, 1> postselection{1};
+    auto survivors = compile_circuit(R"(
+        X_ERROR(0.1) 0 1 2
+        M 0 1 2
+        EXP_VAL Z0
+        DETECTOR rec[-3]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )",
+                                     postselection);
+    const clifft::sampling::SamplingSurvivorResult survivor_scalar =
+        clifft::sampling::sample_k_survivors(survivors, 257, 1, 482, true, 1, std::nullopt,
+                                             uint32_t{1});
+
+    for (uint32_t capacity : std::array<uint32_t, 4>{2, 63, 64, 65}) {
+        const clifft::sampling::SamplingResult fixed_packed =
+            clifft::sampling::sample_k(fixed, 257, 1, 481, 1, std::nullopt, capacity);
+        const clifft::sampling::SamplingSurvivorResult survivor_packed =
+            clifft::sampling::sample_k_survivors(survivors, 257, 1, 482, true, 1, std::nullopt,
+                                                 capacity);
+        CAPTURE(capacity);
+        REQUIRE(fixed_packed.measurements == fixed_scalar.measurements);
+        REQUIRE(fixed_packed.detectors == fixed_scalar.detectors);
+        REQUIRE(fixed_packed.observables == fixed_scalar.observables);
+        REQUIRE(fixed_packed.exp_vals == fixed_scalar.exp_vals);
+        REQUIRE(survivor_packed.total_shots == survivor_scalar.total_shots);
+        REQUIRE(survivor_packed.passed_shots == survivor_scalar.passed_shots);
+        REQUIRE(survivor_packed.logical_errors == survivor_scalar.logical_errors);
+        REQUIRE(survivor_packed.observable_ones == survivor_scalar.observable_ones);
+        REQUIRE(survivor_packed.measurements == survivor_scalar.measurements);
+        REQUIRE(survivor_packed.detectors == survivor_scalar.detectors);
+        REQUIRE(survivor_packed.observables == survivor_scalar.observables);
+        REQUIRE(survivor_packed.exp_vals == survivor_scalar.exp_vals);
+    }
 }
 
 TEST_CASE("Symbolic conditioned sampling rejects asymmetric readout noise") {

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1352,6 +1352,30 @@ TEST_CASE("Threaded fixed-row sampling preserves seeded shot order") {
     }
 }
 
+TEST_CASE("Explicit batch capacities preserve seeded fixed rows") {
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+        X_ERROR(0.125) 0
+        H 0 1
+        T 0
+        M(0.25) 0 1
+        DETECTOR rec[-2] rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        EXP_VAL Z0
+    )"))));
+    const clifft::sampling::SamplingResult scalar =
+        clifft::sampling::sample(executable, 257, uint64_t{91831}, 1, std::nullopt, uint32_t{1});
+
+    for (uint32_t capacity : std::array<uint32_t, 4>{2, 63, 64, 65}) {
+        const clifft::sampling::SamplingResult packed =
+            clifft::sampling::sample(executable, 257, uint64_t{91831}, 1, std::nullopt, capacity);
+        CAPTURE(capacity);
+        REQUIRE(packed.measurements == scalar.measurements);
+        REQUIRE(packed.detectors == scalar.detectors);
+        REQUIRE(packed.observables == scalar.observables);
+        REQUIRE(packed.exp_vals == scalar.exp_vals);
+    }
+}
+
 TEST_CASE("Sampling thread layouts validate explicit worker counts") {
     const ExecutablePlan executable(plan_from("H 0\nM 0\n"));
     REQUIRE_THROWS_WITH(clifft::sampling::sample(executable, 1, uint64_t{11}, 1,
@@ -1485,7 +1509,9 @@ TEST_CASE("Threaded survivor sampling preserves seeded survivors and records") {
             OBSERVABLE_INCLUDE(0) rec[-1]
             EXP_VAL Z1
         )")),
-                                        {.postselection_mask = postselection}));
+                                        {.postselection_mask = postselection,
+                                         .expected_detectors = {},
+                                         .expected_observables = {}}));
     const clifft::sampling::SamplingSurvivorResult serial =
         clifft::sampling::sample_survivors(executable, 257, uint64_t{9184}, true, 1);
 
@@ -1501,6 +1527,41 @@ TEST_CASE("Threaded survivor sampling preserves seeded survivors and records") {
         REQUIRE(threaded.detectors == serial.detectors);
         REQUIRE(threaded.observables == serial.observables);
         REQUIRE(threaded.exp_vals == serial.exp_vals);
+    }
+}
+
+TEST_CASE("Explicit batch capacities preserve seeded survivor rows") {
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+            H 0
+            M 0
+            EXP_VAL Z0
+            DETECTOR rec[-1]
+            H 1
+            T 1
+            EXP_VAL X1
+            M 1
+            OBSERVABLE_INCLUDE(0) rec[-1]
+        )")),
+                                        {.postselection_mask = postselection,
+                                         .expected_detectors = {},
+                                         .expected_observables = {}}));
+    const clifft::sampling::SamplingSurvivorResult scalar = clifft::sampling::sample_survivors(
+        executable, 257, uint64_t{91841}, true, 1, std::nullopt, uint32_t{1});
+
+    for (uint32_t capacity : std::array<uint32_t, 4>{2, 63, 64, 65}) {
+        const clifft::sampling::SamplingSurvivorResult packed = clifft::sampling::sample_survivors(
+            executable, 257, uint64_t{91841}, true, 1, std::nullopt, capacity);
+        CAPTURE(capacity);
+        REQUIRE(packed.total_shots == scalar.total_shots);
+        REQUIRE(packed.passed_shots == scalar.passed_shots);
+        REQUIRE(packed.logical_errors == scalar.logical_errors);
+        REQUIRE(packed.observable_ones == scalar.observable_ones);
+        REQUIRE(packed.measurements == scalar.measurements);
+        REQUIRE(packed.detectors == scalar.detectors);
+        REQUIRE(packed.observables == scalar.observables);
+        REQUIRE(packed.exp_vals == scalar.exp_vals);
     }
 }
 

--- a/tests/test_shot_parallel.cc
+++ b/tests/test_shot_parallel.cc
@@ -16,6 +16,8 @@ TEST_CASE("Shot scheduler resolves bounded worker counts") {
     REQUIRE(clifft::resolve_shot_worker_count(1, 0) == 1);
     REQUIRE(clifft::resolve_shot_worker_count(3, 1) == 1);
     REQUIRE(clifft::resolve_shot_worker_count(3, 99) == 3);
+    REQUIRE(clifft::shot_chunk_size(1000, 4) == 32);
+    REQUIRE(clifft::shot_chunk_size(1000, 4, 64) == 64);
 }
 
 TEST_CASE("Shot scheduler constructs workers before dispatch and visits each shot") {

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -71,6 +71,7 @@ CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim \
 | `CLIFFT_PROFILE_SHOT_WORKERS` | unset | Explicit cross-shot workers; set with intra-shot workers |
 | `CLIFFT_PROFILE_INTRA_SHOT_WORKERS` | unset | Explicit per-shot workers; set with shot workers |
 | `CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH` | 18 | Expert kernel threshold; requires an explicit layout |
+| `CLIFFT_PROFILE_BATCH_SIZE` | auto | Cross-shot batch capacity; `1` forces scalar execution |
 | `CLIFFT_PROFILE_WARMUPS` | 2 | Untimed sample calls |
 | `CLIFFT_PROFILE_REPETITIONS` | 20 | Timed sample calls |
 | `CLIFFT_PROFILE_GENERATED_WIDTH` | unset | Generate a rotation-heavy circuit of this width instead of loading a file |

--- a/tools/profile/profile_sample.cpp
+++ b/tools/profile/profile_sample.cpp
@@ -124,12 +124,14 @@ int main() {
     const char* shot_workers_value = std::getenv("CLIFFT_PROFILE_SHOT_WORKERS");
     const char* intra_workers_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_WORKERS");
     const char* min_active_width_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH");
+    const char* batch_size_value = std::getenv("CLIFFT_PROFILE_BATCH_SIZE");
     const bool has_layout = shot_workers_value != nullptr || intra_workers_value != nullptr;
     const int shot_workers = get_env_int("CLIFFT_PROFILE_SHOT_WORKERS", 0);
     const int intra_shot_workers = get_env_int("CLIFFT_PROFILE_INTRA_SHOT_WORKERS", 0);
     const int intra_shot_min_active_width =
         get_env_int("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH",
                     static_cast<int>(clifft::kDefaultIntraShotMinActiveWidth));
+    const int batch_size = get_env_int("CLIFFT_PROFILE_BATCH_SIZE", 1);
     if (shots < 1 || threads < 0 || warmups < 0 || repetitions < 1) {
         std::cerr << "Error: shots and repetitions must be positive; threads and warmups must be "
                      "non-negative\n";
@@ -155,6 +157,10 @@ int main() {
         std::cerr << "Error: the intra-shot minimum active width must be non-negative\n";
         return 1;
     }
+    if (batch_size_value != nullptr && batch_size < 1) {
+        std::cerr << "Error: batch size must be positive\n";
+        return 1;
+    }
 
     std::cout << "Clifft Sampling Profiler\n";
     std::cout << "========================\n";
@@ -171,6 +177,9 @@ int main() {
                   << " intra-shot\n";
         std::cout << "Min width:   " << intra_shot_min_active_width << "\n";
     }
+    std::cout << "Batch size:  "
+              << (batch_size_value == nullptr ? std::string("auto") : std::to_string(batch_size))
+              << "\n";
     std::cout << "Warmups:     " << warmups << "\n";
     std::cout << "Repetitions: " << repetitions << "\n\n";
 
@@ -197,21 +206,25 @@ int main() {
                                                                  static_cast<uint32_t>(
                                                                      intra_shot_min_active_width)}}
             : std::nullopt;
+    const std::optional<uint32_t> requested_batch_size =
+        batch_size_value == nullptr ? std::nullopt
+                                    : std::optional<uint32_t>{static_cast<uint32_t>(batch_size)};
 
     uint64_t checksum = 0;
     for (int iteration = 0; iteration < warmups; ++iteration) {
-        checksum = mix(checksum, checksum_result(clifft::sampling::sample(
-                                     program, static_cast<uint32_t>(shots), kSeed + iteration,
-                                     static_cast<uint32_t>(threads), thread_layout)));
+        checksum = mix(checksum,
+                       checksum_result(clifft::sampling::sample(
+                           program, static_cast<uint32_t>(shots), kSeed + iteration,
+                           static_cast<uint32_t>(threads), thread_layout, requested_batch_size)));
     }
 
     std::vector<double> samples_ms;
     samples_ms.reserve(static_cast<size_t>(repetitions));
     for (int iteration = 0; iteration < repetitions; ++iteration) {
         const auto start = std::chrono::steady_clock::now();
-        auto result = clifft::sampling::sample(program, static_cast<uint32_t>(shots),
-                                               kSeed + warmups + iteration,
-                                               static_cast<uint32_t>(threads), thread_layout);
+        auto result = clifft::sampling::sample(
+            program, static_cast<uint32_t>(shots), kSeed + warmups + iteration,
+            static_cast<uint32_t>(threads), thread_layout, requested_batch_size);
         const auto end = std::chrono::steady_clock::now();
         samples_ms.push_back(std::chrono::duration<double, std::milli>(end - start).count());
         checksum = mix(checksum, checksum_result(result));


### PR DESCRIPTION
Closes #313.

## Summary

- add a CPU `BatchExecutor` that traverses one immutable executable plan for packed shot lanes
- bit-pack symbols, expression registers, records, detectors, observables, readout faults, and live masks while retaining one existing dense `State` and RNG stream per lane
- preserve seeded shot identity, stable survivor order, expectation sidecars, fixed-k conditioning, postselection, and cross-shot worker composition
- add cost-based live-lane compaction with fixed preallocated storage
- expose `batch_size="auto" | int` on `sample`, `sample_survivors`, `sample_k`, and `sample_k_survivors`
- add profiler control through `CLIFFT_PROFILE_BATCH_SIZE`

## Policy and limits

Automatic mode currently selects up to 512 lanes only for noiseless, peak-active-width-zero CPU plans with at least 64 shots per worker. Benchmarks showed that noisy presampling and action-major dense-state traversal do not yet reliably beat the scalar executor, so those plans conservatively resolve to one lane. Explicit positive capacities force the packed path up to 2048 lanes for profiling and expert use.

Packed execution does not support transition instruments, traps, continuations, record replay, externally supplied presampled symbols, WebAssembly, or combination with intra-shot workers. The existing scalar and trajectory paths remain unchanged.

## Validation

- 876 native test cases, 2,320,358 assertions: pass
- sampling and importance Python suites, 141 tests: pass
- repository pre-commit suite: pass
- profiler target: builds
- forced capacities 2, 63, 64, and 65 match scalar rows for ordinary, survivor, fixed-k, and fixed-k-survivor sampling
- dedicated regression verifies expectation columns computed before rejection remain aligned after compaction

## Benchmark note

On the current VM, automatic batching reduced median time for the existing 50-qubit deep-Clifford 100k-shot workload from 0.0754 s to 0.0587 s, about 22 percent. Noisy surface-code and active-width-10 cultivation workloads resolve to scalar and remained within run-to-run noise.