### PR TITLE
perf(sampling): add Apple NEON active-state kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,14 @@ else()
     set(CLIFFT_X86_RUNTIME_DISPATCH OFF)
 endif()
 
+# Apple Silicon guarantees AArch64 Advanced SIMD, so one NEON translation unit
+# can serve every supported Apple arm64 generation without a CPU feature probe.
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64|aarch64|ARM64)")
+    set(CLIFFT_APPLE_NEON_DISPATCH ON)
+else()
+    set(CLIFFT_APPLE_NEON_DISPATCH OFF)
+endif()
+
 # Fetch production dependencies
 include(cmake/FetchFastFloat.cmake)
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -81,12 +81,17 @@ units use explicit ISA flags, while the rest of the library retains the
 configured CPU baseline. Executable preparation detects the host once and
 uses one backend consistently for the resulting program.
 
+Apple arm64 builds additionally select a NEON backend. Apple Silicon guarantees
+the 128-bit Advanced SIMD baseline, so this backend needs no generation-specific
+feature probe. It currently specializes eligible rank-two fused rotations and
+uses the portable scalar kernels for other operation shapes.
+
 The AVX2 backend requires AVX2, BMI2, and FMA. The AVX-512 backend additionally
 requires AVX-512F and AVX-512DQ. If those features are unavailable, or runtime
 dispatch is not compiled for the platform, Clifft uses its portable scalar
 implementation.
 
-`CLIFFT_FORCE_ISA=scalar`, `avx2`, or `avx512` can force an available backend
+`CLIFFT_FORCE_ISA=scalar`, `neon`, `avx2`, or `avx512` can force an available backend
 in a runtime-dispatch build. This is a diagnostic and testing control, not a
 portable deployment setting; requesting features that the host lacks is an
 error. `clifft.runtime_isa()` reports which backend the process resolved,

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -83,8 +83,10 @@ uses one backend consistently for the resulting program.
 
 Apple arm64 builds additionally select a NEON backend. Apple Silicon guarantees
 the 128-bit Advanced SIMD baseline, so this backend needs no generation-specific
-feature probe. It currently specializes eligible rank-two fused rotations and
-uses the portable scalar kernels for other operation shapes.
+feature probe. It specializes eligible rank-two fused rotations, direct Pauli
+rotations, and diagonal active-measurement probability and collapse. Shape- and
+width-specific thresholds retain the portable scalar kernels where measured
+NEON crossover behavior does not justify vector dispatch.
 
 The AVX2 backend requires AVX2, BMI2, and FMA. The AVX-512 backend additionally
 requires AVX-512F and AVX-512DQ. If those features are unavailable, or runtime

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -69,6 +69,13 @@ if(CLIFFT_X86_RUNTIME_DISPATCH)
     target_compile_definitions(clifft_core PRIVATE CLIFFT_ENABLE_RUNTIME_DISPATCH)
 endif()
 
+# Apple arm64 has a process-wide NEON baseline. Keep its implementation in a
+# separate TU so portable code does not expose architecture-specific types.
+if(CLIFFT_APPLE_NEON_DISPATCH)
+    target_sources(clifft_core PRIVATE sampling/kernels_neon.cc)
+    target_compile_definitions(clifft_core PRIVATE CLIFFT_ENABLE_APPLE_NEON)
+endif()
+
 # Enable position-independent code for use in shared libraries (Python bindings).
 set_target_properties(clifft_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -66,7 +66,7 @@ if(CLIFFT_X86_RUNTIME_DISPATCH)
     set_source_files_properties(sampling/kernels_avx512.cc
         PROPERTIES COMPILE_OPTIONS "-mavx2;-mbmi2;-mfma;-mavx512f;-mavx512dq"
     )
-    target_compile_definitions(clifft_core PRIVATE CLIFFT_ENABLE_RUNTIME_DISPATCH)
+    target_compile_definitions(clifft_core PRIVATE CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
 endif()
 
 # Apple arm64 has a process-wide NEON baseline. Keep its implementation in a

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -13,20 +13,25 @@ namespace clifft::sampling {
 PreparedFusedRotationExecution::PreparedFusedRotationExecution(PreparedFusedRotation rotation,
                                                                ExecutorBackend backend)
     : rotation_(std::move(rotation)) {
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
     switch (backend) {
         case ExecutorBackend::Scalar:
             break;
+        case ExecutorBackend::Neon:
+#if defined(CLIFFT_ENABLE_APPLE_NEON)
+            sidecar_ = prepare_fused_rotation_neon_sidecar(rotation_);
+#endif
+            break;
         case ExecutorBackend::Avx2:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
             sidecar_ = prepare_fused_rotation_avx2_sidecar(rotation_);
+#endif
             break;
         case ExecutorBackend::Avx512:
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
             sidecar_ = prepare_fused_rotation_avx512_sidecar(rotation_);
+#endif
             break;
     }
-#else
-    (void)backend;
-#endif
     assert((sidecar_.storage == nullptr) == (sidecar_.kernel == nullptr) &&
            "fused sidecar storage and serial kernel must be set together");
     assert((sidecar_.kernel == nullptr) == (sidecar_.parallel_kernel == nullptr) &&

--- a/src/clifft/sampling/executable_plan.cc
+++ b/src/clifft/sampling/executable_plan.cc
@@ -22,12 +22,12 @@ PreparedFusedRotationExecution::PreparedFusedRotationExecution(PreparedFusedRota
 #endif
             break;
         case ExecutorBackend::Avx2:
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
             sidecar_ = prepare_fused_rotation_avx2_sidecar(rotation_);
 #endif
             break;
         case ExecutorBackend::Avx512:
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
             sidecar_ = prepare_fused_rotation_avx512_sidecar(rotation_);
 #endif
             break;

--- a/src/clifft/sampling/executable_plan_inspection.cc
+++ b/src/clifft/sampling/executable_plan_inspection.cc
@@ -26,6 +26,8 @@ std::string_view backend_name(ExecutorBackend backend) {
     switch (backend) {
         case ExecutorBackend::Scalar:
             return "scalar";
+        case ExecutorBackend::Neon:
+            return "neon";
         case ExecutorBackend::Avx2:
             return "avx2";
         case ExecutorBackend::Avx512:

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -814,14 +814,14 @@ ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forc
                 break;
 #endif
             case ExecutorBackend::Avx2:
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
                 return execute_actions<ExecutorBackend::Avx2, Mode, IntraShotMode::OpenMP>(
                     forced_records, begin);
 #else
                 break;
 #endif
             case ExecutorBackend::Avx512:
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
                 return execute_actions<ExecutorBackend::Avx512, Mode, IntraShotMode::OpenMP>(
                     forced_records, begin);
 #else
@@ -843,14 +843,14 @@ ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forc
             break;
 #endif
         case ExecutorBackend::Avx2:
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
             return execute_actions<ExecutorBackend::Avx2, Mode, IntraShotMode::Serial>(
                 forced_records, begin);
 #else
             break;
 #endif
         case ExecutorBackend::Avx512:
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH)
             return execute_actions<ExecutorBackend::Avx512, Mode, IntraShotMode::Serial>(
                 forced_records, begin);
 #else

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -794,6 +794,13 @@ ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forc
             case ExecutorBackend::Scalar:
                 return execute_actions<ExecutorBackend::Scalar, Mode, IntraShotMode::OpenMP>(
                     forced_records, begin);
+            case ExecutorBackend::Neon:
+#if defined(CLIFFT_ENABLE_APPLE_NEON)
+                return execute_actions<ExecutorBackend::Neon, Mode, IntraShotMode::OpenMP>(
+                    forced_records, begin);
+#else
+                break;
+#endif
             case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
                 return execute_actions<ExecutorBackend::Avx2, Mode, IntraShotMode::OpenMP>(
@@ -816,6 +823,13 @@ ReplayResult Executor::execute_actions_for_backend(std::span<const uint8_t> forc
         case ExecutorBackend::Scalar:
             return execute_actions<ExecutorBackend::Scalar, Mode, IntraShotMode::Serial>(
                 forced_records, begin);
+        case ExecutorBackend::Neon:
+#if defined(CLIFFT_ENABLE_APPLE_NEON)
+            return execute_actions<ExecutorBackend::Neon, Mode, IntraShotMode::Serial>(
+                forced_records, begin);
+#else
+            break;
+#endif
         case ExecutorBackend::Avx2:
 #if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
             return execute_actions<ExecutorBackend::Avx2, Mode, IntraShotMode::Serial>(

--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -347,7 +347,14 @@ void Executor::execute_action(const ExecutablePlan::ExecuteRotation& action,
         }
         return;
     }
-    if constexpr (Backend == ExecutorBackend::Avx2) {
+    if constexpr (Backend == ExecutorBackend::Neon) {
+        if constexpr (IntraShot == IntraShotMode::OpenMP) {
+            apply_direct_rotation_neon_parallel(state_, action.rotation, action.kernel, sign,
+                                                intra_shot_workers_, intra_shot_min_active_width_);
+        } else {
+            apply_direct_rotation_neon(state_, action.rotation, action.kernel, sign);
+        }
+    } else if constexpr (Backend == ExecutorBackend::Avx2) {
         if constexpr (IntraShot == IntraShotMode::OpenMP) {
             apply_direct_rotation_avx2_parallel(state_, action.rotation, action.kernel, sign,
                                                 intra_shot_workers_, intra_shot_min_active_width_);
@@ -420,7 +427,9 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
         if (action.kernel == ActiveMeasurementKernel::Scalar) {
             return measurement_probabilities(state_, action.measurement);
         }
-        if constexpr (Backend == ExecutorBackend::Avx2) {
+        if constexpr (Backend == ExecutorBackend::Neon) {
+            return active_measurement_probabilities_neon(state_, action.measurement, action.kernel);
+        } else if constexpr (Backend == ExecutorBackend::Avx2) {
             return active_measurement_probabilities_avx2(state_, action.measurement, action.kernel);
         } else if constexpr (Backend == ExecutorBackend::Avx512) {
             return active_measurement_probabilities_avx512(state_, action.measurement,
@@ -455,6 +464,9 @@ void Executor::execute_action(const ExecutablePlan::ExecuteActiveMeasurement& ac
     const double branch_probability = probabilities.for_branch(branch);
     if (action.kernel == ActiveMeasurementKernel::Scalar) {
         collapse_measurement(state_, action.measurement, branch, branch_probability);
+    } else if constexpr (Backend == ExecutorBackend::Neon) {
+        collapse_active_measurement_neon(state_, action.measurement, action.kernel, branch,
+                                         branch_probability);
     } else if constexpr (Backend == ExecutorBackend::Avx2) {
         collapse_active_measurement_avx2(state_, action.measurement, action.kernel, branch,
                                          branch_probability);

--- a/src/clifft/sampling/kernel_dispatch.cc
+++ b/src/clifft/sampling/kernel_dispatch.cc
@@ -10,6 +10,9 @@ namespace {
 
 constexpr uint32_t kMinProfitableAvx2MeasurementWidth = kAvx2LaneIndexBits;
 constexpr uint32_t kMinProfitableAvx512MeasurementWidth = 4;
+constexpr uint32_t kMinProfitableNeonRotationWidth = 3;
+constexpr uint32_t kMinProfitableNeonHighPivotRotationWidth = 4;
+constexpr uint32_t kMinProfitableNeonMeasurementWidth = 6;
 
 ActiveMeasurementKernel select_active_measurement(const PreparedMeasurement& measurement,
                                                   uint64_t vector_lanes, uint32_t lane_index_bits,
@@ -39,14 +42,15 @@ DirectRotationKernel select_direct_rotation(const PreparedRotation& rotation, ui
                                             uint32_t min_active_width,
                                             uint64_t excluded_pairing_bit) noexcept {
     assert(!rotation.pauli.is_identity() && "identity rotations must be removed during planning");
+    if (rotation.pauli.active_width < min_active_width) {
+        return DirectRotationKernel::Scalar;
+    }
     if (rotation.pauli.is_diagonal()) {
-        return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::Diagonal
-                                                               : DirectRotationKernel::Scalar;
+        return DirectRotationKernel::Diagonal;
     }
     const uint64_t pairing_bit = rotation.pauli.pairing_bit;
     if (pairing_bit < vector_lanes) {
-        return rotation.pauli.active_width >= min_active_width ? DirectRotationKernel::LanePaired
-                                                               : DirectRotationKernel::Scalar;
+        return DirectRotationKernel::LanePaired;
     }
     if (pairing_bit == excluded_pairing_bit) {
         return DirectRotationKernel::Scalar;
@@ -84,8 +88,16 @@ DirectRotationKernel resolve_direct_rotation_kernel(const PreparedRotation& rota
                                                     ExecutorBackend backend) noexcept {
     switch (backend) {
         case ExecutorBackend::Scalar:
-        case ExecutorBackend::Neon:
             return DirectRotationKernel::Scalar;
+        case ExecutorBackend::Neon: {
+            const DirectRotationKernel selected = select_direct_rotation(
+                rotation, kNeonDoubleLanes, kMinProfitableNeonRotationWidth, kNoExcludedPairingBit);
+            if (selected == DirectRotationKernel::HighPivot &&
+                rotation.pauli.active_width < kMinProfitableNeonHighPivotRotationWidth) {
+                return DirectRotationKernel::Scalar;
+            }
+            return selected;
+        }
         case ExecutorBackend::Avx2:
             // Stride-16 pairing was neutral or faster than scalar across the
             // measured AVX2 widths, so every high pivot uses the vector kernel.
@@ -104,8 +116,16 @@ ActiveMeasurementKernel resolve_active_measurement_kernel(const PreparedMeasurem
                                                           ExecutorBackend backend) noexcept {
     switch (backend) {
         case ExecutorBackend::Scalar:
-        case ExecutorBackend::Neon:
             return ActiveMeasurementKernel::Scalar;
+        case ExecutorBackend::Neon: {
+            const ActiveMeasurementKernel selected =
+                select_active_measurement(measurement, kNeonDoubleLanes, kNeonLaneIndexBits,
+                                          kMinProfitableNeonMeasurementWidth);
+            // Only diagonal probability plus compaction has a measured NEON
+            // crossover; paired shapes retain the scalar implementation.
+            return selected == ActiveMeasurementKernel::Diagonal ? selected
+                                                                 : ActiveMeasurementKernel::Scalar;
+        }
         case ExecutorBackend::Avx2:
             // The probability-plus-collapse pair wins from one AVX2 block onward.
             return select_active_measurement(measurement, kAvx2DoubleLanes, kAvx2LaneIndexBits,

--- a/src/clifft/sampling/kernel_dispatch.cc
+++ b/src/clifft/sampling/kernel_dispatch.cc
@@ -65,10 +65,13 @@ ExecutorBackend resolve_executor_backend(internal::RuntimeIsa runtime_isa) {
     switch (runtime_isa) {
         case internal::RuntimeIsa::Scalar:
             return ExecutorBackend::Scalar;
+        case internal::RuntimeIsa::Neon:
+            return ExecutorBackend::Neon;
         case internal::RuntimeIsa::Avx2:
             return ExecutorBackend::Avx2;
         case internal::RuntimeIsa::Avx512:
             return ExecutorBackend::Avx512;
+        case internal::RuntimeIsa::TrapNeon:
         case internal::RuntimeIsa::TrapAvx2:
         case internal::RuntimeIsa::TrapAvx512:
         case internal::RuntimeIsa::TrapUnknown:
@@ -81,6 +84,7 @@ DirectRotationKernel resolve_direct_rotation_kernel(const PreparedRotation& rota
                                                     ExecutorBackend backend) noexcept {
     switch (backend) {
         case ExecutorBackend::Scalar:
+        case ExecutorBackend::Neon:
             return DirectRotationKernel::Scalar;
         case ExecutorBackend::Avx2:
             // Stride-16 pairing was neutral or faster than scalar across the
@@ -100,6 +104,7 @@ ActiveMeasurementKernel resolve_active_measurement_kernel(const PreparedMeasurem
                                                           ExecutorBackend backend) noexcept {
     switch (backend) {
         case ExecutorBackend::Scalar:
+        case ExecutorBackend::Neon:
             return ActiveMeasurementKernel::Scalar;
         case ExecutorBackend::Avx2:
             // The probability-plus-collapse pair wins from one AVX2 block onward.
@@ -117,7 +122,8 @@ NewXInstrumentKernel resolve_new_x_instrument_kernel(uint32_t active_width,
                                                      ExecutorBackend backend) noexcept {
     // The AVX-512 backend can use the AVX2 implementation because its required
     // AVX2, BMI2, and FMA features are a subset of that backend's requirements.
-    if (backend != ExecutorBackend::Scalar && active_width >= kMinProfitableAvx2InstrumentWidth) {
+    if ((backend == ExecutorBackend::Avx2 || backend == ExecutorBackend::Avx512) &&
+        active_width >= kMinProfitableAvx2InstrumentWidth) {
         return NewXInstrumentKernel::Vectorized;
     }
     return NewXInstrumentKernel::Scalar;

--- a/src/clifft/sampling/kernel_dispatch.h
+++ b/src/clifft/sampling/kernel_dispatch.h
@@ -15,6 +15,7 @@ namespace clifft::sampling {
 // tags do not encode or rediscover the process ISA.
 enum class ExecutorBackend : uint8_t {
     Scalar,
+    Neon,
     Avx2,
     Avx512,
 };
@@ -61,8 +62,8 @@ enum class NewXInstrumentKernel : uint8_t {
 [[nodiscard]] NewXInstrumentKernel resolve_new_x_instrument_kernel(
     uint32_t active_width, ExecutorBackend backend) noexcept;
 
-// Entry points implemented in translation units compiled with explicit x86
-// ISA flags. Only a matching backend-specialized executor calls them.
+// Entry points implemented in architecture-specific translation units. Only
+// a matching backend-specialized executor calls them.
 void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
                                 DirectRotationKernel kernel, bool sign) noexcept;
 void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
@@ -90,6 +91,8 @@ void collapse_active_measurement_avx512(State& state, const PreparedMeasurement&
 [[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(
     const PreparedFusedRotation& rotation);
 [[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx512_sidecar(
+    const PreparedFusedRotation& rotation);
+[[nodiscard]] FusedRotationSidecar prepare_fused_rotation_neon_sidecar(
     const PreparedFusedRotation& rotation);
 
 void apply_new_x_instrument_no_fire_avx2(State& state, double factor_zero, double factor_one,

--- a/src/clifft/sampling/kernel_dispatch.h
+++ b/src/clifft/sampling/kernel_dispatch.h
@@ -64,6 +64,8 @@ enum class NewXInstrumentKernel : uint8_t {
 
 // Entry points implemented in architecture-specific translation units. Only
 // a matching backend-specialized executor calls them.
+void apply_direct_rotation_neon(State& state, const PreparedRotation& rotation,
+                                DirectRotationKernel kernel, bool sign) noexcept;
 void apply_direct_rotation_avx2(State& state, const PreparedRotation& rotation,
                                 DirectRotationKernel kernel, bool sign) noexcept;
 void apply_direct_rotation_avx512(State& state, const PreparedRotation& rotation,
@@ -74,6 +76,9 @@ void apply_direct_rotation_avx2_parallel(State& state, const PreparedRotation& r
 void apply_direct_rotation_avx512_parallel(State& state, const PreparedRotation& rotation,
                                            DirectRotationKernel kernel, bool sign, uint32_t workers,
                                            uint32_t min_active_width) noexcept;
+void apply_direct_rotation_neon_parallel(State& state, const PreparedRotation& rotation,
+                                         DirectRotationKernel kernel, bool sign, uint32_t workers,
+                                         uint32_t min_active_width) noexcept;
 
 [[nodiscard]] MeasurementProbabilities active_measurement_probabilities_avx2(
     const State& state, const PreparedMeasurement& measurement,
@@ -87,6 +92,12 @@ void collapse_active_measurement_avx2(State& state, const PreparedMeasurement& m
 void collapse_active_measurement_avx512(State& state, const PreparedMeasurement& measurement,
                                         ActiveMeasurementKernel kernel, bool branch,
                                         double branch_probability) noexcept;
+[[nodiscard]] MeasurementProbabilities active_measurement_probabilities_neon(
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept;
+void collapse_active_measurement_neon(State& state, const PreparedMeasurement& measurement,
+                                      ActiveMeasurementKernel kernel, bool branch,
+                                      double branch_probability) noexcept;
 
 [[nodiscard]] FusedRotationSidecar prepare_fused_rotation_avx2_sidecar(
     const PreparedFusedRotation& rotation);

--- a/src/clifft/sampling/kernels_neon.cc
+++ b/src/clifft/sampling/kernels_neon.cc
@@ -1,12 +1,12 @@
-#include "clifft/sampling/kernel_dispatch.h"
-
 #include "clifft/sampling/indexing.h"
+#include "clifft/sampling/kernel_dispatch.h"
 #include "clifft/util/intra_shot_parallel.h"
 
 #include <arm_neon.h>
-
 #include <array>
+#include <bit>
 #include <cassert>
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
@@ -28,6 +28,7 @@ struct alignas(16) LaneWeights {
 
 struct FusedRotationNeonSidecar {
     std::array<bool, kDimension> swap_lanes{};
+    bool pair_vectors = false;
     std::vector<LaneWeights> weights;
 };
 
@@ -35,26 +36,168 @@ float64x2_t maybe_swap_lanes(float64x2_t value, bool swap) noexcept {
     return swap ? vextq_f64(value, value, 1) : value;
 }
 
-void apply_fused_rotation_neon_range(State& state, const PreparedFusedRotation& rotation,
-                                     const FusedRotationNeonSidecar& sidecar,
-                                     uint64_t vector_begin, uint64_t vector_end) noexcept {
+float64x2_t signed_sine_lanes(uint64_t basis, uint64_t z, double sine) noexcept {
+    const bool high_parity = (std::popcount(basis & z) & 1U) != 0;
+    const double first = high_parity ? -sine : sine;
+    const double second = (z & 1U) != 0 ? -first : first;
+    return vsetq_lane_f64(second, vdupq_n_f64(first), 1);
+}
+
+uint64_t inclusive_prefix_parities(uint64_t value) noexcept {
+    value ^= value << 1;
+    value ^= value << 2;
+    value ^= value << 4;
+    value ^= value << 8;
+    value ^= value << 16;
+    value ^= value << 32;
+    return value;
+}
+
+void apply_diagonal_rotation_neon_range(State& state, const PreparedRotation& rotation, double sine,
+                                        uint64_t vector_begin, uint64_t vector_end) noexcept {
     double* const real = state.real_data();
     double* const imag = state.imag_data();
+    const float64x2_t cosine = vdupq_n_f64(rotation.cosine);
+#pragma clang loop unroll_count(2)
+    for (uint64_t vector_index = vector_begin; vector_index < vector_end; ++vector_index) {
+        const uint64_t basis = vector_index * kLanes;
+        const float64x2_t input_real = vld1q_f64(real + basis);
+        const float64x2_t input_imag = vld1q_f64(imag + basis);
+        const float64x2_t signed_sine = signed_sine_lanes(basis, rotation.pauli.z, sine);
+        const float64x2_t output_real =
+            vfmaq_f64(vmulq_f64(cosine, input_real), signed_sine, input_imag);
+        const float64x2_t output_imag =
+            vfmsq_f64(vmulq_f64(cosine, input_imag), signed_sine, input_real);
+        vst1q_f64(real + basis, output_real);
+        vst1q_f64(imag + basis, output_imag);
+    }
+}
+
+template <bool RealPhase>
+void apply_lane_paired_rotation_neon_range(State& state, const PreparedRotation& rotation,
+                                           double sine, uint64_t vector_begin,
+                                           uint64_t vector_end) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const float64x2_t cosine = vdupq_n_f64(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+
+#pragma clang loop unroll_count(2)
+    for (uint64_t vector_index = vector_begin; vector_index < vector_end; ++vector_index) {
+        const uint64_t basis = vector_index * kLanes;
+        const float64x2_t input_real = vld1q_f64(real + basis);
+        const float64x2_t input_imag = vld1q_f64(imag + basis);
+        const float64x2_t partner_real = vextq_f64(input_real, input_real, 1);
+        const float64x2_t partner_imag = vextq_f64(input_imag, input_imag, 1);
+        const float64x2_t basis_sine =
+            signed_sine_lanes(basis, rotation.pauli.z, sine * base_phase);
+        const float64x2_t partner_sine = RealPhase ? basis_sine : vnegq_f64(basis_sine);
+
+        float64x2_t output_real;
+        float64x2_t output_imag;
+        if constexpr (RealPhase) {
+            output_real = vfmaq_f64(vmulq_f64(cosine, input_real), partner_sine, partner_imag);
+            output_imag = vfmsq_f64(vmulq_f64(cosine, input_imag), partner_sine, partner_real);
+        } else {
+            output_real = vfmaq_f64(vmulq_f64(cosine, input_real), partner_sine, partner_real);
+            output_imag = vfmaq_f64(vmulq_f64(cosine, input_imag), partner_sine, partner_imag);
+        }
+        vst1q_f64(real + basis, output_real);
+        vst1q_f64(imag + basis, output_imag);
+    }
+}
+
+template <bool RealPhase>
+void apply_high_pivot_rotation_neon_range(State& state, const PreparedRotation& rotation,
+                                          double sine, uint64_t vector_begin,
+                                          uint64_t vector_end) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pair_stride = rotation.pauli.pairing_bit;
+    const uint64_t pair_period = pair_stride << 1;
+    const uint64_t lower_mask = pair_stride - 1;
+    const bool swap = (rotation.pauli.x & 1U) != 0;
+    const float64x2_t cosine = vdupq_n_f64(rotation.cosine);
+    const double base_phase =
+        RealPhase ? rotation.pauli.even_phase.real() : rotation.pauli.even_phase.imag();
+    const double even_left_sine = sine * base_phase;
+    // Compress away the lane and pairing bits so adjacent vector indices can
+    // update phase parity without a popcount in every hot-loop iteration.
+    const uint64_t compressed_z = ((rotation.pauli.z & (pair_stride - 1) & ~uint64_t{1}) >> 1) |
+                                  ((rotation.pauli.z & ~(pair_period - 1)) >> 2);
+    const uint64_t parity_transitions = inclusive_prefix_parities(compressed_z);
+    float64x2_t left_sine =
+        vsetq_lane_f64((rotation.pauli.z & 1U) != 0 ? -even_left_sine : even_left_sine,
+                       vdupq_n_f64(even_left_sine), 1);
+    if ((std::popcount(vector_begin & compressed_z) & 1U) != 0) {
+        left_sine = vnegq_f64(left_sine);
+    }
+
+#pragma clang loop unroll_count(2)
+    for (uint64_t vector_index = vector_begin; vector_index < vector_end; ++vector_index) {
+        const uint64_t packed = vector_index * kLanes;
+        const uint64_t left = (packed & lower_mask) | ((packed & ~lower_mask) << 1);
+        const uint64_t right_base = (left ^ rotation.pauli.x) & ~(uint64_t{kLanes - 1});
+        const float64x2_t left_real = vld1q_f64(real + left);
+        const float64x2_t left_imag = vld1q_f64(imag + left);
+        const float64x2_t right_real = maybe_swap_lanes(vld1q_f64(real + right_base), swap);
+        const float64x2_t right_imag = maybe_swap_lanes(vld1q_f64(imag + right_base), swap);
+        float64x2_t output_left_real;
+        float64x2_t output_left_imag;
+        float64x2_t output_right_real;
+        float64x2_t output_right_imag;
+        if constexpr (RealPhase) {
+            output_left_real = vfmaq_f64(vmulq_f64(cosine, left_real), left_sine, right_imag);
+            output_left_imag = vfmsq_f64(vmulq_f64(cosine, left_imag), left_sine, right_real);
+            output_right_real = vfmaq_f64(vmulq_f64(cosine, right_real), left_sine, left_imag);
+            output_right_imag = vfmsq_f64(vmulq_f64(cosine, right_imag), left_sine, left_real);
+        } else {
+            output_left_real = vfmsq_f64(vmulq_f64(cosine, left_real), left_sine, right_real);
+            output_left_imag = vfmsq_f64(vmulq_f64(cosine, left_imag), left_sine, right_imag);
+            output_right_real = vfmaq_f64(vmulq_f64(cosine, right_real), left_sine, left_real);
+            output_right_imag = vfmaq_f64(vmulq_f64(cosine, right_imag), left_sine, left_imag);
+        }
+
+        vst1q_f64(real + left, output_left_real);
+        vst1q_f64(imag + left, output_left_imag);
+        vst1q_f64(real + right_base, maybe_swap_lanes(output_right_real, swap));
+        vst1q_f64(imag + right_base, maybe_swap_lanes(output_right_imag, swap));
+        const uint64_t next_vector = vector_index + 1;
+        if (next_vector < vector_end &&
+            ((parity_transitions >> std::countr_zero(next_vector)) & 1U) != 0) {
+            left_sine = vnegq_f64(left_sine);
+        }
+    }
+}
+
+template <size_t Groups>
+void apply_fused_rotation_neon_group(State& state, const PreparedFusedRotation& rotation,
+                                     const FusedRotationNeonSidecar& sidecar,
+                                     uint64_t vector_index) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    std::array<uint64_t, Groups> representatives{};
+    for (size_t group = 0; group < Groups; ++group) {
+        const uint64_t packed = (vector_index + group) * kLanes;
+        uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
+        representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+        representatives[group] = representative;
+    }
+    const size_t selector = selector_index(representatives[0], rotation.selector_masks);
+    const LaneWeights* const matrix = sidecar.weights.data() + selector * kMatrixSize;
+    if constexpr (Groups > 1) {
+        assert(selector_index(representatives[1], rotation.selector_masks) == selector &&
+               "paired NEON orbit groups must share a matrix selector");
+    }
 
     // A pivot above bit zero lets each vector lane carry an independent orbit;
     // this avoids horizontal reductions in the dense four-by-four multiply.
-    for (uint64_t vector_index = vector_begin; vector_index < vector_end; ++vector_index) {
-        const uint64_t packed = vector_index * kLanes;
-        uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
-        representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
-        const LaneWeights* const matrix =
-            sidecar.weights.data() +
-            selector_index(representative, rotation.selector_masks) * kMatrixSize;
-
-        std::array<float64x2_t, kDimension> input_real;
-        std::array<float64x2_t, kDimension> input_imag;
+    std::array<std::array<float64x2_t, kDimension>, Groups> input_real;
+    std::array<std::array<float64x2_t, kDimension>, Groups> input_imag;
+    for (size_t group = 0; group < Groups; ++group) {
         for (size_t column = 0; column < kDimension; ++column) {
-            uint64_t index = representative;
+            uint64_t index = representatives[group];
             if ((column & 1U) != 0) {
                 index ^= rotation.orbit_masks[0];
             }
@@ -62,26 +205,38 @@ void apply_fused_rotation_neon_range(State& state, const PreparedFusedRotation& 
                 index ^= rotation.orbit_masks[1];
             }
             const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
-            input_real[column] = maybe_swap_lanes(vld1q_f64(real + physical_base),
-                                                  sidecar.swap_lanes[column]);
-            input_imag[column] = maybe_swap_lanes(vld1q_f64(imag + physical_base),
-                                                  sidecar.swap_lanes[column]);
+            input_real[group][column] =
+                maybe_swap_lanes(vld1q_f64(real + physical_base), sidecar.swap_lanes[column]);
+            input_imag[group][column] =
+                maybe_swap_lanes(vld1q_f64(imag + physical_base), sidecar.swap_lanes[column]);
+        }
+    }
+
+    for (size_t row = 0; row < kDimension; ++row) {
+        std::array<float64x2_t, Groups> output_real;
+        std::array<float64x2_t, Groups> output_imag;
+        for (size_t group = 0; group < Groups; ++group) {
+            output_real[group] = vdupq_n_f64(0.0);
+            output_imag[group] = vdupq_n_f64(0.0);
+        }
+        for (size_t column = 0; column < kDimension; ++column) {
+            const LaneWeights& weight = matrix[row * kDimension + column];
+            const float64x2_t weight_real = vld1q_f64(weight.real.data());
+            const float64x2_t weight_imag = vld1q_f64(weight.imag.data());
+            for (size_t group = 0; group < Groups; ++group) {
+                output_real[group] =
+                    vfmaq_f64(output_real[group], weight_real, input_real[group][column]);
+                output_real[group] =
+                    vfmsq_f64(output_real[group], weight_imag, input_imag[group][column]);
+                output_imag[group] =
+                    vfmaq_f64(output_imag[group], weight_real, input_imag[group][column]);
+                output_imag[group] =
+                    vfmaq_f64(output_imag[group], weight_imag, input_real[group][column]);
+            }
         }
 
-        for (size_t row = 0; row < kDimension; ++row) {
-            float64x2_t output_real = vdupq_n_f64(0.0);
-            float64x2_t output_imag = vdupq_n_f64(0.0);
-            for (size_t column = 0; column < kDimension; ++column) {
-                const LaneWeights& weight = matrix[row * kDimension + column];
-                const float64x2_t weight_real = vld1q_f64(weight.real.data());
-                const float64x2_t weight_imag = vld1q_f64(weight.imag.data());
-                output_real = vfmaq_f64(output_real, weight_real, input_real[column]);
-                output_real = vfmsq_f64(output_real, weight_imag, input_imag[column]);
-                output_imag = vfmaq_f64(output_imag, weight_real, input_imag[column]);
-                output_imag = vfmaq_f64(output_imag, weight_imag, input_real[column]);
-            }
-
-            uint64_t index = representative;
+        for (size_t group = 0; group < Groups; ++group) {
+            uint64_t index = representatives[group];
             if ((row & 1U) != 0) {
                 index ^= rotation.orbit_masks[0];
             }
@@ -90,10 +245,31 @@ void apply_fused_rotation_neon_range(State& state, const PreparedFusedRotation& 
             }
             const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
             vst1q_f64(real + physical_base,
-                      maybe_swap_lanes(output_real, sidecar.swap_lanes[row]));
+                      maybe_swap_lanes(output_real[group], sidecar.swap_lanes[row]));
             vst1q_f64(imag + physical_base,
-                      maybe_swap_lanes(output_imag, sidecar.swap_lanes[row]));
+                      maybe_swap_lanes(output_imag[group], sidecar.swap_lanes[row]));
         }
+    }
+}
+
+void apply_fused_rotation_neon_range(State& state, const PreparedFusedRotation& rotation,
+                                     const FusedRotationNeonSidecar& sidecar, uint64_t vector_begin,
+                                     uint64_t vector_end) noexcept {
+    if (!sidecar.pair_vectors) {
+        for (uint64_t vector_index = vector_begin; vector_index < vector_end; ++vector_index) {
+            apply_fused_rotation_neon_group<1>(state, rotation, sidecar, vector_index);
+        }
+        return;
+    }
+    if ((vector_begin & 1U) != 0 && vector_begin < vector_end) {
+        apply_fused_rotation_neon_group<1>(state, rotation, sidecar, vector_begin++);
+    }
+    while (vector_begin + 1 < vector_end) {
+        apply_fused_rotation_neon_group<2>(state, rotation, sidecar, vector_begin);
+        vector_begin += 2;
+    }
+    if (vector_begin < vector_end) {
+        apply_fused_rotation_neon_group<1>(state, rotation, sidecar, vector_begin);
     }
 }
 
@@ -130,16 +306,198 @@ void apply_fused_rotation_neon_parallel(State& state, const PreparedFusedRotatio
     });
 }
 
+MeasurementProbabilities active_diagonal_measurement_probabilities_neon_impl(
+    const State& state, const PreparedMeasurement& measurement) noexcept {
+    const double* const real = state.real_data();
+    const double* const imag = state.imag_data();
+    float64x2_t zero_sum = vdupq_n_f64(0.0);
+    float64x2_t one_sum = vdupq_n_f64(0.0);
+    const float64x2_t zero = vdupq_n_f64(0.0);
+
+#pragma clang loop unroll_count(2)
+    for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+        const float64x2_t input_real = vld1q_f64(real + basis);
+        const float64x2_t input_imag = vld1q_f64(imag + basis);
+        const float64x2_t norm =
+            vfmaq_f64(vmulq_f64(input_imag, input_imag), input_real, input_real);
+        const float64x2_t parity = signed_sine_lanes(basis, measurement.pauli.z, 1.0);
+        const uint64x2_t zero_mask = vcgtq_f64(parity, zero);
+        zero_sum = vaddq_f64(zero_sum, vbslq_f64(zero_mask, norm, zero));
+        one_sum = vaddq_f64(one_sum, vbslq_f64(zero_mask, zero, norm));
+    }
+    return MeasurementProbabilities{vaddvq_f64(zero_sum), vaddvq_f64(one_sum)};
+}
+
+void collapse_active_diagonal_measurement_neon_impl(State& state,
+                                                    const PreparedMeasurement& measurement,
+                                                    bool branch,
+                                                    double branch_probability) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+    const uint64_t pivot_bit = uint64_t{1} << measurement.pivot;
+    const double scalar_scale = 1.0 / std::sqrt(branch_probability);
+    assert((measurement.pauli.z & (pivot_bit - 1)) == 0 &&
+           "NEON diagonal compaction requires the lowest measured pivot");
+
+    if (measurement.pivot >= 1) {
+        const float64x2_t scale = vdupq_n_f64(scalar_scale);
+        for (uint64_t packed = 0; packed < measurement.output_size; packed += kLanes) {
+            const uint64_t source0 = insert_zero_bit(packed, measurement.pivot);
+            const bool other_parity =
+                (std::popcount(source0 & measurement.z_without_pivot) & 1U) != 0;
+            const uint64_t source = source0 | (branch != other_parity ? pivot_bit : 0);
+            vst1q_f64(real + packed, vmulq_f64(scale, vld1q_f64(real + source)));
+            vst1q_f64(imag + packed, vmulq_f64(scale, vld1q_f64(imag + source)));
+        }
+    } else {
+        for (uint64_t basis = 0; basis < state.size(); basis += kLanes) {
+            const bool other_parity =
+                (std::popcount(basis & measurement.z_without_pivot) & 1U) != 0;
+            const bool selected_lane_one = branch != other_parity;
+            const float64x2_t selected_real = vld1q_f64(real + basis);
+            const float64x2_t selected_imag = vld1q_f64(imag + basis);
+            real[basis / 2] = scalar_scale * (selected_lane_one ? vgetq_lane_f64(selected_real, 1)
+                                                                : vgetq_lane_f64(selected_real, 0));
+            imag[basis / 2] = scalar_scale * (selected_lane_one ? vgetq_lane_f64(selected_imag, 1)
+                                                                : vgetq_lane_f64(selected_imag, 0));
+        }
+    }
+    state.set_active_width(state.active_width() - 1);
+}
+
 }  // namespace
 
-FusedRotationSidecar prepare_fused_rotation_neon_sidecar(
-    const PreparedFusedRotation& rotation) {
+MeasurementProbabilities active_measurement_probabilities_neon(
+    const State& state, const PreparedMeasurement& measurement,
+    ActiveMeasurementKernel kernel) noexcept {
+    (void)kernel;
+    assert(state.active_width() == measurement.pauli.active_width &&
+           measurement.pauli.active_width >= 6 && kernel == ActiveMeasurementKernel::Diagonal &&
+           measurement.pauli.is_diagonal() &&
+           "NEON active measurement requires a profitable diagonal shape");
+    return active_diagonal_measurement_probabilities_neon_impl(state, measurement);
+}
+
+void collapse_active_measurement_neon(State& state, const PreparedMeasurement& measurement,
+                                      ActiveMeasurementKernel kernel, bool branch,
+                                      double branch_probability) noexcept {
+    (void)kernel;
+    assert(state.active_width() == measurement.pauli.active_width &&
+           measurement.pauli.active_width >= 6 && kernel == ActiveMeasurementKernel::Diagonal &&
+           measurement.pauli.is_diagonal() && is_finite_robust(branch_probability) &&
+           branch_probability > 0.0 &&
+           "NEON active measurement requires a positive-probability diagonal shape");
+    collapse_active_diagonal_measurement_neon_impl(state, measurement, branch, branch_probability);
+}
+
+void apply_direct_rotation_neon(State& state, const PreparedRotation& rotation,
+                                DirectRotationKernel kernel, bool sign) noexcept {
+    assert(state.active_width() == rotation.pauli.active_width && state.active_width() >= 3 &&
+           "NEON rotation requires a profitable matching active width");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+    switch (kernel) {
+        case DirectRotationKernel::Diagonal:
+            assert(rotation.pauli.is_diagonal() &&
+                   "NEON diagonal rotation requires a diagonal Pauli");
+            apply_diagonal_rotation_neon_range(state, rotation, sine, 0, state.size() / kLanes);
+            return;
+        case DirectRotationKernel::HighPivot:
+            assert(!rotation.pauli.is_diagonal() && rotation.pauli.pairing_bit >= kLanes &&
+                   "NEON high-pivot rotation requires a non-diagonal high pairing bit");
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_high_pivot_rotation_neon_range<true>(state, rotation, sine, 0,
+                                                           state.size() / (2 * kLanes));
+            } else {
+                apply_high_pivot_rotation_neon_range<false>(state, rotation, sine, 0,
+                                                            state.size() / (2 * kLanes));
+            }
+            return;
+        case DirectRotationKernel::LanePaired:
+            assert(!rotation.pauli.is_diagonal() && rotation.pauli.x == 1 &&
+                   "NEON lane-paired rotation requires the low pairing bit");
+            if (rotation.pauli.even_phase.real() != 0.0) {
+                apply_lane_paired_rotation_neon_range<true>(state, rotation, sine, 0,
+                                                            state.size() / kLanes);
+            } else {
+                apply_lane_paired_rotation_neon_range<false>(state, rotation, sine, 0,
+                                                             state.size() / kLanes);
+            }
+            return;
+        case DirectRotationKernel::Scalar:
+            assert(false && "scalar rotations must not enter the NEON kernel");
+            return;
+    }
+    assert(false && "unknown direct rotation kernel");
+}
+
+void apply_direct_rotation_neon_parallel(State& state, const PreparedRotation& rotation,
+                                         DirectRotationKernel kernel, bool sign, uint32_t workers,
+                                         uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_direct_rotation_neon(state, rotation, kernel, sign);
+        return;
+    }
+    assert(state.active_width() == rotation.pauli.active_width && state.active_width() >= 3 &&
+           "NEON rotation requires a profitable matching active width");
+    const double sine = sign ? -rotation.sine : rotation.sine;
+    switch (kernel) {
+        case DirectRotationKernel::Diagonal:
+            intra_shot_parallel_ranges(
+                state.size() / kLanes, workers, [&](uint64_t begin, uint64_t end) noexcept {
+                    apply_diagonal_rotation_neon_range(state, rotation, sine, begin, end);
+                });
+            return;
+        case DirectRotationKernel::HighPivot:
+            intra_shot_parallel_ranges(state.size() / (2 * kLanes), workers,
+                                       [&](uint64_t begin, uint64_t end) noexcept {
+                                           if (rotation.pauli.even_phase.real() != 0.0) {
+                                               apply_high_pivot_rotation_neon_range<true>(
+                                                   state, rotation, sine, begin, end);
+                                           } else {
+                                               apply_high_pivot_rotation_neon_range<false>(
+                                                   state, rotation, sine, begin, end);
+                                           }
+                                       });
+            return;
+        case DirectRotationKernel::LanePaired:
+            intra_shot_parallel_ranges(state.size() / kLanes, workers,
+                                       [&](uint64_t begin, uint64_t end) noexcept {
+                                           if (rotation.pauli.even_phase.real() != 0.0) {
+                                               apply_lane_paired_rotation_neon_range<true>(
+                                                   state, rotation, sine, begin, end);
+                                           } else {
+                                               apply_lane_paired_rotation_neon_range<false>(
+                                                   state, rotation, sine, begin, end);
+                                           }
+                                       });
+            return;
+        case DirectRotationKernel::Scalar:
+            assert(false && "scalar rotations must not enter the NEON kernel");
+            return;
+    }
+    assert(false && "unknown direct rotation kernel");
+}
+
+FusedRotationSidecar prepare_fused_rotation_neon_sidecar(const PreparedFusedRotation& rotation) {
     if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 1 ||
         rotation.orbit_pivots[0] >= rotation.orbit_pivots[1]) {
         return {};
     }
 
     auto sidecar = std::make_shared<FusedRotationNeonSidecar>();
+    // Adjacent vector groups can reuse all matrix weights when their varying
+    // representative bit is absent from every selector parity.
+    uint32_t adjacent_physical_bit = 1;
+    for (uint32_t pivot : rotation.orbit_pivots) {
+        if (pivot == adjacent_physical_bit) {
+            ++adjacent_physical_bit;
+        }
+    }
+    const uint64_t adjacent_physical_mask = uint64_t{1} << adjacent_physical_bit;
+    sidecar->pair_vectors = true;
+    for (uint64_t selector_mask : rotation.selector_masks) {
+        sidecar->pair_vectors &= (selector_mask & adjacent_physical_mask) == 0;
+    }
     for (size_t member = 0; member < kDimension; ++member) {
         uint64_t mask = 0;
         if ((member & 1U) != 0) {

--- a/src/clifft/sampling/kernels_neon.cc
+++ b/src/clifft/sampling/kernels_neon.cc
@@ -1,0 +1,177 @@
+#include "clifft/sampling/kernel_dispatch.h"
+
+#include "clifft/sampling/indexing.h"
+#include "clifft/util/intra_shot_parallel.h"
+
+#include <arm_neon.h>
+
+#include <array>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace clifft::sampling {
+
+namespace {
+
+constexpr size_t kLanes = 2;
+constexpr size_t kDimension = 4;
+constexpr size_t kMatrixSize = kDimension * kDimension;
+
+struct alignas(16) LaneWeights {
+    std::array<double, kLanes> real{};
+    std::array<double, kLanes> imag{};
+};
+
+struct FusedRotationNeonSidecar {
+    std::array<bool, kDimension> swap_lanes{};
+    std::vector<LaneWeights> weights;
+};
+
+float64x2_t maybe_swap_lanes(float64x2_t value, bool swap) noexcept {
+    return swap ? vextq_f64(value, value, 1) : value;
+}
+
+void apply_fused_rotation_neon_range(State& state, const PreparedFusedRotation& rotation,
+                                     const FusedRotationNeonSidecar& sidecar,
+                                     uint64_t vector_begin, uint64_t vector_end) noexcept {
+    double* const real = state.real_data();
+    double* const imag = state.imag_data();
+
+    // A pivot above bit zero lets each vector lane carry an independent orbit;
+    // this avoids horizontal reductions in the dense four-by-four multiply.
+    for (uint64_t vector_index = vector_begin; vector_index < vector_end; ++vector_index) {
+        const uint64_t packed = vector_index * kLanes;
+        uint64_t representative = insert_zero_bit(packed, rotation.orbit_pivots[0]);
+        representative = insert_zero_bit(representative, rotation.orbit_pivots[1]);
+        const LaneWeights* const matrix =
+            sidecar.weights.data() +
+            selector_index(representative, rotation.selector_masks) * kMatrixSize;
+
+        std::array<float64x2_t, kDimension> input_real;
+        std::array<float64x2_t, kDimension> input_imag;
+        for (size_t column = 0; column < kDimension; ++column) {
+            uint64_t index = representative;
+            if ((column & 1U) != 0) {
+                index ^= rotation.orbit_masks[0];
+            }
+            if ((column & 2U) != 0) {
+                index ^= rotation.orbit_masks[1];
+            }
+            const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+            input_real[column] = maybe_swap_lanes(vld1q_f64(real + physical_base),
+                                                  sidecar.swap_lanes[column]);
+            input_imag[column] = maybe_swap_lanes(vld1q_f64(imag + physical_base),
+                                                  sidecar.swap_lanes[column]);
+        }
+
+        for (size_t row = 0; row < kDimension; ++row) {
+            float64x2_t output_real = vdupq_n_f64(0.0);
+            float64x2_t output_imag = vdupq_n_f64(0.0);
+            for (size_t column = 0; column < kDimension; ++column) {
+                const LaneWeights& weight = matrix[row * kDimension + column];
+                const float64x2_t weight_real = vld1q_f64(weight.real.data());
+                const float64x2_t weight_imag = vld1q_f64(weight.imag.data());
+                output_real = vfmaq_f64(output_real, weight_real, input_real[column]);
+                output_real = vfmsq_f64(output_real, weight_imag, input_imag[column]);
+                output_imag = vfmaq_f64(output_imag, weight_real, input_imag[column]);
+                output_imag = vfmaq_f64(output_imag, weight_imag, input_real[column]);
+            }
+
+            uint64_t index = representative;
+            if ((row & 1U) != 0) {
+                index ^= rotation.orbit_masks[0];
+            }
+            if ((row & 2U) != 0) {
+                index ^= rotation.orbit_masks[1];
+            }
+            const uint64_t physical_base = index & ~(uint64_t{kLanes - 1});
+            vst1q_f64(real + physical_base,
+                      maybe_swap_lanes(output_real, sidecar.swap_lanes[row]));
+            vst1q_f64(imag + physical_base,
+                      maybe_swap_lanes(output_imag, sidecar.swap_lanes[row]));
+        }
+    }
+}
+
+void apply_fused_rotation_neon(State& state, const PreparedFusedRotation& rotation,
+                               const void* opaque_sidecar) noexcept {
+    const auto& sidecar = *static_cast<const FusedRotationNeonSidecar*>(opaque_sidecar);
+    assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 1 &&
+           rotation.orbit_pivots[0] < rotation.orbit_pivots[1] &&
+           "NEON fused rotation requires ordered pivots above the lane bit");
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+
+    apply_fused_rotation_neon_range(state, rotation, sidecar, 0,
+                                    state.size() / (kDimension * kLanes));
+}
+
+void apply_fused_rotation_neon_parallel(State& state, const PreparedFusedRotation& rotation,
+                                        const void* opaque_sidecar, uint32_t workers,
+                                        uint32_t min_active_width) noexcept {
+    if (!should_parallelize_intra_shot(state.active_width(), workers, min_active_width)) {
+        apply_fused_rotation_neon(state, rotation, opaque_sidecar);
+        return;
+    }
+    const auto& sidecar = *static_cast<const FusedRotationNeonSidecar*>(opaque_sidecar);
+    assert(rotation.orbit_rank == 2 && rotation.orbit_pivots[0] >= 1 &&
+           rotation.orbit_pivots[0] < rotation.orbit_pivots[1] &&
+           "NEON fused rotation requires ordered pivots above the lane bit");
+    assert(state.active_width() == rotation.active_width &&
+           "fused rotation width must match the active state");
+
+    const uint64_t vector_count = state.size() / (kDimension * kLanes);
+    intra_shot_parallel_ranges(vector_count, workers, [&](uint64_t begin, uint64_t end) noexcept {
+        apply_fused_rotation_neon_range(state, rotation, sidecar, begin, end);
+    });
+}
+
+}  // namespace
+
+FusedRotationSidecar prepare_fused_rotation_neon_sidecar(
+    const PreparedFusedRotation& rotation) {
+    if (rotation.orbit_rank != 2 || rotation.orbit_pivots[0] < 1 ||
+        rotation.orbit_pivots[0] >= rotation.orbit_pivots[1]) {
+        return {};
+    }
+
+    auto sidecar = std::make_shared<FusedRotationNeonSidecar>();
+    for (size_t member = 0; member < kDimension; ++member) {
+        uint64_t mask = 0;
+        if ((member & 1U) != 0) {
+            mask ^= rotation.orbit_masks[0];
+        }
+        if ((member & 2U) != 0) {
+            mask ^= rotation.orbit_masks[1];
+        }
+        sidecar->swap_lanes[member] = (mask & 1U) != 0;
+    }
+
+    const size_t num_variants = size_t{1} << rotation.selector_masks.size();
+    assert(rotation.matrices.size() == num_variants * kMatrixSize &&
+           "fused rotation matrix table must cover every selector value");
+    sidecar->weights.resize(num_variants * kMatrixSize);
+    // Neighboring representatives can select different matrices. Expanding
+    // those weights here keeps selector-dependent gathers out of hot execution.
+    for (size_t base_selector = 0; base_selector < num_variants; ++base_selector) {
+        for (size_t lane = 0; lane < kLanes; ++lane) {
+            const size_t selector = base_selector ^ selector_index(lane, rotation.selector_masks);
+            for (size_t element = 0; element < kMatrixSize; ++element) {
+                const std::complex<double> weight =
+                    rotation.matrices[selector * kMatrixSize + element];
+                LaneWeights& expanded = sidecar->weights[base_selector * kMatrixSize + element];
+                expanded.real[lane] = weight.real();
+                expanded.imag[lane] = weight.imag();
+            }
+        }
+    }
+
+    return FusedRotationSidecar{std::move(sidecar), apply_fused_rotation_neon,
+                                apply_fused_rotation_neon_parallel};
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/simd_width.h
+++ b/src/clifft/sampling/simd_width.h
@@ -5,6 +5,10 @@
 
 namespace clifft::sampling {
 
+// Number of double lanes in one 128-bit Apple arm64 NEON vector.
+inline constexpr uint64_t kNeonDoubleLanes = 2;
+inline constexpr uint32_t kNeonLaneIndexBits = std::countr_zero(kNeonDoubleLanes);
+
 // Number of double lanes in one 256-bit vector. Portable selectors use this
 // value without exposing vector types outside ISA-specific translation units.
 inline constexpr uint64_t kAvx2DoubleLanes = 4;

--- a/src/clifft/util/runtime_isa.cc
+++ b/src/clifft/util/runtime_isa.cc
@@ -10,7 +10,7 @@ namespace clifft::internal {
 
 namespace {
 
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH)
+#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH) || defined(CLIFFT_ENABLE_APPLE_NEON)
 
 bool host_supports_avx2_kernel() {
 #if (defined(__GNUC__) || defined(__clang__)) && \
@@ -35,6 +35,14 @@ bool host_supports_avx512_kernel() {
 #endif
 }
 
+bool host_supports_neon_kernel() {
+#if defined(CLIFFT_ENABLE_APPLE_NEON)
+    return true;
+#else
+    return false;
+#endif
+}
+
 std::string normalize_force_isa(const char* environment_value) {
     std::string name(environment_value);
     const auto not_space = [](unsigned char c) { return !std::isspace(c); };
@@ -48,6 +56,9 @@ std::string normalize_force_isa(const char* environment_value) {
 RuntimeIsa resolve_runtime_isa() {
     if (const char* environment_value = std::getenv("CLIFFT_FORCE_ISA")) {
         const std::string name = normalize_force_isa(environment_value);
+        if (name == "neon") {
+            return host_supports_neon_kernel() ? RuntimeIsa::Neon : RuntimeIsa::TrapNeon;
+        }
         if (name == "avx512") {
             return host_supports_avx512_kernel() ? RuntimeIsa::Avx512 : RuntimeIsa::TrapAvx512;
         }
@@ -69,6 +80,9 @@ RuntimeIsa resolve_runtime_isa() {
     }
     if (host_supports_avx2_kernel()) {
         return RuntimeIsa::Avx2;
+    }
+    if (host_supports_neon_kernel()) {
+        return RuntimeIsa::Neon;
     }
     return RuntimeIsa::Scalar;
 }
@@ -92,10 +106,14 @@ const char* runtime_isa_name(RuntimeIsa isa) noexcept {
     switch (isa) {
         case RuntimeIsa::Scalar:
             return "scalar";
+        case RuntimeIsa::Neon:
+            return "neon";
         case RuntimeIsa::Avx2:
             return "avx2";
         case RuntimeIsa::Avx512:
             return "avx512";
+        case RuntimeIsa::TrapNeon:
+            return "trap:neon";
         case RuntimeIsa::TrapAvx2:
             return "trap:avx2";
         case RuntimeIsa::TrapAvx512:
@@ -109,9 +127,15 @@ const char* runtime_isa_name(RuntimeIsa isa) noexcept {
 void validate_runtime_isa(RuntimeIsa isa) {
     switch (isa) {
         case RuntimeIsa::Scalar:
+        case RuntimeIsa::Neon:
         case RuntimeIsa::Avx2:
         case RuntimeIsa::Avx512:
             return;
+        case RuntimeIsa::TrapNeon:
+            throw std::runtime_error(
+                "CLIFFT_FORCE_ISA=neon requested but this build has no Apple arm64 NEON "
+                "backend. Unset CLIFFT_FORCE_ISA to use the auto-detected fallback, or set it "
+                "to 'scalar' explicitly.");
         case RuntimeIsa::TrapAvx2:
             throw std::runtime_error(
                 "CLIFFT_FORCE_ISA=avx2 requested but host CPU lacks one or more required "
@@ -125,8 +149,8 @@ void validate_runtime_isa(RuntimeIsa isa) {
         case RuntimeIsa::TrapUnknown:
             throw std::runtime_error(
                 "CLIFFT_FORCE_ISA is set to an unrecognized value. Accepted values are "
-                "'avx512', 'avx2', 'scalar' (case-insensitive). Unset CLIFFT_FORCE_ISA to "
-                "use the auto-detected fallback.");
+                "'neon', 'avx512', 'avx2', 'scalar' (case-insensitive). Unset "
+                "CLIFFT_FORCE_ISA to use the auto-detected fallback.");
     }
 }
 

--- a/src/clifft/util/runtime_isa.cc
+++ b/src/clifft/util/runtime_isa.cc
@@ -10,7 +10,7 @@ namespace clifft::internal {
 
 namespace {
 
-#if defined(CLIFFT_ENABLE_RUNTIME_DISPATCH) || defined(CLIFFT_ENABLE_APPLE_NEON)
+#if defined(CLIFFT_ENABLE_X86_RUNTIME_DISPATCH) || defined(CLIFFT_ENABLE_APPLE_NEON)
 
 bool host_supports_avx2_kernel() {
 #if (defined(__GNUC__) || defined(__clang__)) && \

--- a/src/clifft/util/runtime_isa.h
+++ b/src/clifft/util/runtime_isa.h
@@ -9,8 +9,10 @@ namespace clifft::internal {
 // CLIFFT_FORCE_ISA, so tests can exercise every portable fallback.
 enum class RuntimeIsa {
     Scalar,
+    Neon,
     Avx2,
     Avx512,
+    TrapNeon,
     TrapAvx2,
     TrapAvx512,
     TrapUnknown,

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -227,8 +227,8 @@ NB_MODULE(_clifft_core, m) {
     m.def(
         "runtime_isa",
         []() { return clifft::internal::runtime_isa_name(clifft::internal::runtime_isa()); },
-        "Return the resolved kernel ISA: 'scalar', 'avx2', 'avx512', or a 'trap:...' value when "
-        "CLIFFT_FORCE_ISA requests an unavailable backend");
+        "Return the resolved kernel ISA: 'scalar', 'neon', 'avx2', 'avx512', or a 'trap:...' "
+        "value when CLIFFT_FORCE_ISA requests an unavailable backend");
 
     register_noncomp(m);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,10 @@ if(CLIFFT_X86_RUNTIME_DISPATCH)
     target_compile_definitions(clifft_tests PRIVATE CLIFFT_TESTS_HAVE_X86_KERNELS)
 endif()
 
+if(CLIFFT_APPLE_NEON_DISPATCH)
+    target_compile_definitions(clifft_tests PRIVATE CLIFFT_TESTS_HAVE_APPLE_NEON)
+endif()
+
 if(CLIFFT_OPENMP_ENABLED)
     target_link_libraries(clifft_tests PRIVATE OpenMP::OpenMP_CXX)
     target_compile_definitions(clifft_tests PRIVATE

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -28,7 +28,7 @@ def test_module_version_attribute() -> None:
 
 def test_runtime_isa_reports_a_kernel_backend() -> None:
     """Test that runtime_isa() reports one of the known kernel backends."""
-    assert clifft.runtime_isa() in {"scalar", "avx2", "avx512"}
+    assert clifft.runtime_isa() in {"scalar", "neon", "avx2", "avx512"}
 
 
 def test_runtime_isa_reflects_forced_scalar_backend() -> None:

--- a/tests/python/test_sampling_integration.py
+++ b/tests/python/test_sampling_integration.py
@@ -1,5 +1,6 @@
 """Integration and boundary tests for the public sampling API."""
 
+import json
 import os
 import platform
 import subprocess
@@ -13,9 +14,10 @@ import stim
 import clifft
 
 _MACHINE = platform.machine().lower()
+_APPLE_SILICON = sys.platform == "darwin" and _MACHINE in {"aarch64", "arm64"}
 _RUNTIME_DISPATCH_BUILD = (
     _MACHINE in {"amd64", "x86_64"} and not platform.python_compiler().startswith("MSC")
-) or (sys.platform == "darwin" and _MACHINE in {"aarch64", "arm64"})
+) or _APPLE_SILICON
 
 
 def test_experimental_namespace_reports_optional_hip_build() -> None:
@@ -67,6 +69,49 @@ def test_unknown_forced_isa_is_rejected_by_compile() -> None:
     assert completed.returncode != 0
     assert "CLIFFT_FORCE_ISA" in completed.stderr
     assert "unrecognized value" in completed.stderr
+
+
+@pytest.mark.skipif(not _APPLE_SILICON, reason="requires the Apple arm64 NEON backend")
+def test_apple_neon_fused_execution_matches_forced_scalar() -> None:
+    assert clifft.runtime_isa() == "neon"
+
+    fixture = Path(__file__).parents[1] / "fixtures" / "qv10.stim"
+    lines = fixture.read_text().splitlines()
+    measurement_start = next(i for i, line in enumerate(lines) if line.startswith("M "))
+    unitary_source = "\n".join(lines[:measurement_start])
+
+    program = clifft.compile(unitary_source)
+    assert program.inspect().startswith("executable_plan backend=neon")
+    assert any(
+        program.inspect_action(action).startswith("FUSED_ROTATION")
+        for action in range(program.num_actions)
+    )
+    neon_state = np.asarray(clifft.get_statevector(program))
+
+    scalar_script = (
+        "import json, sys\n"
+        "import clifft\n"
+        "program = clifft.compile(sys.stdin.read())\n"
+        "state = clifft.get_statevector(program)\n"
+        "print(json.dumps({'isa': clifft.runtime_isa(), "
+        "'state': [[value.real, value.imag] for value in state]}))\n"
+    )
+    environment = os.environ.copy()
+    environment["CLIFFT_FORCE_ISA"] = "scalar"
+    completed = subprocess.run(
+        [sys.executable, "-c", scalar_script],
+        input=unitary_source,
+        capture_output=True,
+        check=True,
+        env=environment,
+        text=True,
+    )
+    scalar_payload = json.loads(completed.stdout)
+    assert scalar_payload["isa"] == "scalar"
+    scalar_pairs = np.asarray(scalar_payload["state"], dtype=np.float64)
+    scalar_state = scalar_pairs[:, 0] + 1j * scalar_pairs[:, 1]
+
+    np.testing.assert_allclose(neon_state, scalar_state, atol=2e-12, rtol=0.0)
 
 
 def test_compile_returns_public_program() -> None:

--- a/tests/python/test_sampling_integration.py
+++ b/tests/python/test_sampling_integration.py
@@ -12,9 +12,10 @@ import stim
 
 import clifft
 
-_RUNTIME_DISPATCH_BUILD = platform.machine().lower() in {"amd64", "x86_64"} and not (
-    platform.python_compiler().startswith("MSC")
-)
+_MACHINE = platform.machine().lower()
+_RUNTIME_DISPATCH_BUILD = (
+    _MACHINE in {"amd64", "x86_64"} and not platform.python_compiler().startswith("MSC")
+) or (sys.platform == "darwin" and _MACHINE in {"aarch64", "arm64"})
 
 
 def test_experimental_namespace_reports_optional_hip_build() -> None:

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -13,6 +13,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -20,8 +21,11 @@ namespace {
 
 using clifft::sampling::ActivePauli;
 using clifft::sampling::AffineBool;
+using clifft::sampling::apply_direct_rotation_neon;
+using clifft::sampling::apply_direct_rotation_neon_parallel;
 using clifft::sampling::apply_fused_rotation;
 using clifft::sampling::apply_rotation;
+using clifft::sampling::DirectRotationKernel;
 using clifft::sampling::ExecutablePlan;
 using clifft::sampling::Executor;
 using clifft::sampling::index;
@@ -215,6 +219,48 @@ TEST_CASE("Apple NEON fused rotation rejects a lane pivot") {
     const auto run = prepare_fused_rotation_run(plan.actions);
     REQUIRE(run.rotation.has_value());
     REQUIRE(prepare_fused_rotation_neon_sidecar(*run.rotation).storage == nullptr);
+}
+
+TEST_CASE("Apple NEON direct rotation serial and parallel match scalar") {
+    constexpr uint32_t kActiveWidth = 10;
+    const std::array cases = {
+        std::pair{ActivePauli{0, 0b1010101011}, DirectRotationKernel::Diagonal},
+        std::pair{ActivePauli{0b0000000001, 0b1010101010}, DirectRotationKernel::LanePaired},
+        std::pair{ActivePauli{0b1000100101, 0b0111011011}, DirectRotationKernel::HighPivot},
+    };
+    for (const auto& [pauli, kernel] : cases) {
+        for (bool sign : {false, true}) {
+            CAPTURE(pauli.x, pauli.z, sign);
+            State expected(kActiveWidth, kActiveWidth);
+            State serial(kActiveWidth, kActiveWidth);
+            State parallel(kActiveWidth, kActiveWidth);
+            for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+                const double real = static_cast<double>((basis * 13) % 29 + 1) / 100.0;
+                const double imag = -static_cast<double>((basis * 7) % 23 + 1) / 90.0;
+                expected.real_data()[basis] = real;
+                expected.imag_data()[basis] = imag;
+                serial.real_data()[basis] = real;
+                serial.imag_data()[basis] = imag;
+                parallel.real_data()[basis] = real;
+                parallel.imag_data()[basis] = imag;
+            }
+            const auto rotation = prepare_rotation(pauli, kActiveWidth, 0.271);
+            apply_rotation(expected, rotation, sign);
+            apply_direct_rotation_neon(serial, rotation, kernel, sign);
+            apply_direct_rotation_neon_parallel(parallel, rotation, kernel, sign, 4, 0);
+            for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+                CAPTURE(basis);
+                REQUIRE_THAT(serial.real_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.real_data()[basis], 2e-12));
+                REQUIRE_THAT(serial.imag_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.imag_data()[basis], 2e-12));
+                REQUIRE_THAT(parallel.real_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.real_data()[basis], 2e-12));
+                REQUIRE_THAT(parallel.imag_data()[basis],
+                             Catch::Matchers::WithinAbs(expected.imag_data()[basis], 2e-12));
+            }
+        }
+    }
 }
 #endif
 

--- a/tests/test_fused_rotation.cc
+++ b/tests/test_fused_rotation.cc
@@ -1,5 +1,6 @@
 #include "clifft/sampling/executor.h"
 #include "clifft/sampling/fused_rotation.h"
+#include "clifft/sampling/kernel_dispatch.h"
 #include "clifft/sampling/kernels.h"
 #include "clifft/util/runtime_isa.h"
 
@@ -26,6 +27,8 @@ using clifft::sampling::Executor;
 using clifft::sampling::index;
 using clifft::sampling::PlannedAction;
 using clifft::sampling::prepare_dynamic_fused_rotation_run;
+using clifft::sampling::prepare_fused_rotation_neon_sidecar;
+using clifft::sampling::prepare_fused_rotation_run;
 using clifft::sampling::prepare_rotation;
 using clifft::sampling::RotateActivePauli;
 using clifft::sampling::SamplingPlan;
@@ -152,6 +155,68 @@ TEST_CASE("Fused rotation falls back for a rank three run") {
     };
     require_matches_scalar(rotation_plan(3, rotations), 0, 3);
 }
+
+#if defined(CLIFFT_TESTS_HAVE_APPLE_NEON)
+TEST_CASE("Apple NEON fused rotation matches scalar") {
+    const std::array rotations = {
+        RotateActivePauli{{0b000110, 0b001011}, 0.17, AffineBool(false)},
+        RotateActivePauli{{0b110001, 0b010101}, -0.23, AffineBool(true)},
+        RotateActivePauli{{0b110111, 0b100011}, 0.31, AffineBool(false)},
+        RotateActivePauli{{0b000110, 0b011001}, -0.11, AffineBool(true)},
+        RotateActivePauli{{0b110001, 0b101010}, 0.29, AffineBool(false)},
+    };
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    const auto run = prepare_fused_rotation_run(plan.actions);
+    REQUIRE(run.action_count == rotations.size());
+    REQUIRE(run.rotation.has_value());
+
+    const auto sidecar = prepare_fused_rotation_neon_sidecar(*run.rotation);
+    REQUIRE(sidecar.storage != nullptr);
+    REQUIRE(sidecar.kernel != nullptr);
+    REQUIRE(sidecar.parallel_kernel != nullptr);
+
+    State expected(6, 6);
+    State actual(6, 6);
+    State parallel(6, 6);
+    for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+        const double real = static_cast<double>(basis + 1) / 100.0;
+        const double imag = -static_cast<double>((basis * 7) % 19 + 1) / 80.0;
+        expected.real_data()[basis] = real;
+        expected.imag_data()[basis] = imag;
+        actual.real_data()[basis] = real;
+        actual.imag_data()[basis] = imag;
+        parallel.real_data()[basis] = real;
+        parallel.imag_data()[basis] = imag;
+    }
+
+    apply_fused_rotation(expected, *run.rotation);
+    sidecar.kernel(actual, *run.rotation, sidecar.storage.get());
+    sidecar.parallel_kernel(parallel, *run.rotation, sidecar.storage.get(), 4, 0);
+    for (uint64_t basis = 0; basis < expected.size(); ++basis) {
+        CAPTURE(basis);
+        REQUIRE_THAT(actual.real_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.real_data()[basis], 2e-12));
+        REQUIRE_THAT(actual.imag_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.imag_data()[basis], 2e-12));
+        REQUIRE_THAT(parallel.real_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.real_data()[basis], 2e-12));
+        REQUIRE_THAT(parallel.imag_data()[basis],
+                     Catch::Matchers::WithinAbs(expected.imag_data()[basis], 2e-12));
+    }
+}
+
+TEST_CASE("Apple NEON fused rotation rejects a lane pivot") {
+    const std::array rotations = {
+        RotateActivePauli{{0b000001, 0b001010}, 0.17, AffineBool(false)},
+        RotateActivePauli{{0b010100, 0b000101}, -0.23, AffineBool(true)},
+        RotateActivePauli{{0b010101, 0b100010}, 0.31, AffineBool(false)},
+    };
+    const SamplingPlan plan = rotation_plan(6, rotations);
+    const auto run = prepare_fused_rotation_run(plan.actions);
+    REQUIRE(run.rotation.has_value());
+    REQUIRE(prepare_fused_rotation_neon_sidecar(*run.rotation).storage == nullptr);
+}
+#endif
 
 TEST_CASE("Dynamic fused rotation matches scalar across affine sign values") {
     const SymbolId first_sign{0};

--- a/tests/test_runtime_isa.cc
+++ b/tests/test_runtime_isa.cc
@@ -12,8 +12,10 @@ using clifft::internal::validate_runtime_isa;
 
 TEST_CASE("Runtime ISA names are stable") {
     REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Scalar)) == "scalar");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Neon)) == "neon");
     REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Avx2)) == "avx2");
     REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::Avx512)) == "avx512");
+    REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapNeon)) == "trap:neon");
     REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapAvx2)) == "trap:avx2");
     REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapAvx512)) == "trap:avx512");
     REQUIRE(std::string_view(runtime_isa_name(RuntimeIsa::TrapUnknown)) == "trap:unknown");
@@ -21,11 +23,14 @@ TEST_CASE("Runtime ISA names are stable") {
 
 TEST_CASE("Runtime ISA validates executable selections") {
     REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Scalar));
+    REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Neon));
     REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Avx2));
     REQUIRE_NOTHROW(validate_runtime_isa(RuntimeIsa::Avx512));
 }
 
 TEST_CASE("Runtime ISA reports forced selection errors") {
+    REQUIRE_THROWS_WITH(validate_runtime_isa(RuntimeIsa::TrapNeon),
+                        ContainsSubstring("CLIFFT_FORCE_ISA=neon requested"));
     REQUIRE_THROWS_WITH(validate_runtime_isa(RuntimeIsa::TrapAvx2),
                         ContainsSubstring("CLIFFT_FORCE_ISA=avx2 requested"));
     REQUIRE_THROWS_WITH(validate_runtime_isa(RuntimeIsa::TrapAvx512),

--- a/tests/test_sampling_kernels.cc
+++ b/tests/test_sampling_kernels.cc
@@ -18,12 +18,14 @@
 
 using clifft::internal::RuntimeIsa;
 using clifft::sampling::activate_zero_coordinate;
+using clifft::sampling::active_measurement_probabilities_neon;
 using clifft::sampling::ActiveMeasurementKernel;
 using clifft::sampling::ActivePauli;
 using clifft::sampling::apply_instrument_no_fire;
 using clifft::sampling::apply_new_x_instrument_no_fire;
 using clifft::sampling::apply_promotion;
 using clifft::sampling::apply_rotation;
+using clifft::sampling::collapse_active_measurement_neon;
 using clifft::sampling::collapse_instrument_source;
 using clifft::sampling::collapse_measurement;
 using clifft::sampling::collapse_new_x_instrument_source;
@@ -351,10 +353,20 @@ TEST_CASE("Direct rotation SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b10000, 0b01111}, 5, ExecutorBackend::Avx2) ==
             DirectRotationKernel::HighPivot);
     REQUIRE(select({0b01, 0b10}, 2, ExecutorBackend::Scalar) == DirectRotationKernel::Scalar);
+
+    REQUIRE(select({0, 0b11}, 2, ExecutorBackend::Neon) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0, 0b101}, 3, ExecutorBackend::Neon) == DirectRotationKernel::Diagonal);
+    REQUIRE(select({0b100, 0b011}, 3, ExecutorBackend::Neon) == DirectRotationKernel::Scalar);
+    REQUIRE(select({0b1000, 0b0111}, 4, ExecutorBackend::Neon) == DirectRotationKernel::HighPivot);
+    REQUIRE(select({0b001, 0b110}, 3, ExecutorBackend::Neon) == DirectRotationKernel::LanePaired);
+    REQUIRE(select({0b0001, 0b1110}, 4, ExecutorBackend::Neon) == DirectRotationKernel::LanePaired);
+    REQUIRE(select({0b000001, 0b111110}, 6, ExecutorBackend::Neon) ==
+            DirectRotationKernel::LanePaired);
 }
 
 TEST_CASE("Sampling executor backend follows the resolved process ISA") {
     REQUIRE(resolve_executor_backend(RuntimeIsa::Scalar) == ExecutorBackend::Scalar);
+    REQUIRE(resolve_executor_backend(RuntimeIsa::Neon) == ExecutorBackend::Neon);
     REQUIRE(resolve_executor_backend(RuntimeIsa::Avx2) == ExecutorBackend::Avx2);
     REQUIRE(resolve_executor_backend(RuntimeIsa::Avx512) == ExecutorBackend::Avx512);
     REQUIRE_THROWS(resolve_executor_backend(RuntimeIsa::TrapUnknown));
@@ -382,6 +394,11 @@ TEST_CASE("Active measurement SIMD selection preserves scalar boundaries") {
     REQUIRE(select({0b100, 0b011}, 3, 2, ExecutorBackend::Avx2) ==
             ActiveMeasurementKernel::HighPivot);
     REQUIRE(select({0b01, 0b110}, 3, 0, ExecutorBackend::Scalar) ==
+            ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0, 0b10000}, 5, 4, ExecutorBackend::Neon) == ActiveMeasurementKernel::Scalar);
+    REQUIRE(select({0, 0b100000}, 6, 5, ExecutorBackend::Neon) ==
+            ActiveMeasurementKernel::Diagonal);
+    REQUIRE(select({0b100000, 0b011111}, 6, 5, ExecutorBackend::Neon) ==
             ActiveMeasurementKernel::Scalar);
 }
 
@@ -643,6 +660,50 @@ TEST_CASE("Diagonal active measurement SIMD matches scalar compaction") {
                     }
                     require_vectors_close(coefficients(vector_state), coefficients(scalar_state));
                 }
+            }
+        }
+    }
+}
+#endif
+
+#if defined(CLIFFT_TESTS_HAVE_APPLE_NEON)
+TEST_CASE("Apple NEON diagonal measurement matches scalar compaction") {
+    constexpr uint32_t kActiveWidth = 6;
+    const uint64_t z_limit = uint64_t{1} << kActiveWidth;
+    const std::vector<std::complex<double>> input = deterministic_state(kActiveWidth);
+    for (uint64_t z = 1; z < z_limit; ++z) {
+        for (uint32_t pivot : valid_measurement_pivots(0, z, kActiveWidth)) {
+            const uint64_t pivot_bit = uint64_t{1} << pivot;
+            if ((z & (pivot_bit - 1)) != 0) {
+                continue;
+            }
+            CAPTURE(z, pivot);
+            const PreparedMeasurement measurement =
+                prepare_measurement({0, z}, kActiveWidth, pivot);
+            State scalar_probability_state(kActiveWidth, kActiveWidth);
+            load_state(scalar_probability_state, input);
+            const MeasurementProbabilities expected =
+                measurement_probabilities(scalar_probability_state, measurement);
+
+            State vector_probability_state(kActiveWidth, kActiveWidth);
+            load_state(vector_probability_state, input);
+            const MeasurementProbabilities actual = active_measurement_probabilities_neon(
+                vector_probability_state, measurement, ActiveMeasurementKernel::Diagonal);
+            REQUIRE_THAT(actual.zero, Catch::Matchers::WithinAbs(expected.zero, kTolerance));
+            REQUIRE_THAT(actual.one, Catch::Matchers::WithinAbs(expected.one, kTolerance));
+
+            for (bool branch : {false, true}) {
+                State scalar_state(kActiveWidth, kActiveWidth);
+                load_state(scalar_state, input);
+                collapse_measurement(scalar_state, measurement, branch,
+                                     expected.for_branch(branch));
+
+                State vector_state(kActiveWidth, kActiveWidth);
+                load_state(vector_state, input);
+                collapse_active_measurement_neon(vector_state, measurement,
+                                                 ActiveMeasurementKernel::Diagonal, branch,
+                                                 actual.for_branch(branch));
+                require_vectors_close(coefficients(vector_state), coefficients(scalar_state));
             }
         }
     }


### PR DESCRIPTION
Closes #299.

## Summary

- add an Apple arm64 NEON executor backend without raising the portable baseline;
- specialize profitable direct Pauli rotations, eligible rank-two fused rotations, and diagonal active-measurement probability/collapse;
- precompute fused kernel weights during executable construction, keeping ordinary dispatch allocation-free and exception-free;
- retain scalar kernels for unsupported shapes and measured width crossovers;
- expose `neon` through `runtime_isa()` and `CLIFFT_FORCE_ISA` for diagnostics and differential benchmarks;
- preserve the existing ISA-neutral plan and executable action descriptors.

Apple Silicon guarantees the 128-bit AArch64 Advanced SIMD baseline, so this backend does not need a generation-specific feature probe. The measured crossover thresholds are intentionally shape-specific. Serial and intra-shot-parallel execution use the same prepared backend selection.

The packed batch executor added by #407 is independent and continues to use its basis-major interleaved implementation. It bypasses the per-shot NEON backend; packed auto-policy follow-up work is tracked in #415.

## Performance

Release build on an M4 Pro with AppleClang 17, OpenMP disabled, one thread, and corpus circuits from `unitaryfoundation/clifft-bench`. Each row compares the same branch forced to `scalar` versus `neon`; parsing and compilation are outside the timed interval. QEC survivor workloads postselect every detector.

| workload | shots per call | peak active width | scalar median | NEON median | speedup |
|---|---:|---:|---:|---:|---:|
| coherent d3 r3 | 100,000 | 7 | 249.67 ms | 175.33 ms | 1.42x |
| coherent d5 r1 | 10,000 | 12 | 1092.70 ms | 808.08 ms | 1.35x |
| coherent d5 r5 | 1 | 22 | 139.50 ms | 86.51 ms | 1.61x |
| cultivation d5 | 20,000 | 10 | 175.72 ms | 130.99 ms | 1.34x |
| quantum volume 10 | 100 | 10 | 6.38 ms | 4.68 ms | 1.36x |
| quantum volume 20 | 1 | 20 | 270.80 ms | 207.68 ms | 1.30x |

Pure-Clifford surface-code execution has no active-state kernels and therefore does not benefit from this backend. Low-width workloads selected by automatic packed batching likewise bypass it.

The expanded direct-rotation and measurement kernels are material rather than incidental: compared with the first fused-only commit, the full backend reduced another 23-37% from the coherent/cultivation workload medians. On QV10 and QV20, where fused actions are common, the expansion reduced another 13% and 4%, respectively.

## Cross-generation behavior

All supported Apple Silicon generations provide the NEON instructions used here. This PR therefore does not introduce M1/M2/M3/M4-specific binaries analogous to AVX2 versus AVX-512. Microarchitectural differences can move small-state crossover points, but unsupported or below-threshold shapes retain the scalar implementation. The performance thresholds in this PR were measured on M4 Pro.

## Validation

- full Debug C++ suite: 923/923 tests passed;
- rebuilt Python extension: 1,364 passed, 6 skipped, 1 expected failure;
- scalar differential coverage for fused rotations, all direct-rotation shapes, and diagonal measurement probability/collapse;
- serial and intra-shot-parallel kernel coverage;
- runtime ISA selection and forced-backend integration coverage;
- optimized Release profiling build;
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`.
