### PR TITLE
feat(optimizer): add structural active-width analysis

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(clifft_core STATIC
     tableau/tableau.cc
     frontend/frontend.cc
     optimizer/hir_pass_manager.cc
+    optimizer/active_width_analysis.cc
     optimizer/drop_non_unitary_pass.cc
     optimizer/commutation.cc
     optimizer/peephole.cc

--- a/src/clifft/optimizer/active_width_analysis.cc
+++ b/src/clifft/optimizer/active_width_analysis.cc
@@ -1,0 +1,306 @@
+#include "clifft/optimizer/active_width_analysis.h"
+
+#include "clifft/optimizer/commutation.h"
+
+#include <algorithm>
+#include <cassert>
+#include <span>
+
+namespace clifft {
+
+namespace {
+
+PauliString pauli_body(const HirModule& hir, const HeisenbergOp& op) {
+    PauliString result(hir.num_qubits);
+    result.mut_x().xor_with(hir.destab_mask(op));
+    result.mut_z().xor_with(hir.stab_mask(op));
+    return result;
+}
+
+// The (x, z) mask pair is treated as one combined GF(2) vector of length
+// 2 * domain, with x occupying [0, domain) and z occupying [domain, 2 *
+// domain), domain = words_per_row * 64. Bits at or beyond num_qubits within
+// each half are always zero -- PauliString and the generator storage both
+// keep that padding clear -- so they are inert dead space at the top of
+// each half and are never selected as a pivot.
+uint32_t combined_domain(uint32_t words_per_row) {
+    return words_per_row * 64;
+}
+
+bool combined_bit_get(MaskView x, MaskView z, uint32_t domain, uint32_t bit) {
+    return bit < domain ? x.bit_get(bit) : z.bit_get(bit - domain);
+}
+
+uint32_t combined_lowest_bit(MaskView x, MaskView z, uint32_t domain) {
+    const uint32_t x_bit = x.lowest_bit();
+    if (x_bit < domain) {
+        return x_bit;
+    }
+    return domain + z.lowest_bit();
+}
+
+}  // namespace
+
+DormantSubspace::DormantSubspace(uint32_t num_qubits)
+    : num_qubits_(num_qubits),
+      words_per_row_((num_qubits + 63) / 64),
+      dimension_(num_qubits),
+      gen_x_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      gen_z_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      echelon_x_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      echelon_z_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      echelon_pivot_(num_qubits, 0),
+      scratch_x_(words_per_row_, 0),
+      scratch_z_(words_per_row_, 0) {
+    // S starts as the span of Z on every qubit: generator q is Z_q.
+    for (uint32_t q = 0; q < num_qubits; ++q) {
+        row_z(q).bit_set(q, true);
+    }
+}
+
+MaskView DormantSubspace::row_x(uint32_t index) const {
+    return MaskView{std::span<const uint64_t>(
+        gen_x_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MaskView DormantSubspace::row_z(uint32_t index) const {
+    return MaskView{std::span<const uint64_t>(
+        gen_z_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::row_x(uint32_t index) {
+    return MutableMaskView{std::span<uint64_t>(
+        gen_x_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::row_z(uint32_t index) {
+    return MutableMaskView{std::span<uint64_t>(
+        gen_z_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::echelon_row_x(uint32_t index) const {
+    return MutableMaskView{std::span<uint64_t>(
+        echelon_x_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::echelon_row_z(uint32_t index) const {
+    return MutableMaskView{std::span<uint64_t>(
+        echelon_z_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+std::optional<uint32_t> DormantSubspace::find_anticommuting_generator(const PauliString& p) const {
+    assert(p.num_qubits() == num_qubits_ && "Pauli body must share the subspace's qubit count");
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        if (anti_commute(row_x(i), row_z(i), p.x(), p.z())) {
+            return i;
+        }
+    }
+    return std::nullopt;
+}
+
+bool DormantSubspace::commutes_with_all(const PauliString& p) const {
+    return !find_anticommuting_generator(p).has_value();
+}
+
+void DormantSubspace::intersect_with_pivot(const PauliString& p, uint32_t pivot) {
+    assert(pivot < dimension_ && "pivot must be a live generator index");
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        if (i == pivot) {
+            continue;
+        }
+        if (anti_commute(row_x(i), row_z(i), p.x(), p.z())) {
+            row_x(i).xor_with(row_x(pivot));
+            row_z(i).xor_with(row_z(pivot));
+        }
+    }
+    const uint32_t last = dimension_ - 1;
+    if (pivot != last) {
+        std::ranges::copy(row_x(last).words, row_x(pivot).words.begin());
+        std::ranges::copy(row_z(last).words, row_z(pivot).words.begin());
+    }
+    --dimension_;
+    echelon_dirty_ = true;
+}
+
+void DormantSubspace::append_generator(const PauliString& p) {
+    assert(dimension_ < num_qubits_ && "S is already Lagrangian; nothing can extend it");
+    std::ranges::copy(p.x().words, row_x(dimension_).words.begin());
+    std::ranges::copy(p.z().words, row_z(dimension_).words.begin());
+    ++dimension_;
+    echelon_dirty_ = true;
+}
+
+bool DormantSubspace::apply_rotation(const PauliString& axis) {
+    const std::optional<uint32_t> pivot = find_anticommuting_generator(axis);
+    if (!pivot.has_value()) {
+        return false;
+    }
+    intersect_with_pivot(axis, *pivot);
+    return true;
+}
+
+DormantSubspace::MeasurementEffect DormantSubspace::apply_measurement(const PauliString& body) {
+    const std::optional<uint32_t> pivot = find_anticommuting_generator(body);
+    if (pivot.has_value()) {
+        intersect_with_pivot(body, *pivot);
+        append_generator(body);
+        return MeasurementEffect::DormantRandom;
+    }
+    if (contains(body)) {
+        return MeasurementEffect::Classical;
+    }
+    append_generator(body);
+    return MeasurementEffect::Active;
+}
+
+std::optional<uint32_t> DormantSubspace::reduce_against_membership_cache(
+    MutableMaskView work_x, MutableMaskView work_z) const {
+    const uint32_t domain = combined_domain(words_per_row_);
+    for (uint32_t row = 0; row < echelon_dimension_; ++row) {
+        const uint32_t pivot = echelon_pivot_[row];
+        if (combined_bit_get(work_x, work_z, domain, pivot)) {
+            work_x.xor_with(echelon_row_x(row));
+            work_z.xor_with(echelon_row_z(row));
+        }
+    }
+    const uint32_t remainder = combined_lowest_bit(work_x, work_z, domain);
+    if (remainder >= 2 * domain) {
+        return std::nullopt;
+    }
+    return remainder;
+}
+
+void DormantSubspace::rebuild_membership_cache_if_dirty() const {
+    if (!echelon_dirty_) {
+        return;
+    }
+    echelon_dimension_ = 0;
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        std::ranges::copy(row_x(i).words, echelon_row_x(echelon_dimension_).words.begin());
+        std::ranges::copy(row_z(i).words, echelon_row_z(echelon_dimension_).words.begin());
+        const std::optional<uint32_t> pivot = reduce_against_membership_cache(
+            echelon_row_x(echelon_dimension_), echelon_row_z(echelon_dimension_));
+        // The generator list is maintained as a basis by intersect_with_pivot
+        // and append_generator, so inserting an already-independent vector
+        // into the echelon form can never reduce it to zero.
+        assert(pivot.has_value() && "generator list was not linearly independent");
+        echelon_pivot_[echelon_dimension_] = pivot.value_or(0);
+        ++echelon_dimension_;
+    }
+    echelon_dirty_ = false;
+}
+
+bool DormantSubspace::contains(const PauliString& p) const {
+    assert(p.num_qubits() == num_qubits_ && "Pauli body must share the subspace's qubit count");
+    rebuild_membership_cache_if_dirty();
+    // Reduce a scratch copy; the cached echelon rows stay put for reuse by
+    // later contains() calls.
+    std::ranges::copy(p.x().words, scratch_x_.begin());
+    std::ranges::copy(p.z().words, scratch_z_.begin());
+    const std::optional<uint32_t> remainder =
+        reduce_against_membership_cache(MutableMaskView{scratch_x_}, MutableMaskView{scratch_z_});
+    return !remainder.has_value();
+}
+
+namespace {
+
+void record_transition(ActiveWidthTrace& trace, uint32_t& width, WidthEffect effect,
+                       uint32_t after) {
+    trace.transitions.push_back(WidthTransition{width, after, effect});
+    width = after;
+    trace.peak_width = std::max(trace.peak_width, width);
+}
+
+void analyze_rotation(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace,
+                      ActiveWidthTrace& trace, uint32_t& width) {
+    const PauliString body = pauli_body(hir, op);
+    if (subspace.apply_rotation(body)) {
+        record_transition(trace, width, WidthEffect::RotationPromote, subspace.active_width());
+    } else if (subspace.contains(body)) {
+        record_transition(trace, width, WidthEffect::RotationStabilizer, width);
+    } else {
+        record_transition(trace, width, WidthEffect::RotationNeutral, width);
+    }
+}
+
+void analyze_measurement(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace,
+                         ActiveWidthTrace& trace, uint32_t& width) {
+    const PauliString body = pauli_body(hir, op);
+    switch (subspace.apply_measurement(body)) {
+        case DormantSubspace::MeasurementEffect::DormantRandom:
+            record_transition(trace, width, WidthEffect::MeasureDormantRandom, width);
+            return;
+        case DormantSubspace::MeasurementEffect::Classical:
+            record_transition(trace, width, WidthEffect::MeasureClassical, width);
+            return;
+        case DormantSubspace::MeasurementEffect::Active:
+            record_transition(trace, width, WidthEffect::MeasureActive, subspace.active_width());
+            return;
+    }
+    assert(false && "unreachable DormantSubspace::MeasurementEffect");
+}
+
+void analyze_instrument(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace,
+                        ActiveWidthTrace& trace, uint32_t& width) {
+    const PauliString body = pauli_body(hir, op);
+    const InstrumentSite& site =
+        hir.instrument_sites.at(static_cast<uint32_t>(op.instrument_site_idx()));
+
+    if (!subspace.commutes_with_all(body)) {
+        const bool traps = hir.neglect_instrument_damping ||
+                           site.probabilities.p_fire[0] == site.probabilities.p_fire[1];
+        if (traps) {
+            record_transition(trace, width, WidthEffect::InstrumentDormantTrap, width);
+            return;
+        }
+        [[maybe_unused]] const bool promoted = subspace.apply_rotation(body);
+        assert(promoted && "instrument body must anticommute with S here");
+        record_transition(trace, width, WidthEffect::InstrumentActivate, subspace.active_width());
+        return;
+    }
+    if (subspace.contains(body)) {
+        record_transition(trace, width, WidthEffect::InstrumentClassical, width);
+        return;
+    }
+    record_transition(trace, width, WidthEffect::InstrumentActive, width);
+}
+
+}  // namespace
+
+ActiveWidthTrace analyze_active_width(const HirModule& hir) {
+    ActiveWidthTrace trace;
+    DormantSubspace subspace(hir.num_qubits);
+    trace.initial_width = subspace.active_width();
+    trace.peak_width = trace.initial_width;
+    trace.transitions.reserve(hir.ops.size());
+
+    uint32_t width = trace.initial_width;
+    for (const HeisenbergOp& op : hir.ops) {
+        switch (op.op_type()) {
+            case OpType::T_GATE:
+            case OpType::PHASE_ROTATION:
+                analyze_rotation(hir, op, subspace, trace, width);
+                break;
+            case OpType::MEASURE:
+                analyze_measurement(hir, op, subspace, trace, width);
+                break;
+            case OpType::INSTRUMENT:
+                analyze_instrument(hir, op, subspace, trace, width);
+                break;
+            case OpType::CONDITIONAL_PAULI:
+            case OpType::NOISE:
+            case OpType::READOUT_NOISE:
+            case OpType::DETECTOR:
+            case OpType::OBSERVABLE:
+            case OpType::EXP_VAL:
+            case OpType::NUM_OP_TYPES:
+                record_transition(trace, width, WidthEffect::None, width);
+                break;
+        }
+    }
+
+    trace.final_width = width;
+    return trace;
+}
+
+}  // namespace clifft

--- a/src/clifft/optimizer/active_width_analysis.h
+++ b/src/clifft/optimizer/active_width_analysis.h
@@ -1,0 +1,171 @@
+#pragma once
+
+// Structural active-width analysis for the Heisenberg IR.
+//
+// The sampling planner's active width is a pure function of one GF(2)
+// linear-algebra object: the unsigned isotropic subspace S of dormant
+// stabilizer generators, initialized to the span of Z on every qubit. Every
+// planner decision -- promote a coordinate, collapse one, or leave the
+// active state untouched -- reduces to whether an operation's Pauli body
+// anticommutes with a generator of S, or, when it commutes with all of
+// them, whether it already lies in S. This module recomputes that same
+// sequence of decisions directly from HIR-frame Pauli masks, using GF(2)
+// elimination in place of the planner's coordinate-frame bookkeeping
+// (promoted-qubit tracking, pivot selection, inverse tableau caching).
+//
+// The payoff is a width predictor cheap enough to evaluate repeatedly: code
+// exploring alternative HIR operation orders can score a candidate order's
+// peak active width without materializing a coordinate frame or an
+// executable plan for it. This file never mutates the HIR and performs no
+// execution; it only answers what the width trace of a fixed operation
+// sequence would look like.
+
+#include "clifft/frontend/hir.h"
+#include "clifft/tableau/pauli_string.h"
+#include "clifft/util/mask_view.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace clifft {
+
+// Tracks the unsigned isotropic subspace S of dormant stabilizer generators
+// in fixed HIR (initial-frame) coordinates. This is the same subspace the
+// sampling planner evolves through its coordinate frame, but represented
+// directly as a GF(2) generator list rather than a physical-to-current basis
+// change, so deciding whether a Pauli anticommutes with S or lies in it
+// costs linear algebra instead of tableau composition.
+//
+// dimension + active_width() == num_qubits always: S is a maximal isotropic
+// (Lagrangian) subspace exactly when active_width() == 0, and every unit the
+// active width grows shrinks S by exactly one dimension.
+class DormantSubspace {
+  public:
+    explicit DormantSubspace(uint32_t num_qubits);
+
+    DormantSubspace(const DormantSubspace&) = default;
+    DormantSubspace& operator=(const DormantSubspace&) = default;
+    DormantSubspace(DormantSubspace&&) = default;
+    DormantSubspace& operator=(DormantSubspace&&) = default;
+
+    [[nodiscard]] uint32_t active_width() const { return num_qubits_ - dimension_; }
+
+    // True when `p` commutes with every current generator of S.
+    [[nodiscard]] bool commutes_with_all(const PauliString& p) const;
+
+    // True when `p` is a product of generators of S, equivalently an element
+    // of S. S is abelian, so an anticommuting Pauli is never in S; callers
+    // that already know commutes_with_all(p) is true use this to tell a
+    // stabilizer Pauli from a width-neutral active one.
+    [[nodiscard]] bool contains(const PauliString& p) const;
+
+    // Applies the planner's rotation bookkeeping for an operation with Pauli
+    // body `axis`: if `axis` anticommutes with a generator of S, replaces S
+    // with S intersect axis-perp (dimension drops by one, active width grows
+    // by one) and returns true. Otherwise leaves S unchanged and returns
+    // false.
+    bool apply_rotation(const PauliString& axis);
+
+    enum class MeasurementEffect : uint8_t { DormantRandom, Classical, Active };
+
+    // Applies the planner's measurement-collapse bookkeeping to `body` and
+    // reports which branch it took. DormantRandom replaces one generator
+    // with `body` (active width unchanged); Active adds `body` as a new,
+    // independent generator (active width drops by one); Classical leaves S
+    // unchanged.
+    MeasurementEffect apply_measurement(const PauliString& body);
+
+  private:
+    [[nodiscard]] MaskView row_x(uint32_t index) const;
+    [[nodiscard]] MaskView row_z(uint32_t index) const;
+    [[nodiscard]] MutableMaskView row_x(uint32_t index);
+    [[nodiscard]] MutableMaskView row_z(uint32_t index);
+    [[nodiscard]] MutableMaskView echelon_row_x(uint32_t index) const;
+    [[nodiscard]] MutableMaskView echelon_row_z(uint32_t index) const;
+
+    [[nodiscard]] std::optional<uint32_t> find_anticommuting_generator(const PauliString& p) const;
+
+    // Replaces S with S intersect p-perp given that generator `pivot`
+    // anticommutes with p: XORs every other anticommuting generator with the
+    // pivot row, then drops the pivot row. Invalidates the membership cache.
+    void intersect_with_pivot(const PauliString& p, uint32_t pivot);
+
+    // Appends `p` as a new, independent generator. Only valid when p is not
+    // already in S, which callers establish before invoking this.
+    void append_generator(const PauliString& p);
+
+    // Reduces the (work_x, work_z) vector against the cached echelon basis
+    // in place and returns the pivot bit of the nonzero remainder, or
+    // nullopt when it reduces to zero (the vector was in the cached span).
+    [[nodiscard]] std::optional<uint32_t> reduce_against_membership_cache(
+        MutableMaskView work_x, MutableMaskView work_z) const;
+
+    // Rebuilds the GF(2) echelon basis from the current generator list when
+    // a change has invalidated it. apply_rotation's promoting branch and
+    // apply_measurement's DormantRandom branch never query membership, so a
+    // run of promotions between two contains() calls rebuilds only once.
+    void rebuild_membership_cache_if_dirty() const;
+
+    uint32_t num_qubits_;
+    uint32_t words_per_row_;
+    uint32_t dimension_;
+    std::vector<uint64_t> gen_x_;
+    std::vector<uint64_t> gen_z_;
+
+    mutable std::vector<uint64_t> echelon_x_;
+    mutable std::vector<uint64_t> echelon_z_;
+    mutable std::vector<uint32_t> echelon_pivot_;
+    mutable uint32_t echelon_dimension_ = 0;
+    mutable bool echelon_dirty_ = true;
+    mutable std::vector<uint64_t> scratch_x_;
+    mutable std::vector<uint64_t> scratch_z_;
+};
+
+// Per-operation classification of how an HIR op moves the active width.
+// Values correspond 1:1 with the sampling planner's action taxonomy (see
+// sampling/plan.h): the Rotation* values classify a T_GATE or
+// PHASE_ROTATION, Measure* a MEASURE, and Instrument* an INSTRUMENT. None
+// covers every op that leaves the active state untouched (NOISE,
+// READOUT_NOISE, CONDITIONAL_PAULI, DETECTOR, OBSERVABLE, EXP_VAL).
+enum class WidthEffect : uint8_t {
+    None,
+    RotationStabilizer,     // p in S: the planner emits no action.
+    RotationNeutral,        // p commutes with S but p not in S: RotateActivePauli.
+    RotationPromote,        // p anticommutes with S: PromoteDormantRotation.
+    MeasureClassical,       // p in S: RecordClassical.
+    MeasureDormantRandom,   // p anticommutes with S: MeasureDormantRandom.
+    MeasureActive,          // p commutes with S but p not in S: MeasureActivePauli.
+    InstrumentClassical,    // p in S: InstrumentMode::Classical.
+    InstrumentActive,       // p commutes with S but p not in S: InstrumentMode::Active.
+    InstrumentActivate,     // p anticommutes with S, damping applies: InstrumentMode::Activate.
+    InstrumentDormantTrap,  // p anticommutes with S, damping neglected:
+                            // InstrumentMode::DormantTrap.
+};
+
+struct WidthTransition {
+    uint32_t before = 0;
+    uint32_t after = 0;
+    WidthEffect effect = WidthEffect::None;
+};
+
+struct ActiveWidthTrace {
+    uint32_t initial_width = 0;
+    uint32_t peak_width = 0;
+    uint32_t final_width = 0;
+    std::vector<WidthTransition> transitions;
+};
+
+// Recomputes the sampling planner's active-width trace directly from HIR,
+// without building a coordinate frame or symbolic Pauli frame and without
+// mutating `hir`. Produces exactly one transition per HIR op, in op order.
+//
+// Unlike the planner, this analysis never throws on width overflow: it
+// predicts the structural trace rather than committing to build a dense
+// coefficient state, so it has no reason to enforce
+// sampling::kDenseActiveWidthLimit. A caller that needs the planner's
+// executable output still goes through sampling::plan_sampling, which
+// enforces that limit itself.
+[[nodiscard]] ActiveWidthTrace analyze_active_width(const HirModule& hir);
+
+}  // namespace clifft

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/tableau/tableau.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/frontend/frontend.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/hir_pass_manager.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/active_width_analysis.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/drop_non_unitary_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/commutation.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/peephole.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(clifft_tests
     test_sampling_kernels.cc
     test_interleaved_batch_kernels.cc
     test_optimizer.cc
+    test_active_width_analysis.cc
     test_source_map.cc
     test_importance_sampling.cc
     test_runtime_isa.cc

--- a/tests/test_active_width_analysis.cc
+++ b/tests/test_active_width_analysis.cc
@@ -1,0 +1,446 @@
+// Differential and unit tests for the structural active-width analysis.
+//
+// The core property under test is that analyze_active_width(hir) reproduces
+// the sampling planner's width trace exactly, without building a coordinate
+// frame. The differential helper below compares peak width, the sequence of
+// width changes in op order, and per-effect action counts between a
+// SamplingPlan and an ActiveWidthTrace built from the same HIR.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/active_width_analysis.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/peephole.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/tableau/pauli_string.h"
+
+#include "instrument_test_helpers.h"
+#include "test_helpers.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace clifft;
+using clifft::sampling::ApplyInstrument;
+using clifft::sampling::InstrumentMode;
+using clifft::sampling::MeasureActivePauli;
+using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::PlannedAction;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::RotateActivePauli;
+using clifft::sampling::SamplingPlan;
+
+namespace {
+
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
+// Runs every comparison the differential tests rely on: peak width, the
+// sequence of width changes in op order, and per-effect action counts.
+// Takes an already-computed plan so a caller decides separately whether a
+// throw from plan_sampling() itself is acceptable for this HIR variant.
+void require_trace_matches_plan(const HirModule& hir, const SamplingPlan& plan) {
+    const ActiveWidthTrace trace = analyze_active_width(hir);
+
+    REQUIRE(trace.transitions.size() == hir.ops.size());
+    REQUIRE(trace.initial_width == plan.initial_active_width);
+    REQUIRE(trace.peak_width == plan.peak_active_width);
+
+    std::vector<std::pair<uint32_t, uint32_t>> plan_changes;
+    for (const PlannedAction& action : plan.actions) {
+        if (action.active_before != action.active_after) {
+            plan_changes.emplace_back(action.active_before, action.active_after);
+        }
+    }
+    std::vector<std::pair<uint32_t, uint32_t>> trace_changes;
+    for (const WidthTransition& transition : trace.transitions) {
+        if (transition.before != transition.after) {
+            trace_changes.emplace_back(transition.before, transition.after);
+        }
+    }
+    REQUIRE(trace_changes == plan_changes);
+
+    const uint32_t plan_final_width =
+        plan.actions.empty() ? plan.initial_active_width : plan.actions.back().active_after;
+    REQUIRE(trace.final_width == plan_final_width);
+
+    size_t plan_promote = 0;
+    size_t plan_rotate_neutral = 0;
+    size_t plan_measure_active = 0;
+    size_t plan_measure_dormant = 0;
+    size_t plan_record_classical = 0;
+    for (const PlannedAction& action : plan.actions) {
+        if (std::holds_alternative<PromoteDormantRotation>(action.action)) {
+            ++plan_promote;
+        } else if (std::holds_alternative<RotateActivePauli>(action.action)) {
+            ++plan_rotate_neutral;
+        } else if (std::holds_alternative<MeasureActivePauli>(action.action)) {
+            ++plan_measure_active;
+        } else if (std::holds_alternative<MeasureDormantRandom>(action.action)) {
+            ++plan_measure_dormant;
+        } else if (std::holds_alternative<RecordClassical>(action.action)) {
+            ++plan_record_classical;
+        }
+    }
+
+    size_t trace_promote = 0;
+    size_t trace_neutral = 0;
+    size_t trace_measure_active = 0;
+    size_t trace_measure_dormant = 0;
+    size_t trace_classical = 0;
+    for (const WidthTransition& transition : trace.transitions) {
+        switch (transition.effect) {
+            case WidthEffect::RotationPromote:
+                ++trace_promote;
+                break;
+            case WidthEffect::RotationNeutral:
+                ++trace_neutral;
+                break;
+            case WidthEffect::MeasureActive:
+                ++trace_measure_active;
+                break;
+            case WidthEffect::MeasureDormantRandom:
+                ++trace_measure_dormant;
+                break;
+            case WidthEffect::MeasureClassical:
+                ++trace_classical;
+                break;
+            default:
+                break;
+        }
+    }
+
+    REQUIRE(plan_promote == trace_promote);
+    REQUIRE(plan_rotate_neutral == trace_neutral);
+    REQUIRE(plan_measure_active == trace_measure_active);
+    REQUIRE(plan_measure_dormant == trace_measure_dormant);
+    REQUIRE(plan_record_classical == trace_classical);
+}
+
+// Best-effort variant of the above for HIR that may legitimately overflow
+// the planner's dense active-width limit (raw or peephole-only HIR for a
+// wide circuit, before the squeeze pass narrows the peak). Returns whether
+// the comparison actually ran.
+bool require_trace_matches_plan_if_plannable(const HirModule& hir) {
+    SamplingPlan plan;
+    try {
+        plan = clifft::sampling::plan_sampling(hir);
+    } catch (const std::exception&) {
+        return false;
+    }
+    require_trace_matches_plan(hir, plan);
+    return true;
+}
+
+HirModule run_peephole_only(const HirModule& source) {
+    HirModule hir = source;
+    HirPassManager passes;
+    passes.add_pass(std::make_unique<PeepholeFusionPass>());
+    passes.run(hir);
+    return hir;
+}
+
+HirModule run_production_pipeline(const HirModule& source) {
+    HirModule hir = source;
+    clifft::default_hir_pass_manager().run(hir);
+    return hir;
+}
+
+// Deterministic Stim-source generator over a small gate set: H, S, CNOT, T,
+// T_DAG, R_Z at a few angles, M, MX, MR, R, DEPOLARIZE1, X_ERROR, and
+// DETECTOR referencing an earlier record. Every generated line is
+// individually valid, so the circuit as a whole always parses and traces.
+std::string random_stim_circuit(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    static const double kAngles[] = {0.1, 0.125, 0.25, 0.3, 0.5, 0.7, 0.75, 1.25, 1.5, 1.75};
+    static const double kNoiseProbs[] = {0.01, 0.02, 0.05, 0.1, 0.2};
+
+    std::string source;
+    uint32_t measurement_count = 0;
+    for (uint32_t op = 0; op < num_ops; ++op) {
+        const uint32_t q = rng() % num_qubits;
+        switch (rng() % 12) {
+            case 0:
+                source += "H " + std::to_string(q) + "\n";
+                break;
+            case 1:
+                source += "S " + std::to_string(q) + "\n";
+                break;
+            case 2: {
+                uint32_t partner = rng() % num_qubits;
+                if (partner == q) {
+                    partner = (partner + 1) % num_qubits;
+                }
+                source += "CNOT " + std::to_string(q) + " " + std::to_string(partner) + "\n";
+                break;
+            }
+            case 3:
+                source += "T " + std::to_string(q) + "\n";
+                break;
+            case 4:
+                source += "T_DAG " + std::to_string(q) + "\n";
+                break;
+            case 5:
+                source += "R_Z(" + std::to_string(kAngles[rng() % std::size(kAngles)]) + ") " +
+                          std::to_string(q) + "\n";
+                break;
+            case 6:
+                source += "M " + std::to_string(q) + "\n";
+                ++measurement_count;
+                break;
+            case 7:
+                source += "MX " + std::to_string(q) + "\n";
+                ++measurement_count;
+                break;
+            case 8:
+                source += "MR " + std::to_string(q) + "\n";
+                ++measurement_count;
+                break;
+            case 9:
+                source += "R " + std::to_string(q) + "\n";
+                break;
+            case 10:
+                source += "DEPOLARIZE1(" +
+                          std::to_string(kNoiseProbs[rng() % std::size(kNoiseProbs)]) + ") " +
+                          std::to_string(q) + "\n";
+                break;
+            case 11:
+                source += "X_ERROR(" + std::to_string(kNoiseProbs[rng() % std::size(kNoiseProbs)]) +
+                          ") " + std::to_string(q) + "\n";
+                break;
+            default:
+                break;
+        }
+        if (measurement_count > 0 && (rng() % 5) == 0) {
+            const uint32_t back = 1 + (rng() % measurement_count);
+            source += "DETECTOR rec[-" + std::to_string(back) + "]\n";
+        }
+    }
+    return source;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Differential tests against the planner
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Active width analysis matches the planner on fixture circuits", "[active_width]") {
+    const std::vector<std::string> mandatory_fixtures = {
+        "coherent_d3_r3.stim",
+        "coherent_d5_r5.stim",
+        "cultivation_d5.stim",
+        "surface_d7_r7_p001.stim",
+    };
+    const std::vector<std::string> all_fixtures = {
+        "coherent_d3_r3.stim",     "coherent_d5_r5.stim", "cultivation_d5.stim",
+        "surface_d7_r7_p001.stim", "qv10.stim",           "surface_d11_r11_p001.stim",
+        "surface_d5_r5_p05.stim",  "target_qec.stim",
+    };
+
+    for (const std::string& fixture : all_fixtures) {
+        const bool mandatory = std::find(mandatory_fixtures.begin(), mandatory_fixtures.end(),
+                                         fixture) != mandatory_fixtures.end();
+        DYNAMIC_SECTION(fixture) {
+            const Circuit circuit = parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/" + fixture);
+            const HirModule raw = trace(circuit);
+            const HirModule peephole_only = run_peephole_only(raw);
+            const HirModule production = run_production_pipeline(raw);
+
+            // Raw and peephole-only HIR for a wide circuit can legitimately
+            // exceed the planner's dense active-width limit before the
+            // squeeze pass narrows the peak. That is an existing planner
+            // limitation orthogonal to this analysis, so treat it as a
+            // skip rather than a failure.
+            if (!require_trace_matches_plan_if_plannable(raw)) {
+                WARN("raw HIR exceeded the planner's dense active-width limit for " << fixture);
+            }
+            if (!require_trace_matches_plan_if_plannable(peephole_only)) {
+                WARN("peephole-only HIR exceeded the planner's dense active-width limit for "
+                     << fixture);
+            }
+
+            // The production pipeline is what real sampling runs, so every
+            // listed fixture must plan and match on it.
+            if (!require_trace_matches_plan_if_plannable(production)) {
+                if (mandatory) {
+                    FAIL("mandatory fixture's production pipeline could not be planned: "
+                         << fixture);
+                } else {
+                    WARN("production pipeline could not be planned for " << fixture);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Active width analysis matches the planner on random circuits", "[active_width]") {
+    constexpr uint32_t kActiveWidthFuzzSeed = 0x41770;
+    constexpr int kTrials = 400;
+
+    std::mt19937 rng(kActiveWidthFuzzSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 9);
+        const uint32_t num_ops = 20 + static_cast<uint32_t>(trial % 30);
+        const std::string source = random_stim_circuit(rng, num_qubits, num_ops);
+        CAPTURE(trial, num_qubits, num_ops, source);
+
+        const HirModule raw = trace(parse(source));
+        const HirModule peephole_only = run_peephole_only(raw);
+        const HirModule production = run_production_pipeline(raw);
+
+        // Active width can never exceed num_qubits (<= 12 here), far below
+        // the planner's dense-state limit, so every variant must plan.
+        require_trace_matches_plan(raw, clifft::sampling::plan_sampling(raw));
+        require_trace_matches_plan(peephole_only, clifft::sampling::plan_sampling(peephole_only));
+        require_trace_matches_plan(production, clifft::sampling::plan_sampling(production));
+    }
+}
+
+TEST_CASE("Active width analysis matches instrument modes across all four branches",
+          "[active_width]") {
+    struct InstrumentCase {
+        const char* name;
+        const char* circuit;
+        bool neglect_damping;
+        InstrumentMode expected_mode;
+        WidthEffect expected_effect;
+    };
+    const InstrumentCase cases[] = {
+        {"classical", "LEVEL_TRANSITION[jump] 0", false, InstrumentMode::Classical,
+         WidthEffect::InstrumentClassical},
+        {"activate", "H 0\nT 0\nH 1\nLEVEL_TRANSITION[jump] 1\nM 1", false,
+         InstrumentMode::Activate, WidthEffect::InstrumentActivate},
+        {"active", "H 0\nT 0\nLEVEL_TRANSITION[jump] 0", false, InstrumentMode::Active,
+         WidthEffect::InstrumentActive},
+        {"dormant trap", "H 0\nLEVEL_TRANSITION[jump] 0", true, InstrumentMode::DormantTrap,
+         WidthEffect::InstrumentDormantTrap},
+    };
+
+    for (const InstrumentCase& test_case : cases) {
+        DYNAMIC_SECTION(test_case.name) {
+            const InstrumentTraceOptions options =
+                clifft::test::source_dependent_jump_options(test_case.neglect_damping);
+            const HirModule hir = trace(parse(test_case.circuit), &options);
+
+            const SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+            const PlannedAction* instrument_action = nullptr;
+            const ApplyInstrument* instrument = nullptr;
+            for (const PlannedAction& action : plan.actions) {
+                if (const auto* candidate = std::get_if<ApplyInstrument>(&action.action)) {
+                    instrument_action = &action;
+                    instrument = candidate;
+                    break;
+                }
+            }
+            REQUIRE(instrument != nullptr);
+            REQUIRE(instrument->mode == test_case.expected_mode);
+
+            const auto instrument_op = std::ranges::find_if(
+                hir.ops, [](const HeisenbergOp& op) { return op.op_type() == OpType::INSTRUMENT; });
+            REQUIRE(instrument_op != hir.ops.end());
+            const auto op_index = static_cast<size_t>(instrument_op - hir.ops.begin());
+
+            const ActiveWidthTrace ir_trace = analyze_active_width(hir);
+            REQUIRE(op_index < ir_trace.transitions.size());
+            const WidthTransition& transition = ir_trace.transitions[op_index];
+
+            REQUIRE(transition.effect == test_case.expected_effect);
+            REQUIRE(transition.before == instrument_action->active_before);
+            REQUIRE(transition.after == instrument_action->active_after);
+
+            require_trace_matches_plan(hir, plan);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DormantSubspace unit tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("DormantSubspace widths across a promote-heavy two-qubit sequence", "[active_width]") {
+    DormantSubspace subspace(2);
+    std::vector<uint32_t> widths{subspace.active_width()};
+
+    REQUIRE(subspace.apply_rotation(PauliString::from_text("+XX")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_rotation(PauliString::from_text("+ZY")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YY")) ==
+            DormantSubspace::MeasurementEffect::Active);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YI")) ==
+            DormantSubspace::MeasurementEffect::Active);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(widths == std::vector<uint32_t>{0, 1, 2, 1, 0});
+}
+
+TEST_CASE("DormantSubspace widths across a collapse-then-promote two-qubit sequence",
+          "[active_width]") {
+    DormantSubspace subspace(2);
+    std::vector<uint32_t> widths{subspace.active_width()};
+
+    REQUIRE(subspace.apply_rotation(PauliString::from_text("+ZY")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YY")) ==
+            DormantSubspace::MeasurementEffect::DormantRandom);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE_FALSE(subspace.apply_rotation(PauliString::from_text("+XX")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YI")) ==
+            DormantSubspace::MeasurementEffect::Active);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(widths == std::vector<uint32_t>{0, 1, 1, 1, 0});
+}
+
+TEST_CASE("DormantSubspace treats a rotation or measurement inside S as inert", "[active_width]") {
+    SECTION("a lone generator") {
+        DormantSubspace subspace(2);
+        const PauliString z0 = PauliString::from_text("+ZI");
+
+        REQUIRE(subspace.commutes_with_all(z0));
+        REQUIRE(subspace.contains(z0));
+
+        REQUIRE_FALSE(subspace.apply_rotation(z0));
+        REQUIRE(subspace.active_width() == 0);
+        REQUIRE(subspace.contains(z0));
+
+        REQUIRE(subspace.apply_measurement(z0) == DormantSubspace::MeasurementEffect::Classical);
+        REQUIRE(subspace.active_width() == 0);
+    }
+
+    SECTION("a product of generators") {
+        DormantSubspace subspace(2);
+        const PauliString zz = PauliString::from_text("+ZZ");
+
+        REQUIRE(subspace.commutes_with_all(zz));
+        REQUIRE(subspace.contains(zz));
+
+        REQUIRE_FALSE(subspace.apply_rotation(zz));
+        REQUIRE(subspace.active_width() == 0);
+        REQUIRE(subspace.contains(zz));
+
+        REQUIRE(subspace.apply_measurement(zz) == DormantSubspace::MeasurementEffect::Classical);
+        REQUIRE(subspace.active_width() == 0);
+    }
+}


### PR DESCRIPTION
Prototype work on the `feature/active-width-scheduling` branch toward #458; review can be less strict than for `main`.

## Summary

Implements PR 1 of #458: a non-mutating structural active-width analysis for the Heisenberg IR.

- `DormantSubspace` (`src/clifft/optimizer/active_width_analysis.h/.cc`) tracks the unsigned isotropic subspace `S` of dormant stabilizer generators directly in HIR (initial-frame) coordinates as a bit-packed GF(2) generator list, with `commutes_with_all`, `contains`, `apply_rotation`, and `apply_measurement`. Anticommute/promote is O(dim S) bit-parallel generator scans; `contains()` membership uses a GF(2) echelon basis that is rebuilt lazily and only when a change has actually invalidated it, so a run of promotions between two membership queries costs nothing extra.
- `analyze_active_width(const HirModule&)` walks the HIR once, classifying every op into a `WidthEffect` (`None`, `RotationStabilizer`, `RotationNeutral`, `RotationPromote`, `MeasureClassical`, `MeasureDormantRandom`, `MeasureActive`, `InstrumentClassical`, `InstrumentActive`, `InstrumentActivate`, `InstrumentDormantTrap`) and returns an `ActiveWidthTrace` (`initial_width`, `peak_width`, `final_width`, one `WidthTransition` per op). It never mutates the HIR, never builds a coordinate frame, and never throws on width overflow (unlike the planner, which enforces `kDenseActiveWidthLimit`; this is a structural predictor, not a plan).
- The instrument branch mirrors `process_instrument` exactly, including the `neglect_instrument_damping` / equal-`p_fire` trap condition.

## Validation

A differential test (`tests/test_active_width_analysis.cc`) compares `analyze_active_width` against `clifft::sampling::plan_sampling` on the same HIR: peak width, the full sequence of width changes in op order (from `PlannedAction::active_before/active_after` vs. the trace's transitions), and per-effect action counts (`PromoteDormantRotation`/`RotationPromote`, `MeasureActivePauli`/`MeasureActive`, `MeasureDormantRandom`/`MeasureDormantRandom`, `RecordClassical`/`MeasureClassical`, `RotateActivePauli`/`RotationNeutral`).

- Every `tests/fixtures/*.stim` fixture (8 files), each checked on raw traced HIR, peephole-only HIR, and the production pipeline (`PeepholeFusionPass` then `StatevectorSqueezePass`) -- 24 checks total, all matched exactly with no skips needed (raw/peephole-only HIR never actually hit the planner's dense-width limit on these fixtures, though the test tolerates it gracefully if it ever does for a non-mandatory fixture).
- 400 seeded (`std::mt19937`, fixed seed) random Stim circuits of 4-12 qubits over H, S, CNOT, T, T_DAG, R_Z, M, MX, MR, R, DEPOLARIZE1, X_ERROR, and DETECTOR, each checked on all three HIR variants.
- All four `InstrumentMode` branches (Classical, Activate, Active, DormantTrap), built via `tests/instrument_test_helpers.h`, checked against both the mode and the width transition.
- Hand-verified `DormantSubspace` unit tests: the two-qubit sequences from the spec (R_XX, R_ZY, M_YY, M_YI -> widths 0,1,2,1,0; R_ZY, M_YY, R_XX, M_YI -> widths 0,1,1,1,0), plus a lone-generator and a product-of-generators membership/inertness check.

## Test commands run

- `cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -G Ninja && cmake --build build-debug -j$(nproc)` -- clean build, no warnings from the new files.
- `ctest --test-dir build-debug --output-on-failure -j$(nproc)` -- 936/936 tests passed.
- `./build-debug/tests/clifft_tests "[active_width]"` -- 12332 assertions in 6 test cases, all passed.
- `just build-wasm` (emscripten/emsdk:3.1.74 Docker image) -- links successfully with `active_width_analysis.cc` registered in `src/wasm/CMakeLists.txt`.
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure` -- all hooks passed.

## Scope note

The parent issue's PR 1 description also mentions "Python exposure for tooling." This PR does not add Python bindings -- it is scoped to the C++ analysis and its differential tests only, per the deliverables given for this PR. Flagging in case that scope was meant to be included here rather than deferred.