### PR TITLE
feat(python): add Stim-compatible compiled samplers

### DIFF
--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -49,6 +49,44 @@ Terminology follows Stim's model:
 
 All three are returned per shot. Detectors and observables are empty arrays when the circuit does not declare them.
 
+## Retained Stim-Compatible Samplers
+
+Use the compiled sampler API when existing code expects Stim's measurement or
+detector sampler shape, or when the same circuit will be sampled repeatedly:
+
+```python
+import clifft
+
+sampler = clifft.compile_detector_sampler("""
+    X_ERROR(0.01) 0
+    M 0
+    DETECTOR rec[-1]
+    OBSERVABLE_INCLUDE(0) rec[-1]
+""", seed=42)
+
+detectors, observables = sampler.sample(
+    10000,
+    separate_observables=True,
+    bit_packed=True,
+)
+```
+
+`CompiledMeasurementSampler.sample()` and `CompiledDetectorSampler.sample()`
+match Stim's common sampling signatures, array shapes, Boolean and
+little-endian packed dtypes, observable placement, and caller-provided output
+arrays. `sample_write()` streams `01` or `b8` rows without materializing a full
+matrix.
+
+The compiled object retains its native plan, executor workers, and scratch
+storage across calls. Python allocates the requested NumPy destination, then
+C++ fills it directly while the GIL is released. A seed reproduces the sequence
+of calls made to a sampler; successive calls advance that sequence.
+
+The existing `compile()` plus `sample()` API remains the general Clifft API. It
+returns measurements, detectors, observables, and expectation values together,
+and its related APIs cover post-selection and importance sampling. The compiled
+sampler classes are the narrower compatibility and repeated-sampling surface.
+
 ## State Vector Extraction
 
 For debugging and small pure-unitary circuits, `get_statevector()` returns the final dense state vector:

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -1,8 +1,9 @@
 # Python API Reference
 
-`clifft.compile()` returns a reusable `Program` consumed by the sampling and
-exact-query functions below. All public sampling functions use that program
-directly; there is no sampler-selection module or backend switch.
+`clifft.compile()` returns a reusable `Program` for Clifft's general sampling
+and exact-query APIs. The compiled sampler classes provide a second,
+Stim-shaped surface for detector-sampling backends; both use the same native
+compiler and execution engine.
 
 ## Compilation
 
@@ -23,6 +24,14 @@ directly; there is no sampler-selection module or backend switch.
 ::: clifft.ParseError
 
 ## Sampling
+
+::: clifft.compile_sampler
+
+::: clifft.CompiledMeasurementSampler
+
+::: clifft.compile_detector_sampler
+
+::: clifft.CompiledDetectorSampler
 
 ::: clifft.sample
 

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -13,6 +13,7 @@
 #include "clifft/optimizer/peephole.h"
 #include "clifft/optimizer/remove_noise_pass.h"
 #include "clifft/optimizer/statevector_squeeze_pass.h"
+#include "clifft/sampling/compiled_sampler.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
 #include "clifft/sampling/state_queries.h"
@@ -21,6 +22,8 @@
 #include "clifft/util/runtime_isa.h"
 #include "clifft/util/version.h"
 
+#include <array>
+#include <fstream>
 #include <limits>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -29,6 +32,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 #include <span>
@@ -42,6 +46,7 @@ namespace {
 
 using ThreadOption = std::variant<int64_t, std::string>;
 using BatchOption = ThreadOption;
+using WritableNumpyArray = nb::ndarray<nb::numpy>;
 
 std::optional<uint32_t> parse_positive_uint32_option(const ThreadOption& option,
                                                      const char* field) {
@@ -66,6 +71,46 @@ uint32_t parse_thread_option(const ThreadOption& option) {
 
 std::optional<uint32_t> parse_batch_option(const BatchOption& option) {
     return parse_positive_uint32_option(option, "batch_size");
+}
+
+clifft::sampling::SamplingFileFormat parse_sampling_file_format(const std::string& format) {
+    if (format == "01") {
+        return clifft::sampling::SamplingFileFormat::Format01;
+    }
+    if (format == "b8") {
+        return clifft::sampling::SamplingFileFormat::B8;
+    }
+    throw std::invalid_argument("format must be '01' or 'b8'");
+}
+
+size_t packed_width(size_t columns) noexcept {
+    return columns / 8 + static_cast<size_t>((columns & 7) != 0);
+}
+
+void validate_sampling_array(const WritableNumpyArray& array, uint32_t shots, size_t columns,
+                             bool bit_packed, const char* field) {
+    const nb::dlpack::dtype expected_dtype = bit_packed ? nb::dtype<uint8_t>() : nb::dtype<bool>();
+    if (array.dtype() != expected_dtype) {
+        throw nb::type_error(
+            (std::string(field) + " dtype must be " + (bit_packed ? "uint8" : "bool")).c_str());
+    }
+    const size_t expected_columns = bit_packed ? packed_width(columns) : columns;
+    if (array.ndim() != 2 || array.shape(0) != shots || array.shape(1) != expected_columns) {
+        throw nb::value_error((std::string(field) + " must have shape (" + std::to_string(shots) +
+                               ", " + std::to_string(expected_columns) + ")")
+                                  .c_str());
+    }
+    if (array.size() != 0 && array.shape(0) > 1 &&
+        array.stride(0) != static_cast<int64_t>(expected_columns)) {
+        throw nb::value_error((std::string(field) + " must be C-contiguous").c_str());
+    }
+    if (array.size() != 0 && array.shape(1) > 1 && array.stride(1) != 1) {
+        throw nb::value_error((std::string(field) + " must be C-contiguous").c_str());
+    }
+}
+
+std::span<uint8_t> sampling_array_bytes(const WritableNumpyArray& array) noexcept {
+    return {static_cast<uint8_t*>(array.data()), array.nbytes()};
 }
 
 std::optional<clifft::sampling::ThreadLayout> parse_thread_layout(
@@ -148,6 +193,44 @@ clifft::HirModule prepare_qasm2_for_lowering(const std::string& qasm_text, bool 
     clifft::Qasm2Import imported = clifft::parse_qasm2(qasm_text);
     return prepare_circuit_for_lowering(imported.circuit, normalize_syndromes, hir_passes,
                                         expected_detectors, expected_observables);
+}
+
+std::unique_ptr<clifft::sampling::CompiledSampler> make_compiled_sampler(
+    clifft::HirModule hir, std::vector<uint8_t> expected_detectors,
+    std::vector<uint8_t> expected_observables, bool detector_profile, std::optional<uint64_t> seed,
+    uint32_t threads, std::optional<uint32_t> batch_size) {
+    auto plan = std::make_shared<const clifft::sampling::ExecutablePlan>(
+        clifft::sampling::plan_sampling(hir, {{}, expected_detectors, expected_observables}));
+    const clifft::sampling::SamplingOutputSelection outputs =
+        detector_profile
+            ? clifft::sampling::SamplingOutputSelection{.detectors = true, .observables = true}
+            : clifft::sampling::SamplingOutputSelection{.measurements = true};
+    return std::make_unique<clifft::sampling::CompiledSampler>(std::move(plan), outputs, seed,
+                                                               threads, batch_size);
+}
+
+std::unique_ptr<clifft::sampling::CompiledSampler> compile_sampler_text(
+    const std::string& stim_text, bool detector_profile, std::optional<uint64_t> seed,
+    uint32_t threads, std::optional<uint32_t> batch_size, clifft::HirPassManager* hir_passes) {
+    std::vector<uint8_t> expected_detectors;
+    std::vector<uint8_t> expected_observables;
+    clifft::HirModule hir = prepare_hir_for_lowering(stim_text, detector_profile, hir_passes,
+                                                     expected_detectors, expected_observables);
+    return make_compiled_sampler(std::move(hir), std::move(expected_detectors),
+                                 std::move(expected_observables), detector_profile, seed, threads,
+                                 batch_size);
+}
+
+std::unique_ptr<clifft::sampling::CompiledSampler> compile_sampler_circuit(
+    const clifft::Circuit& circuit, bool detector_profile, std::optional<uint64_t> seed,
+    uint32_t threads, std::optional<uint32_t> batch_size, clifft::HirPassManager* hir_passes) {
+    std::vector<uint8_t> expected_detectors;
+    std::vector<uint8_t> expected_observables;
+    clifft::HirModule hir = prepare_circuit_for_lowering(circuit, detector_profile, hir_passes,
+                                                         expected_detectors, expected_observables);
+    return make_compiled_sampler(std::move(hir), std::move(expected_detectors),
+                                 std::move(expected_observables), detector_profile, seed, threads,
+                                 batch_size);
 }
 
 }  // namespace
@@ -796,6 +879,233 @@ NB_MODULE(_clifft_core, m) {
                    " actions, peak_active_width=" + std::to_string(p.peak_active_width()) + ", " +
                    std::to_string(p.num_visible_records()) + " measurements)";
         });
+
+    nb::class_<clifft::sampling::CompiledSampler>(m, "_CompiledSampler")
+        .def_prop_ro("num_measurements",
+                     [](const clifft::sampling::CompiledSampler& sampler) {
+                         return sampler.plan().num_visible_records();
+                     })
+        .def_prop_ro("num_detectors",
+                     [](const clifft::sampling::CompiledSampler& sampler) {
+                         return sampler.plan().num_detectors();
+                     })
+        .def_prop_ro("num_observables",
+                     [](const clifft::sampling::CompiledSampler& sampler) {
+                         return sampler.plan().num_observables();
+                     })
+        .def_prop_ro("lane_capacity", &clifft::sampling::CompiledSampler::lane_capacity)
+        .def_prop_ro("worker_count", &clifft::sampling::CompiledSampler::worker_count)
+        .def_prop_ro("calls_completed", &clifft::sampling::CompiledSampler::calls_completed)
+        .def(
+            "_sample_measurements",
+            [](clifft::sampling::CompiledSampler& sampler, uint32_t shots, bool bit_packed,
+               const WritableNumpyArray& output) {
+                const size_t columns = sampler.plan().num_visible_records();
+                validate_sampling_array(output, shots, columns, bit_packed, "output");
+                const clifft::sampling::SamplingBitOutput destination{
+                    .source = clifft::sampling::SamplingBitSource::Measurements,
+                    .packing = bit_packed ? clifft::sampling::SamplingBitPacking::BitPacked
+                                          : clifft::sampling::SamplingBitPacking::Unpacked,
+                    .data = sampling_array_bytes(output),
+                    .row_stride = bit_packed ? packed_width(columns) : columns,
+                };
+                nb::gil_scoped_release release;
+                sampler.sample(shots, {.bits = std::span(&destination, 1)});
+            },
+            nb::arg("shots"), nb::arg("bit_packed"), nb::arg("output"))
+        .def(
+            "_sample_detectors",
+            [](clifft::sampling::CompiledSampler& sampler, uint32_t shots, bool prepend_observables,
+               bool append_observables, bool separate_observables, bool bit_packed,
+               const WritableNumpyArray& detector_output, nb::object observable_output_object) {
+                if (separate_observables && (prepend_observables || append_observables)) {
+                    throw nb::value_error(
+                        "separate_observables cannot be combined with prepending or appending "
+                        "observables");
+                }
+                const size_t detector_columns = sampler.plan().num_detectors();
+                const size_t observable_columns = sampler.plan().num_observables();
+                const size_t main_columns =
+                    detector_columns +
+                    observable_columns * (static_cast<size_t>(prepend_observables) +
+                                          static_cast<size_t>(append_observables));
+                validate_sampling_array(detector_output, shots, main_columns, bit_packed,
+                                        "dets_out");
+
+                std::optional<WritableNumpyArray> observable_output;
+                if (!observable_output_object.is_none()) {
+                    observable_output.emplace(
+                        nb::cast<WritableNumpyArray>(observable_output_object));
+                    validate_sampling_array(*observable_output, shots, observable_columns,
+                                            bit_packed, "obs_out");
+                }
+                if (separate_observables && !observable_output.has_value()) {
+                    throw nb::value_error(
+                        "separate_observables requires an observable output array");
+                }
+
+                std::array<clifft::sampling::SamplingBitOutput, 4> destinations;
+                size_t count = 0;
+                size_t offset = 0;
+                const auto packing = bit_packed ? clifft::sampling::SamplingBitPacking::BitPacked
+                                                : clifft::sampling::SamplingBitPacking::Unpacked;
+                const size_t main_stride = bit_packed ? packed_width(main_columns) : main_columns;
+                auto add_main = [&](clifft::sampling::SamplingBitSource source, size_t columns) {
+                    destinations[count++] = {
+                        .source = source,
+                        .packing = packing,
+                        .data = sampling_array_bytes(detector_output),
+                        .row_stride = main_stride,
+                        .column_offset = offset,
+                    };
+                    offset += columns;
+                };
+                if (prepend_observables) {
+                    add_main(clifft::sampling::SamplingBitSource::Observables, observable_columns);
+                }
+                add_main(clifft::sampling::SamplingBitSource::Detectors, detector_columns);
+                if (append_observables) {
+                    add_main(clifft::sampling::SamplingBitSource::Observables, observable_columns);
+                }
+                if (observable_output.has_value()) {
+                    destinations[count++] = {
+                        .source = clifft::sampling::SamplingBitSource::Observables,
+                        .packing = packing,
+                        .data = sampling_array_bytes(*observable_output),
+                        .row_stride =
+                            bit_packed ? packed_width(observable_columns) : observable_columns,
+                    };
+                }
+
+                nb::gil_scoped_release release;
+                sampler.sample(shots, {.bits = std::span(destinations).first(count)});
+            },
+            nb::arg("shots"), nb::arg("prepend_observables"), nb::arg("append_observables"),
+            nb::arg("separate_observables"), nb::arg("bit_packed"), nb::arg("dets_out"),
+            nb::arg("obs_out") = nb::none())
+        .def(
+            "_sample_write_measurements",
+            [](clifft::sampling::CompiledSampler& sampler, uint32_t shots,
+               const std::string& filepath, const std::string& format) {
+                const auto parsed_format = parse_sampling_file_format(format);
+                std::ofstream output(filepath, std::ios::binary | std::ios::trunc);
+                if (!output.is_open()) {
+                    throw std::runtime_error("failed to open sampling output file: " + filepath);
+                }
+                constexpr std::array sources{clifft::sampling::SamplingBitSource::Measurements};
+                const clifft::sampling::SamplingFileOutput file{
+                    .output = &output,
+                    .format = parsed_format,
+                    .sources = sources,
+                };
+                {
+                    nb::gil_scoped_release release;
+                    sampler.sample_write(shots, std::span(&file, 1));
+                    output.flush();
+                }
+                if (!output) {
+                    throw std::runtime_error("failed to flush sampling output file: " + filepath);
+                }
+            },
+            nb::arg("shots"), nb::arg("filepath"), nb::arg("format"))
+        .def(
+            "_sample_write_detectors",
+            [](clifft::sampling::CompiledSampler& sampler, uint32_t shots,
+               const std::string& filepath, const std::string& format, bool prepend_observables,
+               bool append_observables, std::optional<std::string> obs_out_filepath,
+               const std::string& obs_out_format) {
+                if (obs_out_filepath.has_value() && *obs_out_filepath == filepath) {
+                    throw nb::value_error("obs_out_filepath must differ from filepath");
+                }
+                const auto parsed_format = parse_sampling_file_format(format);
+                const auto parsed_obs_format = parse_sampling_file_format(obs_out_format);
+                std::ofstream output(filepath, std::ios::binary | std::ios::trunc);
+                if (!output.is_open()) {
+                    throw std::runtime_error("failed to open sampling output file: " + filepath);
+                }
+                std::ofstream observable_output;
+                if (obs_out_filepath.has_value()) {
+                    observable_output.open(*obs_out_filepath, std::ios::binary | std::ios::trunc);
+                    if (!observable_output.is_open()) {
+                        throw std::runtime_error("failed to open observable output file: " +
+                                                 *obs_out_filepath);
+                    }
+                }
+
+                std::array<clifft::sampling::SamplingBitSource, 3> main_sources;
+                size_t main_source_count = 0;
+                if (prepend_observables) {
+                    main_sources[main_source_count++] =
+                        clifft::sampling::SamplingBitSource::Observables;
+                }
+                main_sources[main_source_count++] = clifft::sampling::SamplingBitSource::Detectors;
+                if (append_observables) {
+                    main_sources[main_source_count++] =
+                        clifft::sampling::SamplingBitSource::Observables;
+                }
+                constexpr std::array observable_sources{
+                    clifft::sampling::SamplingBitSource::Observables};
+                std::array<clifft::sampling::SamplingFileOutput, 2> files;
+                size_t file_count = 0;
+                files[file_count++] = {
+                    .output = &output,
+                    .format = parsed_format,
+                    .sources = std::span(main_sources).first(main_source_count),
+                };
+                if (obs_out_filepath.has_value()) {
+                    files[file_count++] = {
+                        .output = &observable_output,
+                        .format = parsed_obs_format,
+                        .sources = observable_sources,
+                    };
+                }
+                {
+                    nb::gil_scoped_release release;
+                    sampler.sample_write(shots, std::span(files).first(file_count));
+                    output.flush();
+                    if (obs_out_filepath.has_value()) {
+                        observable_output.flush();
+                    }
+                }
+                if (!output || (obs_out_filepath.has_value() && !observable_output)) {
+                    throw std::runtime_error("failed to flush compiled detector sampler output");
+                }
+            },
+            nb::arg("shots"), nb::arg("filepath"), nb::arg("format"),
+            nb::arg("prepend_observables"), nb::arg("append_observables"),
+            nb::arg("obs_out_filepath") = nb::none(), nb::arg("obs_out_format") = "01");
+
+    m.def(
+        "_compile_fixed_sampler_text",
+        [](const std::string& stim_text, bool detector_profile, std::optional<uint64_t> seed,
+           const ThreadOption& thread_option, const BatchOption& batch_option,
+           clifft::HirPassManager* hir_passes) {
+            const uint32_t threads = parse_thread_option(thread_option);
+            const std::optional<uint32_t> batch_size = parse_batch_option(batch_option);
+            nb::gil_scoped_release release;
+            return compile_sampler_text(stim_text, detector_profile, seed, threads, batch_size,
+                                        hir_passes);
+        },
+        nb::arg("stim_text"), nb::arg("detector_profile"), nb::arg("seed") = nb::none(),
+        nb::arg("threads") = ThreadOption{int64_t{1}},
+        nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::arg("hir_passes") = nb::none());
+
+    m.def(
+        "_compile_fixed_sampler_circuit",
+        [](const clifft::Circuit& circuit, bool detector_profile, std::optional<uint64_t> seed,
+           const ThreadOption& thread_option, const BatchOption& batch_option,
+           clifft::HirPassManager* hir_passes) {
+            const uint32_t threads = parse_thread_option(thread_option);
+            const std::optional<uint32_t> batch_size = parse_batch_option(batch_option);
+            nb::gil_scoped_release release;
+            return compile_sampler_circuit(circuit, detector_profile, seed, threads, batch_size,
+                                           hir_passes);
+        },
+        nb::arg("circuit"), nb::arg("detector_profile"), nb::arg("seed") = nb::none(),
+        nb::arg("threads") = ThreadOption{int64_t{1}},
+        nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::arg("hir_passes") = nb::none());
 
     m.def(
         "lower",

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -72,6 +72,12 @@ from clifft._clifft_core import (
 from clifft._clifft_core import (
     compile as _compile_core,
 )
+from clifft._compiled_sampler import (
+    CompiledDetectorSampler,
+    CompiledMeasurementSampler,
+    compile_detector_sampler,
+    compile_sampler,
+)
 from clifft._sample_result import SampleResult
 
 BasisBitstrings: TypeAlias = str | Sequence[str] | npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
@@ -350,6 +356,8 @@ __all__ = [
     "BasisBitstrings",
     "MeasurementRecords",
     "Circuit",
+    "CompiledDetectorSampler",
+    "CompiledMeasurementSampler",
     "GateType",
     "HeisenbergOp",
     "HirModule",
@@ -367,6 +375,8 @@ __all__ = [
     "Target",
     "basis_probabilities",
     "compile",
+    "compile_detector_sampler",
+    "compile_sampler",
     "compute_reference_syndrome",
     "default_hir_pass_manager",
     "experimental",

--- a/src/python/clifft/_compiled_sampler.py
+++ b/src/python/clifft/_compiled_sampler.py
@@ -1,0 +1,290 @@
+"""Stim-shaped compiled sampler facades over Clifft's retained C++ runtime."""
+
+from __future__ import annotations
+
+import operator
+import os
+from pathlib import Path
+from typing import Literal, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from clifft._clifft_core import (
+    Circuit,
+    HirPassManager,
+    _compile_fixed_sampler_circuit,
+    _compile_fixed_sampler_text,
+    _CompiledSampler,
+    default_hir_pass_manager,
+)
+
+ThreadOption = int | Literal["auto"]
+BatchOption = int | Literal["auto"]
+FileFormat = Literal["01", "b8"]
+SampleArray = npt.NDArray[np.bool_] | npt.NDArray[np.uint8]
+
+
+class _DefaultPasses:
+    pass
+
+
+_DEFAULT_PASSES = _DefaultPasses()
+
+
+def _shot_count(shots: int) -> int:
+    try:
+        value = operator.index(shots)
+    except TypeError as ex:
+        raise TypeError("shots must be an integer") from ex
+    if value < 0 or value > np.iinfo(np.uint32).max:
+        raise ValueError("shots must be between 0 and 2**32 - 1")
+    return value
+
+
+def _path_string(path: os.PathLike[str] | str, field: str) -> str:
+    value = os.fspath(path)
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string or text path-like object")
+    return value
+
+
+def _allocate_sample_array(shots: int, columns: int, bit_packed: bool) -> SampleArray:
+    if bit_packed:
+        return np.empty((shots, (columns + 7) // 8), dtype=np.uint8)
+    return np.empty((shots, columns), dtype=np.bool_)
+
+
+class CompiledMeasurementSampler:
+    """A reusable compiled sampler with Stim-compatible measurement outputs.
+
+    Instances retain their native executor workers and RNG stream. Construct one
+    with :func:`compile_sampler` instead of calling this class directly.
+    """
+
+    __slots__ = ("_native",)
+
+    def __init__(self, native: _CompiledSampler):
+        self._native = native
+
+    @property
+    def num_measurements(self) -> int:
+        return int(self._native.num_measurements)
+
+    def sample(self, shots: int, *, bit_packed: bool = False) -> SampleArray:
+        """Sample measurement rows as bool values or little-endian packed bytes."""
+        shot_count = _shot_count(shots)
+        output = _allocate_sample_array(shot_count, self.num_measurements, bit_packed)
+        self._native._sample_measurements(shot_count, bit_packed, output)
+        return output
+
+    def sample_write(
+        self,
+        shots: int,
+        *,
+        filepath: os.PathLike[str] | str,
+        format: FileFormat = "01",
+    ) -> None:
+        """Stream measurement rows directly to a file in ``01`` or ``b8`` format."""
+        self._native._sample_write_measurements(
+            _shot_count(shots), _path_string(filepath, "filepath"), format
+        )
+
+    def __repr__(self) -> str:
+        return f"CompiledMeasurementSampler(num_measurements={self.num_measurements})"
+
+
+class CompiledDetectorSampler:
+    """A reusable compiled sampler with Stim-compatible detector outputs.
+
+    Detector and observable bits are normalized against the circuit's noiseless
+    reference, matching Stim's detector sampler convention. Construct one with
+    :func:`compile_detector_sampler` instead of calling this class directly.
+    """
+
+    __slots__ = ("_native",)
+
+    def __init__(self, native: _CompiledSampler):
+        self._native = native
+
+    @property
+    def num_detectors(self) -> int:
+        return int(self._native.num_detectors)
+
+    @property
+    def num_observables(self) -> int:
+        return int(self._native.num_observables)
+
+    def sample(
+        self,
+        shots: int,
+        *,
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+        separate_observables: bool = False,
+        bit_packed: bool = False,
+        dets_out: SampleArray | None = None,
+        obs_out: SampleArray | None = None,
+    ) -> SampleArray | tuple[SampleArray, SampleArray]:
+        """Sample detector rows with Stim-compatible observable placement."""
+        if separate_observables and (prepend_observables or append_observables):
+            raise ValueError(
+                "separate_observables cannot be combined with prepending or appending observables"
+            )
+        shot_count = _shot_count(shots)
+        main_columns = self.num_detectors + self.num_observables * (
+            int(prepend_observables) + int(append_observables)
+        )
+        detector_output = (
+            _allocate_sample_array(shot_count, main_columns, bit_packed)
+            if dets_out is None
+            else dets_out
+        )
+        observable_output = obs_out
+        if separate_observables and observable_output is None:
+            observable_output = _allocate_sample_array(shot_count, self.num_observables, bit_packed)
+
+        self._native._sample_detectors(
+            shot_count,
+            prepend_observables,
+            append_observables,
+            separate_observables,
+            bit_packed,
+            detector_output,
+            observable_output,
+        )
+        if separate_observables:
+            return detector_output, cast(SampleArray, observable_output)
+        return detector_output
+
+    def sample_write(
+        self,
+        shots: int,
+        *,
+        filepath: os.PathLike[str] | str,
+        format: FileFormat = "01",
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+        obs_out_filepath: os.PathLike[str] | str | None = None,
+        obs_out_format: FileFormat = "01",
+    ) -> None:
+        """Stream detector and optional observable rows without matrix materialization."""
+        observable_path = (
+            None if obs_out_filepath is None else _path_string(obs_out_filepath, "obs_out_filepath")
+        )
+        self._native._sample_write_detectors(
+            _shot_count(shots),
+            _path_string(filepath, "filepath"),
+            format,
+            prepend_observables,
+            append_observables,
+            observable_path,
+            obs_out_format,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "CompiledDetectorSampler("
+            f"num_detectors={self.num_detectors}, num_observables={self.num_observables})"
+        )
+
+
+def _compile_sampler(
+    circuit: object,
+    *,
+    detector_profile: bool,
+    seed: int | None,
+    threads: ThreadOption,
+    batch_size: BatchOption,
+    hir_passes: HirPassManager | None,
+) -> _CompiledSampler:
+    if isinstance(circuit, Circuit):
+        return _compile_fixed_sampler_circuit(
+            circuit, detector_profile, seed, threads, batch_size, hir_passes
+        )
+    if isinstance(circuit, os.PathLike):
+        text = Path(_path_string(circuit, "circuit")).read_text(encoding="utf-8")
+    elif isinstance(circuit, str):
+        text = circuit
+    else:
+        circuit_type = type(circuit)
+        is_stim_circuit = (
+            circuit_type.__module__.partition(".")[0] == "stim"
+            and circuit_type.__name__ == "Circuit"
+        )
+        if not is_stim_circuit:
+            raise TypeError("circuit must be Stim text, a path, stim.Circuit, or clifft.Circuit")
+        text = str(circuit)
+    return _compile_fixed_sampler_text(
+        text, detector_profile, seed, threads, batch_size, hir_passes
+    )
+
+
+def compile_sampler(
+    circuit: object,
+    *,
+    seed: int | None = None,
+    threads: ThreadOption = 1,
+    batch_size: BatchOption = "auto",
+    hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+) -> CompiledMeasurementSampler:
+    """Compile a retained measurement sampler.
+
+    Args:
+        circuit: Stim-format text, a text path-like object, ``stim.Circuit``, or
+            ``clifft.Circuit``.
+        seed: Optional seed for a reproducible sequence of sampler calls.
+        threads: Positive native worker budget or ``"auto"``.
+        batch_size: Positive packed lane capacity or ``"auto"``.
+        hir_passes: HIR pass manager to run before lowering. The default applies
+            Clifft's standard passes; pass ``None`` to skip optimization.
+
+    Returns:
+        A sampler whose ``sample`` and ``sample_write`` signatures match Stim's
+        common compiled measurement sampler surface.
+    """
+    passes = default_hir_pass_manager() if isinstance(hir_passes, _DefaultPasses) else hir_passes
+    native = _compile_sampler(
+        circuit,
+        detector_profile=False,
+        seed=seed,
+        threads=threads,
+        batch_size=batch_size,
+        hir_passes=passes,
+    )
+    return CompiledMeasurementSampler(native)
+
+
+def compile_detector_sampler(
+    circuit: object,
+    *,
+    seed: int | None = None,
+    threads: ThreadOption = 1,
+    batch_size: BatchOption = "auto",
+    hir_passes: HirPassManager | None | _DefaultPasses = _DEFAULT_PASSES,
+) -> CompiledDetectorSampler:
+    """Compile a retained, reference-normalized detector sampler.
+
+    Args:
+        circuit: Stim-format text, a text path-like object, ``stim.Circuit``, or
+            ``clifft.Circuit``.
+        seed: Optional seed for a reproducible sequence of sampler calls.
+        threads: Positive native worker budget or ``"auto"``.
+        batch_size: Positive packed lane capacity or ``"auto"``.
+        hir_passes: HIR pass manager to run before lowering. The default applies
+            Clifft's standard passes; pass ``None`` to skip optimization.
+
+    Returns:
+        A detector sampler supporting observable placement, separate outputs,
+        caller-owned arrays, bit packing, and native file streaming.
+    """
+    passes = default_hir_pass_manager() if isinstance(hir_passes, _DefaultPasses) else hir_passes
+    native = _compile_sampler(
+        circuit,
+        detector_profile=True,
+        seed=seed,
+        threads=threads,
+        batch_size=batch_size,
+        hir_passes=passes,
+    )
+    return CompiledDetectorSampler(native)

--- a/tests/python/test_compiled_sampler.py
+++ b/tests/python/test_compiled_sampler.py
@@ -1,0 +1,210 @@
+"""Compatibility tests for the retained Stim-shaped sampling API."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import stim
+
+import clifft
+
+MEASUREMENT_CIRCUIT = """
+    X 0 2 8
+    M 0 1 2 3 4 5 6 7 8 9
+"""
+
+DETECTOR_CIRCUIT = """
+    X_ERROR(1) 0
+    M 0 1
+    DETECTOR rec[-2]
+    DETECTOR rec[-1]
+    OBSERVABLE_INCLUDE(0) rec[-2] rec[-1]
+"""
+
+
+def test_measurement_sampler_matches_stim_shapes_dtypes_and_bit_order() -> None:
+    shots = 5
+    actual_sampler = clifft.compile_sampler(MEASUREMENT_CIRCUIT, seed=12, batch_size=65)
+    expected_sampler = stim.Circuit(MEASUREMENT_CIRCUIT).compile_sampler(seed=12)
+
+    actual = actual_sampler.sample(shots)
+    expected = expected_sampler.sample(shots)
+    assert actual.dtype == expected.dtype == np.dtype(np.bool_)
+    assert actual.shape == expected.shape == (shots, 10)
+    np.testing.assert_array_equal(actual, expected)
+
+    actual_packed = actual_sampler.sample(shots, bit_packed=True)
+    expected_packed = expected_sampler.sample(shots, bit_packed=True)
+    assert actual_packed.dtype == expected_packed.dtype == np.dtype(np.uint8)
+    assert actual_packed.shape == expected_packed.shape == (shots, 2)
+    np.testing.assert_array_equal(actual_packed, expected_packed)
+
+
+def test_detector_sampler_matches_stim_observable_placement() -> None:
+    shots = 4
+    actual_sampler = clifft.compile_detector_sampler(DETECTOR_CIRCUIT, seed=13, batch_size=65)
+    expected_sampler = stim.Circuit(DETECTOR_CIRCUIT).compile_detector_sampler(seed=13)
+
+    for prepend, append in [(False, False), (True, False), (False, True), (True, True)]:
+        actual = actual_sampler.sample(
+            shots,
+            prepend_observables=prepend,
+            append_observables=append,
+        )
+        expected = expected_sampler.sample(
+            shots,
+            prepend_observables=prepend,
+            append_observables=append,
+        )
+        np.testing.assert_array_equal(actual, expected)
+
+    actual_packed = actual_sampler.sample(
+        shots, prepend_observables=True, append_observables=True, bit_packed=True
+    )
+    expected_packed = expected_sampler.sample(
+        shots, prepend_observables=True, append_observables=True, bit_packed=True
+    )
+    np.testing.assert_array_equal(actual_packed, expected_packed)
+    np.testing.assert_array_equal(actual_packed, np.full((shots, 1), 0b1011, dtype=np.uint8))
+
+
+def test_detector_sampler_returns_separate_outputs_and_fills_caller_arrays() -> None:
+    sampler = clifft.compile_detector_sampler(DETECTOR_CIRCUIT, seed=14, batch_size=65)
+    detectors, observables = sampler.sample(3, separate_observables=True)
+    np.testing.assert_array_equal(detectors, [[True, False]] * 3)
+    np.testing.assert_array_equal(observables, [[True]] * 3)
+
+    dets_out = np.empty((3, 2), dtype=np.bool_)
+    obs_out = np.empty((3, 1), dtype=np.bool_)
+    returned = sampler.sample(3, dets_out=dets_out, obs_out=obs_out)
+    assert returned is dets_out
+    np.testing.assert_array_equal(dets_out, detectors)
+    np.testing.assert_array_equal(obs_out, observables)
+
+    packed_dets_out = np.empty((3, 1), dtype=np.uint8)
+    packed_obs_out = np.empty((3, 1), dtype=np.uint8)
+    returned_pair = sampler.sample(
+        3,
+        separate_observables=True,
+        bit_packed=True,
+        dets_out=packed_dets_out,
+        obs_out=packed_obs_out,
+    )
+    assert returned_pair[0] is packed_dets_out
+    assert returned_pair[1] is packed_obs_out
+    np.testing.assert_array_equal(packed_dets_out, [[1]] * 3)
+    np.testing.assert_array_equal(packed_obs_out, [[1]] * 3)
+
+
+def test_detector_sampler_uses_stim_reference_normalization() -> None:
+    circuit = """
+        X 0
+        M 0
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    """
+    actual = clifft.compile_detector_sampler(circuit, seed=15).sample(3, separate_observables=True)
+    expected = (
+        stim.Circuit(circuit).compile_detector_sampler(seed=15).sample(3, separate_observables=True)
+    )
+    np.testing.assert_array_equal(actual[0], expected[0])
+    np.testing.assert_array_equal(actual[1], expected[1])
+    assert not np.any(actual[0])
+    assert not np.any(actual[1])
+
+
+def test_compiled_sampler_advances_and_replays_seeded_calls() -> None:
+    circuit = "X_ERROR(0.5) 0\nM 0"
+    first = clifft.compile_sampler(circuit, seed=1601, batch_size=65)
+    replay = clifft.compile_sampler(circuit, seed=1601, batch_size=65)
+
+    first_call = first.sample(257)
+    second_call = first.sample(257)
+    np.testing.assert_array_equal(first_call, replay.sample(257))
+    np.testing.assert_array_equal(second_call, replay.sample(257))
+    assert not np.array_equal(first_call, second_call)
+
+
+@pytest.mark.parametrize("source_kind", ["text", "path", "stim", "clifft"])
+def test_compile_sampler_accepts_common_circuit_inputs(source_kind: str, tmp_path: Path) -> None:
+    source: object
+    if source_kind == "text":
+        source = MEASUREMENT_CIRCUIT
+    elif source_kind == "path":
+        source = tmp_path / "circuit.stim"
+        source.write_text(MEASUREMENT_CIRCUIT, encoding="utf-8")
+    elif source_kind == "stim":
+        source = stim.Circuit(MEASUREMENT_CIRCUIT)
+    else:
+        source = clifft.parse(MEASUREMENT_CIRCUIT)
+    actual = clifft.compile_sampler(source, seed=17, hir_passes=None).sample(2)
+    expected = stim.Circuit(MEASUREMENT_CIRCUIT).compile_sampler(seed=17).sample(2)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_compiled_samplers_handle_empty_output_shapes() -> None:
+    measurement_sampler = clifft.compile_sampler("M 0", seed=18)
+    assert measurement_sampler.sample(0).shape == (0, 1)
+    assert measurement_sampler.sample(0, bit_packed=True).shape == (0, 1)
+
+    detector_sampler = clifft.compile_detector_sampler("M 0", seed=18)
+    detectors, observables = detector_sampler.sample(0, separate_observables=True)
+    assert detectors.shape == (0, 0)
+    assert observables.shape == (0, 0)
+
+
+def test_sample_write_matches_matrix_sampling(tmp_path: Path) -> None:
+    measurement_matrix = clifft.compile_sampler(MEASUREMENT_CIRCUIT, seed=19, batch_size=65).sample(
+        5
+    )
+    measurement_path = tmp_path / "measurements.01"
+    clifft.compile_sampler(MEASUREMENT_CIRCUIT, seed=19, batch_size=65).sample_write(
+        5, filepath=measurement_path, format="01"
+    )
+    expected_text = b"".join(
+        bytes(row.astype(np.uint8) + ord("0")) + b"\n" for row in measurement_matrix
+    )
+    assert measurement_path.read_bytes() == expected_text
+
+    detector_matrix, observable_matrix = clifft.compile_detector_sampler(
+        DETECTOR_CIRCUIT, seed=20, batch_size=65
+    ).sample(5, separate_observables=True, bit_packed=True)
+    detector_path = tmp_path / "detectors.b8"
+    observable_path = tmp_path / "observables.b8"
+    clifft.compile_detector_sampler(DETECTOR_CIRCUIT, seed=20, batch_size=65).sample_write(
+        5,
+        filepath=detector_path,
+        format="b8",
+        obs_out_filepath=observable_path,
+        obs_out_format="b8",
+    )
+    assert detector_path.read_bytes() == detector_matrix.tobytes()
+    assert observable_path.read_bytes() == observable_matrix.tobytes()
+
+
+def test_detector_sampler_rejects_incompatible_output_requests() -> None:
+    sampler = clifft.compile_detector_sampler(DETECTOR_CIRCUIT, seed=21)
+    with pytest.raises(ValueError, match="separate_observables"):
+        sampler.sample(1, separate_observables=True, append_observables=True)
+    with pytest.raises(TypeError, match="dtype"):
+        sampler.sample(2, dets_out=np.empty((2, 2), dtype=np.uint8))
+    with pytest.raises(ValueError, match="shape"):
+        sampler.sample(2, dets_out=np.empty((2, 3), dtype=np.bool_))
+    with pytest.raises((TypeError, ValueError), match="contiguous|incompatible"):
+        sampler.sample(2, dets_out=np.empty((2, 4), dtype=np.bool_)[:, ::2])
+
+
+def test_compiled_detector_distribution_matches_stim() -> None:
+    circuit = """
+        X_ERROR(0.2) 0
+        X_ERROR(0.35) 1
+        M 0 1
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-2] rec[-1]
+    """
+    shots = 20_000
+    actual = clifft.compile_detector_sampler(circuit, seed=22, batch_size=257).sample(shots)
+    expected = stim.Circuit(circuit).compile_detector_sampler(seed=23).sample(shots)
+    assert isinstance(actual, np.ndarray)
+    np.testing.assert_allclose(actual.mean(axis=0), expected.mean(axis=0), atol=0.025, rtol=0)


### PR DESCRIPTION
Part of #425.

## Summary

- add `clifft.compile_sampler` and `CompiledMeasurementSampler` with Stim-compatible `sample(shots, *, bit_packed=False)` and `sample_write` signatures
- add `clifft.compile_detector_sampler` and `CompiledDetectorSampler` with observable prepend/append/separate modes, `dets_out` and `obs_out`, packed rows, and native `sample_write`
- accept Stim-format text, path-like inputs, `stim.Circuit`, and `clifft.Circuit`
- normalize detector and observable outputs against the noiseless reference by default, matching Stim detector semantics
- allocate only the requested NumPy destination in Python; C++ fills it directly with the GIL released and no result-vector copy
- retain the existing `clifft.compile` plus `clifft.sample` API as the general full-result, postselection, expectation-value, and importance-sampling surface

## Compatibility coverage

Tests compare against Stim for:

- Boolean and little-endian packed shapes, dtypes, and bit order
- detector/observable placement and separate outputs
- caller-owned output array identity and validation
- reference-syndrome normalization
- `01` and `b8` file bytes
- deterministic and statistical circuit behavior

Seeded samplers replay the same sequence of calls, while successive calls on one sampler advance.

## Validation

- Python suite: 1,378 passed, 6 skipped, 1 expected failure
- compiled-sampler compatibility suite: 13 passed
- simulation guide code blocks: 8 passed, 5 skipped
- repository pre-commit suite passed

## Stack

- depends on #429, which retains native plans, executors, workers, scratch, and RNG state
- #429 depends on #427
- next PR adds the Sinter sampling-backend adapter

Out of scope: Stim tableau analysis and circuit transformation APIs.