### PR TITLE
docs: make circuit inputs first-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,22 +97,21 @@ result = clifft.sample(program, shots=1000, seed=42)
 print(result.measurements[:5])
 ```
 
-For more details and examples, check out the [documentation](https://unitaryfoundation.github.io/clifft) or take Clifft for a spin in the web-based [interactive playground](https://unitaryfoundation.github.io/clifft/playground/).
+Continue with the [Quick Start](https://unitaryfoundation.github.io/clifft/stable/getting-started/quickstart/),
+or use [Choose a Workflow](https://unitaryfoundation.github.io/clifft/stable/getting-started/choosing-a-workflow/)
+to select an API by the result you need. You can also try Clifft in the
+web-based [interactive playground](https://unitaryfoundation.github.io/clifft/playground/).
 
-## Front-End Integrations
+## Circuit Inputs and Integrations
 
-Clifft's native API accepts Stim-compatible circuit text. If your workflow
-starts in another circuit framework, companion packages make the supported path
-discoverable:
+| Starting point | Path |
+|---|---|
+| Stim-compatible text | Use the native `clifft` API for the broadest feature support. |
+| Unitary OpenQASM 2 text | Pass `input_format="qasm2"` to `clifft.compile()`. |
+| Qiskit `QuantumCircuit` | Use [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit), a Qiskit `BackendV2` provider. |
+| Cirq `cirq.Circuit` | Use [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq), a converter and Cirq-style sampler. |
 
-- **Qiskit**: [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit)
-  provides a Qiskit `BackendV2` provider for running supported
-  `QuantumCircuit` instances on Clifft.
-- **Cirq**: [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq)
-  converts parameter-resolved `cirq.Circuit` instances to Clifft text and
-  provides a Cirq-style sampler backed by Clifft.
-
-See the [front-end integrations guide](https://unitaryfoundation.github.io/clifft/stable/getting-started/integrations/)
+See [Circuit Inputs and Integrations](https://unitaryfoundation.github.io/clifft/stable/getting-started/integrations/)
 for installation commands, minimal examples, and current limitations.
 
 ## Citation

--- a/docs/getting-started/cirq.md
+++ b/docs/getting-started/cirq.md
@@ -1,0 +1,48 @@
+<!--pytest-codeblocks:skipfile-->
+
+# Cirq
+
+The separately released
+[`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) package
+converts supported `cirq.Circuit` objects to Clifft text and provides a
+Cirq-style sampler. Use it when circuit construction and result handling
+already live in Cirq.
+
+Install the adapter:
+
+```bash
+pip install clifft-cirq
+```
+
+Convert or sample a parameter-resolved qubit circuit:
+
+```python
+import cirq
+import clifft_cirq
+
+q0, q1 = cirq.LineQubit.range(2)
+circuit = cirq.Circuit(
+    cirq.H(q0),
+    cirq.CNOT(q0, q1),
+    cirq.measure(q0, q1, key="m"),
+)
+
+converted = clifft_cirq.to_clifft_text(circuit)
+print(converted.clifft_text)
+
+sampler = clifft_cirq.ClifftSampler(seed=123)
+result = sampler.run(circuit, repetitions=1000)
+print(result)
+```
+
+The converter supports parameter-resolved qubit circuits and common one-, two-,
+and three-qubit gates that map to Clifft. It does not model Cirq device, timing,
+calibration, qudit, arbitrary classical-control, or noise-channel semantics.
+
+The companion package is maintained and released independently. See the
+[`clifft-cirq` repository](https://github.com/unitaryfoundation/clifft-cirq)
+for its current supported operations, conversion metadata, and limitations.
+
+Use the native [Stim-compatible input](stim-input.md) for detector annotations,
+observables, post-selection, importance sampling, or other Clifft-specific
+workflows.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -63,3 +63,6 @@ and then requesting intra-shot threads in the child can hang in some OpenMP
 runtimes.
 
 See [Building from Source](../development/building.md) for the full development setup.
+
+Next, follow the [Quick Start](quickstart.md) or choose a path from
+[Circuit Inputs and Integrations](integrations.md).

--- a/docs/getting-started/integrations.md
+++ b/docs/getting-started/integrations.md
@@ -1,96 +1,47 @@
-<!--pytest-codeblocks:skipfile-->
-
-# Front-End Integrations
+# Circuit Inputs and Integrations
 
 Clifft's primary input is Stim-compatible circuit text with Clifft extensions
-for non-Clifford operations. Other supported front ends accept OpenQASM 2 text
-or integrate circuit objects from another quantum software framework.
+for non-Clifford operations. Other input paths accept OpenQASM 2 text or circuit
+objects from another quantum software framework.
 
 OpenQASM 2 support is built into the core `clifft` package. Framework companion
 packages are maintained separately and released on their own schedule; use
 their READMEs as the source of truth for current limitations.
 
-## Integration Options
+## Choose an input
 
-| Starting point | Package | What it provides |
+| Starting point | Package | Details |
 |---|---|---|
-| Stim-compatible text | [`clifft`](https://pypi.org/project/clifft/) | Direct parsing, compilation, sampling, state-vector access, detectors, observables, and QEC-oriented workflows. |
-| Unitary-only OpenQASM 2 text | [`clifft`](https://pypi.org/project/clifft/) | Native parsing and compilation of the [supported subset](openqasm2.md), including the ABSTRACTS gate vocabulary. |
-| Qiskit `QuantumCircuit` | [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) | A Qiskit `BackendV2` provider that runs supported circuits on Clifft and returns Qiskit-style results. |
-| Cirq `cirq.Circuit` | [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) | A converter to Clifft circuit text plus a Cirq-style sampler facade backed by Clifft. |
+| Stim-compatible text | [`clifft`](https://pypi.org/project/clifft/) | [Native input](stim-input.md) with the broadest Clifft feature support. |
+| Unitary OpenQASM 2 text | [`clifft`](https://pypi.org/project/clifft/) | Native parsing of the documented [OpenQASM 2 subset](openqasm2.md). |
+| Qiskit `QuantumCircuit` | [`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) | [Qiskit adapter](qiskit.md) for supported terminal-measurement circuits. |
+| Cirq `cirq.Circuit` | [`clifft-cirq`](https://github.com/unitaryfoundation/clifft-cirq) | [Cirq converter and sampler](cirq.md) for supported qubit circuits. |
 
-Use the native `clifft` API for supported circuit text, detector annotations,
-observables, post-selection, or importance sampling. Use an adapter when
-circuit construction, decomposition, or the surrounding workflow already lives
-in Qiskit or Cirq.
+Use native Stim-compatible text for detector annotations, observables,
+post-selection, or importance sampling. Use OpenQASM 2 for its supported unitary
+interchange subset, or an adapter when circuit construction, decomposition, and
+the surrounding workflow already live in Qiskit or Cirq.
+
+Choosing an input does not select a CPU execution strategy or experimental GPU
+backend. After the circuit reaches Clifft, use
+[Choose a Workflow](choosing-a-workflow.md) to select the result you need.
+
+## Stim-compatible text
+
+This is the native path and the right default for new Clifft-specific code. See
+[Stim-Compatible Text](stim-input.md).
+
+## OpenQASM 2
+
+Core Clifft accepts a unitary subset without requiring Qiskit. See
+[OpenQASM 2 Input](openqasm2.md).
 
 ## Qiskit
 
-Install the Qiskit adapter:
-
-```bash
-pip install clifft-qiskit
-```
-
-Then run a supported `QuantumCircuit` through the Clifft backend:
-
-```python
-from qiskit import QuantumCircuit
-from clifft_qiskit import ClifftProvider
-
-qc = QuantumCircuit(2, 2)
-qc.h(0)
-qc.cx(0, 1)
-qc.measure([0, 1], [0, 1])
-
-backend = ClifftProvider().get_backend("clifft")
-counts = backend.run(qc, shots=1000).result().get_counts()
-print(counts)
-```
-
-The adapter targets terminal-measurement sampling and counts. Unsupported
-semantics, such as mid-circuit measurement, feedforward, `reset`, and other
-non-unitary operations, are rejected explicitly.
-
-See the [`clifft-qiskit` repository](https://github.com/unitaryfoundation/clifft-qiskit)
-for the current supported basis, decomposition behavior, and package-specific
-limitations.
+Use the separately released adapter for supported `QuantumCircuit` objects. See
+[Qiskit](qiskit.md).
 
 ## Cirq
 
-Install the Cirq adapter:
-
-```bash
-pip install clifft-cirq
-```
-
-Convert a parameter-resolved qubit circuit to Clifft text or sample it through
-the Cirq-style facade:
-
-```python
-import cirq
-import clifft_cirq
-
-q0, q1 = cirq.LineQubit.range(2)
-circuit = cirq.Circuit(
-    cirq.H(q0),
-    cirq.CNOT(q0, q1),
-    cirq.measure(q0, q1, key="m"),
-)
-
-converted = clifft_cirq.to_clifft_text(circuit)
-print(converted.clifft_text)
-
-sampler = clifft_cirq.ClifftSampler(seed=123)
-result = sampler.run(circuit, repetitions=1000)
-print(result)
-```
-
-The converter supports parameter-resolved qubit circuits and common one-, two-,
-and three-qubit gates that map to Clifft. It does not model Cirq device,
-timing, calibration, qudit, arbitrary classical-control, or noise-channel
-semantics.
-
-See the [`clifft-cirq` repository](https://github.com/unitaryfoundation/clifft-cirq)
-for the current supported operations, conversion metadata, and package-specific
-limitations.
+Use the separately released converter or sampler for supported `cirq.Circuit`
+objects. See [Cirq](cirq.md).

--- a/docs/getting-started/openqasm2.md
+++ b/docs/getting-started/openqasm2.md
@@ -3,6 +3,9 @@
 Clifft can natively parse and compile a unitary subset of OpenQASM 2.0 without a
 Qiskit runtime dependency.
 
+See [Circuit Inputs and Integrations](integrations.md) to compare this path with
+native Stim-compatible text and the Qiskit or Cirq adapters.
+
 Select the format explicitly when compiling:
 
 ```python

--- a/docs/getting-started/qiskit.md
+++ b/docs/getting-started/qiskit.md
@@ -1,0 +1,43 @@
+<!--pytest-codeblocks:skipfile-->
+
+# Qiskit
+
+The separately released
+[`clifft-qiskit`](https://github.com/unitaryfoundation/clifft-qiskit) package
+provides a Qiskit `BackendV2` provider for supported `QuantumCircuit` objects.
+Use it when circuit construction, decomposition, or result handling already
+lives in Qiskit.
+
+Install the adapter:
+
+```bash
+pip install clifft-qiskit
+```
+
+Then run a supported circuit through the Clifft backend:
+
+```python
+from qiskit import QuantumCircuit
+from clifft_qiskit import ClifftProvider
+
+qc = QuantumCircuit(2, 2)
+qc.h(0)
+qc.cx(0, 1)
+qc.measure([0, 1], [0, 1])
+
+backend = ClifftProvider().get_backend("clifft")
+counts = backend.run(qc, shots=1000).result().get_counts()
+print(counts)
+```
+
+The adapter targets terminal-measurement sampling and counts. Unsupported
+semantics, including mid-circuit measurement, feedforward, `reset`, and other
+non-unitary operations, are rejected explicitly.
+
+The companion package is maintained and released independently. See the
+[`clifft-qiskit` repository](https://github.com/unitaryfoundation/clifft-qiskit)
+for its current supported basis, decomposition behavior, and limitations.
+
+Use the native [Stim-compatible input](stim-input.md) for detector annotations,
+observables, post-selection, importance sampling, or other Clifft-specific
+workflows.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,9 @@
 # Quick Start
 
-This guide walks through compiling and simulating your first quantum circuit with Clifft.
+This guide walks through compiling and simulating your first quantum circuit
+with Clifft. It uses the native Stim-compatible text input; see
+[Circuit Inputs and Integrations](integrations.md) if your circuit starts in
+OpenQASM 2, Qiskit, or Cirq.
 
 ## Your First Circuit
 
@@ -94,8 +97,8 @@ result = clifft.sample(program, shots=10000, seed=42)
 ## Next Steps
 
 - [Choose a Workflow](choosing-a-workflow.md) - select the API that matches the result you need
-- [Compiling Circuits](../guide/compilation.md) - the compilation pipeline in detail
+- [Circuit Inputs and Integrations](integrations.md) - bring a circuit from another format or framework
 - [Simulation](../guide/simulation.md) - sampling, detectors, and observables
 - [Leakage and Loss](../guide/leakage-and-loss.md): noncomputational trajectory sampling
-- [Front-End Integrations](integrations.md): using Clifft from Qiskit or Cirq
 - [Supported Gates](../reference/gates.md) - full gate reference
+- [Compiling Circuits](../guide/compilation.md) - inspect or customize the compilation pipeline

--- a/docs/getting-started/stim-input.md
+++ b/docs/getting-started/stim-input.md
@@ -1,0 +1,33 @@
+# Stim-Compatible Text
+
+Stim-compatible circuit text with Clifft extensions is the native and most
+capable input path. Use it for noise, detectors, observables, post-selection,
+importance sampling, and experimental leakage or loss models.
+
+Pass circuit text directly to `clifft.compile()`:
+
+```python
+import clifft
+
+program = clifft.compile("""
+    H 0
+    CX 0 1
+    T 1
+    M 0 1
+""")
+
+result = clifft.sample(program, shots=1000, seed=42)
+print(result.measurements[:5])
+```
+
+The default `input_format="stim"` is optional. Clifft accepts Stim syntax for
+Clifford gates, noise channels, measurements, repeat blocks, detectors, and
+observables, and adds supported non-Clifford rotations and annotations.
+
+Use `clifft.parse()` or `clifft.parse_file()` when a circuit needs to be
+inspected before compilation. Most applications should call `clifft.compile()`
+directly.
+
+See [Supported Gates](../reference/gates.md) for the complete accepted syntax,
+[Quick Start](quickstart.md) for the basic workflow, and
+[Choose a Workflow](choosing-a-workflow.md) for the available result types.

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,9 +79,10 @@ print(result.measurements[:5])  # First 5 shots.
 
     Multi-level optimization passes reduce active state-vector work before execution.
 
-- **Qiskit and Cirq Integrations**
+- **Multiple Circuit Inputs**
 
-    Run supported circuits from Qiskit or Cirq through companion packages without hand-writing Clifft circuit text.
+    Use native Stim-compatible text, unitary OpenQASM 2, or supported circuits
+    from Qiskit and Cirq companion packages.
 
 - **Active-Width Scaling**
 
@@ -101,9 +102,13 @@ For QEC workflows, Clifft also supports detector-based post-selection, survivor 
 
 [Install Clifft](getting-started/installation.md){ .md-button .md-button--primary }
 
-[Try the Playground]({{ playground_url }}){ .md-button }
+[Quick Start](getting-started/quickstart.md){ .md-button .md-button--primary }
 
-[Use Qiskit or Cirq](getting-started/integrations.md){ .md-button }
+[Choose a Workflow](getting-started/choosing-a-workflow.md){ .md-button }
+
+[Bring Your Circuit](getting-started/integrations.md){ .md-button }
+
+[Try the Playground]({{ playground_url }}){ .md-button }
 
 ## What's New in 0.9.0
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,9 +97,12 @@ nav:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
     - Choose a Workflow: getting-started/choosing-a-workflow.md
-    - Front-End Integrations:
+    - Circuit Inputs:
       - Overview: getting-started/integrations.md
+      - Stim-Compatible Text: getting-started/stim-input.md
       - OpenQASM 2: getting-started/openqasm2.md
+      - Qiskit: getting-started/qiskit.md
+      - Cirq: getting-started/cirq.md
   - User Guide:
     - Compiling Circuits: guide/compilation.md
     - Simulation: guide/simulation.md


### PR DESCRIPTION
## Summary

- rename and reorganize the beginner integration path around circuit inputs
- present Stim-compatible text, OpenQASM 2, Qiskit, and Cirq symmetrically in navigation
- add focused input pages while preserving the old integration-page anchors
- improve home, README, installation, and quick-start routing for new users

## Validation

- `.venv/bin/pytest --codeblocks docs/getting-started/stim-input.md docs/getting-started/quickstart.md -v`
- `.venv/bin/mkdocs build --strict`
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Stacked on #446.

Closes #441
Parent: #409