### PR TITLE
perf(amplitudes): select lower-width commuting schedule

### DIFF
--- a/src/clifft/api/basis_amplitudes.cc
+++ b/src/clifft/api/basis_amplitudes.cc
@@ -60,6 +60,25 @@ Circuit append_terminal_measurements(const Circuit& source) {
     return result;
 }
 
+struct PlannedAmplitude {
+    SamplingPlan plan;
+    std::complex<double> phase;
+};
+
+PlannedAmplitude plan_amplitude(HirModule hir, PhaseAwareCliffordFrame final_clifford_frame,
+                                std::span<const uint8_t> output_records,
+                                std::span<const uint64_t> output_basis,
+                                std::complex<double> source_phase,
+                                StatevectorSqueezePass squeeze_pass) {
+    squeeze_pass.run(hir);
+    PhaseAwareSamplingPlan planned =
+        plan_sampling_phase_aware(hir, std::move(final_clifford_frame), output_records);
+    std::complex<double> phase = source_phase * planned.scalar;
+    phase *= internal::clifford_row_phase(planned.final_tableau, planned.final_clifford_frame,
+                                          output_basis);
+    return PlannedAmplitude{.plan = std::move(planned.plan), .phase = phase};
+}
+
 }  // namespace
 
 BasisAmplitudeQuery::Prepared BasisAmplitudeQuery::prepare(const Circuit& circuit,
@@ -72,18 +91,24 @@ BasisAmplitudeQuery::Prepared BasisAmplitudeQuery::prepare(const Circuit& circui
     }
     PhaseAwareHir traced =
         trace_phase_aware_terminal_measurements(append_terminal_measurements(circuit));
-    // Output effects move left while non-Clifford expansions move right. The
-    // target-aware planner retains forced-branch phases across the resulting
-    // coordinate changes and scalar rotations.
-    StatevectorSqueezePass{}.run(traced.hir);
-    PhaseAwareSamplingPlan planned = plan_sampling_phase_aware(
-        traced.hir, std::move(traced.final_clifford_frame), output_records);
-    std::complex<double> phase = input_phase * traced.source_scalar * planned.scalar;
-    phase *= internal::clifford_row_phase(planned.final_tableau, planned.final_clifford_frame,
-                                          output_basis);
-    return Prepared{.plan = std::move(planned.plan),
+    HirModule alternate_hir = traced.hir;
+    PhaseAwareCliffordFrame alternate_frame = traced.final_clifford_frame;
+    const std::complex<double> source_phase = input_phase * traced.source_scalar;
+
+    // Commuting expansions admit multiple legal schedules around the fixed
+    // output effects. Plan both stable extremes and retain the cheaper dense
+    // state without changing the ordinary sampling pipeline.
+    PlannedAmplitude canonical =
+        plan_amplitude(std::move(traced.hir), std::move(traced.final_clifford_frame),
+                       output_records, output_basis, source_phase, StatevectorSqueezePass{});
+    PlannedAmplitude alternate = plan_amplitude(
+        std::move(alternate_hir), std::move(alternate_frame), output_records, output_basis,
+        source_phase, StatevectorSqueezePass::with_reversed_commuting_expansions());
+    PlannedAmplitude& selected =
+        alternate.plan.peak_active_width < canonical.plan.peak_active_width ? alternate : canonical;
+    return Prepared{.plan = std::move(selected.plan),
                     .output_records = std::move(output_records),
-                    .phase = phase};
+                    .phase = selected.phase};
 }
 
 BasisAmplitudeQuery::BasisAmplitudeQuery(const Circuit& circuit,

--- a/src/clifft/optimizer/statevector_squeeze_pass.cc
+++ b/src/clifft/optimizer/statevector_squeeze_pass.cc
@@ -35,9 +35,9 @@ void StatevectorSqueezePass::run(HirModule& hir) {
                 size_t curr = i;
                 while (curr < hir.ops.size() - 1 &&
                        can_swap(hir.ops[curr], hir.ops[curr + 1], hir)) {
-                    // Don't uselessly reorder two expanding gates past each other
                     auto nt = hir.ops[curr + 1].op_type();
-                    if (nt == OpType::T_GATE || nt == OpType::PHASE_ROTATION) {
+                    if (!reverse_commuting_expansions_ &&
+                        (nt == OpType::T_GATE || nt == OpType::PHASE_ROTATION)) {
                         break;
                     }
                     std::swap(hir.ops[curr], hir.ops[curr + 1]);

--- a/src/clifft/optimizer/statevector_squeeze_pass.h
+++ b/src/clifft/optimizer/statevector_squeeze_pass.h
@@ -13,7 +13,19 @@ namespace clifft {
 /// active coordinates sooner, and non-Clifford expansions are deferred.
 class StatevectorSqueezePass : public HirPass {
   public:
+    StatevectorSqueezePass() = default;
+
+    [[nodiscard]] static StatevectorSqueezePass with_reversed_commuting_expansions() {
+        return StatevectorSqueezePass{true};
+    }
+
     void run(HirModule& hir) override;
+
+  private:
+    explicit StatevectorSqueezePass(bool reverse_commuting_expansions)
+        : reverse_commuting_expansions_(reverse_commuting_expansions) {}
+
+    bool reverse_commuting_expansions_ = false;
 };
 
 }  // namespace clifft

--- a/tests/test_basis_amplitudes.cc
+++ b/tests/test_basis_amplitudes.cc
@@ -221,6 +221,15 @@ TEST_CASE("Basis amplitude query contracts its terminal output effect") {
     check_complex(query.evaluate(), std::polar(0.5, std::numbers::pi / 4.0));
 }
 
+TEST_CASE("Basis amplitude query selects the lower width commuting schedule") {
+    const clifft::Circuit circuit = clifft::parse("H 0 1\nT 0\nTPP Z0*Z1\nH 1");
+    const std::vector<uint64_t> output{0};
+    const clifft::sampling::BasisAmplitudeQuery query(circuit, output);
+
+    CHECK(query.peak_active_width() == 1);
+    check_complex(query.evaluate(), {0.6035533905932737, 0.25});
+}
+
 TEST_CASE("Basis amplitude query avoids whole-state width in either gate order") {
     constexpr uint32_t num_qubits = 60;
     const std::vector<uint64_t> output{0};

--- a/tests/test_optimizer.cc
+++ b/tests/test_optimizer.cc
@@ -1006,6 +1006,22 @@ TEST_CASE("Squeeze: measurement does not bubble past NOISE and EXP_VAL", "[optim
     REQUIRE(hir.ops[3].op_type() == OpType::MEASURE);
 }
 
+TEST_CASE("Squeeze alternate expansion order can reduce peak active width", "[optimizer]") {
+    auto canonical = hir_from(
+        "H 0 1\n"
+        "T 0\n"
+        "TPP Z0*Z1\n"
+        "H 1\n"
+        "M 1");
+    auto alternate = canonical;
+
+    StatevectorSqueezePass{}.run(canonical);
+    StatevectorSqueezePass::with_reversed_commuting_expansions().run(alternate);
+
+    CHECK(clifft::sampling::plan_sampling(canonical).peak_active_width == 2);
+    CHECK(clifft::sampling::plan_sampling(alternate).peak_active_width == 1);
+}
+
 TEST_CASE("Peephole: virtual S conjugation updates EXP_VAL masks", "[optimizer][exp_val]") {
     // Circuit: T 0, T 0, EXP_VAL X0
     // T+T fuses to virtual S on Z0. The S conjugation must update the


### PR DESCRIPTION
## Summary

- expose the reverse ordering of mutually commuting non-Clifford expansions as a second legal squeeze schedule
- prepare both schedules for selected basis-amplitude queries and retain the one with lower peak active width
- keep the default squeeze behavior and ordinary sampling execution path unchanged

This is stacked on #412.

## Results

On the 196-circuit ABSTRACTS corpus, direct Clifft planning improves 105 circuits and worsens none. Median peak active width falls from 11 to 10 and maximum width falls from 28 to 25. The largest individual reduction is 28 to 16.

Planning both schedules raises median amplitude-query preparation from approximately 4.2 ms to 8.1 ms. The tradeoff is query-local and targets the exponential execution parameter.

## Validation

- 947 native tests
- 1,415 Python tests, 6 skipped, 1 expected failure
- 300 randomized QASM circuits against Qiskit
- 114 published Qiskit corpus amplitudes match componentwise within 8.2e-15
- all 196 published PyZX corpus magnitudes match within 8.2e-16
- full pre-commit suite