### PR TITLE
test: exercise fork performance canary

### DIFF
--- a/src/clifft/api/reference_syndrome.cc
+++ b/src/clifft/api/reference_syndrome.cc
@@ -9,7 +9,7 @@ namespace clifft {
 ReferenceSyndrome compute_reference_syndrome(const HirModule& hir) {
     ReferenceSyndrome ref;
 
-    // Make a clean copy and strip all noise
+    // Removing stochastic noise makes the reference circuit deterministic.
     HirModule clean_hir = hir;
     RemoveNoisePass strip;
     strip.run(clean_hir);
@@ -22,7 +22,7 @@ ReferenceSyndrome compute_reference_syndrome(const HirModule& hir) {
         return ref;
     }
 
-    // Run exactly one deterministic shot (seed=0)
+    // A fixed seed keeps the single reference shot deterministic.
     auto clean_res = sampling::sample(clean_program, 1, uint64_t{0});
     ref.detectors = std::move(clean_res.detectors);
     ref.observables = std::move(clean_res.observables);

--- a/src/clifft/api/reference_syndrome.cc
+++ b/src/clifft/api/reference_syndrome.cc
@@ -22,7 +22,7 @@ ReferenceSyndrome compute_reference_syndrome(const HirModule& hir) {
         return ref;
     }
 
-    // A fixed seed keeps the single reference shot deterministic.
+    // A fixed seed makes the single reference shot reproducible across calls.
     auto clean_res = sampling::sample(clean_program, 1, uint64_t{0});
     ref.detectors = std::move(clean_res.detectors);
     ref.observables = std::move(clean_res.observables);


### PR DESCRIPTION
## Summary

- make a harmless source-file change from the `bachase/clifft` fork
- exercise the unprivileged fork canary and trusted reporter end to end

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

This is a temporary workflow smoke test and should be closed rather than merged.