### PR TITLE
docs: separate advanced CPU execution

### DIFF
--- a/docs/getting-started/choosing-a-workflow.md
+++ b/docs/getting-started/choosing-a-workflow.md
@@ -79,8 +79,7 @@ users.
 Advanced callers can tune cross-shot workers, intra-shot OpenMP workers, hybrid
 layouts, and explicit packed capacities. These settings change how a supported
 workflow executes, not its statistical meaning. See
-[Packed Batch Sampling](../guide/simulation.md#packed-batch-sampling) and
-[Parallel Sampling](../guide/simulation.md#parallel-sampling).
+[CPU Execution and Tuning](../guide/cpu-execution.md).
 
 ### GPU (experimental)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,6 +62,9 @@ or use the `spawn` or `forkserver` start method. Forking after a threaded sample
 and then requesting intra-shot threads in the child can hang in some OpenMP
 runtimes.
 
+See [CPU Execution and Tuning](../guide/cpu-execution.md) for automatic
+scheduling, explicit layouts, batching, and memory tradeoffs.
+
 See [Building from Source](../development/building.md) for the full development setup.
 
 Next, follow the [Quick Start](quickstart.md) or choose a path from

--- a/docs/guide/cpu-execution.md
+++ b/docs/guide/cpu-execution.md
@@ -1,0 +1,220 @@
+# CPU Execution and Tuning
+
+CPU execution settings control how a supported sampling workflow uses lanes,
+threads, and memory. They do not change the circuit semantics or select a
+different scientific workflow.
+
+## Defaults First
+
+Start with the sampling function selected in
+[Choose a Workflow](../getting-started/choosing-a-workflow.md). For the four
+fixed-plan sampling functions, keep `batch_size="auto"`. Leave expert layout
+controls unset, and set `threads` only when the process should use a larger CPU
+worker budget:
+
+```python
+import clifft
+
+program = clifft.compile("H 0\nT 0\nM 0")
+result = clifft.sample(program, shots=10_000, seed=42, threads=4)
+```
+
+For a fixed-plan sampler, Clifft decides whether that budget is better spent on
+several shots or within one wide shot. The automatic batch policy separately
+decides whether packing several shots into SIMD lanes is worthwhile.
+
+Use explicit batch capacities or thread layouts only after benchmarking the
+same sampling function, circuit, shot count, and output options used in
+production.
+
+## Controls at a Glance
+
+| Argument | Default | Meaning |
+|---|---|---|
+| `threads` | `1` | Total CPU worker budget. A positive integer bounds workers; `"auto"` uses implementation-reported hardware concurrency. |
+| `thread_layout` | `None` | Expert `(shot_workers, intra_shot_workers)` override. It replaces the automatic layout and ignores `threads`. |
+| `intra_shot_min_active_width` | `None` | Expert active-width threshold for an explicit layout. It requires `thread_layout`; the layout default is 18. |
+| `batch_size` | `"auto"` | Packed lane policy. `1` forces scalar execution; a positive integer requests an explicit capacity. |
+
+Threading and packing are independent forms of parallelism:
+
+- **Cross-shot workers** run different shots concurrently. Each worker owns an
+  executor and its mutable storage.
+- **Intra-shot workers** use an OpenMP team on the active-state work within one
+  shot. The team shares one executor.
+- **Packed execution** represents multiple shots as SIMD lanes within one
+  packed worker. Several packed workers can run concurrently.
+
+Packed execution cannot be combined with intra-shot workers.
+
+## Compatibility by Workflow
+
+| Workflow | Packed `batch_size` | Cross-shot `threads` | Intra-shot layout | Notes |
+|---|---|---|---|---|
+| `sample()` | Automatic or explicit | Yes | Yes | Rejects a program with post-selection. |
+| `sample_survivors()` | Automatic or explicit | Yes | Yes | Automatic packing stays scalar when the program has post-selection; an explicit capacity is supported. |
+| `sample_k()` | Automatic or explicit | Yes | Yes | Fixed-fault workflow without post-selection. |
+| `sample_k_survivors()` | Automatic or explicit | Yes | Yes | Automatic packing stays scalar when the program has post-selection; an explicit capacity is supported. |
+| `noncomp.sample()` | No | Yes | No | Experimental trajectory continuations use cross-shot workers only. |
+| `basis_probabilities()` and `record_probabilities()` | No user control | No user control | No user control | Exact-query APIs do not expose sampling execution settings. |
+| `get_statevector()` | No | No | No | Dense debugging and validation query, not a shot sampler. |
+
+The fixed-plan rows use the same `Program` and execution controls. Their result
+contracts still differ; see [Sampling and Results](simulation.md) and the
+[Importance Sampling tutorial](importance-sampling.md).
+
+## Thread Budget and Automatic Scheduling
+
+`sample()`, `sample_survivors()`, `sample_k()`, `sample_k_survivors()`, and
+[`noncomp.sample()`](leakage-and-loss.md) accept `threads`. It defaults to `1`.
+Pass a positive count to set the total worker budget, or `threads="auto"` to use
+implementation-reported hardware concurrency.
+
+For the fixed-plan samplers, the automatic scheduler chooses one layout:
+
+- If the request has at least as many shots as the worker budget, Clifft uses
+  up to that many cross-shot workers.
+- With fewer shots and `program.peak_active_width >= 18`, an OpenMP-enabled
+  build can spend the budget on intra-shot workers instead.
+- Otherwise Clifft uses the available cross-shot workers, bounded by the shot
+  count.
+
+Automatic scheduling does not create a hybrid layout. Builds without OpenMP
+use cross-shot workers only. `noncomp.sample()` also uses cross-shot workers
+only because each trajectory can compile different continuations.
+
+In containers or processes with CPU-affinity limits, prefer an explicit count
+when reported hardware concurrency exceeds the available CPU quota.
+
+### Explicit and hybrid layouts
+
+Set `thread_layout=(shot_workers, intra_shot_workers)` only when a measured
+workload benefits from overriding the scheduler. The tuple replaces `threads`;
+keep its product within the CPUs available to the process. An intra-shot count
+above one requires an OpenMP-enabled build.
+
+The intra-shot team activates only when the current active width reaches
+`intra_shot_min_active_width`, which defaults to 18 for an explicit layout:
+
+<!--pytest.mark.skip-->
+
+```python
+result = clifft.sample(
+    program,
+    shots=8,
+    thread_layout=(2, 4),
+    intra_shot_min_active_width=17,
+)
+```
+
+This layout runs two shots at once and gives each shot up to four OpenMP workers
+after its active width reaches 17, for at most eight execution threads.
+
+Hybrid layouts require OpenMP processor binding to be disabled. Clifft rejects
+a hybrid layout when `OMP_PROC_BIND` is active. Pure cross-shot and pure
+intra-shot layouts can use OpenMP binding.
+
+## Packed Batch Sampling
+
+A packed batch stores several shots together so CPU SIMD instructions operate
+on their bit columns and active-state data. The four fixed-plan sampling
+functions accept `batch_size`.
+
+The default `"auto"` policy considers packed execution only when all of these
+conditions hold:
+
+- at least 64 shots were requested;
+- the program has no post-selection;
+- peak active width is at most 5; and
+- estimated packed work and memory remain within the automatic budgets.
+
+Long width-5 plans can still fall back to scalar execution. Automatic survivor
+sampling stays scalar for a post-selected plan because survivor lifetimes
+cannot be predicted reliably from the static plan.
+
+Set `batch_size=1` to require scalar execution. A positive integer requests an
+explicit capacity of up to 2048 lanes, bounded by the shot count and packed
+state safety limits:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+scalar = clifft.sample(program, 100_000, seed=42, batch_size=1)
+packed = clifft.sample(program, 100_000, seed=42, batch_size=1024)
+```
+
+An explicit capacity can be useful for post-selected survivor sampling, but it
+should be benchmarked against scalar execution. Rejected lanes stop producing
+outputs and random work immediately. Packed coefficient kernels can continue
+to process their physical positions until repacking is expected to save more
+work than it costs.
+
+### Interaction with thread layouts
+
+Packed workers can run across CPU threads, but a packed capacity above one is
+incompatible with intra-shot workers. An explicit batch request therefore
+fails if the resolved automatic or explicit thread layout uses more than one
+intra-shot worker.
+
+Use an explicit cross-shot layout such as `thread_layout=(4, 1)` when both the
+worker count and packed capacity must be fixed. Use `batch_size=1` for a pure
+intra-shot layout.
+
+Packed execution is unavailable for transition instruments, traps,
+continuations, and WebAssembly. `record_probabilities()` is an exact replay API
+and does not use packed sampling.
+
+## Reproducibility Across Strategies
+
+Workers dynamically claim contiguous shot ranges. With a fixed seed, changing
+`threads` alone produces exactly the same rows and survivor order as a
+one-thread run.
+
+Scalar and packed execution use separate random streams, and different packed
+capacities can also produce different rows. Every supported strategy remains
+statistically equivalent. Keep the workflow and complete execution
+configuration fixed when exact seeded replay is required.
+
+## Memory Tradeoffs
+
+Each cross-shot worker owns a separate executor. Dense coefficient and
+measurement scratch storage uses roughly $24 \times 2^k$ bytes at peak active
+width $k$, in addition to symbolic state, expressions, records, outputs, and
+executor metadata. Intra-shot workers cooperate on one executor and do not
+replicate this storage.
+
+Packed bit columns add $8 \times \lceil b / 64 \rceil$ bytes per column at lane
+capacity $b$, and each packed worker owns a copy. Automatic batching limits
+both per-worker and total packed-worker memory. Fixed-fault workers share an
+immutable conditioning table but retain independent selection scratch and RNG
+state. Noncomputational workers also own their compiled continuations.
+
+Use fewer cross-shot workers or a scalar capacity when memory is more
+constrained than CPU availability.
+
+## OpenMP and Process Runtimes
+
+Intra-shot execution requires an OpenMP-enabled build. Apple Clang users may
+need Homebrew `libomp`. On macOS, loading different OpenMP runtimes from Clifft
+and another scientific package in one process can conflict; process isolation
+is the robust choice.
+
+On POSIX systems, create process workers before using threaded Clifft sampling,
+or use the `spawn` or `forkserver` start method. Forking after a threaded sample
+and then requesting intra-shot threads in the child can hang in some OpenMP
+runtimes.
+
+See [Installation](../getting-started/installation.md#from-source) for build and
+runtime guidance.
+
+## Benchmark Before Overriding
+
+Performance depends on the circuit, active width over time, shot count,
+post-selection lifetime, requested outputs, CPU, and memory limits. Compare the
+defaults with a small set of representative alternatives, such as
+`batch_size=1`, `256`, and `1024`, using the production thread budget and result
+options.
+
+Use `program.peak_active_width` as a first-order cost indicator, but do not
+choose a layout from peak width alone. See [Performance](performance.md) for the
+broader active-width model and benchmark methodology.

--- a/docs/guide/importance-sampling.md
+++ b/docs/guide/importance-sampling.md
@@ -346,7 +346,8 @@ exceeds the number of non-zero-probability sites).
 
 `threads` is the total worker budget. The optional advanced
 `thread_layout=(shot_workers, intra_shot_workers)` override follows the ordinary
-sampling policy described in [Parallel Sampling](simulation.md#parallel-sampling).
+sampling policy described in
+[CPU Execution and Tuning](cpu-execution.md#thread-budget-and-automatic-scheduling).
 The expert `intra_shot_min_active_width` override defaults to 18 and requires an
 explicit layout. `batch_size` follows the ordinary sampling policy: `"auto"`
 selects packed execution for suitable plans without postselection, `1` forces

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -10,6 +10,9 @@ $2^k$ amplitudes, so both the peak width and the time spent at each width matter
 Total qubit count and non-Clifford gate count alone are poor performance
 predictors.
 
+See [CPU Execution and Tuning](cpu-execution.md) before overriding the default
+batch or thread policies.
+
 ## Choosing a simulator
 
 | Regime | Recommended tool | Why |

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -207,142 +207,15 @@ execution use separate random streams, and different packed capacities may do
 so as well. Results from every supported execution strategy remain
 statistically equivalent.
 
-## Advanced CPU Execution
+## CPU Execution Settings
 
-Most users can stop after choosing `sample()` or `sample_survivors()` and keep
-the execution defaults. The settings below tune how supported workflows run on
-the CPU; they do not change the workflow or result contract. A dedicated
-advanced execution guide will collect these controls as the backend
-documentation evolves.
+The fixed-plan samplers support automatic packed batching, cross-shot workers,
+and intra-shot OpenMP workers. Most users should keep `batch_size="auto"` and
+set only a total `threads` budget when more CPU parallelism is needed.
 
-### Packed Batch Sampling
-
-Batching and multithreading are independent forms of parallelism. A packed
-batch stores several shots together so one CPU SIMD instruction can operate on
-them and their state data stays cache-friendly. Multithreading runs work on
-several CPU threads, ideally on separate cores. Clifft can combine both by
-running multiple packed workers.
-
-The four fixed-plan sampling functions accept `batch_size`. Its default,
-`"auto"`, selects packed execution when the plan and request are expected to
-benefit:
-
-```python
-import clifft
-
-program = clifft.compile("M 0")
-result = clifft.sample(program, 100_000, seed=42, batch_size="auto")
-scalar = clifft.sample(program, 100_000, seed=42, batch_size=1)
-packed = clifft.sample(program, 100_000, seed=42, batch_size=1024)
-```
-
-Automatic mode requires at least 64 shots, no postselection, and a peak active
-width of at most 5. Within those limits, it chooses a lane capacity based on the
-plan's work and memory needs; long width-5 plans fall back to scalar execution.
-Postselected plans remain scalar in automatic mode because their benefit
-depends on circuit- and noise-specific survivor lifetimes that cannot be
-predicted reliably from the plan alone.
-
-Set `batch_size=1` to require scalar execution. An explicit positive integer
-requests up to 2048 lanes and overrides the automatic policy, subject to memory
-safety limits. Since the best capacity varies by circuit, sampling function,
-shot count, thread count, and CPU, benchmark a few sizes such as `1`, `256`, and
-`1024` with representative arguments before choosing an override.
-
-With explicit batching and postselection, rejected lanes are masked immediately
-and stop contributing outputs or per-lane random work. Until Clifft repacks the
-remaining live lanes, packed coefficient kernels may still process their
-physical lane positions. Repacking occurs when it is expected to save more work
-than it costs.
-
-Packed execution supports ordinary sampling, post-selected survivor sampling,
-counts-only survivor aggregation, expectation values, and fixed-k importance
-sampling. Current limitations are:
-
-- transition instruments, traps, and continuations stay on the noncomputational
-  trajectory path;
-- packed execution cannot be combined with intra-shot OpenMP workers;
-- WebAssembly uses scalar execution;
-- `record_probabilities()` is an exact replay API and does not use batching.
-
-These restrictions do not remove the corresponding scalar or trajectory
-functionality. `batch_size=1` selects the existing scalar fixed-plan executor.
-
-### Parallel Sampling
-
-`sample()`, `sample_survivors()`, `sample_k()`, `sample_k_survivors()`, and
-[`noncomp.sample()`](leakage-and-loss.md) accept a `threads` argument. It defaults
-to `1`, so existing calls remain serial. Pass a positive count to set the total
-worker budget, or `threads="auto"` to use the implementation-reported hardware
-concurrency. In containers or processes with CPU-affinity limits, set an
-explicit count if the reported hardware concurrency exceeds the available CPU
-quota.
-
-For the fixed-plan symbolic sampler, Clifft automatically chooses one of two
-ways to use that budget:
-
-- With enough shots, it runs several shots at once.
-- With fewer shots and a peak active width of at least 18, an OpenMP-enabled
-  build shares the work within each shot instead.
-
-Clifft does not combine these strategies automatically. Builds without OpenMP
-can only spread work across shots, and `noncomp.sample()` also uses only that
-strategy. The width cutoff is a measured default; advanced users can override
-the layout and cutoff for their hardware.
-
-Most users should use `threads`. The symbolic sampling functions also accept
-the advanced override
-`thread_layout=(shot_workers, intra_shot_workers)`. The override replaces the
-automatic choice, ignores `threads`, and may request a hybrid layout. Both
-counts must be positive, and an intra-shot count above one requires an
-OpenMP-enabled build. The active-width threshold still applies within each
-executor. Keep the layout's worker-count product within the CPUs available to
-the process.
-
-Expert callers can change the threshold for an explicit layout with
-`intra_shot_min_active_width`. It defaults to 18 and is resolved before hot
-execution, so changing it does not add policy or allocation work inside a
-kernel:
-
-<!--pytest.mark.skip-->
-
-```python
-result = clifft.sample(
-    program,
-    shots=8,
-    thread_layout=(2, 4),
-    intra_shot_min_active_width=17,
-)
-```
-
-In this example, Clifft runs two shots at once and gives each shot up to four
-OpenMP workers once its active width reaches 17. It therefore uses at most eight
-execution threads.
-
-Hybrid layouts combine shot workers with OpenMP teams, so they require OpenMP
-processor binding to be disabled. Clifft rejects a hybrid layout when
-`OMP_PROC_BIND` is active. Pure cross-shot and pure intra-shot layouts can use
-OpenMP binding.
-
-Workers dynamically claim contiguous shot ranges from a shared scheduler.
-With a fixed seed, changing `threads` produces exactly the same result.
-`sample()` and `sample_k()` keep each shot at the same row, and the survivor
-APIs return accepted shots in the same order as the corresponding one-thread
-run.
-
-Each cross-shot worker owns a separate executor. Its dense coefficient and
-measurement scratch storage uses roughly $24 \times 2^k$ bytes at peak active width $k$,
-plus lane-scaled packed symbolic state, expression registers, records, outputs,
-and other executor metadata. Each packed bit column uses
-$8 \times \lceil b / 64 \rceil$ bytes at lane capacity $b$, and every cross-shot
-worker owns its own copy. Automatic batch selection accounts for both the
-per-worker footprint and the number of packed workers. Fixed-k workers share one
-immutable conditioning table while retaining independent selection scratch and
-RNG state. Set an explicit layout when memory is more constrained than CPU
-availability. Intra-shot workers cooperate on one executor and do not replicate
-this storage.
-Noncomputational workers also own their trajectory continuations and compile
-new continuations independently as their shots encounter jumps.
+See [CPU Execution and Tuning](cpu-execution.md) for the compatibility matrix,
+automatic policies, expert overrides, reproducibility boundaries, and memory
+tradeoffs.
 
 ## Specialized Workflows
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,7 @@ Clifford-valued rotations earlier during compilation, vectorizes additional
 active-measurement kernels, and fixes complex-interference cases in
 `basis_probabilities()`.
 
-Read [Parallel Sampling](guide/simulation.md#parallel-sampling) for the
+Read [CPU Execution and Tuning](guide/cpu-execution.md) for the
 threading model, memory tradeoffs, and expert controls.
 
 ## What's New in 0.8.0

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -20,6 +20,10 @@
 
 ## Sampling
 
+The four fixed-plan functions share CPU batching and threading arguments. See
+[CPU Execution and Tuning](../guide/cpu-execution.md) for their interaction and
+compatibility limits.
+
 ::: clifft.sample
 
 ::: clifft.sample_survivors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
   - User Guide:
     - Compiling Circuits: guide/compilation.md
     - Sampling and Results: guide/simulation.md
+    - CPU Execution and Tuning: guide/cpu-execution.md
     - Leakage and Loss: guide/leakage-and-loss.md
     - Performance: guide/performance.md
     - Exact Probabilities: guide/strong-simulation.md


### PR DESCRIPTION
## Summary

- extract batching, threading, OpenMP, memory, and reproducibility guidance from the core sampling page
- add a defaults-first CPU execution guide and workflow compatibility matrix
- document automatic scheduling and the thread-layout-before-batch resolution order
- clarify packed and intra-shot incompatibility, post-selection policy, and benchmarking guidance
- route installation, performance, importance-sampling, home, and API reference links to the canonical guide

## Validation

- `.venv/bin/pytest --codeblocks docs/guide/cpu-execution.md docs/guide/simulation.md -v`
- `.venv/bin/mkdocs build --strict`
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Stacked on #448.

Closes #443
Parent: #409