### PR TITLE
refactor(sampling): unify syndrome value representation

### DIFF
--- a/src/clifft/noncomp/trajectory_driver.cc
+++ b/src/clifft/noncomp/trajectory_driver.cc
@@ -446,9 +446,9 @@ SamplingCompiledContinuation compile_sampling_continuation(
                                                  .retain_source_map = true});
         enforce_sampling_active_width_cap(diagnostic, max_active_width_cap);
     }
-    if (plan.num_instrument_sites != rewrite.site_targets.size()) {
+    if (plan.instrument_distributions.size() != rewrite.site_targets.size()) {
         throw std::logic_error("sample_noncomputational: sampling plan has " +
-                               std::to_string(plan.num_instrument_sites) +
+                               std::to_string(plan.instrument_distributions.size()) +
                                " instrument site(s) but the rewrite has " +
                                std::to_string(rewrite.site_targets.size()));
     }

--- a/src/clifft/sampling/batch/bits.cc
+++ b/src/clifft/sampling/batch/bits.cc
@@ -10,6 +10,17 @@ namespace clifft::sampling {
 
 namespace {
 
+size_t packed_storage_bytes(size_t columns, size_t word_capacity) {
+    if (columns != 0 && word_capacity > std::numeric_limits<size_t>::max() / columns) {
+        throw std::length_error("packed batch bit-column allocation exceeds size_t range");
+    }
+    const size_t words = columns * word_capacity;
+    if (words > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
+        throw std::length_error("packed batch bit-column allocation exceeds size_t range");
+    }
+    return words * sizeof(uint64_t);
+}
+
 uint64_t compress_bits_portable(uint64_t bits, uint64_t keep) noexcept {
     uint64_t output = 0;
     uint64_t destination = 1;
@@ -42,6 +53,12 @@ size_t packed_word_count(uint32_t lanes) noexcept {
     return (static_cast<size_t>(lanes) + 63) / 64;
 }
 
+size_t packed_bit_columns_storage_bytes(size_t columns, uint32_t lane_capacity) {
+    return PageAlignedAllocation::allocation_size(
+        packed_storage_bytes(columns, packed_word_count(lane_capacity)),
+        PageAlignedAllocation::Alignment::BasePage);
+}
+
 uint64_t low_lane_mask(uint32_t bits) noexcept {
     if (bits == 0) {
         return 0;
@@ -64,21 +81,25 @@ void fill_low_lane_mask(std::span<uint64_t> output, uint32_t lanes) noexcept {
 PackedBitColumns::PackedBitColumns(size_t columns, uint32_t lane_capacity)
     : columns_(columns),
       lane_capacity_(lane_capacity),
-      word_capacity_(packed_word_count(lane_capacity)) {
-    if (columns_ != 0 && word_capacity_ > std::numeric_limits<size_t>::max() / columns_) {
-        throw std::length_error("packed batch bit-column allocation exceeds size_t range");
+      word_capacity_(packed_word_count(lane_capacity)),
+      storage_(packed_bit_columns_storage_bytes(columns_, lane_capacity_),
+               PageAlignedAllocation::Alignment::BasePage),
+      words_(static_cast<uint64_t*>(storage_.data())) {
+    if (!storage_.zero_initialized()) {
+        std::ranges::fill(std::span<uint64_t>(words_, columns_ * word_capacity_), uint64_t{0});
     }
-    words_.resize(columns_ * word_capacity_, 0);
 }
 
 std::span<uint64_t> PackedBitColumns::column(size_t column_index) noexcept {
     assert(column_index < columns_ && "packed bit column index must be in range");
-    return std::span<uint64_t>(words_).subspan(column_index * word_capacity_, word_capacity_);
+    return std::span<uint64_t>(words_, columns_ * word_capacity_)
+        .subspan(column_index * word_capacity_, word_capacity_);
 }
 
 std::span<const uint64_t> PackedBitColumns::column(size_t column_index) const noexcept {
     assert(column_index < columns_ && "packed bit column index must be in range");
-    return std::span<const uint64_t>(words_).subspan(column_index * word_capacity_, word_capacity_);
+    return std::span<const uint64_t>(words_, columns_ * word_capacity_)
+        .subspan(column_index * word_capacity_, word_capacity_);
 }
 
 bool PackedBitColumns::bit(size_t column_index, uint32_t lane) const noexcept {
@@ -92,7 +113,7 @@ void PackedBitColumns::set_bit(size_t column_index, uint32_t lane) noexcept {
 }
 
 void PackedBitColumns::clear() noexcept {
-    std::ranges::fill(words_, uint64_t{0});
+    std::ranges::fill(std::span<uint64_t>(words_, columns_ * word_capacity_), uint64_t{0});
 }
 
 void PackedBitColumns::assign(size_t column_index, std::span<const uint64_t> source,

--- a/src/clifft/sampling/batch/bits.h
+++ b/src/clifft/sampling/batch/bits.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "clifft/util/page_allocation.h"
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <span>
-#include <vector>
 
 namespace clifft::sampling {
 
@@ -48,10 +49,12 @@ class PackedBitColumns {
     size_t columns_ = 0;
     uint32_t lane_capacity_ = 0;
     size_t word_capacity_ = 0;
-    std::vector<uint64_t> words_;
+    PageAlignedAllocation storage_;
+    uint64_t* words_ = nullptr;
 };
 
 [[nodiscard]] size_t packed_word_count(uint32_t lanes) noexcept;
+[[nodiscard]] size_t packed_bit_columns_storage_bytes(size_t columns, uint32_t lane_capacity);
 [[nodiscard]] uint64_t low_lane_mask(uint32_t bits) noexcept;
 void fill_low_lane_mask(std::span<uint64_t> output, uint32_t lanes) noexcept;
 

--- a/src/clifft/sampling/batch/executor.cc
+++ b/src/clifft/sampling/batch/executor.cc
@@ -497,7 +497,7 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& ac
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action,
                                    size_t action_index) noexcept {
-    const std::span<const uint64_t> outcomes = evaluate_syndrome(action.outcome);
+    const std::span<const uint64_t> outcomes = evaluate_record_parity(action.outcome);
     if (output_mode_ == BatchOutputMode::Rows) {
         detectors_.assign(action.detector, outcomes, live_words_);
     }
@@ -518,7 +518,7 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteObservable& action,
                                    size_t) noexcept {
-    const std::span<const uint64_t> outcomes = evaluate_syndrome(action.outcome);
+    const std::span<const uint64_t> outcomes = evaluate_observable(action.outcome);
     observables_.assign(action.observable, outcomes, live_words_);
 }
 
@@ -530,8 +530,7 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteExpectation& act
     assert(action.exp_val < plan_->num_exp_vals_ &&
            "expectation action must reference preallocated storage");
     double* output = exp_vals_.data() + static_cast<size_t>(action.exp_val) * lane_capacity_;
-    const std::span<const uint64_t> signs = evaluate(action.sign);
-    if (!action.active_projection.has_value()) {
+    if (!action.active.has_value()) {
         for (uint32_t lane = 0; lane < active_lanes(); ++lane) {
             if (is_live(lane)) {
                 output[lane] = 0.0;
@@ -539,7 +538,8 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteExpectation& act
         }
         return;
     }
-    interleaved_expectation_values(state_, *action.active_projection, lane_values_);
+    const std::span<const uint64_t> signs = evaluate(action.active->sign);
+    interleaved_expectation_values(state_, action.active->projection, lane_values_);
     for (uint32_t lane = 0; lane < active_lanes(); ++lane) {
         if (is_live(lane)) {
             output[lane] = lane_bit(signs, lane) ? -lane_values_[lane] : lane_values_[lane];
@@ -562,8 +562,8 @@ std::span<const uint64_t> BatchExecutor::evaluate(
     return expression_registers_.column(expression.register_id);
 }
 
-std::span<const uint64_t> BatchExecutor::evaluate_syndrome(
-    const ExecutablePlan::PreparedSyndromeValue& value) noexcept {
+std::span<const uint64_t> BatchExecutor::evaluate_observable(
+    const ExecutablePlan::PreparedObservableValue& value) noexcept {
     if (const auto* expression = std::get_if<ExecutablePlan::PreparedExpression>(&value)) {
         return evaluate(*expression);
     }

--- a/src/clifft/sampling/batch/executor.cc
+++ b/src/clifft/sampling/batch/executor.cc
@@ -497,10 +497,7 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& ac
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action,
                                    size_t action_index) noexcept {
-    const std::span<const uint64_t> outcomes =
-        action.record_parity == std::numeric_limits<uint32_t>::max()
-            ? evaluate(action.outcome)
-            : evaluate_record_parity(action.record_parity);
+    const std::span<const uint64_t> outcomes = evaluate_syndrome(action.outcome);
     if (output_mode_ == BatchOutputMode::Rows) {
         detectors_.assign(action.detector, outcomes, live_words_);
     }
@@ -521,10 +518,7 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteObservable& action,
                                    size_t) noexcept {
-    const std::span<const uint64_t> outcomes =
-        action.record_parity == std::numeric_limits<uint32_t>::max()
-            ? evaluate(action.outcome)
-            : evaluate_record_parity(action.record_parity);
+    const std::span<const uint64_t> outcomes = evaluate_syndrome(action.outcome);
     observables_.assign(action.observable, outcomes, live_words_);
 }
 
@@ -568,13 +562,18 @@ std::span<const uint64_t> BatchExecutor::evaluate(
     return expression_registers_.column(expression.register_id);
 }
 
-std::span<const uint64_t> BatchExecutor::evaluate_record_parity(uint32_t parity_index) noexcept {
-    assert(parity_index < plan_->batch_record_parities_.size() &&
-           "prepared record parity must be in range");
-    const ExecutablePlan::PreparedRecordParity& parity =
-        plan_->batch_record_parities_[parity_index];
+std::span<const uint64_t> BatchExecutor::evaluate_syndrome(
+    const ExecutablePlan::PreparedSyndromeValue& value) noexcept {
+    if (const auto* expression = std::get_if<ExecutablePlan::PreparedExpression>(&value)) {
+        return evaluate(*expression);
+    }
+    return evaluate_record_parity(std::get<ExecutablePlan::PreparedRecordParity>(value));
+}
+
+std::span<const uint64_t> BatchExecutor::evaluate_record_parity(
+    ExecutablePlan::PreparedRecordParity parity) noexcept {
     const uint32_t end = parity.begin + parity.count;
-    assert(end <= plan_->batch_record_parity_terms_.size() &&
+    assert(end <= plan_->record_parity_terms_.size() &&
            "prepared record parity must stay in its term tape");
     const size_t words = packed_word_count(active_lanes());
     if (parity.constant) {
@@ -584,8 +583,7 @@ std::span<const uint64_t> BatchExecutor::evaluate_record_parity(uint32_t parity_
         std::ranges::fill(std::span<uint64_t>(scratch_words_).first(words), uint64_t{0});
     }
     for (uint32_t term = parity.begin; term < end; ++term) {
-        const std::span<const uint64_t> record =
-            records_.column(plan_->batch_record_parity_terms_[term]);
+        const std::span<const uint64_t> record = records_.column(plan_->record_parity_terms_[term]);
         for (size_t word = 0; word < words; ++word) {
             scratch_words_[word] ^= record[word];
         }

--- a/src/clifft/sampling/batch/executor.h
+++ b/src/clifft/sampling/batch/executor.h
@@ -93,8 +93,8 @@ class BatchExecutor {
 
     [[nodiscard]] std::span<const uint64_t> evaluate(
         ExecutablePlan::PreparedExpression expression) const noexcept;
-    [[nodiscard]] std::span<const uint64_t> evaluate_syndrome(
-        const ExecutablePlan::PreparedSyndromeValue& value) noexcept;
+    [[nodiscard]] std::span<const uint64_t> evaluate_observable(
+        const ExecutablePlan::PreparedObservableValue& value) noexcept;
     [[nodiscard]] std::span<const uint64_t> evaluate_record_parity(
         ExecutablePlan::PreparedRecordParity parity) noexcept;
     [[nodiscard]] bool lane_bit(std::span<const uint64_t> bits, uint32_t lane) const noexcept;

--- a/src/clifft/sampling/batch/executor.h
+++ b/src/clifft/sampling/batch/executor.h
@@ -93,7 +93,10 @@ class BatchExecutor {
 
     [[nodiscard]] std::span<const uint64_t> evaluate(
         ExecutablePlan::PreparedExpression expression) const noexcept;
-    [[nodiscard]] std::span<const uint64_t> evaluate_record_parity(uint32_t parity_index) noexcept;
+    [[nodiscard]] std::span<const uint64_t> evaluate_syndrome(
+        const ExecutablePlan::PreparedSyndromeValue& value) noexcept;
+    [[nodiscard]] std::span<const uint64_t> evaluate_record_parity(
+        ExecutablePlan::PreparedRecordParity parity) noexcept;
     [[nodiscard]] bool lane_bit(std::span<const uint64_t> bits, uint32_t lane) const noexcept;
     [[nodiscard]] bool is_live(uint32_t lane) const noexcept;
     [[nodiscard]] uint32_t active_lanes() const noexcept { return state_.active_lanes(); }

--- a/src/clifft/sampling/batch/interleaved_state.cc
+++ b/src/clifft/sampling/batch/interleaved_state.cc
@@ -55,7 +55,7 @@ size_t interleaved_batch_state_bytes(uint32_t max_active_width, uint32_t lane_ca
     if (coefficient_bytes > std::numeric_limits<size_t>::max() - scratch_bytes) {
         throw std::length_error("interleaved batch allocation exceeds size_t");
     }
-    return coefficient_bytes + scratch_bytes;
+    return PageAlignedAllocation::allocation_size(coefficient_bytes + scratch_bytes);
 }
 
 InterleavedBatchState::InterleavedBatchState(uint32_t max_active_width,

--- a/src/clifft/sampling/batch/policy.cc
+++ b/src/clifft/sampling/batch/policy.cc
@@ -52,7 +52,7 @@ BatchWorkerStorageLayout batch_worker_storage_layout(const ExecutablePlan& plan,
     layout.noise_carrier_columns = plan.num_batch_noise_carriers();
     layout.expression_register_columns = plan.num_expression_registers();
     layout.record_columns =
-        output_mode == BatchOutputMode::Rows || plan.has_batch_record_parities()
+        output_mode == BatchOutputMode::Rows || plan.syndrome_reads_records()
             ? static_cast<size_t>(plan.num_visible_records()) + plan.num_hidden_records()
             : 0;
     layout.detector_columns = output_mode == BatchOutputMode::Rows ? plan.num_detectors() : 0;

--- a/src/clifft/sampling/batch/policy.cc
+++ b/src/clifft/sampling/batch/policy.cc
@@ -52,7 +52,7 @@ BatchWorkerStorageLayout batch_worker_storage_layout(const ExecutablePlan& plan,
     layout.noise_carrier_columns = plan.num_batch_noise_carriers();
     layout.expression_register_columns = plan.num_expression_registers();
     layout.record_columns =
-        output_mode == BatchOutputMode::Rows || plan.syndrome_reads_records()
+        output_mode == BatchOutputMode::Rows || plan.output_parities_read_records()
             ? static_cast<size_t>(plan.num_visible_records()) + plan.num_hidden_records()
             : 0;
     layout.detector_columns = output_mode == BatchOutputMode::Rows ? plan.num_detectors() : 0;

--- a/src/clifft/sampling/batch/policy.cc
+++ b/src/clifft/sampling/batch/policy.cc
@@ -82,7 +82,8 @@ uint64_t batch_worker_storage_bytes(const ExecutablePlan& plan, uint32_t lane_ca
         bytes = saturating_add(bytes, saturating_multiply(entries, entry_bytes));
     };
     const auto add_columns = [&](size_t columns) {
-        add_entries(saturating_multiply(columns, layout.word_capacity), sizeof(uint64_t));
+        bytes =
+            saturating_add(bytes, packed_bit_columns_storage_bytes(columns, layout.lane_capacity));
     };
     add_entries(layout.shot_index_entries, sizeof(uint32_t));
     add_columns(layout.symbol_columns);

--- a/src/clifft/sampling/batch/presampled_program.cc
+++ b/src/clifft/sampling/batch/presampled_program.cc
@@ -10,7 +10,6 @@
 #include <iterator>
 #include <limits>
 #include <stdexcept>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -58,12 +57,14 @@ uint64_t expression_hash(bool constant, std::span<const uint32_t> terms) noexcep
 
 std::optional<BatchPresampledProgram> BatchPresampledProgram::build(
     const ExecutablePlan& executable, const SamplingPlan& source,
-    std::span<const uint32_t> expression_terms, std::span<const uint32_t> expression_term_begins) {
+    std::span<const uint32_t> expression_terms, std::span<const uint32_t> expression_term_begins,
+    std::span<const uint8_t> bound_presampled_symbols) {
 #if defined(__EMSCRIPTEN__)
     (void)executable;
     (void)source;
     (void)expression_terms;
     (void)expression_term_begins;
+    (void)bound_presampled_symbols;
     return std::nullopt;
 #else
     if (executable.has_instruments_) {
@@ -71,39 +72,22 @@ std::optional<BatchPresampledProgram> BatchPresampledProgram::build(
     }
 
     const size_t num_expressions = expression_term_begins.size();
-    std::vector<uint8_t> expression_needed(num_expressions, 1);
-    for (const ExecutablePlan::Action& action : executable.actions_) {
-        std::visit(
-            [&](const auto& typed) {
-                using T = std::decay_t<decltype(typed)>;
-                if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDetector> ||
-                              std::is_same_v<T, ExecutablePlan::ExecuteObservable>) {
-                    if (typed.record_parity != std::numeric_limits<uint32_t>::max()) {
-                        expression_needed[typed.outcome.register_id] = 0;
-                    }
-                }
-            },
-            action);
-    }
-
+    assert(bound_presampled_symbols.size() == source.symbols.size() &&
+           "presampled ownership must parallel plan symbols");
     std::vector<std::vector<uint32_t> > presampled_terms(num_expressions);
     uint64_t original_presampled_terms = 0;
     for (size_t expression = 0; expression < num_expressions; ++expression) {
-        if (expression_needed[expression] == 0) {
-            continue;
-        }
         const uint32_t begin = expression_term_begins[expression];
         const uint32_t end = expression + 1 < num_expressions
                                  ? expression_term_begins[expression + 1]
                                  : static_cast<uint32_t>(expression_terms.size());
         for (uint32_t term = begin; term < end; ++term) {
             const uint32_t symbol = expression_terms[term];
-            const SymbolInfo& info = source.symbols[symbol];
-            if (info.kind != SymbolKind::Presampled) {
+            if (source.symbols[symbol] != SymbolKind::Presampled) {
                 continue;
             }
             ++original_presampled_terms;
-            if (!info.noise_site.has_value()) {
+            if (bound_presampled_symbols[symbol] == 0) {
                 presampled_terms[expression].push_back(symbol);
             }
         }
@@ -124,9 +108,7 @@ std::optional<BatchPresampledProgram> BatchPresampledProgram::build(
             std::ranges::fill(residual, uint64_t{0});
             for (uint32_t expression :
                  executable.expression_dependencies_.dependent_registers(index(outcome.symbol))) {
-                if (expression_needed[expression] != 0) {
-                    residual[expression >> 6] |= uint64_t{1} << (expression & 63);
-                }
+                residual[expression >> 6] |= uint64_t{1} << (expression & 63);
             }
 
             MutableMaskView residual_view(residual);
@@ -189,9 +171,6 @@ std::optional<BatchPresampledProgram> BatchPresampledProgram::build(
     blocks.reserve(expression_term_begins.size());
     interned.reserve(expression_term_begins.size());
     for (size_t expression = 0; expression < expression_term_begins.size(); ++expression) {
-        if (expression_needed[expression] == 0) {
-            continue;
-        }
         std::vector<uint32_t> terms = std::move(presampled_terms[expression]);
 
         const bool constant = executable.expression_register_constants_[expression] != 0;
@@ -320,7 +299,7 @@ std::optional<BatchPresampledProgram> BatchPresampledProgram::build(
     std::vector<uint32_t> carrier_slots(executable.num_symbols_, kUnassigned);
     const auto mark_carrier = [&](uint32_t symbol) {
         assert(symbol < source.symbols.size() &&
-               source.symbols[symbol].kind == SymbolKind::Presampled &&
+               source.symbols[symbol] == SymbolKind::Presampled &&
                "batch carrier must originate from a presampled symbol");
         carrier_slots[symbol] = 0;
     };

--- a/src/clifft/sampling/batch/presampled_program.cc
+++ b/src/clifft/sampling/batch/presampled_program.cc
@@ -298,8 +298,7 @@ std::optional<BatchPresampledProgram> BatchPresampledProgram::build(
     constexpr uint32_t kUnassigned = std::numeric_limits<uint32_t>::max();
     std::vector<uint32_t> carrier_slots(executable.num_symbols_, kUnassigned);
     const auto mark_carrier = [&](uint32_t symbol) {
-        assert(symbol < source.symbols.size() &&
-               source.symbols[symbol] == SymbolKind::Presampled &&
+        assert(symbol < source.symbols.size() && source.symbols[symbol] == SymbolKind::Presampled &&
                "batch carrier must originate from a presampled symbol");
         carrier_slots[symbol] = 0;
     };

--- a/src/clifft/sampling/batch/presampled_program.h
+++ b/src/clifft/sampling/batch/presampled_program.h
@@ -53,7 +53,8 @@ class BatchPresampledProgram {
     [[nodiscard]] static std::optional<BatchPresampledProgram> build(
         const ExecutablePlan& executable, const SamplingPlan& source,
         std::span<const uint32_t> expression_terms,
-        std::span<const uint32_t> expression_term_begins);
+        std::span<const uint32_t> expression_term_begins,
+        std::span<const uint8_t> bound_presampled_symbols);
     void validate(size_t num_noise_outcomes, size_t num_expression_registers) const noexcept;
 
     uint32_t num_carriers_ = 0;

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -42,7 +42,6 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       num_detectors_(plan.num_detectors),
       num_observables_(plan.num_observables),
       num_exp_vals_(plan.num_exp_vals),
-      has_postselection_(plan.has_postselection),
       final_tableau_(plan.final_tableau),
       instrument_distributions_(plan.instrument_distributions) {
     // Keep construction-only lowering state out of the immutable executable.

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -94,8 +94,8 @@ class ExecutablePlan {
     [[nodiscard]] size_t num_expression_registers() const noexcept {
         return expression_register_constants_.size();
     }
-    [[nodiscard]] bool has_batch_record_parities() const noexcept {
-        return !batch_record_parities_.empty();
+    [[nodiscard]] bool syndrome_reads_records() const noexcept {
+        return !record_parity_terms_.empty();
     }
     [[nodiscard]] uint32_t num_readout_noise_sites() const noexcept {
         return num_readout_noise_sites_;
@@ -235,17 +235,17 @@ class ExecutablePlan {
         bool constant = false;
     };
 
+    using PreparedSyndromeValue = std::variant<PreparedExpression, PreparedRecordParity>;
+
     struct ExecuteDetector {
-        PreparedExpression outcome;
+        PreparedSyndromeValue outcome;
         uint32_t detector = 0;
         bool postselected = false;
-        uint32_t record_parity = std::numeric_limits<uint32_t>::max();
     };
 
     struct ExecuteObservable {
-        PreparedExpression outcome;
+        PreparedSyndromeValue outcome;
         uint32_t observable = 0;
-        uint32_t record_parity = std::numeric_limits<uint32_t>::max();
     };
 
     // Exact expectation-value probe of the current state.
@@ -379,8 +379,7 @@ class ExecutablePlan {
     std::optional<BatchPresampledProgram> batch_presampled_program_;
 
     // Packed-only output parities.
-    std::vector<PreparedRecordParity> batch_record_parities_;
-    std::vector<uint32_t> batch_record_parity_terms_;
+    std::vector<uint32_t> record_parity_terms_;
 
     // Instrument inputs and continuation offsets share the same site index.
     std::vector<InstrumentDistribution> instrument_distributions_;

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -235,23 +235,27 @@ class ExecutablePlan {
         bool constant = false;
     };
 
-    using PreparedSyndromeValue = std::variant<PreparedExpression, PreparedRecordParity>;
+    using PreparedObservableValue = std::variant<PreparedExpression, PreparedRecordParity>;
 
     struct ExecuteDetector {
-        PreparedSyndromeValue outcome;
+        PreparedRecordParity outcome;
         uint32_t detector = 0;
         bool postselected = false;
     };
 
     struct ExecuteObservable {
-        PreparedSyndromeValue outcome;
+        PreparedObservableValue outcome;
         uint32_t observable = 0;
     };
 
     // Exact expectation-value probe of the current state.
-    struct ExecuteExpectation {
-        std::optional<PreparedPauli> active_projection;
+    struct PreparedExpectation {
+        PreparedPauli projection;
         PreparedExpression sign;
+    };
+
+    struct ExecuteExpectation {
+        std::optional<PreparedExpectation> active;
         uint32_t exp_val = 0;
     };
 

--- a/src/clifft/sampling/executable_plan.h
+++ b/src/clifft/sampling/executable_plan.h
@@ -94,7 +94,7 @@ class ExecutablePlan {
     [[nodiscard]] size_t num_expression_registers() const noexcept {
         return expression_register_constants_.size();
     }
-    [[nodiscard]] bool syndrome_reads_records() const noexcept {
+    [[nodiscard]] bool output_parities_read_records() const noexcept {
         return !record_parity_terms_.empty();
     }
     [[nodiscard]] uint32_t num_readout_noise_sites() const noexcept {

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -92,8 +92,8 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::compile() {
     prepare_noise_and_boundaries();
     lower_action_stream();
     build_expression_dependencies();
-    output_.batch_presampled_program_ =
-        BatchPresampledProgram::build(output_, source_, expression_terms_, expression_term_begins_);
+    output_.batch_presampled_program_ = BatchPresampledProgram::build(
+        output_, source_, expression_terms_, expression_term_begins_, bound_presampled_symbols_);
     validate_executable_plan();
 }
 
@@ -168,7 +168,7 @@ CLIFFT_BUILDER_FORCE_INLINE size_t ExecutablePlanBuilder::estimate_expression_te
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::prepare_noise_and_boundaries() {
     output_.presampled_symbols_.reserve(source_.symbols.size());
-    std::vector<bool> bound_presampled(source_.symbols.size(), false);
+    bound_presampled_symbols_.assign(source_.symbols.size(), 0);
     output_.noise_sites_.reserve(source_.presampled_noise_sites.size());
     output_.noise_hazards_.reserve(source_.presampled_noise_sites.size());
 
@@ -181,7 +181,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::prepare_noise_and_bounda
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
             cumulative_probability += outcome.probability;
             output_.noise_outcomes_.push_back({index(outcome.symbol), cumulative_probability});
-            bound_presampled[index(outcome.symbol)] = true;
+            bound_presampled_symbols_[index(outcome.symbol)] = 1;
         }
         if (output_.noise_outcomes_.size() != begin) {
             // The validated source permits roundoff-sized disagreement between
@@ -210,11 +210,11 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::prepare_noise_and_bounda
         }
     }
     for (uint32_t symbol = 0; symbol < source_.symbols.size(); ++symbol) {
-        if (source_.symbols[symbol].kind != SymbolKind::Presampled) {
+        if (source_.symbols[symbol] != SymbolKind::Presampled) {
             continue;
         }
         output_.presampled_symbols_.push_back(symbol);
-        if (!bound_presampled[symbol]) {
+        if (bound_presampled_symbols_[symbol] == 0) {
             output_.unbound_presampled_symbols_.push_back(symbol);
         }
     }

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -116,7 +116,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::initialize_program() {
     // avoiding repeated growth of the temporary term tape.
     expression_terms_.reserve(estimate_expression_terms());
     expression_term_begins_.reserve(source_.actions.size());
-    output_.instrument_resume_offsets_.assign(source_.num_instrument_sites,
+    output_.instrument_resume_offsets_.assign(source_.instrument_distributions.size(),
                                               std::numeric_limits<uint32_t>::max());
 }
 
@@ -140,13 +140,17 @@ CLIFFT_BUILDER_FORCE_INLINE size_t ExecutablePlanBuilder::estimate_expression_te
                     num_terms += typed.value.terms().size();
                 } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
                     num_terms += typed.source.terms().size();
-                } else if constexpr (std::is_same_v<T, WriteDetector> ||
-                                     std::is_same_v<T, WriteObservable>) {
+                } else if constexpr (std::is_same_v<T, WriteDetector>) {
+                    // Detector record parities do not use affine registers.
+                } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     if (const auto* expression = std::get_if<AffineBool>(&typed.outcome)) {
                         num_terms += expression->terms().size();
                     }
-                } else if constexpr (std::is_same_v<T, WriteExpectationValue> ||
-                                     std::is_same_v<T, ApplyInstrument>) {
+                } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
+                    if (typed.active.has_value()) {
+                        num_terms += typed.active->sign.terms().size();
+                    }
+                } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     num_terms += typed.sign.terms().size();
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     // Boundaries have no affine payload.
@@ -215,14 +219,15 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::prepare_noise_and_bounda
         }
     }
 
-    boundary_noise_starts_.reserve(source_.num_instrument_sites);
+    boundary_noise_starts_.reserve(source_.instrument_distributions.size());
     for (const PlannedAction& planned : source_.actions) {
         if (const auto* boundary = std::get_if<InstrumentBoundary>(&planned.action)) {
             boundary_noise_starts_.push_back(boundary->next_noise_site);
         }
     }
-    output_.initial_noise_end_ =
-        boundary_noise_starts_.empty() ? source_.num_noise_sites : boundary_noise_starts_.front();
+    output_.initial_noise_end_ = boundary_noise_starts_.empty()
+                                     ? static_cast<uint32_t>(source_.presampled_noise_sites.size())
+                                     : boundary_noise_starts_.front();
 }
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::ensure_expression_term_capacity(
@@ -272,22 +277,25 @@ ExecutablePlanBuilder::prepare_measurement_correction(const AffineBool& outcome,
     return {register_id};
 }
 
-CLIFFT_BUILDER_FORCE_INLINE ExecutablePlan::PreparedSyndromeValue
-ExecutablePlanBuilder::prepare_syndrome_value(const SyndromeValue& value) {
-    if (const auto* expression = std::get_if<AffineBool>(&value)) {
-        return prepare_expression(*expression);
-    }
-    const RecordParity& parity = std::get<RecordParity>(value);
-    if (parity.records.size() >
+CLIFFT_BUILDER_FORCE_INLINE ExecutablePlan::PreparedRecordParity
+ExecutablePlanBuilder::prepare_record_parity(const RecordParity& parity) {
+    if (parity.records().size() >
         std::numeric_limits<uint32_t>::max() - output_.record_parity_terms_.size()) {
         throw std::length_error("sampling executable record parity exceeds uint32 range");
     }
     const uint32_t begin = static_cast<uint32_t>(output_.record_parity_terms_.size());
-    for (RecordSlot record : parity.records) {
+    for (RecordSlot record : parity.records()) {
         output_.record_parity_terms_.push_back(index(record));
     }
-    return ExecutablePlan::PreparedRecordParity{begin, static_cast<uint32_t>(parity.records.size()),
-                                                parity.constant};
+    return {begin, static_cast<uint32_t>(parity.records().size()), parity.constant()};
+}
+
+CLIFFT_BUILDER_FORCE_INLINE ExecutablePlan::PreparedObservableValue
+ExecutablePlanBuilder::prepare_observable_value(const ObservableValue& value) {
+    if (const auto* expression = std::get_if<AffineBool>(&value)) {
+        return prepare_expression(*expression);
+    }
+    return prepare_record_parity(std::get<RecordParity>(value));
 }
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const PlannedAction& planned,
@@ -340,21 +348,22 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
                     output_.num_readout_noise_sites_++, typed.prob_zero_to_one,
                     typed.prob_one_to_zero, batch_symmetric_inverse_hazard});
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
+                output_.has_postselection_ |= typed.postselected;
                 output_.actions_.emplace_back(
-                    ExecutablePlan::ExecuteDetector{prepare_syndrome_value(typed.outcome),
+                    ExecutablePlan::ExecuteDetector{prepare_record_parity(typed.outcome),
                                                     index(typed.detector), typed.postselected});
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
                 output_.actions_.emplace_back(ExecutablePlan::ExecuteObservable{
-                    prepare_syndrome_value(typed.outcome), index(typed.observable)});
+                    prepare_observable_value(typed.outcome), index(typed.observable)});
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
-                std::optional<PreparedPauli> active_projection;
-                if (typed.active_projection.has_value()) {
-                    active_projection =
-                        prepare_pauli(*typed.active_projection, planned.active_before);
+                std::optional<ExecutablePlan::PreparedExpectation> active;
+                if (typed.active.has_value()) {
+                    active = ExecutablePlan::PreparedExpectation{
+                        prepare_pauli(typed.active->projection, planned.active_before),
+                        prepare_expression(typed.active->sign)};
                 }
-                output_.actions_.emplace_back(ExecutablePlan::ExecuteExpectation{
-                    std::move(active_projection), prepare_expression(typed.sign),
-                    index(typed.exp_val)});
+                output_.actions_.emplace_back(
+                    ExecutablePlan::ExecuteExpectation{std::move(active), index(typed.exp_val)});
             } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                 output_.has_instruments_ = true;
                 const uint32_t site = index(typed.site);
@@ -409,9 +418,10 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
                 }
                 throw std::logic_error("validated instrument mode has no executable lowering");
             } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
-                const uint32_t noise_end = boundary_index + 1 < boundary_noise_starts_.size()
-                                               ? boundary_noise_starts_[boundary_index + 1]
-                                               : source_.num_noise_sites;
+                const uint32_t noise_end =
+                    boundary_index + 1 < boundary_noise_starts_.size()
+                        ? boundary_noise_starts_[boundary_index + 1]
+                        : static_cast<uint32_t>(source_.presampled_noise_sites.size());
                 output_.instrument_resume_offsets_[index(typed.site)] =
                     static_cast<uint32_t>(output_.actions_.size());
                 output_.actions_.emplace_back(ExecutablePlan::ExecuteBoundary{
@@ -537,7 +547,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
                    "record parity must name a valid record");
         }
     };
-    auto validate_syndrome_value = [&](const ExecutablePlan::PreparedSyndromeValue& value) {
+    auto validate_observable_value = [&](const ExecutablePlan::PreparedObservableValue& value) {
         if (const auto* expression = std::get_if<ExecutablePlan::PreparedExpression>(&value)) {
             validate_expression(*expression);
         } else {
@@ -571,11 +581,13 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
                     validate_expression(typed.source);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDetector>) {
-                    validate_syndrome_value(typed.outcome);
+                    validate_record_parity(typed.outcome);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteObservable>) {
-                    validate_syndrome_value(typed.outcome);
+                    validate_observable_value(typed.outcome);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteExpectation>) {
-                    validate_expression(typed.sign);
+                    if (typed.active.has_value()) {
+                        validate_expression(typed.active->sign);
+                    }
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {
                     std::visit(
                         [&](const auto& instrument) {

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -142,7 +142,9 @@ CLIFFT_BUILDER_FORCE_INLINE size_t ExecutablePlanBuilder::estimate_expression_te
                     num_terms += typed.source.terms().size();
                 } else if constexpr (std::is_same_v<T, WriteDetector> ||
                                      std::is_same_v<T, WriteObservable>) {
-                    num_terms += typed.outcome.terms().size();
+                    if (const auto* expression = std::get_if<AffineBool>(&typed.outcome)) {
+                        num_terms += expression->terms().size();
+                    }
                 } else if constexpr (std::is_same_v<T, WriteExpectationValue> ||
                                      std::is_same_v<T, ApplyInstrument>) {
                     num_terms += typed.sign.terms().size();
@@ -270,24 +272,22 @@ ExecutablePlanBuilder::prepare_measurement_correction(const AffineBool& outcome,
     return {register_id};
 }
 
-CLIFFT_BUILDER_FORCE_INLINE uint32_t
-ExecutablePlanBuilder::prepare_batch_record_parity(const std::optional<BatchRecordParity>& parity) {
-    if (!parity.has_value()) {
-        return std::numeric_limits<uint32_t>::max();
+CLIFFT_BUILDER_FORCE_INLINE ExecutablePlan::PreparedSyndromeValue
+ExecutablePlanBuilder::prepare_syndrome_value(const SyndromeValue& value) {
+    if (const auto* expression = std::get_if<AffineBool>(&value)) {
+        return prepare_expression(*expression);
     }
-    if (output_.batch_record_parities_.size() >= std::numeric_limits<uint32_t>::max() ||
-        parity->records.size() >
-            std::numeric_limits<uint32_t>::max() - output_.batch_record_parity_terms_.size()) {
-        throw std::length_error("sampling executable batch record parity exceeds uint32 range");
+    const RecordParity& parity = std::get<RecordParity>(value);
+    if (parity.records.size() >
+        std::numeric_limits<uint32_t>::max() - output_.record_parity_terms_.size()) {
+        throw std::length_error("sampling executable record parity exceeds uint32 range");
     }
-    const uint32_t parity_index = static_cast<uint32_t>(output_.batch_record_parities_.size());
-    const uint32_t begin = static_cast<uint32_t>(output_.batch_record_parity_terms_.size());
-    for (RecordSlot record : parity->records) {
-        output_.batch_record_parity_terms_.push_back(index(record));
+    const uint32_t begin = static_cast<uint32_t>(output_.record_parity_terms_.size());
+    for (RecordSlot record : parity.records) {
+        output_.record_parity_terms_.push_back(index(record));
     }
-    output_.batch_record_parities_.push_back(
-        {begin, static_cast<uint32_t>(parity->records.size()), parity->constant});
-    return parity_index;
+    return ExecutablePlan::PreparedRecordParity{begin, static_cast<uint32_t>(parity.records.size()),
+                                                parity.constant};
 }
 
 CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const PlannedAction& planned,
@@ -340,13 +340,12 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
                     output_.num_readout_noise_sites_++, typed.prob_zero_to_one,
                     typed.prob_one_to_zero, batch_symmetric_inverse_hazard});
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
-                output_.actions_.emplace_back(ExecutablePlan::ExecuteDetector{
-                    prepare_expression(typed.outcome), index(typed.detector), typed.postselected,
-                    prepare_batch_record_parity(typed.batch_parity)});
+                output_.actions_.emplace_back(
+                    ExecutablePlan::ExecuteDetector{prepare_syndrome_value(typed.outcome),
+                                                    index(typed.detector), typed.postselected});
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
                 output_.actions_.emplace_back(ExecutablePlan::ExecuteObservable{
-                    prepare_expression(typed.outcome), index(typed.observable),
-                    prepare_batch_record_parity(typed.batch_parity)});
+                    prepare_syndrome_value(typed.outcome), index(typed.observable)});
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                 std::optional<PreparedPauli> active_projection;
                 if (typed.active_projection.has_value()) {
@@ -508,15 +507,6 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
     }
     const size_t num_records =
         static_cast<size_t>(output_.num_visible_records_) + output_.num_hidden_records_;
-    for (const ExecutablePlan::PreparedRecordParity& parity : output_.batch_record_parities_) {
-        const size_t end = static_cast<size_t>(parity.begin) + parity.count;
-        assert(end <= output_.batch_record_parity_terms_.size() &&
-               "batch record parity must stay in its prepared tape");
-        for (size_t term = parity.begin; term < end; ++term) {
-            assert(output_.batch_record_parity_terms_[term] < num_records &&
-                   "batch record parity must name a valid record");
-        }
-    }
     if (source_.source_map.has_value()) {
         assert(output_.action_plan_ranges_.size() == output_.actions_.size() &&
                "executable provenance must remain parallel to the action stream");
@@ -538,10 +528,21 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
         assert(expression.register_id < output_.expression_register_constants_.size() &&
                "action expression is out of range");
     };
-    auto validate_record_parity = [&](uint32_t parity) {
-        assert((parity == std::numeric_limits<uint32_t>::max() ||
-                parity < output_.batch_record_parities_.size()) &&
-               "action record parity is out of range");
+    auto validate_record_parity = [&](ExecutablePlan::PreparedRecordParity parity) {
+        const size_t end = static_cast<size_t>(parity.begin) + parity.count;
+        assert(end <= output_.record_parity_terms_.size() &&
+               "record parity must stay in its prepared tape");
+        for (size_t term = parity.begin; term < end; ++term) {
+            assert(output_.record_parity_terms_[term] < num_records &&
+                   "record parity must name a valid record");
+        }
+    };
+    auto validate_syndrome_value = [&](const ExecutablePlan::PreparedSyndromeValue& value) {
+        if (const auto* expression = std::get_if<ExecutablePlan::PreparedExpression>(&value)) {
+            validate_expression(*expression);
+        } else {
+            validate_record_parity(std::get<ExecutablePlan::PreparedRecordParity>(value));
+        }
     };
     for (const ExecutablePlan::Action& action : output_.actions_) {
         std::visit(
@@ -570,11 +571,9 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::validate_executable_plan
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteReadoutNoise>) {
                     validate_expression(typed.source);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteDetector>) {
-                    validate_expression(typed.outcome);
-                    validate_record_parity(typed.record_parity);
+                    validate_syndrome_value(typed.outcome);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteObservable>) {
-                    validate_expression(typed.outcome);
-                    validate_record_parity(typed.record_parity);
+                    validate_syndrome_value(typed.outcome);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteExpectation>) {
                     validate_expression(typed.sign);
                 } else if constexpr (std::is_same_v<T, ExecutablePlan::ExecuteInstrument>) {

--- a/src/clifft/sampling/executable_plan_builder.h
+++ b/src/clifft/sampling/executable_plan_builder.h
@@ -47,8 +47,8 @@ class ExecutablePlanBuilder {
         const AffineBool& expression);
     [[nodiscard]] ExecutablePlan::PreparedExpression prepare_measurement_correction(
         const AffineBool& outcome, uint32_t branch);
-    [[nodiscard]] uint32_t prepare_batch_record_parity(
-        const std::optional<BatchRecordParity>& parity);
+    [[nodiscard]] ExecutablePlan::PreparedSyndromeValue prepare_syndrome_value(
+        const SyndromeValue& value);
     void ensure_expression_term_capacity(size_t additional_terms) const;
 
     ExecutablePlan& output_;

--- a/src/clifft/sampling/executable_plan_builder.h
+++ b/src/clifft/sampling/executable_plan_builder.h
@@ -47,8 +47,10 @@ class ExecutablePlanBuilder {
         const AffineBool& expression);
     [[nodiscard]] ExecutablePlan::PreparedExpression prepare_measurement_correction(
         const AffineBool& outcome, uint32_t branch);
-    [[nodiscard]] ExecutablePlan::PreparedSyndromeValue prepare_syndrome_value(
-        const SyndromeValue& value);
+    [[nodiscard]] ExecutablePlan::PreparedRecordParity prepare_record_parity(
+        const RecordParity& parity);
+    [[nodiscard]] ExecutablePlan::PreparedObservableValue prepare_observable_value(
+        const ObservableValue& value);
     void ensure_expression_term_capacity(size_t additional_terms) const;
 
     ExecutablePlan& output_;

--- a/src/clifft/sampling/executable_plan_builder.h
+++ b/src/clifft/sampling/executable_plan_builder.h
@@ -60,6 +60,7 @@ class ExecutablePlanBuilder {
     std::vector<uint32_t> expression_terms_;
     std::vector<uint32_t> expression_term_begins_;
     std::vector<uint32_t> boundary_noise_starts_;
+    std::vector<uint8_t> bound_presampled_symbols_;
 };
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -120,7 +120,7 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
             out << '0';
         }
     };
-    const auto write_syndrome_value = [&](const PreparedSyndromeValue& value) {
+    const auto write_observable_value = [&](const PreparedObservableValue& value) {
         if (const auto* expression = std::get_if<PreparedExpression>(&value)) {
             out << 'e' << expression->register_id;
         } else {
@@ -175,20 +175,20 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
             },
             [&](const ExecuteDetector& typed) {
                 out << "WRITE_DETECTOR detector=d" << typed.detector << " outcome=";
-                write_syndrome_value(typed.outcome);
+                write_record_parity(typed.outcome);
                 if (typed.postselected) {
                     out << " postselect";
                 }
             },
             [&](const ExecuteObservable& typed) {
                 out << "WRITE_OBSERVABLE observable=o" << typed.observable << " outcome=";
-                write_syndrome_value(typed.outcome);
+                write_observable_value(typed.outcome);
             },
             [&](const ExecuteExpectation& typed) {
                 out << "WRITE_EXPECTATION exp_val=v" << typed.exp_val << ' ';
-                if (typed.active_projection.has_value()) {
-                    write_prepared_pauli(out, *typed.active_projection);
-                    out << " sign=e" << typed.sign.register_id;
+                if (typed.active.has_value()) {
+                    write_prepared_pauli(out, typed.active->projection);
+                    out << " sign=e" << typed.active->sign.register_id;
                 } else {
                     out << "zero";
                 }

--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -100,17 +100,10 @@ std::string ExecutablePlan::inspect() const {
 std::string ExecutablePlan::inspect_action(size_t action) const {
     const Action& selected = actions_.at(action);
     std::ostringstream out;
-    const auto write_record_parity = [&](uint32_t parity_index) {
-        if (parity_index == std::numeric_limits<uint32_t>::max()) {
-            return;
-        }
-        assert(parity_index < batch_record_parities_.size() &&
-               "inspected record parity must be prepared");
-        const PreparedRecordParity& parity = batch_record_parities_[parity_index];
+    const auto write_record_parity = [&](PreparedRecordParity parity) {
         const size_t end = static_cast<size_t>(parity.begin) + parity.count;
-        assert(end <= batch_record_parity_terms_.size() &&
+        assert(end <= record_parity_terms_.size() &&
                "inspected record parity must stay in its term tape");
-        out << " batch_parity=";
         bool wrote = false;
         if (parity.constant) {
             out << '1';
@@ -120,11 +113,18 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
             if (wrote) {
                 out << '^';
             }
-            out << 'r' << batch_record_parity_terms_[term];
+            out << 'r' << record_parity_terms_[term];
             wrote = true;
         }
         if (!wrote) {
             out << '0';
+        }
+    };
+    const auto write_syndrome_value = [&](const PreparedSyndromeValue& value) {
+        if (const auto* expression = std::get_if<PreparedExpression>(&value)) {
+            out << 'e' << expression->register_id;
+        } else {
+            write_record_parity(std::get<PreparedRecordParity>(value));
         }
     };
     std::visit(
@@ -174,17 +174,15 @@ std::string ExecutablePlan::inspect_action(size_t action) const {
                     << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
             },
             [&](const ExecuteDetector& typed) {
-                out << "WRITE_DETECTOR detector=d" << typed.detector << " outcome=e"
-                    << typed.outcome.register_id;
+                out << "WRITE_DETECTOR detector=d" << typed.detector << " outcome=";
+                write_syndrome_value(typed.outcome);
                 if (typed.postselected) {
                     out << " postselect";
                 }
-                write_record_parity(typed.record_parity);
             },
             [&](const ExecuteObservable& typed) {
-                out << "WRITE_OBSERVABLE observable=o" << typed.observable << " outcome=e"
-                    << typed.outcome.register_id;
-                write_record_parity(typed.record_parity);
+                out << "WRITE_OBSERVABLE observable=o" << typed.observable << " outcome=";
+                write_syndrome_value(typed.outcome);
             },
             [&](const ExecuteExpectation& typed) {
                 out << "WRITE_EXPECTATION exp_val=v" << typed.exp_val << ' ';

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -542,14 +542,14 @@ void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
 
 void Executor::execute_action(const ExecutablePlan::ExecuteDetector& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    const bool outcome = evaluate(action.outcome);
+    const bool outcome = evaluate_syndrome(action.outcome);
     detectors_[action.detector] = static_cast<uint8_t>(outcome);
     discarded_ |= action.postselected && outcome;
 }
 
 void Executor::execute_action(const ExecutablePlan::ExecuteObservable& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    observables_[action.observable] = static_cast<uint8_t>(evaluate(action.outcome));
+    observables_[action.observable] = static_cast<uint8_t>(evaluate_syndrome(action.outcome));
 }
 
 void Executor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
@@ -840,6 +840,23 @@ bool Executor::evaluate(ExecutablePlan::PreparedExpression expression) const noe
            expression.register_id < expression_registers_.size() &&
            "prepared affine expression must refer to the active register file");
     return expression_registers_[expression.register_id] != 0;
+}
+
+bool Executor::evaluate_syndrome(
+    const ExecutablePlan::PreparedSyndromeValue& value) const noexcept {
+    if (const auto* expression = std::get_if<ExecutablePlan::PreparedExpression>(&value)) {
+        return evaluate(*expression);
+    }
+    const ExecutablePlan::PreparedRecordParity parity =
+        std::get<ExecutablePlan::PreparedRecordParity>(value);
+    const size_t end = static_cast<size_t>(parity.begin) + parity.count;
+    assert(end <= plan_->record_parity_terms_.size() &&
+           "prepared record parity must stay in its term tape");
+    bool outcome = parity.constant;
+    for (size_t term = parity.begin; term < end; ++term) {
+        outcome ^= records_[plan_->record_parity_terms_[term]] != 0;
+    }
+    return outcome;
 }
 
 bool Executor::sample_active_branch(MeasurementProbabilities probabilities) noexcept {

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -542,28 +542,28 @@ void Executor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& action,
 
 void Executor::execute_action(const ExecutablePlan::ExecuteDetector& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    const bool outcome = evaluate_syndrome(action.outcome);
+    const bool outcome = evaluate_record_parity(action.outcome);
     detectors_[action.detector] = static_cast<uint8_t>(outcome);
     discarded_ |= action.postselected && outcome;
 }
 
 void Executor::execute_action(const ExecutablePlan::ExecuteObservable& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
-    observables_[action.observable] = static_cast<uint8_t>(evaluate_syndrome(action.outcome));
+    observables_[action.observable] = static_cast<uint8_t>(evaluate_observable(action.outcome));
 }
 
 void Executor::execute_action(const ExecutablePlan::ExecuteExpectation& action,
                               std::span<const uint8_t>, ReplayResult&) noexcept {
     assert(action.exp_val < exp_vals_.size() && "expectation slot must be preallocated");
-    if (!action.active_projection.has_value()) {
+    if (!action.active.has_value()) {
         // Outputs are overwritten instead of cleared at each shot. This store
         // also prevents stale values when a continuation changes the planner's
         // classification of the same probe from active to exact zero.
         exp_vals_[action.exp_val] = 0.0;
         return;
     }
-    const double value = expectation_value(state_, *action.active_projection);
-    exp_vals_[action.exp_val] = evaluate(action.sign) ? -value : value;
+    const double value = expectation_value(state_, action.active->projection);
+    exp_vals_[action.exp_val] = evaluate(action.active->sign) ? -value : value;
 }
 
 void Executor::trap_instrument(uint32_t site, uint8_t source, bool destination_pending) noexcept {
@@ -842,13 +842,15 @@ bool Executor::evaluate(ExecutablePlan::PreparedExpression expression) const noe
     return expression_registers_[expression.register_id] != 0;
 }
 
-bool Executor::evaluate_syndrome(
-    const ExecutablePlan::PreparedSyndromeValue& value) const noexcept {
+bool Executor::evaluate_observable(
+    const ExecutablePlan::PreparedObservableValue& value) const noexcept {
     if (const auto* expression = std::get_if<ExecutablePlan::PreparedExpression>(&value)) {
         return evaluate(*expression);
     }
-    const ExecutablePlan::PreparedRecordParity parity =
-        std::get<ExecutablePlan::PreparedRecordParity>(value);
+    return evaluate_record_parity(std::get<ExecutablePlan::PreparedRecordParity>(value));
+}
+
+bool Executor::evaluate_record_parity(ExecutablePlan::PreparedRecordParity parity) const noexcept {
     const size_t end = static_cast<size_t>(parity.begin) + parity.count;
     assert(end <= plan_->record_parity_terms_.size() &&
            "prepared record parity must stay in its term tape");

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -180,8 +180,10 @@ class Executor {
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
 
     [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
-    [[nodiscard]] bool evaluate_syndrome(
-        const ExecutablePlan::PreparedSyndromeValue& value) const noexcept;
+    [[nodiscard]] bool evaluate_observable(
+        const ExecutablePlan::PreparedObservableValue& value) const noexcept;
+    [[nodiscard]] bool evaluate_record_parity(
+        ExecutablePlan::PreparedRecordParity parity) const noexcept;
     [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
     [[nodiscard]] std::optional<double> force_active_branch(MeasurementProbabilities probabilities,
                                                             bool branch) noexcept;

--- a/src/clifft/sampling/executor.h
+++ b/src/clifft/sampling/executor.h
@@ -180,6 +180,8 @@ class Executor {
                         std::span<const uint8_t> forced_records, ReplayResult& result) noexcept;
 
     [[nodiscard]] bool evaluate(ExecutablePlan::PreparedExpression expression) const noexcept;
+    [[nodiscard]] bool evaluate_syndrome(
+        const ExecutablePlan::PreparedSyndromeValue& value) const noexcept;
     [[nodiscard]] bool sample_active_branch(MeasurementProbabilities probabilities) noexcept;
     [[nodiscard]] std::optional<double> force_active_branch(MeasurementProbabilities probabilities,
                                                             bool branch) noexcept;

--- a/src/clifft/sampling/hip/device_program.h
+++ b/src/clifft/sampling/hip/device_program.h
@@ -44,8 +44,8 @@ inline constexpr uint64_t coefficient_elements_per_shot(uint32_t peak_active_wid
 }
 
 struct Expression {
-    // Syndrome actions interpret terms as record slots when kRecordParity is
-    // set; every other action interprets them as symbol ids.
+    // Detector and observable actions interpret terms as record slots when
+    // kRecordParity is set; every other action interprets them as symbol ids.
     uint32_t term_begin = 0;
     uint32_t term_count = 0;
     uint8_t constant = 0;

--- a/src/clifft/sampling/hip/device_program.h
+++ b/src/clifft/sampling/hip/device_program.h
@@ -27,6 +27,7 @@ enum class ActionTag : uint8_t {
 
 inline constexpr uint8_t kPostselected = 1U << 0;
 inline constexpr uint8_t kAbsentActiveProjection = 1U << 1;
+inline constexpr uint8_t kRecordParity = 1U << 2;
 
 inline constexpr uint64_t coefficient_state_capacity(uint32_t peak_active_width) {
     return uint64_t{1} << peak_active_width;
@@ -43,6 +44,8 @@ inline constexpr uint64_t coefficient_elements_per_shot(uint32_t peak_active_wid
 }
 
 struct Expression {
+    // Syndrome actions interpret terms as record slots when kRecordParity is
+    // set; every other action interprets them as symbol ids.
     uint32_t term_begin = 0;
     uint32_t term_count = 0;
     uint8_t constant = 0;

--- a/src/clifft/sampling/hip/executable_plan.cc
+++ b/src/clifft/sampling/hip/executable_plan.cc
@@ -155,6 +155,33 @@ uint32_t ExecutablePlan::append_expression(const AffineBool& expression) {
     return expression_index;
 }
 
+uint32_t ExecutablePlan::append_record_parity(const RecordParity& parity) {
+    require_uint32_size(expressions_.size(), "record parity storage");
+    require_uint32_size(expression_terms_.size(), "record parity term storage");
+    if (parity.records.size() > std::numeric_limits<uint32_t>::max() - expression_terms_.size()) {
+        throw std::length_error("HIP executable record parity term storage exceeds uint32 range");
+    }
+    const uint32_t parity_index = static_cast<uint32_t>(expressions_.size());
+    const uint32_t term_begin = static_cast<uint32_t>(expression_terms_.size());
+    for (RecordSlot record : parity.records) {
+        expression_terms_.push_back(index(record));
+    }
+    expressions_.push_back({term_begin,
+                            static_cast<uint32_t>(parity.records.size()),
+                            static_cast<uint8_t>(parity.constant),
+                            {}});
+    return parity_index;
+}
+
+void ExecutablePlan::lower_syndrome_value(detail::Action& action, const SyndromeValue& value) {
+    if (const auto* expression = std::get_if<AffineBool>(&value)) {
+        action.expression = append_expression(*expression);
+        return;
+    }
+    action.flags |= detail::kRecordParity;
+    action.expression = append_record_parity(std::get<RecordParity>(value));
+}
+
 detail::Action ExecutablePlan::lower_action(const PlannedAction& planned) {
     return std::visit(
         [&](const auto& typed) -> detail::Action {
@@ -208,11 +235,11 @@ detail::Action ExecutablePlan::lower_action(const PlannedAction& planned) {
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
                 action.tag = detail::ActionTag::WriteDetector;
                 action.flags = typed.postselected ? detail::kPostselected : 0;
-                action.expression = append_expression(typed.outcome);
+                lower_syndrome_value(action, typed.outcome);
                 action.index0 = index(typed.detector);
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
                 action.tag = detail::ActionTag::WriteObservable;
-                action.expression = append_expression(typed.outcome);
+                lower_syndrome_value(action, typed.outcome);
                 action.index0 = index(typed.observable);
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                 action.tag = detail::ActionTag::WriteExpectationValue;

--- a/src/clifft/sampling/hip/executable_plan.cc
+++ b/src/clifft/sampling/hip/executable_plan.cc
@@ -95,7 +95,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
             {begin, static_cast<uint32_t>(noise_outcomes_.size()) - begin, cumulative_probability});
     }
     for (size_t symbol = 0; symbol < plan.symbols.size(); ++symbol) {
-        if (plan.symbols[symbol].kind == SymbolKind::Presampled && !bound_presampled[symbol]) {
+        if (plan.symbols[symbol] == SymbolKind::Presampled && !bound_presampled[symbol]) {
             throw std::invalid_argument(
                 "HIP execution requires a distribution for every presampled symbol");
         }

--- a/src/clifft/sampling/hip/executable_plan.cc
+++ b/src/clifft/sampling/hip/executable_plan.cc
@@ -65,8 +65,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
       num_hidden_records_(plan.num_hidden_records),
       num_detectors_(plan.num_detectors),
       num_observables_(plan.num_observables),
-      num_exp_vals_(plan.num_exp_vals),
-      has_postselection_(plan.has_postselection) {
+      num_exp_vals_(plan.num_exp_vals) {
     plan.validate();
     require_uint32_size(plan.symbols.size(), "symbol storage");
     require_uint32_size(plan.actions.size(), "action storage");
@@ -76,7 +75,7 @@ ExecutablePlan::ExecutablePlan(const SamplingPlan& plan)
             "most " +
             std::to_string(kThreadPerShotMaxActiveWidth));
     }
-    if (plan.num_instrument_sites != 0 || !plan.instrument_distributions.empty()) {
+    if (!plan.instrument_distributions.empty()) {
         throw std::invalid_argument("HIP execution does not support transition instruments");
     }
 
@@ -158,22 +157,22 @@ uint32_t ExecutablePlan::append_expression(const AffineBool& expression) {
 uint32_t ExecutablePlan::append_record_parity(const RecordParity& parity) {
     require_uint32_size(expressions_.size(), "record parity storage");
     require_uint32_size(expression_terms_.size(), "record parity term storage");
-    if (parity.records.size() > std::numeric_limits<uint32_t>::max() - expression_terms_.size()) {
+    if (parity.records().size() > std::numeric_limits<uint32_t>::max() - expression_terms_.size()) {
         throw std::length_error("HIP executable record parity term storage exceeds uint32 range");
     }
     const uint32_t parity_index = static_cast<uint32_t>(expressions_.size());
     const uint32_t term_begin = static_cast<uint32_t>(expression_terms_.size());
-    for (RecordSlot record : parity.records) {
+    for (RecordSlot record : parity.records()) {
         expression_terms_.push_back(index(record));
     }
     expressions_.push_back({term_begin,
-                            static_cast<uint32_t>(parity.records.size()),
-                            static_cast<uint8_t>(parity.constant),
+                            static_cast<uint32_t>(parity.records().size()),
+                            static_cast<uint8_t>(parity.constant()),
                             {}});
     return parity_index;
 }
 
-void ExecutablePlan::lower_syndrome_value(detail::Action& action, const SyndromeValue& value) {
+void ExecutablePlan::lower_observable_value(detail::Action& action, const ObservableValue& value) {
     if (const auto* expression = std::get_if<AffineBool>(&value)) {
         action.expression = append_expression(*expression);
         return;
@@ -234,22 +233,24 @@ detail::Action ExecutablePlan::lower_action(const PlannedAction& planned) {
                 action.value1 = typed.prob_one_to_zero;
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
                 action.tag = detail::ActionTag::WriteDetector;
-                action.flags = typed.postselected ? detail::kPostselected : 0;
-                lower_syndrome_value(action, typed.outcome);
+                has_postselection_ |= typed.postselected;
+                action.flags =
+                    detail::kRecordParity | (typed.postselected ? detail::kPostselected : 0);
+                action.expression = append_record_parity(typed.outcome);
                 action.index0 = index(typed.detector);
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
                 action.tag = detail::ActionTag::WriteObservable;
-                lower_syndrome_value(action, typed.outcome);
+                lower_observable_value(action, typed.outcome);
                 action.index0 = index(typed.observable);
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                 action.tag = detail::ActionTag::WriteExpectationValue;
-                action.expression = append_expression(typed.sign);
                 action.index0 = index(typed.exp_val);
-                if (!typed.active_projection.has_value()) {
+                if (!typed.active.has_value()) {
                     action.flags = detail::kAbsentActiveProjection;
                 } else {
+                    action.expression = append_expression(typed.active->sign);
                     flatten_pauli(action,
-                                  prepare_pauli(*typed.active_projection, planned.active_before));
+                                  prepare_pauli(typed.active->projection, planned.active_before));
                 }
             } else if constexpr (std::is_same_v<T, ApplyInstrument> ||
                                  std::is_same_v<T, InstrumentBoundary>) {

--- a/src/clifft/sampling/hip/executable_plan.h
+++ b/src/clifft/sampling/hip/executable_plan.h
@@ -45,6 +45,8 @@ class ExecutablePlan {
 
   private:
     uint32_t append_expression(const AffineBool& expression);
+    uint32_t append_record_parity(const RecordParity& parity);
+    void lower_syndrome_value(detail::Action& action, const SyndromeValue& value);
     detail::Action lower_action(const PlannedAction& planned);
 
     uint32_t initial_active_width_ = 0;

--- a/src/clifft/sampling/hip/executable_plan.h
+++ b/src/clifft/sampling/hip/executable_plan.h
@@ -46,7 +46,7 @@ class ExecutablePlan {
   private:
     uint32_t append_expression(const AffineBool& expression);
     uint32_t append_record_parity(const RecordParity& parity);
-    void lower_syndrome_value(detail::Action& action, const SyndromeValue& value);
+    void lower_observable_value(detail::Action& action, const ObservableValue& value);
     detail::Action lower_action(const PlannedAction& planned);
 
     uint32_t initial_active_width_ = 0;

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -297,9 +297,6 @@ __device__ bool measure_active(const ProgramView& program, const Action& action,
 template <typename Coefficient>
 __device__ double expectation_value(const Action& action, const Coefficient* real,
                                     const Coefficient* imag) {
-    if ((action.flags & kAbsentActiveProjection) != 0) {
-        return 0.0;
-    }
     if (action.x == 0 && action.z == 0) {
         return 1.0;
     }
@@ -485,6 +482,10 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_
                     evaluate_syndrome(program, symbols, records, action));
                 break;
             case ActionTag::WriteExpectationValue: {
+                if ((action.flags & kAbsentActiveProjection) != 0) {
+                    exp_vals[action.index0] = 0.0;
+                    break;
+                }
                 const double value = expectation_value(action, real, imag);
                 exp_vals[action.index0] =
                     evaluate(program, symbols, action.expression) ? -value : value;

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -119,10 +119,10 @@ __device__ __forceinline__ bool evaluate(const ProgramView& program, const uint8
     return result;
 }
 
-__device__ __forceinline__ bool evaluate_syndrome(const ProgramView& program,
-                                                  const uint8_t* symbols,
-                                                  const uint8_t* records,
-                                                  const Action& action) {
+__device__ __forceinline__ bool evaluate_output_value(const ProgramView& program,
+                                                      const uint8_t* symbols,
+                                                      const uint8_t* records,
+                                                      const Action& action) {
     const uint8_t* values = (action.flags & kRecordParity) != 0 ? records : symbols;
     return evaluate(program, values, action.expression);
 }
@@ -470,7 +470,7 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_
                 break;
             }
             case ActionTag::WriteDetector: {
-                const bool outcome = evaluate_syndrome(program, symbols, records, action);
+                const bool outcome = evaluate_output_value(program, symbols, records, action);
                 detectors[action.index0] = static_cast<uint8_t>(outcome);
                 if ((action.flags & kPostselected) != 0 && outcome) {
                     discarded = true;
@@ -479,7 +479,7 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_
             }
             case ActionTag::WriteObservable:
                 observables[action.index0] = static_cast<uint8_t>(
-                    evaluate_syndrome(program, symbols, records, action));
+                    evaluate_output_value(program, symbols, records, action));
                 break;
             case ActionTag::WriteExpectationValue: {
                 if ((action.flags & kAbsentActiveProjection) != 0) {

--- a/src/clifft/sampling/hip/sampler.hip
+++ b/src/clifft/sampling/hip/sampler.hip
@@ -119,6 +119,14 @@ __device__ __forceinline__ bool evaluate(const ProgramView& program, const uint8
     return result;
 }
 
+__device__ __forceinline__ bool evaluate_syndrome(const ProgramView& program,
+                                                  const uint8_t* symbols,
+                                                  const uint8_t* records,
+                                                  const Action& action) {
+    const uint8_t* values = (action.flags & kRecordParity) != 0 ? records : symbols;
+    return evaluate(program, values, action.expression);
+}
+
 template <typename Coefficient>
 __device__ void apply_rotation(const Action& action, bool sign, Coefficient* real,
                                Coefficient* imag) {
@@ -465,7 +473,7 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_
                 break;
             }
             case ActionTag::WriteDetector: {
-                const bool outcome = evaluate(program, symbols, action.expression);
+                const bool outcome = evaluate_syndrome(program, symbols, records, action);
                 detectors[action.index0] = static_cast<uint8_t>(outcome);
                 if ((action.flags & kPostselected) != 0 && outcome) {
                     discarded = true;
@@ -473,8 +481,8 @@ __global__ void interpret_shots(ProgramView program, SeedRoot seed_root, uint64_
                 break;
             }
             case ActionTag::WriteObservable:
-                observables[action.index0] =
-                    static_cast<uint8_t>(evaluate(program, symbols, action.expression));
+                observables[action.index0] = static_cast<uint8_t>(
+                    evaluate_syndrome(program, symbols, records, action));
                 break;
             case ActionTag::WriteExpectationValue: {
                 const double value = expectation_value(action, real, imag);

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -135,8 +135,10 @@ std::optional<SymbolId> defined_symbol(const SamplingAction& action) {
         action);
 }
 
-void validate_expression(const SamplingPlan& plan, const AffineBool& expression,
-                         uint32_t action_index, std::optional<SymbolId> current_definition,
+void validate_expression(const SamplingPlan& plan,
+                         std::span<const std::optional<uint32_t>> definitions,
+                         const AffineBool& expression, uint32_t action_index,
+                         std::optional<SymbolId> current_definition,
                          bool allow_current_definition) {
     if (!expression.is_canonical()) {
         invalid_plan("action " + std::to_string(action_index) +
@@ -148,25 +150,26 @@ void validate_expression(const SamplingPlan& plan, const AffineBool& expression,
             invalid_plan("action " + std::to_string(action_index) + " references symbol s" +
                          std::to_string(symbol_index) + " out of range");
         }
-        const SymbolInfo& info = plan.symbols[symbol_index];
-        if (info.kind == SymbolKind::Presampled) {
+        if (plan.symbols[symbol_index] == SymbolKind::Presampled) {
             continue;
         }
-        if (!info.defining_action.has_value()) {
+        if (!definitions[symbol_index].has_value()) {
             invalid_plan("symbol s" + std::to_string(symbol_index) + " has no defining action");
         }
         const bool current_is_allowed = allow_current_definition && current_definition == term &&
-                                        *info.defining_action == action_index;
-        if (*info.defining_action >= action_index && !current_is_allowed) {
+                                        *definitions[symbol_index] == action_index;
+        if (*definitions[symbol_index] >= action_index && !current_is_allowed) {
             invalid_plan("action " + std::to_string(action_index) + " references symbol s" +
                          std::to_string(symbol_index) + " before assignment");
         }
     }
 }
 
-void validate_measurement_outcome(const SamplingPlan& plan, const AffineBool& outcome,
-                                  SymbolId branch, uint32_t action_index) {
-    validate_expression(plan, outcome, action_index, branch, true);
+void validate_measurement_outcome(const SamplingPlan& plan,
+                                  std::span<const std::optional<uint32_t>> definitions,
+                                  const AffineBool& outcome, SymbolId branch,
+                                  uint32_t action_index) {
+    validate_expression(plan, definitions, outcome, action_index, branch, true);
     if (std::ranges::find(outcome.terms(), branch) == outcome.terms().end()) {
         invalid_plan("action " + std::to_string(action_index) +
                      " measurement outcome omits branch s" + std::to_string(index(branch)));
@@ -207,10 +210,11 @@ void validate_record_parity(const SamplingPlan& plan, const RecordParity& parity
 }
 
 void validate_observable_value(const SamplingPlan& plan, const ObservableValue& value,
+                               std::span<const std::optional<uint32_t>> definitions,
                                uint32_t action_index,
                                const std::unordered_set<uint32_t>& written_records) {
     if (const auto* expression = std::get_if<AffineBool>(&value)) {
-        validate_expression(plan, *expression, action_index, std::nullopt, false);
+        validate_expression(plan, definitions, *expression, action_index, std::nullopt, false);
     } else {
         validate_record_parity(plan, std::get<RecordParity>(value), action_index, written_records);
     }
@@ -454,9 +458,7 @@ void SamplingPlan::validate() const {
         double total_probability = 0.0;
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {
             const uint32_t symbol_index = index(outcome.symbol);
-            if (symbol_index >= symbols.size() ||
-                symbols[symbol_index].kind != SymbolKind::Presampled ||
-                symbols[symbol_index].noise_site != NoiseSiteId{site_index}) {
+            if (symbol_index >= symbols.size() || symbols[symbol_index] != SymbolKind::Presampled) {
                 invalid_plan("noise site " + std::to_string(site_index) +
                              " references an incompatible symbol");
             }
@@ -500,57 +502,42 @@ void SamplingPlan::validate() const {
     }
 
     for (uint32_t symbol_index = 0; symbol_index < symbols.size(); ++symbol_index) {
-        const SymbolInfo& info = symbols[symbol_index];
-        if (!is_recognized_symbol_kind(info.kind)) {
+        const SymbolKind kind = symbols[symbol_index];
+        if (!is_recognized_symbol_kind(kind)) {
             invalid_plan("symbol s" + std::to_string(symbol_index) + " has an unrecognized kind");
         }
-        if (info.noise_site.has_value() &&
-            (info.kind != SymbolKind::Presampled || index(*info.noise_site) >= num_noise_sites)) {
-            invalid_plan("symbol s" + std::to_string(symbol_index) +
-                         " has an invalid noise-site identity");
-        }
-        if (info.kind == SymbolKind::Unused) {
-            if (info.defining_action.has_value() || info.noise_site.has_value() ||
-                actual_definitions[symbol_index].has_value()) {
+        if (kind == SymbolKind::Unused) {
+            if (actual_definitions[symbol_index].has_value()) {
                 invalid_plan("unused symbol s" + std::to_string(symbol_index) +
-                             " must not have a definition or noise identity");
+                             " must not have a definition");
             }
             continue;
         }
-        if (info.kind == SymbolKind::Presampled) {
-            if (info.defining_action.has_value() || actual_definitions[symbol_index].has_value()) {
+        if (kind == SymbolKind::Presampled) {
+            if (actual_definitions[symbol_index].has_value()) {
                 invalid_plan("presampled symbol s" + std::to_string(symbol_index) +
                              " must be presampled");
             }
-            if (info.noise_site.has_value() && !bound_noise_symbols[symbol_index]) {
-                invalid_plan("noise symbol s" + std::to_string(symbol_index) +
-                             " is absent from its site distribution");
-            }
             continue;
         }
-        if (!info.defining_action.has_value() ||
-            info.defining_action != actual_definitions[symbol_index]) {
-            invalid_plan("symbol s" + std::to_string(symbol_index) +
-                         " definition metadata does not match its action");
+        if (!actual_definitions[symbol_index].has_value()) {
+            invalid_plan("symbol s" + std::to_string(symbol_index) + " has no defining action");
         }
-        const SamplingAction& action = actions[*info.defining_action].action;
-        if (info.kind == SymbolKind::Branch &&
-            !std::holds_alternative<MeasureActivePauli>(action) &&
+        const SamplingAction& action = actions[*actual_definitions[symbol_index]].action;
+        if (kind == SymbolKind::Branch && !std::holds_alternative<MeasureActivePauli>(action) &&
             !std::holds_alternative<MeasureDormantRandom>(action)) {
             invalid_plan("branch symbol s" + std::to_string(symbol_index) +
                          " must be defined by a measurement");
         }
-        if (info.kind == SymbolKind::Derived && !std::holds_alternative<DefineSymbol>(action)) {
+        if (kind == SymbolKind::Derived && !std::holds_alternative<DefineSymbol>(action)) {
             invalid_plan("derived symbol s" + std::to_string(symbol_index) +
                          " must be defined by DefineSymbol");
         }
-        if (info.kind == SymbolKind::Readout &&
-            !std::holds_alternative<ApplyReadoutNoise>(action)) {
+        if (kind == SymbolKind::Readout && !std::holds_alternative<ApplyReadoutNoise>(action)) {
             invalid_plan("readout symbol s" + std::to_string(symbol_index) +
                          " must be defined by ApplyReadoutNoise");
         }
-        if (info.kind == SymbolKind::Instrument &&
-            !std::holds_alternative<ApplyInstrument>(action)) {
+        if (kind == SymbolKind::Instrument && !std::holds_alternative<ApplyInstrument>(action)) {
             invalid_plan("instrument symbol s" + std::to_string(symbol_index) +
                          " must be defined by ApplyInstrument");
         }
@@ -606,7 +593,8 @@ void SamplingPlan::validate() const {
                     if (!is_finite_robust(typed.half_turns)) {
                         invalid_plan("active rotation angle is not finite");
                     }
-                    validate_expression(*this, typed.sign, action_index, definition, false);
+                    validate_expression(*this, actual_definitions, typed.sign, action_index,
+                                        definition, false);
                 } else if constexpr (std::is_same_v<T, PromoteDormantRotation>) {
                     if (planned.active_after != planned.active_before + 1) {
                         invalid_plan("dormant promotion has an invalid width");
@@ -614,7 +602,8 @@ void SamplingPlan::validate() const {
                     if (!is_finite_robust(typed.half_turns)) {
                         invalid_plan("dormant promotion angle is not finite");
                     }
-                    validate_expression(*this, typed.sign, action_index, definition, false);
+                    validate_expression(*this, actual_definitions, typed.sign, action_index,
+                                        definition, false);
                 } else if constexpr (std::is_same_v<T, MeasureActivePauli>) {
                     if (planned.active_before == 0 ||
                         planned.active_after + 1 != planned.active_before ||
@@ -626,7 +615,8 @@ void SamplingPlan::validate() const {
                         invalid_plan("active measurement Pauli is identity");
                     }
                     validate_measurement_pivot(typed, action_index);
-                    validate_measurement_outcome(*this, typed.outcome, typed.branch, action_index);
+                    validate_measurement_outcome(*this, actual_definitions, typed.outcome,
+                                                 typed.branch, action_index);
                     validate_record(*this, typed.record, action_index, written_records);
                     record_values[index(typed.record)] = &typed.outcome;
                 } else if constexpr (std::is_same_v<T, MeasureDormantRandom>) {
@@ -635,28 +625,32 @@ void SamplingPlan::validate() const {
                         typed.dormant_pivot >= num_qubits) {
                         invalid_plan("dormant measurement has an invalid width or pivot");
                     }
-                    validate_measurement_outcome(*this, typed.outcome, typed.branch, action_index);
+                    validate_measurement_outcome(*this, actual_definitions, typed.outcome,
+                                                 typed.branch, action_index);
                     validate_record(*this, typed.record, action_index, written_records);
                     record_values[index(typed.record)] = &typed.outcome;
                 } else if constexpr (std::is_same_v<T, RecordClassical>) {
                     if (planned.active_after != planned.active_before) {
                         invalid_plan("classical record changes active width");
                     }
-                    validate_expression(*this, typed.outcome, action_index, definition, false);
+                    validate_expression(*this, actual_definitions, typed.outcome, action_index,
+                                        definition, false);
                     validate_record(*this, typed.record, action_index, written_records);
                     record_values[index(typed.record)] = &typed.outcome;
                 } else if constexpr (std::is_same_v<T, DefineSymbol>) {
                     if (planned.active_after != planned.active_before) {
                         invalid_plan("symbol definition changes active width");
                     }
-                    validate_expression(*this, typed.value, action_index, definition, false);
+                    validate_expression(*this, actual_definitions, typed.value, action_index,
+                                        definition, false);
                 } else if constexpr (std::is_same_v<T, ApplyReadoutNoise>) {
                     if (planned.active_after != planned.active_before ||
                         !is_probability(typed.prob_zero_to_one) ||
                         !is_probability(typed.prob_one_to_zero)) {
                         invalid_plan("readout noise has invalid width or probabilities");
                     }
-                    validate_expression(*this, typed.source, action_index, definition, false);
+                    validate_expression(*this, actual_definitions, typed.source, action_index,
+                                        definition, false);
                     validate_written_record(*this, typed.record, action_index, written_records);
                     const uint32_t record_index = index(typed.record);
                     if (record_values[record_index] == nullptr ||
@@ -680,7 +674,8 @@ void SamplingPlan::validate() const {
                         !written_observables.insert(index(typed.observable)).second) {
                         invalid_plan("observable write has invalid width or slot");
                     }
-                    validate_observable_value(*this, typed.outcome, action_index, written_records);
+                    validate_observable_value(*this, typed.outcome, actual_definitions,
+                                              action_index, written_records);
                 } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                     if (planned.active_after != planned.active_before ||
                         index(typed.exp_val) >= num_exp_vals ||
@@ -690,8 +685,8 @@ void SamplingPlan::validate() const {
                     if (typed.active.has_value()) {
                         validate_pauli(typed.active->projection, planned.active_before,
                                        action_index);
-                        validate_expression(*this, typed.active->sign, action_index, definition,
-                                            false);
+                        validate_expression(*this, actual_definitions, typed.active->sign,
+                                            action_index, definition, false);
                     }
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     if (index(typed.site) != observed_instruments ||
@@ -732,7 +727,8 @@ void SamplingPlan::validate() const {
                         !typed.destination_flip.has_value()) {
                         invalid_plan("in-line instrument omits its destination-flip symbol");
                     }
-                    validate_expression(*this, typed.sign, action_index, definition, false);
+                    validate_expression(*this, actual_definitions, typed.sign, action_index,
+                                        definition, false);
                     ++observed_instruments;
                 } else if constexpr (std::is_same_v<T, InstrumentBoundary>) {
                     if (planned.active_after != planned.active_before ||

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -39,12 +39,13 @@ std::vector<SymbolId> xor_terms(const std::vector<SymbolId>& left,
     return result;
 }
 
-std::vector<SymbolId> canonicalize_terms(std::vector<SymbolId> terms) {
+template <typename Id>
+std::vector<Id> canonicalize_terms(std::vector<Id> terms) {
     // XOR retains exactly the terms with odd multiplicity. Sorting also gives
     // expressions one deterministic representation.
     std::sort(terms.begin(), terms.end(),
-              [](SymbolId left, SymbolId right) { return index(left) < index(right); });
-    std::vector<SymbolId> result;
+              [](Id left, Id right) { return index(left) < index(right); });
+    std::vector<Id> result;
     for (size_t begin = 0; begin < terms.size();) {
         size_t end = begin + 1;
         while (end < terms.size() && terms[end] == terms[begin]) {
@@ -199,22 +200,15 @@ void validate_written_record(const SamplingPlan& plan, RecordSlot record, uint32
 void validate_record_parity(const SamplingPlan& plan, const RecordParity& parity,
                             uint32_t action_index,
                             const std::unordered_set<uint32_t>& written_records) {
-    uint32_t previous = 0;
-    bool first = true;
-    for (RecordSlot record : parity.records) {
-        if (!first && index(record) <= previous) {
-            invalid_plan("action " + std::to_string(action_index) +
-                         " has noncanonical record parity");
-        }
+    assert(parity.is_canonical() && "record parity construction must preserve canonical terms");
+    for (RecordSlot record : parity.records()) {
         validate_written_record(plan, record, action_index, written_records);
-        previous = index(record);
-        first = false;
     }
 }
 
-void validate_syndrome_value(const SamplingPlan& plan, const SyndromeValue& value,
-                             uint32_t action_index,
-                             const std::unordered_set<uint32_t>& written_records) {
+void validate_observable_value(const SamplingPlan& plan, const ObservableValue& value,
+                               uint32_t action_index,
+                               const std::unordered_set<uint32_t>& written_records) {
     if (const auto* expression = std::get_if<AffineBool>(&value)) {
         validate_expression(plan, *expression, action_index, std::nullopt, false);
     } else {
@@ -277,6 +271,18 @@ AffineBool AffineBool::from_canonical_terms(bool constant, std::vector<SymbolId>
 bool AffineBool::is_canonical() const {
     for (size_t i = 1; i < terms_.size(); ++i) {
         if (index(terms_[i - 1]) >= index(terms_[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+RecordParity::RecordParity(bool constant, std::vector<RecordSlot> records)
+    : constant_(constant), records_(canonicalize_terms(std::move(records))) {}
+
+bool RecordParity::is_canonical() const {
+    for (size_t i = 1; i < records_.size(); ++i) {
+        if (index(records_[i - 1]) >= index(records_[i])) {
             return false;
         }
     }
@@ -371,10 +377,7 @@ uint32_t predicted_dense_passes(const SamplingAction& action) {
                 }
                 return 0;
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
-                return typed.active_projection.has_value() &&
-                               !typed.active_projection->is_identity()
-                           ? 1
-                           : 0;
+                return typed.active.has_value() && !typed.active->projection.is_identity() ? 1 : 0;
             } else if constexpr (std::is_same_v<T, MeasureDormantRandom> ||
                                  std::is_same_v<T, RecordClassical> ||
                                  std::is_same_v<T, DefineSymbol> ||
@@ -411,19 +414,15 @@ void SamplingPlan::validate() const {
     if (source_map.has_value() && !source_map->is_valid_for(actions.size())) {
         invalid_plan("source map does not match the action stream");
     }
-
-    if (presampled_noise_sites.size() != num_noise_sites) {
-        invalid_plan("presampled noise-site table does not match declared count");
+    if (presampled_noise_sites.size() > std::numeric_limits<uint32_t>::max() ||
+        instrument_distributions.size() > std::numeric_limits<uint32_t>::max()) {
+        invalid_plan("noise or instrument site count exceeds uint32 range");
     }
-    if (instrument_distributions.size() != num_instrument_sites) {
-        invalid_plan("instrument distribution table does not match declared count");
-    }
+    const uint32_t num_noise_sites = static_cast<uint32_t>(presampled_noise_sites.size());
+    const uint32_t num_instrument_sites = static_cast<uint32_t>(instrument_distributions.size());
 
     for (uint32_t site_index = 0; site_index < instrument_distributions.size(); ++site_index) {
         const InstrumentDistribution& distribution = instrument_distributions[site_index];
-        if (index(distribution.site) != site_index) {
-            invalid_plan("instrument distributions are not in stable id order");
-        }
         for (uint8_t source = 0; source < 2; ++source) {
             if (!is_probability(distribution.p_fire[source])) {
                 invalid_plan("instrument site " + std::to_string(site_index) +
@@ -448,9 +447,6 @@ void SamplingPlan::validate() const {
     std::vector<bool> bound_noise_symbols(symbols.size(), false);
     for (uint32_t site_index = 0; site_index < presampled_noise_sites.size(); ++site_index) {
         const PresampledNoiseSite& site = presampled_noise_sites[site_index];
-        if (index(site.site) != site_index) {
-            invalid_plan("presampled noise sites are not in stable id order");
-        }
         if (!is_probability(site.total_probability)) {
             invalid_plan("noise site " + std::to_string(site_index) +
                          " has an invalid total probability");
@@ -460,7 +456,7 @@ void SamplingPlan::validate() const {
             const uint32_t symbol_index = index(outcome.symbol);
             if (symbol_index >= symbols.size() ||
                 symbols[symbol_index].kind != SymbolKind::Presampled ||
-                symbols[symbol_index].noise_site != site.site) {
+                symbols[symbol_index].noise_site != NoiseSiteId{site_index}) {
                 invalid_plan("noise site " + std::to_string(site_index) +
                              " references an incompatible symbol");
             }
@@ -568,7 +564,6 @@ void SamplingPlan::validate() const {
     std::unordered_set<uint32_t> written_exp_vals;
     std::vector<const AffineBool*> record_values(total_records, nullptr);
     std::vector<std::optional<AffineBool>> readout_record_values(total_records);
-    bool observed_postselection = false;
     uint32_t observed_instruments = 0;
     uint32_t observed_instrument_boundaries = 0;
     uint32_t previous_noise_boundary = 0;
@@ -678,28 +673,26 @@ void SamplingPlan::validate() const {
                         !written_detectors.insert(index(typed.detector)).second) {
                         invalid_plan("detector write has invalid width or slot");
                     }
-                    validate_syndrome_value(*this, typed.outcome, action_index, written_records);
-                    observed_postselection |= typed.postselected;
+                    validate_record_parity(*this, typed.outcome, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     if (planned.active_after != planned.active_before ||
                         index(typed.observable) >= num_observables ||
                         !written_observables.insert(index(typed.observable)).second) {
                         invalid_plan("observable write has invalid width or slot");
                     }
-                    validate_syndrome_value(*this, typed.outcome, action_index, written_records);
+                    validate_observable_value(*this, typed.outcome, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                     if (planned.active_after != planned.active_before ||
                         index(typed.exp_val) >= num_exp_vals ||
                         !written_exp_vals.insert(index(typed.exp_val)).second) {
                         invalid_plan("expectation write has invalid width or slot");
                     }
-                    if (typed.active_projection.has_value()) {
-                        validate_pauli(*typed.active_projection, planned.active_before,
+                    if (typed.active.has_value()) {
+                        validate_pauli(typed.active->projection, planned.active_before,
                                        action_index);
-                    } else if (typed.sign != AffineBool{}) {
-                        invalid_plan("zero expectation write has an irrelevant symbolic sign");
+                        validate_expression(*this, typed.active->sign, action_index, definition,
+                                            false);
                     }
-                    validate_expression(*this, typed.sign, action_index, definition, false);
                 } else if constexpr (std::is_same_v<T, ApplyInstrument>) {
                     if (index(typed.site) != observed_instruments ||
                         index(typed.site) >= num_instrument_sites) {
@@ -778,9 +771,6 @@ void SamplingPlan::validate() const {
         written_observables.size() != num_observables || written_exp_vals.size() != num_exp_vals) {
         invalid_plan(
             "declared detector, observable, or expectation count does not match the action stream");
-    }
-    if (observed_postselection != has_postselection) {
-        invalid_plan("declared postselection flag does not match detector actions");
     }
     if (observed_instruments != num_instrument_sites ||
         observed_instrument_boundaries != num_instrument_sites) {

--- a/src/clifft/sampling/plan.cc
+++ b/src/clifft/sampling/plan.cc
@@ -196,31 +196,29 @@ void validate_written_record(const SamplingPlan& plan, RecordSlot record, uint32
     }
 }
 
-void validate_batch_record_parity(const SamplingPlan& plan, const BatchRecordParity& parity,
-                                  uint32_t action_index,
-                                  const std::unordered_set<uint32_t>& written_records,
-                                  std::span<const AffineBool* const> record_values,
-                                  const AffineBool& expected) {
+void validate_record_parity(const SamplingPlan& plan, const RecordParity& parity,
+                            uint32_t action_index,
+                            const std::unordered_set<uint32_t>& written_records) {
     uint32_t previous = 0;
     bool first = true;
-    AffineBool actual(parity.constant);
     for (RecordSlot record : parity.records) {
         if (!first && index(record) <= previous) {
             invalid_plan("action " + std::to_string(action_index) +
-                         " has noncanonical batch record parity");
+                         " has noncanonical record parity");
         }
         validate_written_record(plan, record, action_index, written_records);
-        if (record_values[index(record)] == nullptr) {
-            invalid_plan("action " + std::to_string(action_index) +
-                         " batch record parity has no symbolic record value");
-        }
-        actual ^= *record_values[index(record)];
         previous = index(record);
         first = false;
     }
-    if (actual != expected) {
-        invalid_plan("action " + std::to_string(action_index) +
-                     " batch record parity disagrees with its affine outcome");
+}
+
+void validate_syndrome_value(const SamplingPlan& plan, const SyndromeValue& value,
+                             uint32_t action_index,
+                             const std::unordered_set<uint32_t>& written_records) {
+    if (const auto* expression = std::get_if<AffineBool>(&value)) {
+        validate_expression(plan, *expression, action_index, std::nullopt, false);
+    } else {
+        validate_record_parity(plan, std::get<RecordParity>(value), action_index, written_records);
     }
 }
 
@@ -680,11 +678,7 @@ void SamplingPlan::validate() const {
                         !written_detectors.insert(index(typed.detector)).second) {
                         invalid_plan("detector write has invalid width or slot");
                     }
-                    validate_expression(*this, typed.outcome, action_index, definition, false);
-                    if (typed.batch_parity.has_value()) {
-                        validate_batch_record_parity(*this, *typed.batch_parity, action_index,
-                                                     written_records, record_values, typed.outcome);
-                    }
+                    validate_syndrome_value(*this, typed.outcome, action_index, written_records);
                     observed_postselection |= typed.postselected;
                 } else if constexpr (std::is_same_v<T, WriteObservable>) {
                     if (planned.active_after != planned.active_before ||
@@ -692,11 +686,7 @@ void SamplingPlan::validate() const {
                         !written_observables.insert(index(typed.observable)).second) {
                         invalid_plan("observable write has invalid width or slot");
                     }
-                    validate_expression(*this, typed.outcome, action_index, definition, false);
-                    if (typed.batch_parity.has_value()) {
-                        validate_batch_record_parity(*this, *typed.batch_parity, action_index,
-                                                     written_records, record_values, typed.outcome);
-                    }
+                    validate_syndrome_value(*this, typed.outcome, action_index, written_records);
                 } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                     if (planned.active_after != planned.active_before ||
                         index(typed.exp_val) >= num_exp_vals ||

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -197,29 +197,32 @@ struct ApplyReadoutNoise {
     double prob_one_to_zero = 0.0;
 };
 
-// Batch execution can evaluate detector and observable parities from packed
-// record columns instead of expanding every record's full affine history.
-struct BatchRecordParity {
+// A parity over circuit record slots at the point where a syndrome value is
+// written. Record slots are canonicalized in strictly increasing order.
+struct RecordParity {
     bool constant = false;
     std::vector<RecordSlot> records;
 };
 
+// Syndrome writes retain the representation whose dependencies are still
+// available at execution time. Record parity avoids expanding current record
+// snapshots; affine form preserves historical values after a record changes.
+using SyndromeValue = std::variant<AffineBool, RecordParity>;
+
 // Writes a detector parity after the planner has XORed its expected reference
-// parity into the expression. A nonzero postselected detector rejects the shot
-// immediately; later actions and outputs are irrelevant for it.
+// parity into the selected value. A nonzero postselected detector rejects the
+// shot immediately; later actions and outputs are irrelevant for it.
 struct WriteDetector {
-    AffineBool outcome;
+    SyndromeValue outcome;
     DetectorSlot detector{};
     bool postselected = false;
-    std::optional<BatchRecordParity> batch_parity;
 };
 
 // Writes one fully accumulated logical observable after the planner has XORed
-// its expected reference parity into the expression.
+// its expected reference parity into the selected value.
 struct WriteObservable {
-    AffineBool outcome;
+    SyndromeValue outcome;
     ObservableSlot observable{};
-    std::optional<BatchRecordParity> batch_parity;
 };
 
 // Writes a non-destructive Pauli expectation probe. The planner retains only

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -300,21 +300,6 @@ struct PlannedAction {
     SamplingAction action;
 };
 
-// Describes how one symbol is populated. SamplingPlan::validate checks each
-// kind's legal fields and its agreement with the referenced defining action.
-struct SymbolInfo {
-    SymbolKind kind = SymbolKind::Unused;
-
-    // Index of the action that assigns this symbol. Required for Derived,
-    // Branch, Readout, and Instrument; absent for Presampled and Unused.
-    std::optional<uint32_t> defining_action;
-
-    // For a Presampled noise symbol, this identifies its stable HIR noise site.
-    // Nullopt means the presampled event has no noise-site identity. All other
-    // symbol kinds must use nullopt.
-    std::optional<NoiseSiteId> noise_site;
-};
-
 // One nonidentity outcome of a mutually exclusive Pauli-noise site. The
 // identity outcome has the remaining probability and no symbol.
 struct PresampledNoiseOutcome {
@@ -377,7 +362,9 @@ struct SamplingPlan {
     // stream into physical qubits and is never read by ordinary dispatch.
     std::optional<Tableau> final_tableau;
 
-    std::vector<SymbolInfo> symbols;
+    // Defining actions and noise-site membership remain owned by the action
+    // stream and presampled distributions instead of being duplicated here.
+    std::vector<SymbolKind> symbols;
     std::vector<PresampledNoiseSite> presampled_noise_sites;
     std::vector<InstrumentDistribution> instrument_distributions;
     std::vector<PlannedAction> actions;

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -197,9 +197,16 @@ struct ApplyReadoutNoise {
     double prob_one_to_zero = 0.0;
 };
 
-// A parity over circuit record slots at the point where a circuit output is
-// written. Construction sorts the slots and removes even multiplicities so
-// every value has one deterministic representation.
+// Circuit outputs are XOR parities of measurement-record snapshots. A detector
+// is written at its circuit position, where every referenced slot is current.
+// Observable includes instead accumulate until one final write; if a referenced
+// slot changes in between, the planner preserves its historical snapshot as an
+// AffineBool. Otherwise it retains the cheaper RecordParity. Executors consume
+// the chosen representation without repeating this freshness analysis.
+//
+// RecordParity is a parity over current circuit record slots. Construction
+// sorts the slots and removes even multiplicities so every value has one
+// deterministic representation.
 class RecordParity {
   public:
     RecordParity() = default;

--- a/src/clifft/sampling/plan.h
+++ b/src/clifft/sampling/plan.h
@@ -197,23 +197,35 @@ struct ApplyReadoutNoise {
     double prob_one_to_zero = 0.0;
 };
 
-// A parity over circuit record slots at the point where a syndrome value is
-// written. Record slots are canonicalized in strictly increasing order.
-struct RecordParity {
-    bool constant = false;
-    std::vector<RecordSlot> records;
+// A parity over circuit record slots at the point where a circuit output is
+// written. Construction sorts the slots and removes even multiplicities so
+// every value has one deterministic representation.
+class RecordParity {
+  public:
+    RecordParity() = default;
+    RecordParity(bool constant, std::vector<RecordSlot> records);
+
+    [[nodiscard]] bool constant() const { return constant_; }
+    [[nodiscard]] const std::vector<RecordSlot>& records() const { return records_; }
+    [[nodiscard]] bool is_canonical() const;
+
+    friend bool operator==(const RecordParity&, const RecordParity&) = default;
+
+  private:
+    bool constant_ = false;
+    std::vector<RecordSlot> records_;
 };
 
-// Syndrome writes retain the representation whose dependencies are still
+// Observable writes retain the representation whose dependencies are still
 // available at execution time. Record parity avoids expanding current record
 // snapshots; affine form preserves historical values after a record changes.
-using SyndromeValue = std::variant<AffineBool, RecordParity>;
+using ObservableValue = std::variant<AffineBool, RecordParity>;
 
 // Writes a detector parity after the planner has XORed its expected reference
 // parity into the selected value. A nonzero postselected detector rejects the
 // shot immediately; later actions and outputs are irrelevant for it.
 struct WriteDetector {
-    SyndromeValue outcome;
+    RecordParity outcome;
     DetectorSlot detector{};
     bool postselected = false;
 };
@@ -221,16 +233,23 @@ struct WriteDetector {
 // Writes one fully accumulated logical observable after the planner has XORed
 // its expected reference parity into the selected value.
 struct WriteObservable {
-    SyndromeValue outcome;
+    ObservableValue outcome;
     ObservableSlot observable{};
 };
 
 // Writes a non-destructive Pauli expectation probe. The planner retains only
 // the coefficient-kernel input, not the full transformed observable: an absent
 // active projection means dormant X or Y support proved the result is zero.
-struct WriteExpectationValue {
-    std::optional<ActivePauli> active_projection;
+struct ActiveExpectation {
+    ActivePauli projection;
     AffineBool sign;
+};
+
+struct WriteExpectationValue {
+    // Absence is an exact zero proved by dormant X or Y support. Keeping the
+    // sign inside the active form prevents zero probes from carrying an
+    // irrelevant expression.
+    std::optional<ActiveExpectation> active;
     ExpValSlot exp_val{};
 };
 
@@ -304,7 +323,6 @@ struct PresampledNoiseOutcome {
 };
 
 struct PresampledNoiseSite {
-    NoiseSiteId site{};
     // Exact semantic probability copied from the HIR noise site. Execution
     // still uses the ordered outcome probabilities for channel selection.
     double total_probability = 0.0;
@@ -315,7 +333,6 @@ struct PresampledNoiseSite {
 // indices use 0 for g and 1 for e. Computational entries are unconditional;
 // their row sum is at most p_fire[source].
 struct InstrumentDistribution {
-    InstrumentSiteId site{};
     std::array<double, 2> p_fire{};
     std::array<std::array<double, 2>, 2> p_computational_dest{};
 };
@@ -351,12 +368,9 @@ struct SamplingPlan {
     // that every slot in both regions is written exactly once.
     uint32_t num_visible_records = 0;
     uint32_t num_hidden_records = 0;
-    uint32_t num_noise_sites = 0;
-    uint32_t num_instrument_sites = 0;
     uint32_t num_detectors = 0;
     uint32_t num_observables = 0;
     uint32_t num_exp_vals = 0;
-    bool has_postselection = false;
 
     // Present only for pure-state plans eligible for exact final-state
     // queries. It maps the final stabilizer coordinates used by the action

--- a/src/clifft/sampling/plan_inspection.cc
+++ b/src/clifft/sampling/plan_inspection.cc
@@ -82,17 +82,13 @@ std::string_view instrument_mode_name(InstrumentMode mode) {
     return "unknown";
 }
 
-void write_batch_record_parity(std::ostream& out, const std::optional<BatchRecordParity>& parity) {
-    if (!parity.has_value()) {
-        return;
-    }
-    out << " batch_parity=";
+void write_record_parity(std::ostream& out, const RecordParity& parity) {
     bool wrote = false;
-    if (parity->constant) {
+    if (parity.constant) {
         out << '1';
         wrote = true;
     }
-    for (RecordSlot record : parity->records) {
+    for (RecordSlot record : parity.records) {
         if (wrote) {
             out << '^';
         }
@@ -101,6 +97,15 @@ void write_batch_record_parity(std::ostream& out, const std::optional<BatchRecor
     }
     if (!wrote) {
         out << '0';
+    }
+}
+
+void write_syndrome_value(std::ostream& out, const SyndromeValue& value,
+                          std::optional<size_t> max_expression_terms) {
+    if (const auto* expression = std::get_if<AffineBool>(&value)) {
+        out << format_expression(*expression, max_expression_terms);
+    } else {
+        write_record_parity(out, std::get<RecordParity>(value));
     }
 }
 
@@ -144,18 +149,16 @@ void write_action_body(std::ostream& out, const SamplingAction& action,
                     << " p01=" << format_double_roundtrip(typed.prob_zero_to_one)
                     << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
-                out << "WRITE_DETECTOR outcome="
-                    << format_expression(typed.outcome, max_expression_terms) << " detector=d"
-                    << index(typed.detector);
+                out << "WRITE_DETECTOR outcome=";
+                write_syndrome_value(out, typed.outcome, max_expression_terms);
+                out << " detector=d" << index(typed.detector);
                 if (typed.postselected) {
                     out << " postselect";
                 }
-                write_batch_record_parity(out, typed.batch_parity);
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
-                out << "WRITE_OBSERVABLE outcome="
-                    << format_expression(typed.outcome, max_expression_terms) << " observable=o"
-                    << index(typed.observable);
-                write_batch_record_parity(out, typed.batch_parity);
+                out << "WRITE_OBSERVABLE outcome=";
+                write_syndrome_value(out, typed.outcome, max_expression_terms);
+                out << " observable=o" << index(typed.observable);
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                 out << "WRITE_EXPECTATION ";
                 if (typed.active_projection.has_value()) {

--- a/src/clifft/sampling/plan_inspection.cc
+++ b/src/clifft/sampling/plan_inspection.cc
@@ -233,14 +233,7 @@ std::string SamplingPlan::inspect() const {
         << " dust_epsilon=" << format_double_roundtrip(kMeasurementDustEpsilon) << '\n';
     out << "symbols=" << symbols.size() << '\n';
     for (uint32_t i = 0; i < symbols.size(); ++i) {
-        out << "  s" << i << " kind=" << symbol_kind_name(symbols[i].kind);
-        if (symbols[i].defining_action.has_value()) {
-            out << " action=" << *symbols[i].defining_action;
-        }
-        if (symbols[i].noise_site.has_value()) {
-            out << " noise_site=" << index(*symbols[i].noise_site);
-        }
-        out << '\n';
+        out << "  s" << i << " kind=" << symbol_kind_name(symbols[i]) << '\n';
     }
     for (size_t site_index = 0; site_index < presampled_noise_sites.size(); ++site_index) {
         const PresampledNoiseSite& site = presampled_noise_sites[site_index];

--- a/src/clifft/sampling/plan_inspection.cc
+++ b/src/clifft/sampling/plan_inspection.cc
@@ -84,11 +84,11 @@ std::string_view instrument_mode_name(InstrumentMode mode) {
 
 void write_record_parity(std::ostream& out, const RecordParity& parity) {
     bool wrote = false;
-    if (parity.constant) {
+    if (parity.constant()) {
         out << '1';
         wrote = true;
     }
-    for (RecordSlot record : parity.records) {
+    for (RecordSlot record : parity.records()) {
         if (wrote) {
             out << '^';
         }
@@ -100,8 +100,8 @@ void write_record_parity(std::ostream& out, const RecordParity& parity) {
     }
 }
 
-void write_syndrome_value(std::ostream& out, const SyndromeValue& value,
-                          std::optional<size_t> max_expression_terms) {
+void write_observable_value(std::ostream& out, const ObservableValue& value,
+                            std::optional<size_t> max_expression_terms) {
     if (const auto* expression = std::get_if<AffineBool>(&value)) {
         out << format_expression(*expression, max_expression_terms);
     } else {
@@ -150,21 +150,21 @@ void write_action_body(std::ostream& out, const SamplingAction& action,
                     << " p10=" << format_double_roundtrip(typed.prob_one_to_zero);
             } else if constexpr (std::is_same_v<T, WriteDetector>) {
                 out << "WRITE_DETECTOR outcome=";
-                write_syndrome_value(out, typed.outcome, max_expression_terms);
+                write_record_parity(out, typed.outcome);
                 out << " detector=d" << index(typed.detector);
                 if (typed.postselected) {
                     out << " postselect";
                 }
             } else if constexpr (std::is_same_v<T, WriteObservable>) {
                 out << "WRITE_OBSERVABLE outcome=";
-                write_syndrome_value(out, typed.outcome, max_expression_terms);
+                write_observable_value(out, typed.outcome, max_expression_terms);
                 out << " observable=o" << index(typed.observable);
             } else if constexpr (std::is_same_v<T, WriteExpectationValue>) {
                 out << "WRITE_EXPECTATION ";
-                if (typed.active_projection.has_value()) {
-                    out << format_pauli_product(typed.active_projection->x,
-                                                typed.active_projection->z)
-                        << " sign=" << format_expression(typed.sign, max_expression_terms);
+                if (typed.active.has_value()) {
+                    out << format_pauli_product(typed.active->projection.x,
+                                                typed.active->projection.z)
+                        << " sign=" << format_expression(typed.active->sign, max_expression_terms);
                 } else {
                     out << "zero";
                 }
@@ -216,11 +216,17 @@ void write_action_inspection_compact(std::ostream& out, const PlannedAction& pla
 std::string SamplingPlan::inspect() const {
     validate();
 
+    const bool has_postselection = std::ranges::any_of(actions, [](const PlannedAction& planned) {
+        const auto* detector = std::get_if<WriteDetector>(&planned.action);
+        return detector != nullptr && detector->postselected;
+    });
+
     std::ostringstream out;
     out << "sampling_plan qubits=" << num_qubits << " initial_width=" << initial_active_width
         << " peak_width=" << peak_active_width << " visible_records=" << num_visible_records
-        << " hidden_records=" << num_hidden_records << " noise_sites=" << num_noise_sites
-        << " instrument_sites=" << num_instrument_sites << " detectors=" << num_detectors
+        << " hidden_records=" << num_hidden_records
+        << " noise_sites=" << presampled_noise_sites.size()
+        << " instrument_sites=" << instrument_distributions.size() << " detectors=" << num_detectors
         << " observables=" << num_observables << " exp_vals=" << num_exp_vals
         << " postselection=" << has_postselection
         << " final_state_queries=" << final_tableau.has_value()
@@ -236,8 +242,9 @@ std::string SamplingPlan::inspect() const {
         }
         out << '\n';
     }
-    for (const PresampledNoiseSite& site : presampled_noise_sites) {
-        out << "  noise_site " << index(site.site)
+    for (size_t site_index = 0; site_index < presampled_noise_sites.size(); ++site_index) {
+        const PresampledNoiseSite& site = presampled_noise_sites[site_index];
+        out << "  noise_site " << site_index
             << " probability=" << format_double_roundtrip(site.total_probability)
             << " outcomes=" << site.outcomes.size();
         for (const PresampledNoiseOutcome& outcome : site.outcomes) {

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -135,26 +135,28 @@ bool option_bit(std::span<const uint8_t> values, uint32_t index) {
 }
 
 RecordParity make_record_parity(std::span<const uint32_t> records, bool constant) {
-    std::vector<uint32_t> sorted(records.begin(), records.end());
-    std::ranges::sort(sorted);
-    RecordParity result;
-    result.constant = constant;
-    for (size_t begin = 0; begin < sorted.size();) {
-        size_t end = begin + 1;
-        while (end < sorted.size() && sorted[end] == sorted[begin]) {
-            ++end;
-        }
-        if ((end - begin) % 2 != 0) {
-            result.records.push_back(RecordSlot{sorted[begin]});
-        }
-        begin = end;
+    std::vector<RecordSlot> slots;
+    slots.reserve(records.size());
+    for (uint32_t record : records) {
+        slots.push_back(RecordSlot{record});
     }
-    return result;
+    return RecordParity{constant, std::move(slots)};
 }
 
 struct ObservableRecordReference {
     uint32_t record = 0;
     uint32_t generation = 0;
+};
+
+struct PlanningRecord {
+    std::optional<AffineBool> value;
+    uint32_t generation = 0;
+};
+
+struct PendingObservable {
+    AffineBool historical_value;
+    std::vector<ObservableRecordReference> record_snapshots;
+    std::vector<uint32_t> source_lines;
 };
 
 struct PlanningRequirements {
@@ -230,7 +232,6 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
 void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
     plan.presampled_noise_sites.resize(hir.noise_sites.size());
     for (uint32_t site = 0; site < hir.noise_sites.size(); ++site) {
-        plan.presampled_noise_sites[site].site = NoiseSiteId{site};
         plan.presampled_noise_sites[site].total_probability =
             hir.noise_sites[site].total_probability;
     }
@@ -238,7 +239,6 @@ void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
     for (uint32_t site = 0; site < hir.instrument_sites.size(); ++site) {
         const InstrumentProbabilities& probabilities = hir.instrument_sites[site].probabilities;
         InstrumentDistribution distribution;
-        distribution.site = InstrumentSiteId{site};
         for (uint8_t source = 0; source < 2; ++source) {
             distribution.p_fire[source] = probabilities.p_fire[source];
             for (uint8_t destination = 0; destination < 2; ++destination) {
@@ -422,8 +422,6 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     plan.num_qubits = hir.num_qubits;
     plan.num_visible_records = hir.num_measurements;
     plan.num_hidden_records = hir.num_hidden_measurements;
-    plan.num_noise_sites = static_cast<uint32_t>(hir.noise_sites.size());
-    plan.num_instrument_sites = static_cast<uint32_t>(hir.instrument_sites.size());
     plan.num_detectors = hir.num_detectors;
     plan.num_observables = hir.num_observables;
     plan.num_exp_vals = hir.num_exp_vals;
@@ -447,34 +445,28 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     }
     CoordinateFrame coordinates(hir.num_qubits);
     SymbolicPauliFrame symbolic_frame(hir.num_qubits, requirements.symbol_count);
-    std::vector<std::optional<AffineBool>> record_values(static_cast<size_t>(hir.num_measurements) +
-                                                         hir.num_hidden_measurements);
-    std::vector<uint32_t> record_generations(record_values.size(), 0);
-    std::vector<AffineBool> observable_values(hir.num_observables);
-    std::vector<std::vector<ObservableRecordReference>> observable_records(hir.num_observables);
-    std::vector<std::vector<uint32_t>> observable_source_lines;
-    if (plan.source_map.has_value()) {
-        observable_source_lines.resize(hir.num_observables);
-    }
+    std::vector<PlanningRecord> records(static_cast<size_t>(hir.num_measurements) +
+                                        hir.num_hidden_measurements);
+    std::vector<PendingObservable> observables(hir.num_observables);
 
     auto require_record = [&](RecordSlot record, size_t operation_index) -> const AffineBool& {
         const uint32_t record_index = index(record);
-        if (record_index >= record_values.size() || !record_values[record_index].has_value()) {
+        if (record_index >= records.size() || !records[record_index].value.has_value()) {
             throw std::invalid_argument("sampling planner operation " +
                                         std::to_string(operation_index) + " reads record " +
                                         std::to_string(record_index) + " before assignment");
         }
-        return *record_values[record_index];
+        return *records[record_index].value;
     };
 
     auto assign_record = [&](RecordSlot record, AffineBool value, size_t operation_index) {
         const uint32_t record_index = index(record);
-        if (record_index >= record_values.size()) {
+        if (record_index >= records.size()) {
             throw std::invalid_argument("sampling planner operation " +
                                         std::to_string(operation_index) + " writes record " +
                                         std::to_string(record_index) + " out of range");
         }
-        record_values[record_index] = std::move(value);
+        records[record_index].value = std::move(value);
     };
 
     auto record_parity = [&](const std::vector<uint32_t>& records,
@@ -575,8 +567,9 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                                   ApplyReadoutNoise{flip, source, record, entry.prob_zero_to_one,
                                                     entry.prob_one_to_zero}},
                     source_lines);
-                record_values[index(record)] = source ^ AffineBool::symbol(flip);
-                ++record_generations[index(record)];
+                PlanningRecord& updated = records[index(record)];
+                updated.value = source ^ AffineBool::symbol(flip);
+                ++updated.generation;
                 break;
             }
             case OpType::INSTRUMENT: {
@@ -611,7 +604,6 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                                                     hir.detector_targets[targets_index], expected),
                                                 DetectorSlot{detector_index}, postselected}},
                     source_lines);
-                plan.has_postselection |= postselected;
                 ++detector_index;
                 break;
             }
@@ -622,16 +614,14 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     observable_index >= hir.num_observables) {
                     throw std::invalid_argument("sampling planner observable is out of range");
                 }
-                observable_values[observable_index] ^=
-                    record_parity(hir.observable_targets[targets_index], i);
+                PendingObservable& pending = observables[observable_index];
+                pending.historical_value ^= record_parity(hir.observable_targets[targets_index], i);
                 for (uint32_t record : hir.observable_targets[targets_index]) {
-                    observable_records[observable_index].push_back(
-                        {record, record_generations.at(record)});
+                    pending.record_snapshots.push_back({record, records.at(record).generation});
                 }
                 if (plan.source_map.has_value()) {
-                    observable_source_lines[observable_index].insert(
-                        observable_source_lines[observable_index].end(), source_lines.begin(),
-                        source_lines.end());
+                    pending.source_lines.insert(pending.source_lines.end(), source_lines.begin(),
+                                                source_lines.end());
                 }
                 break;
             }
@@ -650,9 +640,9 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     PlannedAction{active_width, active_width,
                                   WriteExpectationValue{
                                       is_zero ? std::nullopt
-                                              : std::optional<ActivePauli>{active_projection(
-                                                    resolved.body, active_width)},
-                                      is_zero ? AffineBool{} : std::move(resolved.sign),
+                                              : std::optional<ActiveExpectation>{ActiveExpectation{
+                                                    active_projection(resolved.body, active_width),
+                                                    std::move(resolved.sign)}},
                                       ExpValSlot{exp_val_index}}},
                     source_lines);
                 break;
@@ -680,28 +670,28 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
         throw std::invalid_argument(
             "sampling planner instrument-site table is inconsistent with HIR");
     }
-    for (uint32_t observable = 0; observable < observable_values.size(); ++observable) {
-        observable_values[observable] ^= option_bit(options.expected_observables, observable);
+    for (uint32_t observable = 0; observable < observables.size(); ++observable) {
+        PendingObservable& pending = observables[observable];
+        pending.historical_value ^= option_bit(options.expected_observables, observable);
         const bool records_are_current =
-            std::ranges::all_of(observable_records[observable], [&](const auto& reference) {
-                return reference.generation == record_generations[reference.record];
+            std::ranges::all_of(pending.record_snapshots, [&](const auto& reference) {
+                return reference.generation == records[reference.record].generation;
             });
-        SyndromeValue outcome;
+        ObservableValue outcome;
         if (records_are_current) {
-            std::vector<uint32_t> records;
-            records.reserve(observable_records[observable].size());
-            for (const ObservableRecordReference& reference : observable_records[observable]) {
-                records.push_back(reference.record);
+            std::vector<uint32_t> snapshot_records;
+            snapshot_records.reserve(pending.record_snapshots.size());
+            for (const ObservableRecordReference& reference : pending.record_snapshots) {
+                snapshot_records.push_back(reference.record);
             }
-            outcome =
-                make_record_parity(records, option_bit(options.expected_observables, observable));
+            outcome = make_record_parity(snapshot_records,
+                                         option_bit(options.expected_observables, observable));
         } else {
-            outcome = std::move(observable_values[observable]);
+            outcome = std::move(pending.historical_value);
         }
         const std::span<const uint32_t> source_lines =
-            plan.source_map.has_value()
-                ? std::span<const uint32_t>(observable_source_lines[observable])
-                : std::span<const uint32_t>{};
+            plan.source_map.has_value() ? std::span<const uint32_t>(pending.source_lines)
+                                        : std::span<const uint32_t>{};
         append_action(
             plan,
             PlannedAction{active_width, active_width,

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -147,6 +147,28 @@ struct ObservableRecordReference {
     uint32_t generation = 0;
 };
 
+void canonicalize_record_snapshots(std::vector<ObservableRecordReference>& references) {
+    std::ranges::sort(references, [](const auto& left, const auto& right) {
+        if (left.record != right.record) {
+            return left.record < right.record;
+        }
+        return left.generation < right.generation;
+    });
+    size_t output = 0;
+    for (size_t begin = 0; begin < references.size();) {
+        size_t end = begin + 1;
+        while (end < references.size() && references[end].record == references[begin].record &&
+               references[end].generation == references[begin].generation) {
+            ++end;
+        }
+        if ((end - begin) % 2 != 0) {
+            references[output++] = references[begin];
+        }
+        begin = end;
+    }
+    references.resize(output);
+}
+
 struct PlanningRecord {
     std::optional<AffineBool> value;
     uint32_t generation = 0;
@@ -589,13 +611,16 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     detector_index >= hir.num_detectors) {
                     throw std::invalid_argument("sampling planner detector is out of range");
                 }
+                const std::vector<uint32_t>& targets = hir.detector_targets[targets_index];
+                for (uint32_t record : targets) {
+                    (void)require_record(RecordSlot{record}, i);
+                }
                 const bool expected = option_bit(options.expected_detectors, detector_index);
                 const bool postselected = option_bit(options.postselection_mask, detector_index);
                 append_action(
                     plan,
                     PlannedAction{active_width, active_width,
-                                  WriteDetector{make_record_parity(
-                                                    hir.detector_targets[targets_index], expected),
+                                  WriteDetector{make_record_parity(targets, expected),
                                                 DetectorSlot{detector_index}, postselected}},
                     source_lines);
                 ++detector_index;
@@ -667,6 +692,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     for (uint32_t observable = 0; observable < observables.size(); ++observable) {
         PendingObservable& pending = observables[observable];
         pending.historical_value ^= option_bit(options.expected_observables, observable);
+        canonicalize_record_snapshots(pending.record_snapshots);
         const bool records_are_current =
             std::ranges::all_of(pending.record_snapshots, [&](const auto& reference) {
                 return reference.generation == records[reference.record].generation;

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -121,13 +121,12 @@ void append_action(SamplingPlan& plan, PlannedAction action,
     }
 }
 
-void define_symbol(SamplingPlan& plan, SymbolId symbol, SymbolKind kind, uint32_t action) {
-    SymbolInfo& info = plan.symbols.at(index(symbol));
-    if (info.kind != SymbolKind::Unused || info.defining_action.has_value() ||
-        info.noise_site.has_value()) {
+void define_symbol(SamplingPlan& plan, SymbolId symbol, SymbolKind kind) {
+    SymbolKind& stored_kind = plan.symbols.at(index(symbol));
+    if (stored_kind != SymbolKind::Unused) {
         throw std::logic_error("sampling planner attempted to redefine a reserved symbol");
     }
-    info = SymbolInfo{kind, action, std::nullopt};
+    stored_kind = kind;
 }
 
 bool option_bit(std::span<const uint8_t> values, uint32_t index) {
@@ -293,8 +292,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
     if (dormant_pivot.has_value()) {
         coordinates.measure_dormant(resolved.body, *dormant_pivot);
 
-        const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-        define_symbol(plan, branch, SymbolKind::Branch, action_index);
+        define_symbol(plan, branch, SymbolKind::Branch);
         Pauli correction(coordinates.current_to_initial().x_output(*dormant_pivot));
         correction.set_sign(false);
         symbolic_frame.apply(correction, AffineBool::symbol(branch));
@@ -329,8 +327,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
     active_body.set_sign(false);
     coordinates.measure_active(active_body, active_width, *pivot);
 
-    const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-    define_symbol(plan, branch, SymbolKind::Branch, action_index);
+    define_symbol(plan, branch, SymbolKind::Branch);
     Pauli correction(coordinates.current_to_initial().x_output(active_width - 1));
     correction.set_sign(false);
     symbolic_frame.apply(correction, AffineBool::symbol(branch));
@@ -390,13 +387,12 @@ void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t n
         mode = source.is_identity() ? InstrumentMode::Classical : InstrumentMode::Active;
     }
 
-    const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
     std::optional<SymbolId> destination_symbol;
     if (mode != InstrumentMode::DormantTrap) {
         // Only an in-line computational destination needs the reserved flip;
         // a trapped continuation resolves its destination instead.
         destination_symbol = destination_flip_symbol;
-        define_symbol(plan, destination_flip_symbol, SymbolKind::Instrument, action_index);
+        define_symbol(plan, destination_flip_symbol, SymbolKind::Instrument);
     }
     append_action(plan,
                   PlannedAction{active_width, active_after,
@@ -539,8 +535,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                         continue;
                     }
                     const SymbolId symbol{static_cast<uint32_t>(plan.symbols.size())};
-                    plan.symbols.push_back(
-                        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{site_index}});
+                    plan.symbols.push_back(SymbolKind::Presampled);
                     plan_site.outcomes.push_back(PresampledNoiseOutcome{symbol, channel.prob});
                     const Pauli body = noise_pauli_from_hir(hir, channel.mask);
                     symbolic_frame.apply(body, AffineBool::symbol(symbol));
@@ -559,8 +554,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                 if (entry.prob_zero_to_one == 0.0 && entry.prob_one_to_zero == 0.0) {
                     break;
                 }
-                const uint32_t action_index = static_cast<uint32_t>(plan.actions.size());
-                define_symbol(plan, flip, SymbolKind::Readout, action_index);
+                define_symbol(plan, flip, SymbolKind::Readout);
                 append_action(
                     plan,
                     PlannedAction{active_width, active_width,

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -134,10 +134,10 @@ bool option_bit(std::span<const uint8_t> values, uint32_t index) {
     return index < values.size() && values[index] != 0;
 }
 
-BatchRecordParity make_batch_record_parity(std::span<const uint32_t> records, bool constant) {
+RecordParity make_record_parity(std::span<const uint32_t> records, bool constant) {
     std::vector<uint32_t> sorted(records.begin(), records.end());
     std::ranges::sort(sorted);
-    BatchRecordParity result;
+    RecordParity result;
     result.constant = constant;
     for (size_t begin = 0; begin < sorted.size();) {
         size_t end = begin + 1;
@@ -602,17 +602,14 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     detector_index >= hir.num_detectors) {
                     throw std::invalid_argument("sampling planner detector is out of range");
                 }
-                AffineBool outcome = record_parity(hir.detector_targets[targets_index], i);
                 const bool expected = option_bit(options.expected_detectors, detector_index);
-                outcome ^= expected;
                 const bool postselected = option_bit(options.postselection_mask, detector_index);
                 append_action(
                     plan,
-                    PlannedAction{
-                        active_width, active_width,
-                        WriteDetector{outcome, DetectorSlot{detector_index}, postselected,
-                                      make_batch_record_parity(hir.detector_targets[targets_index],
-                                                               expected)}},
+                    PlannedAction{active_width, active_width,
+                                  WriteDetector{make_record_parity(
+                                                    hir.detector_targets[targets_index], expected),
+                                                DetectorSlot{detector_index}, postselected}},
                     source_lines);
                 plan.has_postselection |= postselected;
                 ++detector_index;
@@ -685,19 +682,21 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     }
     for (uint32_t observable = 0; observable < observable_values.size(); ++observable) {
         observable_values[observable] ^= option_bit(options.expected_observables, observable);
-        std::optional<BatchRecordParity> batch_parity;
         const bool records_are_current =
             std::ranges::all_of(observable_records[observable], [&](const auto& reference) {
                 return reference.generation == record_generations[reference.record];
             });
+        SyndromeValue outcome;
         if (records_are_current) {
             std::vector<uint32_t> records;
             records.reserve(observable_records[observable].size());
             for (const ObservableRecordReference& reference : observable_records[observable]) {
                 records.push_back(reference.record);
             }
-            batch_parity = make_batch_record_parity(
-                records, option_bit(options.expected_observables, observable));
+            outcome =
+                make_record_parity(records, option_bit(options.expected_observables, observable));
+        } else {
+            outcome = std::move(observable_values[observable]);
         }
         const std::span<const uint32_t> source_lines =
             plan.source_map.has_value()
@@ -706,8 +705,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
         append_action(
             plan,
             PlannedAction{active_width, active_width,
-                          WriteObservable{observable_values[observable], ObservableSlot{observable},
-                                          std::move(batch_parity)}},
+                          WriteObservable{std::move(outcome), ObservableSlot{observable}}},
             source_lines);
     }
 

--- a/src/clifft/util/page_allocation.cc
+++ b/src/clifft/util/page_allocation.cc
@@ -43,42 +43,58 @@ void aligned_free_portable(void* ptr) {
 
 }  // namespace
 
-PageAlignedAllocation::PageAlignedAllocation(size_t requested_bytes) {
+size_t PageAlignedAllocation::allocation_size(size_t requested_bytes, Alignment alignment) {
     if (requested_bytes == 0) {
-        return;
+        return 0;
     }
     const size_t page_aligned = round_up(requested_bytes, kBaseAlignment);
+#if defined(__linux__)
+    const size_t allocation_alignment =
+        alignment == Alignment::HugePageEligible && page_aligned >= kHugePageSize ? kHugePageSize
+                                                                                  : kBaseAlignment;
+    return round_up(page_aligned, allocation_alignment);
+#else
+    (void)alignment;
+    return page_aligned;
+#endif
+}
+
+PageAlignedAllocation::PageAlignedAllocation(size_t requested_bytes, Alignment alignment) {
+    const size_t allocation_bytes = allocation_size(requested_bytes, alignment);
+    if (allocation_bytes == 0) {
+        return;
+    }
 
 #if defined(__linux__)
-    if (page_aligned >= kHugePageSize) {
-        const size_t huge_aligned = round_up(page_aligned, kHugePageSize);
-        void* mapped = mmap(nullptr, huge_aligned, PROT_READ | PROT_WRITE,
+    const bool huge_page_eligible =
+        alignment == Alignment::HugePageEligible && allocation_bytes >= kHugePageSize;
+    if (huge_page_eligible) {
+        void* mapped = mmap(nullptr, allocation_bytes, PROT_READ | PROT_WRITE,
                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
         if (mapped != MAP_FAILED) {
             data_ = mapped;
-            allocated_bytes_ = huge_aligned;
+            allocated_bytes_ = allocation_bytes;
             memory_mapped_ = true;
             return;
         }
     }
 
-    const size_t allocation_alignment =
-        page_aligned >= kHugePageSize ? kHugePageSize : kBaseAlignment;
-    const size_t allocation_bytes = round_up(page_aligned, allocation_alignment);
+    const size_t allocation_alignment = huge_page_eligible ? kHugePageSize : kBaseAlignment;
     data_ = aligned_alloc_portable(allocation_alignment, allocation_bytes);
     if (data_ == nullptr) {
         throw std::bad_alloc();
     }
     allocated_bytes_ = allocation_bytes;
-    if (page_aligned >= kHugePageSize) {
+    if (huge_page_eligible) {
         madvise(data_, allocation_bytes, MADV_HUGEPAGE);
     }
 #else
-    data_ = aligned_alloc_portable(kBaseAlignment, page_aligned);
+    (void)alignment;
+    data_ = aligned_alloc_portable(kBaseAlignment, allocation_bytes);
     if (data_ == nullptr) {
         throw std::bad_alloc();
     }
-    allocated_bytes_ = page_aligned;
+    allocated_bytes_ = allocation_bytes;
 #endif
 }
 

--- a/src/clifft/util/page_allocation.h
+++ b/src/clifft/util/page_allocation.h
@@ -12,14 +12,24 @@ class PageAlignedAllocation {
     static constexpr size_t kBaseAlignment = 4096;
     static constexpr size_t kHugePageSize = 2 * 1024 * 1024;
 
+    enum class Alignment {
+        BasePage,
+        HugePageEligible,
+    };
+
     PageAlignedAllocation() = default;
-    explicit PageAlignedAllocation(size_t requested_bytes);
+    explicit PageAlignedAllocation(size_t requested_bytes,
+                                   Alignment alignment = Alignment::HugePageEligible);
     ~PageAlignedAllocation();
 
     PageAlignedAllocation(const PageAlignedAllocation&) = delete;
     PageAlignedAllocation& operator=(const PageAlignedAllocation&) = delete;
     PageAlignedAllocation(PageAlignedAllocation&& other) noexcept;
     PageAlignedAllocation& operator=(PageAlignedAllocation&& other) noexcept;
+
+    // Exact retained size selected for a request, including platform alignment.
+    [[nodiscard]] static size_t allocation_size(size_t requested_bytes,
+                                                Alignment alignment = Alignment::HugePageEligible);
 
     void reset() noexcept;
 

--- a/tests/test_batch_bits.cc
+++ b/tests/test_batch_bits.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 using clifft::sampling::fill_low_lane_mask;
+using clifft::sampling::packed_bit_columns_storage_bytes;
 using clifft::sampling::packed_word_count;
 using clifft::sampling::PackedBitColumns;
 
@@ -26,6 +27,16 @@ TEST_CASE("Packed batch columns preserve lane boundaries") {
             REQUIRE(columns.bit(2, lane) == ((lane % 3) == 1));
         }
     }
+}
+
+TEST_CASE("Packed batch column footprint includes page alignment") {
+    constexpr size_t columns = 3;
+    constexpr uint32_t lanes = 65;
+    const size_t raw_bytes = columns * packed_word_count(lanes) * sizeof(uint64_t);
+    const size_t storage_bytes = packed_bit_columns_storage_bytes(columns, lanes);
+    REQUIRE(storage_bytes >= raw_bytes);
+    REQUIRE(storage_bytes % clifft::PageAlignedAllocation::kBaseAlignment == 0);
+    REQUIRE(packed_bit_columns_storage_bytes(0, lanes) == 0);
 }
 
 TEST_CASE("Packed batch columns compact every sidecar stably") {

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -31,7 +31,6 @@ using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::State;
 using clifft::sampling::SymbolId;
-using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
 
 SamplingPlan rotation_plan(uint32_t active_width, std::span<const RotateActivePauli> rotations) {
@@ -39,7 +38,7 @@ SamplingPlan rotation_plan(uint32_t active_width, std::span<const RotateActivePa
     plan.num_qubits = active_width;
     plan.initial_active_width = active_width;
     plan.peak_active_width = active_width;
-    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.symbols = {SymbolKind::Presampled};
     for (const RotateActivePauli& rotation : rotations) {
         plan.actions.push_back(PlannedAction{active_width, active_width, rotation});
     }
@@ -172,10 +171,7 @@ TEST_CASE("Dynamic fused rotation matches scalar across affine sign values") {
     plan.num_qubits = 6;
     plan.initial_active_width = 6;
     plan.peak_active_width = 6;
-    plan.symbols = {
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
-    };
+    plan.symbols = {SymbolKind::Presampled, SymbolKind::Presampled};
     for (const RotateActivePauli& rotation : rotations) {
         plan.actions.push_back(PlannedAction{6, 6, rotation});
     }

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -59,8 +59,10 @@ TEST_CASE("HIP executable lowers existing sampling action names") {
     REQUIRE(executable.actions()[0].tag == ActionTag::PromoteDormantRotation);
     REQUIRE(executable.actions()[1].tag == ActionTag::MeasureActivePauli);
     REQUIRE(executable.actions()[2].tag == ActionTag::WriteDetector);
+    REQUIRE((executable.actions()[2].flags & clifft::sampling::hip::detail::kRecordParity) != 0);
     REQUIRE(executable.actions()[3].tag == ActionTag::WriteExpectationValue);
     REQUIRE(executable.actions()[4].tag == ActionTag::WriteObservable);
+    REQUIRE((executable.actions()[4].flags & clifft::sampling::hip::detail::kRecordParity) != 0);
     REQUIRE(executable.num_exp_vals() == 1);
 }
 
@@ -76,6 +78,22 @@ TEST_CASE("HIP executable inspection identifies packed modification points") {
     REQUIRE_THAT(diagnostic, ContainsSubstring("PromoteDormantRotation"));
     REQUIRE_THAT(diagnostic, ContainsSubstring("MeasureActivePauli"));
     REQUIRE_THAT(diagnostic, ContainsSubstring("WriteDetector"));
+}
+
+TEST_CASE("HIP executable preserves selected syndrome representations") {
+    const ExecutablePlan executable(plan_from(R"(
+        X 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        READOUT_NOISE(1) rec[-1]
+        OBSERVABLE_INCLUDE(1) rec[-1]
+    )"));
+
+    REQUIRE(executable.actions().size() == 4);
+    REQUIRE(executable.actions()[2].tag == ActionTag::WriteObservable);
+    REQUIRE((executable.actions()[2].flags & clifft::sampling::hip::detail::kRecordParity) == 0);
+    REQUIRE(executable.actions()[3].tag == ActionTag::WriteObservable);
+    REQUIRE((executable.actions()[3].flags & clifft::sampling::hip::detail::kRecordParity) != 0);
 }
 
 TEST_CASE("HIP executable packs affine terms and categorical noise") {

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -98,13 +98,11 @@ TEST_CASE("HIP executable preserves selected syndrome representations") {
 
 TEST_CASE("HIP executable packs affine terms and categorical noise") {
     SamplingPlan plan;
-    plan.num_noise_sites = 1;
     plan.symbols = {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
     };
     plan.presampled_noise_sites = {PresampledNoiseSite{
-        NoiseSiteId{0},
         0.25,
         {PresampledNoiseOutcome{SymbolId{0}, 0.125}, PresampledNoiseOutcome{SymbolId{1}, 0.125}}}};
 

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -12,12 +12,10 @@
 #include <variant>
 
 using clifft::sampling::AffineBool;
-using clifft::sampling::NoiseSiteId;
 using clifft::sampling::PresampledNoiseOutcome;
 using clifft::sampling::PresampledNoiseSite;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
-using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
 using clifft::sampling::hip::ExecutablePlan;
 using clifft::sampling::hip::detail::ActionTag;
@@ -98,10 +96,7 @@ TEST_CASE("HIP executable preserves selected syndrome representations") {
 
 TEST_CASE("HIP executable packs affine terms and categorical noise") {
     SamplingPlan plan;
-    plan.symbols = {
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
-    };
+    plan.symbols = {SymbolKind::Presampled, SymbolKind::Presampled};
     plan.presampled_noise_sites = {PresampledNoiseSite{
         0.25,
         {PresampledNoiseOutcome{SymbolId{0}, 0.125}, PresampledNoiseOutcome{SymbolId{1}, 0.125}}}};
@@ -175,9 +170,7 @@ TEST_CASE("HIP executable rejects work outside the first device tier") {
     REQUIRE_THROWS_WITH(ExecutablePlan(wide), ContainsSubstring("peak active width"));
 
     SamplingPlan unbound;
-    unbound.symbols = {
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
-    };
+    unbound.symbols = {SymbolKind::Presampled};
     REQUIRE_THROWS_WITH(ExecutablePlan(unbound), ContainsSubstring("presampled symbol"));
 }
 

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -79,19 +79,35 @@ TEST_CASE("HIP executable inspection identifies packed modification points") {
 }
 
 TEST_CASE("HIP executable preserves selected syndrome representations") {
-    const ExecutablePlan executable(plan_from(R"(
-        X 0
+    const SamplingPlan plan = plan_from(R"(
+        X_ERROR(1) 1
+        X_ERROR(1) 0
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
         READOUT_NOISE(1) rec[-1]
         OBSERVABLE_INCLUDE(1) rec[-1]
-    )"));
+    )");
+    const ExecutablePlan executable(plan);
 
     REQUIRE(executable.actions().size() == 4);
-    REQUIRE(executable.actions()[2].tag == ActionTag::WriteObservable);
-    REQUIRE((executable.actions()[2].flags & clifft::sampling::hip::detail::kRecordParity) == 0);
-    REQUIRE(executable.actions()[3].tag == ActionTag::WriteObservable);
-    REQUIRE((executable.actions()[3].flags & clifft::sampling::hip::detail::kRecordParity) != 0);
+    const auto& historical = executable.actions()[2];
+    REQUIRE(historical.tag == ActionTag::WriteObservable);
+    REQUIRE((historical.flags & clifft::sampling::hip::detail::kRecordParity) == 0);
+    const auto& historical_expression = executable.expressions()[historical.expression];
+    REQUIRE(historical_expression.term_count == 1);
+    const auto& planned_record =
+        std::get<clifft::sampling::RecordClassical>(plan.actions[0].action);
+    REQUIRE(planned_record.outcome.terms().size() == 1);
+    const uint32_t historical_symbol = static_cast<uint32_t>(planned_record.outcome.terms()[0]);
+    REQUIRE(historical_symbol != 0);
+    REQUIRE(executable.expression_terms()[historical_expression.term_begin] == historical_symbol);
+
+    const auto& current = executable.actions()[3];
+    REQUIRE(current.tag == ActionTag::WriteObservable);
+    REQUIRE((current.flags & clifft::sampling::hip::detail::kRecordParity) != 0);
+    const auto& current_expression = executable.expressions()[current.expression];
+    REQUIRE(current_expression.term_count == 1);
+    REQUIRE(executable.expression_terms()[current_expression.term_begin] == 0);
 }
 
 TEST_CASE("HIP executable packs affine terms and categorical noise") {

--- a/tests/test_hip_executable_plan.cc
+++ b/tests/test_hip_executable_plan.cc
@@ -78,7 +78,7 @@ TEST_CASE("HIP executable inspection identifies packed modification points") {
     REQUIRE_THAT(diagnostic, ContainsSubstring("WriteDetector"));
 }
 
-TEST_CASE("HIP executable preserves selected syndrome representations") {
+TEST_CASE("HIP executable preserves selected output representations") {
     const SamplingPlan plan = plan_from(R"(
         X_ERROR(1) 1
         X_ERROR(1) 0

--- a/tests/test_hip_sampler.cc
+++ b/tests/test_hip_sampler.cc
@@ -347,6 +347,35 @@ TEST_CASE("HIP sampler applies both asymmetric readout endpoints exactly") {
     }
 }
 
+TEST_CASE("HIP sampler evaluates both observable value domains") {
+    const SamplingPlan plan = plan_from(R"(
+        X_ERROR(1) 1
+        X_ERROR(1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        READOUT_NOISE(1) rec[-1]
+        OBSERVABLE_INCLUDE(1) rec[-1]
+    )");
+    const HipExecutablePlan hip_executable(plan);
+    const CpuExecutablePlan cpu_executable(plan);
+    constexpr uint32_t kShots = 16;
+    const SamplingResult expected = clifft::sampling::sample(cpu_executable, kShots, uint64_t{11});
+    REQUIRE(std::ranges::all_of(expected.measurements, [](uint8_t value) { return value == 0; }));
+    for (uint32_t shot = 0; shot < kShots; ++shot) {
+        REQUIRE(expected.observables[2 * shot] == 1);
+        REQUIRE(expected.observables[2 * shot + 1] == 0);
+    }
+    require_hip_device();
+
+    for (const CoefficientPrecision precision :
+         {CoefficientPrecision::FP64, CoefficientPrecision::FP32}) {
+        const SamplingResult actual = clifft::sampling::hip::sample(
+            hip_executable, kShots, {.seed = uint64_t{11}, .coefficient_precision = precision});
+        CAPTURE(precision);
+        require_same_rows(actual, expected);
+    }
+}
+
 TEST_CASE("HIP sampler matches the full categorical Pauli channel distribution") {
     const SamplingPlan plan = plan_from(R"(
         H 0

--- a/tests/test_inspection_format.cc
+++ b/tests/test_inspection_format.cc
@@ -19,7 +19,6 @@ using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::ApplyInstrument;
 using clifft::sampling::ApplyReadoutNoise;
-using clifft::sampling::BatchRecordParity;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::DetectorSlot;
 using clifft::sampling::ExecutablePlan;
@@ -36,6 +35,7 @@ using clifft::sampling::ObservableSlot;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
+using clifft::sampling::RecordParity;
 using clifft::sampling::RecordSlot;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingAction;
@@ -146,8 +146,8 @@ TEST_CASE("Compact inspection caps affine expressions at four symbol terms") {
 TEST_CASE("Detector inspection appends postselect only when the detector is postselected") {
     SamplingPlan plan;
     plan.actions = {
-        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{0}, true, std::nullopt}},
-        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{1}, false, std::nullopt}},
+        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{0}, true}},
+        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{1}, false}},
     };
 
     CHECK(plan.inspect_action(0) ==
@@ -155,7 +155,7 @@ TEST_CASE("Detector inspection appends postselect only when the detector is post
     CHECK(plan.inspect_action(1) == "w0 dense_passes=0 WRITE_DETECTOR outcome=0 detector=d1");
 }
 
-TEST_CASE("Syndrome inspection renders packed record parity sidecars") {
+TEST_CASE("Syndrome inspection renders the selected record parity value") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
     plan.num_detectors = 1;
@@ -163,21 +163,17 @@ TEST_CASE("Syndrome inspection renders packed record parity sidecars") {
     plan.actions = {
         PlannedAction{0, 0, RecordClassical{AffineBool(true), RecordSlot{0}}},
         PlannedAction{0, 0,
-                      WriteDetector{AffineBool(true), DetectorSlot{0}, false,
-                                    BatchRecordParity{false, {RecordSlot{0}}}}},
+                      WriteDetector{RecordParity{false, {RecordSlot{0}}}, DetectorSlot{0}, false}},
         PlannedAction{0, 0,
-                      WriteObservable{AffineBool(true), ObservableSlot{0},
-                                      BatchRecordParity{false, {RecordSlot{0}}}}},
+                      WriteObservable{RecordParity{false, {RecordSlot{0}}}, ObservableSlot{0}}},
     };
 
-    CHECK(plan.inspect_action(1) ==
-          "w0 dense_passes=0 WRITE_DETECTOR outcome=1 detector=d0 batch_parity=r0");
-    CHECK(plan.inspect_action(2) ==
-          "w0 dense_passes=0 WRITE_OBSERVABLE outcome=1 observable=o0 batch_parity=r0");
+    CHECK(plan.inspect_action(1) == "w0 dense_passes=0 WRITE_DETECTOR outcome=r0 detector=d0");
+    CHECK(plan.inspect_action(2) == "w0 dense_passes=0 WRITE_OBSERVABLE outcome=r0 observable=o0");
     const ExecutablePlan executable(plan);
-    CHECK(executable.inspect_action(1) == "WRITE_DETECTOR detector=d0 outcome=e1 batch_parity=r0");
-    CHECK(executable.inspect_action(2) ==
-          "WRITE_OBSERVABLE observable=o0 outcome=e2 batch_parity=r0");
+    CHECK(executable.num_expression_registers() == 1);
+    CHECK(executable.inspect_action(1) == "WRITE_DETECTOR detector=d0 outcome=r0");
+    CHECK(executable.inspect_action(2) == "WRITE_OBSERVABLE observable=o0 outcome=r0");
 }
 
 TEST_CASE("Executable rotation prints a pairing index only for X-type prepared Paulis") {
@@ -222,8 +218,8 @@ TEST_CASE("Compact inspection mnemonics cover every SamplingAction and its docs 
         PlannedAction{0, 0, RecordClassical{empty, RecordSlot{0}}},
         PlannedAction{0, 0, DefineSymbol{s0, empty}},
         PlannedAction{0, 0, ApplyReadoutNoise{s0, empty, RecordSlot{0}, 0.0, 0.0}},
-        PlannedAction{0, 0, WriteDetector{empty, DetectorSlot{0}, false, std::nullopt}},
-        PlannedAction{0, 0, WriteObservable{empty, ObservableSlot{0}, std::nullopt}},
+        PlannedAction{0, 0, WriteDetector{empty, DetectorSlot{0}, false}},
+        PlannedAction{0, 0, WriteObservable{empty, ObservableSlot{0}}},
         PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, empty, ExpValSlot{0}}},
         PlannedAction{0, 0,
                       ApplyInstrument{InstrumentSiteId{0}, InstrumentMode::Classical, ActivePauli{},

--- a/tests/test_inspection_format.cc
+++ b/tests/test_inspection_format.cc
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+using clifft::sampling::ActiveExpectation;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::ApplyInstrument;
@@ -146,8 +147,8 @@ TEST_CASE("Compact inspection caps affine expressions at four symbol terms") {
 TEST_CASE("Detector inspection appends postselect only when the detector is postselected") {
     SamplingPlan plan;
     plan.actions = {
-        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{0}, true}},
-        PlannedAction{0, 0, WriteDetector{AffineBool{}, DetectorSlot{1}, false}},
+        PlannedAction{0, 0, WriteDetector{RecordParity{}, DetectorSlot{0}, true}},
+        PlannedAction{0, 0, WriteDetector{RecordParity{}, DetectorSlot{1}, false}},
     };
 
     CHECK(plan.inspect_action(0) ==
@@ -218,9 +219,10 @@ TEST_CASE("Compact inspection mnemonics cover every SamplingAction and its docs 
         PlannedAction{0, 0, RecordClassical{empty, RecordSlot{0}}},
         PlannedAction{0, 0, DefineSymbol{s0, empty}},
         PlannedAction{0, 0, ApplyReadoutNoise{s0, empty, RecordSlot{0}, 0.0, 0.0}},
-        PlannedAction{0, 0, WriteDetector{empty, DetectorSlot{0}, false}},
+        PlannedAction{0, 0, WriteDetector{RecordParity{}, DetectorSlot{0}, false}},
         PlannedAction{0, 0, WriteObservable{empty, ObservableSlot{0}}},
-        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, empty, ExpValSlot{0}}},
+        PlannedAction{
+            0, 0, WriteExpectationValue{ActiveExpectation{ActivePauli{}, empty}, ExpValSlot{0}}},
         PlannedAction{0, 0,
                       ApplyInstrument{InstrumentSiteId{0}, InstrumentMode::Classical, ActivePauli{},
                                       empty, s0}},

--- a/tests/test_inspection_format.cc
+++ b/tests/test_inspection_format.cc
@@ -156,7 +156,7 @@ TEST_CASE("Detector inspection appends postselect only when the detector is post
     CHECK(plan.inspect_action(1) == "w0 dense_passes=0 WRITE_DETECTOR outcome=0 detector=d1");
 }
 
-TEST_CASE("Syndrome inspection renders the selected record parity value") {
+TEST_CASE("Detector and observable inspection renders selected record parity values") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
     plan.num_detectors = 1;

--- a/tests/test_page_allocation.cc
+++ b/tests/test_page_allocation.cc
@@ -40,7 +40,25 @@ TEST_CASE("Page-aligned allocation owns rounded movable storage") {
 TEST_CASE("Page-aligned allocation validates edge sizes") {
     PageAlignedAllocation empty(0);
     REQUIRE(empty.empty());
+    REQUIRE(PageAlignedAllocation::allocation_size(0) == 0);
+    REQUIRE(PageAlignedAllocation::allocation_size(17) == PageAlignedAllocation::kBaseAlignment);
     REQUIRE_THROWS_AS(PageAlignedAllocation(std::numeric_limits<size_t>::max()), std::length_error);
+    REQUIRE_THROWS_AS(PageAlignedAllocation::allocation_size(std::numeric_limits<size_t>::max()),
+                      std::length_error);
+}
+
+TEST_CASE("Base-page allocation avoids huge-page size inflation") {
+    constexpr size_t requested = PageAlignedAllocation::kHugePageSize + 17;
+    constexpr size_t expected =
+        PageAlignedAllocation::kHugePageSize + PageAlignedAllocation::kBaseAlignment;
+    REQUIRE(PageAlignedAllocation::allocation_size(
+                requested, PageAlignedAllocation::Alignment::BasePage) == expected);
+
+    PageAlignedAllocation allocation(requested, PageAlignedAllocation::Alignment::BasePage);
+    REQUIRE(allocation.size() == expected);
+    REQUIRE(reinterpret_cast<uintptr_t>(allocation.data()) %
+                PageAlignedAllocation::kBaseAlignment ==
+            0);
 }
 
 #if defined(__linux__)

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -47,7 +47,6 @@ using clifft::sampling::InstrumentMode;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
-using clifft::sampling::NoiseSiteId;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::PresampledNoiseOutcome;
@@ -63,7 +62,6 @@ using clifft::sampling::SamplingPlan;
 using clifft::sampling::SamplingPlanOptions;
 using clifft::sampling::State;
 using clifft::sampling::SymbolId;
-using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
 using clifft::sampling::WriteExpectationValue;
 
@@ -74,10 +72,7 @@ SamplingPlan active_then_dormant_plan(double promotion_half_turns) {
     plan.num_qubits = 2;
     plan.peak_active_width = 1;
     plan.num_visible_records = 2;
-    plan.symbols = {
-        SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
-        SymbolInfo{SymbolKind::Branch, 2, std::nullopt},
-    };
+    plan.symbols = {SymbolKind::Branch, SymbolKind::Branch};
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{promotion_half_turns, AffineBool(false)}},
         PlannedAction{1, 0,
@@ -93,7 +88,7 @@ SamplingPlan active_then_dormant_plan(double promotion_half_turns) {
 SamplingPlan dormant_trap_plan() {
     SamplingPlan plan;
     plan.num_qubits = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
+    plan.symbols = {SymbolKind::Unused};
     plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     plan.actions = {
         PlannedAction{
@@ -111,12 +106,8 @@ SamplingPlan plan_from(std::string_view circuit_text) {
 
 SamplingPlan categorical_noise_plan() {
     SamplingPlan plan;
-    plan.symbols = {
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{1}},
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{1}},
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{3}},
-    };
+    plan.symbols = {SymbolKind::Presampled, SymbolKind::Presampled, SymbolKind::Presampled,
+                    SymbolKind::Presampled};
     plan.presampled_noise_sites = {
         PresampledNoiseSite{0.05, {PresampledNoiseOutcome{SymbolId{0}, 0.05}}},
         PresampledNoiseSite{
@@ -233,7 +224,7 @@ TEST_CASE("Sampling executor does not draw for empty noise sites") {
     plan.num_qubits = 1;
     plan.num_visible_records = 1;
     plan.presampled_noise_sites = {PresampledNoiseSite{0.0, {}}};
-    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Branch};
     plan.actions = {PlannedAction{
         0, 0,
         MeasureDormantRandom{0, SymbolId{0}, AffineBool::symbol(SymbolId{0}), RecordSlot{0}}}};
@@ -254,10 +245,7 @@ TEST_CASE("Sampling executor evaluates presampled and derived affine symbols") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
     plan.num_hidden_records = 1;
-    plan.symbols = {
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
-        SymbolInfo{SymbolKind::Derived, 0, std::nullopt},
-    };
+    plan.symbols = {SymbolKind::Presampled, SymbolKind::Derived};
     plan.actions = {
         PlannedAction{
             0, 0, DefineSymbol{SymbolId{1}, AffineBool(true, std::vector<SymbolId>{SymbolId{0}})}},
@@ -291,7 +279,7 @@ TEST_CASE("Sampling executor applies sampled symbols to later state actions") {
     plan.num_qubits = 2;
     plan.peak_active_width = 1;
     plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Branch};
     plan.actions = {
         PlannedAction{
             0, 0,
@@ -331,9 +319,7 @@ TEST_CASE("Sampling executor fuses constant rotation orbits") {
         plan.num_qubits = active_width;
         plan.initial_active_width = active_width;
         plan.peak_active_width = active_width;
-        plan.symbols = {
-            SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt},
-        };
+        plan.symbols = {SymbolKind::Presampled};
         for (uint32_t axis = 0; axis < active_width; ++axis) {
             plan.actions.push_back(
                 PlannedAction{active_width, active_width,
@@ -429,7 +415,7 @@ TEST_CASE("Sampling replay inverts affine records and preserves branch dependenc
     plan.num_qubits = 2;
     plan.peak_active_width = 1;
     plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Branch};
     plan.actions = {
         PlannedAction{
             0, 0,
@@ -538,7 +524,7 @@ TEST_CASE("Sampling replay checks all records conditional on presampled symbols"
     SamplingPlan plan;
     plan.num_visible_records = 1;
     plan.num_hidden_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.symbols = {SymbolKind::Presampled};
     plan.actions = {
         PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
         PlannedAction{0, 0, RecordClassical{AffineBool(true), RecordSlot{1}}},
@@ -563,7 +549,7 @@ TEST_CASE("Sampling replay checks all records conditional on presampled symbols"
 TEST_CASE("Sampling expression registers reset true symbols between shots") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.symbols = {SymbolKind::Presampled};
     plan.actions = {
         PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
     };
@@ -772,7 +758,7 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
     plan.num_qubits = 2;
     plan.initial_active_width = 1;
     plan.peak_active_width = 2;
-    plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Instrument};
     plan.instrument_distributions = {InstrumentDistribution{{}, {}}};
     plan.actions = {
         PlannedAction{1, 2,
@@ -799,7 +785,7 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
 TEST_CASE("Sampling executable validates its source plan before lowering") {
     SamplingPlan plan;
     plan.num_qubits = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Instrument};
     plan.instrument_distributions = {InstrumentDistribution{{}, {}}};
     plan.actions = {
         PlannedAction{
@@ -1002,8 +988,7 @@ TEST_CASE("Sampling continuation rejects incompatible handoffs") {
 
     SECTION("boundary changes prefix symbol identities") {
         SamplingPlan continuation_plan = root_plan;
-        continuation_plan.symbols.push_back(
-            SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt});
+        continuation_plan.symbols.push_back(SymbolKind::Unused);
         continuation_plan.actions[1] =
             PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 2}};
         const ExecutablePlan continuation(continuation_plan);
@@ -1025,8 +1010,7 @@ TEST_CASE("Sampling continuation rejects incompatible handoffs") {
 
     SECTION("continuation contains an unbound presampled symbol") {
         SamplingPlan continuation_plan = root_plan;
-        continuation_plan.symbols.push_back(
-            SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt});
+        continuation_plan.symbols.push_back(SymbolKind::Presampled);
         const ExecutablePlan continuation(continuation_plan);
         Executor executor(root, 1);
         executor.run_shot();
@@ -1096,7 +1080,7 @@ TEST_CASE("Sampling continuation reconstructs expressions from true prefix symbo
 TEST_CASE("Sampling continuation consumes a forced hidden source record") {
     SamplingPlan root_plan;
     root_plan.num_qubits = 1;
-    root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
+    root_plan.symbols = {SymbolKind::Unused};
     root_plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     root_plan.actions = {
         PlannedAction{
@@ -1107,7 +1091,7 @@ TEST_CASE("Sampling continuation consumes a forced hidden source record") {
     };
     SamplingPlan continuation_plan = root_plan;
     continuation_plan.num_hidden_records = 1;
-    continuation_plan.symbols.push_back(SymbolInfo{SymbolKind::Branch, 2, std::nullopt});
+    continuation_plan.symbols.push_back(SymbolKind::Branch);
     continuation_plan.actions.push_back(PlannedAction{
         0, 0,
         MeasureDormantRandom{0, SymbolId{1}, AffineBool::symbol(SymbolId{1}), RecordSlot{0}}});
@@ -1134,7 +1118,7 @@ TEST_CASE("Sampling continuation overwrites an expectation with exact zero") {
     SamplingPlan root_plan;
     root_plan.num_qubits = 1;
     root_plan.num_exp_vals = 2;
-    root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
+    root_plan.symbols = {SymbolKind::Unused};
     root_plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     root_plan.actions = {
         PlannedAction{
@@ -1377,8 +1361,7 @@ TEST_CASE("Packed presampled expression program matches a categorical statistica
     SamplingPlan plan;
     plan.num_visible_records = num_records;
     for (uint32_t symbol = 0; symbol < num_symbols; ++symbol) {
-        plan.symbols.push_back(
-            SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{symbol / 2}});
+        plan.symbols.push_back(SymbolKind::Presampled);
     }
     std::array<double, num_symbols> outcome_probabilities{};
     for (uint32_t site = 0; site < num_sites; ++site) {
@@ -1894,7 +1877,7 @@ TEST_CASE("Sampling survivor execution normalizes and rejects detectors") {
 TEST_CASE("Sampling batch helpers reject unbound presampled symbols") {
     SamplingPlan plan;
     plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Presampled, std::nullopt, std::nullopt}};
+    plan.symbols = {SymbolKind::Presampled};
     plan.actions = {
         PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}}};
     const ExecutablePlan executable(plan);

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1449,7 +1449,7 @@ TEST_CASE("Packed presampled expression program matches a categorical statistica
     }
 }
 
-TEST_CASE("Packed syndrome outputs preserve record snapshots") {
+TEST_CASE("Packed detector and observable outputs preserve record snapshots") {
     const std::array<uint8_t, 2> expected_detectors{1, 1};
     const std::array<uint8_t, 3> expected_observables{1, 1, 1};
     clifft::sampling::SamplingPlanOptions options;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -30,6 +30,7 @@
 #include <variant>
 #include <vector>
 
+using clifft::sampling::ActiveExpectation;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::apply_rotation;
@@ -92,9 +93,8 @@ SamplingPlan active_then_dormant_plan(double promotion_half_turns) {
 SamplingPlan dormant_trap_plan() {
     SamplingPlan plan;
     plan.num_qubits = 1;
-    plan.num_instrument_sites = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
-    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     plan.actions = {
         PlannedAction{
             0, 0,
@@ -111,7 +111,6 @@ SamplingPlan plan_from(std::string_view circuit_text) {
 
 SamplingPlan categorical_noise_plan() {
     SamplingPlan plan;
-    plan.num_noise_sites = 4;
     plan.symbols = {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{1}},
@@ -119,13 +118,12 @@ SamplingPlan categorical_noise_plan() {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{3}},
     };
     plan.presampled_noise_sites = {
-        PresampledNoiseSite{NoiseSiteId{0}, 0.05, {PresampledNoiseOutcome{SymbolId{0}, 0.05}}},
+        PresampledNoiseSite{0.05, {PresampledNoiseOutcome{SymbolId{0}, 0.05}}},
         PresampledNoiseSite{
-            NoiseSiteId{1},
             0.3,
             {PresampledNoiseOutcome{SymbolId{1}, 0.1}, PresampledNoiseOutcome{SymbolId{2}, 0.2}}},
-        PresampledNoiseSite{NoiseSiteId{2}, 0.0, {}},
-        PresampledNoiseSite{NoiseSiteId{3}, 0.4, {PresampledNoiseOutcome{SymbolId{3}, 0.4}}},
+        PresampledNoiseSite{0.0, {}},
+        PresampledNoiseSite{0.4, {PresampledNoiseOutcome{SymbolId{3}, 0.4}}},
     };
     return plan;
 }
@@ -234,8 +232,7 @@ TEST_CASE("Sampling executor does not draw for empty noise sites") {
     SamplingPlan plan;
     plan.num_qubits = 1;
     plan.num_visible_records = 1;
-    plan.num_noise_sites = 1;
-    plan.presampled_noise_sites = {PresampledNoiseSite{NoiseSiteId{0}, 0.0, {}}};
+    plan.presampled_noise_sites = {PresampledNoiseSite{0.0, {}}};
     plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
     plan.actions = {PlannedAction{
         0, 0,
@@ -775,9 +772,8 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
     plan.num_qubits = 2;
     plan.initial_active_width = 1;
     plan.peak_active_width = 2;
-    plan.num_instrument_sites = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
-    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
+    plan.instrument_distributions = {InstrumentDistribution{{}, {}}};
     plan.actions = {
         PlannedAction{1, 2,
                       ApplyInstrument{InstrumentSiteId{0}, InstrumentMode::Activate,
@@ -803,9 +799,8 @@ TEST_CASE("Sampling executable preserves generic instrument activation") {
 TEST_CASE("Sampling executable validates its source plan before lowering") {
     SamplingPlan plan;
     plan.num_qubits = 1;
-    plan.num_instrument_sites = 1;
     plan.symbols = {SymbolInfo{SymbolKind::Instrument, 0, std::nullopt}};
-    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {}, {}}};
+    plan.instrument_distributions = {InstrumentDistribution{{}, {}}};
     plan.actions = {
         PlannedAction{
             0, 0,
@@ -1101,10 +1096,8 @@ TEST_CASE("Sampling continuation reconstructs expressions from true prefix symbo
 TEST_CASE("Sampling continuation consumes a forced hidden source record") {
     SamplingPlan root_plan;
     root_plan.num_qubits = 1;
-    root_plan.num_instrument_sites = 1;
     root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
-    root_plan.instrument_distributions = {
-        InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    root_plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     root_plan.actions = {
         PlannedAction{
             0, 0,
@@ -1141,22 +1134,24 @@ TEST_CASE("Sampling continuation overwrites an expectation with exact zero") {
     SamplingPlan root_plan;
     root_plan.num_qubits = 1;
     root_plan.num_exp_vals = 2;
-    root_plan.num_instrument_sites = 1;
     root_plan.symbols = {SymbolInfo{SymbolKind::Unused, std::nullopt, std::nullopt}};
-    root_plan.instrument_distributions = {
-        InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    root_plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     root_plan.actions = {
-        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{0}}},
+        PlannedAction{
+            0, 0,
+            WriteExpectationValue{ActiveExpectation{ActivePauli{}, AffineBool{}}, ExpValSlot{0}}},
         PlannedAction{
             0, 0,
             ApplyInstrument{
                 InstrumentSiteId{0}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}},
         PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 1}},
-        PlannedAction{0, 0, WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{1}}},
+        PlannedAction{
+            0, 0,
+            WriteExpectationValue{ActiveExpectation{ActivePauli{}, AffineBool{}}, ExpValSlot{1}}},
     };
     SamplingPlan continuation_plan = root_plan;
     continuation_plan.actions.back() =
-        PlannedAction{0, 0, WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{1}}};
+        PlannedAction{0, 0, WriteExpectationValue{std::nullopt, ExpValSlot{1}}};
     const ExecutablePlan root(root_plan);
     const ExecutablePlan continuation(continuation_plan);
     Executor executor(root, 13);
@@ -1194,9 +1189,7 @@ TEST_CASE("Sampling continuation preserves fused rotation prefixes") {
     root_plan.num_qubits = kActiveWidth + 1;
     root_plan.initial_active_width = kActiveWidth;
     root_plan.peak_active_width = kActiveWidth;
-    root_plan.num_instrument_sites = 1;
-    root_plan.instrument_distributions = {
-        InstrumentDistribution{InstrumentSiteId{0}, {1.0, 1.0}, {}}};
+    root_plan.instrument_distributions = {InstrumentDistribution{{1.0, 1.0}, {}}};
     for (const RotateActivePauli& rotation : prefix_rotations) {
         root_plan.actions.push_back(PlannedAction{kActiveWidth, kActiveWidth, rotation});
     }
@@ -1382,7 +1375,6 @@ TEST_CASE("Packed presampled expression program matches a categorical statistica
     constexpr uint32_t num_records = 40;
     constexpr uint32_t shots = 50'000;
     SamplingPlan plan;
-    plan.num_noise_sites = num_sites;
     plan.num_visible_records = num_records;
     for (uint32_t symbol = 0; symbol < num_symbols; ++symbol) {
         plan.symbols.push_back(
@@ -1396,7 +1388,6 @@ TEST_CASE("Packed presampled expression program matches a categorical statistica
         outcome_probabilities[first_symbol] = first_probability;
         outcome_probabilities[first_symbol + 1] = second_probability;
         plan.presampled_noise_sites.push_back(PresampledNoiseSite{
-            NoiseSiteId{site},
             first_probability + second_probability,
             {PresampledNoiseOutcome{SymbolId{first_symbol}, first_probability},
              PresampledNoiseOutcome{SymbolId{first_symbol + 1}, second_probability}}});

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -96,7 +96,7 @@ SamplingPlan valid_dormant_measurement_plan() {
     return plan;
 }
 
-SamplingPlan valid_syndrome_plan() {
+SamplingPlan valid_output_plan() {
     const SymbolId readout{0};
     SamplingPlan plan;
     plan.num_qubits = 1;
@@ -273,8 +273,8 @@ TEST_CASE("Sampling record parity construction canonicalizes XOR terms") {
     REQUIRE(parity.records() == std::vector<RecordSlot>{RecordSlot{1}});
 }
 
-TEST_CASE("Sampling plan validates affine syndrome values") {
-    SamplingPlan plan = valid_syndrome_plan();
+TEST_CASE("Sampling plan validates affine observable values") {
+    SamplingPlan plan = valid_output_plan();
     auto& observable = std::get<WriteObservable>(plan.actions[3].action);
     observable.outcome = AffineBool::symbol(SymbolId{1});
 
@@ -283,7 +283,7 @@ TEST_CASE("Sampling plan validates affine syndrome values") {
 }
 
 TEST_CASE("Sampling plan rejects stale readout sources") {
-    SamplingPlan plan = valid_syndrome_plan();
+    SamplingPlan plan = valid_output_plan();
     auto& readout = std::get<ApplyReadoutNoise>(plan.actions[1].action);
     readout.source = AffineBool(true);
 
@@ -472,8 +472,8 @@ TEST_CASE("Sampling plan rejects invalid numeric metadata") {
     }
 }
 
-TEST_CASE("Sampling plan validates noise distributions and syndrome actions") {
-    REQUIRE_NOTHROW(valid_syndrome_plan().validate());
+TEST_CASE("Sampling plan validates noise distributions and output actions") {
+    REQUIRE_NOTHROW(valid_output_plan().validate());
 
     SECTION("a noise symbol cannot name two outcomes") {
         SamplingPlan plan = valid_plan();
@@ -492,19 +492,19 @@ TEST_CASE("Sampling plan validates noise distributions and syndrome actions") {
     }
 
     SECTION("readout requires an assigned record") {
-        SamplingPlan plan = valid_syndrome_plan();
+        SamplingPlan plan = valid_output_plan();
         plan.actions.erase(plan.actions.begin());
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
     SECTION("readout probabilities are bounded") {
-        SamplingPlan plan = valid_syndrome_plan();
+        SamplingPlan plan = valid_output_plan();
         std::get<ApplyReadoutNoise>(plan.actions[1].action).prob_zero_to_one = 1.1;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
     SECTION("every declared output is written exactly once") {
-        SamplingPlan plan = valid_syndrome_plan();
+        SamplingPlan plan = valid_output_plan();
         plan.actions.pop_back();
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -22,7 +22,6 @@ using clifft::sampling::InstrumentMode;
 using clifft::sampling::InstrumentSiteId;
 using clifft::sampling::MeasureActivePauli;
 using clifft::sampling::MeasureDormantRandom;
-using clifft::sampling::NoiseSiteId;
 using clifft::sampling::ObservableSlot;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::PresampledNoiseOutcome;
@@ -34,7 +33,6 @@ using clifft::sampling::RecordSlot;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
 using clifft::sampling::SymbolId;
-using clifft::sampling::SymbolInfo;
 using clifft::sampling::SymbolKind;
 using clifft::sampling::WriteDetector;
 using clifft::sampling::WriteExpectationValue;
@@ -53,12 +51,8 @@ SamplingPlan valid_plan() {
     plan.peak_active_width = 1;
     plan.num_visible_records = 1;
     plan.num_hidden_records = 1;
-    plan.symbols = {
-        SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
-        SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
-        SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
-        SymbolInfo{SymbolKind::Instrument, 4, std::nullopt},
-    };
+    plan.symbols = {SymbolKind::Presampled, SymbolKind::Branch, SymbolKind::Derived,
+                    SymbolKind::Instrument};
     plan.presampled_noise_sites = {PresampledNoiseSite{0.1, {PresampledNoiseOutcome{noise, 0.1}}}};
     plan.instrument_distributions = {InstrumentDistribution{{0.0, 0.0}, {}}};
     plan.actions = {
@@ -94,7 +88,7 @@ SamplingPlan valid_dormant_measurement_plan() {
     SamplingPlan plan;
     plan.num_qubits = 1;
     plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Branch};
     plan.actions = {
         PlannedAction{0, 0,
                       MeasureDormantRandom{0, branch, AffineBool::symbol(branch), RecordSlot{0}}},
@@ -109,7 +103,7 @@ SamplingPlan valid_syndrome_plan() {
     plan.num_visible_records = 1;
     plan.num_detectors = 1;
     plan.num_observables = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Readout, 1, std::nullopt}};
+    plan.symbols = {SymbolKind::Readout};
     plan.actions = {
         PlannedAction{0, 0, RecordClassical{AffineBool{}, RecordSlot{0}}},
         PlannedAction{0, 0, ApplyReadoutNoise{readout, AffineBool{}, RecordSlot{0}, 0.1, 0.2}},
@@ -153,7 +147,7 @@ TEST_CASE("Sampling plan validates symbolic and active state invariants") {
 
     const std::string text = plan.inspect();
     REQUIRE(text.find("sampling_plan qubits=2 initial_width=0 peak_width=1") != std::string::npos);
-    REQUIRE(text.find("s0 kind=presampled noise_site=0") != std::string::npos);
+    REQUIRE(text.find("s0 kind=presampled") != std::string::npos);
     REQUIRE(text.find("1 w1->0 dense_passes=2 MEASURE_ACTIVE X0") != std::string::npos);
     REQUIRE(text.find("outcome=s0^s1 record=r0") != std::string::npos);
     REQUIRE(text.find("5 w0 dense_passes=0 INSTRUMENT_BOUNDARY site=0 ") != std::string::npos);
@@ -192,28 +186,22 @@ TEST_CASE("Sampling plan rejects symbolic use before assignment") {
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
 
-TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
-    SECTION("definition metadata disagrees with the action") {
+TEST_CASE("Sampling plan rejects invalid symbol definitions") {
+    SECTION("an action cannot define a presampled symbol") {
         SamplingPlan plan = valid_plan();
-        plan.symbols[2].defining_action = 3;
+        plan.symbols[2] = SymbolKind::Presampled;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
-    SECTION("presampled symbol names a defining action") {
+    SECTION("an action cannot define an unused symbol") {
         SamplingPlan plan = valid_plan();
-        plan.symbols[0].defining_action = 0;
+        plan.symbols[2] = SymbolKind::Unused;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
-    SECTION("noise site is out of range") {
+    SECTION("a dynamic symbol requires a defining action") {
         SamplingPlan plan = valid_plan();
-        plan.symbols[0].noise_site = NoiseSiteId{1};
-        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
-    }
-
-    SECTION("non-presampled symbol names a noise site") {
-        SamplingPlan plan = valid_plan();
-        plan.symbols[1].noise_site = NoiseSiteId{0};
+        plan.symbols.push_back(SymbolKind::Branch);
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
@@ -231,13 +219,13 @@ TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
 
     SECTION("branch kind is defined by a derived-symbol action") {
         SamplingPlan plan = valid_plan();
-        plan.symbols[2].kind = SymbolKind::Branch;
+        plan.symbols[2] = SymbolKind::Branch;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
     SECTION("derived kind is defined by a measurement") {
         SamplingPlan plan = valid_plan();
-        plan.symbols[1].kind = SymbolKind::Derived;
+        plan.symbols[1] = SymbolKind::Derived;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
@@ -256,7 +244,7 @@ TEST_CASE("Sampling plan rejects invalid symbol metadata and definitions") {
 
     SECTION("symbol kind is unrecognized") {
         SamplingPlan plan = valid_plan();
-        plan.symbols[2].kind = static_cast<SymbolKind>(std::numeric_limits<uint8_t>::max());
+        plan.symbols[2] = static_cast<SymbolKind>(std::numeric_limits<uint8_t>::max());
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 }
@@ -326,7 +314,7 @@ TEST_CASE("Sampling plan rejects measurement pivots outside Pauli support") {
     plan.initial_active_width = 2;
     plan.peak_active_width = 2;
     plan.num_visible_records = 1;
-    plan.symbols = {SymbolInfo{SymbolKind::Branch, 0, std::nullopt}};
+    plan.symbols = {SymbolKind::Branch};
     plan.actions = {
         PlannedAction{2, 1,
                       MeasureActivePauli{ActivePauli{1, 0}, 1, branch, AffineBool::symbol(branch),
@@ -496,7 +484,7 @@ TEST_CASE("Sampling plan validates noise distributions and syndrome actions") {
     SECTION("noise outcome probabilities cannot exceed one in total") {
         SamplingPlan plan = valid_plan();
         const SymbolId second_noise{3};
-        plan.symbols.push_back(SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}});
+        plan.symbols.push_back(SymbolKind::Presampled);
         plan.presampled_noise_sites[0].outcomes[0].probability = 0.6;
         plan.presampled_noise_sites[0].outcomes.push_back(
             PresampledNoiseOutcome{second_noise, 0.6});
@@ -506,7 +494,6 @@ TEST_CASE("Sampling plan validates noise distributions and syndrome actions") {
     SECTION("readout requires an assigned record") {
         SamplingPlan plan = valid_syndrome_plan();
         plan.actions.erase(plan.actions.begin());
-        plan.symbols[0].defining_action = 0;
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -12,7 +12,6 @@ using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::ApplyInstrument;
 using clifft::sampling::ApplyReadoutNoise;
-using clifft::sampling::BatchRecordParity;
 using clifft::sampling::DefineSymbol;
 using clifft::sampling::DetectorSlot;
 using clifft::sampling::ExpValSlot;
@@ -29,6 +28,7 @@ using clifft::sampling::PresampledNoiseOutcome;
 using clifft::sampling::PresampledNoiseSite;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
+using clifft::sampling::RecordParity;
 using clifft::sampling::RecordSlot;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
@@ -117,11 +117,9 @@ SamplingPlan valid_syndrome_plan() {
         PlannedAction{0, 0, RecordClassical{AffineBool{}, RecordSlot{0}}},
         PlannedAction{0, 0, ApplyReadoutNoise{readout, AffineBool{}, RecordSlot{0}, 0.1, 0.2}},
         PlannedAction{0, 0,
-                      WriteDetector{AffineBool::symbol(readout), DetectorSlot{0}, true,
-                                    BatchRecordParity{false, {RecordSlot{0}}}}},
+                      WriteDetector{RecordParity{false, {RecordSlot{0}}}, DetectorSlot{0}, true}},
         PlannedAction{0, 0,
-                      WriteObservable{AffineBool::symbol(readout), ObservableSlot{0},
-                                      BatchRecordParity{false, {RecordSlot{0}}}}},
+                      WriteObservable{RecordParity{false, {RecordSlot{0}}}, ObservableSlot{0}}},
     };
     return plan;
 }
@@ -282,14 +280,22 @@ TEST_CASE("Sampling plan rejects record slots outside stable storage") {
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
 
-TEST_CASE("Sampling plan rejects inconsistent record parity sidecars") {
+TEST_CASE("Sampling plan rejects noncanonical syndrome record parity") {
     SamplingPlan plan = valid_syndrome_plan();
     auto& observable = std::get<WriteObservable>(plan.actions[3].action);
-    observable.batch_parity->constant = true;
+    std::get<RecordParity>(observable.outcome).records.push_back(RecordSlot{0});
 
     REQUIRE_THROWS_WITH(plan.validate(),
-                        "invalid SamplingPlan: action 3 batch record parity disagrees with its "
-                        "affine outcome");
+                        "invalid SamplingPlan: action 3 has noncanonical record parity");
+}
+
+TEST_CASE("Sampling plan validates affine syndrome values") {
+    SamplingPlan plan = valid_syndrome_plan();
+    auto& observable = std::get<WriteObservable>(plan.actions[3].action);
+    observable.outcome = AffineBool::symbol(SymbolId{1});
+
+    REQUIRE_THROWS_WITH(plan.validate(),
+                        "invalid SamplingPlan: action 3 references symbol s1 out of range");
 }
 
 TEST_CASE("Sampling plan rejects stale readout sources") {

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+using clifft::sampling::ActiveExpectation;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
 using clifft::sampling::ApplyInstrument;
@@ -52,17 +53,14 @@ SamplingPlan valid_plan() {
     plan.peak_active_width = 1;
     plan.num_visible_records = 1;
     plan.num_hidden_records = 1;
-    plan.num_noise_sites = 1;
-    plan.num_instrument_sites = 1;
     plan.symbols = {
         SymbolInfo{SymbolKind::Presampled, std::nullopt, NoiseSiteId{0}},
         SymbolInfo{SymbolKind::Branch, 1, std::nullopt},
         SymbolInfo{SymbolKind::Derived, 2, std::nullopt},
         SymbolInfo{SymbolKind::Instrument, 4, std::nullopt},
     };
-    plan.presampled_noise_sites = {
-        PresampledNoiseSite{NoiseSiteId{0}, 0.1, {PresampledNoiseOutcome{noise, 0.1}}}};
-    plan.instrument_distributions = {InstrumentDistribution{InstrumentSiteId{0}, {0.0, 0.0}, {}}};
+    plan.presampled_noise_sites = {PresampledNoiseSite{0.1, {PresampledNoiseOutcome{noise, 0.1}}}};
+    plan.instrument_distributions = {InstrumentDistribution{{0.0, 0.0}, {}}};
     plan.actions = {
         PlannedAction{0, 1, PromoteDormantRotation{0.25, AffineBool::symbol(noise)}},
         PlannedAction{1, 0,
@@ -111,7 +109,6 @@ SamplingPlan valid_syndrome_plan() {
     plan.num_visible_records = 1;
     plan.num_detectors = 1;
     plan.num_observables = 1;
-    plan.has_postselection = true;
     plan.symbols = {SymbolInfo{SymbolKind::Readout, 1, std::nullopt}};
     plan.actions = {
         PlannedAction{0, 0, RecordClassical{AffineBool{}, RecordSlot{0}}},
@@ -280,13 +277,12 @@ TEST_CASE("Sampling plan rejects record slots outside stable storage") {
     REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
 }
 
-TEST_CASE("Sampling plan rejects noncanonical syndrome record parity") {
-    SamplingPlan plan = valid_syndrome_plan();
-    auto& observable = std::get<WriteObservable>(plan.actions[3].action);
-    std::get<RecordParity>(observable.outcome).records.push_back(RecordSlot{0});
+TEST_CASE("Sampling record parity construction canonicalizes XOR terms") {
+    const RecordParity parity{
+        true, {RecordSlot{2}, RecordSlot{0}, RecordSlot{2}, RecordSlot{1}, RecordSlot{0}}};
 
-    REQUIRE_THROWS_WITH(plan.validate(),
-                        "invalid SamplingPlan: action 3 has noncanonical record parity");
+    REQUIRE(parity.constant());
+    REQUIRE(parity.records() == std::vector<RecordSlot>{RecordSlot{1}});
 }
 
 TEST_CASE("Sampling plan validates affine syndrome values") {
@@ -525,12 +521,6 @@ TEST_CASE("Sampling plan validates noise distributions and syndrome actions") {
         plan.actions.pop_back();
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
-
-    SECTION("postselection metadata matches detector actions") {
-        SamplingPlan plan = valid_syndrome_plan();
-        plan.has_postselection = false;
-        REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
-    }
 }
 
 TEST_CASE("Sampling plan rejects active widths unsupported by dense storage") {
@@ -584,8 +574,9 @@ TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
     plan.num_exp_vals = 2;
     plan.actions = {
         PlannedAction{1, 1,
-                      WriteExpectationValue{ActivePauli{1, 1}, AffineBool(true), ExpValSlot{0}}},
-        PlannedAction{1, 1, WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{1}}},
+                      WriteExpectationValue{ActiveExpectation{ActivePauli{1, 1}, AffineBool(true)},
+                                            ExpValSlot{0}}},
+        PlannedAction{1, 1, WriteExpectationValue{std::nullopt, ExpValSlot{1}}},
     };
 
     REQUIRE_NOTHROW(plan.validate());
@@ -597,8 +588,9 @@ TEST_CASE("Sampling plan validates expectation output slots and zero probes") {
         std::get<WriteExpectationValue>(plan.actions[1].action).exp_val = ExpValSlot{0};
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
-    SECTION("zero probe carries irrelevant sign") {
-        std::get<WriteExpectationValue>(plan.actions[1].action).sign = AffineBool(true);
+    SECTION("active probe sign references an unavailable symbol") {
+        std::get<WriteExpectationValue>(plan.actions[0].action).active->sign =
+            AffineBool::symbol(SymbolId{0});
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 }
@@ -634,11 +626,11 @@ TEST_CASE("Sampling plan predicts only state touching dense passes") {
     REQUIRE(clifft::sampling::predicted_dense_passes(ApplyReadoutNoise{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(WriteDetector{}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(WriteObservable{}) == 0);
+    REQUIRE(clifft::sampling::predicted_dense_passes(WriteExpectationValue{
+                ActiveExpectation{ActivePauli{1, 0}, AffineBool{}}, ExpValSlot{0}}) == 1);
+    REQUIRE(clifft::sampling::predicted_dense_passes(WriteExpectationValue{
+                ActiveExpectation{ActivePauli{}, AffineBool{}}, ExpValSlot{0}}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(
-                WriteExpectationValue{ActivePauli{1, 0}, AffineBool{}, ExpValSlot{0}}) == 1);
-    REQUIRE(clifft::sampling::predicted_dense_passes(
-                WriteExpectationValue{ActivePauli{}, AffineBool{}, ExpValSlot{0}}) == 0);
-    REQUIRE(clifft::sampling::predicted_dense_passes(
-                WriteExpectationValue{std::nullopt, AffineBool{}, ExpValSlot{0}}) == 0);
+                WriteExpectationValue{std::nullopt, ExpValSlot{0}}) == 0);
     REQUIRE(clifft::sampling::predicted_dense_passes(InstrumentBoundary{}) == 0);
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -32,6 +32,7 @@ using clifft::sampling::MeasureDormantRandom;
 using clifft::sampling::plan_sampling;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
+using clifft::sampling::RecordParity;
 using clifft::sampling::RecordSlot;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
@@ -555,16 +556,16 @@ TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
     REQUIRE(readout.prob_zero_to_one == 0.1);
     REQUIRE(readout.prob_one_to_zero == 0.2);
     const auto& detector = action_as<WriteDetector>(plan, 2);
-    REQUIRE(detector.outcome == (AffineBool::symbol(readout.flip) ^ true));
     REQUIRE(detector.postselected);
-    REQUIRE(detector.batch_parity.has_value());
-    REQUIRE(detector.batch_parity->constant);
-    REQUIRE(detector.batch_parity->records == std::vector<RecordSlot>{RecordSlot{0}});
+    REQUIRE(std::holds_alternative<RecordParity>(detector.outcome));
+    const auto& detector_parity = std::get<RecordParity>(detector.outcome);
+    REQUIRE(detector_parity.constant);
+    REQUIRE(detector_parity.records == std::vector<RecordSlot>{RecordSlot{0}});
     const auto& observable = action_as<WriteObservable>(plan, 3);
-    REQUIRE(observable.outcome == (AffineBool::symbol(readout.flip) ^ true));
-    REQUIRE(observable.batch_parity.has_value());
-    REQUIRE(observable.batch_parity->constant);
-    REQUIRE(observable.batch_parity->records == std::vector<RecordSlot>{RecordSlot{0}});
+    REQUIRE(std::holds_alternative<RecordParity>(observable.outcome));
+    const auto& observable_parity = std::get<RecordParity>(observable.outcome);
+    REQUIRE(observable_parity.constant);
+    REQUIRE(observable_parity.records == std::vector<RecordSlot>{RecordSlot{0}});
 }
 
 TEST_CASE("Sampling planner falls back for historical observable records") {
@@ -583,13 +584,11 @@ TEST_CASE("Sampling planner falls back for historical observable records") {
     const auto& before = action_as<WriteObservable>(plan, 2);
     const auto& after = action_as<WriteObservable>(plan, 3);
     const auto& straddled = action_as<WriteObservable>(plan, 4);
-    REQUIRE(before.outcome == AffineBool(true));
-    REQUIRE_FALSE(before.batch_parity.has_value());
-    REQUIRE(after.outcome == (AffineBool::symbol(readout.flip) ^ true));
-    REQUIRE(after.batch_parity.has_value());
-    REQUIRE(after.batch_parity->records == std::vector<RecordSlot>{RecordSlot{0}});
-    REQUIRE(straddled.outcome == AffineBool::symbol(readout.flip));
-    REQUIRE_FALSE(straddled.batch_parity.has_value());
+    REQUIRE(std::get<AffineBool>(before.outcome) == AffineBool(true));
+    REQUIRE(std::holds_alternative<RecordParity>(after.outcome));
+    REQUIRE(std::get<RecordParity>(after.outcome).records ==
+            std::vector<RecordSlot>{RecordSlot{0}});
+    REQUIRE(std::get<AffineBool>(straddled.outcome) == AffineBool::symbol(readout.flip));
 }
 
 TEST_CASE("Sampling planner reports the dense active width limit") {
@@ -655,5 +654,5 @@ TEST_CASE("Sampling planner target QEC plan characterization") {
     INFO(inspection);
     // After verifying that a reported inspection change is intentional, update
     // this digest to the new value shown by the failed assertion.
-    REQUIRE(fnv1a64(inspection) == 0x2b35d16f42cb24a3ULL);
+    REQUIRE(fnv1a64(inspection) == 0x0a5e07087447f19eULL);
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -85,6 +85,30 @@ TEST_CASE("Sampling planner preserves empty module metadata") {
     REQUIRE(plan.symbols.empty());
 }
 
+TEST_CASE("Sampling planner validates detector records before XOR cancellation") {
+    SECTION("unwritten record") {
+        HirModule hir;
+        hir.num_measurements = 1;
+        hir.num_detectors = 1;
+        hir.detector_targets = {{0, 0}};
+        hir.append_detector(clifft::DetectorIdx{0});
+
+        REQUIRE_THROWS_WITH(plan_sampling(hir),
+                            "sampling planner operation 0 reads record 0 before assignment");
+    }
+
+    SECTION("out of range record") {
+        HirModule hir;
+        hir.num_measurements = 1;
+        hir.num_detectors = 1;
+        hir.detector_targets = {{1, 1}};
+        hir.append_detector(clifft::DetectorIdx{0});
+
+        REQUIRE_THROWS_WITH(plan_sampling(hir),
+                            "sampling planner operation 0 reads record 1 before assignment");
+    }
+}
+
 TEST_CASE("Sampling planner promotes rotations and keeps later active support") {
     HirModule hir(1, 2);
     clifft::test::append_tgate(hir, X(0), 0, false);
@@ -586,6 +610,20 @@ TEST_CASE("Sampling planner falls back for historical observable records") {
     REQUIRE(std::get<RecordParity>(after.outcome).records() ==
             std::vector<RecordSlot>{RecordSlot{0}});
     REQUIRE(std::get<AffineBool>(straddled.outcome) == AffineBool::symbol(readout.flip));
+}
+
+TEST_CASE("Sampling planner cancels observable snapshots before freshness testing") {
+    const SamplingPlan plan = plan_sampling(clifft::trace(clifft::parse(R"(
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1] rec[-1]
+        READOUT_NOISE(1) rec[-1]
+    )")));
+
+    const auto& observable = action_as<WriteObservable>(plan, plan.actions.size() - 1);
+    REQUIRE(std::holds_alternative<RecordParity>(observable.outcome));
+    const auto& parity = std::get<RecordParity>(observable.outcome);
+    REQUIRE_FALSE(parity.constant());
+    REQUIRE(parity.records().empty());
 }
 
 TEST_CASE("Sampling planner reports the dense active width limit") {

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -144,7 +144,7 @@ TEST_CASE("Sampling planner records repeat dormant measurements consistently") {
 
     REQUIRE(plan.actions.size() == 2);
     REQUIRE(plan.symbols.size() == 2);
-    REQUIRE(plan.symbols[1].kind == SymbolKind::Unused);
+    REQUIRE(plan.symbols[1] == SymbolKind::Unused);
     const auto& first = action_as<MeasureDormantRandom>(plan, 0);
     REQUIRE(first.branch == SymbolId{0});
     REQUIRE(first.outcome == AffineBool::symbol(SymbolId{0}));
@@ -330,11 +330,11 @@ TEST_CASE("Sampling planner preserves mixed symbol order at instrument boundarie
                                                           &options));
 
     REQUIRE(plan.symbols.size() == 5);
-    REQUIRE(plan.symbols[0].kind == SymbolKind::Presampled);
-    REQUIRE(plan.symbols[1].kind == SymbolKind::Branch);
-    REQUIRE(plan.symbols[2].kind == SymbolKind::Readout);
-    REQUIRE(plan.symbols[3].kind == SymbolKind::Instrument);
-    REQUIRE(plan.symbols[4].kind == SymbolKind::Presampled);
+    REQUIRE(plan.symbols[0] == SymbolKind::Presampled);
+    REQUIRE(plan.symbols[1] == SymbolKind::Branch);
+    REQUIRE(plan.symbols[2] == SymbolKind::Readout);
+    REQUIRE(plan.symbols[3] == SymbolKind::Instrument);
+    REQUIRE(plan.symbols[4] == SymbolKind::Presampled);
 
     const auto boundary = std::ranges::find_if(plan.actions, [](const auto& action) {
         return std::holds_alternative<InstrumentBoundary>(action.action);
@@ -490,7 +490,7 @@ TEST_CASE("Sampling planner eliminates Pauli noise and feedback into record expr
     REQUIRE(plan.presampled_noise_sites.size() == 1);
     REQUIRE(plan.presampled_noise_sites[0].outcomes.size() == 1);
     const SymbolId noise = plan.presampled_noise_sites[0].outcomes[0].symbol;
-    REQUIRE(plan.symbols[static_cast<uint32_t>(noise)].kind == SymbolKind::Presampled);
+    REQUIRE(plan.symbols[static_cast<uint32_t>(noise)] == SymbolKind::Presampled);
     REQUIRE(plan.actions.size() == 2);
     REQUIRE(action_as<RecordClassical>(plan, 0).outcome == AffineBool::symbol(noise));
     REQUIRE(action_as<RecordClassical>(plan, 1).outcome == AffineBool::symbol(noise));
@@ -549,7 +549,7 @@ TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
     REQUIRE(plan.num_observables == 1);
     REQUIRE(plan.actions.size() == 4);
     const auto& readout = action_as<ApplyReadoutNoise>(plan, 1);
-    REQUIRE(plan.symbols[static_cast<uint32_t>(readout.flip)].kind == SymbolKind::Readout);
+    REQUIRE(plan.symbols[static_cast<uint32_t>(readout.flip)] == SymbolKind::Readout);
     REQUIRE(readout.source == AffineBool(false));
     REQUIRE(readout.prob_zero_to_one == 0.1);
     REQUIRE(readout.prob_one_to_zero == 0.2);
@@ -651,5 +651,5 @@ TEST_CASE("Sampling planner target QEC plan characterization") {
     INFO(inspection);
     // After verifying that a reported inspection change is intentional, update
     // this digest to the new value shown by the failed assertion.
-    REQUIRE(fnv1a64(inspection) == 0x0a5e07087447f19eULL);
+    REQUIRE(fnv1a64(inspection) == 0xad863e67839d8f4fULL);
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -449,15 +449,14 @@ TEST_CASE("Sampling planner classifies active and dormant expectation probes") {
     REQUIRE(plan.actions.size() == 4);
     REQUIRE(plan.final_tableau.has_value());
     const auto& active = action_as<WriteExpectationValue>(plan, 1);
-    REQUIRE(active.active_projection.has_value());
-    REQUIRE_FALSE(active.active_projection->is_identity());
+    REQUIRE(active.active.has_value());
+    REQUIRE_FALSE(active.active->projection.is_identity());
     REQUIRE(active.exp_val == clifft::sampling::ExpValSlot{0});
     const auto& dormant_x = action_as<WriteExpectationValue>(plan, 2);
-    REQUIRE_FALSE(dormant_x.active_projection.has_value());
-    REQUIRE(dormant_x.sign == AffineBool{});
+    REQUIRE_FALSE(dormant_x.active.has_value());
     const auto& dormant_z = action_as<WriteExpectationValue>(plan, 3);
-    REQUIRE(dormant_z.active_projection.has_value());
-    REQUIRE(dormant_z.active_projection->is_identity());
+    REQUIRE(dormant_z.active.has_value());
+    REQUIRE(dormant_z.active->projection.is_identity());
 }
 
 TEST_CASE("Sampling planner propagates stochastic signs into expectation probes") {
@@ -465,17 +464,17 @@ TEST_CASE("Sampling planner propagates stochastic signs into expectation probes"
         plan_sampling(clifft::trace(clifft::parse("X_ERROR(1) 0\nEXP_VAL Z0")));
     REQUIRE_FALSE(noise.final_tableau.has_value());
     const auto& noise_probe = action_as<WriteExpectationValue>(noise, 0);
-    REQUIRE(noise_probe.active_projection.has_value());
-    REQUIRE(noise_probe.active_projection->is_identity());
-    REQUIRE(noise_probe.sign == AffineBool::symbol(SymbolId{0}));
+    REQUIRE(noise_probe.active.has_value());
+    REQUIRE(noise_probe.active->projection.is_identity());
+    REQUIRE(noise_probe.active->sign == AffineBool::symbol(SymbolId{0}));
 
     const SamplingPlan feedback =
         plan_sampling(clifft::trace(clifft::parse("H 0\nM 0\nCX rec[-1] 1\nEXP_VAL Z1")));
     const auto& measurement = action_as<MeasureDormantRandom>(feedback, 0);
     const auto& feedback_probe = action_as<WriteExpectationValue>(feedback, 1);
-    REQUIRE(feedback_probe.active_projection.has_value());
-    REQUIRE(feedback_probe.active_projection->is_identity());
-    REQUIRE(feedback_probe.sign == AffineBool::symbol(measurement.branch));
+    REQUIRE(feedback_probe.active.has_value());
+    REQUIRE(feedback_probe.active->projection.is_identity());
+    REQUIRE(feedback_probe.active->sign == AffineBool::symbol(measurement.branch));
 }
 
 TEST_CASE("Sampling planner eliminates Pauli noise and feedback into record expressions") {
@@ -548,7 +547,6 @@ TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
 
     REQUIRE(plan.num_detectors == 1);
     REQUIRE(plan.num_observables == 1);
-    REQUIRE(plan.has_postselection);
     REQUIRE(plan.actions.size() == 4);
     const auto& readout = action_as<ApplyReadoutNoise>(plan, 1);
     REQUIRE(plan.symbols[static_cast<uint32_t>(readout.flip)].kind == SymbolKind::Readout);
@@ -557,15 +555,14 @@ TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
     REQUIRE(readout.prob_one_to_zero == 0.2);
     const auto& detector = action_as<WriteDetector>(plan, 2);
     REQUIRE(detector.postselected);
-    REQUIRE(std::holds_alternative<RecordParity>(detector.outcome));
-    const auto& detector_parity = std::get<RecordParity>(detector.outcome);
-    REQUIRE(detector_parity.constant);
-    REQUIRE(detector_parity.records == std::vector<RecordSlot>{RecordSlot{0}});
+    const auto& detector_parity = detector.outcome;
+    REQUIRE(detector_parity.constant());
+    REQUIRE(detector_parity.records() == std::vector<RecordSlot>{RecordSlot{0}});
     const auto& observable = action_as<WriteObservable>(plan, 3);
     REQUIRE(std::holds_alternative<RecordParity>(observable.outcome));
     const auto& observable_parity = std::get<RecordParity>(observable.outcome);
-    REQUIRE(observable_parity.constant);
-    REQUIRE(observable_parity.records == std::vector<RecordSlot>{RecordSlot{0}});
+    REQUIRE(observable_parity.constant());
+    REQUIRE(observable_parity.records() == std::vector<RecordSlot>{RecordSlot{0}});
 }
 
 TEST_CASE("Sampling planner falls back for historical observable records") {
@@ -586,7 +583,7 @@ TEST_CASE("Sampling planner falls back for historical observable records") {
     const auto& straddled = action_as<WriteObservable>(plan, 4);
     REQUIRE(std::get<AffineBool>(before.outcome) == AffineBool(true));
     REQUIRE(std::holds_alternative<RecordParity>(after.outcome));
-    REQUIRE(std::get<RecordParity>(after.outcome).records ==
+    REQUIRE(std::get<RecordParity>(after.outcome).records() ==
             std::vector<RecordSlot>{RecordSlot{0}});
     REQUIRE(std::get<AffineBool>(straddled.outcome) == AffineBool::symbol(readout.flip));
 }

--- a/tests/test_sampling_planner.cc
+++ b/tests/test_sampling_planner.cc
@@ -555,7 +555,7 @@ TEST_CASE("Sampling planner carries symbolic frame across coordinate changes") {
                                          AffineBool::symbol(last_measurement.branch)));
 }
 
-TEST_CASE("Sampling planner carries corrected records into syndrome outputs") {
+TEST_CASE("Sampling planner carries corrected records into detector and observable outputs") {
     const HirModule hir = clifft::trace(clifft::parse(R"(
         M 0
         READOUT_NOISE(0.1, 0.2) rec[-1]


### PR DESCRIPTION
## Stack

This PR is stacked on #407. Its base is intentionally `codex/issue-313-interleaved-batches`; review commits `c3ac3f96..d30130e3` here.

## Summary

- replace the duplicated affine outcome plus optional packed-only record-parity sidecar with one backend-neutral output representation
- make detector values record parity by construction; only observables can select between record parity and an affine value for a historical snapshot
- lower the selected representation independently in the scalar CPU, packed CPU, and HIP backends
- stop preparing, validating, formatting, storing, and propagating affine expression registers that a record-parity output supersedes
- keep record-parity terms in one compact tape and allocate packed record columns only when a selected output actually reads them
- represent an active expectation as one projection-plus-sign value, so a zero probe cannot retain an irrelevant sign expression
- remove redundant plan counts and flags that are derivable from owned vectors or actions
- store only each symbol's kind; defining actions and noise-site membership remain owned by the action stream and noise distributions instead of duplicated metadata
- page-align packed bit matrices and account for their exact retained footprint, avoiding allocator-size-dependent cache behavior without inflating large carrier matrices to huge-page boundaries

## Correctness coverage

- canonicalizes record parity on construction and validates the remaining cross-object invariants
- characterizes planner selection around readout mutations and historical observable snapshots
- preserves exact scalar-versus-packed rows across capacities through mixed affine and record-parity outputs
- covers missing and duplicate symbol definitions, action-kind disagreement, use before definition, and duplicate noise binding without constructible metadata disagreements
- validates raw detector targets before XOR cancellation and canonicalizes observable snapshots before freshness selection
- checks HIP term-domain selection and CPU-differential results for historical affine and current record-parity observables in both coefficient precisions
- tests aligned allocation sizing and verifies packed memory-policy accounting uses the actual retained footprint

## Validation

Validation was rerun at `d30130e3`:

- pre-commit: passed
- Debug native CTest: 923/923 non-benchmark entries passed
- Python oracle, structured, statistical, and integration tests: 1,365 passed, 6 HIP-hardware skips
- executable documentation examples: 35 passed, 8 intentional skips
- WebAssembly Release build and smoke tests: passed
- earlier offline HIP `gfx942` build: `clifft_tests` and `clifft_hip_tests` compiled

## Performance

Same-VM A/B against the exact stacked parent `c3ac3f96`, with identical Release/native-CPU/OpenMP builds, one worker pinned to CPU 2, automatic batch selection, and identical seeded checksums. Sampling compilation is outside the timed interval. Lower is better.

| Workload | Parent | This PR | Change |
|---|---:|---:|---:|
| surface d7, 1M shots, aggregate output, median | 250.605 ms | 228.655 ms | -8.8% |
| surface d9, 1M shots, aggregate output, median | 604.055 ms | 545.175 ms | -9.7% |
| generated non-Clifford width 5/depth 20, 100k shots, median | 412.348 ms | 411.845 ms | -0.1% (flat) |
| surface d7 compile, 100-run median total | 12.897 ms | 11.188 ms | -13.3% |

The parent Clifford measurements were repeated after the current run and the table uses the faster parent median, making the reported gains conservative. The packed alignment fix matters because removing redundant expression registers moved some matrices across the system allocator's size threshold; explicit page alignment preserves the intended locality independent of allocator behavior.

Closes #411
