### PR TITLE
perf(sampling): select profitable packed plans automatically

### DIFF
--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -269,12 +269,13 @@ Within each cross-shot worker, the symbolic sampler normally processes shots
 in an adaptive packed batch. Classical symbols, expression results, records,
 detectors, and observables are bit-packed across the batch, while each live
 shot retains its own dense active state and random stream. The automatic
-capacity is bounded by the worker's shot count, a maximum of 512 lanes, and a
-768 KiB dense-state footprint budget. Automatic mode currently selects packing
-only for noiseless peak-active-width-zero plans with at least 64 shots per
-worker. Benchmarks show that per-lane noise sampling and action-major traversal
-of dense states still favor the scalar executor, so noisy and active-state
-plans conservatively fall back to it.
+capacity is bounded by the worker's shot count, a maximum of 2048 lanes, and a
+768 KiB dense-state footprint budget. Automatic mode packs noiseless
+peak-active-width-zero plans with at least 64 shots per worker. It also packs
+plans whose compiler found enough shared presampled expression work to amortize
+at least 512 lanes, and counts-only postselected plans through peak active width
+5. Other noisy, readout-heavy, or wider active-state plans conservatively use
+the scalar executor until they have a benchmark-supported crossover.
 
 The four fixed-plan sampling functions accept `batch_size="auto"` by default.
 Use `batch_size=1` to force the scalar executor when comparing profiles, or a

--- a/src/clifft/sampling/batch_executor.cc
+++ b/src/clifft/sampling/batch_executor.cc
@@ -84,6 +84,14 @@ struct MeasurementBranchClassification {
 uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots, uint32_t shot_workers,
                                 uint32_t intra_shot_workers,
                                 std::optional<uint32_t> requested_batch_size) {
+    return resolve_batch_capacity(plan, shots, shot_workers, intra_shot_workers,
+                                  requested_batch_size, BatchOutputMode::Rows);
+}
+
+uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots, uint32_t shot_workers,
+                                uint32_t intra_shot_workers,
+                                std::optional<uint32_t> requested_batch_size,
+                                BatchOutputMode output_mode) {
     if (requested_batch_size.has_value() && *requested_batch_size == 0) {
         throw std::invalid_argument("batch_size must be a positive integer or 'auto'");
     }
@@ -112,18 +120,27 @@ uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots, uint
     if (worker_shots < kDefaultMinAutoBatchShots) {
         return 1;
     }
-    // Dense action-major lane traversal and per-lane fault presampling do not
-    // yet beat the shot-major executor reliably. Keep those plans scalar until
-    // a benchmark-supported crossover is available; explicit capacities remain
-    // useful for profiling and correctness coverage of the complete executor.
-    if (plan.peak_active_width() != 0 || plan.num_presampled_symbols() != 0 ||
-        plan.has_readout_noise()) {
-        return 1;
-    }
     const size_t state_bytes = State::allocation_bytes_for(plan.peak_active_width());
     const size_t footprint_capacity = std::max<size_t>(1, kDefaultBatchStateBudget / state_bytes);
-    return static_cast<uint32_t>(
+    const uint32_t capacity = static_cast<uint32_t>(
         std::min<size_t>({worker_shots, kDefaultMaxAutoBatchShots, footprint_capacity}));
+    const bool baseline_profitable =
+        plan.peak_active_width() == 0 && plan.num_presampled_symbols() == 0;
+    const bool prepared_symbolic_sharing = plan.has_prepared_batch_expression_program();
+    const bool narrow_aggregate_postselection =
+        output_mode == BatchOutputMode::AggregateSurvivors && plan.has_postselection() &&
+        plan.peak_active_width() <= 5;
+    // Prepared sharing amortizes only across a large bit plane, while narrow
+    // postselected aggregation avoids materializing rejected rows. Dense or
+    // readout-heavy plans retain the scalar path until they have their own
+    // benchmark-supported crossover.
+    if (plan.has_readout_noise() ||
+        (!baseline_profitable &&
+         (capacity < kDefaultMinExpandedAutoBatchShots ||
+          (!prepared_symbolic_sharing && !narrow_aggregate_postselection)))) {
+        return 1;
+    }
+    return capacity;
 #endif
 }
 

--- a/src/clifft/sampling/batch_executor.h
+++ b/src/clifft/sampling/batch_executor.h
@@ -18,10 +18,11 @@ class KFaultSampler;
 
 namespace clifft::sampling {
 
-inline constexpr uint32_t kDefaultMaxAutoBatchShots = 512;
+inline constexpr uint32_t kDefaultMaxAutoBatchShots = 2048;
 inline constexpr uint32_t kMaxExplicitBatchShots = 2048;
 inline constexpr size_t kDefaultBatchStateBudget = 768 * 1024;
 inline constexpr uint32_t kDefaultMinAutoBatchShots = 64;
+inline constexpr uint32_t kDefaultMinExpandedAutoBatchShots = 512;
 
 enum class BatchOutputMode : uint8_t {
     Rows,
@@ -34,6 +35,10 @@ enum class BatchOutputMode : uint8_t {
 [[nodiscard]] uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots,
                                               uint32_t shot_workers, uint32_t intra_shot_workers,
                                               std::optional<uint32_t> requested_batch_size);
+[[nodiscard]] uint32_t resolve_batch_capacity(const ExecutablePlan& plan, uint32_t shots,
+                                              uint32_t shot_workers, uint32_t intra_shot_workers,
+                                              std::optional<uint32_t> requested_batch_size,
+                                              BatchOutputMode output_mode);
 
 // Single-threaded packed executor for fixed plans. It traverses one immutable
 // action stream for every lane while retaining the existing contiguous State

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -92,6 +92,9 @@ class ExecutablePlan {
     [[nodiscard]] uint32_t num_unbound_presampled_symbols() const {
         return static_cast<uint32_t>(unbound_presampled_symbols_.size());
     }
+    [[nodiscard]] bool has_prepared_batch_expression_program() const {
+        return !presampled_initialization_level_offsets_.empty();
+    }
     [[nodiscard]] std::vector<double> noise_site_probabilities() const;
     // Deterministic target-specific inspection for diagnostics and tooling.
     [[nodiscard]] std::string inspect() const;

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -476,8 +476,9 @@ SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<
     }
 
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
-    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
-                                                           resolved.intra_shot_workers, batch_size);
+    const uint32_t batch_capacity =
+        resolve_batch_capacity(plan, shots, resolved.shot_workers, resolved.intra_shot_workers,
+                               batch_size, BatchOutputMode::Rows);
     if (batch_capacity > 1) {
         return sample_fixed_batches(
             plan, shots, seed, resolved, batch_capacity,
@@ -515,8 +516,9 @@ SamplingSurvivorResult sample_survivors(const ExecutablePlan& plan, uint32_t sho
     }
 
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
-    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
-                                                           resolved.intra_shot_workers, batch_size);
+    const uint32_t batch_capacity = resolve_batch_capacity(
+        plan, shots, resolved.shot_workers, resolved.intra_shot_workers, batch_size,
+        keep_records ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors);
     if (batch_capacity > 1) {
         return sample_surviving_batches(
             plan, shots, seed, keep_records, resolved, batch_capacity,
@@ -553,8 +555,9 @@ SamplingResult sample_k(const ExecutablePlan& plan, uint32_t shots, uint32_t k,
             "sample_k_survivors");
     }
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
-    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
-                                                           resolved.intra_shot_workers, batch_size);
+    const uint32_t batch_capacity =
+        resolve_batch_capacity(plan, shots, resolved.shot_workers, resolved.intra_shot_workers,
+                               batch_size, BatchOutputMode::Rows);
     if (shots == 0) {
         return sample_fixed_rows(
             plan, shots, seed, resolved,
@@ -604,8 +607,9 @@ SamplingSurvivorResult sample_k_survivors(const ExecutablePlan& plan, uint32_t s
             "forced-fault survivor sampling requires a distribution for every presampled symbol");
     }
     const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
-    const uint32_t batch_capacity = resolve_batch_capacity(plan, shots, resolved.shot_workers,
-                                                           resolved.intra_shot_workers, batch_size);
+    const uint32_t batch_capacity = resolve_batch_capacity(
+        plan, shots, resolved.shot_workers, resolved.intra_shot_workers, batch_size,
+        keep_records ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors);
     if (shots == 0) {
         return sample_surviving_rows(
             plan, shots, seed, keep_records, resolved,

--- a/tests/test_batch_executor.cc
+++ b/tests/test_batch_executor.cc
@@ -19,6 +19,7 @@ using clifft::KFaultSampler;
 using clifft::make_seed_root;
 using clifft::SeedRoot;
 using clifft::sampling::BatchExecutor;
+using clifft::sampling::BatchOutputMode;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
 using clifft::sampling::resolve_batch_capacity;
@@ -139,7 +140,7 @@ TEST_CASE("Packed executor preserves fixed-fault rows") {
 TEST_CASE("Packed capacity policy bounds worker state footprint") {
     const ExecutablePlan narrow(
         clifft::sampling::plan_sampling(clifft::trace(clifft::parse("H 0 1\nM 0 1\n"))));
-    REQUIRE(resolve_batch_capacity(narrow, 4096, 1, 1, std::nullopt) == 512);
+    REQUIRE(resolve_batch_capacity(narrow, 4096, 1, 1, std::nullopt) == 2048);
     REQUIRE(resolve_batch_capacity(narrow, 1024, 4, 1, std::nullopt) == 256);
     REQUIRE(resolve_batch_capacity(narrow, 63, 1, 1, std::nullopt) == 1);
     REQUIRE(resolve_batch_capacity(narrow, 63, 1, 1, uint32_t{65}) == 63);
@@ -164,4 +165,17 @@ TEST_CASE("Packed capacity policy bounds worker state footprint") {
     const ExecutablePlan noisy = compile_batch_test_plan();
     REQUIRE(resolve_batch_capacity(noisy, 4096, 1, 1, std::nullopt) == 1);
     REQUIRE(resolve_batch_capacity(noisy, 4096, 1, 1, uint32_t{65}) == 65);
+
+    const std::array<uint8_t, 1> postselection{1};
+    clifft::sampling::SamplingPlanOptions options;
+    options.postselection_mask = postselection;
+    const ExecutablePlan postselected(clifft::sampling::plan_sampling(
+        clifft::trace(clifft::parse("H 0 1 2 3 4\nT 0 1 2 3 4\nM 0 1 2 3 4\n"
+                                    "DETECTOR rec[-1]\n")),
+        options));
+    REQUIRE(postselected.peak_active_width() == 5);
+    REQUIRE_FALSE(postselected.has_prepared_batch_expression_program());
+    REQUIRE(resolve_batch_capacity(postselected, 4096, 1, 1, std::nullopt) == 1);
+    REQUIRE(resolve_batch_capacity(postselected, 4096, 1, 1, std::nullopt,
+                                   BatchOutputMode::AggregateSurvivors) == 1024);
 }

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1,5 +1,6 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
+#include "clifft/sampling/batch_executor.h"
 #include "clifft/sampling/executor.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
@@ -56,6 +57,7 @@ using clifft::sampling::record_log_probabilities;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::RecordSlot;
 using clifft::sampling::ReplayResult;
+using clifft::sampling::resolve_batch_capacity;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::sample_records;
 using clifft::sampling::SamplingPlan;
@@ -1406,6 +1408,9 @@ TEST_CASE("Packed presampled expression program preserves shared affine rows") {
     }
 
     const ExecutablePlan executable(plan);
+    REQUIRE(executable.has_prepared_batch_expression_program());
+    REQUIRE(resolve_batch_capacity(executable, 4096, 1, 1, std::nullopt) == 2048);
+    REQUIRE(resolve_batch_capacity(executable, 511, 1, 1, std::nullopt) == 1);
     const clifft::sampling::SamplingResult scalar =
         clifft::sampling::sample(executable, 257, uint64_t{91832}, 1, std::nullopt, uint32_t{1});
 


### PR DESCRIPTION
Stacked on #405. This turns the measured wins into a conservative automatic policy while retaining scalar execution for the observed losing regimes.\n\n## Summary\n\n- raise the automatic ceiling from 512 to 2048 lanes within the existing 768 KiB dense-state budget\n- automatically select large packed batches when executable preparation found profitable shared presampled expressions\n- make selection output-aware so counts-only postselected plans through peak active width 5 can use the packed aggregate path\n- require at least 512 retained lanes for these expanded regimes and keep readout-heavy, wider, or unprepared dense plans scalar\n- preserve the existing five-argument capacity resolver ABI and document the policy\n\n## Performance\n\nMedian 100k-shot results on the development VM:\n\n- surface d7 aggregate postselect-all, auto: 234 ms scalar to 156 ms (1.50x throughput)\n- surface d7 fixed rows, auto: 569 ms scalar to 494 ms (1.15x)\n- distillation aggregate postselect-all, auto: 182 ms scalar to 107 ms (1.71x)\n- 50-qubit deep Clifford: 65.6 ms scalar, 59.0 ms at 512 lanes, 57.4 ms at 2048 lanes\n\nA rotation-heavy width-5 control measured 555 ms scalar versus 560 ms at its 1024-lane footprint capacity, so it remains scalar. Width-6, coherent width-7, and cultivation width-10 controls likewise remain outside the expanded policy.\n\n## Validation\n\n- policy tests cover zero-width, prepared-expression, row versus aggregate, minimum-amortization, state-footprint, explicit override, and intra-shot exclusions\n- full native suite: 2,321,279 assertions across 885 cases\n- repository pre-commit suite\n- automatic-mode profiler checksums match their scalar and explicit-capacity controls\n\nNo clifft-bench changes are included, and this PR should remain stacked until the full series is ready.