### PR TITLE
docs: add workflow contract checks

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -71,6 +71,23 @@ uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failu
 - **Type checker:** mypy (strict mode)
 - **Python version:** 3.12+
 
+### Documentation
+
+- Use **circuit input**, **simulation workflow**, **CPU execution strategy**,
+  and **hardware backend** for the separate choices described in
+  [Choose a Workflow](../getting-started/choosing-a-workflow.md).
+- Update `docs/workflow_contracts.json` when a workflow, public entry point, or
+  experimental backend capability changes. It renders the canonical chooser
+  and GPU tables and is checked against the Python API and HIP implementation.
+- Keep user-guide examples self-contained and executable. Use a code-block skip
+  only when an optional backend, external package, or companion repository owns
+  the runnable integration, and retain focused test coverage at that boundary.
+- Edit public API descriptions in their Python docstrings; the API reference is
+  generated from those signatures and docstrings.
+
+Run `just py-doctest` for examples and `just docs-build` for the strict site
+build before submitting documentation changes.
+
 ## Running Tests
 
 === "Python"

--- a/docs/getting-started/choosing-a-workflow.md
+++ b/docs/getting-started/choosing-a-workflow.md
@@ -32,38 +32,24 @@ path does not select the simulation workflow or execution backend.
 
 ### Sample circuit outcomes
 
-- **I need an output row for every requested shot.** Use `clifft.compile()` and
-  `clifft.sample()` to obtain measurement, detector, observable, and expectation
-  value results. Start with the [Simulation guide](../guide/simulation.md).
-- **I need samples conditioned on post-selection.** Compile with a
-  `postselection_mask`, then use `clifft.sample_survivors()`. It returns survivor
-  counts and can optionally retain each survivor's records. See the
-  [post-selection workflow](../guide/simulation.md#post-selection-survivor-sampling).
-- **I need rare-event estimates conditioned on exactly `k` faults.** Use
-  `clifft.sample_k()` or `clifft.sample_k_survivors()`, then combine the
-  conditional results with the corresponding fault-count probabilities. This
-  is an advanced workflow covered by the
-  [Importance Sampling tutorial](../guide/importance-sampling.md).
+{% for workflow in workflow_contracts['workflows'] if workflow['group'] == 'sampling' %}
+- **{{ workflow['prompt'] }}** {{ workflow['route'] }} See
+  [{{ workflow['guide_label'] }}](../{{ workflow['guide'] }}).
+{% endfor %}
 
 ### Calculate exact probabilities
 
-- **My unitary circuit has no measurements.** Use
-  `clifft.basis_probabilities()` to query selected computational-basis outcomes
-  without constructing every output probability.
-- **My noiseless circuit includes measurements or classical feedback.** Use
-  `clifft.record_probabilities()` to query exact probabilities of selected
-  measurement records.
-
-Both APIs have circuit restrictions. The
-[Strong Simulation tutorial](../guide/strong-simulation.md) explains when to
-use each one.
+{% for workflow in workflow_contracts['workflows'] if workflow['group'] == 'exact' %}
+- **{{ workflow['prompt'] }}** {{ workflow['route'] }} See
+  [{{ workflow['guide_label'] }}](../{{ workflow['guide'] }}).
+{% endfor %}
 
 ### Model leakage or loss
 
-Use the experimental `clifft.noncomp.sample()` trajectory workflow for
-supported noncomputational transitions. It accepts a circuit and model together
-and compiles continuations internally. See
-[Leakage and Loss](../guide/leakage-and-loss.md) for the model and its limits.
+{% for workflow in workflow_contracts['workflows'] if workflow['group'] == 'specialized' %}
+- **{{ workflow['prompt'] }}** {{ workflow['route'] }} See
+  [{{ workflow['guide_label'] }}](../{{ workflow['guide'] }}).
+{% endfor %}
 
 ## 3. Choose performance options
 

--- a/docs/guide/gpu-execution.md
+++ b/docs/guide/gpu-execution.md
@@ -16,9 +16,9 @@ and launch controls do not leak into the stable CPU contract.
 
 | Backend | Status | Selection | Distribution |
 |---|---|---|---|
-| CPU | Stable default | `clifft.compile()` and the ordinary sampling APIs | Published wheels and source builds |
-| AMD HIP | Experimental | Explicit `clifft.experimental.hip` API | HIP-enabled source build only |
-| NVIDIA CUDA | Planned, not implemented | No API or automatic selection | Not available |
+{% for backend in workflow_contracts['backends'] -%}
+| {{ backend['name'] }} | {{ backend['status'] }} | {{ backend['selection'] }} | {{ backend['distribution'] }} |
+{% endfor %}
 
 CUDA will receive its own explicit experimental boundary when an implementation
 exists. The HIP API and current capabilities should not be interpreted as a
@@ -28,17 +28,9 @@ CUDA support promise.
 
 | Workflow or feature | Stable CPU | Experimental HIP |
 |---|---|---|
-| Ordinary fixed-row sampling | Supported | Supported for eligible programs |
-| Post-selected survivor sampling | Supported | Supported for eligible programs |
-| Measurements, detectors, observables, and `EXP_VAL` | Supported | Supported |
-| Pauli and readout noise | Supported | Supported |
-| Fixed-fault importance sampling | Supported | Not supported |
-| Leakage, loss, and transition instruments | Experimental CPU trajectory workflow | Not supported |
-| `basis_probabilities()`, `record_probabilities()`, and `get_statevector()` | Supported subject to each API contract | Not supported through these APIs |
-| Forced-record replay | Used by CPU exact-query internals | Experimental `Sampler.replay_shot()` |
-| Peak active width | Memory-limited CPU execution | `k <= 4` |
-| Coefficient precision | FP64 | FP64 default; FP32 experimental |
-| Asynchronous or multi-GPU execution | Not exposed by the stable sampling API | Not supported |
+{% for capability in workflow_contracts['backend_capabilities'] -%}
+| {{ capability['feature'] }} | {{ capability['cpu'] }} | {{ capability['hip'] }} |
+{% endfor %}
 
 The current HIP tier uses one GPU thread per shot and targets workloads with
 small active states. It supports the existing prepared sampling actions for
@@ -158,7 +150,7 @@ aggregate survivor metadata and retains per-survivor rows only when
 ## Precision, Workspace, and Launch Controls
 
 FP64 coefficient evolution is the default. FP32 reduces coefficient storage
-and is a separate experimental numerical mode:
+and is a separate experimental precision configuration:
 
 ```python
 sampler = hip.Sampler(
@@ -171,7 +163,8 @@ print(sampler.allocated_device_bytes)
 ```
 
 Probability reductions, normalization factors, aggregate statistics, replay
-log-probabilities, and `EXP_VAL` outputs remain FP64 in both modes.
+log-probabilities, and `EXP_VAL` outputs remain FP64 in both precision
+configurations.
 
 - `max_batch_shots` bounds the retained device workspace. Larger requests are
   divided into synchronous launches that reuse it.

--- a/docs/guide/importance-sampling.md
+++ b/docs/guide/importance-sampling.md
@@ -352,7 +352,7 @@ The expert `intra_shot_min_active_width` override defaults to 18 and requires an
 explicit layout. `batch_size` follows the ordinary sampling policy: `"auto"`
 selects packed execution for suitable plans without postselection, `1` forces
 scalar execution, and a positive integer requests an explicit packed lane
-capacity. Automatic mode remains scalar for postselected survivor sampling;
+capacity. Automatic batching remains scalar for postselected survivor sampling;
 benchmark explicit capacities on the target workload and machine when packed
 execution may be beneficial.
 

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -82,33 +82,35 @@ By default, detector and observable values are raw measurement parities. This ma
 
 Use `normalize_syndromes=True` at compile time to XOR detector and observable outputs against a noiseless reference:
 
-<!--pytest.mark.skip-->
-
 ```python
 import clifft
 
 program = clifft.compile(
-    circuit_text,
+    "X 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]",
     normalize_syndromes=True,
 )
 
-result = clifft.sample(program, shots=10000, seed=42)
+result = clifft.sample(program, shots=10, seed=42)
+assert not result.detectors.any()
+assert not result.observables.any()
 ```
 
 This is often useful before passing detector data to decoders. It also composes with post-selection: detectors that fire in the noiseless reference will not cause spurious discards after normalization.
 
 You can also supply explicit reference parities if you've computed them yourself:
 
-<!--pytest.mark.skip-->
-
 ```python
 import clifft
 
 program = clifft.compile(
-    circuit_text,
-    expected_detectors=[1, 0, 0, 1],
+    "X 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]",
+    expected_detectors=[1],
     expected_observables=[1],
 )
+
+result = clifft.sample(program, shots=10, seed=42)
+assert not result.detectors.any()
+assert not result.observables.any()
 ```
 
 !!! note
@@ -127,16 +129,15 @@ For circuits with post-selection, compile with a `postselection_mask` and sample
     It is not bit-packed. If you are converting a bit-packed Sinter mask, unpack
     it first with `numpy.unpackbits(..., count=num_det, bitorder="little")`.
 
-<!--pytest.mark.skip-->
-
 ```python
 import clifft
 
-# Mark detectors 0 and 2 for post-selection
-program = clifft.compile(circuit_text, postselection_mask=[1, 0, 1])
+program = clifft.compile(
+    "H 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]",
+    postselection_mask=[1],
+)
 
-# Only returns stats for shots that pass post-selection
-result = clifft.sample_survivors(program, shots=1_000_000, seed=42)
+result = clifft.sample_survivors(program, shots=10_000, seed=42)
 print(f"Survival rate: {result.passed_shots / result.total_shots:.4f}")
 print(f"Logical errors: {result.logical_errors}")
 ```
@@ -220,15 +221,16 @@ tradeoffs.
 ## Specialized Workflows
 
 These workflows answer different scientific questions. They are not CPU
-execution modes, and their compatibility rules determine which API to call.
+execution strategies, and their compatibility rules determine which API to
+call.
 
 ### State Vector Extraction
 
 `clifft.get_statevector()` expands the final pure unitary state over all
 physical qubits. It is a debugging and validation path, is currently limited to
-10 qubits, and returns the state only up to global phase. See the
-[Quick Start](../getting-started/quickstart.md#state-vector-access) for a minimal
-example.
+10 qubits, and returns the state only up to global phase. See
+[`clifft.get_statevector()`](../reference/python-api.md#clifft.get_statevector)
+for the API contract.
 
 ### Exact Probabilities
 

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -1,4 +1,4 @@
-"""MkDocs macros hook: loads compiler IR and pass metadata."""
+"""MkDocs macros hook: loads validated documentation metadata."""
 
 import json
 from pathlib import Path
@@ -12,6 +12,12 @@ def define_env(env: Any) -> None:
 
     with open(data_path) as f:
         data = json.load(f)
+
+    workflow_contracts_path = docs_dir / "workflow_contracts.json"
+    with open(workflow_contracts_path) as f:
+        workflow_contracts = json.load(f)
+
+    env.variables["workflow_contracts"] = workflow_contracts
 
     site_url = env.conf["site_url"].rstrip("/")
     env.variables["playground_url"] = f"{site_url}/playground/"

--- a/docs/workflow_contracts.json
+++ b/docs/workflow_contracts.json
@@ -1,0 +1,153 @@
+{
+  "workflows": [
+    {
+      "id": "ordinary_sampling",
+      "group": "sampling",
+      "prompt": "I need an output row for every requested shot.",
+      "route": "Use `clifft.compile()` and `clifft.sample()` to obtain measurement, detector, observable, and expectation-value results.",
+      "guide_label": "Sampling and Results",
+      "public_apis": ["clifft.compile", "clifft.sample"],
+      "guide": "guide/simulation.md"
+    },
+    {
+      "id": "survivor_sampling",
+      "group": "sampling",
+      "prompt": "I need samples conditioned on post-selection.",
+      "route": "Compile with a `postselection_mask`, then use `clifft.sample_survivors()`. It returns survivor counts and can optionally retain each survivor's records.",
+      "guide_label": "Post-Selection in Sampling and Results",
+      "public_apis": ["clifft.compile", "clifft.sample_survivors"],
+      "guide": "guide/simulation.md"
+    },
+    {
+      "id": "basis_probabilities",
+      "group": "exact",
+      "prompt": "My unitary circuit has no measurements.",
+      "route": "Use `clifft.basis_probabilities()` to query selected computational-basis outcomes without constructing every output probability.",
+      "guide_label": "Strong Simulation",
+      "public_apis": ["clifft.basis_probabilities"],
+      "guide": "guide/strong-simulation.md"
+    },
+    {
+      "id": "record_probabilities",
+      "group": "exact",
+      "prompt": "My noiseless circuit includes measurements or classical feedback.",
+      "route": "Use `clifft.record_probabilities()` to query exact probabilities of selected measurement records.",
+      "guide_label": "Strong Simulation",
+      "public_apis": ["clifft.record_probabilities"],
+      "guide": "guide/strong-simulation.md"
+    },
+    {
+      "id": "fixed_fault_sampling",
+      "group": "sampling",
+      "prompt": "I need rare-event estimates conditioned on exactly `k` faults.",
+      "route": "Use `clifft.sample_k()` or `clifft.sample_k_survivors()`, then combine the conditional results with the corresponding fault-count probabilities. This is an advanced statistical workflow.",
+      "guide_label": "Importance Sampling",
+      "public_apis": ["clifft.sample_k", "clifft.sample_k_survivors"],
+      "guide": "guide/importance-sampling.md"
+    },
+    {
+      "id": "noncomputational_trajectories",
+      "group": "specialized",
+      "prompt": "I need to model leakage, loss, or another supported noncomputational transition.",
+      "route": "Use the experimental `clifft.noncomp.sample()` trajectory workflow. It accepts a circuit and model together and compiles continuations internally.",
+      "guide_label": "Leakage and Loss",
+      "public_apis": ["clifft.noncomp.sample"],
+      "guide": "guide/leakage-and-loss.md"
+    }
+  ],
+  "inspection_tools": [
+    {
+      "id": "statevector",
+      "purpose": "Debug or validate the complete final pure state of a small unitary circuit.",
+      "contract": "Expands all physical qubits and is currently limited to 10 qubits.",
+      "public_apis": ["clifft.get_statevector"],
+      "guide": "guide/strong-simulation.md"
+    }
+  ],
+  "backends": [
+    {
+      "id": "cpu",
+      "name": "CPU",
+      "status": "Stable default",
+      "selection": "`clifft.compile()` and the ordinary sampling APIs",
+      "distribution": "Published wheels and source builds",
+      "public_apis": ["clifft.compile", "clifft.sample"]
+    },
+    {
+      "id": "hip",
+      "name": "AMD HIP",
+      "status": "Experimental",
+      "selection": "Explicit `clifft.experimental.hip` API",
+      "distribution": "HIP-enabled source build only",
+      "public_apis": ["clifft.experimental.hip.compile", "clifft.experimental.hip.Sampler"],
+      "limits": {
+        "peak_active_width": 4
+      }
+    },
+    {
+      "id": "cuda",
+      "name": "NVIDIA CUDA",
+      "status": "Planned, not implemented",
+      "selection": "No API or automatic selection",
+      "distribution": "Not available",
+      "public_apis": []
+    }
+  ],
+  "backend_capabilities": [
+    {
+      "feature": "Ordinary fixed-row sampling",
+      "cpu": "Supported",
+      "hip": "Supported for eligible programs"
+    },
+    {
+      "feature": "Post-selected survivor sampling",
+      "cpu": "Supported",
+      "hip": "Supported for eligible programs"
+    },
+    {
+      "feature": "Measurements, detectors, observables, and `EXP_VAL`",
+      "cpu": "Supported",
+      "hip": "Supported"
+    },
+    {
+      "feature": "Pauli and readout noise",
+      "cpu": "Supported",
+      "hip": "Supported"
+    },
+    {
+      "feature": "Fixed-fault importance sampling",
+      "cpu": "Supported",
+      "hip": "Not supported"
+    },
+    {
+      "feature": "Leakage, loss, and transition instruments",
+      "cpu": "Experimental CPU trajectory workflow",
+      "hip": "Not supported"
+    },
+    {
+      "feature": "`basis_probabilities()`, `record_probabilities()`, and `get_statevector()`",
+      "cpu": "Supported subject to each API contract",
+      "hip": "Not supported through these APIs"
+    },
+    {
+      "feature": "Forced-record replay",
+      "cpu": "Used by CPU exact-query internals",
+      "hip": "Experimental `Sampler.replay_shot()`"
+    },
+    {
+      "feature": "Peak active width",
+      "cpu": "Memory-limited CPU execution",
+      "hip": "`k <= 4`"
+    },
+    {
+      "feature": "Coefficient precision",
+      "cpu": "FP64",
+      "hip": "FP64 default; FP32 experimental"
+    },
+    {
+      "feature": "Asynchronous or multi-GPU execution",
+      "cpu": "Not exposed by the stable sampling API",
+      "hip": "Not supported"
+    }
+  ]
+}

--- a/tests/python/test_workflow_docs.py
+++ b/tests/python/test_workflow_docs.py
@@ -1,0 +1,145 @@
+"""Validate the workflow and backend contracts used to render user docs."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+DOCS = ROOT / "docs"
+CONTRACTS_PATH = DOCS / "workflow_contracts.json"
+HIP_EXECUTABLE_PLAN_HEADER = ROOT / "src" / "clifft" / "sampling" / "hip" / "executable_plan.h"
+
+EXPECTED_WORKFLOWS = {
+    "ordinary_sampling",
+    "survivor_sampling",
+    "basis_probabilities",
+    "record_probabilities",
+    "fixed_fault_sampling",
+    "noncomputational_trajectories",
+}
+EXPECTED_WORKFLOW_GROUPS = {"sampling": 3, "exact": 2, "specialized": 1}
+EXPECTED_INSPECTION_TOOLS = {"statevector"}
+EXPECTED_BACKEND_STATUS = {
+    "cpu": "Stable default",
+    "hip": "Experimental",
+    "cuda": "Planned, not implemented",
+}
+
+
+@pytest.fixture(scope="module")
+def workflow_contracts() -> dict[str, Any]:
+    """Load the metadata rendered into the workflow and GPU guides."""
+    with open(CONTRACTS_PATH) as f:
+        return json.load(f)  # type: ignore[no-any-return]
+
+
+def _resolve_public_api(dotted_name: str) -> object:
+    """Resolve a public API path without assuming every submodule is eager."""
+    parts = dotted_name.split(".")
+    value: object = importlib.import_module(parts[0])
+    for part in parts[1:]:
+        value = getattr(value, part)
+    return value
+
+
+def test_contract_entries_are_complete(
+    workflow_contracts: dict[str, Any],
+) -> None:
+    """Every documented route has user-facing content, APIs, and a valid guide."""
+    workflows = workflow_contracts["workflows"]
+    assert len(workflows) == len(EXPECTED_WORKFLOWS)
+    assert {entry["id"] for entry in workflows} == EXPECTED_WORKFLOWS
+    assert {
+        group: sum(entry["group"] == group for entry in workflows)
+        for group in EXPECTED_WORKFLOW_GROUPS
+    } == EXPECTED_WORKFLOW_GROUPS
+
+    for entry in workflows:
+        for field in ("id", "group", "prompt", "route", "guide_label", "guide"):
+            assert entry[field], f"{entry['id']} has an empty {field}"
+            assert "\n" not in entry[field], f"{entry['id']} {field} must fit one route"
+        assert entry["public_apis"], f"{entry['id']} has no public API contract"
+        assert (DOCS / entry["guide"]).is_file(), f"{entry['id']} guide does not exist"
+
+    inspection_tools = workflow_contracts["inspection_tools"]
+    assert {entry["id"] for entry in inspection_tools} == EXPECTED_INSPECTION_TOOLS
+    for entry in inspection_tools:
+        for field in ("id", "purpose", "contract", "guide"):
+            assert entry[field], f"{entry['id']} has an empty {field}"
+        assert entry["public_apis"], f"{entry['id']} has no public API contract"
+        assert (DOCS / entry["guide"]).is_file(), f"{entry['id']} guide does not exist"
+
+    backends = workflow_contracts["backends"]
+    assert len(backends) == len(EXPECTED_BACKEND_STATUS)
+    assert {entry["id"]: entry["status"] for entry in backends} == EXPECTED_BACKEND_STATUS
+    for entry in backends:
+        for field in ("id", "name", "status", "selection", "distribution"):
+            assert entry[field], f"{entry['id']} has an empty {field}"
+            assert (
+                "|" not in entry[field]
+            ), f"{entry['id']} {field} contains an unescaped table pipe"
+        assert bool(entry["public_apis"]) == (entry["id"] != "cuda")
+
+    capabilities = workflow_contracts["backend_capabilities"]
+    assert len({entry["feature"] for entry in capabilities}) == len(capabilities)
+    for entry in capabilities:
+        for field in ("feature", "cpu", "hip"):
+            assert entry[field], f"capability has an empty {field}"
+            assert "\n" not in entry[field], f"capability {field} must fit one table row"
+            assert "|" not in entry[field], f"capability {field} contains an unescaped table pipe"
+
+
+def test_every_documented_public_api_resolves(workflow_contracts: dict[str, Any]) -> None:
+    """Catch stale names in workflow and backend routing before release."""
+    documented_apis = {
+        api
+        for section in ("workflows", "inspection_tools", "backends")
+        for entry in workflow_contracts[section]
+        for api in entry["public_apis"]
+    }
+
+    for dotted_name in sorted(documented_apis):
+        assert callable(_resolve_public_api(dotted_name)), f"{dotted_name} is not callable"
+
+
+def test_hip_width_contract_matches_implementation(workflow_contracts: dict[str, Any]) -> None:
+    """Keep the experimental HIP limit aligned with its lowering guard."""
+    header = HIP_EXECUTABLE_PLAN_HEADER.read_text()
+    match = re.search(r"kThreadPerShotMaxActiveWidth\s*=\s*(\d+)", header)
+    assert match, "Could not find the HIP active-width limit"
+    implementation_limit = int(match.group(1))
+
+    backends = {entry["id"]: entry for entry in workflow_contracts["backends"]}
+    documented_limit = backends["hip"]["limits"]["peak_active_width"]
+    assert documented_limit == implementation_limit
+
+    capability = next(
+        entry
+        for entry in workflow_contracts["backend_capabilities"]
+        if entry["feature"] == "Peak active width"
+    )
+    assert capability["hip"] == f"`k <= {implementation_limit}`"
+
+
+def test_contract_metadata_renders_the_canonical_routes_and_tables() -> None:
+    """Prevent the validated data from becoming an unused sidecar."""
+    chooser = (DOCS / "getting-started" / "choosing-a-workflow.md").read_text()
+    gpu_guide = (DOCS / "guide" / "gpu-execution.md").read_text()
+
+    assert chooser.count("{% for workflow in workflow_contracts['workflows']") == len(
+        EXPECTED_WORKFLOW_GROUPS
+    )
+    for field in ("prompt", "route", "guide_label", "guide"):
+        assert f"workflow['{field}']" in chooser
+    assert "get_statevector" not in chooser
+    assert "|---|---|---|---|\n{% for backend in workflow_contracts['backends'] -%}" in gpu_guide
+    assert (
+        "|---|---|---|\n"
+        "{% for capability in workflow_contracts['backend_capabilities'] -%}" in gpu_guide
+    )


### PR DESCRIPTION
## Summary
- render the workflow chooser and GPU status/capability tables from validated documentation metadata
- verify every documented public API name and keep the experimental HIP active-width limit aligned with the implementation
- make core syndrome and survivor examples executable and record the terminology/testing contract for contributors

## Stack
- based on #450
- final child in the #409 documentation stack

## Validation
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `pytest --codeblocks docs README.md -q` (38 passed, 4 skipped)
- `pytest tests/python/test_workflow_docs.py tests/python/test_sampling_integration.py -q` (16 passed, 1 skipped)
- `mkdocs build --strict`

Closes #445