### PR TITLE
perf(sampling): specialize packed hot paths

### DIFF
--- a/src/clifft/sampling/batch_executor.cc
+++ b/src/clifft/sampling/batch_executor.cc
@@ -111,8 +111,10 @@ uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots, uint
 #endif
 }
 
-BatchExecutor::BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity)
+BatchExecutor::BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity,
+                             BatchOutputMode output_mode)
     : plan_(validate_batch_plan(plan)),
+      output_mode_(output_mode),
       lane_capacity_(lane_capacity),
       word_capacity_(packed_word_count(lane_capacity)),
       state_bytes_per_lane_(State::allocation_bytes_for(plan.peak_active_width_)),
@@ -122,12 +124,17 @@ BatchExecutor::BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity)
       shot_indices_(lane_capacity),
       symbols_(plan.num_symbols_, lane_capacity),
       expression_registers_(plan.expression_register_constants_.size(), lane_capacity),
-      records_(static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_,
+      records_(output_mode == BatchOutputMode::Rows
+                   ? static_cast<size_t>(plan.num_visible_records_) + plan.num_hidden_records_
+                   : 0,
                lane_capacity),
-      detectors_(plan.num_detectors_, lane_capacity),
+      detectors_(output_mode == BatchOutputMode::Rows ? plan.num_detectors_ : 0, lane_capacity),
       observables_(plan.num_observables_, lane_capacity),
       forced_readout_(plan.num_readout_noise_sites_, lane_capacity),
-      exp_vals_(checked_product(plan.num_exp_vals_, lane_capacity, "expectation"), 0.0),
+      exp_vals_(output_mode == BatchOutputMode::Rows
+                    ? checked_product(plan.num_exp_vals_, lane_capacity, "expectation")
+                    : 0,
+                0.0),
       live_words_(word_capacity_, 0),
       scratch_words_(word_capacity_, 0),
       compaction_scratch_(word_capacity_, 0) {
@@ -171,7 +178,9 @@ void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_
 #endif
     }
     assert(executed && "unhandled packed sampling executor backend");
-    finalize_live_lanes();
+    if (output_mode_ == BatchOutputMode::Rows) {
+        finalize_live_lanes();
+    }
 }
 
 void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_t shots,
@@ -203,7 +212,9 @@ void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_
 #endif
     }
     assert(executed && "unhandled packed sampling executor backend");
-    finalize_live_lanes();
+    if (output_mode_ == BatchOutputMode::Rows) {
+        finalize_live_lanes();
+    }
 }
 
 void BatchExecutor::reset_batch(const SeedRoot& root, uint32_t first_shot,
@@ -439,7 +450,9 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteActiveMeasuremen
         }
     }
     assign_symbol(action.branch, scratch_words_);
-    records_.assign_xor(action.record, scratch_words_, corrections, live_words_);
+    if (output_mode_ == BatchOutputMode::Rows) {
+        records_.assign_xor(action.record, scratch_words_, corrections, live_words_);
+    }
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDormantMeasurement& action,
@@ -452,12 +465,16 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDormantMeasureme
         }
     }
     assign_symbol(action.branch, scratch_words_);
-    records_.assign_xor(action.record, scratch_words_, corrections, live_words_);
+    if (output_mode_ == BatchOutputMode::Rows) {
+        records_.assign_xor(action.record, scratch_words_, corrections, live_words_);
+    }
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteClassicalRecord& action,
                                    size_t) noexcept {
-    records_.assign(action.record, evaluate(action.outcome), live_words_);
+    if (output_mode_ == BatchOutputMode::Rows) {
+        records_.assign(action.record, evaluate(action.outcome), live_words_);
+    }
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteSymbolDefinition& action,
@@ -486,13 +503,17 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& ac
         }
     }
     assign_symbol(action.flip, scratch_words_);
-    records_.assign_xor(action.record, sources, scratch_words_, live_words_);
+    if (output_mode_ == BatchOutputMode::Rows) {
+        records_.assign_xor(action.record, sources, scratch_words_, live_words_);
+    }
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action,
                                    size_t action_index) noexcept {
     const std::span<const uint64_t> outcomes = evaluate(action.outcome);
-    detectors_.assign(action.detector, outcomes, live_words_);
+    if (output_mode_ == BatchOutputMode::Rows) {
+        detectors_.assign(action.detector, outcomes, live_words_);
+    }
     if (!action.postselected) {
         return;
     }
@@ -515,6 +536,9 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteObservable& acti
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
                                    size_t) noexcept {
+    if (output_mode_ == BatchOutputMode::AggregateSurvivors) {
+        return;
+    }
     assert(action.exp_val < plan_->num_exp_vals_ &&
            "expectation action must reference preallocated storage");
     double* output = exp_vals_.data() + static_cast<size_t>(action.exp_val) * lane_capacity_;
@@ -637,7 +661,7 @@ void BatchExecutor::compact_live_lanes() noexcept {
             state_slots_[destination] = state_slots_[source];
             rngs_[destination] = rngs_[source];
             shot_indices_[destination] = shot_indices_[source];
-            for (uint32_t exp_val = 0; exp_val < plan_->num_exp_vals_; ++exp_val) {
+            for (uint32_t exp_val = 0; exp_val < exp_vals_.size() / lane_capacity_; ++exp_val) {
                 exp_vals_[static_cast<size_t>(exp_val) * lane_capacity_ + destination] =
                     exp_vals_[static_cast<size_t>(exp_val) * lane_capacity_ + source];
             }
@@ -648,6 +672,26 @@ void BatchExecutor::compact_live_lanes() noexcept {
     active_lanes_ = live_count_;
     fill_low_lane_mask(live_words_, active_lanes_);
     ++compactions_;
+}
+
+uint32_t BatchExecutor::accumulate_survivor_counts(
+    std::span<uint64_t> observable_ones) const noexcept {
+    assert(output_mode_ == BatchOutputMode::AggregateSurvivors &&
+           observable_ones.size() == plan_->num_observables_ &&
+           "aggregate survivor outputs must match the prepared observable count");
+    uint32_t logical_errors = 0;
+    const size_t words = packed_word_count(active_lanes_);
+    for (size_t word = 0; word < words; ++word) {
+        const uint64_t live = live_words_[word];
+        uint64_t any_observable = 0;
+        for (uint32_t observable = 0; observable < plan_->num_observables_; ++observable) {
+            const uint64_t ones = observables_.column(observable)[word] & live;
+            observable_ones[observable] += static_cast<uint64_t>(std::popcount(ones));
+            any_observable |= ones;
+        }
+        logical_errors += static_cast<uint32_t>(std::popcount(any_observable));
+    }
+    return logical_errors;
 }
 
 void BatchExecutor::finalize_live_lanes() noexcept {

--- a/src/clifft/sampling/batch_executor.cc
+++ b/src/clifft/sampling/batch_executor.cc
@@ -16,6 +16,14 @@
 
 namespace clifft::sampling {
 
+#if defined(_MSC_VER)
+#define CLIFFT_BATCH_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define CLIFFT_BATCH_NOINLINE __attribute__((noinline))
+#else
+#define CLIFFT_BATCH_NOINLINE
+#endif
+
 namespace {
 
 enum class MeasurementBranchKind : uint8_t {
@@ -137,7 +145,13 @@ BatchExecutor::BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity,
                 0.0),
       live_words_(word_capacity_, 0),
       scratch_words_(word_capacity_, 0),
-      compaction_scratch_(word_capacity_, 0) {
+      compaction_scratch_(word_capacity_, 0),
+      rotation_run_sign_words_(
+          plan.batch_rotation_run_lengths_.empty()
+              ? 0
+              : checked_product(word_capacity_, ExecutablePlan::kMaxBatchRotationRunLength,
+                                "rotation sign scratch"),
+          0) {
     if (lane_capacity_ == 0) {
         throw std::invalid_argument("packed sampling lane capacity must be positive");
     }
@@ -157,12 +171,20 @@ void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_
     [[maybe_unused]] bool executed = false;
     switch (plan_->backend_) {
         case ExecutorBackend::Scalar:
-            execute_actions<ExecutorBackend::Scalar>();
+            if (plan_->batch_rotation_run_lengths_.empty()) {
+                execute_actions<ExecutorBackend::Scalar>();
+            } else {
+                execute_actions_with_rotation_runs<ExecutorBackend::Scalar>();
+            }
             executed = true;
             break;
         case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            execute_actions<ExecutorBackend::Avx2>();
+            if (plan_->batch_rotation_run_lengths_.empty()) {
+                execute_actions<ExecutorBackend::Avx2>();
+            } else {
+                execute_actions_with_rotation_runs<ExecutorBackend::Avx2>();
+            }
             executed = true;
             break;
 #else
@@ -170,7 +192,11 @@ void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_
 #endif
         case ExecutorBackend::Avx512:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            execute_actions<ExecutorBackend::Avx512>();
+            if (plan_->batch_rotation_run_lengths_.empty()) {
+                execute_actions<ExecutorBackend::Avx512>();
+            } else {
+                execute_actions_with_rotation_runs<ExecutorBackend::Avx512>();
+            }
             executed = true;
             break;
 #else
@@ -191,12 +217,20 @@ void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_
     [[maybe_unused]] bool executed = false;
     switch (plan_->backend_) {
         case ExecutorBackend::Scalar:
-            execute_actions<ExecutorBackend::Scalar>();
+            if (plan_->batch_rotation_run_lengths_.empty()) {
+                execute_actions<ExecutorBackend::Scalar>();
+            } else {
+                execute_actions_with_rotation_runs<ExecutorBackend::Scalar>();
+            }
             executed = true;
             break;
         case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            execute_actions<ExecutorBackend::Avx2>();
+            if (plan_->batch_rotation_run_lengths_.empty()) {
+                execute_actions<ExecutorBackend::Avx2>();
+            } else {
+                execute_actions_with_rotation_runs<ExecutorBackend::Avx2>();
+            }
             executed = true;
             break;
 #else
@@ -204,7 +238,11 @@ void BatchExecutor::run_batch(const SeedRoot& root, uint32_t first_shot, uint32_
 #endif
         case ExecutorBackend::Avx512:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
-            execute_actions<ExecutorBackend::Avx512>();
+            if (plan_->batch_rotation_run_lengths_.empty()) {
+                execute_actions<ExecutorBackend::Avx512>();
+            } else {
+                execute_actions_with_rotation_runs<ExecutorBackend::Avx512>();
+            }
             executed = true;
             break;
 #else
@@ -351,21 +389,93 @@ void BatchExecutor::execute_actions() noexcept {
 }
 
 template <ExecutorBackend Backend>
-void BatchExecutor::execute_action(const ExecutablePlan::ExecuteRotation& action, size_t) noexcept {
-    const std::span<const uint64_t> signs = evaluate(action.sign);
+void BatchExecutor::execute_actions_with_rotation_runs() noexcept {
+    for (size_t action_index = 0; action_index < plan_->actions_.size(); ++action_index) {
+        const uint32_t rotation_run = plan_->batch_rotation_run_lengths_[action_index];
+        if (rotation_run != 0) {
+            execute_rotation_run<Backend>(action_index, rotation_run);
+            action_index += rotation_run - 1;
+            continue;
+        }
+        const ExecutablePlan::Action& action = plan_->actions_[action_index];
+        std::visit(
+            [&](const auto& typed) noexcept {
+                using T = std::decay_t<decltype(typed)>;
+                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteRotation> ||
+                              std::is_same_v<T, ExecutablePlan::ExecuteActiveMeasurement>) {
+                    execute_action<Backend>(typed, action_index);
+                } else {
+                    execute_action(typed, action_index);
+                }
+            },
+            action);
+        if (live_count_ == 0) {
+            return;
+        }
+    }
+}
+
+template <ExecutorBackend Backend>
+CLIFFT_BATCH_NOINLINE void BatchExecutor::execute_rotation_run(size_t first_action,
+                                                               uint32_t run_length) noexcept {
+    assert(run_length >= ExecutablePlan::kMinBatchRotationRunLength &&
+           run_length <= ExecutablePlan::kMaxBatchRotationRunLength &&
+           run_length <= plan_->actions_.size() - first_action &&
+           "prepared batch rotation run must fit the action stream");
+    std::array<const ExecutablePlan::ExecuteRotation*, ExecutablePlan::kMaxBatchRotationRunLength>
+        rotations{};
+    std::array<const uint64_t*, ExecutablePlan::kMaxBatchRotationRunLength> signs{};
+    for (uint32_t offset = 0; offset < run_length; ++offset) {
+        rotations[offset] =
+            std::get_if<ExecutablePlan::ExecuteRotation>(&plan_->actions_[first_action + offset]);
+        assert(rotations[offset] != nullptr && "prepared batch run must contain rotations");
+        signs[offset] = evaluate(rotations[offset]->sign).data();
+    }
+    const size_t active_words = packed_word_count(active_lanes_);
+    for (size_t word = 0; word < active_words; ++word) {
+        uint64_t* run_signs =
+            rotation_run_sign_words_.data() + word * ExecutablePlan::kMaxBatchRotationRunLength;
+        for (uint32_t offset = 0; offset < run_length; ++offset) {
+            run_signs[offset] = signs[offset][word];
+        }
+    }
     for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
         if (!is_live(lane)) {
             continue;
         }
-        const bool sign = lane_bit(signs, lane);
-        if (action.kernel == DirectRotationKernel::Scalar) {
-            apply_rotation(state(lane), action.rotation, sign);
-        } else if constexpr (Backend == ExecutorBackend::Avx2) {
-            apply_direct_rotation_avx2(state(lane), action.rotation, action.kernel, sign);
-        } else if constexpr (Backend == ExecutorBackend::Avx512) {
-            apply_direct_rotation_avx512(state(lane), action.rotation, action.kernel, sign);
-        } else {
-            assert(false && "scalar batch executor requires scalar rotation actions");
+        State& lane_state = state(lane);
+        const uint64_t* run_signs =
+            rotation_run_sign_words_.data() +
+            static_cast<size_t>(lane >> 6) * ExecutablePlan::kMaxBatchRotationRunLength;
+        const uint64_t lane_mask = uint64_t{1} << (lane & 63);
+        for (uint32_t offset = 0; offset < run_length; ++offset) {
+            apply_rotation_action<Backend>(lane_state, *rotations[offset],
+                                           (run_signs[offset] & lane_mask) != 0);
+        }
+    }
+}
+
+template <ExecutorBackend Backend>
+void BatchExecutor::apply_rotation_action(State& target,
+                                          const ExecutablePlan::ExecuteRotation& action,
+                                          bool sign) noexcept {
+    if (action.kernel == DirectRotationKernel::Scalar) {
+        apply_rotation(target, action.rotation, sign);
+    } else if constexpr (Backend == ExecutorBackend::Avx2) {
+        apply_direct_rotation_avx2(target, action.rotation, action.kernel, sign);
+    } else if constexpr (Backend == ExecutorBackend::Avx512) {
+        apply_direct_rotation_avx512(target, action.rotation, action.kernel, sign);
+    } else {
+        assert(false && "scalar batch executor requires scalar rotation actions");
+    }
+}
+
+template <ExecutorBackend Backend>
+void BatchExecutor::execute_action(const ExecutablePlan::ExecuteRotation& action, size_t) noexcept {
+    const std::span<const uint64_t> signs = evaluate(action.sign);
+    for (uint32_t lane = 0; lane < active_lanes_; ++lane) {
+        if (is_live(lane)) {
+            apply_rotation_action<Backend>(state(lane), action, lane_bit(signs, lane));
         }
     }
 }
@@ -729,5 +839,7 @@ double BatchExecutor::exp_val(uint32_t lane, uint32_t exp_val_index) const noexc
            "expectation output must be live and in range");
     return exp_vals_[static_cast<size_t>(exp_val_index) * lane_capacity_ + lane];
 }
+
+#undef CLIFFT_BATCH_NOINLINE
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/batch_executor.h
+++ b/src/clifft/sampling/batch_executor.h
@@ -23,6 +23,11 @@ inline constexpr uint32_t kMaxExplicitBatchShots = 2048;
 inline constexpr size_t kDefaultBatchStateBudget = 768 * 1024;
 inline constexpr uint32_t kDefaultMinAutoBatchShots = 64;
 
+enum class BatchOutputMode : uint8_t {
+    Rows,
+    AggregateSurvivors,
+};
+
 // Resolve one worker's retained lane capacity. requested_batch_size is empty
 // for conservative automatic selection, one for the scalar path, or an
 // explicit packed capacity. Validation and allocation happen before dispatch.
@@ -36,7 +41,8 @@ inline constexpr uint32_t kDefaultMinAutoBatchShots = 64;
 // on Executor and are rejected before construction.
 class BatchExecutor {
   public:
-    BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity);
+    BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity,
+                  BatchOutputMode output_mode = BatchOutputMode::Rows);
 
     BatchExecutor(const BatchExecutor&) = delete;
     BatchExecutor& operator=(const BatchExecutor&) = delete;
@@ -50,6 +56,8 @@ class BatchExecutor {
     [[nodiscard]] uint32_t lane_capacity() const noexcept { return lane_capacity_; }
     [[nodiscard]] uint32_t attempted_shots() const noexcept { return attempted_shots_; }
     [[nodiscard]] uint32_t surviving_shots() const noexcept { return live_count_; }
+    [[nodiscard]] uint32_t accumulate_survivor_counts(
+        std::span<uint64_t> observable_ones) const noexcept;
     [[nodiscard]] uint32_t shot_index(uint32_t lane) const noexcept;
     [[nodiscard]] bool measurement(uint32_t lane, uint32_t record) const noexcept;
     [[nodiscard]] bool detector(uint32_t lane, uint32_t detector) const noexcept;
@@ -113,6 +121,7 @@ class BatchExecutor {
     void finalize_live_lanes() noexcept;
 
     const ExecutablePlan* plan_;
+    BatchOutputMode output_mode_ = BatchOutputMode::Rows;
     uint32_t lane_capacity_ = 0;
     size_t word_capacity_ = 0;
     size_t state_bytes_per_lane_ = 0;

--- a/src/clifft/sampling/batch_executor.h
+++ b/src/clifft/sampling/batch_executor.h
@@ -78,6 +78,13 @@ class BatchExecutor {
     template <ExecutorBackend Backend>
     void execute_actions() noexcept;
     template <ExecutorBackend Backend>
+    void execute_actions_with_rotation_runs() noexcept;
+    template <ExecutorBackend Backend>
+    void execute_rotation_run(size_t first_action, uint32_t run_length) noexcept;
+    template <ExecutorBackend Backend>
+    static void apply_rotation_action(State& state, const ExecutablePlan::ExecuteRotation& action,
+                                      bool sign) noexcept;
+    template <ExecutorBackend Backend>
     void execute_action(const ExecutablePlan::ExecuteRotation& action,
                         size_t action_index) noexcept;
     void execute_action(const ExecutablePlan::ExecuteFusedRotation& action,
@@ -145,6 +152,7 @@ class BatchExecutor {
     std::vector<uint64_t> live_words_;
     std::vector<uint64_t> scratch_words_;
     std::vector<uint64_t> compaction_scratch_;
+    std::vector<uint64_t> rotation_run_sign_words_;
 
     uint32_t attempted_shots_ = 0;
     uint32_t active_lanes_ = 0;

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -104,6 +104,9 @@ class ExecutablePlan {
     friend class BatchExecutor;
     friend class ExecutablePlanBuilder;
 
+    static constexpr uint32_t kMinBatchRotationRunLength = 8;
+    static constexpr uint32_t kMaxBatchRotationRunLength = 32;
+
     // To keep actions compact, register_id refers to expression details in the
     // storage near the end of this class.
     struct PreparedExpression {
@@ -360,6 +363,10 @@ class ExecutablePlan {
     std::vector<PreparedFusedRotationExecution> fused_rotations_;
     std::vector<PreparedDynamicFusedRotationExecution> dynamic_fused_rotations_;
     std::vector<Action> actions_;
+    // Nonzero entries mark compiler-prepared direct-rotation runs beginning at
+    // the corresponding action. Batch execution consumes the whole run without
+    // rediscovering action relationships in the hot loop.
+    std::vector<uint8_t> batch_rotation_run_lengths_;
     // Optional debug sidecar parallel to actions_. It stays empty for ordinary
     // compilation and therefore adds no per-action production storage.
     std::vector<PlanActionRange> action_plan_ranges_;

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -89,6 +89,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::compile() {
     initialize_program();
     prepare_noise_and_boundaries();
     lower_action_stream();
+    prepare_batch_rotation_runs();
     build_expression_dependencies();
     validate_executable_plan();
 }
@@ -434,6 +435,35 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::record_action_origin(uin
     output_.action_plan_ranges_.push_back({plan_begin, plan_end});
 }
 
+CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::prepare_batch_rotation_runs() {
+    output_.batch_rotation_run_lengths_.assign(output_.actions_.size(), 0);
+    bool prepared_run = false;
+    size_t action_index = 0;
+    while (action_index < output_.actions_.size()) {
+        if (!std::holds_alternative<ExecutablePlan::ExecuteRotation>(
+                output_.actions_[action_index])) {
+            ++action_index;
+            continue;
+        }
+        size_t run_end = action_index + 1;
+        while (run_end < output_.actions_.size() &&
+               std::holds_alternative<ExecutablePlan::ExecuteRotation>(output_.actions_[run_end])) {
+            ++run_end;
+        }
+        while (run_end - action_index >= ExecutablePlan::kMinBatchRotationRunLength) {
+            const size_t run_length = std::min<size_t>(run_end - action_index,
+                                                       ExecutablePlan::kMaxBatchRotationRunLength);
+            output_.batch_rotation_run_lengths_[action_index] = static_cast<uint8_t>(run_length);
+            prepared_run = true;
+            action_index += run_length;
+        }
+        action_index = run_end;
+    }
+    if (!prepared_run) {
+        output_.batch_rotation_run_lengths_.clear();
+    }
+}
+
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::build_expression_dependencies() {
     output_.expression_dependencies_ = ExecutablePlan::ExpressionDependencies::build(
         output_.num_symbols_, expression_terms_, expression_term_begins_);
@@ -445,6 +475,30 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
            "expression register storage is inconsistent");
     output_.expression_dependencies_.validate(output_.num_symbols_,
                                               output_.expression_register_constants_.size());
+    assert((output_.batch_rotation_run_lengths_.empty() ||
+            output_.batch_rotation_run_lengths_.size() == output_.actions_.size()) &&
+           "batch rotation metadata must be empty or parallel to the action stream");
+    if (!output_.batch_rotation_run_lengths_.empty()) {
+        for (size_t action_index = 0; action_index < output_.actions_.size(); ++action_index) {
+            const uint32_t run_length = output_.batch_rotation_run_lengths_[action_index];
+            if (run_length == 0) {
+                continue;
+            }
+            assert(run_length >= ExecutablePlan::kMinBatchRotationRunLength &&
+                   run_length <= ExecutablePlan::kMaxBatchRotationRunLength &&
+                   run_length <= output_.actions_.size() - action_index &&
+                   "batch rotation run length must be valid");
+            for (size_t offset = 0; offset < run_length; ++offset) {
+                assert(std::holds_alternative<ExecutablePlan::ExecuteRotation>(
+                           output_.actions_[action_index + offset]) &&
+                       "batch rotation run must contain only direct rotations");
+                assert((offset == 0 ||
+                        output_.batch_rotation_run_lengths_[action_index + offset] == 0) &&
+                       "batch rotation runs must not overlap");
+            }
+            action_index += run_length - 1;
+        }
+    }
     if (source_.source_map.has_value()) {
         assert(output_.action_plan_ranges_.size() == output_.actions_.size() &&
                "executable provenance must remain parallel to the action stream");

--- a/src/clifft/sampling/executable_plan_builder.h
+++ b/src/clifft/sampling/executable_plan_builder.h
@@ -33,6 +33,7 @@ class ExecutablePlanBuilder {
     // Scan semantic actions once, selecting CPU descriptors and bounded
     // adjacent-rotation fusion without introducing a general pass pipeline.
     void lower_action_stream();
+    void prepare_batch_rotation_runs();
     void lower_action(const PlannedAction& planned, size_t& boundary_index);
     void record_action_origin(uint32_t plan_begin, uint32_t plan_end);
 

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -89,8 +89,10 @@ struct ConditionedBatchSamplingWorker {
 };
 
 struct BatchSurvivorWorker {
-    BatchSurvivorWorker(const ExecutablePlan& plan, uint32_t capacity)
-        : executor(plan, capacity), counts(plan.num_observables()) {}
+    BatchSurvivorWorker(const ExecutablePlan& plan, uint32_t capacity, bool keep_records)
+        : executor(plan, capacity,
+                   keep_records ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors),
+          counts(plan.num_observables()) {}
 
     BatchExecutor executor;
     SurvivorCounts counts;
@@ -99,8 +101,9 @@ struct BatchSurvivorWorker {
 struct ConditionedBatchSurvivorWorker {
     ConditionedBatchSurvivorWorker(const ExecutablePlan& plan,
                                    std::span<const double> probabilities, uint32_t k,
-                                   uint32_t capacity)
-        : executor(plan, capacity),
+                                   uint32_t capacity, bool keep_records)
+        : executor(plan, capacity,
+                   keep_records ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors),
           fault_sampler(probabilities, k),
           counts(plan.num_observables()) {}
 
@@ -391,6 +394,13 @@ SamplingSurvivorResult sample_surviving_batches(const ExecutablePlan& plan, uint
             for (uint32_t offset = range.begin; offset < range.end;) {
                 const uint32_t batch = std::min(batch_capacity, range.end - offset);
                 run_batch(worker, root, offset, batch);
+                if (!keep_records) {
+                    counts.passed_shots += executor.surviving_shots();
+                    counts.logical_errors +=
+                        executor.accumulate_survivor_counts(counts.observable_ones);
+                    offset += batch;
+                    continue;
+                }
                 for (uint32_t lane = 0; lane < executor.surviving_shots(); ++lane) {
                     ++counts.passed_shots;
                     bool logical_error = false;
@@ -401,9 +411,6 @@ SamplingSurvivorResult sample_surviving_batches(const ExecutablePlan& plan, uint
                         logical_error |= value;
                     }
                     counts.logical_errors += static_cast<uint32_t>(logical_error);
-                    if (!keep_records) {
-                        continue;
-                    }
                     const uint32_t shot = executor.shot_index(lane);
                     survived[shot] = 1;
                     for (uint32_t record = 0; record < plan.num_visible_records(); ++record) {
@@ -513,7 +520,9 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
     if (batch_capacity > 1) {
         return sample_surviving_batches(
             plan, shots, seed, keep_records, resolved, batch_capacity,
-            [&](uint32_t) { return std::make_unique<BatchSurvivorWorker>(plan, batch_capacity); },
+            [&](uint32_t) {
+                return std::make_unique<BatchSurvivorWorker>(plan, batch_capacity, keep_records);
+            },
             [](BatchSurvivorWorker& worker, const SeedRoot& root, uint32_t first_shot,
                uint32_t batch) noexcept { worker.executor.run_batch(root, first_shot, batch); });
     }
@@ -611,8 +620,8 @@ SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t s
         return sample_surviving_batches(
             plan, shots, seed, keep_records, resolved, batch_capacity,
             [&](uint32_t) {
-                return std::make_unique<ConditionedBatchSurvivorWorker>(plan, probabilities, k,
-                                                                        batch_capacity);
+                return std::make_unique<ConditionedBatchSurvivorWorker>(
+                    plan, probabilities, k, batch_capacity, keep_records);
             },
             [](ConditionedBatchSurvivorWorker& worker, const SeedRoot& root, uint32_t first_shot,
                uint32_t batch) noexcept {

--- a/tests/test_importance_sampling.cc
+++ b/tests/test_importance_sampling.cc
@@ -595,12 +595,18 @@ TEST_CASE("Explicit batch capacities preserve conditioned rows and survivors") {
     const clifft::sampling::SamplingSurvivorResult survivor_scalar =
         clifft::sampling::sample_k_survivors(survivors, 257, 1, 482, true, 1, std::nullopt,
                                              uint32_t{1});
+    const clifft::sampling::SamplingSurvivorResult aggregate_scalar =
+        clifft::sampling::sample_k_survivors(survivors, 257, 1, 482, false, 1, std::nullopt,
+                                             uint32_t{1});
 
     for (uint32_t capacity : std::array<uint32_t, 4>{2, 63, 64, 65}) {
         const clifft::sampling::SamplingResult fixed_packed =
             clifft::sampling::sample_k(fixed, 257, 1, 481, 1, std::nullopt, capacity);
         const clifft::sampling::SamplingSurvivorResult survivor_packed =
             clifft::sampling::sample_k_survivors(survivors, 257, 1, 482, true, 1, std::nullopt,
+                                                 capacity);
+        const clifft::sampling::SamplingSurvivorResult aggregate_packed =
+            clifft::sampling::sample_k_survivors(survivors, 257, 1, 482, false, 1, std::nullopt,
                                                  capacity);
         CAPTURE(capacity);
         REQUIRE(fixed_packed.measurements == fixed_scalar.measurements);
@@ -615,6 +621,14 @@ TEST_CASE("Explicit batch capacities preserve conditioned rows and survivors") {
         REQUIRE(survivor_packed.detectors == survivor_scalar.detectors);
         REQUIRE(survivor_packed.observables == survivor_scalar.observables);
         REQUIRE(survivor_packed.exp_vals == survivor_scalar.exp_vals);
+        REQUIRE(aggregate_packed.total_shots == aggregate_scalar.total_shots);
+        REQUIRE(aggregate_packed.passed_shots == aggregate_scalar.passed_shots);
+        REQUIRE(aggregate_packed.logical_errors == aggregate_scalar.logical_errors);
+        REQUIRE(aggregate_packed.observable_ones == aggregate_scalar.observable_ones);
+        REQUIRE(aggregate_packed.measurements.empty());
+        REQUIRE(aggregate_packed.detectors.empty());
+        REQUIRE(aggregate_packed.observables.empty());
+        REQUIRE(aggregate_packed.exp_vals.empty());
     }
 }
 

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1565,6 +1565,42 @@ TEST_CASE("Explicit batch capacities preserve seeded survivor rows") {
     }
 }
 
+TEST_CASE("Explicit batch capacities preserve aggregate survivor counts") {
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+            H 0
+            M 0
+            DETECTOR rec[-1]
+            H 1
+            M 1
+            OBSERVABLE_INCLUDE(0) rec[-1]
+            H 2
+            M 2
+            OBSERVABLE_INCLUDE(1) rec[-1]
+            EXP_VAL Z2
+        )")),
+                                        {.postselection_mask = postselection,
+                                         .expected_detectors = {},
+                                         .expected_observables = {}}));
+    const clifft::sampling::SamplingSurvivorResult scalar = clifft::sampling::sample_survivors(
+        executable, 257, uint64_t{91842}, false, 1, std::nullopt, uint32_t{1});
+
+    for (uint32_t capacity : std::array<uint32_t, 4>{2, 63, 64, 65}) {
+        const clifft::sampling::SamplingSurvivorResult packed = clifft::sampling::sample_survivors(
+            executable, 257, uint64_t{91842}, false, 1, std::nullopt, capacity);
+        CAPTURE(capacity);
+        REQUIRE(packed.total_shots == scalar.total_shots);
+        REQUIRE(packed.passed_shots == scalar.passed_shots);
+        REQUIRE(packed.logical_errors == scalar.logical_errors);
+        REQUIRE(packed.observable_ones == scalar.observable_ones);
+        REQUIRE(packed.measurements.empty());
+        REQUIRE(packed.detectors.empty());
+        REQUIRE(packed.observables.empty());
+        REQUIRE(packed.exp_vals.empty());
+    }
+}
+
 TEST_CASE("Sampling survivor execution normalizes and rejects detectors") {
     const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
         H 0

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1376,6 +1376,47 @@ TEST_CASE("Explicit batch capacities preserve seeded fixed rows") {
     }
 }
 
+TEST_CASE("Explicit batch capacities preserve long dynamic rotation runs") {
+    constexpr uint32_t width = 6;
+    SamplingPlan plan;
+    plan.num_qubits = width;
+    plan.initial_active_width = width;
+    plan.peak_active_width = width;
+    plan.num_noise_sites = 3;
+    plan.num_exp_vals = width;
+    for (uint32_t symbol = 0; symbol < 3; ++symbol) {
+        plan.symbols.push_back(
+            SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{symbol}});
+        plan.presampled_noise_sites.push_back(PresampledNoiseSite{
+            NoiseSiteId{symbol}, 0.5, {PresampledNoiseOutcome{SymbolId{symbol}, 0.5}}});
+    }
+    for (uint32_t rotation = 0; rotation < 40; ++rotation) {
+        const uint64_t x = uint64_t{1} << (rotation % width);
+        const uint64_t z = uint64_t{1} << ((rotation * 5 + 1) % width);
+        plan.actions.push_back(
+            PlannedAction{width, width,
+                          RotateActivePauli{{x, z},
+                                            0.125 + 0.01 * static_cast<double>(rotation % 5),
+                                            AffineBool::symbol(SymbolId{rotation % 3})}});
+    }
+    for (uint32_t axis = 0; axis < width; ++axis) {
+        plan.actions.push_back(
+            PlannedAction{width, width,
+                          WriteExpectationValue{ActivePauli{0, uint64_t{1} << axis}, AffineBool{},
+                                                ExpValSlot{axis}}});
+    }
+    const ExecutablePlan executable(plan);
+    const clifft::sampling::SamplingResult scalar =
+        clifft::sampling::sample(executable, 257, uint64_t{8675309}, 1, std::nullopt, uint32_t{1});
+
+    for (uint32_t capacity : std::array<uint32_t, 5>{2, 63, 64, 65, 128}) {
+        const clifft::sampling::SamplingResult packed =
+            clifft::sampling::sample(executable, 257, uint64_t{8675309}, 1, std::nullopt, capacity);
+        CAPTURE(capacity);
+        REQUIRE(packed.exp_vals == scalar.exp_vals);
+    }
+}
+
 TEST_CASE("Sampling thread layouts validate explicit worker counts") {
     const ExecutablePlan executable(plan_from("H 0\nM 0\n"));
     REQUIRE_THROWS_WITH(clifft::sampling::sample(executable, 1, uint64_t{11}, 1,

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -72,6 +72,8 @@ CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim \
 | `CLIFFT_PROFILE_INTRA_SHOT_WORKERS` | unset | Explicit per-shot workers; set with shot workers |
 | `CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH` | 18 | Expert kernel threshold; requires an explicit layout |
 | `CLIFFT_PROFILE_BATCH_SIZE` | auto | Cross-shot batch capacity; `1` forces scalar execution |
+| `CLIFFT_PROFILE_AGGREGATE_SURVIVORS` | unset | Profile counts-only survivor sampling instead of fixed-row output |
+| `CLIFFT_PROFILE_POSTSELECT_ALL` | unset | Mark every detector for postselection; requires aggregate survivors |
 | `CLIFFT_PROFILE_WARMUPS` | 2 | Untimed sample calls |
 | `CLIFFT_PROFILE_REPETITIONS` | 20 | Timed sample calls |
 | `CLIFFT_PROFILE_GENERATED_WIDTH` | unset | Generate a rotation-heavy circuit of this width instead of loading a file |

--- a/tools/profile/profile_sample.cpp
+++ b/tools/profile/profile_sample.cpp
@@ -94,6 +94,15 @@ uint64_t checksum_result(const clifft::sampling::SamplingResult& result) {
     return checksum;
 }
 
+uint64_t checksum_result(const clifft::sampling::SamplingSurvivorResult& result) {
+    uint64_t checksum = mix(result.total_shots, result.passed_shots);
+    checksum = mix(checksum, result.logical_errors);
+    for (uint64_t value : result.observable_ones) {
+        checksum = mix(checksum, value);
+    }
+    return checksum;
+}
+
 void summarize(std::vector<double> samples_ms, int shots) {
     std::sort(samples_ms.begin(), samples_ms.end());
     const double sum = std::accumulate(samples_ms.begin(), samples_ms.end(), 0.0);
@@ -121,6 +130,8 @@ int main() {
     const int generated_width = get_env_int("CLIFFT_PROFILE_GENERATED_WIDTH", 0);
     const int generated_depth =
         get_env_int("CLIFFT_PROFILE_GENERATED_DEPTH", kDefaultGeneratedDepth);
+    const bool aggregate_survivors = get_env_int("CLIFFT_PROFILE_AGGREGATE_SURVIVORS", 0) != 0;
+    const bool postselect_all = get_env_int("CLIFFT_PROFILE_POSTSELECT_ALL", 0) != 0;
     const char* shot_workers_value = std::getenv("CLIFFT_PROFILE_SHOT_WORKERS");
     const char* intra_workers_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_WORKERS");
     const char* min_active_width_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH");
@@ -161,6 +172,10 @@ int main() {
         std::cerr << "Error: batch size must be positive\n";
         return 1;
     }
+    if (postselect_all && !aggregate_survivors) {
+        std::cerr << "Error: postselection requires aggregate survivor profiling\n";
+        return 1;
+    }
 
     std::cout << "Clifft Sampling Profiler\n";
     std::cout << "========================\n";
@@ -190,7 +205,13 @@ int main() {
     clifft::HirModule hir = clifft::trace(circuit);
     auto pass_manager = clifft::default_hir_pass_manager();
     pass_manager.run(hir);
-    clifft::sampling::SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+    std::vector<uint8_t> postselection_mask;
+    if (postselect_all) {
+        postselection_mask.assign(hir.num_detectors, 1);
+    }
+    clifft::sampling::SamplingPlanOptions plan_options;
+    plan_options.postselection_mask = postselection_mask;
+    clifft::sampling::SamplingPlan plan = clifft::sampling::plan_sampling(hir, plan_options);
 
     std::cout << "Plan: " << hir.num_qubits << " qubits, peak active width "
               << plan.peak_active_width << ", " << plan.actions.size() << " actions\n\n";
@@ -209,25 +230,30 @@ int main() {
     const std::optional<uint32_t> requested_batch_size =
         batch_size_value == nullptr ? std::nullopt
                                     : std::optional<uint32_t>{static_cast<uint32_t>(batch_size)};
+    const auto run_sample = [&](uint64_t seed) {
+        if (aggregate_survivors) {
+            return checksum_result(clifft::sampling::sample_survivors(
+                program, static_cast<uint32_t>(shots), seed, false, static_cast<uint32_t>(threads),
+                thread_layout, requested_batch_size));
+        }
+        return checksum_result(clifft::sampling::sample(program, static_cast<uint32_t>(shots), seed,
+                                                        static_cast<uint32_t>(threads),
+                                                        thread_layout, requested_batch_size));
+    };
 
     uint64_t checksum = 0;
     for (int iteration = 0; iteration < warmups; ++iteration) {
-        checksum = mix(checksum,
-                       checksum_result(clifft::sampling::sample(
-                           program, static_cast<uint32_t>(shots), kSeed + iteration,
-                           static_cast<uint32_t>(threads), thread_layout, requested_batch_size)));
+        checksum = mix(checksum, run_sample(kSeed + iteration));
     }
 
     std::vector<double> samples_ms;
     samples_ms.reserve(static_cast<size_t>(repetitions));
     for (int iteration = 0; iteration < repetitions; ++iteration) {
         const auto start = std::chrono::steady_clock::now();
-        auto result = clifft::sampling::sample(
-            program, static_cast<uint32_t>(shots), kSeed + warmups + iteration,
-            static_cast<uint32_t>(threads), thread_layout, requested_batch_size);
+        const uint64_t result_checksum = run_sample(kSeed + warmups + iteration);
         const auto end = std::chrono::steady_clock::now();
         samples_ms.push_back(std::chrono::duration<double, std::milli>(end - start).count());
-        checksum = mix(checksum, checksum_result(result));
+        checksum = mix(checksum, result_checksum);
     }
 
     summarize(samples_ms, shots);


### PR DESCRIPTION
Stacked on #403. This keeps the initial packed executor review separate from the data-driven hot-path follow-ups.\n\n## Summary\n\n- add aggregate-survivor profiling controls and postselect-all fixture support\n- keep counts-only packed sampling out of row materialization and final survivor compaction\n- compile direct-rotation runs of 8 to 32 actions and execute each run shot-major to reuse per-lane state\n- retain ordinary dispatch for shorter runs so surface-code, cultivation, and distillation plans stay neutral\n\n## Performance\n\nOn the development VM, 100k-shot coherent d3r3 sampling at an explicit 2048-lane capacity improved from about 333 ms to 273 ms (1.22x throughput). Counts-only postselection also avoids storage and compaction that callers do not consume.\n\n## Validation\n\n- full native suite: 2,321,267 assertions across 884 cases\n- explicit capacities through multi-word and partial batches\n- repository pre-commit suite\n\nNo clifft-bench update is included, and this PR should remain stacked until the performance series is ready.