### PR TITLE
ci: support release candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,18 @@
 name: Release
 
-# Trigger on version tags (e.g., v0.1.0, v1.2.3)
+# Trigger on final and release-candidate version tags.
 on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
   workflow_dispatch:
     # Manual dispatch always publishes to TestPyPI only.
     # PyPI publishing requires a version tag push.
     inputs:
       test_version:
-        description: "Version for TestPyPI (e.g. 0.8.0.dev1). Required because PyPI rejects local version specifiers from untagged builds."
+        description: "Unique TestPyPI-only version (e.g. 0.10.0rc1.dev1). Do not reuse a version intended for a tag."
         required: true
-        default: "0.8.0.dev1"
 
 permissions:
   contents: read
@@ -262,13 +262,23 @@ jobs:
 
       - name: Extract release notes from CHANGELOG.md
         run: |
-          # Extract the section for this version from the committed changelog.
-          # Matches from "## [X.Y.Z]" to the next "## [" or end of file.
+          extract_notes() {
+            local version="$1"
+            awk -v ver="$version" '
+              /^## \[/ { if (found) exit; if ($0 ~ "^## \\[" ver "\\]") found=1; next }
+              found { print }
+            ' CHANGELOG.md
+          }
+
           VERSION="${GITHUB_REF_NAME#v}"
-          awk -v ver="$VERSION" '
-            /^## \[/ { if (found) exit; if ($0 ~ "^## \\[" ver "\\]") found=1; next }
-            found { print }
-          ' CHANGELOG.md > RELEASE_NOTES.md
+          extract_notes "$VERSION" > RELEASE_NOTES.md
+
+          # Release candidates normally share the final release's prepared
+          # changelog section instead of duplicating it under an rc heading.
+          if [[ ! -s RELEASE_NOTES.md && "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc[0-9]+$ ]]; then
+            BASE_VERSION="${BASH_REMATCH[1]}"
+            extract_notes "$BASE_VERSION" > RELEASE_NOTES.md
+          fi
 
           if [ ! -s RELEASE_NOTES.md ]; then
             echo "No entry found for $VERSION in CHANGELOG.md, using tag message." >&2
@@ -279,16 +289,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          release_args=()
+          if [[ "${GITHUB_REF_NAME}" =~ rc[0-9]+$ ]]; then
+            release_args+=(--prerelease)
+          fi
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --notes-file RELEASE_NOTES.md
+            --notes-file RELEASE_NOTES.md \
+            "${release_args[@]}"
 
   # -----------------------------------------------------------
   # Publish versioned documentation and playground
   # -----------------------------------------------------------
   publish-docs:
     needs: [github-release]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Release candidates publish packages and a GitHub prerelease, but no docs.
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      !contains(github.ref_name, 'rc')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   # -----------------------------------------------------------
   # Publish to PyPI (only on tag push, after TestPyPI)
@@ -255,46 +256,61 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    outputs:
+      prerelease: ${{ steps.release_metadata.outputs.prerelease }}
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract release notes from CHANGELOG.md
+      - name: Classify release
+        id: release_metadata
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc[0-9]+$ ]]; then
+            echo "notes_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "notes_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          NOTES_VERSION: ${{ steps.release_metadata.outputs.notes_version }}
+        run: |
+          # Print the body beneath "## [VERSION]" up to the next release
+          # heading. The release heading itself is not part of GitHub's notes.
           extract_notes() {
             local version="$1"
-            awk -v ver="$version" '
-              /^## \[/ { if (found) exit; if ($0 ~ "^## \\[" ver "\\]") found=1; next }
+            awk -v heading="## [${version}]" '
+              /^## \[/ {
+                if (found) exit
+                if (index($0, heading) == 1) found=1
+                next
+              }
               found { print }
             ' CHANGELOG.md
           }
 
-          VERSION="${GITHUB_REF_NAME#v}"
-          extract_notes "$VERSION" > RELEASE_NOTES.md
+          extract_notes "$NOTES_VERSION" > RELEASE_NOTES.md
 
-          # Release candidates normally share the final release's prepared
-          # changelog section instead of duplicating it under an rc heading.
-          if [[ ! -s RELEASE_NOTES.md && "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc[0-9]+$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            extract_notes "$BASE_VERSION" > RELEASE_NOTES.md
-          fi
-
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "No entry found for $VERSION in CHANGELOG.md, using tag message." >&2
-            echo "Release $VERSION" > RELEASE_NOTES.md
+          if ! grep -q '[^[:space:]]' RELEASE_NOTES.md; then
+            echo "CHANGELOG.md has no substantive [$NOTES_VERSION] release notes." >&2
+            exit 1
           fi
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ steps.release_metadata.outputs.prerelease }}
         run: |
           release_args=()
-          if [[ "${GITHUB_REF_NAME}" =~ rc[0-9]+$ ]]; then
+          if [[ "$PRERELEASE" == "true" ]]; then
             release_args+=(--prerelease)
           fi
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
             --notes-file RELEASE_NOTES.md \
             "${release_args[@]}"
 
@@ -307,7 +323,7 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v') &&
-      !contains(github.ref_name, 'rc')
+      needs.github-release.outputs.prerelease != 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     concurrency:

--- a/cliff.toml
+++ b/cliff.toml
@@ -57,7 +57,7 @@ commit_parsers = [
 ]
 
 filter_commits = false
-tag_pattern = "v[0-9].*"
+tag_pattern = '^v[0-9]+\.[0-9]+\.[0-9]+$'
 sort_commits = "newest"
 
 [remote.github]

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -17,12 +17,50 @@ building and benchmarking representative Linux wheels; do not replace it with a 
 The version is determined automatically from git tags:
 
 - **Tagged commits** (e.g., `v1.2.3`): version is `1.2.3`
+- **Release-candidate tags** (e.g., `v1.3.0rc1`): version is `1.3.0rc1`
 - **Development builds** (e.g., `1.2.4.dev3+g1a2b3c4`): the latest tag,
   commit distance, and hash determine the version
 
 There is no hardcoded version in `pyproject.toml`. The git tag is the single source of truth.
 
+## Release candidates
+
+Use a release candidate when the package must be installed from PyPI for validation before the
+final release. Complete the changelog and docs-home preparation described below before tagging the
+first candidate. Prepare the final release section, such as `## [0.3.0]`, rather than a separate rc
+section; the GitHub prerelease uses that section for its notes. The final release date may remain
+unset until the final tag.
+
+Optionally run the manual TestPyPI workflow first with a unique development version such as
+`0.3.0rc1.dev1`. Do not use `0.3.0rc1` for that smoke run: the tag-triggered workflow publishes the
+same artifacts to TestPyPI before PyPI, and TestPyPI rejects a duplicate version.
+
+Tag the prepared commit using the canonical Python release-candidate form:
+
+```bash
+git tag v0.3.0rc1
+git push origin v0.3.0rc1
+```
+
+The tag builds and tests the release artifacts, publishes them to TestPyPI and PyPI, and creates a
+GitHub prerelease. It does not publish versioned docs, update `stable`, or refresh the root
+Playground. Install the published wheel explicitly for validation:
+
+```bash
+python -m pip install --only-binary=:all: "clifft==0.3.0rc1"
+python -c "import clifft; print(clifft.__version__)"
+```
+
+After validation, update the existing final changelog section and make documentation-only changes
+without regenerating the changelog from `--unreleased`: the rc tag is now the latest version tag and
+would hide earlier release commits from that view. If runtime, packaging, compiler, or build inputs
+change, increment the candidate tag (for example, `v0.3.0rc2`) and repeat validation. Otherwise,
+create the final tag using the normal process below.
+
 ## Release process
+
+Follow every step for a release made without a candidate. When finalizing a validated candidate,
+update the already-prepared changelog and docs instead of generating them again.
 
 ### 1. Test on TestPyPI (optional but recommended)
 
@@ -31,11 +69,13 @@ Manual dispatch always publishes to TestPyPI only — it cannot publish to PyPI.
 
 1. Go to **Actions** > **Release** > **Run workflow**
 2. Select the branch (usually `main`)
-3. Wait for builds to complete, then verify:
+3. Enter a unique `test_version` used only for this TestPyPI upload
+4. Wait for builds to complete, then verify the exact version:
 
     ```bash
+    TEST_VERSION=0.3.0.dev1
     pip install --index-url https://test.pypi.org/simple/ \
-        --extra-index-url https://pypi.org/simple/ clifft
+        --extra-index-url https://pypi.org/simple/ "clifft==$TEST_VERSION"
     python -c "import clifft; print(clifft.__version__)"
     ```
 
@@ -50,6 +90,8 @@ git cliff --unreleased --tag vX.Y.Z --prepend CHANGELOG.md
 This prepends only the unreleased changes since the previous tag and preserves
 older hand-edited release sections. Do not use `-o CHANGELOG.md` for routine
 releases unless you intentionally want to regenerate the entire changelog.
+Generate this section before the first release candidate. After an rc tag exists,
+edit the prepared section directly rather than running this command again.
 
 Keep each changelog paragraph and list item on one physical line, and use blank
 lines only to separate Markdown blocks. The release workflow copies the
@@ -122,9 +164,10 @@ Then verify the hosted docs and Playground:
 
 Documentation is versioned separately from package builds. Pushes to `main`
 publish unreleased documentation to
-`https://unitaryfoundation.github.io/clifft/dev/`. Tagged releases publish the
-exact release version, update the `stable` docs copy, and refresh the root
+`https://unitaryfoundation.github.io/clifft/dev/`. Final release tags publish
+the exact release version, update the `stable` docs copy, and refresh the root
 stable Playground at `https://unitaryfoundation.github.io/clifft/playground/`.
+Release-candidate tags do not publish documentation.
 If a lower SemVer patch line is released after a newer stable version, the
 workflow publishes the exact version docs but leaves `stable` and the root
 Playground unchanged.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -19,7 +19,8 @@ The version is determined automatically from git tags:
 - **Tagged commits** (e.g., `v1.2.3`): version is `1.2.3`
 - **Release-candidate tags** (e.g., `v1.3.0rc1`): version is `1.3.0rc1`
 - **Development builds** (e.g., `1.2.4.dev3+g1a2b3c4`): the latest tag,
-  commit distance, and hash determine the version
+  commit distance, and hash determine the version. After `v1.3.0rc1`, the default
+  setuptools-scm progression is `1.3.0rc2.devN+gHASH`.
 
 There is no hardcoded version in `pyproject.toml`. The git tag is the single source of truth.
 
@@ -27,19 +28,19 @@ There is no hardcoded version in `pyproject.toml`. The git tag is the single sou
 
 Use a release candidate when the package must be installed from PyPI for validation before the
 final release. Complete the changelog and docs-home preparation described below before tagging the
-first candidate. Prepare the final release section, such as `## [0.3.0]`, rather than a separate rc
-section; the GitHub prerelease uses that section for its notes. The final release date may remain
-unset until the final tag.
+first candidate. Prepare the final release section, such as `## [1.3.0]`, rather than a separate rc
+section; the GitHub prerelease uses that section for its notes. `git-cliff` writes the preparation
+date into that heading, so update it to the actual publication date before creating the final tag.
 
 Optionally run the manual TestPyPI workflow first with a unique development version such as
-`0.3.0rc1.dev1`. Do not use `0.3.0rc1` for that smoke run: the tag-triggered workflow publishes the
-same artifacts to TestPyPI before PyPI, and TestPyPI rejects a duplicate version.
+`1.3.0rc1.dev1`. Do not use `1.3.0rc1` for that smoke run: TestPyPI files are immutable, so the
+tag-triggered workflow would skip the smoke artifacts instead of uploading the tagged artifacts.
 
 Tag the prepared commit using the canonical Python release-candidate form:
 
 ```bash
-git tag v0.3.0rc1
-git push origin v0.3.0rc1
+git tag v1.3.0rc1
+git push origin v1.3.0rc1
 ```
 
 The tag builds and tests the release artifacts, publishes them to TestPyPI and PyPI, and creates a
@@ -47,15 +48,15 @@ GitHub prerelease. It does not publish versioned docs, update `stable`, or refre
 Playground. Install the published wheel explicitly for validation:
 
 ```bash
-python -m pip install --only-binary=:all: "clifft==0.3.0rc1"
+python -m pip install --only-binary=:all: "clifft==1.3.0rc1"
 python -c "import clifft; print(clifft.__version__)"
 ```
 
 After validation, update the existing final changelog section and make documentation-only changes
-without regenerating the changelog from `--unreleased`: the rc tag is now the latest version tag and
-would hide earlier release commits from that view. If runtime, packaging, compiler, or build inputs
-change, increment the candidate tag (for example, `v0.3.0rc2`) and repeat validation. Otherwise,
-create the final tag using the normal process below.
+without prepending a duplicate section. `git-cliff` ignores rc tags, so an unreleased preview still
+covers every commit since the previous final release. If runtime, packaging, compiler, or build
+inputs change, increment the candidate tag (for example, `v1.3.0rc2`) and repeat validation.
+Otherwise, create the final tag using the normal process below.
 
 ## Release process
 
@@ -73,7 +74,7 @@ Manual dispatch always publishes to TestPyPI only — it cannot publish to PyPI.
 4. Wait for builds to complete, then verify the exact version:
 
     ```bash
-    TEST_VERSION=0.3.0.dev1
+    TEST_VERSION=1.3.0.dev1
     pip install --index-url https://test.pypi.org/simple/ \
         --extra-index-url https://pypi.org/simple/ "clifft==$TEST_VERSION"
     python -c "import clifft; print(clifft.__version__)"
@@ -90,8 +91,8 @@ git cliff --unreleased --tag vX.Y.Z --prepend CHANGELOG.md
 This prepends only the unreleased changes since the previous tag and preserves
 older hand-edited release sections. Do not use `-o CHANGELOG.md` for routine
 releases unless you intentionally want to regenerate the entire changelog.
-Generate this section before the first release candidate. After an rc tag exists,
-edit the prepared section directly rather than running this command again.
+Generate this section before the first release candidate. After an rc tag exists, edit the prepared
+section directly to avoid prepending a duplicate; rc tags do not truncate unreleased previews.
 
 Keep each changelog paragraph and list item on one physical line, and use blank
 lines only to separate Markdown blocks. The release workflow copies the


### PR DESCRIPTION
## Summary

- trigger the release workflow for canonical `vX.Y.ZrcN` tags
- publish RC artifacts through TestPyPI and PyPI, then mark the GitHub Release as a prerelease
- classify RCs once, reuse the prepared final-version changelog section for RC notes, and skip all RC docs/playground deployment
- make release-note extraction exact and fail closed when the final section is missing or blank
- keep `git-cliff` based on final tags so RC tags cannot truncate final release notes
- make TestPyPI uploads rerunnable while keeping production PyPI strict
- document RC preparation, post-RC development versions, changelog timing, and the final-release gate

## Validation

- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- `uv run --frozen --group docs mkdocs build --strict`
- simulated an intermediate RC tag and verified `git-cliff` retains pre-RC and post-RC commits
- exercised final and RC classification, exact changelog-heading matching, and blank-note rejection locally
