### PR TITLE
fix(ci): resolve fork canary pull requests

### DIFF
--- a/.github/workflows/performance-canary-reporter.yml
+++ b/.github/workflows/performance-canary-reporter.yml
@@ -24,8 +24,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Resolve trusted workflow run metadata
         id: resolve

--- a/.github/workflows/performance-canary-reporter.yml
+++ b/.github/workflows/performance-canary-reporter.yml
@@ -45,16 +45,23 @@ jobs:
               return;
             }
 
-            const associatedPulls = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: run.head_sha,
-                per_page: 100,
-              }
-            );
-            const candidates = associatedPulls.filter(pr =>
+            const headOwner = run.head_repository.owner?.login;
+            if (!headOwner || !run.head_branch) {
+              core.warning('Fork canary run is missing head repository metadata');
+              core.setOutput('should_report', 'false');
+              return;
+            }
+            // Fork-only commits are not addressable through the upstream
+            // commit-to-PR endpoint, so resolve by owner and branch before
+            // binding the candidate back to the immutable run SHA.
+            const headPulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${headOwner}:${run.head_branch}`,
+              per_page: 100,
+            });
+            const candidates = headPulls.filter(pr =>
               pr.state === 'open' &&
               pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}` &&
               pr.head.sha === run.head_sha &&

--- a/.github/workflows/performance-canary.yml
+++ b/.github/workflows/performance-canary.yml
@@ -284,7 +284,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     steps:
       - name: Download benchmark evidence
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

- resolve fork PRs through GitHub’s `head=owner:branch` filter
- retain exact upstream repository, fork repository, and immutable head-SHA checks before reporting

## Context

The post-merge fork smoke test in #438 showed that `workflow_run.pull_requests` is empty for this fork run and the upstream commit-to-PR endpoint cannot resolve a commit that exists only in the fork. The reporter therefore failed closed before downloading evidence.

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- verified the replacement query resolves exactly #438, after which the existing repository and SHA filters bind it to run `33422523038`

After this merges, a new push to #438 will complete the end-to-end reporter test.