### PR TITLE
ci: support fork PR performance canaries

### DIFF
--- a/.github/workflows/performance-canary-reporter.yml
+++ b/.github/workflows/performance-canary-reporter.yml
@@ -24,7 +24,8 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pull-requests: write
+      issues: write
+      pull-requests: read
     steps:
       - name: Resolve trusted workflow run metadata
         id: resolve

--- a/.github/workflows/performance-canary-reporter.yml
+++ b/.github/workflows/performance-canary-reporter.yml
@@ -1,0 +1,253 @@
+name: Performance canary reporter
+
+on:
+  workflow_run:
+    workflows: [Performance canary]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: performance-canary-reporter-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: report fork comparison
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Resolve trusted workflow run metadata
+        id: resolve
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const workflowPath = '.github/workflows/performance-canary.yml';
+            const {data: workflow} = await github.rest.actions.getWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'performance-canary.yml',
+            });
+            if (run.workflow_id !== workflow.id || run.path !== workflowPath) {
+              core.warning('Ignoring a run that did not use the canonical canary workflow');
+              core.setOutput('should_report', 'false');
+              return;
+            }
+
+            const associatedPulls = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: run.head_sha,
+                per_page: 100,
+              }
+            );
+            const candidates = associatedPulls.filter(pr =>
+              pr.state === 'open' &&
+              pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}` &&
+              pr.head.sha === run.head_sha &&
+              pr.head.repo?.full_name === run.head_repository.full_name
+            );
+            if (candidates.length !== 1) {
+              core.warning(`Expected one open PR for canary run; found ${candidates.length}`);
+              core.setOutput('should_report', 'false');
+              return;
+            }
+
+            const {data: pull} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: candidates[0].number,
+            });
+            if (files.length !== pull.changed_files) {
+              core.warning('Fork canary reporting requires a complete changed-file listing');
+              core.setOutput('should_report', 'false');
+              return;
+            }
+            if (
+              pull.draft ||
+              pull.head.sha !== run.head_sha ||
+              pull.head.repo?.full_name !== run.head_repository.full_name
+            ) {
+              core.notice('Ignoring an obsolete or draft fork canary run');
+              core.setOutput('should_report', 'false');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pull.number,
+              per_page: 100,
+            });
+            if (
+              files.some(file =>
+                file.filename === workflowPath || file.previous_filename === workflowPath
+              )
+            ) {
+              core.warning('Fork canary reporting is disabled when its producer workflow changes');
+              core.setOutput('should_report', 'false');
+              return;
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              }
+            );
+            // Recover the run's original base revision from artifact metadata so
+            // an unrelated base-branch update cannot rebind a completed comparison.
+            const artifactPattern = new RegExp(
+              `^performance-canary-${pull.number}-([0-9a-f]{40})$`
+            );
+            const matchingArtifacts = artifacts.flatMap(artifact => {
+              const match = artifact.name.match(artifactPattern);
+              return match && !artifact.expired ? [{artifact, baseSha: match[1]}] : [];
+            });
+            const artifactReady =
+              matchingArtifacts.length === 1 &&
+              matchingArtifacts[0].artifact.size_in_bytes <= 10 * 1024 * 1024;
+            if (!artifactReady) {
+              core.warning('Canary evidence is missing, ambiguous, expired, or too large');
+            }
+            const artifactName = artifactReady ? matchingArtifacts[0].artifact.name : '';
+            const baseSha = artifactReady ? matchingArtifacts[0].baseSha : pull.base.sha;
+
+            core.setOutput('should_report', 'true');
+            core.setOutput('artifact_ready', artifactReady ? 'true' : 'false');
+            core.setOutput('artifact_name', artifactName);
+            core.setOutput('pr_number', String(pull.number));
+            core.setOutput('base_label', pull.base.ref);
+            core.setOutput('base_sha', baseSha);
+            core.setOutput('head_repository', pull.head.repo.full_name);
+            core.setOutput('head_sha', pull.head.sha);
+
+      - name: Checkout trusted reporter
+        if: steps.resolve.outputs.should_report == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted-reporter
+          persist-credentials: false
+
+      - name: Download untrusted benchmark evidence
+        id: download
+        if: >-
+          steps.resolve.outputs.should_report == 'true' &&
+          steps.resolve.outputs.artifact_ready == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ steps.resolve.outputs.artifact_name }}
+          path: ${{ runner.temp }}/canary-evidence
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Render validated comparison
+        id: render
+        if: steps.download.outcome == 'success'
+        continue-on-error: true
+        env:
+          BASE_LABEL: ${{ steps.resolve.outputs.base_label }}
+          BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
+          HEAD_REPOSITORY: ${{ steps.resolve.outputs.head_repository }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/trusted-canary-report"
+          python3 trusted-reporter/tools/ci/benchmark_canary.py fork-report \
+            --output "$RUNNER_TEMP/trusted-canary-report/report.md" \
+            --evidence "$RUNNER_TEMP/canary-evidence" \
+            --repository "$GITHUB_REPOSITORY" \
+            --pr-number "$PR_NUMBER" \
+            --base-label "$BASE_LABEL" \
+            --base-sha "$BASE_SHA" \
+            --head-repository "$HEAD_REPOSITORY" \
+            --head-sha "$HEAD_SHA" \
+            --run-id "$RUN_ID" \
+            --run-url "$RUN_URL"
+
+      - name: Render trusted failure report
+        if: >-
+          steps.resolve.outputs.should_report == 'true' &&
+          steps.render.outcome != 'success'
+        env:
+          BASE_LABEL: ${{ steps.resolve.outputs.base_label }}
+          BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+        run: |
+          python3 trusted-reporter/tools/ci/benchmark_canary.py failure \
+            --output "$RUNNER_TEMP/trusted-canary-report/report.md" \
+            --base-label "$BASE_LABEL" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --run-url "$RUN_URL"
+
+      - name: Add trusted report to workflow summary
+        if: steps.resolve.outputs.should_report == 'true'
+        run: cat "$RUNNER_TEMP/trusted-canary-report/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create or update sticky comment
+        if: steps.resolve.outputs.should_report == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          REPORT_PATH: ${{ runner.temp }}/trusted-canary-report/report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- clifft-performance-canary -->';
+            const body = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const issue_number = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed('Resolved PR number is invalid');
+              return;
+            }
+            if (!body.startsWith(`${marker}\n`) || body.length > 60_000) {
+              core.setFailed('Trusted benchmark report is invalid');
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/performance-canary-reporter.yml
+++ b/.github/workflows/performance-canary-reporter.yml
@@ -70,11 +70,8 @@ jobs:
               repo: context.repo.repo,
               pull_number: candidates[0].number,
             });
-            if (files.length !== pull.changed_files) {
-              core.warning('Fork canary reporting requires a complete changed-file listing');
-              core.setOutput('should_report', 'false');
-              return;
-            }
+            // Re-check live PR metadata so an obsolete workflow_run cannot
+            // publish results after the fork branch has moved.
             if (
               pull.draft ||
               pull.head.sha !== run.head_sha ||
@@ -91,12 +88,17 @@ jobs:
               pull_number: pull.number,
               per_page: 100,
             });
+            if (files.length !== pull.changed_files) {
+              core.warning('Fork canary reporting requires a complete changed-file listing');
+              core.setOutput('should_report', 'false');
+              return;
+            }
             if (
               files.some(file =>
                 file.filename === workflowPath || file.previous_filename === workflowPath
               )
             ) {
-              core.warning('Fork canary reporting is disabled when its producer workflow changes');
+              core.warning('Fork canary reporting is disabled when its producer contract changes');
               core.setOutput('should_report', 'false');
               return;
             }
@@ -139,7 +141,7 @@ jobs:
 
       - name: Checkout trusted reporter
         if: steps.resolve.outputs.should_report == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: trusted-reporter

--- a/.github/workflows/performance-canary.yml
+++ b/.github/workflows/performance-canary.yml
@@ -23,9 +23,7 @@ concurrency:
 jobs:
   benchmark:
     name: advisory benchmark
-    if: >-
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -48,21 +46,42 @@ jobs:
       BENCHMARK_MIN_TIME: "0.5"
       BENCHMARK_WARMUP_TIME: "0.2"
     steps:
-      - name: Checkout PR revision
-        uses: actions/checkout@v4
+      - name: Checkout PR benchmark harness
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      # The Clifft source and build paths stay fixed across both revisions. The
-      # benchmark definition and fixtures come from the PR for both binaries.
-      - name: Checkout normalized benchmark source
-        uses: actions/checkout@v4
+      # Fork code runs without secrets or write permissions and uses benchmark
+      # definitions from the trusted base revision.
+      - name: Checkout trusted benchmark harness
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      # The Clifft source and build paths stay fixed across both revisions. The
+      # benchmark definition and fixtures come from one trusted revision for
+      # both binaries when the PR originates from a fork.
+      - name: Checkout normalized benchmark source
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           path: benchmark-source
           persist-credentials: false
+
+      - name: Fetch base revision for fork comparison
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git -C benchmark-source remote add base "$GITHUB_SERVER_URL/$BASE_REPOSITORY.git"
+          git -C benchmark-source fetch --no-tags --depth=1 base "$BASE_SHA"
 
       - name: Install native build tools
         uses: ./.github/actions/setup-native-tools
@@ -97,6 +116,28 @@ jobs:
             --base-label "$BASE_LABEL" \
             --base-sha "$BASE_SHA" \
             --head-sha "$HEAD_SHA"
+
+      - name: Record benchmark evidence metadata
+        env:
+          BASE_LABEL: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 tools/ci/benchmark_canary.py manifest \
+            --output canary-results/manifest.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --pr-number "$PR_NUMBER" \
+            --base-label "$BASE_LABEL" \
+            --base-sha "$BASE_SHA" \
+            --head-repository "$HEAD_REPOSITORY" \
+            --head-sha "$HEAD_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --repetitions "$BENCHMARK_REPETITIONS" \
+            --min-time "$BENCHMARK_MIN_TIME" \
+            --warmup-time "$BENCHMARK_WARMUP_TIME" \
+            --cpu-core "$BENCHMARK_CPU_CORE"
 
       - name: Build and run paired benchmarks
         id: benchmark
@@ -191,6 +232,7 @@ jobs:
         env:
           BASE_LABEL: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BENCHMARK_SHA: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.sha || github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           python3 tools/ci/benchmark_canary.py report \
@@ -202,6 +244,7 @@ jobs:
             --head-first canary-results/head-first \
             --head-second canary-results/head-second \
             --base-second canary-results/base-second \
+            --benchmark-sha "$BENCHMARK_SHA" \
             --repetitions "$BENCHMARK_REPETITIONS" \
             --min-time "$BENCHMARK_MIN_TIME" \
             --warmup-time "$BENCHMARK_WARMUP_TIME" \
@@ -219,9 +262,9 @@ jobs:
 
       - name: Upload benchmark evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: performance-canary-${{ github.event.pull_request.number }}
+          name: performance-canary-${{ github.event.pull_request.number }}-${{ github.event.pull_request.base.sha }}
           path: canary-results/
           retention-days: 7
 
@@ -239,13 +282,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Download benchmark evidence
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: performance-canary-${{ github.event.pull_request.number }}
+          name: performance-canary-${{ github.event.pull_request.number }}-${{ github.event.pull_request.base.sha }}
           path: canary-results
 
       - name: Create or update sticky comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/performance-canary.yml
+++ b/.github/workflows/performance-canary.yml
@@ -42,13 +42,15 @@ jobs:
       CCACHE_COMPILERCHECK: content
       OMP_DYNAMIC: "FALSE"
       OMP_NUM_THREADS: "1"
+      # These values are also enforced by the trusted fork reporter's CANARY_*
+      # constants, so changing the workload contract requires updating both.
       BENCHMARK_REPETITIONS: "3"
       BENCHMARK_MIN_TIME: "0.5"
       BENCHMARK_WARMUP_TIME: "0.2"
     steps:
       - name: Checkout PR benchmark harness
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -57,7 +59,7 @@ jobs:
       # definitions from the trusted base revision.
       - name: Checkout trusted benchmark harness
         if: github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
@@ -66,7 +68,7 @@ jobs:
       # benchmark definition and fixtures come from one trusted revision for
       # both binaries when the PR originates from a fork.
       - name: Checkout normalized benchmark source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -266,6 +268,9 @@ jobs:
         with:
           name: performance-canary-${{ github.event.pull_request.number }}-${{ github.event.pull_request.base.sha }}
           path: canary-results/
+          # The reporter bounds the stored artifact size before downloading it.
+          # Disabling compression makes that bound resist highly compressible input.
+          compression-level: 0
           retention-days: 7
 
   comment:

--- a/.github/workflows/performance-canary.yml
+++ b/.github/workflows/performance-canary.yml
@@ -284,7 +284,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
     steps:
       - name: Download benchmark evidence
         uses: actions/download-artifact@v8

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
-# This directory is also a standalone driver so CI can use the benchmark
-# definition from the PR while compiling either the base or PR source tree.
+# This directory is also a standalone driver so CI can hold the benchmark
+# definition fixed while compiling either the base or proposed source tree.
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     project(clifft_benchmarks LANGUAGES CXX)
 

--- a/tests/python/test_benchmark_canary.py
+++ b/tests/python/test_benchmark_canary.py
@@ -23,6 +23,11 @@ def _load_benchmark_canary_module():
 
 benchmark_canary = _load_benchmark_canary_module()
 
+REPOSITORY = "unitaryfoundation/clifft"
+HEAD_REPOSITORY = "contributor/clifft"
+BASE_SHA = "1" * 40
+HEAD_SHA = "2" * 40
+
 
 def _write_results(
     path: Path,
@@ -59,6 +64,37 @@ def _write_results(
             }
         )
     path.write_text(json.dumps({"context": {}, "benchmarks": benchmarks}))
+    return path
+
+
+def _write_fork_evidence(path: Path) -> Path:
+    path.mkdir()
+    for directory_name, multiplier in (
+        ("base-first", 1.0),
+        ("head-first", 1.1),
+        ("head-second", 1.1),
+        ("base-second", 1.0),
+    ):
+        directory = path / directory_name
+        directory.mkdir()
+        for index, name in enumerate(benchmark_canary.DISPLAY_NAMES, start=1):
+            _write_results(directory / f"{name}.json", {name: index * 100.0 * multiplier})
+    benchmark_canary.write_manifest(
+        path / "manifest.json",
+        repository=REPOSITORY,
+        pr_number=123,
+        base_label="main",
+        base_sha=BASE_SHA,
+        head_repository=HEAD_REPOSITORY,
+        head_sha=HEAD_SHA,
+        run_id=456,
+        repetitions=benchmark_canary.CANARY_REPETITIONS,
+        min_time=benchmark_canary.CANARY_MIN_TIME,
+        warmup_time=benchmark_canary.CANARY_WARMUP_TIME,
+        cpu_core="3",
+        cpu="Example CPU",
+        compiler="Example compiler",
+    )
     return path
 
 
@@ -107,7 +143,7 @@ def test_report_classifies_paired_changes(tmp_path: Path) -> None:
     assert "<summary>View 4 benchmark results</summary>" not in report
     assert "<sub>Compared <code>main</code> (<code>1234567</code>)" in report
     assert "Example CPU" in report
-    assert "Pinned logical CPU: 3" in report
+    assert "Pinned logical CPU: <code>3</code>" in report
     assert "Release, x86-64-v2, ThinLTO, lld" in report
     assert "[View workflow run](https://example.com/run)" in report
 
@@ -284,3 +320,131 @@ def test_parser_combines_one_benchmark_per_file(tmp_path: Path) -> None:
     _write_results(directory / "two.json", {"two": 200.0})
 
     assert set(benchmark_canary.parse_google_benchmarks(directory)) == {"one", "two"}
+
+
+def test_fork_report_validates_evidence_and_uses_base_workloads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evidence = _write_fork_evidence(tmp_path / "evidence")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.example")
+    monkeypatch.setenv("GITHUB_REPOSITORY", REPOSITORY)
+
+    report = benchmark_canary.render_fork_report(
+        evidence,
+        expected_repository=REPOSITORY,
+        expected_pr_number=123,
+        expected_base_label="main",
+        expected_base_sha=BASE_SHA,
+        expected_head_repository=HEAD_REPOSITORY,
+        expected_head_sha=HEAD_SHA,
+        expected_run_id=456,
+        run_url="https://github.example/run/456",
+    )
+
+    assert "**Possible regression detected:** 9 of 9 benchmarks were at least 10% slower." in report
+    assert f"/{REPOSITORY}/blob/{BASE_SHA}/benchmarks/clifft_benchmarks.cc#L" in report
+    assert f"/{REPOSITORY}/blob/{HEAD_SHA}/benchmarks/clifft_benchmarks.cc#L" not in report
+    assert "<code>Example CPU</code>" in report
+    assert "Workloads and fixtures come from the base revision for fork isolation." in report
+    assert "[View workflow run](https://github.example/run/456)" in report
+
+
+def test_fork_report_rejects_manifest_not_bound_to_run(tmp_path: Path) -> None:
+    evidence = _write_fork_evidence(tmp_path / "evidence")
+    manifest_path = evidence / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["head_sha"] = "3" * 40
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="head_sha does not match"):
+        benchmark_canary.render_fork_report(
+            evidence,
+            expected_repository=REPOSITORY,
+            expected_pr_number=123,
+            expected_base_label="main",
+            expected_base_sha=BASE_SHA,
+            expected_head_repository=HEAD_REPOSITORY,
+            expected_head_sha=HEAD_SHA,
+            expected_run_id=456,
+            run_url="https://github.example/run/456",
+        )
+
+
+def test_fork_report_rejects_base_revision_not_bound_to_artifact(tmp_path: Path) -> None:
+    evidence = _write_fork_evidence(tmp_path / "evidence")
+    manifest_path = evidence / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["base_sha"] = "3" * 40
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="base_sha does not match"):
+        benchmark_canary.render_fork_report(
+            evidence,
+            expected_repository=REPOSITORY,
+            expected_pr_number=123,
+            expected_base_label="main",
+            expected_base_sha=BASE_SHA,
+            expected_head_repository=HEAD_REPOSITORY,
+            expected_head_sha=HEAD_SHA,
+            expected_run_id=456,
+            run_url="https://github.example/run/456",
+        )
+
+
+def test_fork_report_rejects_unexpected_workload_files(tmp_path: Path) -> None:
+    evidence = _write_fork_evidence(tmp_path / "evidence")
+    _write_results(evidence / "base-first" / "invented.json", {"invented": 100.0})
+
+    with pytest.raises(ValueError, match="unexpected file set"):
+        benchmark_canary.render_fork_report(
+            evidence,
+            expected_repository=REPOSITORY,
+            expected_pr_number=123,
+            expected_base_label="main",
+            expected_base_sha=BASE_SHA,
+            expected_head_repository=HEAD_REPOSITORY,
+            expected_head_sha=HEAD_SHA,
+            expected_run_id=456,
+            run_url="https://github.example/run/456",
+        )
+
+
+def test_fork_report_rejects_multiline_environment_text(tmp_path: Path) -> None:
+    evidence = _write_fork_evidence(tmp_path / "evidence")
+    manifest_path = evidence / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["compiler"] = "compiler\nforged report"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="invalid compiler"):
+        benchmark_canary.render_fork_report(
+            evidence,
+            expected_repository=REPOSITORY,
+            expected_pr_number=123,
+            expected_base_label="main",
+            expected_base_sha=BASE_SHA,
+            expected_head_repository=HEAD_REPOSITORY,
+            expected_head_sha=HEAD_SHA,
+            expected_run_id=456,
+            run_url="https://github.example/run/456",
+        )
+
+
+def test_manifest_rejects_settings_not_supported_by_reporter(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="settings do not match"):
+        benchmark_canary.write_manifest(
+            tmp_path / "manifest.json",
+            repository=REPOSITORY,
+            pr_number=123,
+            base_label="main",
+            base_sha=BASE_SHA,
+            head_repository=HEAD_REPOSITORY,
+            head_sha=HEAD_SHA,
+            run_id=456,
+            repetitions=4,
+            min_time=benchmark_canary.CANARY_MIN_TIME,
+            warmup_time=benchmark_canary.CANARY_WARMUP_TIME,
+            cpu_core="3",
+            cpu="Example CPU",
+            compiler="Example compiler",
+        )

--- a/tests/python/test_benchmark_canary.py
+++ b/tests/python/test_benchmark_canary.py
@@ -344,7 +344,7 @@ def test_fork_report_validates_evidence_and_uses_base_workloads(
     assert "**Possible regression detected:** 9 of 9 benchmarks were at least 10% slower." in report
     assert f"/{REPOSITORY}/blob/{BASE_SHA}/benchmarks/clifft_benchmarks.cc#L" in report
     assert f"/{REPOSITORY}/blob/{HEAD_SHA}/benchmarks/clifft_benchmarks.cc#L" not in report
-    assert "<code>Example CPU</code>" in report
+    assert "Runner CPU: ` Example CPU `" in report
     assert "Workloads and fixtures come from the base revision for fork isolation." in report
     assert "[View workflow run](https://github.example/run/456)" in report
 
@@ -428,6 +428,31 @@ def test_fork_report_rejects_multiline_environment_text(tmp_path: Path) -> None:
             expected_run_id=456,
             run_url="https://github.example/run/456",
         )
+
+
+def test_fork_report_quotes_markdown_in_environment_text(tmp_path: Path) -> None:
+    evidence = _write_fork_evidence(tmp_path / "evidence")
+    manifest_path = evidence / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["cpu"] = "[click](https://example.invalid)"
+    manifest["compiler"] = "compiler `with` backticks"
+    manifest_path.write_text(json.dumps(manifest))
+
+    report = benchmark_canary.render_fork_report(
+        evidence,
+        expected_repository=REPOSITORY,
+        expected_pr_number=123,
+        expected_base_label="main",
+        expected_base_sha=BASE_SHA,
+        expected_head_repository=HEAD_REPOSITORY,
+        expected_head_sha=HEAD_SHA,
+        expected_run_id=456,
+        run_url="https://github.example/run/456",
+    )
+
+    assert "Runner CPU: ` [click](https://example.invalid) `" in report
+    assert "Compiler: `` compiler `with` backticks ``" in report
+    assert "<code>[click]" not in report
 
 
 def test_manifest_rejects_settings_not_supported_by_reporter(tmp_path: Path) -> None:

--- a/tools/ci/benchmark_canary.py
+++ b/tools/ci/benchmark_canary.py
@@ -20,6 +20,13 @@ COMMENT_MARKER = "<!-- clifft-performance-canary -->"
 MATERIAL_CHANGE_THRESHOLD = 0.05
 MAX_RELATIVE_STDDEV = 0.05
 POSSIBLE_CHANGE_THRESHOLD = 0.10
+CANARY_MANIFEST_SCHEMA = 1
+CANARY_REPETITIONS = 3
+CANARY_MIN_TIME = 0.5
+CANARY_WARMUP_TIME = 0.2
+MAX_MANIFEST_BYTES = 16 * 1024
+MAX_RESULT_BYTES = 1024 * 1024
+MAX_BENCHMARK_ROWS = 100
 BENCHMARK_SOURCE = Path(__file__).resolve().parents[2] / "benchmarks" / "clifft_benchmarks.cc"
 
 DISPLAY_NAMES = {
@@ -46,6 +53,7 @@ TIME_UNIT_TO_NS = {
 class BenchmarkEstimate:
     median_ns: float
     relative_stddev: float
+    sample_count: int
 
 
 @dataclass(frozen=True)
@@ -96,6 +104,8 @@ def parse_google_benchmarks(path: Path) -> dict[str, BenchmarkEstimate]:
         benchmarks = payload.get("benchmarks")
         if not isinstance(benchmarks, list):
             raise ValueError(f"malformed Google Benchmark output: {result_path}")
+        if len(benchmarks) > MAX_BENCHMARK_ROWS:
+            raise ValueError(f"too many Google Benchmark rows: {result_path}")
 
         repetitions: dict[str, list[float]] = defaultdict(list)
         for benchmark in benchmarks:
@@ -123,7 +133,7 @@ def parse_google_benchmarks(path: Path) -> dict[str, BenchmarkEstimate]:
             relative_stddev = (
                 statistics.stdev(values) / statistics.mean(values) if len(values) > 1 else 0
             )
-            results[name] = BenchmarkEstimate(median_ns, relative_stddev)
+            results[name] = BenchmarkEstimate(median_ns, relative_stddev, len(values))
 
     if not results:
         raise ValueError(f"no Google Benchmark results found: {path}")
@@ -357,6 +367,7 @@ def render_report(
     compiler: str | None = None,
     cpu_core: str | None = None,
     run_url: str | None = None,
+    benchmark_sha: str | None = None,
 ) -> str:
     lines = [
         COMMENT_MARKER,
@@ -386,7 +397,7 @@ def render_report(
             "|---|---:|---:|---:|---|",
         ]
     )
-    source_links = _benchmark_source_links(head_sha)
+    source_links = _benchmark_source_links(benchmark_sha or head_sha)
     for comparison in comparisons:
         name = DISPLAY_NAMES.get(comparison.name, comparison.name).replace("|", "\\|")
         if comparison.name in source_links:
@@ -406,10 +417,10 @@ def render_report(
             "<details>",
             "<summary>Environment and method</summary>",
             "",
-            f"- Runner CPU: {_environment_value(cpu, 'cpu')}",
-            f"- Pinned logical CPU: {cpu_core or 'unknown'}",
+            f"- Runner CPU: <code>{html.escape(_environment_value(cpu, 'cpu'))}</code>",
+            f"- Pinned logical CPU: <code>{html.escape(cpu_core or 'unknown')}</code>",
             "- ISA: AVX2 runtime backend (forced)",
-            f"- Compiler: {_environment_value(compiler, 'compiler')}",
+            f"- Compiler: <code>{html.escape(_environment_value(compiler, 'compiler'))}</code>",
             "- Build: Release, x86-64-v2, ThinLTO, lld, and OpenMP enabled.",
             f"- Each pass warms every workload for at least {warmup_time:g} seconds, then runs "
             f"{repetitions} Google Benchmark repetitions with at least {min_time:g} seconds of "
@@ -423,6 +434,8 @@ def render_report(
             "not establish release performance.",
         ]
     )
+    if benchmark_sha and benchmark_sha != head_sha:
+        lines.append("- Workloads and fixtures come from the base revision for fork isolation.")
     if added:
         lines.append(f"- Added in the PR and not compared: {', '.join(added)}")
     if removed:
@@ -444,12 +457,204 @@ def render_failure(
         "",
         "**The canary could not produce a comparison.** This does not block merging.",
         "",
-        f"Attempted to compare `{base_label}` (`{base_sha[:7]}`) with this PR (`{head_sha[:7]}`).",
+        f"Attempted to compare <code>{html.escape(base_label)}</code> "
+        f"(<code>{html.escape(base_sha[:7])}</code>) with this PR "
+        f"(<code>{html.escape(head_sha[:7])}</code>).",
     ]
     resolved_run_url = _run_url(run_url)
     if resolved_run_url:
         lines.extend(["", f"[View workflow run]({resolved_run_url})"])
     return "\n".join(lines) + "\n"
+
+
+def write_manifest(
+    path: Path,
+    *,
+    repository: str,
+    pr_number: int,
+    base_label: str,
+    base_sha: str,
+    head_repository: str,
+    head_sha: str,
+    run_id: int,
+    repetitions: int,
+    min_time: float,
+    warmup_time: float,
+    cpu_core: str,
+    cpu: str | None = None,
+    compiler: str | None = None,
+) -> None:
+    if (
+        repetitions != CANARY_REPETITIONS
+        or min_time != CANARY_MIN_TIME
+        or warmup_time != CANARY_WARMUP_TIME
+    ):
+        raise ValueError("benchmark settings do not match the trusted reporter")
+    payload = {
+        "schema": CANARY_MANIFEST_SCHEMA,
+        "repository": repository,
+        "pr_number": pr_number,
+        "base_label": base_label,
+        "base_sha": base_sha,
+        "head_repository": head_repository,
+        "head_sha": head_sha,
+        "run_id": run_id,
+        "repetitions": repetitions,
+        "min_time": min_time,
+        "warmup_time": warmup_time,
+        "cpu_core": cpu_core,
+        "cpu": _environment_value(cpu, "cpu"),
+        "compiler": _environment_value(compiler, "compiler"),
+    }
+    write_report(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _validated_plain_text(value: object, field: str, max_length: int = 256) -> str:
+    if not isinstance(value, str) or not value or len(value) > max_length:
+        raise ValueError(f"invalid {field} in benchmark manifest")
+    if any(ord(character) < 0x20 or ord(character) > 0x7E for character in value):
+        raise ValueError(f"invalid {field} in benchmark manifest")
+    return value
+
+
+def _load_fork_manifest(
+    evidence: Path,
+    *,
+    expected_repository: str,
+    expected_pr_number: int,
+    expected_base_label: str,
+    expected_base_sha: str,
+    expected_head_repository: str,
+    expected_head_sha: str,
+    expected_run_id: int,
+) -> dict[str, object]:
+    manifest_path = evidence / "manifest.json"
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise ValueError("benchmark manifest is missing or is not a regular file")
+    if manifest_path.stat().st_size > MAX_MANIFEST_BYTES:
+        raise ValueError("benchmark manifest is too large")
+    payload = json.loads(manifest_path.read_text())
+    expected_fields = {
+        "schema",
+        "repository",
+        "pr_number",
+        "base_label",
+        "base_sha",
+        "head_repository",
+        "head_sha",
+        "run_id",
+        "repetitions",
+        "min_time",
+        "warmup_time",
+        "cpu_core",
+        "cpu",
+        "compiler",
+    }
+    if not isinstance(payload, dict) or set(payload) != expected_fields:
+        raise ValueError("benchmark manifest has an unexpected schema")
+
+    exact_values = {
+        "schema": CANARY_MANIFEST_SCHEMA,
+        "repository": expected_repository,
+        "pr_number": expected_pr_number,
+        "base_label": expected_base_label,
+        "base_sha": expected_base_sha,
+        "head_repository": expected_head_repository,
+        "head_sha": expected_head_sha,
+        "run_id": expected_run_id,
+        "repetitions": CANARY_REPETITIONS,
+        "min_time": CANARY_MIN_TIME,
+        "warmup_time": CANARY_WARMUP_TIME,
+    }
+    for field, expected in exact_values.items():
+        if type(payload[field]) is not type(expected) or payload[field] != expected:
+            raise ValueError(f"benchmark manifest {field} does not match the workflow run")
+
+    sha_pattern = re.compile(r"^[0-9a-f]{40}$")
+    if not sha_pattern.fullmatch(expected_base_sha) or not sha_pattern.fullmatch(expected_head_sha):
+        raise ValueError("workflow metadata contains an invalid commit SHA")
+    _validated_plain_text(payload["repository"], "repository")
+    _validated_plain_text(payload["base_label"], "base label")
+    _validated_plain_text(payload["head_repository"], "head repository")
+    cpu_core = _validated_plain_text(payload["cpu_core"], "CPU core", 16)
+    if not cpu_core.isdigit():
+        raise ValueError("invalid CPU core in benchmark manifest")
+    _validated_plain_text(payload["cpu"], "CPU", 256)
+    _validated_plain_text(payload["compiler"], "compiler", 512)
+    return payload
+
+
+def _validate_fork_results(path: Path, repetitions: int) -> None:
+    expected_names = set(DISPLAY_NAMES)
+    expected_files = {f"{name}.json" for name in expected_names}
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError(f"benchmark evidence directory is missing: {path.name}")
+    entries = list(path.iterdir())
+    if {entry.name for entry in entries} != expected_files:
+        raise ValueError(f"benchmark evidence has an unexpected file set: {path.name}")
+    for result_path in entries:
+        if result_path.is_symlink() or not result_path.is_file():
+            raise ValueError(f"benchmark evidence is not a regular file: {result_path.name}")
+        if result_path.stat().st_size > MAX_RESULT_BYTES:
+            raise ValueError(f"benchmark evidence is too large: {result_path.name}")
+
+    estimates = parse_google_benchmarks(path)
+    if set(estimates) != expected_names:
+        raise ValueError(f"benchmark evidence has an unexpected workload set: {path.name}")
+    for name, estimate in estimates.items():
+        if estimate.sample_count != repetitions:
+            raise ValueError(f"benchmark {name!r} has an unexpected repetition count")
+
+
+def render_fork_report(
+    evidence: Path,
+    *,
+    expected_repository: str,
+    expected_pr_number: int,
+    expected_base_label: str,
+    expected_base_sha: str,
+    expected_head_repository: str,
+    expected_head_sha: str,
+    expected_run_id: int,
+    run_url: str,
+) -> str:
+    manifest = _load_fork_manifest(
+        evidence,
+        expected_repository=expected_repository,
+        expected_pr_number=expected_pr_number,
+        expected_base_label=expected_base_label,
+        expected_base_sha=expected_base_sha,
+        expected_head_repository=expected_head_repository,
+        expected_head_sha=expected_head_sha,
+        expected_run_id=expected_run_id,
+    )
+    result_directories = [
+        evidence / "base-first",
+        evidence / "head-first",
+        evidence / "head-second",
+        evidence / "base-second",
+    ]
+    for result_directory in result_directories:
+        _validate_fork_results(result_directory, CANARY_REPETITIONS)
+    comparisons, added, removed = compare_runs(*result_directories)
+    if added or removed:
+        raise ValueError("fork benchmark evidence changed the trusted workload set")
+    return render_report(
+        comparisons,
+        base_label=expected_base_label,
+        base_sha=expected_base_sha,
+        head_sha=expected_head_sha,
+        repetitions=CANARY_REPETITIONS,
+        min_time=CANARY_MIN_TIME,
+        warmup_time=CANARY_WARMUP_TIME,
+        added=added,
+        removed=removed,
+        cpu=str(manifest["cpu"]),
+        compiler=str(manifest["compiler"]),
+        cpu_core=str(manifest["cpu_core"]),
+        run_url=run_url,
+        benchmark_sha=expected_base_sha,
+    )
 
 
 def write_report(path: Path, content: str) -> None:
@@ -486,6 +691,35 @@ def main() -> None:
     report_parser.add_argument("--cpu")
     report_parser.add_argument("--compiler")
     report_parser.add_argument("--cpu-core")
+    report_parser.add_argument("--benchmark-sha")
+
+    manifest_parser = subparsers.add_parser("manifest")
+    manifest_parser.add_argument("--output", type=Path, required=True)
+    manifest_parser.add_argument("--repository", required=True)
+    manifest_parser.add_argument("--pr-number", type=int, required=True)
+    manifest_parser.add_argument("--base-label", required=True)
+    manifest_parser.add_argument("--base-sha", required=True)
+    manifest_parser.add_argument("--head-repository", required=True)
+    manifest_parser.add_argument("--head-sha", required=True)
+    manifest_parser.add_argument("--run-id", type=int, required=True)
+    manifest_parser.add_argument("--repetitions", type=int, required=True)
+    manifest_parser.add_argument("--min-time", type=float, required=True)
+    manifest_parser.add_argument("--warmup-time", type=float, required=True)
+    manifest_parser.add_argument("--cpu-core", required=True)
+    manifest_parser.add_argument("--cpu")
+    manifest_parser.add_argument("--compiler")
+
+    fork_report_parser = subparsers.add_parser("fork-report")
+    fork_report_parser.add_argument("--output", type=Path, required=True)
+    fork_report_parser.add_argument("--base-label", required=True)
+    fork_report_parser.add_argument("--base-sha", required=True)
+    fork_report_parser.add_argument("--head-sha", required=True)
+    fork_report_parser.add_argument("--run-url", required=True)
+    fork_report_parser.add_argument("--evidence", type=Path, required=True)
+    fork_report_parser.add_argument("--repository", required=True)
+    fork_report_parser.add_argument("--pr-number", type=int, required=True)
+    fork_report_parser.add_argument("--head-repository", required=True)
+    fork_report_parser.add_argument("--run-id", type=int, required=True)
     args = parser.parse_args()
 
     if args.command == "failure":
@@ -495,7 +729,8 @@ def main() -> None:
             head_sha=args.head_sha,
             run_url=args.run_url,
         )
-    else:
+        write_report(args.output, content)
+    elif args.command == "report":
         comparisons, added, removed = compare_runs(
             args.base_first, args.head_first, args.head_second, args.base_second
         )
@@ -513,8 +748,39 @@ def main() -> None:
             compiler=args.compiler,
             cpu_core=args.cpu_core,
             run_url=args.run_url,
+            benchmark_sha=args.benchmark_sha,
         )
-    write_report(args.output, content)
+        write_report(args.output, content)
+    elif args.command == "manifest":
+        write_manifest(
+            args.output,
+            repository=args.repository,
+            pr_number=args.pr_number,
+            base_label=args.base_label,
+            base_sha=args.base_sha,
+            head_repository=args.head_repository,
+            head_sha=args.head_sha,
+            run_id=args.run_id,
+            repetitions=args.repetitions,
+            min_time=args.min_time,
+            warmup_time=args.warmup_time,
+            cpu_core=args.cpu_core,
+            cpu=args.cpu,
+            compiler=args.compiler,
+        )
+    else:
+        content = render_fork_report(
+            args.evidence,
+            expected_repository=args.repository,
+            expected_pr_number=args.pr_number,
+            expected_base_label=args.base_label,
+            expected_base_sha=args.base_sha,
+            expected_head_repository=args.head_repository,
+            expected_head_sha=args.head_sha,
+            expected_run_id=args.run_id,
+            run_url=args.run_url,
+        )
+        write_report(args.output, content)
 
 
 if __name__ == "__main__":

--- a/tools/ci/benchmark_canary.py
+++ b/tools/ci/benchmark_canary.py
@@ -219,6 +219,14 @@ def _threshold_percent(threshold: float) -> str:
     return f"{threshold:.0%}"
 
 
+def _markdown_code_span(value: str) -> str:
+    longest_backtick_run = max((len(run) for run in re.findall(r"`+", value)), default=0)
+    delimiter = "`" * (longest_backtick_run + 1)
+    # Padding preserves leading/trailing spaces while keeping any shorter
+    # backtick runs inside the code span rather than executable Markdown.
+    return f"{delimiter} {value} {delimiter}"
+
+
 def _summary(comparisons: list[Comparison]) -> str:
     assessments = [comparison.assessment for comparison in comparisons]
     regressions = assessments.count("Possible regression")
@@ -417,10 +425,10 @@ def render_report(
             "<details>",
             "<summary>Environment and method</summary>",
             "",
-            f"- Runner CPU: <code>{html.escape(_environment_value(cpu, 'cpu'))}</code>",
+            f"- Runner CPU: {_markdown_code_span(_environment_value(cpu, 'cpu'))}",
             f"- Pinned logical CPU: <code>{html.escape(cpu_core or 'unknown')}</code>",
             "- ISA: AVX2 runtime backend (forced)",
-            f"- Compiler: <code>{html.escape(_environment_value(compiler, 'compiler'))}</code>",
+            f"- Compiler: {_markdown_code_span(_environment_value(compiler, 'compiler'))}",
             "- Build: Release, x86-64-v2, ThinLTO, lld, and OpenMP enabled.",
             f"- Each pass warms every workload for at least {warmup_time:g} seconds, then runs "
             f"{repetitions} Google Benchmark repetitions with at least {min_time:g} seconds of "


### PR DESCRIPTION
## Summary

- run fork PR code in the existing read-only canary job, with workloads and fixtures held to the trusted base revision
- add a default-branch `workflow_run` reporter that regenerates the sticky comment without executing or republishing fork-controlled content
- bind evidence to the canonical workflow, PR, run, base, and head revisions and reject stale, modified-workflow, oversized, malformed, or unexpected results

Same-repository PR behavior remains unchanged apart from recording the evidence manifest used by the fork reporter.

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `just py-test` (1,383 passed, 6 skipped, 1 xfailed)
- trusted rendering exercised against the real artifact from PR #436

The new reporter only becomes active once it exists on the default branch, so its final end-to-end check is a temporary fork PR after merge.

Closes #434