### PR TITLE
feat(api): add native unitary OpenQASM 2 input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 
 Built and maintained by the [Unitary Foundation](https://unitary.foundation).
 
-Clifft accepts Stim-format circuits, extends them with non-Clifford gates, and
-compiles them into symbolic-coordinate sampling plans. It is designed for
-circuits whose dominant structure is Clifford, but whose behavior depends on
-localized non-Clifford operations.
+Clifft accepts Stim-format circuits with non-Clifford extensions and a native
+unitary OpenQASM 2 subset, then compiles them into symbolic-coordinate sampling
+plans. It is designed for circuits whose dominant structure is Clifford, but
+whose behavior depends on localized non-Clifford operations.
 
 The dense active state has `2^k` amplitudes, where `k` is its active width. The
 main simulation cost therefore scales with `2^k`, rather than directly with the
@@ -51,8 +51,9 @@ benchmarks.
 
 ## Why Clifft?
 
-- **Stim-compatible format and API**: parse Stim-format circuits with noise,
-  detectors, observables, and repeat blocks, plus non-Clifford extensions.
+- **Native circuit formats**: parse Stim-format circuits with noise, detectors,
+  observables, and repeat blocks, plus unitary OpenQASM 2 input and non-Clifford
+  extensions.
 - **Exact near-Clifford simulation**: simulate localized non-Clifford effects
   without approximating the quantum state.
 - **Optimizing compiler pipeline**: resolve Clifford coordinates and symbolic

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 
 Built and maintained by the [Unitary Foundation](https://unitary.foundation).
 
-Clifft accepts Stim-format circuits with non-Clifford extensions and a native
-unitary OpenQASM 2 subset, then compiles them into symbolic-coordinate sampling
-plans. It is designed for circuits whose dominant structure is Clifford, but
-whose behavior depends on localized non-Clifford operations.
+Clifft accepts Stim-format circuits, extends them with non-Clifford gates, and
+compiles them into symbolic-coordinate sampling plans. It is designed for
+circuits whose dominant structure is Clifford, but whose behavior depends on
+localized non-Clifford operations.
 
 The dense active state has `2^k` amplitudes, where `k` is its active width. The
 main simulation cost therefore scales with `2^k`, rather than directly with the
@@ -51,9 +51,8 @@ benchmarks.
 
 ## Why Clifft?
 
-- **Native circuit formats**: parse Stim-format circuits with noise, detectors,
-  observables, and repeat blocks, plus unitary OpenQASM 2 input and non-Clifford
-  extensions.
+- **Stim-compatible format and API**: parse Stim-format circuits with noise,
+  detectors, observables, and repeat blocks, plus non-Clifford extensions.
 - **Exact near-Clifford simulation**: simulate localized non-Clifford effects
   without approximating the quantum state.
 - **Optimizing compiler pipeline**: resolve Clifford coordinates and symbolic

--- a/docs/getting-started/integrations.md
+++ b/docs/getting-started/integrations.md
@@ -2,10 +2,11 @@
 
 # Front-End Integrations
 
-Clifft's native input is Stim-compatible circuit text with Clifft extensions for
-non-Clifford operations. If your circuits are already written in another quantum
-software framework, companion packages can translate or route supported circuits
-to Clifft without hand-writing that text.
+Clifft natively accepts Stim-compatible circuit text with Clifft extensions for
+non-Clifford operations and a documented unitary OpenQASM 2 subset. If your
+circuits already live as objects in another quantum software framework,
+companion packages can translate or route supported circuits to Clifft without
+hand-writing either text format.
 
 These packages are maintained separately from the core `clifft` package and are
 released on their own schedule. Use their READMEs as the source of truth for the
@@ -16,12 +17,13 @@ full supported operation set and current limitations.
 | Starting point | Package | What it provides |
 |---|---|---|
 | Stim-compatible text | [`clifft`](https://pypi.org/project/clifft/) | Direct parsing, compilation, sampling, state-vector access, detectors, observables, and QEC-oriented workflows. |
+| Unitary-only OpenQASM 2 text | [`clifft`](https://pypi.org/project/clifft/) | Native parsing and compilation of the [supported subset](openqasm2.md), including the ABSTRACTS gate vocabulary. |
 | Qiskit `QuantumCircuit` | [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) | A Qiskit `BackendV2` provider that runs supported circuits on Clifft and returns Qiskit-style results. |
 | Cirq `cirq.Circuit` | [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) | A converter to Clifft circuit text plus a Cirq-style sampler facade backed by Clifft. |
 
-Use the native `clifft` API when you are already working with Stim-style circuit
-text, detector annotations, observables, post-selection, or importance sampling.
-Use an adapter when the circuit construction, decomposition, or surrounding
+Use the native `clifft` API when you are working with supported circuit text,
+detector annotations, observables, post-selection, or importance sampling. Use
+an adapter when circuit construction, decomposition, or the surrounding
 workflow already lives in Qiskit or Cirq.
 
 ## Qiskit

--- a/docs/getting-started/integrations.md
+++ b/docs/getting-started/integrations.md
@@ -2,15 +2,13 @@
 
 # Front-End Integrations
 
-Clifft natively accepts Stim-compatible circuit text with Clifft extensions for
-non-Clifford operations and a documented unitary OpenQASM 2 subset. If your
-circuits already live as objects in another quantum software framework,
-companion packages can translate or route supported circuits to Clifft without
-hand-writing either text format.
+Clifft's primary input is Stim-compatible circuit text with Clifft extensions
+for non-Clifford operations. Other supported front ends accept OpenQASM 2 text
+or integrate circuit objects from another quantum software framework.
 
-These packages are maintained separately from the core `clifft` package and are
-released on their own schedule. Use their READMEs as the source of truth for the
-full supported operation set and current limitations.
+OpenQASM 2 support is built into the core `clifft` package. Framework companion
+packages are maintained separately and released on their own schedule; use
+their READMEs as the source of truth for current limitations.
 
 ## Integration Options
 
@@ -21,10 +19,10 @@ full supported operation set and current limitations.
 | Qiskit `QuantumCircuit` | [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) | A Qiskit `BackendV2` provider that runs supported circuits on Clifft and returns Qiskit-style results. |
 | Cirq `cirq.Circuit` | [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) | A converter to Clifft circuit text plus a Cirq-style sampler facade backed by Clifft. |
 
-Use the native `clifft` API when you are working with supported circuit text,
-detector annotations, observables, post-selection, or importance sampling. Use
-an adapter when circuit construction, decomposition, or the surrounding
-workflow already lives in Qiskit or Cirq.
+Use the native `clifft` API for supported circuit text, detector annotations,
+observables, post-selection, or importance sampling. Use an adapter when
+circuit construction, decomposition, or the surrounding workflow already lives
+in Qiskit or Cirq.
 
 ## Qiskit
 

--- a/docs/getting-started/openqasm2.md
+++ b/docs/getting-started/openqasm2.md
@@ -49,6 +49,11 @@ classical conditions, custom gate declarations, opaque declarations, and
 nonstandard include files. These statements fail during parsing rather than
 being dropped or assigned approximate semantics.
 
+Custom gate declarations are the intended next unitary-format extension. A
+future bounded macro expander can use the same parser and phase rules for gate
+bodies, including an embedded source definition of the remaining unitary
+`qelib1.inc` vocabulary, without widening this initial contract implicitly.
+
 OpenQASM 3 is not part of this contract. Its standard library, gate modifiers,
 global-phase operation, declarations, and dynamic-circuit features need a
 separately specified importer extension.
@@ -63,14 +68,19 @@ import clifft
 source = "OPENQASM 2.0; qreg q[1]; U(0, 0, 0) q[0];"
 imported = clifft.parse_qasm2(source)
 print(imported.circuit)
-print(imported.global_phase_turns)
+print(imported.global_phase_half_turns)
 ```
 
-`global_phase_turns` is a value `t` representing the correction
+`global_phase_half_turns` is a value `t` representing the correction
 `exp(1j * pi * t)`. OpenQASM 2's Euler gates and Clifft's internal `U3`
 representation can differ by this phase. Keeping it beside the ordinary AST
 lets future phase-sensitive compilation consume the exact source convention
 without adding scalar bookkeeping to sampling HIR, plans, or executor state.
+
+For the ambiguity between the OpenQASM 2 specification's displayed `U` matrix,
+its prose, and `qelib1.inc`, Clifft follows Qiskit's de-facto convention:
+`U`/`u1`/`u2`/`u3` use Qiskit's cosine-top-left Euler matrix, while `rz` is the
+symmetric `RZGate` and therefore contributes no source-phase correction.
 
 The current sampling, probability, and state-vector APIs are phase-insensitive,
 so ordinary `compile(..., input_format="qasm2")` does not propagate this value

--- a/docs/getting-started/openqasm2.md
+++ b/docs/getting-started/openqasm2.md
@@ -1,0 +1,79 @@
+# Native OpenQASM 2 Input
+
+Clifft can natively parse and compile a unitary subset of OpenQASM 2.0. This
+path has no Qiskit runtime dependency and is intended for unitary simulation
+and exact-query workflows such as the
+[ABSTRACTS benchmark](https://github.com/mjsutcliffe99/ABSTRACTS).
+
+Select the format explicitly when compiling:
+
+```python
+import clifft
+
+source = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+h q[0];
+t q[1];
+cx q[0], q[1];
+"""
+
+program = clifft.compile(source, input_format="qasm2")
+probabilities = clifft.basis_probabilities(program, ["00", "11"])
+```
+
+Clifft does not guess the format from the input text. The default
+`input_format="stim"` continues to select Clifft's Stim-compatible syntax.
+
+## Supported Syntax
+
+The initial importer supports:
+
+- the required `OPENQASM 2.0;` version statement;
+- the built-in `U` and `CX` gates;
+- the built-in `qelib1.inc` include, without reading an external file;
+- quantum-register declarations, indexed operands, and register broadcasting;
+- `id`, `x`, `y`, `z`, `h`, `s`, `sdg`, `t`, `tdg`, `rx`, `ry`, `rz`, `u1`,
+  `u2`, `u3`, `cx`, `cy`, `cz`, and `swap`;
+- finite constant angle expressions using `pi`, arithmetic, powers, `sin`,
+  `cos`, `tan`, `exp`, `ln`, and `sqrt`;
+- `//` and `/* ... */` comments; and
+- `barrier` statements, which are discarded as no-ops.
+
+Declared register width is preserved even when some qubits are unused.
+Register-valued gate operands are expanded using OpenQASM broadcasting rules.
+
+The initial contract rejects classical registers, measurements, resets,
+classical conditions, custom gate declarations, opaque declarations, and
+nonstandard include files. These statements fail during parsing rather than
+being dropped or assigned approximate semantics.
+
+OpenQASM 3 is not part of this contract. Its standard library, gate modifiers,
+global-phase operation, declarations, and dynamic-circuit features need a
+separately specified importer extension.
+
+## Parsing and Source Phase
+
+Use `parse_qasm2()` when the lowered circuit needs to be inspected:
+
+```python
+import clifft
+
+source = "OPENQASM 2.0; qreg q[1]; U(0, 0, 0) q[0];"
+imported = clifft.parse_qasm2(source)
+print(imported.circuit)
+print(imported.global_phase_turns)
+```
+
+`global_phase_turns` is a value `t` representing the correction
+`exp(1j * pi * t)`. OpenQASM 2's Euler gates and Clifft's internal `U3`
+representation can differ by this phase. Keeping it beside the ordinary AST
+lets future phase-sensitive compilation consume the exact source convention
+without adding scalar bookkeeping to sampling HIR, plans, or executor state.
+
+The current sampling, probability, and state-vector APIs are phase-insensitive,
+so ordinary `compile(..., input_format="qasm2")` does not propagate this value
+beyond the import boundary.
+
+`parse_qasm2_file()` provides the corresponding file entry point.

--- a/docs/getting-started/openqasm2.md
+++ b/docs/getting-started/openqasm2.md
@@ -1,9 +1,7 @@
-# Native OpenQASM 2 Input
+# OpenQASM 2 Input
 
-Clifft can natively parse and compile a unitary subset of OpenQASM 2.0. This
-path has no Qiskit runtime dependency and is intended for unitary simulation
-and exact-query workflows such as the
-[ABSTRACTS benchmark](https://github.com/mjsutcliffe99/ABSTRACTS).
+Clifft can natively parse and compile a unitary subset of OpenQASM 2.0 without a
+Qiskit runtime dependency.
 
 Select the format explicitly when compiling:
 
@@ -28,7 +26,7 @@ Clifft does not guess the format from the input text. The default
 
 ## Supported Syntax
 
-The initial importer supports:
+The importer supports:
 
 - the required `OPENQASM 2.0;` version statement;
 - the built-in `U` and `CX` gates;
@@ -44,19 +42,10 @@ The initial importer supports:
 Declared register width is preserved even when some qubits are unused.
 Register-valued gate operands are expanded using OpenQASM broadcasting rules.
 
-The initial contract rejects classical registers, measurements, resets,
-classical conditions, custom gate declarations, opaque declarations, and
-nonstandard include files. These statements fail during parsing rather than
-being dropped or assigned approximate semantics.
-
-Custom gate declarations are the intended next unitary-format extension. A
-future bounded macro expander can use the same parser and phase rules for gate
-bodies, including an embedded source definition of the remaining unitary
-`qelib1.inc` vocabulary, without widening this initial contract implicitly.
-
-OpenQASM 3 is not part of this contract. Its standard library, gate modifiers,
-global-phase operation, declarations, and dynamic-circuit features need a
-separately specified importer extension.
+The importer rejects classical registers, measurements, resets, classical
+conditions, custom gate declarations, opaque declarations, and nonstandard
+include files. These statements fail during parsing rather than being dropped
+or assigned approximate semantics. Support may expand in the future.
 
 ## Parsing and Source Phase
 
@@ -71,19 +60,14 @@ print(imported.circuit)
 print(imported.global_phase_half_turns)
 ```
 
-`global_phase_half_turns` is a value `t` representing the correction
-`exp(1j * pi * t)`. OpenQASM 2's Euler gates and Clifft's internal `U3`
-representation can differ by this phase. Keeping it beside the ordinary AST
-lets future phase-sensitive compilation consume the exact source convention
-without adding scalar bookkeeping to sampling HIR, plans, or executor state.
+Clifft is generally insensitive to global phase, but the importer retains the
+source correction for potential future phase-sensitive use cases.
+`global_phase_half_turns` is a value `t` representing
+`exp(1j * pi * t)`. Current sampling, probability, and state-vector APIs do not
+propagate it beyond the import boundary.
 
-For the ambiguity between the OpenQASM 2 specification's displayed `U` matrix,
-its prose, and `qelib1.inc`, Clifft follows Qiskit's de-facto convention:
+For gate phase conventions, Clifft follows Qiskit's de-facto convention:
 `U`/`u1`/`u2`/`u3` use Qiskit's cosine-top-left Euler matrix, while `rz` is the
 symmetric `RZGate` and therefore contributes no source-phase correction.
-
-The current sampling, probability, and state-vector APIs are phase-insensitive,
-so ordinary `compile(..., input_format="qasm2")` does not propagate this value
-beyond the import boundary.
 
 `parse_qasm2_file()` provides the corresponding file entry point.

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -12,6 +12,10 @@ directly; there is no sampler-selection module or backend switch.
 
 ::: clifft.parse_file
 
+::: clifft.parse_qasm2
+
+::: clifft.parse_qasm2_file
+
 ::: clifft.trace
 
 ::: clifft.lower
@@ -66,6 +70,8 @@ Sampling under a five-level leakage/loss model. See the
 ## Circuit and IR Inspection
 
 ::: clifft.Circuit
+
+::: clifft.Qasm2Import
 
 ::: clifft.AstNode
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
   - Getting Started:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
+    - Native OpenQASM 2 Input: getting-started/openqasm2.md
     - Front-End Integrations: getting-started/integrations.md
   - User Guide:
     - Compiling Circuits: guide/compilation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,8 +96,9 @@ nav:
   - Getting Started:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
-    - Native OpenQASM 2 Input: getting-started/openqasm2.md
-    - Front-End Integrations: getting-started/integrations.md
+    - Front-End Integrations:
+      - Overview: getting-started/integrations.md
+      - OpenQASM 2: getting-started/openqasm2.md
   - User Guide:
     - Compiling Circuits: guide/compilation.md
     - Simulation: guide/simulation.md

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_library(clifft_core STATIC
     circuit/parser.cc
+    circuit/qasm2_parser.cc
     tableau/pauli_string.cc
     tableau/tableau.cc
     frontend/frontend.cc

--- a/src/clifft/circuit/qasm2_parser.cc
+++ b/src/clifft/circuit/qasm2_parser.cc
@@ -1,0 +1,665 @@
+#include "clifft/circuit/qasm2_parser.h"
+
+#include "clifft/circuit/parser.h"
+#include "clifft/util/config.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <fast_float/fast_float.h>
+#include <fstream>
+#include <limits>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace clifft {
+
+namespace {
+
+enum class TokenKind : uint8_t {
+    End,
+    Identifier,
+    Number,
+    String,
+    Symbol,
+};
+
+struct Token {
+    TokenKind kind = TokenKind::End;
+    std::string_view text;
+    uint32_t line = 1;
+};
+
+class Lexer {
+  public:
+    explicit Lexer(std::string_view text) : text_(text) {}
+
+    Token next() {
+        skip_space_and_comments();
+        if (offset_ == text_.size()) {
+            return {.kind = TokenKind::End, .line = line_};
+        }
+
+        const size_t start = offset_;
+        const uint32_t token_line = line_;
+        const char first = text_[offset_];
+
+        if (is_identifier_start(first)) {
+            ++offset_;
+            while (offset_ < text_.size() && is_identifier_continue(text_[offset_])) {
+                ++offset_;
+            }
+            return {TokenKind::Identifier, text_.substr(start, offset_ - start), token_line};
+        }
+
+        if (std::isdigit(static_cast<unsigned char>(first)) ||
+            (first == '.' && offset_ + 1 < text_.size() &&
+             std::isdigit(static_cast<unsigned char>(text_[offset_ + 1])))) {
+            scan_number();
+            return {TokenKind::Number, text_.substr(start, offset_ - start), token_line};
+        }
+
+        if (first == '"') {
+            ++offset_;
+            const size_t content_start = offset_;
+            while (offset_ < text_.size() && text_[offset_] != '"') {
+                if (text_[offset_] == '\n' || text_[offset_] == '\r') {
+                    throw ParseError("Unterminated string literal", token_line);
+                }
+                if (text_[offset_] == '\\') {
+                    throw ParseError("Escapes are not supported in include paths", token_line);
+                }
+                ++offset_;
+            }
+            if (offset_ == text_.size()) {
+                throw ParseError("Unterminated string literal", token_line);
+            }
+            const std::string_view content = text_.substr(content_start, offset_ - content_start);
+            ++offset_;
+            return {TokenKind::String, content, token_line};
+        }
+
+        ++offset_;
+        return {TokenKind::Symbol, text_.substr(start, 1), token_line};
+    }
+
+  private:
+    static bool is_identifier_start(char c) {
+        return std::isalpha(static_cast<unsigned char>(c)) || c == '_';
+    }
+
+    static bool is_identifier_continue(char c) {
+        return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+    }
+
+    void scan_number() {
+        while (offset_ < text_.size() &&
+               std::isdigit(static_cast<unsigned char>(text_[offset_]))) {
+            ++offset_;
+        }
+        if (offset_ < text_.size() && text_[offset_] == '.') {
+            ++offset_;
+            while (offset_ < text_.size() &&
+                   std::isdigit(static_cast<unsigned char>(text_[offset_]))) {
+                ++offset_;
+            }
+        }
+        if (offset_ < text_.size() && (text_[offset_] == 'e' || text_[offset_] == 'E')) {
+            ++offset_;
+            if (offset_ < text_.size() && (text_[offset_] == '+' || text_[offset_] == '-')) {
+                ++offset_;
+            }
+            const size_t exponent_start = offset_;
+            while (offset_ < text_.size() &&
+                   std::isdigit(static_cast<unsigned char>(text_[offset_]))) {
+                ++offset_;
+            }
+            if (exponent_start == offset_) {
+                throw ParseError("Malformed numeric exponent", line_);
+            }
+        }
+    }
+
+    void skip_space_and_comments() {
+        while (offset_ < text_.size()) {
+            const char current = text_[offset_];
+            if (std::isspace(static_cast<unsigned char>(current))) {
+                line_ += current == '\n';
+                ++offset_;
+                continue;
+            }
+            if (current != '/' || offset_ + 1 == text_.size()) {
+                return;
+            }
+            const char next = text_[offset_ + 1];
+            if (next == '/') {
+                offset_ += 2;
+                while (offset_ < text_.size() && text_[offset_] != '\n') {
+                    ++offset_;
+                }
+                continue;
+            }
+            if (next != '*') {
+                return;
+            }
+
+            const uint32_t comment_line = line_;
+            offset_ += 2;
+            bool closed = false;
+            while (offset_ + 1 < text_.size()) {
+                line_ += text_[offset_] == '\n';
+                if (text_[offset_] == '*' && text_[offset_ + 1] == '/') {
+                    offset_ += 2;
+                    closed = true;
+                    break;
+                }
+                ++offset_;
+            }
+            if (!closed) {
+                throw ParseError("Unterminated block comment", comment_line);
+            }
+        }
+    }
+
+    std::string_view text_;
+    size_t offset_ = 0;
+    uint32_t line_ = 1;
+};
+
+enum class PhaseRule : uint8_t {
+    None,
+    QasmU,
+};
+
+struct GateSpec {
+    GateType gate;
+    uint8_t num_args;
+    uint8_t num_qubits;
+    PhaseRule phase_rule = PhaseRule::None;
+    bool identity = false;
+    bool requires_qelib1 = true;
+};
+
+const GateSpec* find_gate(std::string_view name) {
+    // U and CX are built into OpenQASM 2.0. The remaining entries are the
+    // directly lowerable unitary portion of qelib1.inc.
+    static const std::unordered_map<std::string_view, GateSpec> gates = {
+        {"U", {GateType::U3, 3, 1, PhaseRule::QasmU, false, false}},
+        {"CX", {GateType::CX, 0, 2, PhaseRule::None, false, false}},
+        {"id", {GateType::I, 0, 1, PhaseRule::None, true}},
+        {"x", {GateType::X, 0, 1}},
+        {"y", {GateType::Y, 0, 1}},
+        {"z", {GateType::Z, 0, 1}},
+        {"h", {GateType::H, 0, 1}},
+        {"s", {GateType::S, 0, 1}},
+        {"sdg", {GateType::S_DAG, 0, 1}},
+        {"t", {GateType::T, 0, 1}},
+        {"tdg", {GateType::T_DAG, 0, 1}},
+        {"rx", {GateType::R_X, 1, 1}},
+        {"ry", {GateType::R_Y, 1, 1}},
+        {"rz", {GateType::R_Z, 1, 1}},
+        {"u1", {GateType::U3, 1, 1, PhaseRule::QasmU}},
+        {"u2", {GateType::U3, 2, 1, PhaseRule::QasmU}},
+        {"u3", {GateType::U3, 3, 1, PhaseRule::QasmU}},
+        {"cx", {GateType::CX, 0, 2}},
+        {"cy", {GateType::CY, 0, 2}},
+        {"cz", {GateType::CZ, 0, 2}},
+        {"swap", {GateType::SWAP, 0, 2}},
+    };
+    const auto it = gates.find(name);
+    return it == gates.end() ? nullptr : &it->second;
+}
+
+struct Register {
+    uint32_t offset;
+    uint32_t width;
+};
+
+struct QubitArgument {
+    uint32_t offset;
+    uint32_t width;
+
+    uint32_t at(uint32_t index) const { return offset + (width == 1 ? 0 : index); }
+};
+
+class Parser {
+  public:
+    Parser(std::string_view text, size_t max_ops) : lexer_(text), max_ops_(max_ops) {
+        const auto non_ascii = std::find_if(text.begin(), text.end(), [](char c) {
+            return static_cast<unsigned char>(c) > 127;
+        });
+        if (non_ascii != text.end()) {
+            throw ParseError("Non-ASCII/Unicode character detected. Only plain ASCII is supported.",
+                             0);
+        }
+        advance();
+    }
+
+    Qasm2Import parse() {
+        expect_identifier("OPENQASM");
+        if (token_.kind != TokenKind::Number || token_.text != "2.0") {
+            if (token_.kind == TokenKind::Number && token_.text == "3.0") {
+                throw ParseError("OpenQASM 3 is not supported; expected OPENQASM 2.0", token_.line);
+            }
+            throw ParseError("Expected OpenQASM version 2.0", token_.line);
+        }
+        advance();
+        expect_symbol(';');
+
+        while (token_.kind != TokenKind::End) {
+            if (is_identifier("include")) {
+                parse_include();
+            } else if (is_identifier("qreg")) {
+                parse_qreg();
+            } else if (is_identifier("barrier")) {
+                parse_barrier();
+            } else if (is_identifier("creg") || is_identifier("measure") ||
+                       is_identifier("reset") || is_identifier("if")) {
+                throw ParseError("Non-unitary and classical statements are not supported by the "
+                                 "OpenQASM 2 importer",
+                                 token_.line);
+            } else if (is_identifier("gate") || is_identifier("opaque")) {
+                throw ParseError("Custom gate and opaque declarations are not supported", token_.line);
+            } else if (token_.kind == TokenKind::Identifier) {
+                parse_gate();
+            } else {
+                throw ParseError("Expected an OpenQASM 2 statement", token_.line);
+            }
+        }
+
+        return std::move(result_);
+    }
+
+  private:
+    void advance() { token_ = lexer_.next(); }
+
+    bool is_identifier(std::string_view value) const {
+        return token_.kind == TokenKind::Identifier && token_.text == value;
+    }
+
+    bool is_symbol(char value) const {
+        return token_.kind == TokenKind::Symbol && token_.text.size() == 1 &&
+               token_.text.front() == value;
+    }
+
+    void expect_identifier(std::string_view value) {
+        if (!is_identifier(value)) {
+            throw ParseError("Expected '" + std::string(value) + "'", token_.line);
+        }
+        advance();
+    }
+
+    void expect_symbol(char value) {
+        if (!is_symbol(value)) {
+            throw ParseError("Expected '" + std::string(1, value) + "'", token_.line);
+        }
+        advance();
+    }
+
+    bool consume_symbol(char value) {
+        if (!is_symbol(value)) {
+            return false;
+        }
+        advance();
+        return true;
+    }
+
+    std::string parse_identifier() {
+        if (token_.kind != TokenKind::Identifier) {
+            throw ParseError("Expected identifier", token_.line);
+        }
+        std::string result(token_.text);
+        advance();
+        return result;
+    }
+
+    uint32_t parse_uint() {
+        if (token_.kind != TokenKind::Number || token_.text.find_first_of(".eE") !=
+                                                   std::string_view::npos) {
+            throw ParseError("Expected a non-negative integer", token_.line);
+        }
+        uint64_t value = 0;
+        for (const char c : token_.text) {
+            value = value * 10 + static_cast<uint64_t>(c - '0');
+            if (value > std::numeric_limits<uint32_t>::max()) {
+                throw ParseError("Integer exceeds the supported range", token_.line);
+            }
+        }
+        advance();
+        return static_cast<uint32_t>(value);
+    }
+
+    void parse_include() {
+        const uint32_t line = token_.line;
+        advance();
+        if (token_.kind != TokenKind::String) {
+            throw ParseError("Expected include path string", token_.line);
+        }
+        if (token_.text != "qelib1.inc") {
+            throw ParseError("Only the built-in qelib1.inc include is supported", line);
+        }
+        qelib1_included_ = true;
+        advance();
+        expect_symbol(';');
+    }
+
+    void parse_qreg() {
+        const uint32_t line = token_.line;
+        advance();
+        const std::string name = parse_identifier();
+        if (registers_.contains(name)) {
+            throw ParseError("Duplicate quantum register '" + name + "'", line);
+        }
+        expect_symbol('[');
+        const uint32_t width = parse_uint();
+        if (width == 0) {
+            throw ParseError("Quantum register width must be positive", line);
+        }
+        expect_symbol(']');
+        expect_symbol(';');
+
+        const uint64_t next_qubit = static_cast<uint64_t>(result_.circuit.num_qubits) + width;
+        if (next_qubit > std::numeric_limits<uint32_t>::max()) {
+            throw ParseError("Total quantum register width exceeds the supported range", line);
+        }
+        registers_.emplace(name, Register{result_.circuit.num_qubits, width});
+        result_.circuit.num_qubits = static_cast<uint32_t>(next_qubit);
+    }
+
+    QubitArgument parse_qubit_argument() {
+        const uint32_t line = token_.line;
+        const std::string name = parse_identifier();
+        const auto found = registers_.find(name);
+        if (found == registers_.end()) {
+            throw ParseError("Unknown quantum register '" + name + "'", line);
+        }
+        const Register reg = found->second;
+        if (!consume_symbol('[')) {
+            return {reg.offset, reg.width};
+        }
+        const uint32_t index = parse_uint();
+        if (index >= reg.width) {
+            throw ParseError("Quantum register index is out of range", line);
+        }
+        expect_symbol(']');
+        return {reg.offset + index, 1};
+    }
+
+    std::vector<QubitArgument> parse_qubit_arguments(size_t max_arguments = 3) {
+        std::vector<QubitArgument> arguments;
+        arguments.push_back(parse_qubit_argument());
+        while (consume_symbol(',')) {
+            arguments.push_back(parse_qubit_argument());
+            if (arguments.size() > max_arguments) {
+                throw ParseError("Too many quantum arguments", token_.line);
+            }
+        }
+        return arguments;
+    }
+
+    void parse_barrier() {
+        advance();
+        (void)parse_qubit_arguments(kMaxTargetsPerInstruction);
+        expect_symbol(';');
+    }
+
+    double parse_expression() { return parse_additive(); }
+
+    double parse_additive() {
+        double value = parse_multiplicative();
+        while (is_symbol('+') || is_symbol('-')) {
+            const bool subtract = is_symbol('-');
+            advance();
+            const double rhs = parse_multiplicative();
+            value = subtract ? value - rhs : value + rhs;
+        }
+        return value;
+    }
+
+    double parse_multiplicative() {
+        double value = parse_power();
+        while (is_symbol('*') || is_symbol('/')) {
+            const bool divide = is_symbol('/');
+            advance();
+            const double rhs = parse_power();
+            value = divide ? value / rhs : value * rhs;
+        }
+        return value;
+    }
+
+    double parse_power() {
+        double value = parse_unary();
+        if (consume_symbol('^')) {
+            value = std::pow(value, parse_power());
+        }
+        return value;
+    }
+
+    double parse_unary() {
+        if (consume_symbol('+')) {
+            return parse_unary();
+        }
+        if (consume_symbol('-')) {
+            return -parse_unary();
+        }
+        return parse_primary();
+    }
+
+    double parse_primary() {
+        if (consume_symbol('(')) {
+            const double value = parse_expression();
+            expect_symbol(')');
+            return value;
+        }
+        if (token_.kind == TokenKind::Number) {
+            double value = 0;
+            const auto parsed = fast_float::from_chars(token_.text.data(),
+                                                       token_.text.data() + token_.text.size(), value);
+            if (parsed.ec != std::errc{} || parsed.ptr != token_.text.data() + token_.text.size()) {
+                throw ParseError("Invalid numeric literal", token_.line);
+            }
+            advance();
+            return value;
+        }
+        if (is_identifier("pi")) {
+            advance();
+            return std::numbers::pi;
+        }
+        if (token_.kind == TokenKind::Identifier) {
+            const uint32_t line = token_.line;
+            const std::string function = parse_identifier();
+            expect_symbol('(');
+            const double value = parse_expression();
+            expect_symbol(')');
+            if (function == "sin")
+                return std::sin(value);
+            if (function == "cos")
+                return std::cos(value);
+            if (function == "tan")
+                return std::tan(value);
+            if (function == "exp")
+                return std::exp(value);
+            if (function == "ln")
+                return std::log(value);
+            if (function == "sqrt")
+                return std::sqrt(value);
+            throw ParseError("Unsupported expression function '" + function + "'", line);
+        }
+        throw ParseError("Expected a constant angle expression", token_.line);
+    }
+
+    std::vector<double> parse_gate_arguments() {
+        std::vector<double> arguments;
+        if (!consume_symbol('(')) {
+            return arguments;
+        }
+        if (consume_symbol(')')) {
+            return arguments;
+        }
+        arguments.push_back(parse_expression());
+        while (consume_symbol(',')) {
+            if (arguments.size() == 3) {
+                throw ParseError("Too many gate arguments", token_.line);
+            }
+            arguments.push_back(parse_expression());
+        }
+        expect_symbol(')');
+        for (const double value : arguments) {
+            if (!std::isfinite(value)) {
+                throw ParseError("Gate arguments must evaluate to finite values", token_.line);
+            }
+        }
+        return arguments;
+    }
+
+    static std::vector<double> lower_arguments(std::string_view gate_name,
+                                                const std::vector<double>& radians) {
+        const double to_half_turns = 1.0 / std::numbers::pi;
+        if (gate_name == "u1") {
+            return {0.0, 0.0, radians[0] * to_half_turns};
+        }
+        if (gate_name == "u2") {
+            return {0.5, radians[0] * to_half_turns, radians[1] * to_half_turns};
+        }
+        std::vector<double> result;
+        result.reserve(radians.size());
+        for (const double value : radians) {
+            result.push_back(value * to_half_turns);
+        }
+        return result;
+    }
+
+    static double qasm_u_phase_turns(std::string_view gate_name,
+                                     const std::vector<double>& radians) {
+        double phi = 0.0;
+        double lambda = 0.0;
+        if (gate_name == "u1") {
+            lambda = radians[0];
+        } else if (gate_name == "u2") {
+            phi = radians[0];
+            lambda = radians[1];
+        } else {
+            phi = radians[1];
+            lambda = radians[2];
+        }
+        return (phi + lambda) / (2.0 * std::numbers::pi);
+    }
+
+    void parse_gate() {
+        const uint32_t line = token_.line;
+        const std::string gate_name = parse_identifier();
+        const GateSpec* spec = find_gate(gate_name);
+        if (spec == nullptr) {
+            throw ParseError("Unsupported unitary OpenQASM 2 gate '" + gate_name + "'", line);
+        }
+        if (spec->requires_qelib1 && !qelib1_included_) {
+            throw ParseError("Gate '" + gate_name + "' requires include \"qelib1.inc\"", line);
+        }
+
+        const std::vector<double> radians = parse_gate_arguments();
+        if (radians.size() != spec->num_args) {
+            throw ParseError("Gate '" + gate_name + "' expects " +
+                                 std::to_string(spec->num_args) + " angle arguments",
+                             line);
+        }
+        const std::vector<QubitArgument> qubits = parse_qubit_arguments();
+        if (qubits.size() != spec->num_qubits) {
+            throw ParseError("Gate '" + gate_name + "' expects " +
+                                 std::to_string(spec->num_qubits) + " quantum arguments",
+                             line);
+        }
+        expect_symbol(';');
+
+        uint32_t broadcast_width = 1;
+        for (const QubitArgument& qubit : qubits) {
+            broadcast_width = std::max(broadcast_width, qubit.width);
+        }
+        for (const QubitArgument& qubit : qubits) {
+            if (qubit.width != 1 && qubit.width != broadcast_width) {
+                throw ParseError("Register operands must have matching widths", line);
+            }
+        }
+
+        if (spec->phase_rule == PhaseRule::QasmU) {
+            result_.global_phase_turns = std::remainder(
+                result_.global_phase_turns +
+                    static_cast<double>(broadcast_width) * qasm_u_phase_turns(gate_name, radians),
+                2.0);
+        }
+        if (spec->identity) {
+            return;
+        }
+        if (broadcast_width > max_ops_ - std::min(max_ops_, result_.circuit.nodes.size())) {
+            throw ParseError("Circuit exceeds maximum lowered operations limit", line);
+        }
+
+        const std::vector<double> lowered_args = lower_arguments(gate_name, radians);
+        for (uint32_t index = 0; index < broadcast_width; ++index) {
+            std::vector<Target> targets;
+            targets.reserve(qubits.size());
+            std::unordered_set<uint32_t> used;
+            for (const QubitArgument& qubit : qubits) {
+                const uint32_t target = qubit.at(index);
+                if (!used.insert(target).second) {
+                    throw ParseError("A gate application cannot use the same qubit twice", line);
+                }
+                targets.push_back(Target::qubit(target));
+            }
+            result_.circuit.nodes.push_back(
+                {spec->gate, std::move(targets), lowered_args, line, {}});
+        }
+    }
+
+    Lexer lexer_;
+    Token token_;
+    size_t max_ops_;
+    bool qelib1_included_ = false;
+    std::unordered_map<std::string, Register> registers_;
+    Qasm2Import result_;
+};
+
+}  // namespace
+
+Qasm2Import parse_qasm2(std::string_view text) {
+    return parse_qasm2(text, kMaxUnrolledOps);
+}
+
+Qasm2Import parse_qasm2(std::string_view text, size_t max_ops) {
+    Parser parser(text, max_ops);
+    return parser.parse();
+}
+
+Qasm2Import parse_qasm2_file(const std::string& path) {
+    return parse_qasm2_file(path, kMaxUnrolledOps);
+}
+
+Qasm2Import parse_qasm2_file(const std::string& path, size_t max_ops) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) {
+        throw std::runtime_error("Cannot open file: " + path);
+    }
+    const std::streamoff length = file.tellg();
+    if (length < 0) {
+        throw std::runtime_error("Error determining file size: " + path);
+    }
+    constexpr std::streamsize kMaxFileSize = 1024LL * 1024LL * 1024LL;
+    if (length > kMaxFileSize) {
+        throw std::runtime_error("Circuit file exceeds 1GB memory limit (" +
+                                 std::to_string(length) + " bytes).");
+    }
+    std::string contents(static_cast<size_t>(length), '\0');
+    file.seekg(0, std::ios::beg);
+    if (!contents.empty() && !file.read(contents.data(), length)) {
+        throw std::runtime_error("Error reading file: " + path);
+    }
+    return parse_qasm2(contents, max_ops);
+}
+
+}  // namespace clifft

--- a/src/clifft/circuit/qasm2_parser.cc
+++ b/src/clifft/circuit/qasm2_parser.cc
@@ -2,6 +2,7 @@
 
 #include "clifft/circuit/parser.h"
 #include "clifft/util/config.h"
+#include "clifft/util/numeric.h"
 
 #include <algorithm>
 #include <cctype>
@@ -100,8 +101,7 @@ class Lexer {
     }
 
     void scan_number() {
-        while (offset_ < text_.size() &&
-               std::isdigit(static_cast<unsigned char>(text_[offset_]))) {
+        while (offset_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[offset_]))) {
             ++offset_;
         }
         if (offset_ < text_.size() && text_[offset_] == '.') {
@@ -232,9 +232,8 @@ struct QubitArgument {
 class Parser {
   public:
     Parser(std::string_view text, size_t max_ops) : lexer_(text), max_ops_(max_ops) {
-        const auto non_ascii = std::find_if(text.begin(), text.end(), [](char c) {
-            return static_cast<unsigned char>(c) > 127;
-        });
+        const auto non_ascii = std::find_if(
+            text.begin(), text.end(), [](char c) { return static_cast<unsigned char>(c) > 127; });
         if (non_ascii != text.end()) {
             throw ParseError("Non-ASCII/Unicode character detected. Only plain ASCII is supported.",
                              0);
@@ -262,11 +261,13 @@ class Parser {
                 parse_barrier();
             } else if (is_identifier("creg") || is_identifier("measure") ||
                        is_identifier("reset") || is_identifier("if")) {
-                throw ParseError("Non-unitary and classical statements are not supported by the "
-                                 "OpenQASM 2 importer",
-                                 token_.line);
+                throw ParseError(
+                    "Non-unitary and classical statements are not supported by the "
+                    "OpenQASM 2 importer",
+                    token_.line);
             } else if (is_identifier("gate") || is_identifier("opaque")) {
-                throw ParseError("Custom gate and opaque declarations are not supported", token_.line);
+                throw ParseError("Custom gate and opaque declarations are not supported",
+                                 token_.line);
             } else if (token_.kind == TokenKind::Identifier) {
                 parse_gate();
             } else {
@@ -321,8 +322,8 @@ class Parser {
     }
 
     uint32_t parse_uint() {
-        if (token_.kind != TokenKind::Number || token_.text.find_first_of(".eE") !=
-                                                   std::string_view::npos) {
+        if (token_.kind != TokenKind::Number ||
+            token_.text.find_first_of(".eE") != std::string_view::npos) {
             throw ParseError("Expected a non-negative integer", token_.line);
         }
         uint64_t value = 0;
@@ -460,8 +461,8 @@ class Parser {
         }
         if (token_.kind == TokenKind::Number) {
             double value = 0;
-            const auto parsed = fast_float::from_chars(token_.text.data(),
-                                                       token_.text.data() + token_.text.size(), value);
+            const auto parsed = fast_float::from_chars(
+                token_.text.data(), token_.text.data() + token_.text.size(), value);
             if (parsed.ec != std::errc{} || parsed.ptr != token_.text.data() + token_.text.size()) {
                 throw ParseError("Invalid numeric literal", token_.line);
             }
@@ -512,7 +513,7 @@ class Parser {
         }
         expect_symbol(')');
         for (const double value : arguments) {
-            if (!std::isfinite(value)) {
+            if (!is_finite_robust(value)) {
                 throw ParseError("Gate arguments must evaluate to finite values", token_.line);
             }
         }
@@ -520,7 +521,7 @@ class Parser {
     }
 
     static std::vector<double> lower_arguments(std::string_view gate_name,
-                                                const std::vector<double>& radians) {
+                                               const std::vector<double>& radians) {
         const double to_half_turns = 1.0 / std::numbers::pi;
         if (gate_name == "u1") {
             return {0.0, 0.0, radians[0] * to_half_turns};
@@ -565,8 +566,8 @@ class Parser {
 
         const std::vector<double> radians = parse_gate_arguments();
         if (radians.size() != spec->num_args) {
-            throw ParseError("Gate '" + gate_name + "' expects " +
-                                 std::to_string(spec->num_args) + " angle arguments",
+            throw ParseError("Gate '" + gate_name + "' expects " + std::to_string(spec->num_args) +
+                                 " angle arguments",
                              line);
         }
         const std::vector<QubitArgument> qubits = parse_qubit_arguments();

--- a/src/clifft/circuit/qasm2_parser.cc
+++ b/src/clifft/circuit/qasm2_parser.cc
@@ -4,7 +4,6 @@
 #include "clifft/util/config.h"
 #include "clifft/util/numeric.h"
 
-#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -51,6 +50,9 @@ class Lexer {
         const size_t start = offset_;
         const uint32_t token_line = line_;
         const char first = text_[offset_];
+        if (static_cast<unsigned char>(first) > 127) {
+            throw ParseError("Non-ASCII/Unicode character outside a comment", token_line);
+        }
 
         if (is_identifier_start(first)) {
             ++offset_;
@@ -71,6 +73,9 @@ class Lexer {
             ++offset_;
             const size_t content_start = offset_;
             while (offset_ < text_.size() && text_[offset_] != '"') {
+                if (static_cast<unsigned char>(text_[offset_]) > 127) {
+                    throw ParseError("Non-ASCII/Unicode character outside a comment", token_line);
+                }
                 if (text_[offset_] == '\n' || text_[offset_] == '\r') {
                     throw ParseError("Unterminated string literal", token_line);
                 }
@@ -231,15 +236,7 @@ struct QubitArgument {
 
 class Parser {
   public:
-    Parser(std::string_view text, size_t max_ops) : lexer_(text), max_ops_(max_ops) {
-        const auto non_ascii = std::find_if(
-            text.begin(), text.end(), [](char c) { return static_cast<unsigned char>(c) > 127; });
-        if (non_ascii != text.end()) {
-            throw ParseError("Non-ASCII/Unicode character detected. Only plain ASCII is supported.",
-                             0);
-        }
-        advance();
-    }
+    Parser(std::string_view text, size_t max_ops) : lexer_(text), max_ops_(max_ops) { advance(); }
 
     Qasm2Import parse() {
         expect_identifier("OPENQASM");
@@ -425,20 +422,20 @@ class Parser {
     }
 
     double parse_multiplicative() {
-        double value = parse_power();
+        double value = parse_unary();
         while (is_symbol('*') || is_symbol('/')) {
             const bool divide = is_symbol('/');
             advance();
-            const double rhs = parse_power();
+            const double rhs = parse_unary();
             value = divide ? value / rhs : value * rhs;
         }
         return value;
     }
 
     double parse_power() {
-        double value = parse_unary();
+        double value = parse_primary();
         if (consume_symbol('^')) {
-            value = std::pow(value, parse_power());
+            value = std::pow(value, parse_unary());
         }
         return value;
     }
@@ -450,7 +447,7 @@ class Parser {
         if (consume_symbol('-')) {
             return -parse_unary();
         }
-        return parse_primary();
+        return parse_power();
     }
 
     double parse_primary() {
@@ -537,8 +534,8 @@ class Parser {
         return result;
     }
 
-    static double qasm_u_phase_turns(std::string_view gate_name,
-                                     const std::vector<double>& radians) {
+    static double qasm_u_phase_half_turns(std::string_view gate_name,
+                                          const std::vector<double>& radians) {
         double phi = 0.0;
         double lambda = 0.0;
         if (gate_name == "u1") {
@@ -589,9 +586,9 @@ class Parser {
         }
 
         if (spec->phase_rule == PhaseRule::QasmU) {
-            result_.global_phase_turns = std::remainder(
-                result_.global_phase_turns +
-                    static_cast<double>(broadcast_width) * qasm_u_phase_turns(gate_name, radians),
+            result_.global_phase_half_turns = std::remainder(
+                result_.global_phase_half_turns + static_cast<double>(broadcast_width) *
+                                                      qasm_u_phase_half_turns(gate_name, radians),
                 2.0);
         }
         if (spec->identity) {

--- a/src/clifft/circuit/qasm2_parser.h
+++ b/src/clifft/circuit/qasm2_parser.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// Native unitary OpenQASM 2.0 importer.
+
+#include "clifft/circuit/circuit.h"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace clifft {
+
+// The imported AST stays phase-free so ordinary sampling compilation does not
+// acquire scalar bookkeeping. Phase-sensitive consumers can apply
+// exp(i * pi * global_phase_turns) at their separate compilation boundary.
+struct Qasm2Import {
+    Circuit circuit;
+    double global_phase_turns = 0.0;
+};
+
+// Parse and lower the supported unitary OpenQASM 2.0 subset.
+[[nodiscard]] Qasm2Import parse_qasm2(std::string_view text);
+
+// Parse with an explicit limit on the number of lowered AST nodes.
+[[nodiscard]] Qasm2Import parse_qasm2(std::string_view text, size_t max_ops);
+
+// Parse an OpenQASM 2.0 file.
+[[nodiscard]] Qasm2Import parse_qasm2_file(const std::string& path);
+
+// Parse a file with an explicit lowered-node limit.
+[[nodiscard]] Qasm2Import parse_qasm2_file(const std::string& path, size_t max_ops);
+
+}  // namespace clifft

--- a/src/clifft/circuit/qasm2_parser.h
+++ b/src/clifft/circuit/qasm2_parser.h
@@ -12,10 +12,10 @@ namespace clifft {
 
 // The imported AST stays phase-free so ordinary sampling compilation does not
 // acquire scalar bookkeeping. Phase-sensitive consumers can apply
-// exp(i * pi * global_phase_turns) at their separate compilation boundary.
+// exp(i * pi * global_phase_half_turns) at their separate compilation boundary.
 struct Qasm2Import {
     Circuit circuit;
-    double global_phase_turns = 0.0;
+    double global_phase_half_turns = 0.0;
 };
 
 // Parse and lower the supported unitary OpenQASM 2.0 subset.

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -35,12 +35,28 @@ static_assert(std::numeric_limits<double>::is_iec559,
 
 // -ffast-math implies -ffinite-math-only, which can fold away
 // std::isfinite() and NaN-aware comparisons. Inspect the exponent bits
-// instead: a non-finite double has all exponent bits set.
+// instead: a non-finite double has all exponent bits set. Keep the integer
+// predicate out of line so the compiler cannot propagate finite-math
+// assumptions from the floating-point value into the bit test.
+namespace detail {
+
+#if defined(_MSC_VER)
+__declspec(noinline)
+#else
+__attribute__((noinline))
+#endif
+inline bool
+binary64_bits_are_finite(uint64_t bits) {
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
+}
+
+}  // namespace detail
+
 inline bool is_finite_robust(double value) {
     uint64_t bits;
     std::memcpy(&bits, &value, sizeof(bits));
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
-    return (bits & kExpMask) != kExpMask;
+    return detail::binary64_bits_are_finite(bits);
 }
 
 // Return the Clifford representative when alpha is within the shared absolute

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -33,31 +33,34 @@ enum class CliffordRotation : uint8_t { IDENTITY = 0, SQRT = 1, PAULI = 2, SQRT_
 static_assert(std::numeric_limits<double>::is_iec559,
               "Clifft probability validation requires IEEE 754 doubles");
 
-// -ffast-math implies -ffinite-math-only, which can fold away
-// std::isfinite() and NaN-aware comparisons. Inspect the exponent bits
-// instead: a non-finite double has all exponent bits set. Keep the integer
-// predicate out of line so the compiler cannot propagate finite-math
-// assumptions from the floating-point value into the bit test; Apple Clang 17
-// on arm64 was observed to fold the otherwise-inline check.
+// Make a binary64 representation opaque to floating-point value propagation.
+// Apple Clang 17 on arm64 was observed to fold exponent checks derived directly
+// from a double when -ffast-math asserted that the source must be finite.
 namespace detail {
 
-#if defined(_MSC_VER)
-__declspec(noinline)
+inline uint64_t opaque_binary64_bits(double value) {
+    uint64_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__EMSCRIPTEN__)
+    // An empty register barrier emits no instructions while making the value
+    // opaque to the optimizer.
+    __asm__ __volatile__("" : "+r"(bits));
 #else
-__attribute__((noinline))
+    volatile uint64_t opaque_bits = bits;
+    bits = opaque_bits;
 #endif
-inline bool
-binary64_bits_are_finite(uint64_t bits) {
-    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
-    return (bits & kExpMask) != kExpMask;
+    return bits;
 }
 
 }  // namespace detail
 
+// -ffast-math implies -ffinite-math-only, which can fold away
+// std::isfinite() and NaN-aware comparisons. Inspect the exponent bits instead:
+// a non-finite double has all exponent bits set.
 inline bool is_finite_robust(double value) {
-    uint64_t bits;
-    std::memcpy(&bits, &value, sizeof(bits));
-    return detail::binary64_bits_are_finite(bits);
+    const uint64_t bits = detail::opaque_binary64_bits(value);
+    constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+    return (bits & kExpMask) != kExpMask;
 }
 
 // Return the Clifford representative when alpha is within the shared absolute
@@ -82,10 +85,17 @@ inline std::optional<CliffordRotation> classify_clifford_rotation(double alpha) 
     return static_cast<CliffordRotation>(residue);
 }
 
-// The finite check must precede the comparisons: under -ffast-math the
-// compiler may otherwise assume a NaN input is impossible.
+// Compare binary64 magnitudes so -ffast-math cannot assume that NaN and
+// infinity inputs are impossible. IEEE 754 ordering matches unsigned integer
+// ordering for nonnegative finite values; preserve the usual acceptance of
+// negative zero as a probability.
 inline bool is_probability(double value) {
-    return is_finite_robust(value) && value >= 0.0 && value <= 1.0;
+    const uint64_t bits = detail::opaque_binary64_bits(value);
+    constexpr uint64_t kSignMask = 0x8000000000000000ULL;
+    constexpr uint64_t kMagnitudeMask = ~kSignMask;
+    constexpr uint64_t kOneBits = 0x3FF0000000000000ULL;
+    const uint64_t magnitude = bits & kMagnitudeMask;
+    return magnitude == 0 || ((bits & kSignMask) == 0 && magnitude <= kOneBits);
 }
 
 }  // namespace clifft

--- a/src/clifft/util/numeric.h
+++ b/src/clifft/util/numeric.h
@@ -37,7 +37,8 @@ static_assert(std::numeric_limits<double>::is_iec559,
 // std::isfinite() and NaN-aware comparisons. Inspect the exponent bits
 // instead: a non-finite double has all exponent bits set. Keep the integer
 // predicate out of line so the compiler cannot propagate finite-math
-// assumptions from the floating-point value into the bit test.
+// assumptions from the floating-point value into the bit test; Apple Clang 17
+// on arm64 was observed to fold the otherwise-inline check.
 namespace detail {
 
 #if defined(_MSC_VER)

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -408,7 +408,7 @@ NB_MODULE(_clifft_core, m) {
         m, "Qasm2Import",
         "A natively parsed unitary OpenQASM 2 circuit and its source phase correction")
         .def_ro("circuit", &clifft::Qasm2Import::circuit)
-        .def_ro("global_phase_turns", &clifft::Qasm2Import::global_phase_turns,
+        .def_ro("global_phase_half_turns", &clifft::Qasm2Import::global_phase_half_turns,
                 "Source phase correction t representing exp(i * pi * t).")
         .def_prop_ro(
             "num_qubits",
@@ -418,7 +418,8 @@ NB_MODULE(_clifft_core, m) {
         .def("__repr__", [](const clifft::Qasm2Import& imported) {
             return "Qasm2Import(" + std::to_string(imported.circuit.nodes.size()) + " ops, " +
                    std::to_string(imported.circuit.num_qubits) +
-                   " qubits, phase_turns=" + std::to_string(imported.global_phase_turns) + ")";
+                   " qubits, phase_half_turns=" + std::to_string(imported.global_phase_half_turns) +
+                   ")";
         });
 
     m.def(

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -1,6 +1,7 @@
 #include "clifft/api/reference_syndrome.h"
 #include "clifft/circuit/circuit.h"
 #include "clifft/circuit/parser.h"
+#include "clifft/circuit/qasm2_parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/noncomp/level.h"
 #include "clifft/noncomp/model.h"
@@ -98,11 +99,12 @@ nb::ndarray<nb::numpy, T, nb::c_contig> vec_to_numpy(std::vector<T> vec,
     return nb::ndarray<nb::numpy, T, nb::c_contig>(data, shape, owner);
 }
 
-clifft::HirModule prepare_hir_for_lowering(const std::string& stim_text, bool normalize_syndromes,
-                                           clifft::HirPassManager* hir_passes,
-                                           std::vector<uint8_t>& expected_detectors,
-                                           std::vector<uint8_t>& expected_observables) {
-    clifft::HirModule hir = clifft::trace(clifft::parse(stim_text));
+clifft::HirModule prepare_circuit_for_lowering(const clifft::Circuit& circuit,
+                                               bool normalize_syndromes,
+                                               clifft::HirPassManager* hir_passes,
+                                               std::vector<uint8_t>& expected_detectors,
+                                               std::vector<uint8_t>& expected_observables) {
+    clifft::HirModule hir = clifft::trace(circuit);
     if (hir_passes != nullptr) {
         hir_passes->run(hir);
     }
@@ -117,6 +119,23 @@ clifft::HirModule prepare_hir_for_lowering(const std::string& stim_text, bool no
     expected_detectors = std::move(reference.detectors);
     expected_observables = std::move(reference.observables);
     return hir;
+}
+
+clifft::HirModule prepare_hir_for_lowering(const std::string& stim_text, bool normalize_syndromes,
+                                           clifft::HirPassManager* hir_passes,
+                                           std::vector<uint8_t>& expected_detectors,
+                                           std::vector<uint8_t>& expected_observables) {
+    return prepare_circuit_for_lowering(clifft::parse(stim_text), normalize_syndromes, hir_passes,
+                                        expected_detectors, expected_observables);
+}
+
+clifft::HirModule prepare_qasm2_for_lowering(const std::string& qasm_text, bool normalize_syndromes,
+                                             clifft::HirPassManager* hir_passes,
+                                             std::vector<uint8_t>& expected_detectors,
+                                             std::vector<uint8_t>& expected_observables) {
+    clifft::Qasm2Import imported = clifft::parse_qasm2(qasm_text);
+    return prepare_circuit_for_lowering(imported.circuit, normalize_syndromes, hir_passes,
+                                        expected_detectors, expected_observables);
 }
 
 }  // namespace
@@ -385,6 +404,23 @@ NB_MODULE(_clifft_core, m) {
                    " measurements)";
         });
 
+    nb::class_<clifft::Qasm2Import>(
+        m, "Qasm2Import",
+        "A natively parsed unitary OpenQASM 2 circuit and its source phase correction")
+        .def_ro("circuit", &clifft::Qasm2Import::circuit)
+        .def_ro("global_phase_turns", &clifft::Qasm2Import::global_phase_turns,
+                "Source phase correction t representing exp(i * pi * t).")
+        .def_prop_ro(
+            "num_qubits",
+            [](const clifft::Qasm2Import& imported) { return imported.circuit.num_qubits; })
+        .def("__len__",
+             [](const clifft::Qasm2Import& imported) { return imported.circuit.nodes.size(); })
+        .def("__repr__", [](const clifft::Qasm2Import& imported) {
+            return "Qasm2Import(" + std::to_string(imported.circuit.nodes.size()) + " ops, " +
+                   std::to_string(imported.circuit.num_qubits) +
+                   " qubits, phase_turns=" + std::to_string(imported.global_phase_turns) + ")";
+        });
+
     m.def(
         "parse",
         [](std::string_view text) {
@@ -415,6 +451,36 @@ NB_MODULE(_clifft_core, m) {
         },
         nb::arg("path"), nb::arg("max_ops"),
         "Parse a quantum circuit from a file with an explicit AST node limit.");
+    m.def(
+        "parse_qasm2",
+        [](std::string_view text) {
+            nb::gil_scoped_release release;
+            return clifft::parse_qasm2(text);
+        },
+        nb::arg("text"), "Parse and lower a unitary OpenQASM 2 circuit.");
+    m.def(
+        "parse_qasm2",
+        [](std::string_view text, size_t max_ops) {
+            nb::gil_scoped_release release;
+            return clifft::parse_qasm2(text, max_ops);
+        },
+        nb::arg("text"), nb::arg("max_ops"),
+        "Parse and lower a unitary OpenQASM 2 circuit with an explicit AST node limit.");
+    m.def(
+        "parse_qasm2_file",
+        [](const std::string& path) {
+            nb::gil_scoped_release release;
+            return clifft::parse_qasm2_file(path);
+        },
+        nb::arg("path"), "Parse and lower a unitary OpenQASM 2 circuit file.");
+    m.def(
+        "parse_qasm2_file",
+        [](const std::string& path, size_t max_ops) {
+            nb::gil_scoped_release release;
+            return clifft::parse_qasm2_file(path, max_ops);
+        },
+        nb::arg("path"), nb::arg("max_ops"),
+        "Parse and lower a unitary OpenQASM 2 file with an explicit AST node limit.");
 
     nb::enum_<clifft::OpType>(m, "OpType", "Heisenberg IR operation types")
         .value("T_GATE", clifft::OpType::T_GATE)
@@ -791,6 +857,25 @@ NB_MODULE(_clifft_core, m) {
         "    normalize_syndromes: If True, auto-compute reference parities from a\n"
         "        noiseless reference shot (mutually exclusive with explicit parities).\n"
         "    hir_passes: Optional HirPassManager to run on the HIR before lowering.\n");
+
+    m.def(
+        "_compile_qasm2",
+        [](const std::string& qasm_text, std::vector<uint8_t> postselection_mask,
+           std::vector<uint8_t> expected_detectors, std::vector<uint8_t> expected_observables,
+           bool normalize_syndromes, clifft::HirPassManager* hir_passes) {
+            nb::gil_scoped_release release;
+            clifft::HirModule hir =
+                prepare_qasm2_for_lowering(qasm_text, normalize_syndromes, hir_passes,
+                                           expected_detectors, expected_observables);
+
+            return clifft::sampling::ExecutablePlan(clifft::sampling::plan_sampling(
+                hir, {postselection_mask, expected_detectors, expected_observables}));
+        },
+        nb::arg("qasm_text"), nb::arg("postselection_mask") = std::vector<uint8_t>{},
+        nb::arg("expected_detectors") = std::vector<uint8_t>{},
+        nb::arg("expected_observables") = std::vector<uint8_t>{},
+        nb::arg("normalize_syndromes") = false, nb::arg("hir_passes") = nb::none(),
+        "Compile a unitary OpenQASM 2 circuit string to an executable program.");
 
     m.def(
         "sample",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -1,10 +1,10 @@
 """Clifft.
 
 A fast exact simulator for near-Clifford quantum circuits. Clifft accepts
-Stim-format circuits with non-Clifford extensions and compiles them into a
-symbolic-coordinate sampling plan whose cost scales with the active-state
-dimension rather than the full Hilbert space. If the active width is `k`, this
-dimension is `2^k`.
+Stim-format circuits with non-Clifford extensions and a native unitary
+OpenQASM 2 subset, then compiles them into a symbolic-coordinate sampling plan
+whose cost scales with the active-state dimension rather than the full Hilbert
+space. If the active width is `k`, this dimension is `2^k`.
 """
 
 # ruff: noqa: E402
@@ -13,7 +13,7 @@ from __future__ import annotations
 import importlib
 from collections.abc import Sequence
 from types import ModuleType
-from typing import TYPE_CHECKING, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -41,6 +41,7 @@ from clifft._clifft_core import (
     ParseError,
     PeepholeFusionPass,
     Program,
+    Qasm2Import,
     RemoveNoisePass,
     StatevectorSqueezePass,
     Target,
@@ -52,6 +53,8 @@ from clifft._clifft_core import (
     lower,
     parse,
     parse_file,
+    parse_qasm2,
+    parse_qasm2_file,
     runtime_isa,
     sample,
     sample_k,
@@ -59,6 +62,9 @@ from clifft._clifft_core import (
     sample_survivors,
     trace,
     version,
+)
+from clifft._clifft_core import (
+    _compile_qasm2 as _compile_qasm2_core,
 )
 from clifft._clifft_core import (
     _prepare_hir_for_lowering as _prepare_hir_for_lowering,
@@ -295,6 +301,7 @@ def compile(
     expected_observables: list[int] | None = None,
     normalize_syndromes: bool = False,
     hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+    input_format: Literal["stim", "qasm2"] = "stim",
 ) -> Program:
     """Compile a quantum circuit string to an executable sampling program.
 
@@ -307,7 +314,7 @@ def compile(
     that 0 means 'matches noiseless reference' and 1 means 'error'.
 
     Args:
-        stim_text: Circuit in .stim text format.
+        stim_text: Circuit text in the format selected by ``input_format``.
         postselection_mask: Optional list of uint8 flags, one per detector.
             Detectors where mask[i] != 0 become post-selection checks
             that abort the shot early if their parity is non-zero.
@@ -317,10 +324,18 @@ def compile(
             noiseless reference shot (mutually exclusive with explicit parities).
         hir_passes: HirPassManager to run on the HIR before lowering.
             Defaults to ``default_hir_pass_manager()``. Pass ``None`` to skip.
+        input_format: ``"stim"`` for Clifft's Stim-compatible syntax or
+            ``"qasm2"`` for the supported unitary OpenQASM 2 subset.
     """
     if isinstance(hir_passes, _DefaultPasses):
         hir_passes = default_hir_pass_manager()
-    return _compile_core(
+    if input_format == "stim":
+        compile_core = _compile_core
+    elif input_format == "qasm2":
+        compile_core = _compile_qasm2_core
+    else:
+        raise ValueError("input_format must be 'stim' or 'qasm2'")
+    return compile_core(
         stim_text,
         postselection_mask if postselection_mask is not None else [],
         expected_detectors if expected_detectors is not None else [],
@@ -345,6 +360,7 @@ __all__ = [
     "ParseError",
     "PeepholeFusionPass",
     "Program",
+    "Qasm2Import",
     "RemoveNoisePass",
     "SampleResult",
     "StatevectorSqueezePass",
@@ -359,6 +375,8 @@ __all__ = [
     "noncomp",
     "parse",
     "parse_file",
+    "parse_qasm2",
+    "parse_qasm2_file",
     "record_probabilities",
     "runtime_isa",
     "sample",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -1,10 +1,10 @@
 """Clifft.
 
 A fast exact simulator for near-Clifford quantum circuits. Clifft accepts
-Stim-format circuits with non-Clifford extensions and a native unitary
-OpenQASM 2 subset, then compiles them into a symbolic-coordinate sampling plan
-whose cost scales with the active-state dimension rather than the full Hilbert
-space. If the active width is `k`, this dimension is `2^k`.
+Stim-format circuits with non-Clifford extensions and compiles them into a
+symbolic-coordinate sampling plan whose cost scales with the active-state
+dimension rather than the full Hilbert space. If the active width is `k`, this
+dimension is `2^k`.
 """
 
 # ruff: noqa: E402

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -25,6 +25,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/FetchNlohmannJson.cmake)
 # Build the core library (reuses the same source list)
 add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/circuit/parser.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/circuit/qasm2_parser.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/tableau/pauli_string.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/tableau/tableau.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/frontend/frontend.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(clifft_tests
     test_benchmarks.cc
     test_bitmask.cc
     test_mask_view.cc
+    test_numeric.cc
     test_page_allocation.cc
     test_parser.cc
     test_qasm2_parser.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(clifft_tests
     test_mask_view.cc
     test_page_allocation.cc
     test_parser.cc
+    test_qasm2_parser.cc
     test_reference_clifford.cc
     test_tableau.cc
     test_hir.cc

--- a/tests/python/test_qasm2.py
+++ b/tests/python/test_qasm2.py
@@ -1,0 +1,129 @@
+"""Native unitary OpenQASM 2 import and compilation contracts."""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from conftest import assert_statevectors_equiv
+from qiskit import qasm2
+from qiskit.quantum_info import Statevector
+
+import clifft
+
+
+ABSTRACTS_STYLE_QASM = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[4];
+s q[0];
+t q[1];
+cx q[0], q[2];
+rx(0.5*pi) q[3];
+"""
+
+
+def test_parse_qasm2_exposes_lowered_circuit_and_phase() -> None:
+    """The public import retains both the reusable AST and source phase."""
+    imported = clifft.parse_qasm2(
+        """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        u1(pi/2) q[0];
+        """
+    )
+
+    assert isinstance(imported, clifft.Qasm2Import)
+    assert isinstance(imported.circuit, clifft.Circuit)
+    assert imported.num_qubits == 1
+    assert len(imported) == 1
+    assert imported.global_phase_turns == pytest.approx(0.25)
+    assert imported.circuit.nodes[0].gate == clifft.GateType.U3
+
+
+def test_compile_accepts_qasm2_as_an_explicit_input_format() -> None:
+    """QASM input flows through the ordinary compiler after native lowering."""
+    qasm = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        h q[0];
+        cx q[0], q[1];
+    """
+    program = clifft.compile(qasm, input_format="qasm2")
+    probabilities = clifft.basis_probabilities(program, ["00", "01", "10", "11"])
+    np.testing.assert_allclose(probabilities, [0.5, 0.0, 0.0, 0.5], atol=1e-12)
+
+
+def test_abstracts_style_qasm_matches_qiskit_statevector() -> None:
+    """The benchmark's complete gate vocabulary agrees with an independent parser."""
+    program = clifft.compile(ABSTRACTS_STYLE_QASM, hir_passes=None, input_format="qasm2")
+    actual = clifft.get_statevector(program)
+    expected = np.asarray(Statevector.from_instruction(qasm2.loads(ABSTRACTS_STYLE_QASM)).data)
+    assert_statevectors_equiv(actual, expected)
+
+
+def test_qasm2_euler_and_register_broadcast_match_qiskit() -> None:
+    """Parameterized source semantics survive native register expansion."""
+    source = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg a[2];
+        qreg b[2];
+        h a;
+        u3(pi/3, -pi/5, pi/7) b;
+        cx a,b;
+        cz a[0],b[1];
+    """
+    program = clifft.compile(source, hir_passes=None, input_format="qasm2")
+    actual = clifft.get_statevector(program)
+    expected = np.asarray(Statevector.from_instruction(qasm2.loads(source)).data)
+    assert_statevectors_equiv(actual, expected)
+
+
+def test_parse_qasm2_file() -> None:
+    """The file entry point returns the same import metadata."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".qasm", delete=False) as handle:
+        handle.write(ABSTRACTS_STYLE_QASM)
+        path = Path(handle.name)
+
+    try:
+        imported = clifft.parse_qasm2_file(str(path))
+        assert imported.num_qubits == 4
+        assert len(imported) == 4
+    finally:
+        path.unlink()
+
+
+def test_compile_rejects_unknown_input_format() -> None:
+    """Input selection is explicit rather than content-sniffed."""
+    with pytest.raises(ValueError, match="input_format"):
+        clifft.compile("H 0", input_format="qasm3")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "creg c[1];",
+        "reset q[0];",
+        "measure q[0] -> c[0];",
+        "if(c==1) x q[0];",
+    ],
+)
+def test_qasm2_unitary_scope_rejects_dynamic_statements(statement: str) -> None:
+    """The initial importer never assigns accidental semantics to dynamic circuits."""
+    source = f"""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        {statement}
+    """
+    with pytest.raises(clifft.ParseError, match="Non-unitary and classical"):
+        clifft.parse_qasm2(source)
+
+
+def test_qasm3_header_has_a_specific_error() -> None:
+    """QASM 3 is reserved for a separately specified importer extension."""
+    with pytest.raises(clifft.ParseError, match="OpenQASM 3 is not supported"):
+        clifft.parse_qasm2("OPENQASM 3.0;")

--- a/tests/python/test_qasm2.py
+++ b/tests/python/test_qasm2.py
@@ -11,7 +11,6 @@ from qiskit.quantum_info import Statevector
 
 import clifft
 
-
 ABSTRACTS_STYLE_QASM = """
 OPENQASM 2.0;
 include "qelib1.inc";

--- a/tests/python/test_qasm2.py
+++ b/tests/python/test_qasm2.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from conftest import assert_statevectors_equiv
-from qiskit import qasm2
+from qiskit import QuantumCircuit, qasm2
 from qiskit.quantum_info import Statevector
 
 import clifft
@@ -37,7 +37,7 @@ def test_parse_qasm2_exposes_lowered_circuit_and_phase() -> None:
     assert isinstance(imported.circuit, clifft.Circuit)
     assert imported.num_qubits == 1
     assert len(imported) == 1
-    assert imported.global_phase_turns == pytest.approx(0.25)
+    assert imported.global_phase_half_turns == pytest.approx(0.25)
     assert imported.circuit.nodes[0].gate == clifft.GateType.U3
 
 
@@ -79,6 +79,44 @@ def test_qasm2_euler_and_register_broadcast_match_qiskit() -> None:
     actual = clifft.get_statevector(program)
     expected = np.asarray(Statevector.from_instruction(qasm2.loads(source)).data)
     assert_statevectors_equiv(actual, expected)
+
+
+@pytest.mark.parametrize("expression", ["-2^2", "2^-1", "2^3^2"])
+def test_qasm2_power_precedence_matches_qiskit(expression: str) -> None:
+    """Unary signs and right-associative powers follow Qiskit's grammar."""
+    source = 'OPENQASM 2.0; include "qelib1.inc"; qreg q[1]; ' f"rz({expression}) q[0];"
+    imported = clifft.parse_qasm2(source)
+    actual = imported.circuit.nodes[0].args[0] * np.pi
+    expected = float(qasm2.loads(source).data[0].operation.params[0])
+    assert actual == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "OPENQASM 2.0; qreg q[1]; U(0.31, -0.47, 0.59) q[0];",
+        ('OPENQASM 2.0; include "qelib1.inc"; qreg q[1]; ' "u1(0.37) q[0];"),
+        ('OPENQASM 2.0; include "qelib1.inc"; qreg q[1]; ' "u2(-0.23, 0.41) q[0];"),
+        ('OPENQASM 2.0; include "qelib1.inc"; qreg q[1]; ' "u3(0.31, -0.47, 0.59) q[0];"),
+        ('OPENQASM 2.0; include "qelib1.inc"; qreg q[3]; ' "u3(0.31, -0.47, 0.59) q;"),
+    ],
+)
+def test_qasm2_phase_sidecar_reconstructs_exact_qiskit_statevector(source: str) -> None:
+    """The sidecar restores source amplitudes without phase alignment."""
+    imported = clifft.parse_qasm2(source)
+    internal = QuantumCircuit(imported.num_qubits)
+    for node in imported.circuit.nodes:
+        assert node.gate == clifft.GateType.U3
+        theta, phi, lam = (angle * np.pi for angle in node.args)
+        qubit = node.targets[0].value
+        internal.rz(lam, qubit)
+        internal.ry(theta, qubit)
+        internal.rz(phi, qubit)
+
+    internal_state = np.asarray(Statevector.from_instruction(internal).data)
+    actual = np.exp(1j * np.pi * imported.global_phase_half_turns) * internal_state
+    expected = np.asarray(Statevector.from_instruction(qasm2.loads(source)).data)
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
 
 
 def test_parse_qasm2_file() -> None:

--- a/tests/test_numeric.cc
+++ b/tests/test_numeric.cc
@@ -1,0 +1,32 @@
+#include "clifft/util/numeric.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <limits>
+
+#include "test_helpers.h"
+
+using namespace clifft;
+
+TEST_CASE("Robust finite checks survive finite-math optimization") {
+    CHECK(is_finite_robust(0.0));
+    CHECK(is_finite_robust(std::numeric_limits<double>::lowest()));
+    CHECK(is_finite_robust(std::numeric_limits<double>::max()));
+    CHECK_FALSE(is_finite_robust(clifft::test::opaque_nan()));
+    CHECK_FALSE(is_finite_robust(clifft::test::opaque_infinity()));
+    CHECK_FALSE(is_finite_robust(
+        clifft::test::opaque_nonfinite(0xFFF0000000000000ULL)));
+}
+
+TEST_CASE("Probability checks survive finite-math optimization") {
+    CHECK(is_probability(0.0));
+    CHECK(is_probability(-0.0));
+    CHECK(is_probability(0.5));
+    CHECK(is_probability(1.0));
+    CHECK_FALSE(is_probability(-0.01));
+    CHECK_FALSE(is_probability(1.01));
+    CHECK_FALSE(is_probability(clifft::test::opaque_nan()));
+    CHECK_FALSE(is_probability(clifft::test::opaque_infinity()));
+    CHECK_FALSE(is_probability(
+        clifft::test::opaque_nonfinite(0xFFF0000000000000ULL)));
+}

--- a/tests/test_numeric.cc
+++ b/tests/test_numeric.cc
@@ -1,10 +1,9 @@
 #include "clifft/util/numeric.h"
 
-#include <catch2/catch_test_macros.hpp>
-
-#include <limits>
-
 #include "test_helpers.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <limits>
 
 using namespace clifft;
 
@@ -14,8 +13,7 @@ TEST_CASE("Robust finite checks survive finite-math optimization") {
     CHECK(is_finite_robust(std::numeric_limits<double>::max()));
     CHECK_FALSE(is_finite_robust(clifft::test::opaque_nan()));
     CHECK_FALSE(is_finite_robust(clifft::test::opaque_infinity()));
-    CHECK_FALSE(is_finite_robust(
-        clifft::test::opaque_nonfinite(0xFFF0000000000000ULL)));
+    CHECK_FALSE(is_finite_robust(clifft::test::opaque_nonfinite(0xFFF0000000000000ULL)));
 }
 
 TEST_CASE("Probability checks survive finite-math optimization") {
@@ -27,6 +25,5 @@ TEST_CASE("Probability checks survive finite-math optimization") {
     CHECK_FALSE(is_probability(1.01));
     CHECK_FALSE(is_probability(clifft::test::opaque_nan()));
     CHECK_FALSE(is_probability(clifft::test::opaque_infinity()));
-    CHECK_FALSE(is_probability(
-        clifft::test::opaque_nonfinite(0xFFF0000000000000ULL)));
+    CHECK_FALSE(is_probability(clifft::test::opaque_nonfinite(0xFFF0000000000000ULL)));
 }

--- a/tests/test_qasm2_parser.cc
+++ b/tests/test_qasm2_parser.cc
@@ -1,0 +1,201 @@
+#include "clifft/circuit/parser.h"
+#include "clifft/circuit/qasm2_parser.h"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+using namespace clifft;
+
+TEST_CASE("OpenQASM 2 imports the ABSTRACTS gate vocabulary") {
+    const Qasm2Import imported = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[4];
+        s q[0];
+        t q[1];
+        cx q[0], q[2];
+        rx(0.5*pi) q[3];
+    )");
+
+    REQUIRE(imported.circuit.num_qubits == 4);
+    REQUIRE(imported.circuit.nodes.size() == 4);
+    CHECK(imported.circuit.nodes[0].gate == GateType::S);
+    CHECK(imported.circuit.nodes[1].gate == GateType::T);
+    CHECK(imported.circuit.nodes[2].gate == GateType::CX);
+    CHECK(imported.circuit.nodes[2].targets[0].value() == 0);
+    CHECK(imported.circuit.nodes[2].targets[1].value() == 2);
+    CHECK(imported.circuit.nodes[3].gate == GateType::R_X);
+    REQUIRE(imported.circuit.nodes[3].args.size() == 1);
+    CHECK(imported.circuit.nodes[3].args[0] == Catch::Approx(0.5));
+    CHECK(imported.global_phase_turns == 0.0);
+}
+
+TEST_CASE("OpenQASM 2 preserves declared widths and broadcasts registers") {
+    const Qasm2Import imported = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg control[2];
+        qreg target[2];
+        h control;
+        cx control, target;
+        cz control[0], target;
+    )");
+
+    REQUIRE(imported.circuit.num_qubits == 4);
+    REQUIRE(imported.circuit.nodes.size() == 6);
+    CHECK(imported.circuit.nodes[0].targets[0].value() == 0);
+    CHECK(imported.circuit.nodes[1].targets[0].value() == 1);
+    CHECK(imported.circuit.nodes[2].targets[0].value() == 0);
+    CHECK(imported.circuit.nodes[2].targets[1].value() == 2);
+    CHECK(imported.circuit.nodes[3].targets[0].value() == 1);
+    CHECK(imported.circuit.nodes[3].targets[1].value() == 3);
+    CHECK(imported.circuit.nodes[4].targets[0].value() == 0);
+    CHECK(imported.circuit.nodes[4].targets[1].value() == 2);
+    CHECK(imported.circuit.nodes[5].targets[0].value() == 0);
+    CHECK(imported.circuit.nodes[5].targets[1].value() == 3);
+}
+
+TEST_CASE("OpenQASM 2 evaluates constant angle expressions") {
+    const Qasm2Import imported = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        rx(sqrt(4)*pi/4) q[0];
+        ry(2^3*pi/8) q[1];
+        rz(cos(0)*pi) q[2];
+    )");
+
+    REQUIRE(imported.circuit.nodes.size() == 3);
+    CHECK(imported.circuit.nodes[0].args[0] == Catch::Approx(0.5));
+    CHECK(imported.circuit.nodes[1].args[0] == Catch::Approx(1.0));
+    CHECK(imported.circuit.nodes[2].args[0] == Catch::Approx(1.0));
+}
+
+TEST_CASE("OpenQASM 2 lowers Euler gates with their source phase") {
+    const Qasm2Import u1 = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        u1(pi/2) q[0];
+    )");
+    REQUIRE(u1.circuit.nodes.size() == 1);
+    CHECK(u1.circuit.nodes[0].gate == GateType::U3);
+    REQUIRE(u1.circuit.nodes[0].args.size() == 3);
+    CHECK(u1.circuit.nodes[0].args[0] == 0.0);
+    CHECK(u1.circuit.nodes[0].args[1] == 0.0);
+    CHECK(u1.circuit.nodes[0].args[2] == Catch::Approx(0.5));
+    CHECK(u1.global_phase_turns == Catch::Approx(0.25));
+
+    const Qasm2Import u2 = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        u2(pi/3, pi/7) q[0];
+    )");
+    REQUIRE(u2.circuit.nodes.size() == 1);
+    REQUIRE(u2.circuit.nodes[0].args.size() == 3);
+    CHECK(u2.circuit.nodes[0].args[0] == Catch::Approx(0.5));
+    CHECK(u2.circuit.nodes[0].args[1] == Catch::Approx(1.0 / 3.0));
+    CHECK(u2.circuit.nodes[0].args[2] == Catch::Approx(1.0 / 7.0));
+    CHECK(u2.global_phase_turns == Catch::Approx(5.0 / 21.0));
+
+    const Qasm2Import builtin = parse_qasm2(R"(
+        OPENQASM 2.0;
+        qreg q[1];
+        U(pi/3, pi/5, -pi/7) q[0];
+    )");
+    REQUIRE(builtin.circuit.nodes.size() == 1);
+    REQUIRE(builtin.circuit.nodes[0].args.size() == 3);
+    CHECK(builtin.circuit.nodes[0].args[0] == Catch::Approx(1.0 / 3.0));
+    CHECK(builtin.circuit.nodes[0].args[1] == Catch::Approx(1.0 / 5.0));
+    CHECK(builtin.circuit.nodes[0].args[2] == Catch::Approx(-1.0 / 7.0));
+    CHECK(builtin.global_phase_turns == Catch::Approx(1.0 / 35.0));
+}
+
+TEST_CASE("OpenQASM 2 phase corrections include register broadcast") {
+    const Qasm2Import imported = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        u1(pi/2) q;
+    )");
+    CHECK(imported.circuit.nodes.size() == 3);
+    CHECK(imported.global_phase_turns == Catch::Approx(0.75));
+}
+
+TEST_CASE("OpenQASM 2 accepts comments barriers and builtins") {
+    const Qasm2Import imported = parse_qasm2(R"(
+        /* header */ OPENQASM 2.0;
+        qreg q[2]; // builtins do not require qelib1
+        U(0, 0, 0) q[0];
+        CX q[0], q[1];
+        barrier q[0], q[1];
+    )");
+    REQUIRE(imported.circuit.nodes.size() == 2);
+    CHECK(imported.circuit.nodes[0].source_line == 4);
+    CHECK(imported.circuit.nodes[1].source_line == 5);
+}
+
+TEST_CASE("OpenQASM 2 identity preserves metadata without an operation") {
+    const Qasm2Import imported = parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[9];
+        id q;
+    )");
+    CHECK(imported.circuit.num_qubits == 9);
+    CHECK(imported.circuit.nodes.empty());
+}
+
+TEST_CASE("OpenQASM 2 rejects unsupported language features") {
+    const std::vector<std::string> sources = {
+        "OPENQASM 3.0;",
+        "OPENQASM 2.0; include \"other.inc\";",
+        "OPENQASM 2.0; creg c[1];",
+        "OPENQASM 2.0; qreg q[1]; reset q[0];",
+        "OPENQASM 2.0; qreg q[1]; measure q[0];",
+        "OPENQASM 2.0; gate custom a { U(0,0,0) a; }",
+        "OPENQASM 2.0; opaque custom a;",
+    };
+    for (const std::string& source : sources) {
+        CHECK_THROWS_AS(parse_qasm2(source), ParseError);
+    }
+}
+
+TEST_CASE("OpenQASM 2 validates registers gates and expressions") {
+    const std::vector<std::string> sources = {
+        "OPENQASM 2.0; qreg q[0];",
+        "OPENQASM 2.0; qreg q[1]; qreg q[1];",
+        "OPENQASM 2.0; qreg q[1]; x q[0];",
+        "OPENQASM 2.0; include \"qelib1.inc\"; qreg q[1]; x q[1];",
+        "OPENQASM 2.0; include \"qelib1.inc\"; qreg q[1]; rx(1/0) q[0];",
+        "OPENQASM 2.0; include \"qelib1.inc\"; qreg q[1]; rx(foo(1)) q[0];",
+        "OPENQASM 2.0; include \"qelib1.inc\"; qreg q[1]; ch q[0],q[0];",
+        "OPENQASM 2.0; qreg q[1]; CX q[0],q[0];",
+    };
+    for (const std::string& source : sources) {
+        CHECK_THROWS_AS(parse_qasm2(source), ParseError);
+    }
+}
+
+TEST_CASE("OpenQASM 2 validates register broadcast and operation limits") {
+    CHECK_THROWS_AS(parse_qasm2(R"(
+        OPENQASM 2.0;
+        qreg a[2];
+        qreg b[3];
+        CX a,b;
+    )"),
+                    ParseError);
+
+    CHECK_THROWS_AS(parse_qasm2(R"(
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        h q;
+    )",
+                                2),
+                    ParseError);
+}

--- a/tests/test_qasm2_parser.cc
+++ b/tests/test_qasm2_parser.cc
@@ -3,6 +3,7 @@
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <numbers>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ TEST_CASE("OpenQASM 2 imports the ABSTRACTS gate vocabulary") {
     CHECK(imported.circuit.nodes[3].gate == GateType::R_X);
     REQUIRE(imported.circuit.nodes[3].args.size() == 1);
     CHECK(imported.circuit.nodes[3].args[0] == Catch::Approx(0.5));
-    CHECK(imported.global_phase_turns == 0.0);
+    CHECK(imported.global_phase_half_turns == 0.0);
 }
 
 TEST_CASE("OpenQASM 2 preserves declared widths and broadcasts registers") {
@@ -61,16 +62,22 @@ TEST_CASE("OpenQASM 2 evaluates constant angle expressions") {
     const Qasm2Import imported = parse_qasm2(R"(
         OPENQASM 2.0;
         include "qelib1.inc";
-        qreg q[3];
+        qreg q[6];
         rx(sqrt(4)*pi/4) q[0];
         ry(2^3*pi/8) q[1];
         rz(cos(0)*pi) q[2];
+        rz(-2^2) q[3];
+        rz(2^-1) q[4];
+        rz(2^3^2) q[5];
     )");
 
-    REQUIRE(imported.circuit.nodes.size() == 3);
+    REQUIRE(imported.circuit.nodes.size() == 6);
     CHECK(imported.circuit.nodes[0].args[0] == Catch::Approx(0.5));
     CHECK(imported.circuit.nodes[1].args[0] == Catch::Approx(1.0));
     CHECK(imported.circuit.nodes[2].args[0] == Catch::Approx(1.0));
+    CHECK(imported.circuit.nodes[3].args[0] == Catch::Approx(-4.0 / std::numbers::pi));
+    CHECK(imported.circuit.nodes[4].args[0] == Catch::Approx(0.5 / std::numbers::pi));
+    CHECK(imported.circuit.nodes[5].args[0] == Catch::Approx(512.0 / std::numbers::pi));
 }
 
 TEST_CASE("OpenQASM 2 lowers Euler gates with their source phase") {
@@ -86,7 +93,7 @@ TEST_CASE("OpenQASM 2 lowers Euler gates with their source phase") {
     CHECK(u1.circuit.nodes[0].args[0] == 0.0);
     CHECK(u1.circuit.nodes[0].args[1] == 0.0);
     CHECK(u1.circuit.nodes[0].args[2] == Catch::Approx(0.5));
-    CHECK(u1.global_phase_turns == Catch::Approx(0.25));
+    CHECK(u1.global_phase_half_turns == Catch::Approx(0.25));
 
     const Qasm2Import u2 = parse_qasm2(R"(
         OPENQASM 2.0;
@@ -99,7 +106,7 @@ TEST_CASE("OpenQASM 2 lowers Euler gates with their source phase") {
     CHECK(u2.circuit.nodes[0].args[0] == Catch::Approx(0.5));
     CHECK(u2.circuit.nodes[0].args[1] == Catch::Approx(1.0 / 3.0));
     CHECK(u2.circuit.nodes[0].args[2] == Catch::Approx(1.0 / 7.0));
-    CHECK(u2.global_phase_turns == Catch::Approx(5.0 / 21.0));
+    CHECK(u2.global_phase_half_turns == Catch::Approx(5.0 / 21.0));
 
     const Qasm2Import builtin = parse_qasm2(R"(
         OPENQASM 2.0;
@@ -111,7 +118,7 @@ TEST_CASE("OpenQASM 2 lowers Euler gates with their source phase") {
     CHECK(builtin.circuit.nodes[0].args[0] == Catch::Approx(1.0 / 3.0));
     CHECK(builtin.circuit.nodes[0].args[1] == Catch::Approx(1.0 / 5.0));
     CHECK(builtin.circuit.nodes[0].args[2] == Catch::Approx(-1.0 / 7.0));
-    CHECK(builtin.global_phase_turns == Catch::Approx(1.0 / 35.0));
+    CHECK(builtin.global_phase_half_turns == Catch::Approx(1.0 / 35.0));
 }
 
 TEST_CASE("OpenQASM 2 phase corrections include register broadcast") {
@@ -122,20 +129,33 @@ TEST_CASE("OpenQASM 2 phase corrections include register broadcast") {
         u1(pi/2) q;
     )");
     CHECK(imported.circuit.nodes.size() == 3);
-    CHECK(imported.global_phase_turns == Catch::Approx(0.75));
+    CHECK(imported.global_phase_half_turns == Catch::Approx(0.75));
 }
 
 TEST_CASE("OpenQASM 2 accepts comments barriers and builtins") {
-    const Qasm2Import imported = parse_qasm2(R"(
-        /* header */ OPENQASM 2.0;
-        qreg q[2]; // builtins do not require qelib1
-        U(0, 0, 0) q[0];
-        CX q[0], q[1];
-        barrier q[0], q[1];
-    )");
+    const std::string source =
+        "/* author \xC3\xA9 */ OPENQASM 2.0;\n"
+        "qreg q[2]; // \xCE\xB8 rotation\n"
+        "U(0, 0, 0) q[0];\n"
+        "CX q[0], q[1];\n"
+        "barrier q[0], q[1];\n";
+    const Qasm2Import imported = parse_qasm2(source);
     REQUIRE(imported.circuit.nodes.size() == 2);
-    CHECK(imported.circuit.nodes[0].source_line == 4);
-    CHECK(imported.circuit.nodes[1].source_line == 5);
+    CHECK(imported.circuit.nodes[0].source_line == 3);
+    CHECK(imported.circuit.nodes[1].source_line == 4);
+}
+
+TEST_CASE("OpenQASM 2 reports non-ASCII syntax at its source line") {
+    const std::string source =
+        "OPENQASM 2.0;\n"
+        "qreg q[1];\n"
+        "\xCE\xB8 q[0];\n";
+    try {
+        (void)parse_qasm2(source);
+        FAIL("Expected ParseError");
+    } catch (const ParseError& error) {
+        CHECK(error.line() == 3);
+    }
 }
 
 TEST_CASE("OpenQASM 2 identity preserves metadata without an operation") {

--- a/tests/test_qasm2_parser.cc
+++ b/tests/test_qasm2_parser.cc
@@ -3,7 +3,6 @@
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
-
 #include <string>
 #include <vector>
 
@@ -161,6 +160,7 @@ TEST_CASE("OpenQASM 2 rejects unsupported language features") {
         "OPENQASM 2.0; opaque custom a;",
     };
     for (const std::string& source : sources) {
+        CAPTURE(source);
         CHECK_THROWS_AS(parse_qasm2(source), ParseError);
     }
 }
@@ -177,6 +177,7 @@ TEST_CASE("OpenQASM 2 validates registers gates and expressions") {
         "OPENQASM 2.0; qreg q[1]; CX q[0],q[0];",
     };
     for (const std::string& source : sources) {
+        CAPTURE(source);
         CHECK_THROWS_AS(parse_qasm2(source), ParseError);
     }
 }


### PR DESCRIPTION
## Summary

- add a dependency-free native OpenQASM 2.0 parser and lowerer for the documented unitary subset
- expose explicit `parse_qasm2()`, `parse_qasm2_file()`, and `compile(..., input_format="qasm2")` Python entry points without format sniffing
- preserve OpenQASM-to-Clifft Euler-gate phase corrections in a `Qasm2Import.global_phase_half_turns` sidecar, while keeping ordinary `Circuit`, HIR, plans, and executor state phase-free
- preserve declared register widths, implement register broadcasting and Qiskit-compatible constant-expression precedence, and tolerate UTF-8 in comments
- document the Qiskit phase convention selected where the OpenQASM 2 specification is ambiguous
- validate the complete gate vocabulary against Qiskit and confirm all 196 current ABSTRACTS QASM circuits parse successfully

The advertised contract is OpenQASM 2 only. OpenQASM 3 is intentionally deferred: its `stdgates.inc` semantics, `U` phase convention, gate modifiers, `gphase`, declarations, and dynamic-circuit surface deserve a separately specified subset instead of an accidental compatibility claim.

Measurements, resets, classical conditions, and custom/opaque gate declarations are rejected initially. Measurement/reset import for Clifft sampling can be added independently; this PR does not assign an implicit meaning to non-unitary amplitudes. A bounded custom-gate macro expander, including an embedded source definition of the remaining unitary `qelib1.inc` vocabulary, is the designated unitary-format follow-up.

The Release fast-math hardening was reproduced with Apple Clang 17 on arm64. Finite and probability checks now use inline integer validation behind a zero-instruction optimizer barrier on native Clang/GCC, with a volatile fallback for other toolchains. This preserves nonfinite validation without adding a function-call boundary to existing code paths.

## Test plan

- [x] Debug C++ tests pass (`ctest --test-dir build -E Bench --output-on-failure`): 876 passed
- [x] Release OpenQASM C++ tests pass with `-ffast-math`: 11 passed
- [x] Release numeric validation tests pass with `-ffast-math`: 2 passed
- [x] Python tests pass (`uv run pytest tests/python/ -q`): 1,347 passed, 7 skipped, 1 xfailed
- [x] Qiskit componentwise phase reconstruction passes for `U`, `u1`, `u2`, `u3`, and register broadcast without global-phase alignment
- [x] Doc examples pass (`uv run pytest --codeblocks docs/ README.md -v`): 34 passed, 8 skipped
- [x] Strict MkDocs build passes
- [x] Pre-commit checks pass (`uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`)
- [x] All 196 QASM files in `mjsutcliffe99/ABSTRACTS` parse with the native importer

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under the project's Apache-2.0 license.
- [ ] If this contribution was AI-assisted, I have reviewed the generated code and included an `Assisted-by:` git trailer in the commit message.

The required `Assisted-by:` trailer is present. The remaining checkbox is left for human review before merge.
