### PR TITLE
feat(sampling): retain native postselected rows

### DIFF
--- a/src/clifft/sampling/compiled_sampler.cc
+++ b/src/clifft/sampling/compiled_sampler.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <limits>
 #include <ostream>
@@ -140,7 +141,8 @@ void write_scalar_outputs(SamplingOutputBuffer output, const Executor& executor,
 
 void write_batch_outputs(SamplingOutputBuffer output, const BatchExecutor& executor,
                          uint32_t first_shot, uint32_t shots, const ExecutablePlan& plan) noexcept {
-    assert(executor.surviving_shots() == shots && "compiled fixed-row batch must retain all shots");
+    assert(executor.surviving_shots() == shots &&
+           "compiled output batch must contain the requested live rows");
     for (const SamplingBitOutput& destination : output.bits) {
         executor.write_bit_rows(
             destination.source, destination.packing,
@@ -209,9 +211,6 @@ CompiledSampler::CompiledSampler(std::shared_ptr<const ExecutablePlan> plan,
     if (plan_->has_instruments()) {
         throw std::invalid_argument("compiled samplers do not support instrument traps");
     }
-    if (plan_->has_postselection()) {
-        throw std::invalid_argument("fixed-row compiled samplers do not support postselection");
-    }
     if (plan_->num_unbound_presampled_symbols() != 0) {
         throw std::invalid_argument(
             "compiled samplers require a distribution for every presampled symbol");
@@ -272,6 +271,10 @@ void CompiledSampler::execute_rows(const SeedRoot& root, uint32_t first_root_sho
 
 void CompiledSampler::sample(uint32_t shots, SamplingOutputBuffer output) {
     validate_output(*plan_, available_outputs_, shots, output);
+    if (plan_->has_postselection()) {
+        throw std::invalid_argument(
+            "fixed-row compiled sampling does not support postselection; use survivor sampling");
+    }
     std::lock_guard lock(mutex_);
     if (shots == 0) {
         clear_bit_outputs(shots, output);
@@ -283,7 +286,68 @@ void CompiledSampler::sample(uint32_t shots, SamplingOutputBuffer output) {
     ++calls_completed_;
 }
 
+uint32_t CompiledSampler::execute_survivors(const SeedRoot& root, uint32_t shots,
+                                            SamplingOutputBuffer output) {
+    clear_bit_outputs(shots, output);
+    if (shots == 0) {
+        return 0;
+    }
+
+    std::atomic<uint32_t> next_output{0};
+    const uint32_t requested_workers =
+        std::min<uint32_t>(static_cast<uint32_t>(workers_.size()), shots);
+    if (lane_capacity_ > 1) {
+        (void)run_shot_ranges(
+            shots, requested_workers, [&](uint32_t worker) { return workers_[worker].get(); },
+            [&](Worker* worker, ShotRange range) noexcept {
+                for (uint32_t first_shot = range.begin; first_shot < range.end;) {
+                    const uint32_t batch = std::min(lane_capacity_, range.end - first_shot);
+                    worker->batch->run_batch(root, first_shot, batch);
+                    const uint32_t survivors = worker->batch->surviving_shots();
+                    const uint32_t first_output =
+                        next_output.fetch_add(survivors, std::memory_order_relaxed);
+                    write_batch_outputs(output, *worker->batch, first_output, survivors, *plan_);
+                    first_shot += batch;
+                }
+            },
+            lane_capacity_);
+    } else {
+        (void)run_shot_ranges(
+            shots, requested_workers, [&](uint32_t worker) { return workers_[worker].get(); },
+            [&](Worker* worker, ShotRange range) noexcept {
+                for (uint32_t shot = range.begin; shot < range.end; ++shot) {
+                    reseed_executor(*worker->scalar, root, shot);
+                    worker->scalar->run_shot();
+                    if (worker->scalar->discarded()) {
+                        continue;
+                    }
+                    const uint32_t output_shot =
+                        next_output.fetch_add(1, std::memory_order_relaxed);
+                    write_scalar_outputs(output, *worker->scalar, output_shot);
+                }
+            });
+    }
+    return next_output.load(std::memory_order_relaxed);
+}
+
+uint32_t CompiledSampler::sample_survivors(uint32_t shots, SamplingOutputBuffer output) {
+    validate_output(*plan_, available_outputs_, shots, output);
+    std::lock_guard lock(mutex_);
+    if (shots == 0) {
+        clear_bit_outputs(shots, output);
+        return 0;
+    }
+
+    const SeedRoot root = call_seed_root(seed_root_, calls_completed_);
+    const uint32_t survivors = execute_survivors(root, shots, output);
+    ++calls_completed_;
+    return survivors;
+}
+
 void CompiledSampler::sample_write(uint32_t shots, std::span<const SamplingFileOutput> outputs) {
+    if (plan_->has_postselection()) {
+        throw std::invalid_argument("compiled sample_write does not support postselection");
+    }
     std::vector<PreparedFileOutput> files;
     files.reserve(outputs.size());
     size_t bytes_per_shot = 0;

--- a/src/clifft/sampling/compiled_sampler.h
+++ b/src/clifft/sampling/compiled_sampler.h
@@ -23,7 +23,7 @@ struct SamplingFileOutput {
     std::span<const SamplingBitSource> sources;
 };
 
-// Stateful fixed-row sampler used by Stim-compatible facades. The executable
+// Stateful sampler used by Stim-compatible facades. The executable
 // plan, executor contexts, worker scratch, and sampler RNG root outlive every
 // sample call. Calls are serialized so one sampler advances one reproducible
 // stream even when Python releases the GIL.
@@ -41,6 +41,7 @@ class CompiledSampler {
     CompiledSampler& operator=(CompiledSampler&&) = delete;
 
     void sample(uint32_t shots, SamplingOutputBuffer output);
+    [[nodiscard]] uint32_t sample_survivors(uint32_t shots, SamplingOutputBuffer output);
     void sample_write(uint32_t shots, std::span<const SamplingFileOutput> outputs);
 
     [[nodiscard]] const ExecutablePlan& plan() const noexcept { return *plan_; }
@@ -58,6 +59,8 @@ class CompiledSampler {
 
     void execute_rows(const SeedRoot& root, uint32_t first_root_shot, uint32_t shots,
                       SamplingOutputBuffer output);
+    [[nodiscard]] uint32_t execute_survivors(const SeedRoot& root, uint32_t shots,
+                                             SamplingOutputBuffer output);
 
     std::shared_ptr<const ExecutablePlan> plan_;
     SamplingOutputSelection available_outputs_;

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -197,10 +197,12 @@ clifft::HirModule prepare_qasm2_for_lowering(const std::string& qasm_text, bool 
 
 std::unique_ptr<clifft::sampling::CompiledSampler> make_compiled_sampler(
     clifft::HirModule hir, std::vector<uint8_t> expected_detectors,
-    std::vector<uint8_t> expected_observables, bool detector_profile, std::optional<uint64_t> seed,
-    uint32_t threads, std::optional<uint32_t> batch_size) {
-    auto plan = std::make_shared<const clifft::sampling::ExecutablePlan>(
-        clifft::sampling::plan_sampling(hir, {{}, expected_detectors, expected_observables}));
+    std::vector<uint8_t> expected_observables, std::vector<uint8_t> postselection_mask,
+    bool detector_profile, std::optional<uint64_t> seed, uint32_t threads,
+    std::optional<uint32_t> batch_size) {
+    auto plan =
+        std::make_shared<const clifft::sampling::ExecutablePlan>(clifft::sampling::plan_sampling(
+            hir, {postselection_mask, expected_detectors, expected_observables}));
     const clifft::sampling::SamplingOutputSelection outputs =
         detector_profile
             ? clifft::sampling::SamplingOutputSelection{.detectors = true, .observables = true}
@@ -217,8 +219,24 @@ std::unique_ptr<clifft::sampling::CompiledSampler> compile_sampler_text(
     clifft::HirModule hir = prepare_hir_for_lowering(stim_text, detector_profile, hir_passes,
                                                      expected_detectors, expected_observables);
     return make_compiled_sampler(std::move(hir), std::move(expected_detectors),
-                                 std::move(expected_observables), detector_profile, seed, threads,
-                                 batch_size);
+                                 std::move(expected_observables), {}, detector_profile, seed,
+                                 threads, batch_size);
+}
+
+std::unique_ptr<clifft::sampling::CompiledSampler> compile_postselected_sampler_text(
+    const std::string& stim_text, std::vector<uint8_t> postselection_mask,
+    std::optional<uint64_t> seed, uint32_t threads, std::optional<uint32_t> batch_size,
+    clifft::HirPassManager* hir_passes) {
+    std::vector<uint8_t> expected_detectors;
+    std::vector<uint8_t> expected_observables;
+    clifft::HirModule hir = prepare_hir_for_lowering(stim_text, true, hir_passes,
+                                                     expected_detectors, expected_observables);
+    if (postselection_mask.size() != hir.num_detectors) {
+        throw std::invalid_argument("postselection mask length must equal the detector count");
+    }
+    return make_compiled_sampler(std::move(hir), std::move(expected_detectors),
+                                 std::move(expected_observables), std::move(postselection_mask),
+                                 true, seed, threads, batch_size);
 }
 
 std::unique_ptr<clifft::sampling::CompiledSampler> compile_sampler_circuit(
@@ -229,8 +247,8 @@ std::unique_ptr<clifft::sampling::CompiledSampler> compile_sampler_circuit(
     clifft::HirModule hir = prepare_circuit_for_lowering(circuit, detector_profile, hir_passes,
                                                          expected_detectors, expected_observables);
     return make_compiled_sampler(std::move(hir), std::move(expected_detectors),
-                                 std::move(expected_observables), detector_profile, seed, threads,
-                                 batch_size);
+                                 std::move(expected_observables), {}, detector_profile, seed,
+                                 threads, batch_size);
 }
 
 }  // namespace
@@ -984,6 +1002,34 @@ NB_MODULE(_clifft_core, m) {
             nb::arg("separate_observables"), nb::arg("bit_packed"), nb::arg("dets_out"),
             nb::arg("obs_out") = nb::none())
         .def(
+            "_sample_postselected_detectors",
+            [](clifft::sampling::CompiledSampler& sampler, uint32_t shots,
+               const WritableNumpyArray& detector_output,
+               const WritableNumpyArray& observable_output) {
+                const size_t detector_columns = sampler.plan().num_detectors();
+                const size_t observable_columns = sampler.plan().num_observables();
+                validate_sampling_array(detector_output, shots, detector_columns, true, "dets_out");
+                validate_sampling_array(observable_output, shots, observable_columns, true,
+                                        "obs_out");
+                const std::array destinations{
+                    clifft::sampling::SamplingBitOutput{
+                        .source = clifft::sampling::SamplingBitSource::Detectors,
+                        .packing = clifft::sampling::SamplingBitPacking::BitPacked,
+                        .data = sampling_array_bytes(detector_output),
+                        .row_stride = packed_width(detector_columns),
+                    },
+                    clifft::sampling::SamplingBitOutput{
+                        .source = clifft::sampling::SamplingBitSource::Observables,
+                        .packing = clifft::sampling::SamplingBitPacking::BitPacked,
+                        .data = sampling_array_bytes(observable_output),
+                        .row_stride = packed_width(observable_columns),
+                    },
+                };
+                nb::gil_scoped_release release;
+                return sampler.sample_survivors(shots, {.bits = destinations});
+            },
+            nb::arg("shots"), nb::arg("dets_out"), nb::arg("obs_out"))
+        .def(
             "_sample_write_measurements",
             [](clifft::sampling::CompiledSampler& sampler, uint32_t shots,
                const std::string& filepath, const std::string& format) {
@@ -1103,6 +1149,22 @@ NB_MODULE(_clifft_core, m) {
                                            hir_passes);
         },
         nb::arg("circuit"), nb::arg("detector_profile"), nb::arg("seed") = nb::none(),
+        nb::arg("threads") = ThreadOption{int64_t{1}},
+        nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::arg("hir_passes") = nb::none());
+
+    m.def(
+        "_compile_postselected_detector_sampler_text",
+        [](const std::string& stim_text, std::vector<uint8_t> postselection_mask,
+           std::optional<uint64_t> seed, const ThreadOption& thread_option,
+           const BatchOption& batch_option, clifft::HirPassManager* hir_passes) {
+            const uint32_t threads = parse_thread_option(thread_option);
+            const std::optional<uint32_t> batch_size = parse_batch_option(batch_option);
+            nb::gil_scoped_release release;
+            return compile_postselected_sampler_text(stim_text, std::move(postselection_mask), seed,
+                                                     threads, batch_size, hir_passes);
+        },
+        nb::arg("stim_text"), nb::arg("postselection_mask"), nb::arg("seed") = nb::none(),
         nb::arg("threads") = ThreadOption{int64_t{1}},
         nb::arg("batch_size") = BatchOption{std::string{"auto"}},
         nb::arg("hir_passes") = nb::none());

--- a/src/python/clifft/_compiled_sampler.py
+++ b/src/python/clifft/_compiled_sampler.py
@@ -15,6 +15,7 @@ from clifft._clifft_core import (
     HirPassManager,
     _compile_fixed_sampler_circuit,
     _compile_fixed_sampler_text,
+    _compile_postselected_detector_sampler_text,
     _CompiledSampler,
     default_hir_pass_manager,
 )
@@ -182,6 +183,24 @@ class CompiledDetectorSampler:
             obs_out_format,
         )
 
+    def _sample_postselected(
+        self, shots: int
+    ) -> tuple[npt.NDArray[np.uint8], npt.NDArray[np.uint8], int]:
+        """Return packed survivor rows for Sinter's batch-level orchestration."""
+        shot_count = _shot_count(shots)
+        detectors = cast(
+            npt.NDArray[np.uint8],
+            _allocate_sample_array(shot_count, self.num_detectors, True),
+        )
+        observables = cast(
+            npt.NDArray[np.uint8],
+            _allocate_sample_array(shot_count, self.num_observables, True),
+        )
+        survivors = int(
+            self._native._sample_postselected_detectors(shot_count, detectors, observables)
+        )
+        return detectors[:survivors], observables[:survivors], survivors
+
     def __repr__(self) -> str:
         return (
             "CompiledDetectorSampler("
@@ -286,5 +305,23 @@ def compile_detector_sampler(
         threads=threads,
         batch_size=batch_size,
         hir_passes=passes,
+    )
+    return CompiledDetectorSampler(native)
+
+
+def _compile_postselected_detector_sampler(
+    stim_text: str,
+    postselection_mask: list[int],
+    *,
+    threads: ThreadOption,
+    batch_size: BatchOption,
+) -> CompiledDetectorSampler:
+    native = _compile_postselected_detector_sampler_text(
+        stim_text,
+        postselection_mask,
+        None,
+        threads,
+        batch_size,
+        default_hir_pass_manager(),
     )
     return CompiledDetectorSampler(native)

--- a/tests/python/test_compiled_sampler.py
+++ b/tests/python/test_compiled_sampler.py
@@ -7,6 +7,7 @@ import pytest
 import stim
 
 import clifft
+from clifft._compiled_sampler import _compile_postselected_detector_sampler
 
 MEASUREMENT_CIRCUIT = """
     X 0 2 8
@@ -208,3 +209,27 @@ def test_compiled_detector_distribution_matches_stim() -> None:
     expected = stim.Circuit(circuit).compile_detector_sampler(seed=23).sample(shots)
     assert isinstance(actual, np.ndarray)
     np.testing.assert_allclose(actual.mean(axis=0), expected.mean(axis=0), atol=0.025, rtol=0)
+
+
+def test_private_postselected_sampler_returns_only_packed_survivor_rows() -> None:
+    sampler = _compile_postselected_detector_sampler(
+        """
+        X_ERROR(0.5) 0
+        M 0
+        DETECTOR rec[-1]
+        X_ERROR(1) 1
+        M 1
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        """,
+        [1, 0],
+        threads=2,
+        batch_size=65,
+    )
+    detectors, observables, survivors = sampler._sample_postselected(1000)
+
+    assert 400 < survivors < 600
+    assert detectors.shape == (survivors, 1)
+    assert observables.shape == (survivors, 1)
+    np.testing.assert_array_equal(detectors, np.full((survivors, 1), 0b10, dtype=np.uint8))
+    np.testing.assert_array_equal(observables, np.ones((survivors, 1), dtype=np.uint8))

--- a/tests/test_compiled_sampler.cc
+++ b/tests/test_compiled_sampler.cc
@@ -246,3 +246,44 @@ TEST_CASE("Compiled sampler validates retained sources before advancing") {
     REQUIRE(sampler.calls_completed() == 0);
     REQUIRE(sample_all(sampler, 65).measurements == sample_all(replay, 65).measurements);
 }
+
+TEST_CASE("Compiled sampler retains packed rows from surviving shots") {
+    const clifft::HirModule hir = clifft::trace(clifft::parse(R"(
+        X_ERROR(0.5) 0
+        M 0
+        DETECTOR rec[-1]
+        X_ERROR(1) 1
+        M 1
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )"));
+    constexpr std::array<uint8_t, 2> postselection{1, 0};
+    const auto plan = std::make_shared<const ExecutablePlan>(
+        clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection}));
+    constexpr SamplingOutputSelection outputs{.detectors = true, .observables = true};
+    CompiledSampler sampler(plan, outputs, uint64_t{81239}, 4, uint32_t{65});
+
+    constexpr uint32_t shots = 513;
+    std::vector<uint8_t> detectors(shots, 0xFF);
+    std::vector<uint8_t> observables(shots, 0xFF);
+    const std::array destinations{
+        SamplingBitOutput{.source = SamplingBitSource::Detectors,
+                          .packing = SamplingBitPacking::BitPacked,
+                          .data = detectors,
+                          .row_stride = 1},
+        SamplingBitOutput{.source = SamplingBitSource::Observables,
+                          .packing = SamplingBitPacking::BitPacked,
+                          .data = observables,
+                          .row_stride = 1},
+    };
+    const uint32_t survivors = sampler.sample_survivors(shots, {.bits = destinations});
+
+    REQUIRE(survivors > 200);
+    REQUIRE(survivors < 310);
+    for (uint32_t shot = 0; shot < survivors; ++shot) {
+        REQUIRE(detectors[shot] == 0b10);
+        REQUIRE(observables[shot] == 0b1);
+    }
+    REQUIRE(sampler.calls_completed() == 1);
+    REQUIRE_THROWS_AS(sampler.sample(shots, {.bits = destinations}), std::invalid_argument);
+}


### PR DESCRIPTION
## Summary

- allow retained compiled samplers to execute plans with detector postselection
- terminate rejected scalar shots and compact live packed batch lanes inside C++
- write surviving detector and observable rows directly into caller-owned packed buffers
- expose a private Python bridge for the upcoming Sinter backend

## Performance contract

The hot dispatch remains allocation-free and exception-free. Output storage is validated and cleared before execution, retained workers are reused across calls, and rejected shots stop at their postselected detector. The Python bridge performs one native call and returns zero-copy prefix views of the surviving rows.

## Validation

- `build-debug/tests/clifft_tests 'Compiled sampler*'`
- `uv run --frozen --only-group dev pytest -q tests/python/test_compiled_sampler.py`
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Stacked on #430. This is the native prerequisite for the Sinter adapter.