### PR TITLE
fix(api)!: expose valid nanobind signatures

### DIFF
--- a/.github/scripts/artifact_smoke.py
+++ b/.github/scripts/artifact_smoke.py
@@ -10,12 +10,23 @@ keep those markers stable.
 from __future__ import annotations
 
 import argparse
+import ast
 import sys
 from pathlib import Path
 
 import clifft
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def validate_typing_artifacts() -> None:
+    package_dir = Path(clifft.__file__).resolve().parent
+    stub_path = package_dir / "_clifft_core.pyi"
+    marker_path = package_dir / "py.typed"
+
+    if not marker_path.is_file():
+        raise AssertionError(f"typing marker is missing: {marker_path}")
+    ast.parse(stub_path.read_text(), filename=str(stub_path))
 
 
 def parse_python_version(value: str) -> tuple[int, int]:
@@ -51,6 +62,7 @@ def main() -> None:
     print(f"python={sys.version.split()[0]}", flush=True)
     print(f"version={clifft.__version__}  baseline={clifft.CPU_BASELINE}", flush=True)
     print(f"isa={clifft.runtime_isa()}", flush=True)
+    validate_typing_artifacts()
 
     symbolic = clifft.compile((_PROJECT_ROOT / "tests/fixtures/qv10.stim").read_text())
     result = clifft.sample(symbolic, shots=1, seed=280)

--- a/.github/scripts/artifact_smoke.py
+++ b/.github/scripts/artifact_smoke.py
@@ -26,6 +26,8 @@ def validate_typing_artifacts() -> None:
 
     if not marker_path.is_file():
         raise AssertionError(f"typing marker is missing: {marker_path}")
+    if not stub_path.is_file():
+        raise AssertionError(f"nanobind stub is missing: {stub_path}")
     ast.parse(stub_path.read_text(), filename=str(stub_path))
 
 

--- a/docs/griffe_extensions.py
+++ b/docs/griffe_extensions.py
@@ -1,0 +1,51 @@
+"""Griffe extensions used by the API reference build."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from griffe import Attribute, Class, Extension, Function, Inspector, Module, visit
+
+
+def _merge_stub_signatures(dynamic: Module | Class, stub: Module | Class) -> None:
+    for name, stub_member in stub.members.items():
+        dynamic_member = dynamic.members.get(name)
+
+        if isinstance(dynamic_member, Function) and isinstance(stub_member, Function):
+            dynamic_member.parameters = deepcopy(stub_member.parameters)
+            dynamic_member.returns = deepcopy(stub_member.returns)
+            dynamic_member.overloads = deepcopy(stub_member.overloads)
+        elif isinstance(dynamic_member, Attribute) and isinstance(stub_member, Attribute):
+            dynamic_member.annotation = deepcopy(stub_member.annotation)
+        elif isinstance(dynamic_member, Class) and isinstance(stub_member, Class):
+            if "__init__" not in stub_member.members:
+                dynamic_member.members.pop("__init__", None)
+            _merge_stub_signatures(dynamic_member, stub_member)
+
+
+class NanobindStubSignatures(Extension):
+    """Prefer generated stub signatures when Griffe inspects nanobind objects."""
+
+    def on_module_members(
+        self,
+        *,
+        node: Any,
+        mod: Module,
+        agent: Any,
+        **kwargs: Any,
+    ) -> None:
+        if mod.path != "clifft._clifft_core" or not isinstance(agent, Inspector):
+            return
+
+        module_file = getattr(node.obj, "__file__", None)
+        if module_file is None:
+            raise RuntimeError("clifft._clifft_core has no module file")
+
+        stub_path = Path(module_file).with_name("_clifft_core.pyi")
+        if not stub_path.is_file():
+            raise FileNotFoundError(f"nanobind stub not found: {stub_path}")
+
+        stub = visit("_clifft_core_stub", stub_path, stub_path.read_text())
+        _merge_stub_signatures(mod, stub)

--- a/docs/griffe_extensions.py
+++ b/docs/griffe_extensions.py
@@ -16,11 +16,10 @@ def _merge_stub_signatures(dynamic: Module | Class, stub: Module | Class) -> Non
         if isinstance(dynamic_member, Function) and isinstance(stub_member, Function):
             dynamic_member.parameters = deepcopy(stub_member.parameters)
             dynamic_member.returns = deepcopy(stub_member.returns)
-            dynamic_member.overloads = deepcopy(stub_member.overloads)
         elif isinstance(dynamic_member, Attribute) and isinstance(stub_member, Attribute):
             dynamic_member.annotation = deepcopy(stub_member.annotation)
         elif isinstance(dynamic_member, Class) and isinstance(stub_member, Class):
-            if "__init__" not in stub_member.members:
+            if "__init__" not in stub_member.members and "__init__" not in stub_member.overloads:
                 dynamic_member.members.pop("__init__", None)
             _merge_stub_signatures(dynamic_member, stub_member)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,9 @@ plugins:
             show_signature_annotations: true
             separate_signature: true
             merge_init_into_class: true
+            overloads_only: true
+            extensions:
+              - docs/griffe_extensions.py:NanobindStubSignatures
             filters:
               - "!^__"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ no_implicit_optional = true
 strict_equality = true
 
 [[tool.mypy.overrides]]
-module = ["numpy.*", "stim.*", "pytest.*", "clifft", "clifft._clifft_core", "qiskit.*", "qiskit_aer.*", "matplotlib", "matplotlib.*"]
+module = ["numpy.*", "stim.*", "pytest.*", "clifft", "clifft._clifft_core", "qiskit.*", "qiskit_aer.*", "matplotlib", "matplotlib.*", "griffe", "griffe.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -729,7 +729,7 @@ NB_MODULE(_clifft_core, m) {
         .def(nb::init<>())
         .def(
             "add",
-            [](clifft::HirPassManager& pm, clifft::HirPass& pass) {
+            [](clifft::HirPassManager& pm, clifft::HirPass& hir_pass) {
                 // HirPassManager needs unique_ptr ownership, but Python owns the pass.
                 // Use a thin non-owning wrapper that delegates to the Python-owned pass.
                 struct BorrowedPass : clifft::HirPass {
@@ -737,9 +737,9 @@ NB_MODULE(_clifft_core, m) {
                     explicit BorrowedPass(clifft::HirPass& r) : ref(r) {}
                     void run(clifft::HirModule& hir) override { ref.run(hir); }
                 };
-                pm.add_pass(std::make_unique<BorrowedPass>(pass));
+                pm.add_pass(std::make_unique<BorrowedPass>(hir_pass));
             },
-            nb::arg("pass"), nb::keep_alive<1, 2>(),
+            nb::arg("hir_pass"), nb::keep_alive<1, 2>(),
             "Add an optimization pass. Passes run in the order added.")
         .def(
             "run", [](clifft::HirPassManager& pm, clifft::HirModule& hir) { pm.run(hir); },
@@ -929,6 +929,11 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("threads") = int64_t{1}, nb::arg("thread_layout") = nb::none(),
         nb::arg("intra_shot_min_active_width") = nb::none(),
         nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::sig("def sample(program: Program, shots: int, seed: int | None = None, "
+                "threads: int | typing.Literal['auto'] = 1, "
+                "thread_layout: tuple[int, int] | None = None, "
+                "intra_shot_min_active_width: int | None = None, "
+                "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"),
         "Run a compiled program and return a SampleResult.\n\n"
         "Raises ValueError for post-selected programs because fixed-row output\n"
         "cannot represent discarded shots. Use sample_survivors() instead.\n\n"
@@ -985,6 +990,11 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("threads") = int64_t{1}, nb::arg("thread_layout") = nb::none(),
         nb::arg("intra_shot_min_active_width") = nb::none(),
         nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::sig("def sample_k(program: Program, shots: int, k: int, seed: int | None = None, "
+                "threads: int | typing.Literal['auto'] = 1, "
+                "thread_layout: tuple[int, int] | None = None, "
+                "intra_shot_min_active_width: int | None = None, "
+                "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"),
         "Sample with exactly k forced faults per shot (importance sampling).\n\n"
         "Sites are drawn from the exact conditional Poisson-Binomial\n"
         "distribution. Results are conditioned on K=k and must be combined\n"
@@ -1058,6 +1068,12 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
         nb::arg("thread_layout") = nb::none(), nb::arg("intra_shot_min_active_width") = nb::none(),
         nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::sig("def sample_k_survivors(program: Program, shots: int, k: int, "
+                "seed: int | None = None, keep_records: bool = False, "
+                "threads: int | typing.Literal['auto'] = 1, "
+                "thread_layout: tuple[int, int] | None = None, "
+                "intra_shot_min_active_width: int | None = None, "
+                "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"),
         "Sample survivors with exactly k forced faults per shot.\n\n"
         "Results are conditioned on K=k. To estimate the overall logical\n"
         "error rate across strata, weight numerator and denominator\n"
@@ -1102,6 +1118,11 @@ NB_MODULE(_clifft_core, m) {
         nb::arg("keep_records") = false, nb::arg("threads") = int64_t{1},
         nb::arg("thread_layout") = nb::none(), nb::arg("intra_shot_min_active_width") = nb::none(),
         nb::arg("batch_size") = BatchOption{std::string{"auto"}},
+        nb::sig("def sample_survivors(program: Program, shots: int, seed: int | None = None, "
+                "keep_records: bool = False, threads: int | typing.Literal['auto'] = 1, "
+                "thread_layout: tuple[int, int] | None = None, "
+                "intra_shot_min_active_width: int | None = None, "
+                "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"),
         "Sample shots and return results only for surviving (non-discarded) shots.\n\n"
         "If seed is None (default), uses hardware entropy. threads is a positive\n"
         "total worker budget or 'auto' to use the implementation-reported hardware\n"

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -10,6 +10,37 @@ import pytest
 
 import clifft
 
+_SAMPLING_SIGNATURES = {
+    "sample": (
+        "def sample(program: Program, shots: int, seed: int | None = None, "
+        "threads: int | typing.Literal['auto'] = 1, "
+        "thread_layout: tuple[int, int] | None = None, "
+        "intra_shot_min_active_width: int | None = None, "
+        "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"
+    ),
+    "sample_k": (
+        "def sample_k(program: Program, shots: int, k: int, seed: int | None = None, "
+        "threads: int | typing.Literal['auto'] = 1, "
+        "thread_layout: tuple[int, int] | None = None, "
+        "intra_shot_min_active_width: int | None = None, "
+        "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"
+    ),
+    "sample_k_survivors": (
+        "def sample_k_survivors(program: Program, shots: int, k: int, seed: int | None = None, "
+        "keep_records: bool = False, threads: int | typing.Literal['auto'] = 1, "
+        "thread_layout: tuple[int, int] | None = None, "
+        "intra_shot_min_active_width: int | None = None, "
+        "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"
+    ),
+    "sample_survivors": (
+        "def sample_survivors(program: Program, shots: int, seed: int | None = None, "
+        "keep_records: bool = False, threads: int | typing.Literal['auto'] = 1, "
+        "thread_layout: tuple[int, int] | None = None, "
+        "intra_shot_min_active_width: int | None = None, "
+        "batch_size: int | typing.Literal['auto'] = 'auto') -> clifft.SampleResult"
+    ),
+}
+
 
 def test_version() -> None:
     """Test that version() returns a valid version string."""
@@ -44,17 +75,18 @@ def test_runtime_isa_reflects_forced_scalar_backend() -> None:
 
 
 @pytest.mark.parametrize(
-    "function_name",
-    ["sample", "sample_k", "sample_k_survivors", "sample_survivors"],
+    ("function_name", "expected_signature"),
+    _SAMPLING_SIGNATURES.items(),
 )
-def test_sampling_signature_has_public_result_type(function_name: str) -> None:
-    """Test that nanobind metadata describes the stable public result type."""
+def test_sampling_signature_matches_public_contract(
+    function_name: str,
+    expected_signature: str,
+) -> None:
+    """Test that nanobind metadata matches the public sampling contract."""
     function = getattr(clifft, function_name)
     signatures = function.__nb_signature__
     assert len(signatures) == 1
-    signature = signatures[0][0]
-    assert "typing.Literal['auto']" in signature
-    assert signature.endswith("-> clifft.SampleResult")
+    assert signatures[0][0] == expected_signature
 
 
 def test_hir_pass_manager_add_has_valid_keyword_name() -> None:
@@ -62,8 +94,9 @@ def test_hir_pass_manager_add_has_valid_keyword_name() -> None:
     manager = clifft.HirPassManager()
     manager.add(hir_pass=clifft.PeepholeFusionPass())
 
-    signature = clifft.HirPassManager.add.__nb_signature__[0][0]
-    assert "hir_pass: clifft._clifft_core.HirPass" in signature
+    signatures = clifft.HirPassManager.add.__nb_signature__
+    assert len(signatures) == 1
+    assert signatures[0][0] == ("def add(self, hir_pass: clifft._clifft_core.HirPass) -> None")
 
 
 # --------------------------------------------------------------------------

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -43,6 +43,29 @@ def test_runtime_isa_reflects_forced_scalar_backend() -> None:
     assert output.strip() == "scalar"
 
 
+@pytest.mark.parametrize(
+    "function_name",
+    ["sample", "sample_k", "sample_k_survivors", "sample_survivors"],
+)
+def test_sampling_signature_has_public_result_type(function_name: str) -> None:
+    """Test that nanobind metadata describes the stable public result type."""
+    function = getattr(clifft, function_name)
+    signatures = function.__nb_signature__
+    assert len(signatures) == 1
+    signature = signatures[0][0]
+    assert "typing.Literal['auto']" in signature
+    assert signature.endswith("-> clifft.SampleResult")
+
+
+def test_hir_pass_manager_add_has_valid_keyword_name() -> None:
+    """Test that pass managers expose a keyword that is valid Python syntax."""
+    manager = clifft.HirPassManager()
+    manager.add(hir_pass=clifft.PeepholeFusionPass())
+
+    signature = clifft.HirPassManager.add.__nb_signature__[0][0]
+    assert "hir_pass: clifft._clifft_core.HirPass" in signature
+
+
 # --------------------------------------------------------------------------
 # Parser tests
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- correct the generated nanobind stub by renaming the invalid `pass` parameter to `hir_pass`
- add precise public signatures for the sampling APIs, including `Literal["auto"]` parameters and `SampleResult` returns
- make the API reference prefer generated stub signatures over native `*args, **kwargs` inspection output
- validate the packaged `_clifft_core.pyi` and `py.typed` marker in the artifact smoke test

## Compatibility

`HirPassManager.add()` now accepts `hir_pass=` instead of `pass=`. Positional calls are unchanged; ordinary `pass=` syntax was never valid Python, though callers using dictionary expansion may need to update the key.

## Validation

- `uv run --frozen pytest tests/python/ -n logical --maxprocesses 4 -v` (1390 passed, 7 skipped)
- `uv run --locked --group docs mkdocs build --strict`
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure`
- artifact smoke validation against an editable install

Follow-up to #455.
