### PR TITLE
ci: queue docs preview deployments

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+paths:
+  .github/workflows/pr_preview.yml:
+    ignore:
+      # GitHub supports concurrency.queue, but actionlint v1.7.12 does not yet.
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -80,6 +80,7 @@ jobs:
     concurrency:
       group: docs-deploy
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- keep writes to the shared `gh-pages` branch serialized
- set `queue: max` so bursty stacked-PR updates retain up to 100 pending deployments instead of replacing them
- preserve the existing per-PR `cancel-in-progress: true`, so a new commit still cancels that PRs stale workflow
- narrowly suppress the known `actionlint` v1.7.12 false positive for `concurrency.queue` until upstream support lands (rhysd/actionlint#654)

## Validation
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- YAML validation and all remaining Actions workflow lint checks pass