### PR TITLE
fix(sampling): defer classical postselection lane compaction

### DIFF
--- a/src/clifft/sampling/batch/executor.cc
+++ b/src/clifft/sampling/batch/executor.cc
@@ -606,6 +606,12 @@ bool BatchExecutor::should_compact(size_t action_index) const noexcept {
     if (live_count_ == 0 || live_count_ == active_lanes()) {
         return false;
     }
+    // Classical packed actions already carry rejected lanes as masked bits. With
+    // no coefficient state, reclaiming those lanes cannot reduce the fixed-width
+    // sidecar operations enough to justify moving every retained column.
+    if (plan_->peak_active_width() == 0) {
+        return false;
+    }
     const uint64_t remaining_actions = plan_->actions_.size() - action_index - 1;
     if (remaining_actions == 0) {
         return false;

--- a/tools/profile/README.md
+++ b/tools/profile/README.md
@@ -58,6 +58,7 @@ the public sampling API.
 
 ```bash
 CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim \
+  CLIFFT_PROFILE_API=sample \
   CLIFFT_PROFILE_SHOTS=1 \
   CLIFFT_PROFILE_THREADS=1 \
   ./build-profile/profile_sample
@@ -73,11 +74,44 @@ CLIFFT_CIRCUIT_FILE=tools/bench/fixtures/qv20_seed42.stim \
 | `CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH` | 18 | Expert kernel threshold; requires an explicit layout |
 | `CLIFFT_PROFILE_WARMUPS` | 2 | Untimed sample calls |
 | `CLIFFT_PROFILE_REPETITIONS` | 20 | Timed sample calls |
+| `CLIFFT_PROFILE_API` | `sample` | Public API to profile: `sample`, `sample_survivors`, `sample_k`, or `sample_k_survivors` |
 | `CLIFFT_PROFILE_BATCH_SIZE` | auto | Force a positive packed lane capacity; `1` selects scalar execution |
-| `CLIFFT_PROFILE_AGGREGATE_SURVIVORS` | unset | Profile counts-only survivor sampling instead of fixed-row output |
-| `CLIFFT_PROFILE_POSTSELECT_ALL` | unset | Mark every detector for postselection; requires aggregate survivors |
+| `CLIFFT_PROFILE_KEEP_RECORDS` | unset | Retain surviving rows for either survivor API |
+| `CLIFFT_PROFILE_FIXED_K` | 1 | Fault count for either fixed-fault API |
+| `CLIFFT_PROFILE_POSTSELECTION` | `none` | Survivor detector mask: `none`, `all`, `first-half`, `last-half`, or `alternating` |
+| `CLIFFT_PROFILE_AGGREGATE_SURVIVORS` | unset | Legacy alias selecting `sample_survivors` when `CLIFFT_PROFILE_API` is unset |
+| `CLIFFT_PROFILE_POSTSELECT_ALL` | unset | Legacy alias for `CLIFFT_PROFILE_POSTSELECTION=all` |
 | `CLIFFT_PROFILE_GENERATED_WIDTH` | unset | Generate a rotation-heavy circuit of this width instead of loading a file |
 | `CLIFFT_PROFILE_GENERATED_DEPTH` | 20 | Layers in the generated circuit |
+
+The profiler prints a final `RESULT` line with the requested batch setting,
+effective lane capacity and worker count, timing, survival rate, and retained
+row count. For example, this compares scalar and automatic execution of the
+aggregate survivor path with every detector postselected:
+
+```bash
+for batch in 1 auto; do
+  env CLIFFT_CIRCUIT_FILE=tests/fixtures/surface_d7_r7_p001.stim \
+    CLIFFT_PROFILE_API=sample_survivors \
+    CLIFFT_PROFILE_KEEP_RECORDS=0 \
+    CLIFFT_PROFILE_POSTSELECTION=all \
+    CLIFFT_PROFILE_SHOTS=100000 \
+    CLIFFT_PROFILE_BATCH_SIZE="$batch" \
+    ./build-profile/profile_sample
+done
+```
+
+To run the complete public-API matrix and retain the raw results as CSV:
+
+```bash
+python3 tools/profile/run_sampling_mode_matrix.py \
+  --output /tmp/clifft-sampling-mode-matrix.csv
+```
+
+The matrix covers ordinary and fixed-fault sampling, aggregate and retained
+survivor output, with and without postselection. Explicit capacities can be
+changed with `--batches`; scalar (`1`) and `auto` are always required. Use
+`--apis`, `--keep-records`, and `--postselection` to run a focused subset.
 
 ## Probability queries
 

--- a/tools/profile/profile_sample.cpp
+++ b/tools/profile/profile_sample.cpp
@@ -10,9 +10,13 @@
 #include "clifft/frontend/frontend.h"
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_factory.h"
+#include "clifft/sampling/batch/policy.h"
 #include "clifft/sampling/executable_plan.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
+#include "clifft/util/fault_sampling.h"
+#include "clifft/util/intra_shot_parallel.h"
+#include "clifft/util/shot_parallel.h"
 
 #include <algorithm>
 #include <bit>
@@ -20,11 +24,15 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -37,9 +45,69 @@ constexpr int kDefaultRepetitions = 20;
 constexpr int kDefaultGeneratedDepth = 20;
 constexpr uint64_t kSeed = 42;
 
+enum class ProfileApi : uint8_t {
+    Sample,
+    SampleSurvivors,
+    SampleK,
+    SampleKSurvivors,
+};
+
+struct SamplingSummary {
+    double minimum = 0.0;
+    double median = 0.0;
+    double mean = 0.0;
+    double p95 = 0.0;
+    double maximum = 0.0;
+};
+
 int get_env_int(const char* name, int default_value) {
     const char* value = std::getenv(name);
     return value == nullptr ? default_value : std::stoi(value);
+}
+
+std::string get_env_string(const char* name, std::string default_value) {
+    const char* value = std::getenv(name);
+    return value == nullptr ? std::move(default_value) : std::string(value);
+}
+
+ProfileApi parse_profile_api(std::string_view value) {
+    if (value == "sample") {
+        return ProfileApi::Sample;
+    }
+    if (value == "sample_survivors") {
+        return ProfileApi::SampleSurvivors;
+    }
+    if (value == "sample_k") {
+        return ProfileApi::SampleK;
+    }
+    if (value == "sample_k_survivors") {
+        return ProfileApi::SampleKSurvivors;
+    }
+    std::cerr << "Error: API must be sample, sample_survivors, sample_k, or "
+                 "sample_k_survivors\n";
+    std::exit(1);
+}
+
+const char* profile_api_name(ProfileApi api) noexcept {
+    switch (api) {
+        case ProfileApi::Sample:
+            return "sample";
+        case ProfileApi::SampleSurvivors:
+            return "sample_survivors";
+        case ProfileApi::SampleK:
+            return "sample_k";
+        case ProfileApi::SampleKSurvivors:
+            return "sample_k_survivors";
+    }
+    return "unknown";
+}
+
+bool is_survivor_api(ProfileApi api) noexcept {
+    return api == ProfileApi::SampleSurvivors || api == ProfileApi::SampleKSurvivors;
+}
+
+bool is_fixed_k_api(ProfileApi api) noexcept {
+    return api == ProfileApi::SampleK || api == ProfileApi::SampleKSurvivors;
 }
 
 std::string read_file(const std::string& path) {
@@ -101,6 +169,18 @@ uint64_t checksum_result(const clifft::sampling::SamplingSurvivorResult& result)
     for (uint64_t value : result.observable_ones) {
         checksum = mix(checksum, value);
     }
+    for (uint8_t value : result.measurements) {
+        checksum = mix(checksum, value);
+    }
+    for (uint8_t value : result.detectors) {
+        checksum = mix(checksum, value);
+    }
+    for (uint8_t value : result.observables) {
+        checksum = mix(checksum, value);
+    }
+    for (double value : result.exp_vals) {
+        checksum = mix(checksum, std::bit_cast<uint64_t>(value));
+    }
     return checksum;
 }
 
@@ -111,7 +191,7 @@ uint64_t checksum_result(const ProfileResult& result) {
     return std::visit([](const auto& typed) { return checksum_result(typed); }, result);
 }
 
-void summarize(std::vector<double> samples_ms, int shots) {
+SamplingSummary summarize(std::vector<double> samples_ms, int shots) {
     std::sort(samples_ms.begin(), samples_ms.end());
     const double sum = std::accumulate(samples_ms.begin(), samples_ms.end(), 0.0);
     const double mean = sum / static_cast<double>(samples_ms.size());
@@ -125,6 +205,62 @@ void summarize(std::vector<double> samples_ms, int shots) {
     std::cout << "  p95:    " << p95 << " ms\n";
     std::cout << "  max:    " << samples_ms.back() << " ms\n";
     std::cout << "  median per shot: " << median / static_cast<double>(shots) << " ms\n";
+    return {.minimum = samples_ms.front(),
+            .median = median,
+            .mean = mean,
+            .p95 = p95,
+            .maximum = samples_ms.back()};
+}
+
+std::vector<uint8_t> make_postselection_mask(std::string_view mode, uint32_t detectors) {
+    std::vector<uint8_t> mask(detectors, 0);
+    if (mode == "none") {
+        return mask;
+    }
+    if (mode == "all") {
+        std::ranges::fill(mask, uint8_t{1});
+        return mask;
+    }
+    if (mode == "first-half") {
+        std::ranges::fill(mask.begin(), mask.begin() + (mask.size() + 1) / 2, uint8_t{1});
+        return mask;
+    }
+    if (mode == "last-half") {
+        std::ranges::fill(mask.begin() + mask.size() / 2, mask.end(), uint8_t{1});
+        return mask;
+    }
+    if (mode == "alternating") {
+        for (size_t detector = 0; detector < mask.size(); detector += 2) {
+            mask[detector] = 1;
+        }
+        return mask;
+    }
+    std::cerr << "Error: postselection must be none, all, first-half, last-half, or "
+                 "alternating\n";
+    std::exit(1);
+}
+
+clifft::sampling::ThreadLayout resolve_profile_thread_layout(
+    const clifft::sampling::ExecutablePlan& plan, uint32_t shots, uint32_t threads,
+    std::optional<clifft::sampling::ThreadLayout> override) {
+    if (override.has_value()) {
+        override->shot_workers = std::min(override->shot_workers, shots);
+        if (!clifft::should_parallelize_intra_shot(plan.peak_active_width(),
+                                                   override->intra_shot_workers,
+                                                   override->intra_shot_min_active_width)) {
+            override->intra_shot_workers = 1;
+        }
+        return *override;
+    }
+    const uint32_t budget = clifft::resolve_thread_budget(threads);
+    if (shots < budget &&
+        clifft::should_parallelize_intra_shot(plan.peak_active_width(), budget,
+                                              clifft::kDefaultIntraShotMinActiveWidth)) {
+        return {.shot_workers = 1,
+                .intra_shot_workers = budget,
+                .intra_shot_min_active_width = clifft::kDefaultIntraShotMinActiveWidth};
+    }
+    return {.shot_workers = std::min(shots, budget), .intra_shot_workers = 1};
 }
 
 }  // namespace
@@ -138,19 +274,32 @@ int main() {
     const int generated_width = get_env_int("CLIFFT_PROFILE_GENERATED_WIDTH", 0);
     const int generated_depth =
         get_env_int("CLIFFT_PROFILE_GENERATED_DEPTH", kDefaultGeneratedDepth);
-    const bool aggregate_survivors = get_env_int("CLIFFT_PROFILE_AGGREGATE_SURVIVORS", 0) != 0;
-    const bool postselect_all = get_env_int("CLIFFT_PROFILE_POSTSELECT_ALL", 0) != 0;
+    const char* api_value = std::getenv("CLIFFT_PROFILE_API");
+    const bool legacy_aggregate_survivors =
+        get_env_int("CLIFFT_PROFILE_AGGREGATE_SURVIVORS", 0) != 0;
+    const ProfileApi api = parse_profile_api(
+        api_value == nullptr ? (legacy_aggregate_survivors ? "sample_survivors" : "sample")
+                             : api_value);
+    const bool keep_records = get_env_int("CLIFFT_PROFILE_KEEP_RECORDS", 0) != 0;
+    const char* fixed_k_value = std::getenv("CLIFFT_PROFILE_FIXED_K");
+    const int fixed_k = get_env_int("CLIFFT_PROFILE_FIXED_K", 1);
+    const bool legacy_postselect_all = get_env_int("CLIFFT_PROFILE_POSTSELECT_ALL", 0) != 0;
+    const std::string postselection =
+        get_env_string("CLIFFT_PROFILE_POSTSELECTION",
+                       legacy_postselect_all ? std::string("all") : std::string("none"));
     const char* shot_workers_value = std::getenv("CLIFFT_PROFILE_SHOT_WORKERS");
     const char* intra_workers_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_WORKERS");
     const char* min_active_width_value = std::getenv("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH");
     const char* batch_size_value = std::getenv("CLIFFT_PROFILE_BATCH_SIZE");
+    const bool batch_is_auto =
+        batch_size_value == nullptr || std::string_view(batch_size_value) == "auto";
     const bool has_layout = shot_workers_value != nullptr || intra_workers_value != nullptr;
     const int shot_workers = get_env_int("CLIFFT_PROFILE_SHOT_WORKERS", 0);
     const int intra_shot_workers = get_env_int("CLIFFT_PROFILE_INTRA_SHOT_WORKERS", 0);
     const int intra_shot_min_active_width =
         get_env_int("CLIFFT_PROFILE_INTRA_SHOT_MIN_ACTIVE_WIDTH",
                     static_cast<int>(clifft::kDefaultIntraShotMinActiveWidth));
-    const int batch_size = get_env_int("CLIFFT_PROFILE_BATCH_SIZE", 0);
+    const int batch_size = batch_is_auto ? 0 : std::stoi(batch_size_value);
     if (shots < 1 || threads < 0 || warmups < 0 || repetitions < 1) {
         std::cerr << "Error: shots and repetitions must be positive; threads and warmups must be "
                      "non-negative\n";
@@ -176,12 +325,24 @@ int main() {
         std::cerr << "Error: the intra-shot minimum active width must be non-negative\n";
         return 1;
     }
-    if (batch_size_value != nullptr && batch_size < 1) {
-        std::cerr << "Error: batch size must be positive\n";
+    if (!batch_is_auto && batch_size < 1) {
+        std::cerr << "Error: batch size must be a positive integer or auto\n";
         return 1;
     }
-    if (postselect_all && !aggregate_survivors) {
-        std::cerr << "Error: postselection requires aggregate survivor profiling\n";
+    if (!is_survivor_api(api) && postselection != "none") {
+        std::cerr << "Error: postselection requires a survivor sampling API\n";
+        return 1;
+    }
+    if (!is_survivor_api(api) && keep_records) {
+        std::cerr << "Error: keep_records requires a survivor sampling API\n";
+        return 1;
+    }
+    if (!is_fixed_k_api(api) && fixed_k_value != nullptr) {
+        std::cerr << "Error: fixed k requires sample_k or sample_k_survivors\n";
+        return 1;
+    }
+    if (fixed_k < 0) {
+        std::cerr << "Error: fixed k must be non-negative\n";
         return 1;
     }
 
@@ -195,6 +356,14 @@ int main() {
     }
     std::cout << "Shots:       " << shots << "\n";
     std::cout << "Threads:     " << threads << "\n";
+    std::cout << "API:         " << profile_api_name(api) << "\n";
+    if (is_survivor_api(api)) {
+        std::cout << "Keep rows:   " << (keep_records ? "yes" : "no") << "\n";
+        std::cout << "Postselect:  " << postselection << "\n";
+    }
+    if (is_fixed_k_api(api)) {
+        std::cout << "Fixed k:     " << fixed_k << "\n";
+    }
     if (has_layout) {
         std::cout << "Layout:      " << shot_workers << " shot x " << intra_shot_workers
                   << " intra-shot\n";
@@ -202,9 +371,8 @@ int main() {
     }
     std::cout << "Warmups:     " << warmups << "\n";
     std::cout << "Repetitions: " << repetitions << "\n";
-    if (batch_size_value != nullptr) {
-        std::cout << "Batch size:  " << batch_size << "\n";
-    }
+    std::cout << "Batch req:   "
+              << (batch_is_auto ? std::string("auto") : std::to_string(batch_size)) << "\n";
     std::cout << "\n";
 
     const std::string circuit_text = circuit_file != nullptr && !std::string(circuit_file).empty()
@@ -214,10 +382,8 @@ int main() {
     clifft::HirModule hir = clifft::trace(circuit);
     auto pass_manager = clifft::default_hir_pass_manager();
     pass_manager.run(hir);
-    std::vector<uint8_t> postselection_mask;
-    if (postselect_all) {
-        postselection_mask.assign(hir.num_detectors, 1);
-    }
+    const std::vector<uint8_t> postselection_mask =
+        make_postselection_mask(postselection, hir.num_detectors);
     clifft::sampling::SamplingPlanOptions plan_options;
     plan_options.postselection_mask = postselection_mask;
     clifft::sampling::SamplingPlan plan = clifft::sampling::plan_sampling(hir, plan_options);
@@ -237,17 +403,69 @@ int main() {
                                                                      intra_shot_min_active_width)}}
             : std::nullopt;
     const std::optional<uint32_t> requested_batch_size =
-        batch_size_value == nullptr ? std::nullopt
-                                    : std::optional<uint32_t>{static_cast<uint32_t>(batch_size)};
+        batch_is_auto ? std::nullopt : std::optional<uint32_t>{static_cast<uint32_t>(batch_size)};
+    const clifft::sampling::ThreadLayout resolved_layout = resolve_profile_thread_layout(
+        program, static_cast<uint32_t>(shots), static_cast<uint32_t>(threads), thread_layout);
+    const clifft::sampling::BatchOutputMode output_mode =
+        is_survivor_api(api) && !keep_records
+            ? clifft::sampling::BatchOutputMode::AggregateSurvivors
+            : clifft::sampling::BatchOutputMode::Rows;
+    const clifft::sampling::BatchSamplingMode sampling_mode =
+        is_fixed_k_api(api) ? clifft::sampling::BatchSamplingMode::FixedFaults
+                            : clifft::sampling::BatchSamplingMode::Ordinary;
+    uint64_t additional_worker_bytes =
+        is_survivor_api(api) ? static_cast<uint64_t>(program.num_observables()) * sizeof(uint64_t)
+                             : 0;
+    std::unique_ptr<clifft::KFaultDistribution> fault_distribution;
+    if (is_fixed_k_api(api)) {
+        fault_distribution = std::make_unique<clifft::KFaultDistribution>(
+            program.noise_site_probabilities(), static_cast<uint32_t>(fixed_k));
+        additional_worker_bytes += fault_distribution->worker_scratch_bytes();
+    }
+    const clifft::sampling::BatchExecutionPolicy batch_policy =
+        clifft::sampling::resolve_batch_execution_policy(
+            program, static_cast<uint32_t>(shots), resolved_layout.shot_workers,
+            resolved_layout.intra_shot_workers, output_mode, requested_batch_size, sampling_mode,
+            additional_worker_bytes);
+    const uint32_t effective_workers =
+        batch_policy.lane_capacity > 1 ? batch_policy.worker_count : resolved_layout.shot_workers;
+    const uint64_t batch_worker_bytes =
+        batch_policy.lane_capacity > 1
+            ? clifft::sampling::batch_detail::batch_worker_storage_bytes(
+                  program, batch_policy.lane_capacity, output_mode, sampling_mode) +
+                  additional_worker_bytes
+            : 0;
+
+    std::cout << "Policy: " << batch_policy.lane_capacity << " lanes x " << effective_workers
+              << " workers; layout " << resolved_layout.shot_workers << " shot x "
+              << resolved_layout.intra_shot_workers << " intra-shot";
+    if (batch_worker_bytes != 0) {
+        std::cout << "; " << batch_worker_bytes << " retained bytes/worker";
+    }
+    std::cout << "\n\n";
+
     const auto run_sample = [&](uint64_t sample_seed) -> ProfileResult {
-        if (aggregate_survivors) {
-            return clifft::sampling::sample_survivors(
-                program, static_cast<uint32_t>(shots), sample_seed, false,
-                static_cast<uint32_t>(threads), thread_layout, requested_batch_size);
+        switch (api) {
+            case ProfileApi::Sample:
+                return clifft::sampling::sample(program, static_cast<uint32_t>(shots), sample_seed,
+                                                static_cast<uint32_t>(threads), thread_layout,
+                                                requested_batch_size);
+            case ProfileApi::SampleSurvivors:
+                return clifft::sampling::sample_survivors(
+                    program, static_cast<uint32_t>(shots), sample_seed, keep_records,
+                    static_cast<uint32_t>(threads), thread_layout, requested_batch_size);
+            case ProfileApi::SampleK:
+                return clifft::sampling::sample_k(program, static_cast<uint32_t>(shots),
+                                                  static_cast<uint32_t>(fixed_k), sample_seed,
+                                                  static_cast<uint32_t>(threads), thread_layout,
+                                                  requested_batch_size);
+            case ProfileApi::SampleKSurvivors:
+                return clifft::sampling::sample_k_survivors(
+                    program, static_cast<uint32_t>(shots), static_cast<uint32_t>(fixed_k),
+                    sample_seed, keep_records, static_cast<uint32_t>(threads), thread_layout,
+                    requested_batch_size);
         }
-        return clifft::sampling::sample(program, static_cast<uint32_t>(shots), sample_seed,
-                                        static_cast<uint32_t>(threads), thread_layout,
-                                        requested_batch_size);
+        std::abort();
     };
 
     uint64_t checksum = 0;
@@ -258,15 +476,35 @@ int main() {
 
     std::vector<double> samples_ms;
     samples_ms.reserve(static_cast<size_t>(repetitions));
+    uint32_t passed_shots = static_cast<uint32_t>(shots);
+    size_t retained_rows = static_cast<size_t>(shots);
     for (int iteration = 0; iteration < repetitions; ++iteration) {
         const auto start = std::chrono::steady_clock::now();
         const ProfileResult result = run_sample(kSeed + warmups + iteration);
         const auto end = std::chrono::steady_clock::now();
         samples_ms.push_back(std::chrono::duration<double, std::milli>(end - start).count());
         checksum = mix(checksum, checksum_result(result));
+        if (const auto* survivor = std::get_if<clifft::sampling::SamplingSurvivorResult>(&result)) {
+            passed_shots = survivor->passed_shots;
+            retained_rows = keep_records ? survivor->passed_shots : 0;
+        }
     }
 
-    summarize(samples_ms, shots);
+    const SamplingSummary summary = summarize(samples_ms, shots);
     std::cout << "Checksum: " << checksum << "\n";
+    std::cout << std::setprecision(10) << "RESULT" << " api=" << profile_api_name(api)
+              << " keep_records=" << static_cast<int>(keep_records)
+              << " fixed_k=" << (is_fixed_k_api(api) ? fixed_k : -1)
+              << " postselection=" << (is_survivor_api(api) ? postselection : "none")
+              << " requested_batch="
+              << (batch_is_auto ? std::string("auto") : std::to_string(batch_size))
+              << " effective_batch=" << batch_policy.lane_capacity
+              << " effective_workers=" << effective_workers
+              << " shot_workers=" << resolved_layout.shot_workers
+              << " intra_shot_workers=" << resolved_layout.intra_shot_workers
+              << " worker_bytes=" << batch_worker_bytes << " median_ms=" << summary.median
+              << " mean_ms=" << summary.mean << " passed_shots=" << passed_shots
+              << " survival=" << static_cast<double>(passed_shots) / static_cast<double>(shots)
+              << " retained_rows=" << retained_rows << " checksum=" << checksum << "\n";
     return 0;
 }

--- a/tools/profile/run_sampling_mode_matrix.py
+++ b/tools/profile/run_sampling_mode_matrix.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Compare scalar, automatic, and explicit batching across public sampling APIs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Mode:
+    api: str
+    keep_records: int = 0
+    postselection: str = "none"
+
+    @property
+    def name(self) -> str:
+        if self.api in {"sample", "sample_k"}:
+            return self.api
+        return f"{self.api}/keep={self.keep_records}/ps={self.postselection}"
+
+
+def parse_result(output: str) -> dict[str, str]:
+    for line in reversed(output.splitlines()):
+        if line.startswith("RESULT "):
+            return dict(field.split("=", 1) for field in line.split()[1:])
+    raise RuntimeError("profile_sample did not emit a RESULT line")
+
+
+def run_case(
+    executable: Path,
+    circuit: Path,
+    mode: Mode,
+    batch: str,
+    args: argparse.Namespace,
+) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CLIFFT_CIRCUIT_FILE": str(circuit),
+            "CLIFFT_PROFILE_API": mode.api,
+            "CLIFFT_PROFILE_KEEP_RECORDS": str(mode.keep_records),
+            "CLIFFT_PROFILE_POSTSELECTION": mode.postselection,
+            "CLIFFT_PROFILE_FIXED_K": str(args.fixed_k),
+            "CLIFFT_PROFILE_SHOTS": str(args.shots),
+            "CLIFFT_PROFILE_THREADS": str(args.threads),
+            "CLIFFT_PROFILE_WARMUPS": str(args.warmups),
+            "CLIFFT_PROFILE_REPETITIONS": str(args.repetitions),
+            "CLIFFT_PROFILE_BATCH_SIZE": batch,
+        }
+    )
+    if mode.api not in {"sample_k", "sample_k_survivors"}:
+        environment.pop("CLIFFT_PROFILE_FIXED_K")
+    completed = subprocess.run(
+        [str(executable)],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"{mode.name} batch={batch} failed with exit {completed.returncode}:\n"
+            f"{completed.stdout}{completed.stderr}"
+        )
+    result = parse_result(completed.stdout)
+    result["mode"] = mode.name
+    result["circuit"] = str(circuit)
+    return result
+
+
+def classify(scalar_ms: float, auto: dict[str, str], threshold: float) -> str:
+    if int(auto["effective_batch"]) == 1:
+        return "auto-ineligible"
+    auto_ms = float(auto["median_ms"])
+    if auto_ms > scalar_ms * (1.0 + threshold):
+        return "regression"
+    if auto_ms < scalar_ms * (1.0 - threshold):
+        return "win"
+    return "neutral"
+
+
+def format_change(scalar_ms: float, candidate_ms: float) -> str:
+    return f"{(candidate_ms / scalar_ms - 1.0) * 100.0:+.1f}%"
+
+
+def build_modes(
+    apis: list[str], keep_records_modes: list[int], postselection_modes: list[str]
+) -> list[Mode]:
+    modes = [Mode(api) for api in ("sample", "sample_k") if api in apis]
+    for api in ("sample_survivors", "sample_k_survivors"):
+        if api not in apis:
+            continue
+        for keep_records in keep_records_modes:
+            for postselection in postselection_modes:
+                modes.append(Mode(api, keep_records, postselection))
+    return modes
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    fields = ["circuit", "mode"]
+    fields.extend(key for key in rows[0] if key not in fields)
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--executable", type=Path, default=Path("build-profile/profile_sample"))
+    parser.add_argument(
+        "--circuit", type=Path, default=Path("tests/fixtures/surface_d7_r7_p001.stim")
+    )
+    parser.add_argument("--shots", type=int, default=100_000)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--repetitions", type=int, default=7)
+    parser.add_argument("--fixed-k", type=int, default=1)
+    parser.add_argument(
+        "--apis",
+        nargs="+",
+        default=["sample", "sample_survivors", "sample_k", "sample_k_survivors"],
+        choices=["sample", "sample_survivors", "sample_k", "sample_k_survivors"],
+    )
+    parser.add_argument("--keep-records", nargs="+", type=int, default=[0, 1], choices=[0, 1])
+    parser.add_argument("--batches", nargs="+", default=["1", "auto", "64", "256", "1024", "2048"])
+    parser.add_argument(
+        "--postselection",
+        nargs="+",
+        default=["none", "all"],
+        choices=["none", "all", "first-half", "last-half", "alternating"],
+    )
+    parser.add_argument("--threshold", type=float, default=0.10)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if args.shots < 1 or args.threads < 0 or args.warmups < 0 or args.repetitions < 1:
+        parser.error("shots and repetitions must be positive; threads and warmups non-negative")
+    if "1" not in args.batches or "auto" not in args.batches:
+        parser.error("batches must include both 1 and auto")
+    if not 0.0 <= args.threshold < 1.0:
+        parser.error("threshold must be in [0, 1)")
+
+    executable = args.executable.resolve()
+    circuit = args.circuit.resolve()
+    if not executable.is_file():
+        parser.error(f"executable does not exist: {executable}")
+    if not circuit.is_file():
+        parser.error(f"circuit does not exist: {circuit}")
+
+    modes = build_modes(args.apis, args.keep_records, args.postselection)
+    rows: list[dict[str, str]] = []
+    total = len(modes) * len(args.batches)
+    completed = 0
+    for mode_index, mode in enumerate(modes):
+        batches = args.batches if mode_index % 2 == 0 else list(reversed(args.batches))
+        for batch in batches:
+            completed += 1
+            print(
+                f"[{completed:02d}/{total:02d}] {mode.name} batch={batch}",
+                file=sys.stderr,
+                flush=True,
+            )
+            rows.append(run_case(executable, circuit, mode, batch, args))
+
+    if args.output is not None:
+        write_csv(args.output, rows)
+
+    print(
+        "| Mode | Auto lanes | Scalar ms | Auto ms | Auto delta | Class | "
+        "Best explicit | Survival |"
+    )
+    print("|---|---:|---:|---:|---:|---|---:|---:|")
+    for mode in modes:
+        mode_rows = {row["requested_batch"]: row for row in rows if row["mode"] == mode.name}
+        scalar = mode_rows["1"]
+        auto = mode_rows["auto"]
+        scalar_ms = float(scalar["median_ms"])
+        auto_ms = float(auto["median_ms"])
+        explicit = [row for batch, row in mode_rows.items() if batch not in {"1", "auto"}]
+        if explicit:
+            best = min(explicit, key=lambda row: float(row["median_ms"]))
+            best_explicit = (
+                f"{best['requested_batch']}: {float(best['median_ms']):.3f} ms "
+                f"({format_change(scalar_ms, float(best['median_ms']))})"
+            )
+        else:
+            best_explicit = "n/a"
+        print(
+            f"| {mode.name} | {auto['effective_batch']} | {scalar_ms:.3f} | "
+            f"{auto_ms:.3f} | {format_change(scalar_ms, auto_ms)} | "
+            f"{classify(scalar_ms, auto, args.threshold)} | {best_explicit} | "
+            f"{float(auto['survival']):.3%} |"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- keep rejected lanes logically masked for classical packed plans instead of repeatedly compacting fixed-width sidecar columns
- retain the existing physical compaction heuristic for plans with coefficient state
- expand `profile_sample` and add a matrix runner covering all four public sampling APIs, survivor output modes, postselection masks, and batch settings

## Why

For `peak_active_width == 0`, packed classical operations already mask rejected lanes. Midstream compaction moves every retained record, expression, detector, observable, and forced-readout column, but does not make most of those fixed-capacity operations cheaper. Deferring physical compaction until retained rows are finalized removes that repeated movement while preserving logical lane death.

This addresses the known classical-plan regression from #415 without applying the same rule to active coefficient state, where carrying dead lanes can remain expensive.

## Performance

Release build, one EPYC worker, d7, 100,000 shots, all detectors postselected:

| API | Output | Auto before | Auto after | Auto vs scalar after |
|---|---|---:|---:|---:|
| `sample_survivors` | aggregate | 1371.9 ms | 24.0 ms | 90.2% faster |
| `sample_survivors` | rows | 1550.9 ms | 89.5 ms | 66.9% faster |
| `sample_k_survivors`, k=1 | aggregate | 1124.4 ms | 14.5 ms | 94.3% faster |
| `sample_k_survivors`, k=1 | rows | 1235.4 ms | 79.1 ms | 71.6% faster |

The d5 and d7 fixed-fault sweeps covered k = 0, 1, 2, 4, 8, and 16; every postselected aggregate and retained-row comparison was faster with automatic batching after this change. Partial masks and eight-worker controls were also batching wins.

## Validation

- `ctest --test-dir build-profile --output-on-failure -j4`: 929/929 passed
- all repository pre-commit hooks passed
- sampling matrix checked ordinary/fixed-fault APIs, aggregate/row outputs, no/partial/all postselection, explicit capacities, and one/eight workers

The active-width cost model and cache-aware tuning remain a stacked follow-up to keep this fix focused.
