### PR TITLE
feat(sampling): retain compiled sampler workers

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(clifft_core STATIC
     sampling/batch/executor.cc
     sampling/batch/policy.cc
     sampling/batch/presampled_program.cc
+    sampling/compiled_sampler.cc
     sampling/kernel_dispatch.cc
     sampling/executable_plan.cc
     sampling/executable_plan_inspection.cc

--- a/src/clifft/sampling/compiled_sampler.cc
+++ b/src/clifft/sampling/compiled_sampler.cc
@@ -1,0 +1,363 @@
+#include "clifft/sampling/compiled_sampler.h"
+
+#include "clifft/sampling/batch/executor.h"
+#include "clifft/sampling/batch/policy.h"
+#include "clifft/sampling/executor.h"
+#include "clifft/util/shot_parallel.h"
+#include "clifft/util/shot_seed.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <limits>
+#include <ostream>
+#include <stdexcept>
+
+namespace clifft::sampling {
+
+namespace {
+
+inline constexpr size_t kTargetStreamBufferBytes = 8 * 1024 * 1024;
+
+size_t checked_output_size(uint32_t shots, size_t stride) {
+    if (stride != 0 && shots > std::numeric_limits<size_t>::max() / stride) {
+        throw std::length_error("compiled sampler output size exceeds size_t range");
+    }
+    return static_cast<size_t>(shots) * stride;
+}
+
+size_t bit_source_width(const ExecutablePlan& plan, SamplingBitSource source) noexcept {
+    switch (source) {
+        case SamplingBitSource::Measurements:
+            return plan.num_visible_records();
+        case SamplingBitSource::Detectors:
+            return plan.num_detectors();
+        case SamplingBitSource::Observables:
+            return plan.num_observables();
+    }
+    assert(false && "compiled sampler bit source must be valid");
+    return 0;
+}
+
+bool source_available(SamplingOutputSelection available, SamplingBitSource source) noexcept {
+    switch (source) {
+        case SamplingBitSource::Measurements:
+            return available.measurements;
+        case SamplingBitSource::Detectors:
+            return available.detectors;
+        case SamplingBitSource::Observables:
+            return available.observables;
+    }
+    return false;
+}
+
+std::span<const uint8_t> scalar_bit_source(const Executor& executor,
+                                           SamplingBitSource source) noexcept {
+    switch (source) {
+        case SamplingBitSource::Measurements:
+            return executor.visible_records();
+        case SamplingBitSource::Detectors:
+            return executor.detectors();
+        case SamplingBitSource::Observables:
+            return executor.observables();
+    }
+    assert(false && "compiled sampler bit source must be valid");
+    return {};
+}
+
+void validate_output(const ExecutablePlan& plan, SamplingOutputSelection available, uint32_t shots,
+                     SamplingOutputBuffer output) {
+    for (const SamplingBitOutput& destination : output.bits) {
+        if (!source_available(available, destination.source)) {
+            throw std::invalid_argument("compiled sampler output source was not retained");
+        }
+        const size_t columns = bit_source_width(plan, destination.source);
+        if (destination.column_offset > std::numeric_limits<size_t>::max() - columns) {
+            throw std::length_error("compiled sampler output column range exceeds size_t");
+        }
+        const size_t end_column = destination.column_offset + columns;
+        const size_t minimum_stride =
+            destination.packing == SamplingBitPacking::BitPacked
+                ? end_column / 8 + static_cast<size_t>((end_column & 7) != 0)
+                : end_column;
+        if (destination.row_stride < minimum_stride) {
+            throw std::invalid_argument("compiled sampler bit output row stride is too small");
+        }
+        if (destination.data.size() < checked_output_size(shots, destination.row_stride)) {
+            throw std::invalid_argument("compiled sampler bit output buffer is too small");
+        }
+    }
+    if (!output.exp_vals.empty()) {
+        if (!available.exp_vals) {
+            throw std::invalid_argument("compiled sampler expectation output was not retained");
+        }
+        if (output.exp_val_row_stride < plan.num_exp_vals()) {
+            throw std::invalid_argument(
+                "compiled sampler expectation output row stride is too small");
+        }
+        if (output.exp_vals.size() < checked_output_size(shots, output.exp_val_row_stride)) {
+            throw std::invalid_argument("compiled sampler expectation output buffer is too small");
+        }
+    }
+}
+
+void clear_bit_outputs(uint32_t shots, SamplingOutputBuffer output) noexcept {
+    for (const SamplingBitOutput& destination : output.bits) {
+        std::ranges::fill(
+            destination.data.first(static_cast<size_t>(shots) * destination.row_stride),
+            uint8_t{0});
+    }
+}
+
+void reseed_executor(Executor& executor, const SeedRoot& root, uint32_t shot) noexcept {
+    const std::array<uint64_t, 4> words = derive_state(root, shot, kSamplingExecutorDomain);
+    executor.reseed_full(words[0], words[1], words[2], words[3]);
+}
+
+void write_scalar_outputs(SamplingOutputBuffer output, const Executor& executor,
+                          uint32_t shot) noexcept {
+    for (const SamplingBitOutput& destination : output.bits) {
+        const std::span<const uint8_t> source = scalar_bit_source(executor, destination.source);
+        if (source.empty()) {
+            continue;
+        }
+        uint8_t* row = destination.data.data() + static_cast<size_t>(shot) * destination.row_stride;
+        if (destination.packing == SamplingBitPacking::Unpacked) {
+            std::ranges::copy(source, row + destination.column_offset);
+            continue;
+        }
+        for (size_t column = 0; column < source.size(); ++column) {
+            row[(destination.column_offset + column) >> 3] |=
+                source[column] << ((destination.column_offset + column) & 7);
+        }
+    }
+    if (!output.exp_vals.empty()) {
+        std::ranges::copy(
+            executor.exp_vals(),
+            output.exp_vals.begin() + static_cast<size_t>(shot) * output.exp_val_row_stride);
+    }
+}
+
+void write_batch_outputs(SamplingOutputBuffer output, const BatchExecutor& executor,
+                         uint32_t first_shot, uint32_t shots, const ExecutablePlan& plan) noexcept {
+    assert(executor.surviving_shots() == shots && "compiled fixed-row batch must retain all shots");
+    for (const SamplingBitOutput& destination : output.bits) {
+        executor.write_bit_rows(
+            destination.source, destination.packing,
+            destination.data.subspan(static_cast<size_t>(first_shot) * destination.row_stride),
+            destination.row_stride, destination.column_offset);
+    }
+    if (!output.exp_vals.empty()) {
+        for (uint32_t lane = 0; lane < shots; ++lane) {
+            double* row = output.exp_vals.data() +
+                          static_cast<size_t>(first_shot + lane) * output.exp_val_row_stride;
+            for (uint32_t exp_val = 0; exp_val < plan.num_exp_vals(); ++exp_val) {
+                row[exp_val] = executor.exp_val(lane, exp_val);
+            }
+        }
+    }
+}
+
+SeedRoot call_seed_root(const SeedRoot& sampler_root, uint64_t call) noexcept {
+    const std::array<uint64_t, 4> words =
+        derive_state(sampler_root, call, kCompiledSamplerCallDomain);
+    return {{words[0], words[1], words[2], words[3]}};
+}
+
+size_t checked_add(size_t left, size_t right, const char* message) {
+    if (right > std::numeric_limits<size_t>::max() - left) {
+        throw std::length_error(message);
+    }
+    return left + right;
+}
+
+struct PreparedFileOutput {
+    std::ostream* output = nullptr;
+    SamplingFileFormat format = SamplingFileFormat::Format01;
+    std::span<const SamplingBitSource> sources;
+    size_t columns = 0;
+    size_t row_stride = 0;
+    std::vector<uint8_t> rows;
+    std::unique_ptr<SamplingRowWriter> writer;
+};
+
+}  // namespace
+
+struct CompiledSampler::Worker {
+    Worker(const ExecutablePlan& plan, uint32_t lane_capacity,
+           SamplingOutputSelection available_outputs)
+        : scalar(lane_capacity == 1 ? std::make_unique<Executor>(plan, 0) : nullptr),
+          batch(lane_capacity > 1 ? std::make_unique<BatchExecutor>(
+                                        plan, lane_capacity, BatchOutputMode::Rows,
+                                        BatchSamplingMode::Ordinary, available_outputs)
+                                  : nullptr) {}
+
+    std::unique_ptr<Executor> scalar;
+    std::unique_ptr<BatchExecutor> batch;
+};
+
+CompiledSampler::CompiledSampler(std::shared_ptr<const ExecutablePlan> plan,
+                                 SamplingOutputSelection available_outputs,
+                                 std::optional<uint64_t> seed, uint32_t threads,
+                                 std::optional<uint32_t> batch_size)
+    : plan_(std::move(plan)),
+      available_outputs_(available_outputs),
+      seed_root_(seed.has_value() ? seed_root_from_seed(*seed) : make_seed_root(1, std::nullopt)) {
+    if (plan_ == nullptr) {
+        throw std::invalid_argument("compiled sampler requires an executable plan");
+    }
+    if (plan_->has_instruments()) {
+        throw std::invalid_argument("compiled samplers do not support instrument traps");
+    }
+    if (plan_->has_postselection()) {
+        throw std::invalid_argument("fixed-row compiled samplers do not support postselection");
+    }
+    if (plan_->num_unbound_presampled_symbols() != 0) {
+        throw std::invalid_argument(
+            "compiled samplers require a distribution for every presampled symbol");
+    }
+
+    const uint32_t thread_budget = resolve_thread_budget(threads);
+    const uint64_t planning_shots64 =
+        static_cast<uint64_t>(kDefaultMaxAutoBatchShots) * thread_budget;
+    const uint32_t planning_shots = static_cast<uint32_t>(std::min<uint64_t>(
+        std::numeric_limits<uint32_t>::max(), std::max<uint64_t>(1, planning_shots64)));
+    const BatchExecutionPolicy policy = resolve_batch_execution_policy(
+        *plan_, planning_shots, thread_budget, 1, BatchOutputMode::Rows, batch_size,
+        BatchSamplingMode::Ordinary, 0, available_outputs_);
+    lane_capacity_ = policy.lane_capacity;
+    const uint32_t worker_count =
+        lane_capacity_ > 1 ? policy.worker_count : std::max(uint32_t{1}, thread_budget);
+    workers_.reserve(worker_count);
+    for (uint32_t worker = 0; worker < worker_count; ++worker) {
+        workers_.push_back(std::make_unique<Worker>(*plan_, lane_capacity_, available_outputs_));
+    }
+}
+
+CompiledSampler::~CompiledSampler() = default;
+
+void CompiledSampler::execute_rows(const SeedRoot& root, uint32_t first_root_shot, uint32_t shots,
+                                   SamplingOutputBuffer output) {
+    clear_bit_outputs(shots, output);
+    if (shots == 0) {
+        return;
+    }
+
+    const uint32_t requested_workers =
+        std::min<uint32_t>(static_cast<uint32_t>(workers_.size()), shots);
+    if (lane_capacity_ > 1) {
+        (void)run_shot_ranges(
+            shots, requested_workers, [&](uint32_t worker) { return workers_[worker].get(); },
+            [&](Worker* worker, ShotRange range) noexcept {
+                for (uint32_t first_shot = range.begin; first_shot < range.end;) {
+                    const uint32_t batch = std::min(lane_capacity_, range.end - first_shot);
+                    worker->batch->run_batch(root, first_root_shot + first_shot, batch);
+                    write_batch_outputs(output, *worker->batch, first_shot, batch, *plan_);
+                    first_shot += batch;
+                }
+            },
+            lane_capacity_);
+    } else {
+        (void)run_shot_ranges(
+            shots, requested_workers, [&](uint32_t worker) { return workers_[worker].get(); },
+            [&](Worker* worker, ShotRange range) noexcept {
+                for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                    reseed_executor(*worker->scalar, root, first_root_shot + shot);
+                    worker->scalar->run_shot();
+                    write_scalar_outputs(output, *worker->scalar, shot);
+                }
+            });
+    }
+}
+
+void CompiledSampler::sample(uint32_t shots, SamplingOutputBuffer output) {
+    validate_output(*plan_, available_outputs_, shots, output);
+    std::lock_guard lock(mutex_);
+    if (shots == 0) {
+        clear_bit_outputs(shots, output);
+        return;
+    }
+
+    const SeedRoot root = call_seed_root(seed_root_, calls_completed_);
+    execute_rows(root, 0, shots, output);
+    ++calls_completed_;
+}
+
+void CompiledSampler::sample_write(uint32_t shots, std::span<const SamplingFileOutput> outputs) {
+    std::vector<PreparedFileOutput> files;
+    files.reserve(outputs.size());
+    size_t bytes_per_shot = 0;
+    for (const SamplingFileOutput& requested : outputs) {
+        if (requested.output == nullptr) {
+            throw std::invalid_argument("compiled sampler file output requires a stream");
+        }
+        size_t columns = 0;
+        for (SamplingBitSource source : requested.sources) {
+            if (!source_available(available_outputs_, source)) {
+                throw std::invalid_argument("compiled sampler file source was not retained");
+            }
+            columns = checked_add(columns, bit_source_width(*plan_, source),
+                                  "compiled sampler file row exceeds size_t");
+        }
+        const size_t row_stride = columns / 8 + static_cast<size_t>((columns & 7) != 0);
+        bytes_per_shot =
+            checked_add(bytes_per_shot, row_stride, "compiled sampler file buffers exceed size_t");
+        files.push_back({.output = requested.output,
+                         .format = requested.format,
+                         .sources = requested.sources,
+                         .columns = columns,
+                         .row_stride = row_stride});
+    }
+
+    uint32_t buffer_shots = std::min(shots, kDefaultMaxAutoBatchShots);
+    if (buffer_shots != 0 && bytes_per_shot != 0) {
+        const size_t byte_limited = std::max<size_t>(1, kTargetStreamBufferBytes / bytes_per_shot);
+        buffer_shots = static_cast<uint32_t>(
+            std::min<size_t>(buffer_shots, std::min<size_t>(byte_limited, UINT32_MAX)));
+    }
+    buffer_shots = std::max(uint32_t{1}, buffer_shots);
+
+    std::vector<SamplingBitOutput> destinations;
+    size_t destination_count = 0;
+    for (const PreparedFileOutput& file : files) {
+        destination_count = checked_add(destination_count, file.sources.size(),
+                                        "compiled sampler file destination count exceeds size_t");
+    }
+    destinations.reserve(destination_count);
+    for (PreparedFileOutput& file : files) {
+        file.rows.resize(checked_output_size(buffer_shots, file.row_stride));
+        file.writer = std::make_unique<SamplingRowWriter>(*file.output, file.format, file.columns,
+                                                          buffer_shots);
+        size_t column_offset = 0;
+        for (SamplingBitSource source : file.sources) {
+            destinations.push_back({.source = source,
+                                    .packing = SamplingBitPacking::BitPacked,
+                                    .data = file.rows,
+                                    .row_stride = file.row_stride,
+                                    .column_offset = column_offset});
+            column_offset += bit_source_width(*plan_, source);
+        }
+    }
+
+    std::lock_guard lock(mutex_);
+    if (shots == 0) {
+        return;
+    }
+    const SeedRoot root = call_seed_root(seed_root_, calls_completed_);
+    for (uint32_t first_shot = 0; first_shot < shots;) {
+        const uint32_t batch = std::min(buffer_shots, shots - first_shot);
+        execute_rows(root, first_shot, batch, {.bits = destinations});
+        for (PreparedFileOutput& file : files) {
+            file.writer->write_packed_rows(file.rows, batch, file.row_stride);
+        }
+        first_shot += batch;
+    }
+    ++calls_completed_;
+}
+
+uint64_t CompiledSampler::calls_completed() const {
+    std::lock_guard lock(mutex_);
+    return calls_completed_;
+}
+
+}  // namespace clifft::sampling

--- a/src/clifft/sampling/compiled_sampler.h
+++ b/src/clifft/sampling/compiled_sampler.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/output_writer.h"
+#include "clifft/sampling/results.h"
+#include "clifft/util/shot_seed.h"
+
+#include <cstdint>
+#include <iosfwd>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace clifft::sampling {
+
+// One file emitted by CompiledSampler::sample_write. Sources are concatenated
+// in order and may repeat, matching detector samplers that prepend or append
+// observables while also writing them to a separate file.
+struct SamplingFileOutput {
+    std::ostream* output = nullptr;
+    SamplingFileFormat format = SamplingFileFormat::Format01;
+    std::span<const SamplingBitSource> sources;
+};
+
+// Stateful fixed-row sampler used by Stim-compatible facades. The executable
+// plan, executor contexts, worker scratch, and sampler RNG root outlive every
+// sample call. Calls are serialized so one sampler advances one reproducible
+// stream even when Python releases the GIL.
+class CompiledSampler {
+  public:
+    CompiledSampler(std::shared_ptr<const ExecutablePlan> plan,
+                    SamplingOutputSelection available_outputs,
+                    std::optional<uint64_t> seed = std::nullopt, uint32_t threads = 1,
+                    std::optional<uint32_t> batch_size = std::nullopt);
+    ~CompiledSampler();
+
+    CompiledSampler(const CompiledSampler&) = delete;
+    CompiledSampler& operator=(const CompiledSampler&) = delete;
+    CompiledSampler(CompiledSampler&&) = delete;
+    CompiledSampler& operator=(CompiledSampler&&) = delete;
+
+    void sample(uint32_t shots, SamplingOutputBuffer output);
+    void sample_write(uint32_t shots, std::span<const SamplingFileOutput> outputs);
+
+    [[nodiscard]] const ExecutablePlan& plan() const noexcept { return *plan_; }
+    [[nodiscard]] SamplingOutputSelection available_outputs() const noexcept {
+        return available_outputs_;
+    }
+    [[nodiscard]] uint32_t lane_capacity() const noexcept { return lane_capacity_; }
+    [[nodiscard]] uint32_t worker_count() const noexcept {
+        return static_cast<uint32_t>(workers_.size());
+    }
+    [[nodiscard]] uint64_t calls_completed() const;
+
+  private:
+    struct Worker;
+
+    void execute_rows(const SeedRoot& root, uint32_t first_root_shot, uint32_t shots,
+                      SamplingOutputBuffer output);
+
+    std::shared_ptr<const ExecutablePlan> plan_;
+    SamplingOutputSelection available_outputs_;
+    SeedRoot seed_root_{};
+    uint32_t lane_capacity_ = 1;
+    std::vector<std::unique_ptr<Worker>> workers_;
+    mutable std::mutex mutex_;
+    uint64_t calls_completed_ = 0;
+};
+
+}  // namespace clifft::sampling

--- a/src/clifft/util/shot_seed_domains.h
+++ b/src/clifft/util/shot_seed_domains.h
@@ -10,6 +10,7 @@ namespace clifft {
 inline constexpr uint64_t kSamplingExecutorDomain = 0x01;
 inline constexpr uint64_t kHipSamplingExecutorDomain = 0x02;
 inline constexpr uint64_t kBatchSamplingExecutorDomain = 0x03;
+inline constexpr uint64_t kCompiledSamplerCallDomain = 0x04;
 inline constexpr uint64_t kTrajectoryDriverDomain = 0x11;
 inline constexpr uint64_t kTrajectoryExecutorDomain = 0x12;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(clifft_tests
     test_bitmask.cc
     test_batch_bits.cc
     test_batch_executor.cc
+    test_compiled_sampler.cc
     test_mask_view.cc
     test_numeric.cc
     test_page_allocation.cc

--- a/tests/test_benchmarks.cc
+++ b/tests/test_benchmarks.cc
@@ -15,13 +15,16 @@
 #include "clifft/circuit/parser.h"
 #include "clifft/frontend/frontend.h"
 #include "clifft/optimizer/pass_factory.h"
+#include "clifft/sampling/compiled_sampler.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
 
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 using namespace clifft;
 
@@ -125,6 +128,21 @@ TEST_CASE("Bench: surface d7 detector output materialization", "[bench]") {
     };
     BENCHMARK("surface-d7 packed dets x10k") {
         return sampling::sample_packed_selected(mod, 10000, detectors_only, 0);
+    };
+
+    auto retained_plan = std::make_shared<const sampling::ExecutablePlan>(std::move(mod));
+    sampling::CompiledSampler retained(retained_plan, detectors_only, uint64_t{0}, 1);
+    const size_t row_stride = (retained_plan->num_detectors() + 7) / 8;
+    std::vector<uint8_t> rows(10000 * row_stride);
+    const sampling::SamplingBitOutput destination{
+        .source = sampling::SamplingBitSource::Detectors,
+        .packing = sampling::SamplingBitPacking::BitPacked,
+        .data = rows,
+        .row_stride = row_stride,
+    };
+    BENCHMARK("surface-d7 retained dets x10k") {
+        retained.sample(10000, {.bits = std::span(&destination, 1)});
+        return rows.front();
     };
 }
 

--- a/tests/test_compiled_sampler.cc
+++ b/tests/test_compiled_sampler.cc
@@ -1,0 +1,248 @@
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/sampling/compiled_sampler.h"
+#include "clifft/sampling/planner.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using clifft::sampling::CompiledSampler;
+using clifft::sampling::ExecutablePlan;
+using clifft::sampling::SamplingBitOutput;
+using clifft::sampling::SamplingBitPacking;
+using clifft::sampling::SamplingBitSource;
+using clifft::sampling::SamplingOutputSelection;
+using clifft::sampling::SamplingResult;
+
+namespace {
+
+std::shared_ptr<const ExecutablePlan> compiled_test_plan() {
+    return std::make_shared<const ExecutablePlan>(
+        clifft::sampling::plan_sampling(clifft::trace(clifft::parse(R"(
+            X_ERROR(0.25) 0
+            H 1
+            M 0 1
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+            OBSERVABLE_INCLUDE(0) rec[-2] rec[-1]
+        )"))));
+}
+
+SamplingResult sample_all(CompiledSampler& sampler, uint32_t shots) {
+    const ExecutablePlan& plan = sampler.plan();
+    const SamplingOutputSelection available = sampler.available_outputs();
+    SamplingResult result;
+    std::vector<SamplingBitOutput> destinations;
+    if (available.measurements) {
+        result.measurements.resize(static_cast<size_t>(shots) * plan.num_visible_records());
+        destinations.push_back(SamplingBitOutput{
+            .source = SamplingBitSource::Measurements,
+            .data = result.measurements,
+            .row_stride = plan.num_visible_records(),
+        });
+    }
+    if (available.detectors) {
+        result.detectors.resize(static_cast<size_t>(shots) * plan.num_detectors());
+        destinations.push_back(SamplingBitOutput{
+            .source = SamplingBitSource::Detectors,
+            .data = result.detectors,
+            .row_stride = plan.num_detectors(),
+        });
+    }
+    if (available.observables) {
+        result.observables.resize(static_cast<size_t>(shots) * plan.num_observables());
+        destinations.push_back(SamplingBitOutput{
+            .source = SamplingBitSource::Observables,
+            .data = result.observables,
+            .row_stride = plan.num_observables(),
+        });
+    }
+    sampler.sample(shots, {.bits = destinations});
+    return result;
+}
+
+}  // namespace
+
+TEST_CASE("Compiled sampler retains a reproducible advancing stream") {
+    const auto plan = compiled_test_plan();
+    constexpr SamplingOutputSelection outputs{
+        .measurements = true,
+        .detectors = true,
+        .observables = true,
+    };
+    CompiledSampler first(plan, outputs, uint64_t{81234}, 1, uint32_t{65});
+    CompiledSampler replay(plan, outputs, uint64_t{81234}, 1, uint32_t{65});
+
+    const SamplingResult first_call = sample_all(first, 129);
+    const SamplingResult replay_first_call = sample_all(replay, 129);
+    REQUIRE(first_call.measurements == replay_first_call.measurements);
+    REQUIRE(first_call.detectors == replay_first_call.detectors);
+    REQUIRE(first_call.observables == replay_first_call.observables);
+
+    const SamplingResult second_call = sample_all(first, 129);
+    const SamplingResult replay_second_call = sample_all(replay, 129);
+    REQUIRE(second_call.measurements == replay_second_call.measurements);
+    REQUIRE(second_call.detectors == replay_second_call.detectors);
+    REQUIRE(second_call.observables == replay_second_call.observables);
+    REQUIRE(second_call.measurements != first_call.measurements);
+    REQUIRE(first.calls_completed() == 2);
+    REQUIRE(replay.calls_completed() == 2);
+    REQUIRE(first.lane_capacity() == 65);
+}
+
+TEST_CASE("Compiled sampler shot streams ignore retained worker count") {
+    const auto plan = compiled_test_plan();
+    constexpr SamplingOutputSelection outputs{
+        .measurements = true,
+        .detectors = true,
+        .observables = true,
+    };
+    CompiledSampler serial(plan, outputs, uint64_t{81235}, 1, uint32_t{65});
+    CompiledSampler threaded(plan, outputs, uint64_t{81235}, 4, uint32_t{65});
+    const SamplingResult serial_result = sample_all(serial, 521);
+    const SamplingResult threaded_result = sample_all(threaded, 521);
+    REQUIRE(serial_result.measurements == threaded_result.measurements);
+    REQUIRE(serial_result.detectors == threaded_result.detectors);
+    REQUIRE(serial_result.observables == threaded_result.observables);
+    REQUIRE(serial.worker_count() == 1);
+    REQUIRE(threaded.worker_count() == 4);
+}
+
+TEST_CASE("Compiled sampler writes packed composed outputs directly") {
+    const auto plan = compiled_test_plan();
+    constexpr SamplingOutputSelection outputs{
+        .detectors = true,
+        .observables = true,
+    };
+    CompiledSampler sampler(plan, outputs, uint64_t{81236}, 1, uint32_t{65});
+    CompiledSampler unpacked_sampler(plan, outputs, uint64_t{81236}, 1, uint32_t{65});
+    constexpr uint32_t shots = 129;
+    const size_t combined_columns = plan->num_observables() + plan->num_detectors();
+    const size_t combined_stride = (combined_columns + 7) / 8;
+    std::vector<uint8_t> combined(static_cast<size_t>(shots) * combined_stride, 0xFF);
+    const std::array<SamplingBitOutput, 2> packed_destinations{
+        SamplingBitOutput{
+            .source = SamplingBitSource::Observables,
+            .packing = SamplingBitPacking::BitPacked,
+            .data = combined,
+            .row_stride = combined_stride,
+        },
+        SamplingBitOutput{
+            .source = SamplingBitSource::Detectors,
+            .packing = SamplingBitPacking::BitPacked,
+            .data = combined,
+            .row_stride = combined_stride,
+            .column_offset = plan->num_observables(),
+        },
+    };
+    sampler.sample(shots, {.bits = packed_destinations});
+
+    SamplingResult unpacked;
+    unpacked.detectors.resize(static_cast<size_t>(shots) * plan->num_detectors());
+    unpacked.observables.resize(static_cast<size_t>(shots) * plan->num_observables());
+    const std::array<SamplingBitOutput, 2> unpacked_destinations{
+        SamplingBitOutput{.source = SamplingBitSource::Detectors,
+                          .data = unpacked.detectors,
+                          .row_stride = plan->num_detectors()},
+        SamplingBitOutput{.source = SamplingBitSource::Observables,
+                          .data = unpacked.observables,
+                          .row_stride = plan->num_observables()},
+    };
+    unpacked_sampler.sample(shots, {.bits = unpacked_destinations});
+
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        for (uint32_t observable = 0; observable < plan->num_observables(); ++observable) {
+            const uint8_t bit =
+                (combined[static_cast<size_t>(shot) * combined_stride + (observable >> 3)] >>
+                 (observable & 7)) &
+                1;
+            REQUIRE(bit ==
+                    unpacked.observables[static_cast<size_t>(shot) * plan->num_observables() +
+                                         observable]);
+        }
+        for (uint32_t detector = 0; detector < plan->num_detectors(); ++detector) {
+            const size_t column = plan->num_observables() + detector;
+            const uint8_t bit =
+                (combined[static_cast<size_t>(shot) * combined_stride + (column >> 3)] >>
+                 (column & 7)) &
+                1;
+            REQUIRE(
+                bit ==
+                unpacked.detectors[static_cast<size_t>(shot) * plan->num_detectors() + detector]);
+        }
+    }
+}
+
+TEST_CASE("Compiled sampler streams composed files from one advancing call") {
+    const auto plan = compiled_test_plan();
+    constexpr SamplingOutputSelection outputs{
+        .detectors = true,
+        .observables = true,
+    };
+    CompiledSampler sampler(plan, outputs, uint64_t{81237}, 2, uint32_t{65});
+    CompiledSampler expected_sampler(plan, outputs, uint64_t{81237}, 2, uint32_t{65});
+    constexpr uint32_t shots = 129;
+    const SamplingResult expected = sample_all(expected_sampler, shots);
+
+    std::ostringstream main_output(std::ios::binary);
+    std::ostringstream observable_output;
+    constexpr std::array main_sources{
+        SamplingBitSource::Observables,
+        SamplingBitSource::Detectors,
+        SamplingBitSource::Observables,
+    };
+    constexpr std::array observable_sources{SamplingBitSource::Observables};
+    const std::array files{
+        clifft::sampling::SamplingFileOutput{
+            .output = &main_output,
+            .format = clifft::sampling::SamplingFileFormat::B8,
+            .sources = main_sources,
+        },
+        clifft::sampling::SamplingFileOutput{
+            .output = &observable_output,
+            .format = clifft::sampling::SamplingFileFormat::Format01,
+            .sources = observable_sources,
+        },
+    };
+    sampler.sample_write(shots, files);
+
+    const std::string packed = main_output.str();
+    REQUIRE(packed.size() == shots);
+    std::string observable_text;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const uint8_t observable = expected.observables[shot];
+        const uint8_t detector0 = expected.detectors[static_cast<size_t>(shot) * 2];
+        const uint8_t detector1 = expected.detectors[static_cast<size_t>(shot) * 2 + 1];
+        const uint8_t expected_byte =
+            observable | (detector0 << 1) | (detector1 << 2) | (observable << 3);
+        REQUIRE(static_cast<uint8_t>(packed[shot]) == expected_byte);
+        observable_text += static_cast<char>('0' + observable);
+        observable_text += '\n';
+    }
+    REQUIRE(observable_output.str() == observable_text);
+    REQUIRE(sampler.calls_completed() == 1);
+}
+
+TEST_CASE("Compiled sampler validates retained sources before advancing") {
+    const auto plan = compiled_test_plan();
+    constexpr SamplingOutputSelection measurements_only{.measurements = true};
+    CompiledSampler sampler(plan, measurements_only, uint64_t{81238}, 1, uint32_t{65});
+    CompiledSampler replay(plan, measurements_only, uint64_t{81238}, 1, uint32_t{65});
+
+    std::vector<uint8_t> unavailable(plan->num_detectors());
+    const SamplingBitOutput unavailable_destination{
+        .source = SamplingBitSource::Detectors,
+        .data = unavailable,
+        .row_stride = plan->num_detectors(),
+    };
+    REQUIRE_THROWS_AS(sampler.sample(1, {.bits = std::span(&unavailable_destination, 1)}),
+                      std::invalid_argument);
+    sampler.sample(0, {});
+    REQUIRE(sampler.calls_completed() == 0);
+    REQUIRE(sample_all(sampler, 65).measurements == sample_all(replay, 65).measurements);
+}


### PR DESCRIPTION
Part of #425.

## Summary

- add a stateful fixed-row `CompiledSampler` that retains its executable plan, scalar or packed executors, worker scratch, batch policy, and sampler RNG root across calls
- advance a deterministic per-call stream while keeping shot results independent of retained worker count for a fixed batching configuration
- write unpacked, packed, and composed detector/observable rows directly into caller-owned buffers
- stream composed outputs to `01` and `b8` files in bounded native chunks, including simultaneous detector and observable files
- serialize calls on one sampler so GIL-released clients observe one well-defined stream

The hot execution path remains in C++. Validation, destination setup, and any stream scratch growth happen before dispatch; ordinary dispatch and kernels keep the existing allocation-free and exception-free contract.

## Validation

- Debug C++ suite: 943/943 non-benchmark tests passed
- focused compiled-sampler coverage: seeded replay and advancement, worker-count invariance, direct packed composition, streaming, zero-shot and validation behavior
- Release benchmark coverage added for retained packed detector output
- repository pre-commit suite passed

## Stack

- depends on #427
- next PR adds the thin Stim-shaped Python API and zero-copy NumPy bindings

Out of scope: reproducing Stim tableau analysis or circuit transformation APIs; this stack targets a Stim-compatible sampling backend.