### PR TITLE
ci: preview docs for stacked pull requests

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -2,7 +2,6 @@ name: Docs PR Preview
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, reopened, synchronize, closed]
     paths:
       - 'docs/**'


### PR DESCRIPTION
## Summary
- run the docs preview workflow for qualifying pull requests targeting any branch
- retain the existing path filters, per-PR preview directories, serialized deployment, and fork deployment guard
- allow later pull requests in a stack to receive their own docs previews

## Validation
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- Actions workflow lint and YAML validation pass locally