### PR TITLE
build: use Clang ThinLTO for Linux wheels

### DIFF
--- a/.github/scripts/install_manylinux_clang.sh
+++ b/.github/scripts/install_manylinux_clang.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: install_manylinux_clang.sh CLANG_VERSION" >&2
+    exit 2
+fi
+
+readonly clang_version="$1"
+readonly clang_root="/opt/clang"
+readonly openmp_root="/opt/clifft-openmp"
+
+# The static manylinux compiler intentionally reuses the image's libstdc++ and
+# libgcc. Install only the matching OpenMP development/runtime package here so
+# auditwheel can bundle the non-policy runtime into the repaired wheel.
+dnf install -y libomp-devel
+manylinux-install-clang -v "${clang_version}"
+
+mapfile -t omp_headers < <(rpm -ql libomp-devel | awk '/\/omp\.h$/ { print }')
+if [[ ${#omp_headers[@]} -ne 1 || ! -f "${omp_headers[0]}" ]]; then
+    echo "libomp-devel did not provide omp.h" >&2
+    exit 1
+fi
+readonly omp_header="${omp_headers[0]}"
+
+# AlmaLinux installs omp.h below its system Clang resource directory. Expose a
+# stable include path so a newer pinned static Clang can discover that header.
+mkdir -p "${openmp_root}/include"
+omp_include_dir="$(dirname "${omp_header}")"
+for header in omp.h omp-tools.h ompt.h ompt-multiplex.h ompx.h; do
+    if [[ -f "${omp_include_dir}/${header}" ]]; then
+        ln -s "${omp_include_dir}/${header}" "${openmp_root}/include/${header}"
+    fi
+done
+
+"${clang_root}/bin/clang++" --version
+"${clang_root}/bin/ld.lld" --version
+test -f /usr/lib64/libomp.so

--- a/.github/scripts/install_ubuntu_clang.sh
+++ b/.github/scripts/install_ubuntu_clang.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: install_ubuntu_clang.sh CLANG_VERSION INSTALL_ROOT" >&2
+    exit 2
+fi
+
+readonly clang_version="$1"
+readonly install_root="$2"
+
+if [[ "$(uname -m)" != "x86_64" ]]; then
+    echo "the native Clang CI installer supports only x86_64" >&2
+    exit 1
+fi
+if [[ "${clang_version}" != "22.1.8.1" ]]; then
+    echo "no checksum is pinned for Clang ${clang_version}" >&2
+    exit 1
+fi
+if [[ -e "${install_root}" ]]; then
+    echo "install root already exists: ${install_root}" >&2
+    exit 1
+fi
+
+readonly archive_name="static-clang-linux-amd64.tar.xz"
+readonly archive_sha256="6a5419dbb658dd9c379e4cddc2a130d33aef458add0c7ccd1f529f12b0a4d67a"
+readonly archive_url="https://github.com/mayeut/static-clang-images/releases/download/v${clang_version}/${archive_name}"
+staging="$(mktemp -d)"
+readonly staging
+trap 'rm -rf -- "${staging}"' EXIT
+
+curl --fail --silent --show-error --location \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 15 --max-time 300 \
+    --output "${staging}/${archive_name}" "${archive_url}"
+echo "${archive_sha256}  ${staging}/${archive_name}" | sha256sum --check
+tar -C "${staging}" -xJf "${staging}/${archive_name}"
+test -x "${staging}/clang/bin/clang++"
+
+mkdir -p "$(dirname "${install_root}")"
+mv "${staging}/clang" "${install_root}"
+
+# The static archive defaults to its build host's musl target. Match the GNU
+# driver configuration applied by manylinux before using it on Ubuntu.
+readonly gcc_triple="$(gcc -dumpmachine)"
+readonly driver_config="ubuntu-x86_64.cfg"
+printf '%s\n' \
+    '-target x86_64-unknown-linux-gnu' \
+    '-march=x86-64' \
+    '--gcc-toolchain=/usr' \
+    "--gcc-triple=${gcc_triple}" \
+    >"${install_root}/bin/${driver_config}"
+for driver in clang clang++ clang-cpp; do
+    printf '@%s\n' "${driver_config}" >"${install_root}/bin/${driver}.cfg"
+done
+
+readonly system_openmp_include="/usr/lib/llvm-18/lib/clang/18/include"
+readonly system_openmp_library="/usr/lib/llvm-18/lib/libomp.so"
+test -f "${system_openmp_include}/omp.h"
+test -f "${system_openmp_library}"
+
+# Keep the older OpenMP resource directory out of CPATH: its stdint.h would
+# shadow the pinned compiler's resource header. Expose only OpenMP headers.
+readonly openmp_root="$(dirname "${install_root}")/clifft-openmp"
+mkdir -p "${openmp_root}/include"
+for header in omp.h omp-tools.h ompt.h ompt-multiplex.h ompx.h; do
+    if [[ -f "${system_openmp_include}/${header}" ]]; then
+        ln -s "${system_openmp_include}/${header}" "${openmp_root}/include/${header}"
+    fi
+done
+
+"${install_root}/bin/clang++" --version
+"${install_root}/bin/ld.lld" --version
+
+: "${GITHUB_ENV:?GITHUB_ENV must identify the GitHub Actions environment file}"
+: "${GITHUB_PATH:?GITHUB_PATH must identify the GitHub Actions path file}"
+{
+    echo "CC=${install_root}/bin/clang"
+    echo "CXX=${install_root}/bin/clang++"
+    echo "CPATH=${openmp_root}/include${CPATH:+:${CPATH}}"
+    echo "LIBRARY_PATH=$(dirname "${system_openmp_library}")${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+    echo "LDFLAGS=-fuse-ld=lld"
+} >>"${GITHUB_ENV}"
+echo "${install_root}/bin" >>"${GITHUB_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CLIFFT_LINUX_WHEEL_CLANG_VERSION: "22.1.8.1"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -294,10 +297,14 @@ jobs:
     env:
       CMAKE_BUILD_TYPE: Release
       CLIFFT_CPU_BASELINE: x86-64-v2
+      CLIFFT_INTERPROCEDURAL_OPTIMIZATION: "ON"
+      CLIFFT_OPENMP: "ON"
       CMAKE_GENERATOR: Ninja
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
       CCACHE_COMPILERCHECK: content
+      # Catch2 3.5 uses __COUNTER__, which Clang 22 diagnoses under -Wpedantic.
+      CXXFLAGS: -Wno-c2y-extensions
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -309,6 +316,14 @@ jobs:
         uses: ./.github/actions/setup-native-tools
         with:
           install-qemu: "true"
+
+      - name: Install pinned Clang and OpenMP
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libomp-18-dev
+          .github/scripts/install_ubuntu_clang.sh \
+            "${{ env.CLIFFT_LINUX_WHEEL_CLANG_VERSION }}" \
+            "$RUNNER_TEMP/clifft-clang"
 
       - name: Install Intel SDE
         run: |
@@ -324,7 +339,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
+          key: ${{ runner.os }}-ccache-clang-${{ env.CLIFFT_LINUX_WHEEL_CLANG_VERSION }}-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
           # Caches saved from PR runs are scoped to the PR ref and cannot be
           # reused elsewhere; saving only on main limits repo cache eviction.
           save: ${{ github.ref == 'refs/heads/main' }}
@@ -334,6 +349,8 @@ jobs:
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ env.CLIFFT_INTERPROCEDURAL_OPTIMIZATION }} \
+            -DCLIFFT_OPENMP=${{ env.CLIFFT_OPENMP }} \
             -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
 
       - name: Build C++ tests
@@ -343,6 +360,8 @@ jobs:
         run: |
           python3 tools/ci/audit_build_flags.py \
             --compile-commands build/compile_commands.json
+          rg --quiet -- '-flto=thin' build/compile_commands.json
+          rg --quiet -- '-fuse-ld=lld' build/build.ninja
 
       - name: Run C++ smoke tests
         run: |
@@ -361,10 +380,10 @@ jobs:
           python-version: "3.12"
 
       # assert() stays active in the optimized extension so the full
-      # Python suite checks invariants through GCC optimized codegen and
-      # -ffast-math. ISA dispatch does not depend on NDEBUG, so the
-      # emulated smokes below reuse this wheel; the published artifact
-      # keeps its own smoke in the release workflow.
+      # Python suite checks invariants through the shipping Clang, ThinLTO,
+      # and -ffast-math codegen. ISA dispatch does not depend on NDEBUG, so the
+      # emulated smokes below reuse this wheel; repaired artifacts are checked
+      # separately by linux-release-wheel-smoke and the release workflow.
       - name: Install Python package (release baseline, asserts on)
         env:
           SKBUILD_CMAKE_BUILD_TYPE: Release
@@ -400,6 +419,60 @@ jobs:
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx auto pass avx512
       - name: SDE smoke -- Skylake-X + FORCE_ISA=avx512
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512 intra-shot
+
+  # Build and test the repaired manylinux artifacts on every pull request.
+  # This uses the same compiler, ThinLTO, linker, OpenMP, and CPU baselines as
+  # the release workflow while the GCC jobs retain source-build coverage.
+  linux-release-wheel-smoke:
+    name: Linux release wheel (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x86_64
+            cpu_baseline: x86-64-v2
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            cpu_baseline: generic
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and test repaired wheel
+        uses: pypa/cibuildwheel@v4.2
+        env:
+          CIBW_BUILD: "cp312-manylinux_*"
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_LINUX: >-
+            CC=/opt/clang/bin/clang
+            CXX=/opt/clang/bin/clang++
+            CPATH=/opt/clifft-openmp/include
+            LDFLAGS=-fuse-ld=lld
+            CLIFFT_CPU_BASELINE=${{ matrix.cpu_baseline }}
+            CLIFFT_INTERPROCEDURAL_OPTIMIZATION=ON
+            CLIFFT_OPENMP=ON
+            SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0.dev0
+          CIBW_BEFORE_ALL_LINUX: >-
+            bash {package}/.github/scripts/install_manylinux_clang.sh
+            ${{ env.CLIFFT_LINUX_WHEEL_CLANG_VERSION }}
+          CIBW_BEFORE_BUILD: pip install setuptools-scm
+          CIBW_TEST_COMMAND_LINUX: >-
+            python {project}/.github/scripts/artifact_smoke.py --exercise-intra-shot
+            &&
+            python {project}/tools/ci/audit_python_exports.py
+
+      - name: Upload repaired wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-linux-wheel-${{ matrix.arch }}
+          path: wheelhouse/*.whl
 
   # Round-trips the packaging pipeline on every pull request: the sdist
   # must be complete and buildable, it must produce a cp312-abi3 wheel,
@@ -584,6 +657,7 @@ jobs:
       - hip-offline-build
       - build-and-test
       - release-cpp-smoke
+      - linux-release-wheel-smoke
       - package-smoke
       - cross-platform
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,8 +360,8 @@ jobs:
         run: |
           python3 tools/ci/audit_build_flags.py \
             --compile-commands build/compile_commands.json
-          rg --quiet -- '-flto=thin' build/compile_commands.json
-          rg --quiet -- '-fuse-ld=lld' build/build.ninja
+          grep --quiet -- '-flto=thin' build/compile_commands.json
+          grep --quiet -- '-fuse-ld=lld' build/build.ninja
 
       - name: Run C++ smoke tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,63 @@ jobs:
       - name: SDE smoke -- Skylake-X + FORCE_ISA=avx512
         run: PYTHON=$(pwd)/.smoke-venv/bin/python .github/scripts/wheel_smoke.sh sde skx avx512 pass avx512 intra-shot
 
+  # Source and sdist consumers commonly build with the system GCC. Exercise
+  # its optimized -ffast-math behavior without duplicating the shipping-wheel
+  # Python and ISA-emulation coverage above.
+  gcc-release-cpp:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc
+      CXX: g++
+      CMAKE_BUILD_TYPE: Release
+      CLIFFT_CPU_BASELINE: x86-64-v2
+      CLIFFT_INTERPROCEDURAL_OPTIMIZATION: "OFF"
+      CLIFFT_OPENMP: "ON"
+      CMAKE_GENERATOR: Ninja
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_COMPILERCHECK: content
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pinned build tools
+        uses: ./.github/actions/setup-native-tools
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ccache-gcc-${{ env.CMAKE_BUILD_TYPE }}-${{ env.CLIFFT_CPU_BASELINE }}
+          save: ${{ github.ref == 'refs/heads/main' }}
+          evict-old-files: job
+
+      - name: Configure C++ build
+        run: |
+          g++ --version
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ env.CLIFFT_INTERPROCEDURAL_OPTIMIZATION }} \
+            -DCLIFFT_OPENMP=${{ env.CLIFFT_OPENMP }} \
+            -DCLIFFT_CPU_BASELINE=${{ env.CLIFFT_CPU_BASELINE }}
+
+      - name: Build C++ tests
+        run: cmake --build build --target clifft_tests --parallel
+
+      - name: Audit release build flags
+        run: |
+          python3 tools/ci/audit_build_flags.py \
+            --compile-commands build/compile_commands.json
+
+      - name: Run C++ tests
+        run: |
+          ctest --test-dir build \
+            --build-config ${{ env.CMAKE_BUILD_TYPE }} \
+            --output-on-failure \
+            --parallel \
+            --timeout 300 \
+            -E "Bench"
+        shell: bash
+
   # Build and test the repaired manylinux artifacts on every pull request.
   # This uses the same compiler, ThinLTO, linker, OpenMP, and CPU baselines as
   # the release workflow while the GCC jobs retain source-build coverage.
@@ -657,6 +714,7 @@ jobs:
       - hip-offline-build
       - build-and-test
       - release-cpp-smoke
+      - gcc-release-cpp
       - linux-release-wheel-smoke
       - package-smoke
       - cross-platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CLIFFT_LINUX_WHEEL_CLANG_VERSION: "22.1.8.1"
+
 jobs:
   # -----------------------------------------------------------
   # Build sdist (source distribution)
@@ -76,26 +79,44 @@ jobs:
           fetch-depth: 0  # Full history for setuptools-scm
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v4.2
         env:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: "*-musllinux*"
-          # manylinux_2_28 (AlmaLinux 8, GCC 12) supports the explicit
-          # x86-64 baseline flags used for Linux wheels.
+          # manylinux_2_28 retains the glibc 2.28 compatibility policy while
+          # providing the pinned static Clang installer used below.
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT: >-
             CLIFFT_CPU_BASELINE=${{ matrix.cpu_baseline }}
             ${{ matrix.cibw_environment || '' }}
             ${{ inputs.test_version && format('SETUPTOOLS_SCM_PRETEND_VERSION={0}', inputs.test_version) || '' }}
-          # Install build dependencies inside the cibuildwheel container
+          CIBW_ENVIRONMENT_LINUX: >-
+            CC=/opt/clang/bin/clang
+            CXX=/opt/clang/bin/clang++
+            CPATH=/opt/clifft-openmp/include
+            LDFLAGS=-fuse-ld=lld
+            CLIFFT_CPU_BASELINE=${{ matrix.cpu_baseline }}
+            CLIFFT_INTERPROCEDURAL_OPTIMIZATION=ON
+            CLIFFT_OPENMP=ON
+            ${{ inputs.test_version && format('SETUPTOOLS_SCM_PRETEND_VERSION={0}', inputs.test_version) || '' }}
+          CIBW_BEFORE_ALL_LINUX: >-
+            bash {package}/.github/scripts/install_manylinux_clang.sh
+            ${{ env.CLIFFT_LINUX_WHEEL_CLANG_VERSION }}
+          # Install Python build dependencies inside the cibuildwheel environment.
           CIBW_BEFORE_BUILD: pip install setuptools-scm
           # Apple Clang needs Homebrew's runtime for intra-shot OpenMP kernels.
           CIBW_BEFORE_ALL_MACOS: brew install libomp
           # Smoke-test: import the built package and audit exported symbols
           CIBW_TEST_COMMAND: >-
             python -c "import clifft; print(clifft.__version__); print(clifft.CPU_BASELINE); print(type(clifft.compile('M 0')).__name__)"
+            &&
+            python {project}/tools/ci/audit_python_exports.py
+          # Exercise the repaired wheel against its bundled OpenMP runtime on
+          # both Linux architectures.
+          CIBW_TEST_COMMAND_LINUX: >-
+            python {project}/.github/scripts/artifact_smoke.py --exercise-intra-shot
             &&
             python {project}/tools/ci/audit_python_exports.py
           # Test the repaired wheel's bundled runtime, not the source build.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -48,7 +48,7 @@ The editable install (`-e .`) means you can re-run `uv pip install -e .` after m
 - Published wheels use explicit portable baselines chosen in CI.
 - Local Python source builds and standalone C++ Release builds default to `CLIFFT_CPU_BASELINE=native`.
 - Supported values are `native`, `generic`, `x86-64-v2`, and `x86-64-v3`.
-- Linux `x86_64` wheels use `x86-64-v2` as the global baseline. Higher-ISA symbolic sampling kernels are compiled separately and selected at runtime when the host supports them.
+- Linux wheels use a pinned Clang toolchain with ThinLTO. Linux `x86_64` wheels use `x86-64-v2` as the global baseline; higher-ISA symbolic sampling kernels are compiled separately and selected at runtime when the host supports them.
 
 Override the default when needed:
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -7,6 +7,11 @@ derive the package version from git tags. The release workflow builds
 wheels for Linux (x86_64, aarch64), macOS (arm64), and Windows (amd64), then publishes to
 PyPI via trusted publishers.
 
+Linux wheels use the exact Clang version pinned by `CLIFFT_LINUX_WHEEL_CLANG_VERSION` in the
+release workflow, the matching `lld` linker, and ThinLTO. Update that pin deliberately after
+building and benchmarking representative Linux wheels; do not replace it with a floating
+`latest` toolchain.
+
 ## Versioning
 
 The version is determined automatically from git tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ fallback_version = "0.0.0"
 
 [tool.scikit-build.cmake.define]
 CLIFFT_CPU_BASELINE = { env = "CLIFFT_CPU_BASELINE", default = "native" }
+CMAKE_INTERPROCEDURAL_OPTIMIZATION = { env = "CLIFFT_INTERPROCEDURAL_OPTIMIZATION", default = "OFF" }
+CLIFFT_OPENMP = { env = "CLIFFT_OPENMP", default = "AUTO" }
 
 [tool.ruff]
 line-length = 100

--- a/src/clifft/circuit/parser.cc
+++ b/src/clifft/circuit/parser.cc
@@ -84,6 +84,22 @@ std::string_view trim(std::string_view s) {
     return s;
 }
 
+bool is_explicit_nonfinite_literal(std::string_view token) {
+    if (!token.empty() && (token.front() == '+' || token.front() == '-')) {
+        token.remove_prefix(1);
+    }
+    if (token.size() < 3) {
+        return false;
+    }
+    const auto ascii_lower = [](char c) {
+        return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    };
+    const std::array<char, 3> prefix{ascii_lower(token[0]), ascii_lower(token[1]),
+                                     ascii_lower(token[2])};
+    return prefix == std::array<char, 3>{'n', 'a', 'n'} ||
+           prefix == std::array<char, 3>{'i', 'n', 'f'};
+}
+
 }  // namespace
 
 // Tags are trimmed as they are parsed, and a '#' starts a comment that
@@ -263,6 +279,11 @@ class Parser {
                 std::string_view token = trim(
                     comma_pos == std::string_view::npos ? args_str : args_str.substr(0, comma_pos));
                 if (!token.empty()) {
+                    // fast_float materializes these from nonfinite constants, whose behavior is
+                    // undefined under the Release build's -ffast-math assumptions.
+                    if (is_explicit_nonfinite_literal(token)) {
+                        throw ParseError("Invalid gate argument: " + std::string(token), line_num);
+                    }
                     double val = 0.0;
                     auto result =
                         fast_float::from_chars(token.data(), token.data() + token.size(), val);

--- a/src/clifft/sampling/executable_plan_builder.cc
+++ b/src/clifft/sampling/executable_plan_builder.cc
@@ -279,7 +279,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::prepare_noise_and_bounda
     if (uniform_site_probabilities && uniform_site_probability.has_value() &&
         *uniform_site_probability > 0.0) {
         const double inverse_hazard = 1.0 / bernoulli_hazard(*uniform_site_probability);
-        if (std::isfinite(inverse_hazard)) {
+        if (is_finite_robust(inverse_hazard)) {
             output_.uniform_noise_inverse_hazard_ = inverse_hazard;
         }
     }
@@ -413,7 +413,7 @@ CLIFFT_BUILDER_FORCE_INLINE void ExecutablePlanBuilder::lower_action(const Plann
                     typed.prob_zero_to_one > 0.0 &&
                     typed.prob_zero_to_one <= kMaxSparseBatchReadoutProbability) {
                     const double inverse_hazard = 1.0 / bernoulli_hazard(typed.prob_zero_to_one);
-                    if (std::isfinite(inverse_hazard)) {
+                    if (is_finite_robust(inverse_hazard)) {
                         batch_symmetric_inverse_hazard = inverse_hazard;
                     }
                 }

--- a/src/clifft/util/fault_sampling.cc
+++ b/src/clifft/util/fault_sampling.cc
@@ -14,12 +14,13 @@ namespace clifft {
 namespace {
 
 inline constexpr double kMaxConditioningRow = 0x1p500;
+inline constexpr double kLogZero = -std::numeric_limits<double>::max();
 
 double log_add_exp(double first, double second) noexcept {
-    if (first == -std::numeric_limits<double>::infinity()) {
+    if (first == kLogZero) {
         return second;
     }
-    if (second == -std::numeric_limits<double>::infinity()) {
+    if (second == kLogZero) {
         return first;
     }
     const double greater = std::max(first, second);
@@ -96,7 +97,7 @@ KFaultDistribution::KFaultDistribution(std::span<const double> probabilities, ui
     const long double normalization = static_cast<long double>(uncertain_sites_.size()) / odds_sum;
     for (double& odds : odds_ratios) {
         odds = static_cast<double>(static_cast<long double>(odds) * normalization);
-        stable &= odds > 0.0 && std::isfinite(odds);
+        stable &= odds > 0.0 && is_finite_robust(odds);
     }
     selection_probabilities_.assign(rows * stride, 0.0);
     std::vector<double> row_scale_ratios(uncertain_sites_.size(), 1.0);
@@ -113,7 +114,7 @@ KFaultDistribution::KFaultDistribution(std::span<const double> probabilities, ui
                     odds_ratios[row] * selection_probabilities_[(row + 1) * stride + selected - 1];
             }
             selection_probabilities_[row * stride + selected] = value;
-            stable &= value > 0.0 && std::isfinite(value);
+            stable &= value > 0.0 && is_finite_robust(value);
             row_max = std::max(row_max, value);
         }
         if (stable && row_max > kMaxConditioningRow) {
@@ -139,7 +140,7 @@ KFaultDistribution::KFaultDistribution(std::span<const double> probabilities, ui
             const double probability =
                 odds_ratios[row] * selection_probabilities_[(row + 1) * stride + selected - 1] *
                 row_scale_ratios[row] / selection_probabilities_[row * stride + selected];
-            if (!(probability > 0.0 && probability < 1.0 && std::isfinite(probability))) {
+            if (!(probability > 0.0 && probability < 1.0 && is_finite_robust(probability))) {
                 stable = false;
                 break;
             }
@@ -159,8 +160,10 @@ KFaultDistribution::KFaultDistribution(std::span<const double> probabilities, ui
         const double probability = probabilities[site];
         log_odds_ratios.push_back(std::log(probability) - std::log1p(-probability));
     }
-    const double log_zero = -std::numeric_limits<double>::infinity();
-    selection_probabilities_.assign(rows * stride, log_zero);
+    // Keep the log-zero sentinel finite because -ffast-math makes expressions
+    // containing infinity undefined. Structurally impossible entries are
+    // never added to a log odds value below.
+    selection_probabilities_.assign(rows * stride, kLogZero);
     selection_probabilities_[uncertain_sites_.size() * stride] = 0.0;
     for (size_t row = uncertain_sites_.size(); row-- > 0;) {
         const uint32_t remaining = static_cast<uint32_t>(uncertain_sites_.size() - row);
@@ -168,10 +171,12 @@ KFaultDistribution::KFaultDistribution(std::span<const double> probabilities, ui
         const uint32_t max_selected = std::min(remaining, remaining_k_);
         for (uint32_t selected = min_selected; selected <= max_selected; ++selected) {
             const double without_site = selection_probabilities_[(row + 1) * stride + selected];
-            double with_site = log_zero;
+            double with_site = kLogZero;
             if (selected != 0) {
-                with_site = log_odds_ratios[row] +
-                            selection_probabilities_[(row + 1) * stride + selected - 1];
+                const double suffix = selection_probabilities_[(row + 1) * stride + selected - 1];
+                if (suffix != kLogZero) {
+                    with_site = log_odds_ratios[row] + suffix;
+                }
             }
             selection_probabilities_[row * stride + selected] =
                 log_add_exp(without_site, with_site);

--- a/src/clifft/util/noise_sampling.h
+++ b/src/clifft/util/noise_sampling.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "clifft/util/numeric.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -15,7 +17,7 @@ inline constexpr uint32_t kNoNoiseSite = std::numeric_limits<uint32_t>::max();
 // clamp keeps a probability rounded to one finite and aligned with the finest
 // probability step of the repository's deterministic [0, 1) RNG conversion.
 [[nodiscard]] inline double bernoulli_hazard(double probability) noexcept {
-    assert(std::isfinite(probability) && probability >= 0.0 &&
+    assert(is_finite_robust(probability) && probability >= 0.0 &&
            "noise probability must be finite and nonnegative");
     return -std::log1p(-std::min(probability, 1.0 - 0x1.0p-53));
 }

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -6,6 +6,7 @@
 #include "clifft/sampling/state_queries.h"
 #include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/noise_sampling.h"
+#include "clifft/util/numeric.h"
 #include "clifft/util/shot_seed.h"
 #include "clifft/util/xoshiro.h"
 
@@ -1861,7 +1862,8 @@ TEST_CASE("Packed survivors retain long-tail rows after heavy rejection") {
         REQUIRE_THAT(result.exp_vals[offset], Catch::Matchers::WithinAbs(1.0, 1e-12));
     }
     REQUIRE(std::ranges::all_of(result.exp_vals, [](double value) {
-        return std::isfinite(value) && value >= -1.000000000001 && value <= 1.000000000001;
+        return clifft::is_finite_robust(value) && value >= -1.000000000001 &&
+               value <= 1.000000000001;
     }));
     REQUIRE(replay.passed_shots == result.passed_shots);
     REQUIRE(replay.logical_errors == result.logical_errors);

--- a/tests/test_sampling_plan.cc
+++ b/tests/test_sampling_plan.cc
@@ -1,6 +1,8 @@
 #include "clifft/sampling/plan.h"
 #include "clifft/util/numeric.h"
 
+#include "test_helpers.h"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <limits>
@@ -459,15 +461,14 @@ TEST_CASE("Sampling plan rejects invalid numeric metadata") {
 
     SECTION("active rotation angle is not finite") {
         SamplingPlan plan = valid_rotation_plan();
-        std::get<RotateActivePauli>(plan.actions[0].action).half_turns =
-            std::numeric_limits<double>::quiet_NaN();
+        std::get<RotateActivePauli>(plan.actions[0].action).half_turns = clifft::test::opaque_nan();
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 
     SECTION("dormant promotion angle is not finite") {
         SamplingPlan plan = valid_plan();
         std::get<PromoteDormantRotation>(plan.actions[0].action).half_turns =
-            std::numeric_limits<double>::infinity();
+            clifft::test::opaque_infinity();
         REQUIRE_THROWS_AS(plan.validate(), std::invalid_argument);
     }
 }


### PR DESCRIPTION
## Summary

- pin Linux release wheels to static Clang 22.1.8.1 and lld
- enable ThinLTO and explicit OpenMP for Linux wheel builds
- bundle and exercise the OpenMP runtime in repaired-wheel tests
- upgrade cibuildwheel to v4.2 for the current manylinux toolchain

## Validation

- built a cp312 manylinux x86_64 wheel with cibuildwheel 4.2.0
- verified compile and link commands contain -flto=thin and use ld.lld
- passed strict abi3audit after auditwheel bundled libomp
- passed installed-wheel intra-shot OpenMP smoke and export audit
- passed the full pre-commit suite

Performance validation of the exact Clang 22 wheel is tracked as the final gate before marking this ready.

Related: #317