### PR TITLE
docs: expose experimental GPU workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ benchmarks.
 For QEC workflows, Clifft also supports detector-based post-selection, survivor
 sampling, and stratified importance sampling for rare-event estimation.
 
+An [experimental AMD HIP backend](https://unitaryfoundation.github.io/clifft/stable/guide/gpu-execution/)
+is available through an explicit source build and separate API. It is not part
+of the stable CPU wheels or selected automatically.
+
 ## Installation
 
 <!--pytest.mark.skip-->

--- a/docs/development/hip-backend.md
+++ b/docs/development/hip-backend.md
@@ -1,10 +1,15 @@
 <!--pytest-codeblocks:skipfile-->
 
-# Experimental HIP Sampling Backend
+# HIP Backend Internals
 
 Clifft has an optional AMD HIP sampling backend for Linux x86-64 and
-MI300X-class `gfx942` devices. It is a development target, not a public API or
-an automatically selected runtime backend. The default build remains CPU-only.
+MI300X-class `gfx942` devices. It exposes a source-build-only experimental API,
+not a stable or automatically selected runtime backend. The default build
+remains CPU-only.
+
+This page documents the compiler and runtime boundary for contributors. See
+[Experimental GPU Execution](../guide/gpu-execution.md) for the user-facing
+support matrix, build workflow, and Python examples.
 
 The semantic boundary is `sampling::SamplingPlan`:
 

--- a/docs/development/hip-kernel-development.md
+++ b/docs/development/hip-kernel-development.md
@@ -6,6 +6,9 @@ This guide is the handoff point for extending the experimental AMD backend.
 The backend is intentionally private below `SamplingPlan`: changes to its
 packed actions, workspace, and kernels do not define a cross-backend ABI.
 
+For the experimental user contract and minimal Python workflow, start with
+[Experimental GPU Execution](../guide/gpu-execution.md).
+
 ## Build a Developer Installation
 
 The ordinary Python package always contains `clifft.experimental.hip`, but its
@@ -29,7 +32,7 @@ CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON \
 ```
 
 For C++ iteration, use the standalone build documented in
-[Experimental HIP Sampling Backend](hip-backend.md). Both paths compile device
+[HIP Backend Internals](hip-backend.md). Both paths compile device
 code offline; only kernel-launch tests require a visible GPU.
 
 ## Python Iteration Loop

--- a/docs/getting-started/choosing-a-workflow.md
+++ b/docs/getting-started/choosing-a-workflow.md
@@ -86,5 +86,5 @@ workflow executes, not its statistical meaning. See
 GPU execution is experimental and is never selected automatically. The current
 HIP backend uses the separate `clifft.experimental.hip` API, supports only its
 documented subset, and requires an explicit HIP-enabled source build. See the
-[Experimental HIP Sampling Backend](../development/hip-backend.md) before using
+[Experimental GPU Execution](../guide/gpu-execution.md) guide before using
 it.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,6 +23,10 @@ pip install clifft
 All other platforms and CPU families should build from source. See
 [Building from Source](../development/building.md).
 
+Published wheels use the stable CPU backend. The current AMD HIP backend is an
+explicit, source-build-only experiment; see
+[Experimental GPU Execution](../guide/gpu-execution.md).
+
 ## From Source
 
 For development, or if pre-built wheels are not available for your platform or CPU family:

--- a/docs/guide/cpu-execution.md
+++ b/docs/guide/cpu-execution.md
@@ -4,6 +4,9 @@ CPU execution settings control how a supported sampling workflow uses lanes,
 threads, and memory. They do not change the circuit semantics or select a
 different scientific workflow.
 
+GPU execution is separate and never selected by these controls. See
+[Experimental GPU Execution](gpu-execution.md) for the current HIP boundary.
+
 ## Defaults First
 
 Start with the sampling function selected in

--- a/docs/guide/gpu-execution.md
+++ b/docs/guide/gpu-execution.md
@@ -1,0 +1,214 @@
+<!--pytest-codeblocks:skipfile-->
+
+# Experimental GPU Execution
+
+!!! warning "Experimental and source-build only"
+    GPU execution is not part of Clifft's stable API or published wheels. The
+    current HIP backend has a narrow hardware and workload tier, requires an
+    explicit source build, and may change without compatibility guarantees.
+    It is never selected automatically.
+
+Clifft's stable Python API executes on the CPU. Experimental GPU backends use
+separate program and sampler types so backend-specific precision, workspace,
+and launch controls do not leak into the stable CPU contract.
+
+## Backend Status
+
+| Backend | Status | Selection | Distribution |
+|---|---|---|---|
+| CPU | Stable default | `clifft.compile()` and the ordinary sampling APIs | Published wheels and source builds |
+| AMD HIP | Experimental | Explicit `clifft.experimental.hip` API | HIP-enabled source build only |
+| NVIDIA CUDA | Planned, not implemented | No API or automatic selection | Not available |
+
+CUDA will receive its own explicit experimental boundary when an implementation
+exists. The HIP API and current capabilities should not be interpreted as a
+CUDA support promise.
+
+## Current Capability Matrix
+
+| Workflow or feature | Stable CPU | Experimental HIP |
+|---|---|---|
+| Ordinary fixed-row sampling | Supported | Supported for eligible programs |
+| Post-selected survivor sampling | Supported | Supported for eligible programs |
+| Measurements, detectors, observables, and `EXP_VAL` | Supported | Supported |
+| Pauli and readout noise | Supported | Supported |
+| Fixed-fault importance sampling | Supported | Not supported |
+| Leakage, loss, and transition instruments | Experimental CPU trajectory workflow | Not supported |
+| `basis_probabilities()`, `record_probabilities()`, and `get_statevector()` | Supported subject to each API contract | Not supported through these APIs |
+| Forced-record replay | Used by CPU exact-query internals | Experimental `Sampler.replay_shot()` |
+| Peak active width | Memory-limited CPU execution | `k <= 4` |
+| Coefficient precision | FP64 | FP64 default; FP32 experimental |
+| Asynchronous or multi-GPU execution | Not exposed by the stable sampling API | Not supported |
+
+The current HIP tier uses one GPU thread per shot and targets workloads with
+small active states. It supports the existing prepared sampling actions for
+rotations, measurements, expressions, supported noise, post-selection,
+observables, and expectation-value probes. Unsupported programs are rejected
+during lowering rather than silently falling back to the CPU.
+
+## Hardware and Build Requirements
+
+The current documented target is Linux `x86_64` with ROCm and an MI300X-class
+`gfx942` device. Hardware validation is still manual. Other AMD architectures
+can be development build targets, but they do not yet have the same conformance
+coverage.
+
+The ordinary `pip install clifft` package is CPU-only. Build an editable HIP
+installation from a checkout:
+
+```bash
+git clone https://github.com/unitaryfoundation/clifft.git
+cd clifft
+
+uv venv
+CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx942" \
+    uv pip install -e .
+```
+
+When the HIP compiler and ROCm root are installed under `/usr`, provide them
+explicitly:
+
+```bash
+CMAKE_ARGS="-DCLIFFT_ENABLE_HIP=ON \
+    -DCMAKE_HIP_ARCHITECTURES=gfx942 \
+    -DCMAKE_HIP_COMPILER=/usr/bin/clang++-17 \
+    -DCMAKE_HIP_COMPILER_ROCM_ROOT=/usr" \
+    uv pip install -e .
+```
+
+The build can compile device code without a visible GPU. Sampling requires a
+compatible device at runtime. Check all three states before constructing a
+sampler:
+
+```python
+from clifft.experimental import hip
+
+print(hip.is_built())
+print(hip.is_available())
+print(hip.backend_info())
+```
+
+- `is_built()` reports whether the optional native extension is installed.
+- `is_available()` reports whether the extension loaded and sees an AMD GPU.
+- `backend_info()` explains a missing build or load failure and lists visible
+  devices when the runtime is available.
+
+Clifft does not yet publish a supported ROCm and driver compatibility matrix.
+Treat successful local conformance tests as a requirement for experimental
+use.
+
+## Compile and Reuse a HIP Sampler
+
+The experimental facade compiles Stim-compatible text through the shared HIR
+and semantic sampling-plan pipeline, then lowers it into a private HIP program:
+
+```python
+from clifft.experimental import hip
+
+program = hip.compile("""
+    H 0
+    T 0
+    H 0
+    M 0
+    OBSERVABLE_INCLUDE(0) rec[-1]
+""")
+
+sampler = hip.Sampler(program)
+result = sampler.sample(100_000, seed=1234)
+print(result.measurements.shape)
+print(result.observables.shape)
+```
+
+`hip.Program` is not a CPU `clifft.Program`, and neither type is accepted by the
+other backend's sampling functions. `hip.compile()` currently accepts
+Stim-compatible text; it does not expose the stable CPU `input_format` switch.
+
+Construct one `hip.Sampler` per concurrently active caller and reuse it for
+repeated requests. Construction uploads the program and allocates a bounded
+workspace on the device that is current at that time. Calls on one sampler are
+synchronous and must not overlap.
+
+## Post-Selected Survivors
+
+Compile the detector mask into the HIP program and call the survivor method:
+
+```python
+from clifft.experimental import hip
+
+program = hip.compile(
+    "H 0\nM 0\nDETECTOR rec[-1]",
+    postselection_mask=[1],
+)
+sampler = hip.Sampler(program)
+result = sampler.sample_survivors(
+    100_000,
+    keep_records=True,
+    seed=42,
+)
+
+print(result.passed_shots, result.total_shots)
+print(result.measurements.shape)
+```
+
+`Sampler.sample()` rejects a post-selected program because fixed-row output
+cannot represent discarded shots. `Sampler.sample_survivors()` always returns
+aggregate survivor metadata and retains per-survivor rows only when
+`keep_records=True`.
+
+## Precision, Workspace, and Launch Controls
+
+FP64 coefficient evolution is the default. FP32 reduces coefficient storage
+and is a separate experimental numerical mode:
+
+```python
+sampler = hip.Sampler(
+    program,
+    precision="fp32",
+    max_batch_shots=16_384,
+)
+result = sampler.sample_survivors(100_000, seed=42, block_size=256)
+print(sampler.allocated_device_bytes)
+```
+
+Probability reductions, normalization factors, aggregate statistics, replay
+log-probabilities, and `EXP_VAL` outputs remain FP64 in both modes.
+
+- `max_batch_shots` bounds the retained device workspace. Larger requests are
+  divided into synchronous launches that reuse it.
+- `block_size` controls HIP launch geometry and must be between 1 and 1024.
+- `allocated_device_bytes` exposes retained workspace size for experiments.
+
+These controls are backend-specific. They are not equivalents of CPU
+`batch_size`, `threads`, or `thread_layout`.
+
+## Seeds and Cross-Backend Comparison
+
+A fixed seed repeats within the same HIP precision and configuration. Splitting
+one request across different retained workspace batch sizes preserves each
+seeded HIP row because kernels receive the global shot index.
+
+CPU and HIP use separate random-stream domains. The same user seed does not
+produce matching CPU and GPU rows, and FP32 and FP64 should be treated as
+separate numerical configurations. Compare deterministic branches directly and
+stochastic results statistically.
+
+## Unsupported Workloads
+
+The current HIP backend rejects:
+
+- peak active width above 4;
+- transition instruments, leakage, and loss;
+- `sample_k()` and other fixed-fault importance sampling;
+- the stable exact-probability and state-vector query APIs;
+- asynchronous calls and overlapping calls on one sampler; and
+- multi-GPU execution.
+
+There is no automatic CPU fallback. Keep a stable CPU path when a production
+workflow requires broader capability or compatibility guarantees.
+
+## Developer Documentation
+
+Users experimenting with the backend should start on this page. Backend
+contributors should continue with [HIP Backend Internals](../development/hip-backend.md)
+and [HIP Kernel Development](../development/hip-kernel-development.md) for the
+private executable format, conformance strategy, and kernel extension rules.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -13,6 +13,10 @@ predictors.
 See [CPU Execution and Tuning](cpu-execution.md) before overriding the default
 batch or thread policies.
 
+GPU execution has a separate experimental support tier and is not represented
+by the CPU results on this page. See
+[Experimental GPU Execution](gpu-execution.md).
+
 ## Choosing a simulator
 
 | Regime | Recommended tool | Why |

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,12 @@ print(result.measurements[:5])  # First 5 shots.
     measurement classification, and back-action on the computational state.
     See the [Leakage and Loss guide](guide/leakage-and-loss.md).
 
+- **GPU Execution (Experimental)**
+
+    Build the AMD HIP backend explicitly for its current small-active-width
+    sampling tier. It uses a separate experimental API and is never selected
+    automatically. See [Experimental GPU Execution](guide/gpu-execution.md).
+
 </div>
 
 For QEC workflows, Clifft also supports detector-based post-selection, survivor sampling, and stratified importance sampling for rare-event estimation.

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -32,6 +32,29 @@ compatibility limits.
 
 ::: clifft.sample_k_survivors
 
+## Experimental Hardware Backends
+
+!!! warning "Experimental"
+    These APIs require backend-specific source builds and may change without
+    compatibility guarantees. They are not selected by the regular CPU API.
+
+See [Experimental GPU Execution](../guide/gpu-execution.md) for the current
+hardware and workflow limits.
+
+::: clifft.experimental.hip.is_built
+
+::: clifft.experimental.hip.is_available
+
+::: clifft.experimental.hip.backend_info
+
+::: clifft.experimental.hip.compile
+
+::: clifft.experimental.hip.Program
+
+::: clifft.experimental.hip.Sampler
+
+::: clifft.experimental.hip.ReplayResult
+
 ## Leakage and Loss (experimental)
 
 Sampling under a five-level leakage/loss model. See the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Compiling Circuits: guide/compilation.md
     - Sampling and Results: guide/simulation.md
     - CPU Execution and Tuning: guide/cpu-execution.md
+    - Experimental GPU Execution: guide/gpu-execution.md
     - Leakage and Loss: guide/leakage-and-loss.md
     - Performance: guide/performance.md
     - Exact Probabilities: guide/strong-simulation.md
@@ -130,7 +131,7 @@ nav:
     - Contributing: development/contributing.md
     - Building from Source: development/building.md
     - Experimental:
-      - HIP Sampling Backend: development/hip-backend.md
+      - HIP Backend Internals: development/hip-backend.md
       - HIP Kernel Development: development/hip-kernel-development.md
     - Testing Strategy: development/testing.md
     - Tableau Conventions: development/tableau-conventions.md


### PR DESCRIPTION
## Summary

- add a user-facing experimental GPU guide with a prominent source-build-only disclaimer
- document the HIP build, availability checks, retained sampler workflow, survivors, precision, workspace, seeds, and unsupported workloads
- add a stable CPU versus experimental HIP capability matrix
- list CUDA as planned but unavailable, without implying an API or support contract
- separate user guidance from HIP backend and kernel-development internals
- expose the experimental HIP API in generated reference documentation

## Validation

- `.venv/bin/pytest tests/python/test_sampling_integration.py -v`
- `.venv/bin/mkdocs build --strict`
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`

Stacked on #449.

Closes #444
Parent: #409