### PR TITLE
fix: retain final Z pivot signs in basis queries

### DIFF
--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -327,7 +327,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
     std::vector<BasisMask> z_sign_masks(sign_masks.begin() + static_cast<std::ptrdiff_t>(rank_x),
                                         sign_masks.end());
     size_t rank_z = 0;
-    std::vector<DynamicSignTerm> base_terms;
+    std::vector<uint32_t> z_pivot_cols;
     // Pure Z constraints fix one base bit at a time. After binding x, each
     // pivot equation says whether the corresponding bit of the affine base
     // string is 0 or 1.
@@ -354,9 +354,18 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
                 multiply_row_by(z_rows[r], z_sign_masks[r], z_rows[rank_z], z_sign_masks[rank_z]);
             }
         }
-        base_terms.push_back(DynamicSignTerm{
-            .bit = col, .static_sign = z_rows[rank_z].sign(), .sign_mask = z_sign_masks[rank_z]});
+        z_pivot_cols.push_back(col);
         ++rank_z;
+    }
+
+    // Later pivots update earlier rows during Gauss-Jordan elimination. Build
+    // the affine base only after the complete RREF is available so each term
+    // includes those later substitutions.
+    std::vector<DynamicSignTerm> base_terms;
+    base_terms.reserve(rank_z);
+    for (size_t r = 0; r < rank_z; ++r) {
+        base_terms.push_back(DynamicSignTerm{
+            .bit = z_pivot_cols[r], .static_sign = z_rows[r].sign(), .sign_mask = z_sign_masks[r]});
     }
 
     std::vector<IdentityConstraint> identity_constraints;

--- a/src/clifft/api/basis_probabilities.cc
+++ b/src/clifft/api/basis_probabilities.cc
@@ -328,6 +328,7 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
                                         sign_masks.end());
     size_t rank_z = 0;
     std::vector<uint32_t> z_pivot_cols;
+    z_pivot_cols.reserve(z_rows.size());
     // Pure Z constraints fix one base bit at a time. After binding x, each
     // pivot equation says whether the corresponding bit of the affine base
     // string is 0 or 1.
@@ -364,8 +365,9 @@ std::complex<double> BoundStabilizerAmplitudeQuery::amplitude(MaskView basis,
     std::vector<DynamicSignTerm> base_terms;
     base_terms.reserve(rank_z);
     for (size_t r = 0; r < rank_z; ++r) {
-        base_terms.push_back(DynamicSignTerm{
-            .bit = z_pivot_cols[r], .static_sign = z_rows[r].sign(), .sign_mask = z_sign_masks[r]});
+        base_terms.push_back(DynamicSignTerm{.bit = z_pivot_cols[r],
+                                             .static_sign = z_rows[r].sign(),
+                                             .sign_mask = std::move(z_sign_masks[r])});
     }
 
     std::vector<IdentityConstraint> identity_constraints;

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -504,6 +504,27 @@ TEST_CASE("Sampling basis probabilities conjugate a complex Clifford frame") {
     }
 }
 
+TEST_CASE("Sampling basis probabilities apply later Z pivot sign updates") {
+    const ExecutablePlan executable(plan_from("R_X(-2.3) 2\nTPP X0*X1*Y2\n"));
+    const std::vector<double> probabilities = clifft::sampling::basis_probabilities(
+        executable, std::array<uint64_t, 4>{0, 3, 4, 7}, 4, 1);
+
+    const double rx_zero = std::pow(std::cos(-2.3 * std::numbers::pi / 2.0), 2);
+    const double rx_one = std::pow(std::sin(-2.3 * std::numbers::pi / 2.0), 2);
+    const double tpp_no_flip = std::pow(std::cos(std::numbers::pi / 8.0), 2);
+    const double tpp_flip = std::pow(std::sin(std::numbers::pi / 8.0), 2);
+    const std::array<double, 4> expected{
+        rx_zero * tpp_no_flip,
+        rx_one * tpp_flip,
+        rx_one * tpp_no_flip,
+        rx_zero * tpp_flip,
+    };
+
+    for (size_t k = 0; k < expected.size(); ++k) {
+        REQUIRE_THAT(probabilities[k], Catch::Matchers::WithinAbs(expected[k], 1e-12));
+    }
+}
+
 TEST_CASE("Sampling statevectors reject nonunitary and oversized plans") {
     const ExecutablePlan measured(plan_from("H 0\nM 0\n"));
     REQUIRE_THROWS_AS(clifft::sampling::get_statevector(measured), std::invalid_argument);


### PR DESCRIPTION
## Summary

- build affine base terms after Z-block Gauss-Jordan elimination completes
- prevent later pivots from leaving previously copied dynamic signs stale
- add a deterministic entangled regression with analytic probabilities

This separates an existing basis_probabilities correctness fix from the phase-aware amplitude work in #412.

## Test plan

- [x] C++ suite: 929 passed, excluding benchmarks
- [x] Python suite: 1,365 passed, 6 skipped, 1 expected failure
- [x] Regression verified to fail on main and pass with this fix
- [x] Pre-commit checks pass

## Contributor agreement

- [x] I confirm this contribution is my original work or I have the right to submit it, and I license it under the Apache-2.0 license.
- [x] If this contribution was AI-assisted, I have reviewed the generated code and included an Assisted-by git trailer in the commit message.

The required Assisted-by trailer is present; the review checkbox is left for human confirmation.