### PR TITLE
feat(sampling): add native packed output and sinks

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(clifft_core STATIC
     sampling/batch/interleaved_kernels.cc
     sampling/batch/interleaved_state.cc
     sampling/kernels.cc
+    sampling/output_writer.cc
     sampling/sampler.cc
     sampling/state.cc
     api/basis_probabilities.cc

--- a/src/clifft/sampling/batch/bits.cc
+++ b/src/clifft/sampling/batch/bits.cc
@@ -35,6 +35,18 @@ uint64_t compress_bits_portable(uint64_t bits, uint64_t keep) noexcept {
     return output;
 }
 
+// The input bytes are eight bit columns across eight lanes. The output bytes
+// are the corresponding eight lane rows. This orientation also preserves the
+// little-endian column order used by Stim's b8 matrices.
+uint64_t transpose_8x8(uint64_t bits) noexcept {
+    uint64_t swap = (bits ^ (bits >> 7)) & 0x00AA00AA00AA00AAULL;
+    bits ^= swap ^ (swap << 7);
+    swap = (bits ^ (bits >> 14)) & 0x0000CCCC0000CCCCULL;
+    bits ^= swap ^ (swap << 14);
+    swap = (bits ^ (bits >> 28)) & 0x00000000F0F0F0F0ULL;
+    return bits ^ swap ^ (swap << 28);
+}
+
 #ifndef NDEBUG
 uint32_t count_lane_bits(std::span<const uint64_t> bits, uint32_t lanes) noexcept {
     const size_t live_words = packed_word_count(lanes);
@@ -152,6 +164,80 @@ void PackedBitColumns::xor_into(size_t column_index, std::span<const uint64_t> s
 #endif
     for (size_t word = 0; word < word_capacity_; ++word) {
         destination[word] ^= source[word];
+    }
+}
+
+void PackedBitColumns::write_unpacked_rows(uint32_t lanes, size_t columns,
+                                           std::span<uint8_t> destination, size_t row_stride,
+                                           size_t column_offset) const noexcept {
+    assert(lanes <= lane_capacity_ && columns <= columns_ && column_offset <= row_stride &&
+           columns <= row_stride - column_offset &&
+           (lanes == 0 || destination.size() >= static_cast<size_t>(lanes) * row_stride) &&
+           "unpacked row destination must cover every requested lane and column");
+    for (uint32_t lane_base = 0; lane_base < lanes; lane_base += 8) {
+        const size_t word = lane_base >> 6;
+        const uint32_t shift = lane_base & 63;
+        const uint32_t lane_count = std::min(uint32_t{8}, lanes - lane_base);
+        for (size_t column_base = 0; column_base < columns; column_base += 8) {
+            const size_t column_count = std::min(size_t{8}, columns - column_base);
+            uint64_t column_bytes = 0;
+            for (size_t column_offset_in_block = 0; column_offset_in_block < column_count;
+                 ++column_offset_in_block) {
+                const uint8_t lane_bits = static_cast<uint8_t>(
+                    column(column_base + column_offset_in_block)[word] >> shift);
+                column_bytes |= static_cast<uint64_t>(lane_bits) << (8 * column_offset_in_block);
+            }
+            const uint64_t row_bytes = transpose_8x8(column_bytes);
+            for (uint32_t lane = 0; lane < lane_count; ++lane) {
+                const uint8_t bits = static_cast<uint8_t>(row_bytes >> (8 * lane));
+                uint8_t* row = destination.data() +
+                               static_cast<size_t>(lane_base + lane) * row_stride + column_offset;
+                for (size_t column = 0; column < column_count; ++column) {
+                    row[column_base + column] = (bits >> column) & uint8_t{1};
+                }
+            }
+        }
+    }
+}
+
+void PackedBitColumns::write_packed_rows(uint32_t lanes, size_t columns,
+                                         std::span<uint8_t> destination, size_t row_stride,
+                                         size_t bit_offset) const noexcept {
+    const size_t end_bit = bit_offset + columns;
+    const size_t required_stride = end_bit / 8 + static_cast<size_t>((end_bit & 7) != 0);
+    assert(lanes <= lane_capacity_ && columns <= columns_ && bit_offset <= end_bit &&
+           row_stride >= required_stride &&
+           (lanes == 0 || destination.size() >= static_cast<size_t>(lanes) * row_stride) &&
+           "packed row destination must cover every requested lane and column");
+    (void)required_stride;
+    for (uint32_t lane_base = 0; lane_base < lanes; lane_base += 8) {
+        const size_t word = lane_base >> 6;
+        const uint32_t shift = lane_base & 63;
+        const uint32_t lane_count = std::min(uint32_t{8}, lanes - lane_base);
+        for (size_t column_base = 0; column_base < columns; column_base += 8) {
+            const size_t column_count = std::min(size_t{8}, columns - column_base);
+            uint64_t column_bytes = 0;
+            for (size_t column_in_block = 0; column_in_block < column_count; ++column_in_block) {
+                const uint8_t lane_bits =
+                    static_cast<uint8_t>(column(column_base + column_in_block)[word] >> shift);
+                column_bytes |= static_cast<uint64_t>(lane_bits) << (8 * column_in_block);
+            }
+            const uint64_t row_bytes = transpose_8x8(column_bytes);
+            const size_t destination_bit = bit_offset + column_base;
+            const size_t destination_byte = destination_bit >> 3;
+            const uint32_t destination_shift = destination_bit & 7;
+            for (uint32_t lane = 0; lane < lane_count; ++lane) {
+                uint8_t* row =
+                    destination.data() + static_cast<size_t>(lane_base + lane) * row_stride;
+                const uint16_t bits = static_cast<uint8_t>(row_bytes >> (8 * lane));
+                row[destination_byte] |= static_cast<uint8_t>(bits << destination_shift);
+                if (destination_shift != 0 && destination_byte + 1 < row_stride &&
+                    column_count > 8 - destination_shift) {
+                    row[destination_byte + 1] |=
+                        static_cast<uint8_t>(bits >> (8 - destination_shift));
+                }
+            }
+        }
     }
 }
 

--- a/src/clifft/sampling/batch/bits.h
+++ b/src/clifft/sampling/batch/bits.h
@@ -40,6 +40,14 @@ class PackedBitColumns {
     void copy(size_t destination, size_t source) noexcept;
     void xor_into(size_t column, std::span<const uint64_t> source) noexcept;
 
+    // Transpose the lane-major view into caller-owned row-major output. Packed
+    // rows use little-endian bits and may begin at an arbitrary destination
+    // bit, so independently produced column groups can share a row.
+    void write_unpacked_rows(uint32_t lanes, size_t columns, std::span<uint8_t> destination,
+                             size_t row_stride, size_t column_offset) const noexcept;
+    void write_packed_rows(uint32_t lanes, size_t columns, std::span<uint8_t> destination,
+                           size_t row_stride, size_t bit_offset) const noexcept;
+
     // Stable-compacts every column using keep_mask. scratch is one fixed-size
     // word row prepared by the owning executor before dispatch.
     void compact(std::span<const uint64_t> keep_mask, uint32_t old_lanes, uint32_t new_lanes,

--- a/src/clifft/sampling/batch/executor.cc
+++ b/src/clifft/sampling/batch/executor.cc
@@ -58,10 +58,11 @@ enum class MeasurementBranchKind : uint8_t {
 }  // namespace
 
 BatchExecutor::BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity,
-                             BatchOutputMode output_mode, BatchSamplingMode sampling_mode)
+                             BatchOutputMode output_mode, BatchSamplingMode sampling_mode,
+                             SamplingOutputSelection outputs)
     : BatchExecutor(plan, output_mode, sampling_mode,
                     batch_detail::batch_worker_storage_layout(plan, lane_capacity, output_mode,
-                                                              sampling_mode)) {}
+                                                              sampling_mode, outputs)) {}
 
 BatchExecutor::BatchExecutor(const ExecutablePlan& plan, BatchOutputMode output_mode,
                              BatchSamplingMode sampling_mode,
@@ -489,8 +490,11 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteReadoutNoise& ac
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action) noexcept {
+    if (detectors_.num_columns() == 0 && !action.postselected) {
+        return;
+    }
     const std::span<const uint64_t> outcomes = evaluate_record_parity(action.outcome);
-    if (output_mode_ == BatchOutputMode::Rows) {
+    if (detectors_.num_columns() != 0) {
         detectors_.assign(action.detector, outcomes, live_words_);
     }
     if (!action.postselected) {
@@ -509,12 +513,15 @@ void BatchExecutor::execute_action(const ExecutablePlan::ExecuteDetector& action
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteObservable& action) noexcept {
+    if (observables_.num_columns() == 0) {
+        return;
+    }
     const std::span<const uint64_t> outcomes = evaluate_observable(action.outcome);
     observables_.assign(action.observable, outcomes, live_words_);
 }
 
 void BatchExecutor::execute_action(const ExecutablePlan::ExecuteExpectation& action) noexcept {
-    if (output_mode_ == BatchOutputMode::AggregateSurvivors) {
+    if (exp_vals_.empty()) {
         return;
     }
     assert(action.exp_val < plan_->num_exp_vals_ &&
@@ -639,7 +646,7 @@ void BatchExecutor::compact_live_lanes() noexcept {
             shot_indices_[destination] = shot_indices_[source];
         }
     }
-    if (output_mode_ == BatchOutputMode::Rows) {
+    if (!exp_vals_.empty()) {
         for (uint32_t exp_val = 0; exp_val < plan_->num_exp_vals_; ++exp_val) {
             double* values = exp_vals_.data() + static_cast<size_t>(exp_val) * lane_capacity_;
             for (destination = 0; destination < live_count_; ++destination) {
@@ -707,6 +714,35 @@ double BatchExecutor::exp_val(uint32_t lane, uint32_t exp_val_index) const noexc
     assert(lane < live_count_ && exp_val_index < plan_->num_exp_vals_ &&
            "expectation output must be live and in range");
     return exp_vals_[static_cast<size_t>(exp_val_index) * lane_capacity_ + lane];
+}
+
+void BatchExecutor::write_bit_rows(SamplingBitSource source, SamplingBitPacking packing,
+                                   std::span<uint8_t> destination, size_t row_stride,
+                                   size_t column_offset) const noexcept {
+    assert(active_lanes() == live_count_ && "batch outputs require finalized live lanes");
+    const PackedBitColumns* columns = nullptr;
+    switch (source) {
+        case SamplingBitSource::Measurements:
+            columns = &records_;
+            break;
+        case SamplingBitSource::Detectors:
+            columns = &detectors_;
+            break;
+        case SamplingBitSource::Observables:
+            columns = &observables_;
+            break;
+    }
+    assert(columns != nullptr && "sampling bit source must be valid");
+    const size_t output_columns = source == SamplingBitSource::Measurements
+                                      ? plan_->num_visible_records_
+                                      : columns->num_columns();
+    if (packing == SamplingBitPacking::BitPacked) {
+        columns->write_packed_rows(live_count_, output_columns, destination, row_stride,
+                                   column_offset);
+    } else {
+        columns->write_unpacked_rows(live_count_, output_columns, destination, row_stride,
+                                     column_offset);
+    }
 }
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/batch/executor.h
+++ b/src/clifft/sampling/batch/executor.h
@@ -5,6 +5,7 @@
 #include "clifft/sampling/batch/interleaved_state.h"
 #include "clifft/sampling/batch/policy.h"
 #include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/results.h"
 #include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
 
@@ -26,7 +27,8 @@ class BatchExecutor {
   public:
     BatchExecutor(const ExecutablePlan& plan, uint32_t lane_capacity,
                   BatchOutputMode output_mode = BatchOutputMode::Rows,
-                  BatchSamplingMode sampling_mode = BatchSamplingMode::Ordinary);
+                  BatchSamplingMode sampling_mode = BatchSamplingMode::Ordinary,
+                  SamplingOutputSelection outputs = SamplingOutputSelection::all());
 
     BatchExecutor(const BatchExecutor&) = delete;
     BatchExecutor& operator=(const BatchExecutor&) = delete;
@@ -45,6 +47,9 @@ class BatchExecutor {
     [[nodiscard]] bool detector(uint32_t lane, uint32_t detector) const noexcept;
     [[nodiscard]] bool observable(uint32_t lane, uint32_t observable) const noexcept;
     [[nodiscard]] double exp_val(uint32_t lane, uint32_t exp_val) const noexcept;
+    void write_bit_rows(SamplingBitSource source, SamplingBitPacking packing,
+                        std::span<uint8_t> destination, size_t row_stride,
+                        size_t column_offset) const noexcept;
 
   private:
     BatchExecutor(const ExecutablePlan& plan, BatchOutputMode output_mode,

--- a/src/clifft/sampling/batch/policy.cc
+++ b/src/clifft/sampling/batch/policy.cc
@@ -28,7 +28,8 @@ namespace batch_detail {
 BatchWorkerStorageLayout batch_worker_storage_layout(const ExecutablePlan& plan,
                                                      uint32_t lane_capacity,
                                                      BatchOutputMode output_mode,
-                                                     BatchSamplingMode sampling_mode) {
+                                                     BatchSamplingMode sampling_mode,
+                                                     SamplingOutputSelection outputs) {
     BatchWorkerStorageLayout layout;
     layout.peak_active_width = plan.peak_active_width();
     layout.initial_active_width = plan.initial_active_width();
@@ -41,15 +42,23 @@ BatchWorkerStorageLayout batch_worker_storage_layout(const ExecutablePlan& plan,
             : 0;
     layout.noise_carrier_columns = plan.num_batch_noise_carriers();
     layout.expression_register_columns = plan.num_expression_registers();
+    const bool evaluates_output_parities = outputs.detectors || outputs.observables ||
+                                           plan.has_postselection() ||
+                                           output_mode == BatchOutputMode::AggregateSurvivors;
     layout.record_columns =
-        output_mode == BatchOutputMode::Rows || plan.output_parities_read_records()
+        (output_mode == BatchOutputMode::Rows && outputs.measurements) ||
+                (evaluates_output_parities && plan.output_parities_read_records())
             ? static_cast<size_t>(plan.num_visible_records()) + plan.num_hidden_records()
             : 0;
-    layout.detector_columns = output_mode == BatchOutputMode::Rows ? plan.num_detectors() : 0;
-    layout.observable_columns = plan.num_observables();
+    layout.detector_columns =
+        output_mode == BatchOutputMode::Rows && outputs.detectors ? plan.num_detectors() : 0;
+    layout.observable_columns = (output_mode == BatchOutputMode::AggregateSurvivors ||
+                                 outputs.observables || plan.has_postselection())
+                                    ? plan.num_observables()
+                                    : 0;
     layout.forced_readout_columns =
         sampling_mode == BatchSamplingMode::FixedFaults ? plan.num_readout_noise_sites() : 0;
-    layout.exp_value_entries = output_mode == BatchOutputMode::Rows
+    layout.exp_value_entries = output_mode == BatchOutputMode::Rows && outputs.exp_vals
                                    ? static_cast<uint64_t>(plan.num_exp_vals()) * lane_capacity
                                    : 0;
     layout.live_word_entries = layout.word_capacity;
@@ -64,9 +73,10 @@ BatchWorkerStorageLayout batch_worker_storage_layout(const ExecutablePlan& plan,
 }
 
 uint64_t batch_worker_storage_bytes(const ExecutablePlan& plan, uint32_t lane_capacity,
-                                    BatchOutputMode output_mode, BatchSamplingMode sampling_mode) {
+                                    BatchOutputMode output_mode, BatchSamplingMode sampling_mode,
+                                    SamplingOutputSelection outputs) {
     const BatchWorkerStorageLayout layout =
-        batch_worker_storage_layout(plan, lane_capacity, output_mode, sampling_mode);
+        batch_worker_storage_layout(plan, lane_capacity, output_mode, sampling_mode, outputs);
     uint64_t bytes = interleaved_batch_state_bytes(layout.peak_active_width, layout.lane_capacity);
     const auto add_entries = [&](uint64_t entries, size_t entry_bytes) {
         bytes = saturating_add_u64(bytes, saturating_multiply_u64(entries, entry_bytes));
@@ -100,7 +110,8 @@ uint64_t batch_worker_storage_bytes(const ExecutablePlan& plan, uint32_t lane_ca
 BatchExecutionPolicy resolve_batch_execution_policy(
     const ExecutablePlan& plan, uint32_t shots, uint32_t shot_workers, uint32_t intra_shot_workers,
     BatchOutputMode output_mode, std::optional<uint32_t> requested_batch_size,
-    BatchSamplingMode sampling_mode, uint64_t additional_worker_bytes) {
+    BatchSamplingMode sampling_mode, uint64_t additional_worker_bytes,
+    SamplingOutputSelection outputs) {
     if (requested_batch_size.has_value() && *requested_batch_size == 0) {
         throw std::invalid_argument("batch_size must be a positive integer or 'auto'");
     }
@@ -159,9 +170,10 @@ BatchExecutionPolicy resolve_batch_execution_policy(
             capacity = std::bit_floor(capacity - 1);
             continue;
         }
-        const uint64_t worker_bytes = saturating_add_u64(
-            batch_detail::batch_worker_storage_bytes(plan, capacity, output_mode, sampling_mode),
-            additional_worker_bytes);
+        const uint64_t worker_bytes =
+            saturating_add_u64(batch_detail::batch_worker_storage_bytes(plan, capacity, output_mode,
+                                                                        sampling_mode, outputs),
+                               additional_worker_bytes);
         if (worker_bytes <= kDefaultBatchWorkerBudget) {
             const uint32_t requested_workers = batch_worker_count(shots, shot_workers, capacity);
             const uint64_t memory_workers = std::max<uint64_t>(

--- a/src/clifft/sampling/batch/policy.h
+++ b/src/clifft/sampling/batch/policy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "clifft/sampling/results.h"
 #include "clifft/util/numeric.h"
 
 #include <cassert>
@@ -173,15 +174,15 @@ struct BatchWorkerStorageLayout {
     size_t lane_value_entries = 0;
 };
 
-[[nodiscard]] BatchWorkerStorageLayout batch_worker_storage_layout(const ExecutablePlan& plan,
-                                                                   uint32_t lane_capacity,
-                                                                   BatchOutputMode output_mode,
-                                                                   BatchSamplingMode sampling_mode);
+[[nodiscard]] BatchWorkerStorageLayout batch_worker_storage_layout(
+    const ExecutablePlan& plan, uint32_t lane_capacity, BatchOutputMode output_mode,
+    BatchSamplingMode sampling_mode,
+    SamplingOutputSelection outputs = SamplingOutputSelection::all());
 
-[[nodiscard]] uint64_t batch_worker_storage_bytes(const ExecutablePlan& plan,
-                                                  uint32_t lane_capacity,
-                                                  BatchOutputMode output_mode,
-                                                  BatchSamplingMode sampling_mode);
+[[nodiscard]] uint64_t batch_worker_storage_bytes(
+    const ExecutablePlan& plan, uint32_t lane_capacity, BatchOutputMode output_mode,
+    BatchSamplingMode sampling_mode,
+    SamplingOutputSelection outputs = SamplingOutputSelection::all());
 
 }  // namespace batch_detail
 
@@ -192,6 +193,7 @@ struct BatchWorkerStorageLayout {
     const ExecutablePlan& plan, uint32_t shots, uint32_t shot_workers, uint32_t intra_shot_workers,
     BatchOutputMode output_mode, std::optional<uint32_t> requested_batch_size,
     BatchSamplingMode sampling_mode = BatchSamplingMode::Ordinary,
-    uint64_t additional_worker_bytes = 0);
+    uint64_t additional_worker_bytes = 0,
+    SamplingOutputSelection outputs = SamplingOutputSelection::all());
 
 }  // namespace clifft::sampling

--- a/src/clifft/sampling/output_writer.cc
+++ b/src/clifft/sampling/output_writer.cc
@@ -1,0 +1,99 @@
+#include "clifft/sampling/output_writer.h"
+
+#include <limits>
+#include <ostream>
+#include <stdexcept>
+
+namespace clifft::sampling {
+
+namespace {
+
+size_t checked_product(size_t left, size_t right, const char* message) {
+    if (left != 0 && right > std::numeric_limits<size_t>::max() / left) {
+        throw std::length_error(message);
+    }
+    return left * right;
+}
+
+void write_bytes(std::ostream& output, const char* data, size_t size) {
+    if (size == 0) {
+        return;
+    }
+    if (size > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+        throw std::length_error("sampling output batch exceeds streamsize range");
+    }
+    output.write(data, static_cast<std::streamsize>(size));
+    if (!output) {
+        throw std::runtime_error("failed to write sampling output");
+    }
+}
+
+}  // namespace
+
+SamplingRowWriter::SamplingRowWriter(std::ostream& output, SamplingFileFormat format,
+                                     size_t columns, uint32_t max_batch_shots)
+    : output_(&output),
+      format_(format),
+      columns_(columns),
+      packed_row_bytes_(columns / 8 + static_cast<size_t>((columns & 7) != 0)),
+      max_batch_shots_(max_batch_shots) {
+    if (max_batch_shots == 0) {
+        throw std::invalid_argument("sampling writer batch capacity must be positive");
+    }
+    if (format_ != SamplingFileFormat::Format01 && format_ != SamplingFileFormat::B8) {
+        throw std::invalid_argument("unsupported sampling file format");
+    }
+    if (format_ == SamplingFileFormat::Format01) {
+        if (columns_ == std::numeric_limits<size_t>::max()) {
+            throw std::length_error("sampling 01 row width exceeds size_t range");
+        }
+        scratch_.resize(checked_product(max_batch_shots_, columns_ + 1,
+                                        "sampling 01 batch exceeds size_t range"));
+    }
+}
+
+void SamplingRowWriter::write_packed_rows(std::span<const uint8_t> rows, uint32_t shots,
+                                          size_t row_stride) {
+    if (shots > max_batch_shots_) {
+        throw std::invalid_argument("sampling writer batch exceeds retained capacity");
+    }
+    if (row_stride < packed_row_bytes_) {
+        throw std::invalid_argument("sampling writer row stride is too small");
+    }
+    const size_t required =
+        checked_product(shots, row_stride, "sampling writer input exceeds size_t range");
+    if (rows.size() < required) {
+        throw std::invalid_argument("sampling writer input buffer is too small");
+    }
+    if (shots == 0) {
+        return;
+    }
+
+    if (format_ == SamplingFileFormat::B8) {
+        if (row_stride == packed_row_bytes_) {
+            write_bytes(*output_, reinterpret_cast<const char*>(rows.data()),
+                        static_cast<size_t>(shots) * packed_row_bytes_);
+            return;
+        }
+        for (uint32_t shot = 0; shot < shots; ++shot) {
+            write_bytes(
+                *output_,
+                reinterpret_cast<const char*>(rows.data() + static_cast<size_t>(shot) * row_stride),
+                packed_row_bytes_);
+        }
+        return;
+    }
+
+    const size_t encoded_stride = columns_ + 1;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const uint8_t* input = rows.data() + static_cast<size_t>(shot) * row_stride;
+        char* encoded = scratch_.data() + static_cast<size_t>(shot) * encoded_stride;
+        for (size_t column = 0; column < columns_; ++column) {
+            encoded[column] = static_cast<char>('0' + ((input[column >> 3] >> (column & 7)) & 1));
+        }
+        encoded[columns_] = '\n';
+    }
+    write_bytes(*output_, scratch_.data(), static_cast<size_t>(shots) * encoded_stride);
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/output_writer.h
+++ b/src/clifft/sampling/output_writer.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iosfwd>
+#include <span>
+#include <vector>
+
+namespace clifft::sampling {
+
+enum class SamplingFileFormat : uint8_t {
+    Format01,
+    B8,
+};
+
+// Encodes completed little-endian packed batches into the two common Stim
+// result formats. Format01 scratch is retained at construction so each write
+// is an allocation-free batch-boundary operation.
+class SamplingRowWriter {
+  public:
+    SamplingRowWriter(std::ostream& output, SamplingFileFormat format, size_t columns,
+                      uint32_t max_batch_shots);
+
+    void write_packed_rows(std::span<const uint8_t> rows, uint32_t shots, size_t row_stride);
+
+    [[nodiscard]] size_t columns() const noexcept { return columns_; }
+    [[nodiscard]] size_t packed_row_bytes() const noexcept { return packed_row_bytes_; }
+
+  private:
+    std::ostream* output_;
+    SamplingFileFormat format_;
+    size_t columns_;
+    size_t packed_row_bytes_;
+    uint32_t max_batch_shots_;
+    std::vector<char> scratch_;
+};
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/results.h
+++ b/src/clifft/sampling/results.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <vector>
 
 namespace clifft::sampling {
@@ -23,8 +24,50 @@ struct SamplingOutputSelection {
     }
 };
 
+enum class SamplingBitSource : uint8_t {
+    Measurements,
+    Detectors,
+    Observables,
+};
+
+enum class SamplingBitPacking : uint8_t {
+    Unpacked,
+    BitPacked,
+};
+
+// Describes one destination for a Boolean output matrix. row_stride is in
+// bytes for both formats. column_offset is a byte offset for unpacked output
+// and a bit offset for packed output, which permits native detector/observable
+// composition without a temporary matrix.
+struct SamplingBitOutput {
+    SamplingBitSource source = SamplingBitSource::Measurements;
+    SamplingBitPacking packing = SamplingBitPacking::Unpacked;
+    std::span<uint8_t> data;
+    size_t row_stride = 0;
+    size_t column_offset = 0;
+};
+
+// Caller-owned destinations for fixed-row sampling. A source may appear more
+// than once, allowing observables to be emitted separately and composed into
+// a detector matrix in the same pass. Destination storage is validated and
+// cleared before execution; hot dispatch never allocates it.
+struct SamplingOutputBuffer {
+    std::span<const SamplingBitOutput> bits;
+    std::span<double> exp_vals;
+    size_t exp_val_row_stride = 0;
+};
+
 // Backend-neutral row-major outputs from ordinary sampling.
 struct SamplingResult {
+    std::vector<uint8_t> measurements;
+    std::vector<uint8_t> detectors;
+    std::vector<uint8_t> observables;
+    std::vector<double> exp_vals;
+};
+
+// Little-endian packed Boolean rows plus ordinary floating-point expectation
+// rows. Each Boolean vector has shots * ceil(columns / 8) bytes when selected.
+struct PackedSamplingResult {
     std::vector<uint8_t> measurements;
     std::vector<uint8_t> detectors;
     std::vector<uint8_t> observables;

--- a/src/clifft/sampling/sampler.cc
+++ b/src/clifft/sampling/sampler.cc
@@ -23,6 +23,21 @@ void reseed_executor_for_shot(Executor& executor, const SeedRoot& root, uint32_t
     executor.reseed_full(words[0], words[1], words[2], words[3]);
 }
 
+void validate_fixed_sampling_plan(const ExecutablePlan& plan) {
+    if (plan.has_instruments()) {
+        throw std::invalid_argument(
+            "fixed-plan sampling does not support instrument traps; use the trajectory driver");
+    }
+    if (plan.num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "batch sampling requires a distribution for every presampled symbol");
+    }
+    if (plan.has_postselection()) {
+        throw std::invalid_argument(
+            "fixed-row sampling does not support postselection; use sample_survivors");
+    }
+}
+
 struct SamplingWorker {
     SamplingWorker(const ExecutablePlan& plan, uint32_t intra_shot_workers,
                    uint32_t intra_shot_min_active_width)
@@ -74,7 +89,9 @@ struct ConditionedSurvivorWorker {
 };
 
 struct BatchSamplingWorker {
-    BatchSamplingWorker(const ExecutablePlan& plan, uint32_t capacity) : executor(plan, capacity) {}
+    BatchSamplingWorker(const ExecutablePlan& plan, uint32_t capacity,
+                        SamplingOutputSelection outputs)
+        : executor(plan, capacity, BatchOutputMode::Rows, BatchSamplingMode::Ordinary, outputs) {}
 
     BatchExecutor executor;
 };
@@ -91,9 +108,11 @@ struct ConditionedBatchSamplingWorker {
 };
 
 struct BatchSurvivorWorker {
-    BatchSurvivorWorker(const ExecutablePlan& plan, uint32_t capacity, bool keep_records)
+    BatchSurvivorWorker(const ExecutablePlan& plan, uint32_t capacity,
+                        SamplingOutputSelection outputs)
         : executor(plan, capacity,
-                   keep_records ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors),
+                   outputs.any() ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors,
+                   BatchSamplingMode::Ordinary, outputs),
           counts(plan.num_observables()) {}
 
     BatchExecutor executor;
@@ -181,6 +200,183 @@ void allocate_row_outputs(Output& output, uint32_t shots, const ExecutablePlan& 
     if (outputs.exp_vals) {
         output.exp_vals.resize(checked_output_size(shots, plan.num_exp_vals()));
     }
+}
+
+size_t bit_source_width(const ExecutablePlan& plan, SamplingBitSource source) noexcept {
+    switch (source) {
+        case SamplingBitSource::Measurements:
+            return plan.num_visible_records();
+        case SamplingBitSource::Detectors:
+            return plan.num_detectors();
+        case SamplingBitSource::Observables:
+            return plan.num_observables();
+    }
+    assert(false && "sampling bit source must be valid");
+    return 0;
+}
+
+std::span<const uint8_t> scalar_bit_source(const Executor& executor,
+                                           SamplingBitSource source) noexcept {
+    switch (source) {
+        case SamplingBitSource::Measurements:
+            return executor.visible_records();
+        case SamplingBitSource::Detectors:
+            return executor.detectors();
+        case SamplingBitSource::Observables:
+            return executor.observables();
+    }
+    assert(false && "sampling bit source must be valid");
+    return {};
+}
+
+SamplingOutputSelection validate_output_buffer(const ExecutablePlan& plan, uint32_t shots,
+                                               SamplingOutputBuffer output) {
+    SamplingOutputSelection selection;
+    for (const SamplingBitOutput& destination : output.bits) {
+        const size_t columns = bit_source_width(plan, destination.source);
+        if (destination.column_offset > std::numeric_limits<size_t>::max() - columns) {
+            throw std::length_error("sampling output column range exceeds size_t");
+        }
+        const size_t end_column = destination.column_offset + columns;
+        const size_t minimum_stride =
+            destination.packing == SamplingBitPacking::BitPacked
+                ? end_column / 8 + static_cast<size_t>((end_column & 7) != 0)
+                : end_column;
+        if (destination.row_stride < minimum_stride) {
+            throw std::invalid_argument("sampling bit output row stride is too small");
+        }
+        const size_t required_size = checked_output_size(shots, destination.row_stride);
+        if (destination.data.size() < required_size) {
+            throw std::invalid_argument("sampling bit output buffer is too small");
+        }
+        switch (destination.source) {
+            case SamplingBitSource::Measurements:
+                selection.measurements = true;
+                break;
+            case SamplingBitSource::Detectors:
+                selection.detectors = true;
+                break;
+            case SamplingBitSource::Observables:
+                selection.observables = true;
+                break;
+        }
+    }
+    if (!output.exp_vals.empty()) {
+        if (output.exp_val_row_stride < plan.num_exp_vals()) {
+            throw std::invalid_argument("sampling expectation output row stride is too small");
+        }
+        const size_t required_size = checked_output_size(shots, output.exp_val_row_stride);
+        if (output.exp_vals.size() < required_size) {
+            throw std::invalid_argument("sampling expectation output buffer is too small");
+        }
+        selection.exp_vals = true;
+    }
+    return selection;
+}
+
+void clear_bit_outputs(uint32_t shots, SamplingOutputBuffer output) noexcept {
+    for (const SamplingBitOutput& destination : output.bits) {
+        const size_t size = static_cast<size_t>(shots) * destination.row_stride;
+        std::ranges::fill(destination.data.first(size), uint8_t{0});
+    }
+}
+
+void write_scalar_outputs(SamplingOutputBuffer output, const Executor& executor, uint32_t shot,
+                          const ExecutablePlan& plan) noexcept {
+    for (const SamplingBitOutput& destination : output.bits) {
+        const std::span<const uint8_t> source = scalar_bit_source(executor, destination.source);
+        if (source.empty()) {
+            continue;
+        }
+        uint8_t* row = destination.data.data() + static_cast<size_t>(shot) * destination.row_stride;
+        if (destination.packing == SamplingBitPacking::Unpacked) {
+            std::ranges::copy(source, row + destination.column_offset);
+            continue;
+        }
+        for (size_t column = 0; column < source.size(); ++column) {
+            row[(destination.column_offset + column) >> 3] |=
+                source[column] << ((destination.column_offset + column) & 7);
+        }
+    }
+    if (!output.exp_vals.empty()) {
+        std::ranges::copy(
+            executor.exp_vals(),
+            output.exp_vals.begin() + static_cast<size_t>(shot) * output.exp_val_row_stride);
+    }
+    (void)plan;
+}
+
+void write_batch_outputs(SamplingOutputBuffer output, const BatchExecutor& executor, uint32_t lanes,
+                         const ExecutablePlan& plan) noexcept {
+    assert(executor.surviving_shots() == lanes && "fixed-row batch must retain every shot");
+    if (lanes == 0) {
+        return;
+    }
+    const uint32_t first_shot = executor.shot_index(0);
+    for (uint32_t lane = 1; lane < lanes; ++lane) {
+        assert(executor.shot_index(lane) == first_shot + lane &&
+               "fixed-row batch output lanes must preserve shot order");
+    }
+    for (const SamplingBitOutput& destination : output.bits) {
+        const size_t offset = static_cast<size_t>(first_shot) * destination.row_stride;
+        executor.write_bit_rows(destination.source, destination.packing,
+                                destination.data.subspan(offset), destination.row_stride,
+                                destination.column_offset);
+    }
+    if (!output.exp_vals.empty()) {
+        for (uint32_t lane = 0; lane < lanes; ++lane) {
+            double* row = output.exp_vals.data() +
+                          static_cast<size_t>(first_shot + lane) * output.exp_val_row_stride;
+            for (uint32_t exp_val = 0; exp_val < plan.num_exp_vals(); ++exp_val) {
+                row[exp_val] = executor.exp_val(lane, exp_val);
+            }
+        }
+    }
+}
+
+template <typename MakeWorker, typename RunShot>
+void sample_fixed_rows_into(const ExecutablePlan& plan, uint32_t shots, SamplingOutputBuffer output,
+                            std::optional<uint64_t> seed, ThreadLayout thread_layout,
+                            MakeWorker&& make_worker, RunShot&& run_shot) {
+    if (shots == 0) {
+        return;
+    }
+    const SeedRoot root = make_seed_root(shots, seed);
+    (void)run_shot_ranges(shots, thread_layout.shot_workers, std::forward<MakeWorker>(make_worker),
+                          [&](auto& worker_handle, ShotRange range) {
+                              auto& worker = *worker_handle;
+                              Executor& executor = worker.executor;
+                              for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                                  reseed_executor_for_shot(executor, root, shot);
+                                  run_shot(worker);
+                                  write_scalar_outputs(output, executor, shot, plan);
+                              }
+                          });
+}
+
+template <typename MakeWorker, typename RunBatch>
+void sample_fixed_batches_into(const ExecutablePlan& plan, uint32_t shots,
+                               SamplingOutputBuffer output, std::optional<uint64_t> seed,
+                               BatchExecutionPolicy batch_policy, MakeWorker&& make_worker,
+                               RunBatch&& run_batch) {
+    if (shots == 0) {
+        return;
+    }
+    const SeedRoot root = make_seed_root(shots, seed);
+    const uint32_t batch_capacity = batch_policy.lane_capacity;
+    (void)run_shot_ranges(
+        shots, batch_policy.worker_count, std::forward<MakeWorker>(make_worker),
+        [&](auto& worker_handle, ShotRange range) {
+            auto& worker = *worker_handle;
+            BatchExecutor& executor = worker.executor;
+            for (uint32_t offset = range.begin; offset < range.end;) {
+                const uint32_t batch = std::min(batch_capacity, range.end - offset);
+                run_batch(worker, root, offset, batch);
+                write_batch_outputs(output, executor, batch, plan);
+                offset += batch;
+            }
+        },
+        batch_capacity);
 }
 
 template <typename Output>
@@ -455,6 +651,39 @@ SamplingSurvivorResult sample_surviving_batches(const ExecutablePlan& plan, uint
     return result;
 }
 
+void run_fixed_sampling_into(const ExecutablePlan& plan, uint32_t shots,
+                             SamplingOutputBuffer output, SamplingOutputSelection outputs,
+                             std::optional<uint64_t> seed, uint32_t threads,
+                             std::optional<ThreadLayout> thread_layout,
+                             std::optional<uint32_t> batch_size) {
+    const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
+    const BatchExecutionPolicy batch_policy = resolve_batch_execution_policy(
+        plan, shots, resolved.shot_workers, resolved.intra_shot_workers, BatchOutputMode::Rows,
+        batch_size, BatchSamplingMode::Ordinary, 0, outputs);
+    if constexpr (kPackedBatchExecutionAvailable) {
+        if (batch_policy.lane_capacity > 1) {
+            sample_fixed_batches_into(
+                plan, shots, output, seed, batch_policy,
+                [&](uint32_t) {
+                    return std::make_unique<BatchSamplingWorker>(plan, batch_policy.lane_capacity,
+                                                                 outputs);
+                },
+                [](BatchSamplingWorker& worker, const SeedRoot& root, uint32_t first_shot,
+                   uint32_t batch) noexcept {
+                    worker.executor.run_batch(root, first_shot, batch);
+                });
+            return;
+        }
+    }
+    sample_fixed_rows_into(
+        plan, shots, output, seed, resolved,
+        [&](uint32_t) {
+            return std::make_unique<SamplingWorker>(plan, resolved.intra_shot_workers,
+                                                    resolved.intra_shot_min_active_width);
+        },
+        [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
+}
+
 }  // namespace
 
 SamplingResult sample(const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed,
@@ -468,43 +697,95 @@ SamplingResult sample_selected(const ExecutablePlan& plan, uint32_t shots,
                                SamplingOutputSelection outputs, std::optional<uint64_t> seed,
                                uint32_t threads, std::optional<ThreadLayout> thread_layout,
                                std::optional<uint32_t> batch_size) {
-    if (plan.has_instruments()) {
-        throw std::invalid_argument(
-            "fixed-plan sampling does not support instrument traps; use the trajectory driver");
-    }
-    if (plan.num_unbound_presampled_symbols() != 0) {
-        throw std::invalid_argument(
-            "batch sampling requires a distribution for every presampled symbol");
-    }
-    if (plan.has_postselection()) {
-        throw std::invalid_argument(
-            "fixed-row sampling does not support postselection; use sample_survivors");
-    }
-
-    const ThreadLayout resolved = resolve_thread_layout(plan, shots, threads, thread_layout);
-    const BatchExecutionPolicy batch_policy = resolve_batch_execution_policy(
-        plan, shots, resolved.shot_workers, resolved.intra_shot_workers, BatchOutputMode::Rows,
-        batch_size);
-    if constexpr (kPackedBatchExecutionAvailable) {
-        if (batch_policy.lane_capacity > 1) {
-            return sample_fixed_batches(
-                plan, shots, outputs, seed, batch_policy,
-                [&](uint32_t) {
-                    return std::make_unique<BatchSamplingWorker>(plan, batch_policy.lane_capacity);
-                },
-                [](BatchSamplingWorker& worker, const SeedRoot& root, uint32_t first_shot,
-                   uint32_t batch) noexcept {
-                    worker.executor.run_batch(root, first_shot, batch);
-                });
+    validate_fixed_sampling_plan(plan);
+    SamplingResult result;
+    allocate_row_outputs(result, shots, plan, outputs);
+    std::array<SamplingBitOutput, 3> bit_outputs;
+    size_t output_count = 0;
+    const auto add_output = [&](bool selected, SamplingBitSource source, std::vector<uint8_t>& data,
+                                size_t stride) {
+        if (selected) {
+            bit_outputs[output_count++] = {
+                .source = source,
+                .data = data,
+                .row_stride = stride,
+            };
         }
+    };
+    add_output(outputs.measurements, SamplingBitSource::Measurements, result.measurements,
+               plan.num_visible_records());
+    add_output(outputs.detectors, SamplingBitSource::Detectors, result.detectors,
+               plan.num_detectors());
+    add_output(outputs.observables, SamplingBitSource::Observables, result.observables,
+               plan.num_observables());
+    run_fixed_sampling_into(
+        plan, shots,
+        {.bits = std::span<const SamplingBitOutput>(bit_outputs).first(output_count),
+         .exp_vals = result.exp_vals,
+         .exp_val_row_stride = plan.num_exp_vals()},
+        outputs, seed, threads, thread_layout, batch_size);
+    return result;
+}
+
+void sample_into(const ExecutablePlan& plan, uint32_t shots, SamplingOutputBuffer output,
+                 std::optional<uint64_t> seed, uint32_t threads,
+                 std::optional<ThreadLayout> thread_layout, std::optional<uint32_t> batch_size) {
+    validate_fixed_sampling_plan(plan);
+    const SamplingOutputSelection outputs = validate_output_buffer(plan, shots, output);
+    clear_bit_outputs(shots, output);
+    run_fixed_sampling_into(plan, shots, output, outputs, seed, threads, thread_layout, batch_size);
+}
+
+PackedSamplingResult sample_packed_selected(const ExecutablePlan& plan, uint32_t shots,
+                                            SamplingOutputSelection outputs,
+                                            std::optional<uint64_t> seed, uint32_t threads,
+                                            std::optional<ThreadLayout> thread_layout,
+                                            std::optional<uint32_t> batch_size) {
+    validate_fixed_sampling_plan(plan);
+    PackedSamplingResult result;
+    const auto packed_stride = [](size_t columns) noexcept {
+        return columns / 8 + static_cast<size_t>((columns & 7) != 0);
+    };
+    const size_t measurement_stride = packed_stride(plan.num_visible_records());
+    const size_t detector_stride = packed_stride(plan.num_detectors());
+    const size_t observable_stride = packed_stride(plan.num_observables());
+    if (outputs.measurements) {
+        result.measurements.resize(checked_output_size(shots, measurement_stride));
     }
-    return sample_fixed_rows(
-        plan, shots, outputs, seed, resolved,
-        [&](uint32_t) {
-            return std::make_unique<SamplingWorker>(plan, resolved.intra_shot_workers,
-                                                    resolved.intra_shot_min_active_width);
-        },
-        [](SamplingWorker& worker) noexcept { worker.executor.run_shot(); });
+    if (outputs.detectors) {
+        result.detectors.resize(checked_output_size(shots, detector_stride));
+    }
+    if (outputs.observables) {
+        result.observables.resize(checked_output_size(shots, observable_stride));
+    }
+    if (outputs.exp_vals) {
+        result.exp_vals.resize(checked_output_size(shots, plan.num_exp_vals()));
+    }
+    std::array<SamplingBitOutput, 3> bit_outputs;
+    size_t output_count = 0;
+    const auto add_output = [&](bool selected, SamplingBitSource source, std::vector<uint8_t>& data,
+                                size_t stride) {
+        if (selected) {
+            bit_outputs[output_count++] = {
+                .source = source,
+                .packing = SamplingBitPacking::BitPacked,
+                .data = data,
+                .row_stride = stride,
+            };
+        }
+    };
+    add_output(outputs.measurements, SamplingBitSource::Measurements, result.measurements,
+               measurement_stride);
+    add_output(outputs.detectors, SamplingBitSource::Detectors, result.detectors, detector_stride);
+    add_output(outputs.observables, SamplingBitSource::Observables, result.observables,
+               observable_stride);
+    run_fixed_sampling_into(
+        plan, shots,
+        {.bits = std::span<const SamplingBitOutput>(bit_outputs).first(output_count),
+         .exp_vals = result.exp_vals,
+         .exp_val_row_stride = plan.num_exp_vals()},
+        outputs, seed, threads, thread_layout, batch_size);
+    return result;
 }
 
 std::vector<uint8_t> sample_records(const ExecutablePlan& plan, uint32_t shots,
@@ -545,14 +826,14 @@ SamplingSurvivorResult sample_survivors_selected(const ExecutablePlan& plan, uin
         outputs.any() ? BatchOutputMode::Rows : BatchOutputMode::AggregateSurvivors;
     const BatchExecutionPolicy batch_policy = resolve_batch_execution_policy(
         plan, shots, resolved.shot_workers, resolved.intra_shot_workers, output_mode, batch_size,
-        BatchSamplingMode::Ordinary, survivor_worker_bytes(plan));
+        BatchSamplingMode::Ordinary, survivor_worker_bytes(plan), outputs);
     if constexpr (kPackedBatchExecutionAvailable) {
         if (batch_policy.lane_capacity > 1) {
             return sample_surviving_batches(
                 plan, shots, outputs, seed, batch_policy,
                 [&](uint32_t) {
                     return std::make_unique<BatchSurvivorWorker>(plan, batch_policy.lane_capacity,
-                                                                 outputs.any());
+                                                                 outputs);
                 },
                 [](BatchSurvivorWorker& worker, const SeedRoot& root, uint32_t first_shot,
                    uint32_t batch) noexcept {

--- a/src/clifft/sampling/sampler.h
+++ b/src/clifft/sampling/sampler.h
@@ -69,6 +69,21 @@ struct ThreadLayout {
     std::optional<ThreadLayout> thread_layout = std::nullopt,
     std::optional<uint32_t> batch_size = std::nullopt);
 
+// Samples fixed rows directly into caller-owned destinations. Boolean sources
+// may be emitted more than once and composed at arbitrary column offsets.
+// Storage is validated and initialized before hot execution.
+void sample_into(const ExecutablePlan& plan, uint32_t shots, SamplingOutputBuffer output,
+                 std::optional<uint64_t> seed = std::nullopt, uint32_t threads = 1,
+                 std::optional<ThreadLayout> thread_layout = std::nullopt,
+                 std::optional<uint32_t> batch_size = std::nullopt);
+
+// Allocates little-endian packed Boolean rows for the selected sources.
+[[nodiscard]] PackedSamplingResult sample_packed_selected(
+    const ExecutablePlan& plan, uint32_t shots, SamplingOutputSelection outputs,
+    std::optional<uint64_t> seed = std::nullopt, uint32_t threads = 1,
+    std::optional<ThreadLayout> thread_layout = std::nullopt,
+    std::optional<uint32_t> batch_size = std::nullopt);
+
 [[nodiscard]] SamplingSurvivorResult sample_survivors(
     const ExecutablePlan& plan, uint32_t shots, std::optional<uint64_t> seed = std::nullopt,
     bool keep_records = false, uint32_t threads = 1,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(clifft_tests
     test_sampling_planner.cc
     test_sampling_planner_frame.cc
     test_sampling_executor.cc
+    test_sampling_output.cc
     test_fused_rotation.cc
     test_sampling_kernels.cc
     test_interleaved_batch_kernels.cc

--- a/tests/test_batch_bits.cc
+++ b/tests/test_batch_bits.cc
@@ -74,3 +74,43 @@ TEST_CASE("Packed batch low masks clear padding") {
     REQUIRE(words[1] == 1);
     REQUIRE(words[2] == 0);
 }
+
+TEST_CASE("Packed batch columns transpose directly into row outputs") {
+    constexpr size_t columns = 13;
+    for (uint32_t lanes : std::array<uint32_t, 8>{1, 7, 8, 9, 63, 64, 65, 130}) {
+        PackedBitColumns values(columns, lanes);
+        for (size_t column = 0; column < columns; ++column) {
+            for (uint32_t lane = 0; lane < lanes; ++lane) {
+                if (((lane * 17 + column * 5) % 11) < 4) {
+                    values.set_bit(column, lane);
+                }
+            }
+        }
+
+        constexpr size_t unpacked_offset = 2;
+        constexpr size_t unpacked_stride = unpacked_offset + columns + 1;
+        std::vector<uint8_t> unpacked(static_cast<size_t>(lanes) * unpacked_stride, 0xA5);
+        values.write_unpacked_rows(lanes, columns, unpacked, unpacked_stride, unpacked_offset);
+
+        constexpr size_t packed_offset = 3;
+        constexpr size_t packed_stride = 3;
+        std::vector<uint8_t> packed(static_cast<size_t>(lanes) * packed_stride, 0);
+        values.write_packed_rows(lanes, columns, packed, packed_stride, packed_offset);
+
+        CAPTURE(lanes);
+        for (uint32_t lane = 0; lane < lanes; ++lane) {
+            REQUIRE(unpacked[static_cast<size_t>(lane) * unpacked_stride] == 0xA5);
+            REQUIRE(unpacked[static_cast<size_t>(lane) * unpacked_stride + 1] == 0xA5);
+            for (size_t column = 0; column < columns; ++column) {
+                const bool expected = values.bit(column, lane);
+                CAPTURE(lane, column);
+                REQUIRE(unpacked[static_cast<size_t>(lane) * unpacked_stride + unpacked_offset +
+                                 column] == static_cast<uint8_t>(expected));
+                REQUIRE(((packed[static_cast<size_t>(lane) * packed_stride +
+                                 ((packed_offset + column) >> 3)] >>
+                          ((packed_offset + column) & 7)) &
+                         uint8_t{1}) == static_cast<uint8_t>(expected));
+            }
+        }
+    }
+}

--- a/tests/test_batch_executor.cc
+++ b/tests/test_batch_executor.cc
@@ -346,6 +346,40 @@ TEST_CASE("Packed capacity policy bounds worker state footprint") {
                 .lane_capacity == 1);
 }
 
+TEST_CASE("Packed worker storage follows selected external outputs") {
+    const ExecutablePlan executable = compile_batch_test_plan();
+    const auto detectors = clifft::sampling::batch_detail::batch_worker_storage_layout(
+        executable, 65, BatchOutputMode::Rows, BatchSamplingMode::Ordinary, {.detectors = true});
+    REQUIRE(detectors.record_columns == executable.num_visible_records());
+    REQUIRE(detectors.detector_columns == executable.num_detectors());
+    REQUIRE(detectors.observable_columns == 0);
+    REQUIRE(detectors.exp_value_entries == 0);
+
+    const auto measurements = clifft::sampling::batch_detail::batch_worker_storage_layout(
+        executable, 65, BatchOutputMode::Rows, BatchSamplingMode::Ordinary, {.measurements = true});
+    REQUIRE(measurements.record_columns == executable.num_visible_records());
+    REQUIRE(measurements.detector_columns == 0);
+    REQUIRE(measurements.observable_columns == 0);
+    REQUIRE(measurements.exp_value_entries == 0);
+
+    const auto none = clifft::sampling::batch_detail::batch_worker_storage_layout(
+        executable, 65, BatchOutputMode::Rows, BatchSamplingMode::Ordinary, {});
+    REQUIRE(none.record_columns == 0);
+    REQUIRE(none.detector_columns == 0);
+    REQUIRE(none.observable_columns == 0);
+    REQUIRE(none.exp_value_entries == 0);
+
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan postselected = compile_batch_test_plan(postselection);
+    const auto survivor_rows = clifft::sampling::batch_detail::batch_worker_storage_layout(
+        postselected, 65, BatchOutputMode::Rows, BatchSamplingMode::Ordinary,
+        {.measurements = true});
+    REQUIRE(survivor_rows.record_columns == postselected.num_visible_records());
+    REQUIRE(survivor_rows.detector_columns == 0);
+    REQUIRE(survivor_rows.observable_columns == postselected.num_observables());
+    REQUIRE(survivor_rows.exp_value_entries == 0);
+}
+
 TEST_CASE("Packed capacity policy accounts for lane-scaled sidecars") {
     constexpr uint32_t shots = 100'000;
     const ExecutablePlan d7 = compile_batch_fixture("surface_d7_r7_p001.stim");

--- a/tests/test_benchmarks.cc
+++ b/tests/test_benchmarks.cc
@@ -116,6 +116,18 @@ TEST_CASE("Bench: surface d7 r7 p1e-3 sampling 10000 shots", "[bench]") {
     };
 }
 
+TEST_CASE("Bench: surface d7 detector output materialization", "[bench]") {
+    auto mod = compile_circuit(fixture("surface_d7_r7_p001.stim"));
+    const sampling::SamplingOutputSelection detectors_only{.detectors = true};
+
+    BENCHMARK("surface-d7 unpacked dets x10k") {
+        return sampling::sample_selected(mod, 10000, detectors_only, 0);
+    };
+    BENCHMARK("surface-d7 packed dets x10k") {
+        return sampling::sample_packed_selected(mod, 10000, detectors_only, 0);
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Surface code d=5 r=5 with high physical noise (p=0.05): forces most NOISE
 // sites to fire, exercising the APPLY_PAULI / NOISE full-mask XOR + popcount

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -1328,6 +1328,174 @@ TEST_CASE("Selected survivor sampling compacts only requested output matrices") 
     REQUIRE(selected.exp_vals.empty());
 }
 
+TEST_CASE("Packed sampling writes little endian selected rows") {
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+        H 0 1 2 3 4 5 6 7 8 9
+        M 0 1 2 3 4 5 6 7 8 9
+        DETECTOR rec[-10]
+        DETECTOR rec[-9]
+        DETECTOR rec[-8]
+        DETECTOR rec[-7]
+        DETECTOR rec[-6]
+        DETECTOR rec[-5]
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-10] rec[-1]
+        OBSERVABLE_INCLUDE(1) rec[-9] rec[-2]
+        OBSERVABLE_INCLUDE(2) rec[-8] rec[-3]
+        EXP_VAL Z0
+    )"))));
+    constexpr uint32_t shots = 129;
+    const clifft::sampling::SamplingOutputSelection outputs{
+        .detectors = true,
+        .observables = true,
+        .exp_vals = true,
+    };
+    const auto bit = [](std::span<const uint8_t> rows, size_t stride, uint32_t shot,
+                        size_t column) {
+        return (rows[static_cast<size_t>(shot) * stride + (column >> 3)] >> (column & 7)) &
+               uint8_t{1};
+    };
+
+    for (uint32_t capacity : std::array<uint32_t, 2>{1, 65}) {
+        const clifft::sampling::SamplingResult unpacked = clifft::sampling::sample_selected(
+            executable, shots, outputs, uint64_t{91823}, 1, std::nullopt, capacity);
+        const clifft::sampling::PackedSamplingResult packed =
+            clifft::sampling::sample_packed_selected(executable, shots, outputs, uint64_t{91823}, 1,
+                                                     std::nullopt, capacity);
+        constexpr size_t detector_stride = 2;
+        constexpr size_t observable_stride = 1;
+        CAPTURE(capacity);
+        REQUIRE(packed.measurements.empty());
+        REQUIRE(packed.detectors.size() == shots * detector_stride);
+        REQUIRE(packed.observables.size() == shots * observable_stride);
+        REQUIRE(packed.exp_vals == unpacked.exp_vals);
+        for (uint32_t shot = 0; shot < shots; ++shot) {
+            for (uint32_t detector = 0; detector < executable.num_detectors(); ++detector) {
+                REQUIRE(bit(packed.detectors, detector_stride, shot, detector) ==
+                        unpacked.detectors[static_cast<size_t>(shot) * executable.num_detectors() +
+                                           detector]);
+            }
+            for (uint32_t observable = 0; observable < executable.num_observables(); ++observable) {
+                REQUIRE(
+                    bit(packed.observables, observable_stride, shot, observable) ==
+                    unpacked.observables[static_cast<size_t>(shot) * executable.num_observables() +
+                                         observable]);
+            }
+            REQUIRE((packed.detectors[static_cast<size_t>(shot) * detector_stride + 1] & 0xFC) ==
+                    0);
+            REQUIRE((packed.observables[shot] & 0xF8) == 0);
+        }
+    }
+}
+
+TEST_CASE("Caller output buffers compose detector and observable rows") {
+    const ExecutablePlan executable(clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+        H 0 1 2 3
+        M 0 1 2 3
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-4] rec[-1]
+        OBSERVABLE_INCLUDE(1) rec[-3] rec[-2]
+        EXP_VAL Z0
+    )"))));
+    constexpr uint32_t shots = 129;
+    const clifft::sampling::SamplingResult expected =
+        clifft::sampling::sample(executable, shots, uint64_t{91824}, 1, std::nullopt, 65);
+    const size_t measurement_stride = executable.num_visible_records() + 2;
+    const size_t logical_bits = executable.num_observables() * 2 + executable.num_detectors();
+    const size_t combined_stride = (logical_bits + 7) / 8 + 1;
+    std::vector<uint8_t> measurements(shots * measurement_stride, 0xFF);
+    std::vector<uint8_t> combined(shots * combined_stride, 0xFF);
+    std::vector<double> exp_vals(shots * 3, -17.0);
+    const std::array<clifft::sampling::SamplingBitOutput, 4> destinations{
+        clifft::sampling::SamplingBitOutput{
+            .source = clifft::sampling::SamplingBitSource::Measurements,
+            .data = measurements,
+            .row_stride = measurement_stride,
+            .column_offset = 1,
+        },
+        clifft::sampling::SamplingBitOutput{
+            .source = clifft::sampling::SamplingBitSource::Observables,
+            .packing = clifft::sampling::SamplingBitPacking::BitPacked,
+            .data = combined,
+            .row_stride = combined_stride,
+        },
+        clifft::sampling::SamplingBitOutput{
+            .source = clifft::sampling::SamplingBitSource::Detectors,
+            .packing = clifft::sampling::SamplingBitPacking::BitPacked,
+            .data = combined,
+            .row_stride = combined_stride,
+            .column_offset = executable.num_observables(),
+        },
+        clifft::sampling::SamplingBitOutput{
+            .source = clifft::sampling::SamplingBitSource::Observables,
+            .packing = clifft::sampling::SamplingBitPacking::BitPacked,
+            .data = combined,
+            .row_stride = combined_stride,
+            .column_offset = executable.num_observables() + executable.num_detectors(),
+        },
+    };
+    clifft::sampling::sample_into(
+        executable, shots, {.bits = destinations, .exp_vals = exp_vals, .exp_val_row_stride = 3},
+        uint64_t{91824}, 1, std::nullopt, 65);
+
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const size_t expected_measurement =
+            static_cast<size_t>(shot) * executable.num_visible_records();
+        const size_t measurement_row = static_cast<size_t>(shot) * measurement_stride;
+        REQUIRE(measurements[measurement_row] == 0);
+        REQUIRE(measurements[measurement_row + measurement_stride - 1] == 0);
+        for (uint32_t record = 0; record < executable.num_visible_records(); ++record) {
+            REQUIRE(measurements[measurement_row + 1 + record] ==
+                    expected.measurements[expected_measurement + record]);
+        }
+        const auto combined_bit = [&](size_t column) {
+            return (combined[static_cast<size_t>(shot) * combined_stride + (column >> 3)] >>
+                    (column & 7)) &
+                   uint8_t{1};
+        };
+        for (uint32_t observable = 0; observable < executable.num_observables(); ++observable) {
+            const uint8_t value =
+                expected.observables[static_cast<size_t>(shot) * executable.num_observables() +
+                                     observable];
+            REQUIRE(combined_bit(observable) == value);
+            REQUIRE(combined_bit(executable.num_observables() + executable.num_detectors() +
+                                 observable) == value);
+        }
+        for (uint32_t detector = 0; detector < executable.num_detectors(); ++detector) {
+            REQUIRE(combined_bit(executable.num_observables() + detector) ==
+                    expected.detectors[static_cast<size_t>(shot) * executable.num_detectors() +
+                                       detector]);
+        }
+        REQUIRE(exp_vals[static_cast<size_t>(shot) * 3] == expected.exp_vals[shot]);
+        REQUIRE(exp_vals[static_cast<size_t>(shot) * 3 + 1] == -17.0);
+        REQUIRE(exp_vals[static_cast<size_t>(shot) * 3 + 2] == -17.0);
+        REQUIRE(combined[static_cast<size_t>(shot) * combined_stride + combined_stride - 1] == 0);
+    }
+}
+
+TEST_CASE("Caller output buffers reject undersized rows before sampling") {
+    const ExecutablePlan executable(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse("M 0 1 2"))));
+    std::vector<uint8_t> output(4, 0xA5);
+    const clifft::sampling::SamplingBitOutput destination{
+        .source = clifft::sampling::SamplingBitSource::Measurements,
+        .packing = clifft::sampling::SamplingBitPacking::BitPacked,
+        .data = output,
+        .row_stride = 1,
+        .column_offset = 6,
+    };
+    REQUIRE_THROWS_WITH(
+        clifft::sampling::sample_into(executable, 4, {.bits = {&destination, 1}}, uint64_t{91825}),
+        "sampling bit output row stride is too small");
+    REQUIRE(std::ranges::all_of(output, [](uint8_t value) { return value == 0xA5; }));
+}
+
 TEST_CASE("Sampling executor presamples mutually exclusive Pauli noise") {
     const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
         E(0.5) X0

--- a/tests/test_sampling_output.cc
+++ b/tests/test_sampling_output.cc
@@ -1,0 +1,50 @@
+#include "clifft/sampling/output_writer.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+using clifft::sampling::SamplingFileFormat;
+using clifft::sampling::SamplingRowWriter;
+
+TEST_CASE("Sampling row writer streams common Stim formats") {
+    constexpr std::array<uint8_t, 6> rows{0x55, 0x01, 0xAA, 0x02, 0xFF, 0x03};
+
+    std::ostringstream text;
+    SamplingRowWriter text_writer(text, SamplingFileFormat::Format01, 10, 3);
+    text_writer.write_packed_rows(rows, 2, 2);
+    text_writer.write_packed_rows(std::span<const uint8_t>(rows).subspan(4), 1, 2);
+    REQUIRE(text.str() == "1010101010\n0101010101\n1111111111\n");
+
+    std::ostringstream binary;
+    SamplingRowWriter binary_writer(binary, SamplingFileFormat::B8, 10, 3);
+    constexpr std::array<uint8_t, 9> padded_rows{0x55, 0x01, 0xCC, 0xAA, 0x02,
+                                                 0xCC, 0xFF, 0x03, 0xCC};
+    binary_writer.write_packed_rows(padded_rows, 3, 3);
+    REQUIRE(binary.str() == std::string("\x55\x01\xAA\x02\xFF\x03", 6));
+}
+
+TEST_CASE("Sampling row writer preserves empty row semantics") {
+    std::ostringstream text;
+    SamplingRowWriter text_writer(text, SamplingFileFormat::Format01, 0, 3);
+    text_writer.write_packed_rows({}, 3, 0);
+    REQUIRE(text.str() == "\n\n\n");
+
+    std::ostringstream binary;
+    SamplingRowWriter binary_writer(binary, SamplingFileFormat::B8, 0, 3);
+    binary_writer.write_packed_rows({}, 3, 0);
+    REQUIRE(binary.str().empty());
+}
+
+TEST_CASE("Sampling row writer validates retained batch bounds") {
+    std::ostringstream output;
+    SamplingRowWriter writer(output, SamplingFileFormat::B8, 9, 2);
+    constexpr std::array<uint8_t, 4> rows{};
+    REQUIRE_THROWS_WITH(writer.write_packed_rows(rows, 3, 2),
+                        "sampling writer batch exceeds retained capacity");
+    REQUIRE_THROWS_WITH(writer.write_packed_rows(rows, 2, 1),
+                        "sampling writer row stride is too small");
+}


### PR DESCRIPTION
## Summary

- transpose native packed batch columns directly into little-endian row bytes
- write packed or unpacked results into caller-owned strided buffers, including native detector/observable composition
- propagate output selection into packed-worker storage and skip unrequested detector, observable, and expectation work
- add retained-scratch streaming encoders for Stim's common `01` and `b8` formats
- add an end-to-end detector materialization benchmark

This is the second layer of #425 and is stacked on #426. It deliberately stops below the Python facade: retained compiled samplers and nanobind buffer wiring belong to the next PR.

## Performance

On the release surface-code d7 fixture, 10,000 detector-only shots measured approximately:

- unpacked rows: 2.15 ms
- packed rows: 1.48 ms

That is about a 31% reduction for end-to-end sampling plus output materialization on this machine.

## Test plan

- [x] Debug C++ suite passes excluding opt-in benchmarks (938/938)
- [x] Scalar and packed-capacity paths match unpacked rows exactly
- [x] Tests cover little-endian order, partial bytes, arbitrary offsets, duplicate observable destinations, caller strides, empty rows, and undersized-buffer validation
- [x] `01` and `b8` streaming encoder tests pass
- [x] Release materialization benchmark exercised
- [x] Pre-commit checks pass

## Contributor agreement

- [x] I confirm this contribution is my original work (or I have the right to submit it) and I license it under this project's Apache-2.0 license.
- [x] I have reviewed the AI-assisted code and included `Assisted-by:` git trailers in the commits.

Contributes to #425.
