### PR TITLE
perf(sampling): share presampled batch expressions

### DIFF
--- a/src/clifft/sampling/batch_bits.cc
+++ b/src/clifft/sampling/batch_bits.cc
@@ -4,6 +4,7 @@
 #include <bit>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 
 namespace clifft::sampling {
 
@@ -112,6 +113,11 @@ void PackedBitColumns::assign_xor(size_t column_index, std::span<const uint64_t>
     for (size_t word = 0; word < word_capacity_; ++word) {
         destination[word] = (left[word] ^ right[word]) & live_mask[word];
     }
+}
+
+void PackedBitColumns::copy(size_t destination_index, size_t source_index) noexcept {
+    const std::span<const uint64_t> source = std::as_const(*this).column(source_index);
+    std::ranges::copy(source, column(destination_index).begin());
 }
 
 void PackedBitColumns::xor_into(size_t column_index, std::span<const uint64_t> source) noexcept {

--- a/src/clifft/sampling/batch_bits.h
+++ b/src/clifft/sampling/batch_bits.h
@@ -33,6 +33,7 @@ class PackedBitColumns {
                 std::span<const uint64_t> live_mask) noexcept;
     void assign_xor(size_t column, std::span<const uint64_t> left, std::span<const uint64_t> right,
                     std::span<const uint64_t> live_mask) noexcept;
+    void copy(size_t destination, size_t source) noexcept;
     void xor_into(size_t column, std::span<const uint64_t> source) noexcept;
 
     // Stable-compacts every column using keep_mask. scratch is one fixed-size

--- a/src/clifft/sampling/batch_executor.cc
+++ b/src/clifft/sampling/batch_executor.cc
@@ -24,6 +24,14 @@ namespace clifft::sampling {
 #define CLIFFT_BATCH_NOINLINE
 #endif
 
+// Keep the packed executor's hot loop cluster on a stable instruction-cache
+// boundary when unrelated preparation code changes the final link layout.
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__) && !defined(__EMSCRIPTEN__)
+#define CLIFFT_BATCH_HOT_ALIGNMENT __attribute__((aligned(4096)))
+#else
+#define CLIFFT_BATCH_HOT_ALIGNMENT
+#endif
+
 namespace {
 
 enum class MeasurementBranchKind : uint8_t {
@@ -280,12 +288,47 @@ void BatchExecutor::reset_batch(const SeedRoot& root, uint32_t first_shot,
     initialize_expression_registers();
 }
 
-void BatchExecutor::initialize_expression_registers() noexcept {
+CLIFFT_BATCH_HOT_ALIGNMENT void BatchExecutor::initialize_expression_registers() noexcept {
     for (size_t expression = 0; expression < plan_->expression_register_constants_.size();
          ++expression) {
         if (plan_->expression_register_constants_[expression] != 0) {
             expression_registers_.assign(expression, live_words_, live_words_);
         }
+    }
+}
+
+void BatchExecutor::initialize_presampled_expressions() noexcept {
+    assert(!plan_->presampled_initialization_level_offsets_.empty() &&
+           plan_->presampled_initialization_level_offsets_.size() ==
+               plan_->presampled_delta_level_offsets_.size() &&
+           "presampled expression program must contain matching levels");
+    const size_t levels = plan_->presampled_initialization_level_offsets_.size() - 1;
+    for (size_t level = 0; level < levels; ++level) {
+        const uint32_t initialization_begin =
+            plan_->presampled_initialization_level_offsets_[level];
+        const uint32_t initialization_end =
+            plan_->presampled_initialization_level_offsets_[level + 1];
+        for (uint32_t index = initialization_begin; index < initialization_end; ++index) {
+            const ExecutablePlan::PresampledExpressionInitialization& initialization =
+                plan_->presampled_initializations_[index];
+            if (initialization.parent == std::numeric_limits<uint32_t>::max()) {
+                continue;
+            }
+            expression_registers_.copy(initialization.destination, initialization.parent);
+            if (initialization.invert_parent) {
+                expression_registers_.xor_into(initialization.destination, live_words_);
+            }
+        }
+        const uint32_t delta_begin = plan_->presampled_delta_level_offsets_[level];
+        const uint32_t delta_end = plan_->presampled_delta_level_offsets_[level + 1];
+        for (uint32_t index = delta_begin; index < delta_end; ++index) {
+            const ExecutablePlan::PresampledExpressionDelta& delta =
+                plan_->presampled_deltas_[index];
+            expression_registers_.xor_into(delta.destination, symbols_.column(delta.symbol));
+        }
+    }
+    for (const ExecutablePlan::PresampledExpressionCopy& copy : plan_->presampled_copies_) {
+        expression_registers_.copy(copy.destination, copy.source);
     }
 }
 
@@ -308,8 +351,12 @@ void BatchExecutor::sample_presampled_noise() noexcept {
             first_candidate = site + 1;
         }
     }
-    for (uint32_t symbol : plan_->presampled_symbols_) {
-        propagate_symbol(symbol);
+    if (plan_->presampled_initialization_level_offsets_.empty()) {
+        for (uint32_t symbol : plan_->presampled_symbols_) {
+            propagate_symbol(symbol);
+        }
+    } else {
+        initialize_presampled_expressions();
     }
 }
 
@@ -329,8 +376,12 @@ void BatchExecutor::assign_forced_faults(KFaultSampler& fault_sampler) noexcept 
             }
         }
     }
-    for (uint32_t symbol : plan_->presampled_symbols_) {
-        propagate_symbol(symbol);
+    if (plan_->presampled_initialization_level_offsets_.empty()) {
+        for (uint32_t symbol : plan_->presampled_symbols_) {
+            propagate_symbol(symbol);
+        }
+    } else {
+        initialize_presampled_expressions();
     }
 }
 

--- a/src/clifft/sampling/batch_executor.h
+++ b/src/clifft/sampling/batch_executor.h
@@ -72,6 +72,7 @@ class BatchExecutor {
     void assign_forced_faults(KFaultSampler& fault_sampler) noexcept;
     void activate_noise_site(uint32_t lane, uint32_t site) noexcept;
     void initialize_expression_registers() noexcept;
+    void initialize_presampled_expressions() noexcept;
     void propagate_symbol(uint32_t symbol) noexcept;
     void assign_symbol(uint32_t symbol, std::span<const uint64_t> values) noexcept;
 

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <span>
 #include <string>
@@ -136,6 +137,22 @@ class ExecutablePlan {
 
         std::vector<uint32_t> offsets_;
         std::vector<uint32_t> targets_;
+    };
+
+    struct PresampledExpressionInitialization {
+        uint32_t destination = 0;
+        uint32_t parent = std::numeric_limits<uint32_t>::max();
+        bool invert_parent = false;
+    };
+
+    struct PresampledExpressionDelta {
+        uint32_t symbol = 0;
+        uint32_t destination = 0;
+    };
+
+    struct PresampledExpressionCopy {
+        uint32_t source = 0;
+        uint32_t destination = 0;
     };
 
     // CPU action descriptors. They contain only fixed operands and indices;
@@ -370,6 +387,14 @@ class ExecutablePlan {
     // Optional debug sidecar parallel to actions_. It stays empty for ordinary
     // compilation and therefore adds no per-action production storage.
     std::vector<PlanActionRange> action_plan_ranges_;
+    // Optional batch initialization sidecars stay after the ordinary hot plan
+    // fields so plans that reject the cost model preserve their existing
+    // action and noise metadata locality.
+    std::vector<uint32_t> presampled_initialization_level_offsets_;
+    std::vector<PresampledExpressionInitialization> presampled_initializations_;
+    std::vector<uint32_t> presampled_delta_level_offsets_;
+    std::vector<PresampledExpressionDelta> presampled_deltas_;
+    std::vector<PresampledExpressionCopy> presampled_copies_;
 };
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -5,11 +5,13 @@
 #include <algorithm>
 #include <bit>
 #include <cassert>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <span>
 #include <stdexcept>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 namespace clifft::sampling {
@@ -33,6 +35,37 @@ inline constexpr bool kAlwaysFalse = false;
 bool activates_new_x(const ApplyInstrument& instrument, uint32_t active_after) {
     return instrument.mode == InstrumentMode::Activate && active_after > 0 &&
            instrument.source.z == 0 && instrument.source.x == (uint64_t{1} << (active_after - 1));
+}
+
+struct PresampledExpressionBlock {
+    bool constant = false;
+    std::vector<uint32_t> terms;
+    std::vector<uint32_t> registers;
+    uint32_t parent = std::numeric_limits<uint32_t>::max();
+    bool invert_parent = false;
+    uint32_t depth = 0;
+    std::vector<uint32_t> delta_terms;
+};
+
+inline constexpr uint64_t kMinBatchExpressionTerms = 1024;
+inline constexpr uint64_t kBatchExpressionCostNumerator = 3;
+inline constexpr uint64_t kBatchExpressionCostDenominator = 4;
+
+std::vector<uint32_t> symmetric_difference(std::span<const uint32_t> left,
+                                           std::span<const uint32_t> right) {
+    std::vector<uint32_t> result;
+    result.reserve(left.size() + right.size());
+    std::ranges::set_symmetric_difference(left, right, std::back_inserter(result));
+    return result;
+}
+
+uint64_t expression_hash(bool constant, std::span<const uint32_t> terms) noexcept {
+    uint64_t hash = constant ? 0x9e3779b97f4a7c15ULL : 0xcbf29ce484222325ULL;
+    for (uint32_t term : terms) {
+        hash ^= term;
+        hash *= 0x100000001b3ULL;
+    }
+    return hash;
 }
 
 }  // namespace
@@ -91,6 +124,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::compile() {
     lower_action_stream();
     prepare_batch_rotation_runs();
     build_expression_dependencies();
+    prepare_batch_expression_initialization();
     validate_executable_plan();
 }
 
@@ -469,12 +503,186 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::build_expression_depende
         output_.num_symbols_, expression_terms_, expression_term_begins_);
 }
 
+void ExecutablePlanBuilder::prepare_batch_expression_initialization() {
+    if (output_.has_instruments_) {
+        return;
+    }
+    std::unordered_multimap<uint64_t, uint32_t> interned;
+    std::vector<PresampledExpressionBlock> blocks;
+    blocks.reserve(expression_term_begins_.size());
+    interned.reserve(expression_term_begins_.size());
+    uint64_t original_presampled_terms = 0;
+    for (size_t expression = 0; expression < expression_term_begins_.size(); ++expression) {
+        const uint32_t begin = expression_term_begins_[expression];
+        const uint32_t end = expression + 1 < expression_term_begins_.size()
+                                 ? expression_term_begins_[expression + 1]
+                                 : static_cast<uint32_t>(expression_terms_.size());
+        std::vector<uint32_t> terms;
+        for (uint32_t term = begin; term < end; ++term) {
+            const uint32_t symbol = expression_terms_[term];
+            if (source_.symbols[symbol].kind == SymbolKind::Presampled) {
+                terms.push_back(symbol);
+                ++original_presampled_terms;
+            }
+        }
+        const bool constant = output_.expression_register_constants_[expression] != 0;
+        const uint64_t hash = expression_hash(constant, terms);
+        uint32_t block_index = std::numeric_limits<uint32_t>::max();
+        const auto [first, last] = interned.equal_range(hash);
+        for (auto position = first; position != last; ++position) {
+            const PresampledExpressionBlock& candidate = blocks[position->second];
+            if (candidate.constant == constant && candidate.terms == terms) {
+                block_index = position->second;
+                break;
+            }
+        }
+        if (block_index == std::numeric_limits<uint32_t>::max()) {
+            block_index = static_cast<uint32_t>(blocks.size());
+            PresampledExpressionBlock block;
+            block.constant = constant;
+            block.terms = std::move(terms);
+            blocks.push_back(std::move(block));
+            interned.emplace(hash, block_index);
+        }
+        blocks[block_index].registers.push_back(static_cast<uint32_t>(expression));
+    }
+    if (original_presampled_terms == 0) {
+        return;
+    }
+
+    std::vector<std::vector<uint32_t>> blocks_by_symbol(output_.num_symbols_);
+    std::vector<uint32_t> intersection_counts(blocks.size(), 0);
+    std::vector<uint32_t> candidate_parents;
+    uint32_t max_depth = 0;
+    for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
+        PresampledExpressionBlock& block = blocks[block_index];
+        block.delta_terms = block.terms;
+        uint64_t best_cost = block.delta_terms.size();
+        // A parent can beat direct initialization only when it shares a term.
+        // Accumulating intersections through the symbol index scores every
+        // viable earlier block exactly without scanning every term pair.
+        candidate_parents.clear();
+        for (uint32_t symbol : block.terms) {
+            for (uint32_t parent_index : blocks_by_symbol[symbol]) {
+                if (intersection_counts[parent_index]++ == 0) {
+                    candidate_parents.push_back(parent_index);
+                }
+            }
+        }
+        std::ranges::sort(candidate_parents);
+        for (uint32_t parent_index : candidate_parents) {
+            const bool invert_parent = block.constant != blocks[parent_index].constant;
+            const uint64_t cost = static_cast<uint64_t>(block.terms.size()) +
+                                  blocks[parent_index].terms.size() -
+                                  2 * static_cast<uint64_t>(intersection_counts[parent_index]) +
+                                  static_cast<uint64_t>(invert_parent);
+            if (cost < best_cost) {
+                best_cost = cost;
+                block.parent = parent_index;
+                block.invert_parent = invert_parent;
+            }
+        }
+        for (uint32_t parent_index : candidate_parents) {
+            intersection_counts[parent_index] = 0;
+        }
+        if (block.parent != std::numeric_limits<uint32_t>::max()) {
+            block.delta_terms = symmetric_difference(block.terms, blocks[block.parent].terms);
+            block.depth = blocks[block.parent].depth + 1;
+        }
+        max_depth = std::max(max_depth, block.depth);
+        for (uint32_t symbol : block.terms) {
+            blocks_by_symbol[symbol].push_back(static_cast<uint32_t>(block_index));
+        }
+    }
+
+    uint64_t prepared_operations = 0;
+    for (const PresampledExpressionBlock& block : blocks) {
+        prepared_operations += block.delta_terms.size();
+        prepared_operations += static_cast<uint64_t>(block.invert_parent);
+        prepared_operations +=
+            static_cast<uint64_t>(block.parent != std::numeric_limits<uint32_t>::max());
+        prepared_operations += block.registers.size() - 1;
+    }
+    // The staged program trades each retained edge for extra parent and copy
+    // passes. Require a substantial execution-work reduction so small or
+    // weakly related expression sets stay on the simpler dependency path.
+    if (original_presampled_terms < kMinBatchExpressionTerms ||
+        prepared_operations * kBatchExpressionCostDenominator >
+            original_presampled_terms * kBatchExpressionCostNumerator) {
+        return;
+    }
+
+    std::vector<std::vector<ExecutablePlan::PresampledExpressionInitialization>>
+        initializations_by_level(static_cast<size_t>(max_depth) + 1);
+    std::vector<std::vector<ExecutablePlan::PresampledExpressionDelta>> deltas_by_level(
+        static_cast<size_t>(max_depth) + 1);
+    for (const PresampledExpressionBlock& block : blocks) {
+        assert(!block.registers.empty() && "interned expression block must have a destination");
+        const uint32_t destination = block.registers.front();
+        const uint32_t parent = block.parent == std::numeric_limits<uint32_t>::max()
+                                    ? std::numeric_limits<uint32_t>::max()
+                                    : blocks[block.parent].registers.front();
+        initializations_by_level[block.depth].push_back({destination, parent, block.invert_parent});
+        for (uint32_t symbol : block.delta_terms) {
+            deltas_by_level[block.depth].push_back({symbol, destination});
+        }
+        for (size_t register_index = 1; register_index < block.registers.size(); ++register_index) {
+            output_.presampled_copies_.push_back({destination, block.registers[register_index]});
+        }
+    }
+
+    output_.presampled_initialization_level_offsets_.push_back(0);
+    output_.presampled_delta_level_offsets_.push_back(0);
+    for (size_t level = 0; level < initializations_by_level.size(); ++level) {
+        auto& deltas = deltas_by_level[level];
+        std::ranges::sort(deltas, {}, &ExecutablePlan::PresampledExpressionDelta::symbol);
+        output_.presampled_initializations_.insert(output_.presampled_initializations_.end(),
+                                                   initializations_by_level[level].begin(),
+                                                   initializations_by_level[level].end());
+        output_.presampled_deltas_.insert(output_.presampled_deltas_.end(), deltas.begin(),
+                                          deltas.end());
+        output_.presampled_initialization_level_offsets_.push_back(
+            static_cast<uint32_t>(output_.presampled_initializations_.size()));
+        output_.presampled_delta_level_offsets_.push_back(
+            static_cast<uint32_t>(output_.presampled_deltas_.size()));
+    }
+}
+
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan() const {
 #ifndef NDEBUG
     assert(expression_term_begins_.size() == output_.expression_register_constants_.size() &&
            "expression register storage is inconsistent");
     output_.expression_dependencies_.validate(output_.num_symbols_,
                                               output_.expression_register_constants_.size());
+    if (!output_.presampled_initialization_level_offsets_.empty()) {
+        assert(output_.presampled_initialization_level_offsets_.size() ==
+                   output_.presampled_delta_level_offsets_.size() &&
+               output_.presampled_initialization_level_offsets_.front() == 0 &&
+               output_.presampled_delta_level_offsets_.front() == 0 &&
+               output_.presampled_initialization_level_offsets_.back() ==
+                   output_.presampled_initializations_.size() &&
+               output_.presampled_delta_level_offsets_.back() ==
+                   output_.presampled_deltas_.size() &&
+               "presampled expression levels must cover their operation tapes");
+        for (const ExecutablePlan::PresampledExpressionInitialization& initialization :
+             output_.presampled_initializations_) {
+            assert(initialization.destination < output_.expression_register_constants_.size() &&
+                   (initialization.parent == std::numeric_limits<uint32_t>::max() ||
+                    initialization.parent < output_.expression_register_constants_.size()) &&
+                   "presampled expression initialization must name valid registers");
+        }
+        for (const ExecutablePlan::PresampledExpressionDelta& delta : output_.presampled_deltas_) {
+            assert(delta.symbol < source_.symbols.size() &&
+                   source_.symbols[delta.symbol].kind == SymbolKind::Presampled &&
+                   delta.destination < output_.expression_register_constants_.size() &&
+                   "presampled expression delta must name valid storage");
+        }
+        for (const ExecutablePlan::PresampledExpressionCopy& copy : output_.presampled_copies_) {
+            assert(copy.source < output_.expression_register_constants_.size() &&
+                   copy.destination < output_.expression_register_constants_.size() &&
+                   "presampled expression copy must name valid registers");
+        }
+    }
     assert((output_.batch_rotation_run_lengths_.empty() ||
             output_.batch_rotation_run_lengths_.size() == output_.actions_.size()) &&
            "batch rotation metadata must be empty or parallel to the action stream");

--- a/src/clifft/sampling/executable_plan_builder.h
+++ b/src/clifft/sampling/executable_plan_builder.h
@@ -39,6 +39,7 @@ class ExecutablePlanBuilder {
 
     // Transpose action-order affine terms into symbol-to-register CSR storage.
     void build_expression_dependencies();
+    void prepare_batch_expression_initialization();
 
     // Check construction-only invariants in Debug builds.
     void validate_executable_plan() const;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1376,6 +1376,47 @@ TEST_CASE("Explicit batch capacities preserve seeded fixed rows") {
     }
 }
 
+TEST_CASE("Packed presampled expression program preserves shared affine rows") {
+    constexpr uint32_t num_symbols = 64;
+    constexpr uint32_t num_unique_expressions = 32;
+    constexpr uint32_t num_records = 40;
+    SamplingPlan plan;
+    plan.num_noise_sites = num_symbols;
+    plan.num_visible_records = num_records;
+    for (uint32_t symbol = 0; symbol < num_symbols; ++symbol) {
+        plan.symbols.push_back(
+            SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{symbol}});
+        plan.presampled_noise_sites.push_back(PresampledNoiseSite{
+            NoiseSiteId{symbol}, 0.125, {PresampledNoiseOutcome{SymbolId{symbol}, 0.125}}});
+    }
+    for (uint32_t record = 0; record < num_records; ++record) {
+        const uint32_t expression = record % num_unique_expressions;
+        std::vector<SymbolId> terms;
+        terms.reserve(48);
+        for (uint32_t symbol = 0; symbol < 48; ++symbol) {
+            if (symbol != expression) {
+                terms.push_back(SymbolId{symbol});
+            }
+        }
+        terms.push_back(SymbolId{48 + expression % 16});
+        plan.actions.push_back(PlannedAction{
+            0, 0,
+            RecordClassical{AffineBool::from_canonical_terms(expression % 2 != 0, std::move(terms)),
+                            RecordSlot{record}}});
+    }
+
+    const ExecutablePlan executable(plan);
+    const clifft::sampling::SamplingResult scalar =
+        clifft::sampling::sample(executable, 257, uint64_t{91832}, 1, std::nullopt, uint32_t{1});
+
+    for (uint32_t capacity : std::array<uint32_t, 5>{2, 63, 64, 65, 128}) {
+        const clifft::sampling::SamplingResult packed =
+            clifft::sampling::sample(executable, 257, uint64_t{91832}, 1, std::nullopt, capacity);
+        CAPTURE(capacity);
+        REQUIRE(packed.measurements == scalar.measurements);
+    }
+}
+
 TEST_CASE("Explicit batch capacities preserve long dynamic rotation runs") {
     constexpr uint32_t width = 6;
     SamplingPlan plan;


### PR DESCRIPTION
Stacked on #404. This closes the main symbolic-layer gap identified in the SymFT comparison without expanding the product surface.\n\n## Summary\n\n- split each affine register into its presampled contribution and causal residual during executable preparation\n- intern repeated presampled partials and compile an exact parent/delta/copy program by dependency level\n- score candidate parents through a symbol inverted index, avoiding a quadratic preparation scan\n- sort each level by source symbol for locality and retain the original dependency path when a conservative cost model rejects the program\n- stabilize the x86 packed hot-loop layout against unrelated builder code-size changes\n\nThe runtime performs no topology discovery or allocation; all sharing and scheduling metadata is immutable and precomputed.\n\n## Performance\n\nFor 100k aggregate, postselect-all shots with an explicit 2048-lane batch on the development VM:\n\n- surface d7: about 211 ms with the planner disabled to 152.5 ms enabled; scalar is about 234 ms\n- cultivation d5: about 1,138 ms on the parent to 1,029 ms here in an alternating comparison\n- distillation and small coherent plans reject the expression program and retain the existing path\n\nExecutable preparation rises from roughly 1.6 to 12.8 ms on surface d7 and 2.1 to 16.5 ms on cultivation d5. This is a one-time compile cost, and the inverted index replaces the earlier 100+ ms quadratic prototype.\n\n## Validation\n\n- dedicated scalar-vs-packed test forces parent deltas, constant inversion, and duplicate copies across 2, 63, 64, 65, and 128 lanes\n- full native suite: 2,321,272 assertions across 885 cases\n- repository pre-commit suite\n- final profiler build and checksum comparison\n\nNo clifft-bench changes are included, and this PR should remain stacked until the complete performance series is ready.