### PR TITLE
feat(planner): resolve noise signs from logical positions

### DIFF
--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -460,6 +460,33 @@ struct HirModule {
     /// invalidated the map for that op.
     std::vector<std::vector<uint32_t>> source_map;
 
+    // Every NOISE channel is presampled: its symbol's value exists before
+    // the action stream, not at the schedule position where the planner
+    // happens to consume it. That is what lets an operation cross a NOISE
+    // op at all -- the crossing only changes which presampled symbols the
+    // planner must fold into the operation's sign, not when noise is
+    // sampled. logical_noise_prefix[i], when non-empty, is the number of
+    // NOISE ops that logically precede ops[i] in the original circuit, and
+    // the planner resolves ops[i]'s noise-dependent sign from that count
+    // instead of from ops[i]'s position among the NOISE ops before it in
+    // `ops`. Noise sites themselves never move, so a logical position is
+    // always expressible as a plain site count.
+    //
+    // Empty means schedule semantics: every operation's logical position
+    // equals its schedule position, i.e. today's behavior with nothing
+    // reordered across noise.
+    //
+    // Contract for passes, mirroring source_map: an entry travels with its
+    // operation, and a pass that deletes an operation drops its entry. A
+    // pass that removes NOISE ops must clear the vector entirely, because
+    // once the sites are gone there is nothing left for a stale entry to
+    // correct for. A pass that absorbs a virtual Clifford gate into later
+    // operation and noise-site masks must not run while an entry disagrees
+    // with its schedule position, because the correction it implies
+    // compares an operation's mask against noise-site masks that the frame
+    // change may have moved into a different basis.
+    std::vector<uint32_t> logical_noise_prefix;
+
     std::optional<Tableau> final_tableau;
 
     // Hidden measurement slot trace() assigned to the requested node's
@@ -480,6 +507,31 @@ struct HirModule {
             }
         }
         return true;
+    }
+
+    /// True when logical_noise_prefix is materialized and parallel to ops.
+    /// An empty ops list is never considered materialized, since an empty
+    /// vector cannot then be distinguished from the schedule-semantics
+    /// sentinel.
+    [[nodiscard]] bool has_logical_noise_prefix() const {
+        return !ops.empty() && logical_noise_prefix.size() == ops.size();
+    }
+
+    /// Fills logical_noise_prefix with each operation's schedule-order
+    /// noise count, making today's implicit schedule semantics explicit.
+    /// A no-op when the vector is already non-empty.
+    void materialize_logical_noise_prefix() {
+        if (!logical_noise_prefix.empty()) {
+            return;
+        }
+        logical_noise_prefix.reserve(ops.size());
+        uint32_t schedule_count = 0;
+        for (const HeisenbergOp& op : ops) {
+            logical_noise_prefix.push_back(schedule_count);
+            if (op.op_type() == OpType::NOISE) {
+                ++schedule_count;
+            }
+        }
     }
 
     // --- Mask accessors ---

--- a/src/clifft/optimizer/commutation.h
+++ b/src/clifft/optimizer/commutation.h
@@ -2,23 +2,12 @@
 
 #include "clifft/frontend/hir.h"
 #include "clifft/util/mask_view.h"
+#include "clifft/util/symplectic.h"
 
 #include <cassert>
 #include <cstdint>
 
 namespace clifft {
-
-/// Symplectic inner product over runtime-width mask views. Returns true if
-/// the two Pauli strings anti-commute. All four views must share num_words().
-inline bool anti_commute(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
-    assert(x1.num_words() == z1.num_words() && z1.num_words() == x2.num_words() &&
-           x2.num_words() == z2.num_words());
-    int parity = 0;
-    for (uint32_t i = 0; i < x1.num_words(); ++i) {
-        parity += std::popcount((x1.words[i] & z2.words[i]) ^ (z1.words[i] & x2.words[i]));
-    }
-    return (parity & 1) != 0;
-}
 
 /// Returns true if the two HIR operations can be safely swapped in the
 /// ops vector without changing program semantics or PRNG trajectory.

--- a/src/clifft/optimizer/drop_non_unitary_pass.cc
+++ b/src/clifft/optimizer/drop_non_unitary_pass.cc
@@ -50,6 +50,9 @@ void DropNonUnitaryPass::run(HirModule& hir) {
     hir.detector_targets.clear();
     hir.observable_targets.clear();
     hir.noise_channel_masks = PauliMaskArena{};
+    // With every noise site gone there is nothing left for a logical
+    // position to correct for.
+    hir.logical_noise_prefix.clear();
 
     hir.num_measurements = 0;
     hir.num_hidden_measurements = 0;

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -344,11 +344,46 @@ size_t eliminate_terminal_measurement_phases(HirModule& hir, std::vector<uint8_t
 
 }  // namespace
 
+namespace {
+
+// True when every operation's logical_noise_prefix entry equals its
+// schedule position, i.e. nothing has yet been reordered across a noise
+// site. An empty vector (schedule semantics) trivially satisfies this.
+bool logical_noise_prefix_is_consistent(const HirModule& hir) {
+    if (!hir.has_logical_noise_prefix()) {
+        return true;
+    }
+    uint32_t schedule_count = 0;
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        if (hir.logical_noise_prefix[i] != schedule_count) {
+            return false;
+        }
+        if (hir.ops[i].op_type() == OpType::NOISE) {
+            ++schedule_count;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
 void PeepholeFusionPass::run(HirModule& hir) {
     cancellations_ = 0;
     fusions_ = 0;
 
+    // Virtual S and Pauli absorption below conjugates every later operation
+    // and noise-site mask in schedule order. The planner's logical-noise
+    // correction compares an operation's mask against noise-site masks that
+    // may then sit in a different Clifford frame than the one they were
+    // recorded against, unless every mask is still at its schedule
+    // position. Bail out rather than risk that mismatch; fusion on an
+    // already-consistent vector proceeds exactly as before.
+    if (!logical_noise_prefix_is_consistent(hir)) {
+        return;
+    }
+
     bool has_source_map = hir.source_map.size() == hir.ops.size();
+    bool has_lnp = hir.has_logical_noise_prefix();
 
     bool changed = true;
     while (changed) {
@@ -571,6 +606,9 @@ void PeepholeFusionPass::run(HirModule& hir) {
                         if (has_source_map) {
                             hir.source_map[write] = std::move(hir.source_map[read]);
                         }
+                        if (has_lnp) {
+                            hir.logical_noise_prefix[write] = hir.logical_noise_prefix[read];
+                        }
                     }
                     ++write;
                 }
@@ -578,6 +616,9 @@ void PeepholeFusionPass::run(HirModule& hir) {
             hir.ops.erase(hir.ops.begin() + static_cast<ptrdiff_t>(write), hir.ops.end());
             if (has_source_map) {
                 hir.source_map.resize(write);
+            }
+            if (has_lnp) {
+                hir.logical_noise_prefix.resize(write);
             }
         }
     }

--- a/src/clifft/optimizer/remove_noise_pass.cc
+++ b/src/clifft/optimizer/remove_noise_pass.cc
@@ -31,6 +31,9 @@ void RemoveNoisePass::run(HirModule& hir) {
     // be dropped without dropping the arena itself. Replace with an empty
     // arena so the slots don't sit around as dead weight after removal.
     hir.noise_channel_masks = PauliMaskArena{};
+    // With every noise site gone there is nothing left for a logical
+    // position to correct for.
+    hir.logical_noise_prefix.clear();
 }
 
 }  // namespace clifft

--- a/src/clifft/optimizer/statevector_squeeze_pass.cc
+++ b/src/clifft/optimizer/statevector_squeeze_pass.cc
@@ -32,6 +32,7 @@ bool can_bypass_to(const HirModule& hir, size_t moving, size_t target) {
 
 void StatevectorSqueezePass::run(HirModule& hir) {
     bool has_sm = hir.source_map.size() == hir.ops.size();
+    bool has_lnp = hir.has_logical_noise_prefix();
 
     // EXP_VAL acts as a hard barrier via can_swap(), so neither sweep
     // will move operations across an expectation value probe.
@@ -46,6 +47,9 @@ void StatevectorSqueezePass::run(HirModule& hir) {
             std::swap(hir.ops[curr - 1], hir.ops[curr]);
             if (has_sm) {
                 std::swap(hir.source_map[curr - 1], hir.source_map[curr]);
+            }
+            if (has_lnp) {
+                std::swap(hir.logical_noise_prefix[curr - 1], hir.logical_noise_prefix[curr]);
             }
             --curr;
         }
@@ -90,6 +94,14 @@ void StatevectorSqueezePass::run(HirModule& hir) {
                                 hir.source_map.begin() + static_cast<std::ptrdiff_t>(curr + 1),
                                 hir.source_map.begin() + static_cast<std::ptrdiff_t>(target + 1));
                         }
+                        if (has_lnp) {
+                            std::rotate(hir.logical_noise_prefix.begin() +
+                                            static_cast<std::ptrdiff_t>(curr),
+                                        hir.logical_noise_prefix.begin() +
+                                            static_cast<std::ptrdiff_t>(curr + 1),
+                                        hir.logical_noise_prefix.begin() +
+                                            static_cast<std::ptrdiff_t>(target + 1));
+                        }
                         --*target_it;
                         curr = target;
                         continue;
@@ -101,6 +113,10 @@ void StatevectorSqueezePass::run(HirModule& hir) {
                     std::swap(hir.ops[curr], hir.ops[curr + 1]);
                     if (has_sm) {
                         std::swap(hir.source_map[curr], hir.source_map[curr + 1]);
+                    }
+                    if (has_lnp) {
+                        std::swap(hir.logical_noise_prefix[curr],
+                                  hir.logical_noise_prefix[curr + 1]);
                     }
                     auto crossed =
                         std::upper_bound(non_expansions.begin(), non_expansions.end(), curr);

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -109,7 +109,12 @@ ResolvedPauli resolve_pauli(const Pauli& initial_body, const AffineBool& initial
     Pauli body = coordinates.to_current(initial_body);
     sign ^= body.sign();
     body.set_sign(false);
-    sign ^= logical_noise_correction(hir, initial_body, noise_site_symbol_base, crossing);
+    // Schedule and logical positions agree unless a materialized
+    // logical_noise_prefix moved this operation across a noise site; skip
+    // building and XORing in a correction that would resolve to nothing.
+    if (crossing.schedule_count != crossing.logical_prefix) {
+        sign ^= logical_noise_correction(hir, initial_body, noise_site_symbol_base, crossing);
+    }
     return ResolvedPauli{std::move(body), std::move(sign)};
 }
 
@@ -235,7 +240,10 @@ struct PlanningRequirements {
     // site's own nonzero channels, i.e. the value plan.symbols.size() will
     // have when the main loop's NOISE case starts pushing that site's
     // symbols. Indexed by NoiseSiteIdx; sized to hir.noise_sites.size() even
-    // though only sites actually reached by a NOISE op are meaningful.
+    // though only sites actually reached by a NOISE op are meaningful. Left
+    // empty when HIR has no materialized logical_noise_prefix, since no
+    // operation can then cross a noise site and nothing needs a base to
+    // correct from.
     std::vector<uint32_t> noise_site_symbol_base;
 };
 
@@ -260,7 +268,12 @@ bool operation_supports_final_state_queries(OpType type) {
 
 PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
     PlanningRequirements result;
-    result.noise_site_symbol_base.assign(hir.noise_sites.size(), 0);
+    // Only a materialized logical_noise_prefix can move an operation across
+    // a noise site, so only that case needs a base to correct from.
+    const bool track_noise_site_symbol_base = hir.has_logical_noise_prefix();
+    if (track_noise_site_symbol_base) {
+        result.noise_site_symbol_base.assign(hir.noise_sites.size(), 0);
+    }
     auto add = [&](size_t amount) {
         if (amount > std::numeric_limits<uint32_t>::max() - result.symbol_count) {
             throw std::length_error("sampling planner symbol count exceeds uint32 range");
@@ -282,7 +295,9 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
                 if (site_index >= hir.noise_sites.size()) {
                     throw std::invalid_argument("sampling planner noise site is out of range");
                 }
-                result.noise_site_symbol_base[site_index] = result.symbol_count;
+                if (track_noise_site_symbol_base) {
+                    result.noise_site_symbol_base[site_index] = result.symbol_count;
+                }
                 const NoiseSite& site = hir.noise_sites[site_index];
                 add(std::ranges::count_if(site.channels, [](const NoiseChannel& channel) {
                     return channel.prob != 0.0;
@@ -661,7 +676,11 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                 }
                 ++next_noise_site;
                 const NoiseSite& hir_site = hir.noise_sites[site_index];
-                assert(plan.symbols.size() == requirements.noise_site_symbol_base[site_index] &&
+                // The base is only populated when HIR has a materialized
+                // logical_noise_prefix; skip the check rather than index an
+                // empty vector when it was left untracked.
+                assert((!hir.has_logical_noise_prefix() ||
+                        plan.symbols.size() == requirements.noise_site_symbol_base[site_index]) &&
                        "sampling planner symbol prepass disagrees with the schedule-order "
                        "allocation it precomputed for this noise site");
                 PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -3,9 +3,9 @@
 #include "clifft/sampling/planner_frame.h"
 #include "clifft/util/hir_introspection.h"
 #include "clifft/util/numeric.h"
+#include "clifft/util/symplectic.h"
 
 #include <algorithm>
-#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -24,18 +24,6 @@ using Pauli = internal::PlannerPauli;
 using Tableau = internal::PlannerTableau;
 using internal::CoordinateFrame;
 using internal::SymbolicPauliFrame;
-
-// Symplectic inner product over runtime-width mask views: true when the two
-// Pauli strings anti-commute. optimizer/commutation.h has the same helper,
-// but sampling/ has no other dependency on optimizer/, so this stays a
-// local copy rather than introducing one.
-bool anti_commute(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
-    int parity = 0;
-    for (uint32_t i = 0; i < x1.num_words(); ++i) {
-        parity += std::popcount((x1.words[i] & z2.words[i]) ^ (z1.words[i] & x2.words[i]));
-    }
-    return (parity & 1) != 0;
-}
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -5,6 +5,7 @@
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -23,6 +24,18 @@ using Pauli = internal::PlannerPauli;
 using Tableau = internal::PlannerTableau;
 using internal::CoordinateFrame;
 using internal::SymbolicPauliFrame;
+
+// Symplectic inner product over runtime-width mask views: true when the two
+// Pauli strings anti-commute. optimizer/commutation.h has the same helper,
+// but sampling/ has no other dependency on optimizer/, so this stays a
+// local copy rather than introducing one.
+bool anti_commute(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
+    int parity = 0;
+    for (uint32_t i = 0; i < x1.num_words(); ++i) {
+        parity += std::popcount((x1.words[i] & z2.words[i]) ^ (z1.words[i] & x2.words[i]));
+    }
+    return (parity & 1) != 0;
+}
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
@@ -55,13 +68,60 @@ struct ResolvedPauli {
     AffineBool sign;
 };
 
+// An operation's schedule position and logical position, both expressed as
+// noise-site counts: how many NOISE ops the planner has processed in
+// schedule order when it reaches the operation (schedule_count) versus how
+// many logically precede the operation in the original circuit
+// (logical_prefix). The two agree unless HirModule::logical_noise_prefix
+// moved the operation across a noise site.
+struct NoiseCrossing {
+    uint32_t schedule_count = 0;
+    uint32_t logical_prefix = 0;
+};
+
+// The affine correction an operation picks up for every site it logically
+// crossed. The symbolic frame already folded each site's channels in at
+// that site's schedule position. For a site between an operation's schedule
+// and logical positions, that frame contribution is exactly wrong for the
+// operation's logical position: either missing (the operation moved earlier
+// than the site) or spurious (it moved later than the site). XORing the
+// same site's channel symbols back in fixes both directions, since XOR is
+// its own inverse.
+AffineBool logical_noise_correction(const HirModule& hir, const Pauli& initial_body,
+                                    std::span<const uint32_t> noise_site_symbol_base,
+                                    NoiseCrossing crossing) {
+    AffineBool correction;
+    const uint32_t begin = std::min(crossing.schedule_count, crossing.logical_prefix);
+    const uint32_t end = std::max(crossing.schedule_count, crossing.logical_prefix);
+    for (uint32_t site = begin; site < end; ++site) {
+        const NoiseSite& noise_site = hir.noise_sites[site];
+        uint32_t local_index = 0;
+        for (const NoiseChannel& channel : noise_site.channels) {
+            if (channel.prob == 0.0) {
+                continue;
+            }
+            const PauliMaskView channel_view = hir.noise_channel_masks.at(channel.mask);
+            if (anti_commute(initial_body.x(), initial_body.z(), channel_view.x(),
+                             channel_view.z())) {
+                correction ^=
+                    AffineBool::symbol(SymbolId{noise_site_symbol_base[site] + local_index});
+            }
+            ++local_index;
+        }
+    }
+    return correction;
+}
+
 ResolvedPauli resolve_pauli(const Pauli& initial_body, const AffineBool& initial_sign,
-                            CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame) {
+                            CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame,
+                            const HirModule& hir, std::span<const uint32_t> noise_site_symbol_base,
+                            NoiseCrossing crossing) {
     AffineBool sign = initial_sign;
     sign ^= symbolic_frame.sign_for(initial_body);
     Pauli body = coordinates.to_current(initial_body);
     sign ^= body.sign();
     body.set_sign(false);
+    sign ^= logical_noise_correction(hir, initial_body, noise_site_symbol_base, crossing);
     return ResolvedPauli{std::move(body), std::move(sign)};
 }
 
@@ -183,6 +243,12 @@ struct PendingObservable {
 struct PlanningRequirements {
     uint32_t symbol_count = 0;
     bool supports_final_state_queries = true;
+    // noise_site_symbol_base[site] is the symbol count reserved before that
+    // site's own nonzero channels, i.e. the value plan.symbols.size() will
+    // have when the main loop's NOISE case starts pushing that site's
+    // symbols. Indexed by NoiseSiteIdx; sized to hir.noise_sites.size() even
+    // though only sites actually reached by a NOISE op are meaningful.
+    std::vector<uint32_t> noise_site_symbol_base;
 };
 
 bool operation_supports_final_state_queries(OpType type) {
@@ -206,6 +272,7 @@ bool operation_supports_final_state_queries(OpType type) {
 
 PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
     PlanningRequirements result;
+    result.noise_site_symbol_base.assign(hir.noise_sites.size(), 0);
     auto add = [&](size_t amount) {
         if (amount > std::numeric_limits<uint32_t>::max() - result.symbol_count) {
             throw std::length_error("sampling planner symbol count exceeds uint32 range");
@@ -227,6 +294,7 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
                 if (site_index >= hir.noise_sites.size()) {
                     throw std::invalid_argument("sampling planner noise site is out of range");
                 }
+                result.noise_site_symbol_base[site_index] = result.symbol_count;
                 const NoiseSite& site = hir.noise_sites[site_index];
                 add(std::ranges::count_if(site.channels, [](const NoiseChannel& channel) {
                     return channel.prob != 0.0;
@@ -248,6 +316,44 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
         }
     }
     return result;
+}
+
+// Validates logical_noise_prefix before any symbol is reserved. NOISE sites
+// are always processed in circuit order (checked separately, below), so
+// their logical position is always their schedule position; the same holds
+// for every other operation that is not a T_GATE, PHASE_ROTATION, or
+// MEASURE, since the optimizer never moves those across a noise site. Only
+// those three op types may legitimately disagree with their schedule count.
+void validate_logical_noise_prefix(const HirModule& hir) {
+    if (hir.logical_noise_prefix.empty()) {
+        return;
+    }
+    if (hir.logical_noise_prefix.size() != hir.ops.size()) {
+        throw std::invalid_argument(
+            "sampling planner logical noise prefix size does not match the operation count");
+    }
+    const auto num_noise_sites = static_cast<uint32_t>(hir.noise_sites.size());
+    uint32_t schedule_count = 0;
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        const HeisenbergOp& op = hir.ops[i];
+        const uint32_t entry = hir.logical_noise_prefix[i];
+        if (entry > num_noise_sites) {
+            throw std::invalid_argument("sampling planner logical noise prefix at operation " +
+                                        std::to_string(i) + " exceeds the noise site count");
+        }
+        const OpType type = op.op_type();
+        const bool may_cross_noise =
+            type == OpType::T_GATE || type == OpType::PHASE_ROTATION || type == OpType::MEASURE;
+        if (!may_cross_noise && entry != schedule_count) {
+            throw std::invalid_argument(
+                "sampling planner logical noise prefix at operation " + std::to_string(i) +
+                " must equal its schedule position for an operation that cannot move across "
+                "noise");
+        }
+        if (type == OpType::NOISE) {
+            ++schedule_count;
+        }
+    }
 }
 
 void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
@@ -273,8 +379,11 @@ void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
 
 bool process_rotation(const Pauli& body, double half_turns, const AffineBool& sign,
                       SamplingPlan& plan, uint32_t& active_width, CoordinateFrame& coordinates,
-                      SymbolicPauliFrame& symbolic_frame, std::span<const uint32_t> source_lines) {
-    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame);
+                      SymbolicPauliFrame& symbolic_frame, const HirModule& hir,
+                      std::span<const uint32_t> noise_site_symbol_base, NoiseCrossing crossing,
+                      std::span<const uint32_t> source_lines) {
+    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame, hir,
+                                           noise_site_symbol_base, crossing);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (!dormant_pivot.has_value()) {
         const ActivePauli active = active_projection(resolved.body, active_width);
@@ -308,8 +417,11 @@ bool process_rotation(const Pauli& body, double half_turns, const AffineBool& si
 AffineBool process_measurement(const Pauli& body, const AffineBool& sign, RecordSlot record,
                                SymbolId branch, SamplingPlan& plan, uint32_t& active_width,
                                CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame,
-                               std::span<const uint32_t> source_lines) {
-    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame);
+                               const HirModule& hir,
+                               std::span<const uint32_t> noise_site_symbol_base,
+                               NoiseCrossing crossing, std::span<const uint32_t> source_lines) {
+    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame, hir,
+                                           noise_site_symbol_base, crossing);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (dormant_pivot.has_value()) {
         coordinates.measure_dormant(resolved.body, *dormant_pivot);
@@ -363,6 +475,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
 }
 
 void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t next_noise_site,
+                        uint32_t logical_prefix, std::span<const uint32_t> noise_site_symbol_base,
                         SamplingPlan& plan, uint32_t& active_width, CoordinateFrame& coordinates,
                         SymbolicPauliFrame& symbolic_frame,
                         std::span<const uint32_t> source_lines) {
@@ -374,7 +487,8 @@ void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t n
     const Pauli destination_flip = pauli_from_mask(hir, hir_site.destination_flip_mask);
     const InstrumentDistribution& distribution = plan.instrument_distributions.at(index(site));
     ResolvedPauli resolved =
-        resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame);
+        resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame, hir,
+                      noise_site_symbol_base, NoiseCrossing{next_noise_site, logical_prefix});
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
 
     InstrumentMode mode = InstrumentMode::Classical;
@@ -436,6 +550,8 @@ void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t n
 }  // namespace
 
 SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
+    validate_logical_noise_prefix(hir);
+
     SamplingPlan plan;
     plan.num_qubits = hir.num_qubits;
     plan.num_visible_records = hir.num_measurements;
@@ -456,6 +572,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     // The packed symbolic frame needs its row count up front. Count only;
     // operations and their Paulis are consumed directly from HIR below.
     const PlanningRequirements requirements = inspect_planning_requirements(hir);
+    const std::span<const uint32_t> noise_site_symbol_base(requirements.noise_site_symbol_base);
     plan.symbols.reserve(requirements.symbol_count);
     initialize_site_metadata(hir, plan);
     if (requirements.supports_final_state_queries) {
@@ -506,30 +623,36 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
         const HeisenbergOp& op = hir.ops[i];
         const std::span<const uint32_t> source_lines =
             plan.source_map.has_value() ? source_lines_for(hir, i) : std::span<const uint32_t>{};
+        // Absent when the vector is not materialized: every operation's
+        // logical position is then its schedule position, which keeps the
+        // logical_noise_correction interval empty and the plan unchanged.
+        const uint32_t logical_prefix =
+            hir.has_logical_noise_prefix() ? hir.logical_noise_prefix[i] : next_noise_site;
+        const NoiseCrossing crossing{next_noise_site, logical_prefix};
         supports_final_state_queries &= operation_supports_final_state_queries(op.op_type());
         switch (op.op_type()) {
             case OpType::T_GATE: {
                 const double half_turns = op.is_dagger() ? -0.25 : 0.25;
                 const Pauli body = pauli_from_hir(hir, op);
-                final_coordinates_changed |=
-                    process_rotation(body, half_turns, AffineBool(hir.sign(op)), plan, active_width,
-                                     coordinates, symbolic_frame, source_lines);
+                final_coordinates_changed |= process_rotation(
+                    body, half_turns, AffineBool(hir.sign(op)), plan, active_width, coordinates,
+                    symbolic_frame, hir, noise_site_symbol_base, crossing, source_lines);
                 break;
             }
             case OpType::PHASE_ROTATION: {
                 const Pauli body = pauli_from_hir(hir, op);
-                final_coordinates_changed |=
-                    process_rotation(body, op.alpha(), AffineBool(hir.sign(op)), plan, active_width,
-                                     coordinates, symbolic_frame, source_lines);
+                final_coordinates_changed |= process_rotation(
+                    body, op.alpha(), AffineBool(hir.sign(op)), plan, active_width, coordinates,
+                    symbolic_frame, hir, noise_site_symbol_base, crossing, source_lines);
                 break;
             }
             case OpType::MEASURE: {
                 const RecordSlot record{static_cast<uint32_t>(op.meas_record_idx())};
                 const SymbolId branch = reserve_symbol(plan);
                 const Pauli body = pauli_from_hir(hir, op);
-                const AffineBool outcome =
-                    process_measurement(body, AffineBool(hir.sign(op)), record, branch, plan,
-                                        active_width, coordinates, symbolic_frame, source_lines);
+                const AffineBool outcome = process_measurement(
+                    body, AffineBool(hir.sign(op)), record, branch, plan, active_width, coordinates,
+                    symbolic_frame, hir, noise_site_symbol_base, crossing, source_lines);
                 assign_record(record, outcome, i);
                 break;
             }
@@ -550,6 +673,9 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                 }
                 ++next_noise_site;
                 const NoiseSite& hir_site = hir.noise_sites[site_index];
+                assert(plan.symbols.size() == requirements.noise_site_symbol_base[site_index] &&
+                       "sampling planner symbol prepass disagrees with the schedule-order "
+                       "allocation it precomputed for this noise site");
                 PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];
                 plan_site.outcomes.reserve(hir_site.channels.size());
                 for (const NoiseChannel& channel : hir_site.channels) {
@@ -600,8 +726,8 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     throw std::invalid_argument(
                         "sampling planner instrument omits its destination flip");
                 }
-                process_instrument(hir, op, next_noise_site, plan, active_width, coordinates,
-                                   symbolic_frame, source_lines);
+                process_instrument(hir, op, next_noise_site, logical_prefix, noise_site_symbol_base,
+                                   plan, active_width, coordinates, symbolic_frame, source_lines);
                 ++next_instrument_site;
                 break;
             }
@@ -652,7 +778,8 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                 }
                 const Pauli body = pauli_from_hir(hir, op);
                 ResolvedPauli resolved =
-                    resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame);
+                    resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame, hir,
+                                  noise_site_symbol_base, crossing);
                 const bool is_zero = first_x_at_or_above(resolved.body, active_width).has_value();
                 append_action(
                     plan,

--- a/src/clifft/util/symplectic.h
+++ b/src/clifft/util/symplectic.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Symplectic inner product over runtime-width mask views, needed by both
+// optimizer/ (commutation analysis) and sampling/ (the planner's
+// logical-noise-crossing sign correction) without either depending on the
+// other.
+
+#include "clifft/util/mask_view.h"
+
+#include <bit>
+#include <cassert>
+#include <cstdint>
+
+namespace clifft {
+
+// Returns true if the two Pauli strings anti-commute. All four views must
+// share num_words().
+inline bool anti_commute(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
+    assert(x1.num_words() == z1.num_words() && z1.num_words() == x2.num_words() &&
+           x2.num_words() == z2.num_words());
+    int parity = 0;
+    for (uint32_t i = 0; i < x1.num_words(); ++i) {
+        parity += std::popcount((x1.words[i] & z2.words[i]) ^ (z1.words[i] & x2.words[i]));
+    }
+    return (parity & 1) != 0;
+}
+
+}  // namespace clifft

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(clifft_tests
     test_interleaved_batch_kernels.cc
     test_optimizer.cc
     test_source_map.cc
+    test_logical_noise_prefix.cc
     test_importance_sampling.cc
     test_runtime_isa.cc
     test_shot_parallel.cc

--- a/tests/test_logical_noise_prefix.cc
+++ b/tests/test_logical_noise_prefix.cc
@@ -225,15 +225,18 @@ HirModule run_production_pipeline(const HirModule& source) {
 // Materializing logical_noise_prefix must never change what plan_sampling
 // produces: an empty vector and a freshly materialized one both describe
 // schedule semantics, just with the counts spelled out explicitly. A HIR
-// that the planner cannot plan at all (legitimately, e.g. a raw or
-// peephole-only wide circuit that has not been through the squeeze pass
-// yet) is skipped rather than failed, matching the active-width analysis
-// tests' precedent for the same class of fixture.
+// that the planner cannot plan at all because it exceeds the dense-state
+// active-width limit (legitimately, e.g. a raw or peephole-only wide
+// circuit that has not been through the squeeze pass yet) is skipped
+// rather than failed, matching the active-width analysis tests' precedent
+// for the same class of fixture. Any other exception -- including the
+// planner's own logical_noise_prefix validation -- is a bug and must
+// propagate to fail the test rather than being treated as an expected skip.
 void check_inert_if_plannable(const HirModule& hir) {
     SamplingPlan schedule_plan;
     try {
         schedule_plan = clifft::sampling::plan_sampling(hir);
-    } catch (const std::exception&) {
+    } catch (const std::overflow_error&) {
         return;
     }
     HirModule materialized = hir;

--- a/tests/test_logical_noise_prefix.cc
+++ b/tests/test_logical_noise_prefix.cc
@@ -9,7 +9,6 @@
 #include "clifft/optimizer/commutation.h"
 #include "clifft/optimizer/drop_non_unitary_pass.h"
 #include "clifft/optimizer/hir_pass_manager.h"
-#include "clifft/optimizer/pass_factory.h"
 #include "clifft/optimizer/peephole.h"
 #include "clifft/optimizer/remove_noise_pass.h"
 #include "clifft/optimizer/statevector_squeeze_pass.h"
@@ -194,8 +193,13 @@ std::vector<std::string> realize_noise(const GeneratedCircuit& circuit, std::mt1
 }
 
 // ---------------------------------------------------------------------------
-// Pipeline helpers, mirroring tests/test_active_width_analysis.cc
+// Pipeline helpers
 // ---------------------------------------------------------------------------
+
+// Built from named passes rather than default_hir_pass_manager(), so this
+// suite's runtime and behavior track only the passes it actually exercises
+// -- what this file's tests are about -- and not whatever else the default
+// pipeline happens to grow.
 
 HirModule run_peephole_only(const HirModule& source) {
     HirModule hir = source;
@@ -207,7 +211,10 @@ HirModule run_peephole_only(const HirModule& source) {
 
 HirModule run_production_pipeline(const HirModule& source) {
     HirModule hir = source;
-    clifft::default_hir_pass_manager().run(hir);
+    HirPassManager passes;
+    passes.add_pass(std::make_unique<PeepholeFusionPass>());
+    passes.add_pass(std::make_unique<StatevectorSqueezePass>());
+    passes.run(hir);
     return hir;
 }
 

--- a/tests/test_logical_noise_prefix.cc
+++ b/tests/test_logical_noise_prefix.cc
@@ -16,6 +16,7 @@
 #include "clifft/sampling/plan.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
+#include "clifft/util/symplectic.h"
 
 #include "test_helpers.h"
 
@@ -190,6 +191,78 @@ std::vector<std::string> realize_noise(const GeneratedCircuit& circuit, std::mt1
         realized.push_back(replacement[i].empty() ? circuit.lines[i] : replacement[i]);
     }
     return realized;
+}
+
+// Same movable-gate mix as generate_noisy_circuit, plus DEPOLARIZE2 on a
+// random pair and a PAULI_CHANNEL_1 whose P(Y) argument is always exactly
+// zero, so that channel is structurally absent rather than merely
+// improbable. Used only for sampling-equivalence: unlike
+// generate_noisy_circuit, it has no realize_noise counterpart.
+std::string generate_multi_channel_noisy_source(std::mt19937& rng, uint32_t num_qubits,
+                                                uint32_t num_ops) {
+    static const double kAngles[] = {0.125, 0.25, 0.375, 0.625, 0.75, 0.875};
+    static const double kNoiseProbs[] = {0.05, 0.1, 0.2, 0.3};
+
+    std::vector<std::string> lines;
+    uint32_t measurement_count = 0;
+    for (uint32_t op = 0; op < num_ops; ++op) {
+        const uint32_t q = rng() % num_qubits;
+        switch (rng() % 11) {
+            case 0:
+                lines.push_back("T " + std::to_string(q));
+                break;
+            case 1:
+                lines.push_back("T_DAG " + std::to_string(q));
+                break;
+            case 2:
+                lines.push_back("R_Z(" + std::to_string(kAngles[rng() % std::size(kAngles)]) +
+                                ") " + std::to_string(q));
+                break;
+            case 3:
+                lines.push_back("M " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 4:
+                lines.push_back("MX " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 5:
+                lines.push_back("MR " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 6:
+                lines.push_back("R " + std::to_string(q));
+                break;
+            case 7: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                lines.push_back("DEPOLARIZE1(" + std::to_string(prob) + ") " + std::to_string(q));
+                break;
+            }
+            case 8: {
+                // A second target distinct from q, so DEPOLARIZE2 always
+                // gets two real qubits even at the smallest generated width.
+                const uint32_t q2 = (q + 1 + rng() % (num_qubits - 1)) % num_qubits;
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                lines.push_back("DEPOLARIZE2(" + std::to_string(prob) + ") " + std::to_string(q) +
+                                " " + std::to_string(q2));
+                break;
+            }
+            case 9: {
+                const double px = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                const double pz = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                lines.push_back("PAULI_CHANNEL_1(" + std::to_string(px) + ", 0, " +
+                                std::to_string(pz) + ") " + std::to_string(q));
+                break;
+            }
+            default:
+                break;
+        }
+        if (measurement_count > 0 && (rng() % 5) == 0) {
+            const uint32_t back = 1 + (rng() % measurement_count);
+            lines.push_back("DETECTOR rec[-" + std::to_string(back) + "]");
+        }
+    }
+    return join_lines(lines);
 }
 
 // ---------------------------------------------------------------------------
@@ -419,6 +492,121 @@ TEST_CASE("Logical noise prefix folds in exactly the anticommuting DEPOLARIZE1 c
     REQUIRE(action_as<RecordClassical>(naive_plan, 0).outcome == AffineBool(false));
 }
 
+TEST_CASE(
+    "Logical noise prefix folds in exactly the anticommuting DEPOLARIZE2 channels for a "
+    "moved rotation",
+    "[logical_noise_prefix]") {
+    const HirModule original =
+        clifft::trace(clifft::parse("H 0\nH 1\nDEPOLARIZE2(0.2) 0 1\nT 0\nM 0\nM 1\n"));
+    REQUIRE(original.ops.size() == 4);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[1].op_type() == OpType::T_GATE);
+    REQUIRE(original.ops[2].op_type() == OpType::MEASURE);
+    REQUIRE(original.ops[3].op_type() == OpType::MEASURE);
+    REQUIRE(original.noise_sites.at(0).channels.size() == 15);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    const AffineBool original_sign = action_as<PromoteDormantRotation>(original_plan, 0).sign;
+
+    // Move T before DEPOLARIZE2, keeping its logical prefix at 1: it still
+    // logically follows the noise site.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [T_GATE, NOISE, MEASURE, MEASURE]
+    reordered.logical_noise_prefix = {1, 0, 1, 1};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    const auto& reordered_outcomes = reordered_plan.presampled_noise_sites.at(0).outcomes;
+    REQUIRE(reordered_outcomes.size() == 15);
+
+    // Build the expected sign from this plan's own channel symbols. A
+    // two-qubit channel folds in exactly when its Pauli anticommutes with
+    // the rotation's initial-frame body under the full symplectic inner
+    // product, not just the component on the rotation's own qubit.
+    AffineBool expected;
+    const std::vector<NoiseChannel>& channels = reordered.noise_sites.at(0).channels;
+    const HeisenbergOp& t_op = reordered.ops[0];
+    for (size_t ch = 0; ch < channels.size(); ++ch) {
+        const PauliMaskView mask = reordered.noise_channel_masks.at(channels[ch].mask);
+        if (anti_commute(reordered.destab_mask(t_op), reordered.stab_mask(t_op), mask.x(),
+                         mask.z())) {
+            expected ^= AffineBool::symbol(reordered_outcomes[ch].symbol);
+        }
+    }
+    REQUIRE(action_as<PromoteDormantRotation>(reordered_plan, 0).sign == expected);
+
+    // T_GATE never reserves a prepass symbol, so moving it ahead of the
+    // site does not shift any channel's symbol numbering: the correction
+    // reproduces the original plan's sign expression term for term.
+    REQUIRE(action_as<PromoteDormantRotation>(reordered_plan, 0).sign == original_sign);
+
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<PromoteDormantRotation>(naive_plan, 0).sign == AffineBool(false));
+}
+
+TEST_CASE(
+    "Logical noise prefix indexes a moved measurement's correction by nonzero "
+    "PAULI_CHANNEL_1 channel",
+    "[logical_noise_prefix]") {
+    const HirModule original =
+        clifft::trace(clifft::parse("H 0\nPAULI_CHANNEL_1(0.1, 0, 0.1) 0\nMX 0\n"));
+    REQUIRE(original.ops.size() == 2);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[1].op_type() == OpType::MEASURE);
+    // The zero-probability P(Y) argument never becomes a channel: only the
+    // X and Z channels survive, so this site's outcomes are indexed by
+    // nonzero channel only, with no reserved gap where Y would have been.
+    REQUIRE(original.noise_sites.at(0).channels.size() == 2);
+
+    const HeisenbergOp& measure_op = original.ops[1];
+    const std::vector<NoiseChannel>& channels = original.noise_sites.at(0).channels;
+
+    // Build the expected record from a plan's own channel symbols, keyed by
+    // position in noise_sites(0).channels -- which the reorder below leaves
+    // untouched -- rather than by PAULI_CHANNEL_1's original 3-argument
+    // (X, Y, Z) position.
+    auto expected_outcome = [&](const SamplingPlan& plan) {
+        AffineBool expected;
+        const auto& outcomes = plan.presampled_noise_sites.at(0).outcomes;
+        REQUIRE(outcomes.size() == channels.size());
+        for (size_t ch = 0; ch < channels.size(); ++ch) {
+            const PauliMaskView mask = original.noise_channel_masks.at(channels[ch].mask);
+            if (anti_commute(original.destab_mask(measure_op), original.stab_mask(measure_op),
+                             mask.x(), mask.z())) {
+                expected ^= AffineBool::symbol(outcomes[ch].symbol);
+            }
+        }
+        return expected;
+    };
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    REQUIRE(action_as<RecordClassical>(original_plan, 0).outcome ==
+            expected_outcome(original_plan));
+
+    // Move MX before the channel, keeping its logical prefix at 1: it still
+    // logically follows the noise site.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [MEASURE, NOISE]
+    reordered.logical_noise_prefix = {1, 0};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    REQUIRE(action_as<RecordClassical>(reordered_plan, 0).outcome ==
+            expected_outcome(reordered_plan));
+
+    // The reordered plan's record expression matches the original plan's:
+    // the same channel-index selection, computed the same way, just
+    // renumbered because MX's own branch symbol is now reserved before the
+    // site's channel symbols instead of after.
+    REQUIRE(action_as<RecordClassical>(original_plan, 0).outcome.terms().size() ==
+            action_as<RecordClassical>(reordered_plan, 0).outcome.terms().size());
+
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<RecordClassical>(naive_plan, 0).outcome == AffineBool(false));
+}
+
 // ---------------------------------------------------------------------------
 // Reordering helper shared by sampling-equivalence and legality-oracle tests
 // ---------------------------------------------------------------------------
@@ -595,6 +783,33 @@ TEST_CASE("Logical noise prefix preserves the sampling distribution across noise
                                       8 * static_cast<int>(reordered.ops.size()) + 8);
 
         check_sampling_equivalent(original, reordered, kShots, 0x1234, 0x5678);
+    }
+}
+
+TEST_CASE(
+    "Logical noise prefix preserves the sampling distribution across DEPOLARIZE2 and "
+    "PAULI_CHANNEL_1 reorders",
+    "[logical_noise_prefix]") {
+    constexpr uint32_t kShots = 20000;
+    constexpr uint32_t kTrials = 10;
+    std::mt19937 circuit_rng(0xD0DE2);
+    std::mt19937 control_rng(0x51DE9A2);
+    for (uint32_t trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + (trial % 5);
+        const uint32_t num_ops = 25 + (trial % 20);
+        const std::string source =
+            generate_multi_channel_noisy_source(circuit_rng, num_qubits, num_ops);
+        CAPTURE(trial, num_qubits, num_ops, source);
+
+        const HirModule original = clifft::trace(clifft::parse(source));
+        HirModule reordered = original;
+        std::vector<size_t> original_index(reordered.ops.size());
+        std::iota(original_index.begin(), original_index.end(), 0);
+        std::mt19937 reorder_rng(control_rng());
+        randomly_reorder_across_noise(reordered, original_index, reorder_rng,
+                                      8 * static_cast<int>(reordered.ops.size()) + 8);
+
+        check_sampling_equivalent(original, reordered, kShots, control_rng(), control_rng());
     }
 }
 

--- a/tests/test_logical_noise_prefix.cc
+++ b/tests/test_logical_noise_prefix.cc
@@ -1,0 +1,815 @@
+// Tests for HirModule::logical_noise_prefix: the side vector that lets the
+// sampling planner resolve an operation's noise-dependent sign from its
+// logical (original-circuit) position instead of its schedule position, so
+// a T_GATE, PHASE_ROTATION, or MEASURE can move across a NOISE op.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/commutation.h"
+#include "clifft/optimizer/drop_non_unitary_pass.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/peephole.h"
+#include "clifft/optimizer/remove_noise_pass.h"
+#include "clifft/optimizer/statevector_squeeze_pass.h"
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/sampling/sampler.h"
+
+#include "test_helpers.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace clifft;
+using clifft::sampling::AffineBool;
+using clifft::sampling::ExecutablePlan;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::SamplingPlan;
+using clifft::sampling::SymbolId;
+
+namespace {
+
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
+template <typename T>
+const T& action_as(const SamplingPlan& plan, size_t index) {
+    return std::get<T>(plan.actions.at(index).action);
+}
+
+// ---------------------------------------------------------------------------
+// Random noisy circuit generation
+// ---------------------------------------------------------------------------
+
+// A generated circuit plus, for each NOISE line, enough information to
+// realize a fixed firing outcome for it later (the legality-oracle test).
+struct GeneratedCircuit {
+    struct NoiseLine {
+        size_t line_index = 0;
+        uint32_t qubit = 0;
+        bool is_depolarize1 = false;
+        double prob = 0.0;
+    };
+
+    std::vector<std::string> lines;
+    std::vector<NoiseLine> noise_lines;
+};
+
+double next_unit(std::mt19937& rng) {
+    return static_cast<double>(rng() >> 11) * 0x1.0p-53;
+}
+
+// Deterministic generator over a small gate set: T, T_DAG, R_Z at a few
+// angles, M, MX, MR, R, X_ERROR, DEPOLARIZE1, and DETECTORs referencing
+// earlier records. Every generated line is individually valid, so the
+// circuit as a whole always parses and traces.
+GeneratedCircuit generate_noisy_circuit(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    static const double kAngles[] = {0.125, 0.25, 0.375, 0.625, 0.75, 0.875};
+    static const double kNoiseProbs[] = {0.05, 0.1, 0.2, 0.3};
+
+    GeneratedCircuit circuit;
+    uint32_t measurement_count = 0;
+    for (uint32_t op = 0; op < num_ops; ++op) {
+        const uint32_t q = rng() % num_qubits;
+        switch (rng() % 9) {
+            case 0:
+                circuit.lines.push_back("T " + std::to_string(q));
+                break;
+            case 1:
+                circuit.lines.push_back("T_DAG " + std::to_string(q));
+                break;
+            case 2:
+                circuit.lines.push_back("R_Z(" +
+                                        std::to_string(kAngles[rng() % std::size(kAngles)]) + ") " +
+                                        std::to_string(q));
+                break;
+            case 3:
+                circuit.lines.push_back("M " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 4:
+                circuit.lines.push_back("MX " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 5:
+                circuit.lines.push_back("MR " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 6:
+                circuit.lines.push_back("R " + std::to_string(q));
+                break;
+            case 7: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                circuit.lines.push_back("X_ERROR(" + std::to_string(prob) + ") " +
+                                        std::to_string(q));
+                circuit.noise_lines.push_back(
+                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/false, prob});
+                break;
+            }
+            case 8: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                circuit.lines.push_back("DEPOLARIZE1(" + std::to_string(prob) + ") " +
+                                        std::to_string(q));
+                circuit.noise_lines.push_back(
+                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/true, prob});
+                break;
+            }
+            default:
+                break;
+        }
+        if (measurement_count > 0 && (rng() % 5) == 0) {
+            const uint32_t back = 1 + (rng() % measurement_count);
+            circuit.lines.push_back("DETECTOR rec[-" + std::to_string(back) + "]");
+        }
+    }
+    return circuit;
+}
+
+std::string join_lines(const std::vector<std::string>& lines) {
+    std::string text;
+    for (const std::string& line : lines) {
+        text += line;
+        text += '\n';
+    }
+    return text;
+}
+
+std::string generate_noisy_source(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    return join_lines(generate_noisy_circuit(rng, num_qubits, num_ops).lines);
+}
+
+// Replaces every noise line with the explicit Pauli its fixed realization
+// fired, or drops the line if it did not fire. Uses its own RNG stream so
+// the realization is reproducible but independent of any reordering draws.
+std::vector<std::string> realize_noise(const GeneratedCircuit& circuit, std::mt19937& rng) {
+    std::vector<uint8_t> drop(circuit.lines.size(), 0);
+    std::vector<std::string> replacement(circuit.lines.size());
+    for (const GeneratedCircuit::NoiseLine& noise : circuit.noise_lines) {
+        const double roll = next_unit(rng);
+        if (noise.is_depolarize1) {
+            if (roll >= noise.prob) {
+                drop[noise.line_index] = 1;
+                continue;
+            }
+            static const char* const paulis[] = {"X", "Y", "Z"};
+            replacement[noise.line_index] =
+                std::string(paulis[rng() % 3]) + " " + std::to_string(noise.qubit);
+        } else {
+            if (roll >= noise.prob) {
+                drop[noise.line_index] = 1;
+                continue;
+            }
+            replacement[noise.line_index] = "X " + std::to_string(noise.qubit);
+        }
+    }
+
+    std::vector<std::string> realized;
+    realized.reserve(circuit.lines.size());
+    for (size_t i = 0; i < circuit.lines.size(); ++i) {
+        if (drop[i]) {
+            continue;
+        }
+        realized.push_back(replacement[i].empty() ? circuit.lines[i] : replacement[i]);
+    }
+    return realized;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline helpers, mirroring tests/test_active_width_analysis.cc
+// ---------------------------------------------------------------------------
+
+HirModule run_peephole_only(const HirModule& source) {
+    HirModule hir = source;
+    HirPassManager passes;
+    passes.add_pass(std::make_unique<PeepholeFusionPass>());
+    passes.run(hir);
+    return hir;
+}
+
+HirModule run_production_pipeline(const HirModule& source) {
+    HirModule hir = source;
+    clifft::default_hir_pass_manager().run(hir);
+    return hir;
+}
+
+// ---------------------------------------------------------------------------
+// Inertness
+// ---------------------------------------------------------------------------
+
+// Materializing logical_noise_prefix must never change what plan_sampling
+// produces: an empty vector and a freshly materialized one both describe
+// schedule semantics, just with the counts spelled out explicitly. A HIR
+// that the planner cannot plan at all (legitimately, e.g. a raw or
+// peephole-only wide circuit that has not been through the squeeze pass
+// yet) is skipped rather than failed, matching the active-width analysis
+// tests' precedent for the same class of fixture.
+void check_inert_if_plannable(const HirModule& hir) {
+    SamplingPlan schedule_plan;
+    try {
+        schedule_plan = clifft::sampling::plan_sampling(hir);
+    } catch (const std::exception&) {
+        return;
+    }
+    HirModule materialized = hir;
+    materialized.materialize_logical_noise_prefix();
+    const SamplingPlan materialized_plan = clifft::sampling::plan_sampling(materialized);
+    REQUIRE(schedule_plan.inspect() == materialized_plan.inspect());
+}
+
+TEST_CASE("Logical noise prefix is inert on fixture circuits", "[logical_noise_prefix]") {
+    static const char* const fixtures[] = {
+        "coherent_d3_r3.stim",     "coherent_d5_r5.stim", "cultivation_d5.stim",
+        "surface_d7_r7_p001.stim", "qv10.stim",           "surface_d11_r11_p001.stim",
+        "surface_d5_r5_p05.stim",  "target_qec.stim",
+    };
+    for (const char* fixture : fixtures) {
+        DYNAMIC_SECTION(fixture) {
+            const Circuit circuit =
+                clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/" + fixture);
+            const HirModule raw = clifft::trace(circuit);
+            check_inert_if_plannable(raw);
+            check_inert_if_plannable(run_peephole_only(raw));
+            check_inert_if_plannable(run_production_pipeline(raw));
+        }
+    }
+}
+
+TEST_CASE("Logical noise prefix is inert on random noisy circuits", "[logical_noise_prefix]") {
+    constexpr uint32_t kSeed = 0x1e94a1;
+    constexpr int kTrials = 200;
+    std::mt19937 rng(kSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 6);
+        const uint32_t num_ops = 15 + static_cast<uint32_t>(trial % 25);
+        const std::string source = generate_noisy_source(rng, num_qubits, num_ops);
+        CAPTURE(trial, num_qubits, num_ops, source);
+
+        const HirModule raw = clifft::trace(clifft::parse(source));
+        check_inert_if_plannable(raw);
+        check_inert_if_plannable(run_peephole_only(raw));
+        check_inert_if_plannable(run_production_pipeline(raw));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exact sign correction
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Logical noise prefix corrects a measurement moved earlier than its noise site",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("H 0\nZ_ERROR(0.3) 0\nMX 0\n"));
+    REQUIRE(original.ops.size() == 2);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[1].op_type() == OpType::MEASURE);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    REQUIRE(original_plan.actions.size() == 1);
+    const SymbolId original_noise =
+        original_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<RecordClassical>(original_plan, 0).outcome ==
+            AffineBool::symbol(original_noise));
+
+    // Reorder to H 0; MX 0; Z_ERROR(0.3) 0, keeping the measurement's
+    // logical prefix at 1: it still logically follows the noise site.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);
+    reordered.logical_noise_prefix = {1, 0};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    REQUIRE(reordered_plan.actions.size() == 1);
+    const SymbolId reordered_noise =
+        reordered_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<RecordClassical>(reordered_plan, 0).outcome ==
+            AffineBool::symbol(reordered_noise));
+
+    // With the vector cleared (naive schedule semantics), the identical
+    // reordered ops resolve to the wrong, constant outcome.
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<RecordClassical>(naive_plan, 0).outcome == AffineBool(false));
+}
+
+TEST_CASE("Logical noise prefix corrects a rotation moved earlier than its noise site",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("H 0\nX_ERROR(0.3) 0\nT 0\nM 0\n"));
+    REQUIRE(original.ops.size() == 3);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[1].op_type() == OpType::T_GATE);
+    REQUIRE(original.ops[2].op_type() == OpType::MEASURE);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    const SymbolId original_noise =
+        original_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<PromoteDormantRotation>(original_plan, 0).sign ==
+            AffineBool::symbol(original_noise));
+
+    // Move T before X_ERROR, keeping its logical prefix at 1.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [T_GATE, NOISE, MEASURE]
+    reordered.logical_noise_prefix = {1, 0, 1};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    const SymbolId reordered_noise =
+        reordered_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<PromoteDormantRotation>(reordered_plan, 0).sign ==
+            AffineBool::symbol(reordered_noise));
+
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<PromoteDormantRotation>(naive_plan, 0).sign == AffineBool(false));
+}
+
+TEST_CASE("Logical noise prefix corrects a rotation moved later than its noise site",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("H 0\nT 0\nX_ERROR(0.3) 0\nM 0\n"));
+    REQUIRE(original.ops.size() == 3);
+    REQUIRE(original.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(original.ops[1].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[2].op_type() == OpType::MEASURE);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    // No noise logically precedes T in the original circuit.
+    REQUIRE(action_as<PromoteDormantRotation>(original_plan, 0).sign == AffineBool(false));
+
+    // Move T after X_ERROR, keeping its logical prefix at 0: the site never
+    // logically preceded it, even though it now sits after it in schedule.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [NOISE, T_GATE, MEASURE]
+    reordered.logical_noise_prefix = {0, 0, 1};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    REQUIRE(action_as<PromoteDormantRotation>(reordered_plan, 0).sign == AffineBool(false));
+
+    // Naive schedule semantics incorrectly picks up the noise dependency.
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    const SymbolId naive_noise = naive_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<PromoteDormantRotation>(naive_plan, 0).sign ==
+            AffineBool::symbol(naive_noise));
+}
+
+TEST_CASE("Logical noise prefix folds in exactly the anticommuting DEPOLARIZE1 channels",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("DEPOLARIZE1(0.3) 0\nM 0\n"));
+    REQUIRE(original.ops.size() == 2);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.noise_sites.at(0).channels.size() == 3);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    // Two of DEPOLARIZE1's three channels (X, Y) anticommute with the pure
+    // Z body a plain M measures; the third (Z) commutes.
+    REQUIRE(action_as<RecordClassical>(original_plan, 0).outcome.terms().size() == 2);
+
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [MEASURE, NOISE]
+    reordered.logical_noise_prefix = {1, 0};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    const auto& reordered_outcomes = reordered_plan.presampled_noise_sites.at(0).outcomes;
+    REQUIRE(reordered_outcomes.size() == 3);
+
+    // Build the expected outcome from this plan's own channel symbols
+    // rather than assuming a fixed channel order.
+    AffineBool expected;
+    const std::vector<NoiseChannel>& channels = reordered.noise_sites.at(0).channels;
+    for (size_t ch = 0; ch < channels.size(); ++ch) {
+        const PauliMaskView mask = reordered.noise_channel_masks.at(channels[ch].mask);
+        if (mask.x().bit_get(0)) {  // anticommutes with the pure Z body iff X is set
+            expected ^= AffineBool::symbol(reordered_outcomes[ch].symbol);
+        }
+    }
+    REQUIRE(expected.terms().size() == 2);
+    REQUIRE(action_as<RecordClassical>(reordered_plan, 0).outcome == expected);
+
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<RecordClassical>(naive_plan, 0).outcome == AffineBool(false));
+}
+
+// ---------------------------------------------------------------------------
+// Reordering helper shared by sampling-equivalence and legality-oracle tests
+// ---------------------------------------------------------------------------
+
+bool is_movable_across_noise(const HeisenbergOp& op) {
+    return op.op_type() == OpType::T_GATE || op.op_type() == OpType::PHASE_ROTATION ||
+           op.op_type() == OpType::MEASURE;
+}
+
+// Swaps hir.ops[i] and hir.ops[i+1], carrying every parallel side vector
+// along with its own operation: source_map and logical_noise_prefix when
+// present, and the caller's own original-index bookkeeping.
+void swap_adjacent_ops(HirModule& hir, std::vector<size_t>& original_index, size_t i) {
+    std::swap(hir.ops[i], hir.ops[i + 1]);
+    std::swap(original_index[i], original_index[i + 1]);
+    if (hir.source_map.size() == hir.ops.size()) {
+        std::swap(hir.source_map[i], hir.source_map[i + 1]);
+    }
+    if (hir.has_logical_noise_prefix()) {
+        std::swap(hir.logical_noise_prefix[i], hir.logical_noise_prefix[i + 1]);
+    }
+}
+
+// Randomly walks movable operations (T_GATE, PHASE_ROTATION, MEASURE) one
+// position left or right at a time: unconditionally across an adjacent
+// NOISE op (bypassing can_swap's noise clause -- the crossing this feature
+// makes sound), or otherwise only when can_swap allows it. Materializes
+// logical_noise_prefix first so every moved operation keeps the entry it
+// started with. original_index must start as 0..ops.size()-1; after the
+// walk, original_index[i] is the original position of the op now at i.
+void randomly_reorder_across_noise(HirModule& hir, std::vector<size_t>& original_index,
+                                   std::mt19937& rng, int iterations) {
+    hir.materialize_logical_noise_prefix();
+    for (int iter = 0; iter < iterations && hir.ops.size() >= 2; ++iter) {
+        std::vector<size_t> movable;
+        for (size_t i = 0; i < hir.ops.size(); ++i) {
+            if (is_movable_across_noise(hir.ops[i])) {
+                movable.push_back(i);
+            }
+        }
+        if (movable.empty()) {
+            return;
+        }
+        const size_t i = movable[rng() % movable.size()];
+        const bool go_right = (rng() % 2) == 0;
+        if (go_right && i + 1 < hir.ops.size()) {
+            const bool neighbor_is_noise = hir.ops[i + 1].op_type() == OpType::NOISE;
+            if (neighbor_is_noise || can_swap(hir.ops[i], hir.ops[i + 1], hir)) {
+                swap_adjacent_ops(hir, original_index, i);
+            }
+        } else if (!go_right && i > 0) {
+            const bool neighbor_is_noise = hir.ops[i - 1].op_type() == OpType::NOISE;
+            if (neighbor_is_noise || can_swap(hir.ops[i - 1], hir.ops[i], hir)) {
+                swap_adjacent_ops(hir, original_index, i - 1);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sampling equivalence
+// ---------------------------------------------------------------------------
+
+double tolerance_at_6_sigma(double mean_a, double mean_b, uint32_t shots) {
+    // A floor keeps the tolerance from collapsing to zero for a column that
+    // is (near-)deterministic in both samples.
+    constexpr double kMinP = 1e-3;
+    const double pooled = std::clamp(0.5 * (mean_a + mean_b), kMinP, 1.0 - kMinP);
+    return 6.0 * std::sqrt(2.0 * pooled * (1.0 - pooled) / shots);
+}
+
+double column_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t column,
+                   uint32_t shots) {
+    uint64_t ones = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        ones += values[static_cast<size_t>(shot) * num_columns + column];
+    }
+    return static_cast<double>(ones) / shots;
+}
+
+double parity_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t col_a,
+                   uint32_t col_b, uint32_t shots) {
+    uint64_t ones = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const uint8_t a = values[static_cast<size_t>(shot) * num_columns + col_a];
+        const uint8_t b = values[static_cast<size_t>(shot) * num_columns + col_b];
+        ones += static_cast<uint8_t>(a ^ b);
+    }
+    return static_cast<double>(ones) / shots;
+}
+
+void check_columns_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
+                         uint32_t num_columns, uint32_t shots, const char* label) {
+    for (uint32_t col = 0; col < num_columns; ++col) {
+        const double mean_a = column_mean(a, num_columns, col, shots);
+        const double mean_b = column_mean(b, num_columns, col, shots);
+        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
+        INFO(label << " column " << col << ": " << mean_a << " vs " << mean_b << ", tol " << tol);
+        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
+    }
+}
+
+void check_parities_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
+                          uint32_t num_columns, uint32_t shots, const char* label) {
+    for (uint32_t col = 0; col + 1 < num_columns; ++col) {
+        const double mean_a = parity_mean(a, num_columns, col, col + 1, shots);
+        const double mean_b = parity_mean(b, num_columns, col, col + 1, shots);
+        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
+        INFO(label << " parity (" << col << "," << col + 1 << "): " << mean_a << " vs " << mean_b
+                   << ", tol " << tol);
+        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
+    }
+}
+
+// Samples `original` and `reordered` with different seeds and requires
+// every record column mean, every detector column mean, and every
+// consecutive-pair record parity to agree within a cross-binomial tolerance.
+// The point is distributional equality, not bit-exact records.
+void check_sampling_equivalent(const HirModule& original, const HirModule& reordered,
+                               uint32_t shots, uint64_t seed_a, uint64_t seed_b) {
+    const ExecutablePlan plan_a(clifft::sampling::plan_sampling(original));
+    const ExecutablePlan plan_b(clifft::sampling::plan_sampling(reordered));
+    REQUIRE(plan_a.num_visible_records() == plan_b.num_visible_records());
+    REQUIRE(plan_a.num_detectors() == plan_b.num_detectors());
+
+    const clifft::sampling::SamplingResult result_a =
+        clifft::sampling::sample(plan_a, shots, seed_a);
+    const clifft::sampling::SamplingResult result_b =
+        clifft::sampling::sample(plan_b, shots, seed_b);
+
+    check_columns_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
+                        shots, "record");
+    check_columns_agree(result_a.detectors, result_b.detectors, plan_a.num_detectors(), shots,
+                        "detector");
+    check_parities_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
+                         shots, "record");
+}
+
+TEST_CASE("Logical noise prefix preserves the sampling distribution across noise-crossing reorders",
+          "[logical_noise_prefix]") {
+    constexpr uint32_t kShots = 20000;
+
+    SECTION("random circuits") {
+        constexpr uint32_t kTrials = 30;
+        std::mt19937 circuit_rng(0xC0FFEE);
+        std::mt19937 control_rng(0x51DE9A1);
+        for (uint32_t trial = 0; trial < kTrials; ++trial) {
+            const uint32_t num_qubits = 4 + (trial % 5);
+            const uint32_t num_ops = 25 + (trial % 20);
+            const std::string source = generate_noisy_source(circuit_rng, num_qubits, num_ops);
+            CAPTURE(trial, num_qubits, num_ops, source);
+
+            const HirModule original = clifft::trace(clifft::parse(source));
+            HirModule reordered = original;
+            std::vector<size_t> original_index(reordered.ops.size());
+            std::iota(original_index.begin(), original_index.end(), 0);
+            std::mt19937 reorder_rng(control_rng());
+            randomly_reorder_across_noise(reordered, original_index, reorder_rng,
+                                          8 * static_cast<int>(reordered.ops.size()) + 8);
+
+            check_sampling_equivalent(original, reordered, kShots, control_rng(), control_rng());
+        }
+    }
+
+    SECTION("coherent_d3_r3 fixture") {
+        const Circuit circuit =
+            clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/coherent_d3_r3.stim");
+        const HirModule original = clifft::trace(circuit);
+        HirModule reordered = original;
+        std::vector<size_t> original_index(reordered.ops.size());
+        std::iota(original_index.begin(), original_index.end(), 0);
+        std::mt19937 reorder_rng(0x517EE7);
+        randomly_reorder_across_noise(reordered, original_index, reorder_rng,
+                                      8 * static_cast<int>(reordered.ops.size()) + 8);
+
+        check_sampling_equivalent(original, reordered, kShots, 0x1234, 0x5678);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legality oracle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A logical-noise-prefix reorder is a legal can_swap reordering of the realized circuit",
+          "[logical_noise_prefix]") {
+    constexpr uint32_t kTrials = 30;
+    std::mt19937 circuit_rng(0xA11CE);
+    for (uint32_t trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + (trial % 5);
+        const uint32_t num_ops = 20 + (trial % 20);
+        const GeneratedCircuit generated = generate_noisy_circuit(circuit_rng, num_qubits, num_ops);
+        const std::string noisy_source = join_lines(generated.lines);
+        CAPTURE(trial, num_qubits, num_ops, noisy_source);
+
+        HirModule noisy = clifft::trace(clifft::parse(noisy_source));
+        std::vector<uint8_t> is_noise_original(noisy.ops.size());
+        for (size_t i = 0; i < noisy.ops.size(); ++i) {
+            is_noise_original[i] = noisy.ops[i].op_type() == OpType::NOISE ? 1 : 0;
+        }
+
+        std::vector<size_t> original_index(noisy.ops.size());
+        std::iota(original_index.begin(), original_index.end(), 0);
+        std::mt19937 reorder_rng(0xB0B0 + trial);
+        randomly_reorder_across_noise(noisy, original_index, reorder_rng,
+                                      6 * static_cast<int>(noisy.ops.size()) + 6);
+
+        std::mt19937 realize_rng(0xFACADE + trial);
+        const std::string realized_source = join_lines(realize_noise(generated, realize_rng));
+        CAPTURE(realized_source);
+        const HirModule realized = clifft::trace(clifft::parse(realized_source));
+
+        // Map each non-noise original index to its position in the
+        // noise-free realized HIR by counting how many earlier original
+        // positions were noise sites.
+        std::vector<size_t> orig_to_realized(is_noise_original.size(), 0);
+        size_t realized_cursor = 0;
+        for (size_t i = 0; i < is_noise_original.size(); ++i) {
+            if (!is_noise_original[i]) {
+                orig_to_realized[i] = realized_cursor++;
+            }
+        }
+        REQUIRE(realized_cursor == realized.ops.size());
+
+        // The reordering is legal exactly when every pair that ended up
+        // inverted relative to original order is a can_swap-legal
+        // transposition: that is a sufficient condition for reachability by
+        // adjacent transpositions, since any sequence of legal adjacent
+        // swaps that sorts the permutation back to original order must, at
+        // some point, swap every such pair directly.
+        for (size_t p = 0; p < original_index.size(); ++p) {
+            if (is_noise_original[original_index[p]]) {
+                continue;
+            }
+            for (size_t q = p + 1; q < original_index.size(); ++q) {
+                if (is_noise_original[original_index[q]]) {
+                    continue;
+                }
+                const size_t orig_a = original_index[p];
+                const size_t orig_b = original_index[q];
+                if (orig_a <= orig_b) {
+                    continue;  // not inverted relative to original order
+                }
+                const size_t ra = orig_to_realized[orig_a];
+                const size_t rb = orig_to_realized[orig_b];
+                CAPTURE(p, q, orig_a, orig_b, ra, rb);
+                CHECK(can_swap(realized.ops[rb], realized.ops[ra], realized));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass maintenance
+// ---------------------------------------------------------------------------
+
+TEST_CASE("StatevectorSqueezePass keeps logical_noise_prefix parallel and attached to its op",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse(R"(
+        T 0
+        T 1
+        H 1
+        DEPOLARIZE1(0.1) 0
+        M 1
+        M 0
+    )"));
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    hir.materialize_logical_noise_prefix();
+
+    // source_map (the source line) uniquely tags each surviving op here, so
+    // pairing it with logical_noise_prefix lets us confirm the entry
+    // followed the same op through however the pass permutes them.
+    auto snapshot = [](const HirModule& module) {
+        std::vector<std::pair<std::vector<uint32_t>, uint32_t>> tagged;
+        for (size_t i = 0; i < module.ops.size(); ++i) {
+            tagged.emplace_back(module.source_map[i], module.logical_noise_prefix[i]);
+        }
+        std::ranges::sort(tagged);
+        return tagged;
+    };
+    const auto before = snapshot(hir);
+
+    StatevectorSqueezePass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.has_logical_noise_prefix());
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    REQUIRE(snapshot(hir) == before);
+}
+
+TEST_CASE("PeepholeFusionPass fuses normally when logical_noise_prefix is consistent",
+          "[logical_noise_prefix]") {
+    HirModule with_prefix = clifft::trace(clifft::parse("H 0\nT 0\nT 0\nM 0\n"));
+    with_prefix.materialize_logical_noise_prefix();
+    HirModule without_prefix = clifft::trace(clifft::parse("H 0\nT 0\nT 0\nM 0\n"));
+
+    PeepholeFusionPass pass_with;
+    pass_with.run(with_prefix);
+    PeepholeFusionPass pass_without;
+    pass_without.run(without_prefix);
+
+    REQUIRE(clifft::sampling::plan_sampling(with_prefix).inspect() ==
+            clifft::sampling::plan_sampling(without_prefix).inspect());
+    if (!with_prefix.ops.empty()) {
+        REQUIRE(with_prefix.has_logical_noise_prefix());
+    }
+}
+
+TEST_CASE("PeepholeFusionPass leaves an inconsistent logical_noise_prefix unchanged",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("H 0\nZ_ERROR(0.3) 0\nT 0\nT 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.ops.size() == 4);
+    REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.ops[1].op_type() == OpType::T_GATE);
+    // Force the first T to look like it logically precedes the noise site,
+    // which the schedule count (1) disagrees with.
+    hir.logical_noise_prefix[1] = 0;
+
+    const size_t ops_before = hir.ops.size();
+    const std::vector<uint32_t> prefix_before = hir.logical_noise_prefix;
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == ops_before);
+    REQUIRE(hir.logical_noise_prefix == prefix_before);
+    size_t t_gate_count = 0;
+    for (const HeisenbergOp& op : hir.ops) {
+        t_gate_count += op.op_type() == OpType::T_GATE ? 1 : 0;
+    }
+    REQUIRE(t_gate_count == 2);  // the fusable pair was not fused
+}
+
+TEST_CASE("RemoveNoisePass clears logical_noise_prefix", "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.has_logical_noise_prefix());
+
+    RemoveNoisePass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.logical_noise_prefix.empty());
+    REQUIRE(hir.noise_sites.empty());
+}
+
+TEST_CASE("DropNonUnitaryPass clears logical_noise_prefix", "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nT 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.has_logical_noise_prefix());
+
+    DropNonUnitaryPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.logical_noise_prefix.empty());
+    REQUIRE(hir.noise_sites.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Logical noise prefix validation rejects a wrong-size vector", "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\n"));
+    REQUIRE(hir.ops.size() == 2);
+    hir.logical_noise_prefix = {0};
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+TEST_CASE("Logical noise prefix validation rejects a DETECTOR entry that disagrees with schedule",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\nDETECTOR rec[-1]\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.ops.back().op_type() == OpType::DETECTOR);
+    hir.logical_noise_prefix.back() = 0;  // was 1
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+TEST_CASE(
+    "Logical noise prefix validation rejects a NOISE entry that disagrees with its site index",
+    "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.ops.front().op_type() == OpType::NOISE);
+    hir.logical_noise_prefix.front() = 1;  // only one noise site exists; must be 0
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+TEST_CASE("Logical noise prefix validation rejects an entry above the noise site count",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nT 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    const auto t_gate = std::ranges::find_if(
+        hir.ops, [](const HeisenbergOp& op) { return op.op_type() == OpType::T_GATE; });
+    REQUIRE(t_gate != hir.ops.end());
+    const size_t t_index = static_cast<size_t>(t_gate - hir.ops.begin());
+    hir.logical_noise_prefix[t_index] = 2;  // only one noise site exists
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+}  // namespace


### PR DESCRIPTION
Prototype work on the `feature/active-width-scheduling` branch toward #458; review can be less strict than for `main`.

Pauli noise is presampled: every `NOISE` channel gets a `SymbolKind::Presampled` symbol whose value exists before the action stream, so a `T_GATE`, `PHASE_ROTATION`, or `MEASURE` moved across a `NOISE` op only needs its sign corrected by an affine function of that site's symbols (`R_p E = E R_{+-p}`, `E Pi_r(p) = Pi_{r xor [E,p]}(p) E`); it does not need the noise itself resampled at a different point. `HirModule::logical_noise_prefix` is the bookkeeping that makes this expressible: `logical_noise_prefix[i]`, when non-empty, is the number of `NOISE` ops that logically precede `ops[i]` in the original circuit. It is a parallel side vector in the style of `source_map` -- empty means schedule semantics (today's behavior, unchanged), and passes that reorder, delete, or strip noise from ops keep it consistent the same way they already keep `source_map` consistent. Noise sites themselves never move, so a logical position is always a plain site count.

The planner change is the enabling step. `plan_sampling` validates the vector up front (size, in-range entries, and that only the three movable op types may disagree with their schedule count -- `NOISE` itself and every barrier must match it exactly, which is also what proves their correction interval is always empty). A symbol prepass precomputes, for each `NOISE` site, the first symbol id its nonzero channels receive under the unchanged schedule-order allocation, so plans without the vector remain byte-for-byte identical. After resolving an operation's sign the usual way, the planner XORs in the channel symbols of every site between its schedule and logical positions: such a site's frame contribution is either missing (the operation moved earlier than the site) or spurious (it moved later), and XORing the same site back in fixes both directions. `StatevectorSqueezePass` and `PeepholeFusionPass` carry entries through their swaps, rotates, and deletions; `PeepholeFusionPass` additionally refuses to run at all when the vector disagrees with schedule position anywhere, because its virtual S/Pauli absorption conjugates later masks in schedule order and could move a noise-site mask into a different Clifford frame than a stale logical position was recorded against. `RemoveNoisePass` and `DropNonUnitaryPass` clear the vector outright, since both strip every `NOISE` op unconditionally.

## Validation

- Inertness: materializing `logical_noise_prefix` (schedule counts made explicit) never changes `plan_sampling(hir).inspect()`, checked on every `tests/fixtures/*.stim` fixture (raw, peephole-only, and production-pipeline HIR) and on 200 seeded random noisy circuits.
- Exact sign correction: four hand-built cases (a measurement and a rotation each moved earlier than their noise site, a rotation moved later, and a `DEPOLARIZE1` site whose two anticommuting channels must both fold in) check the corrected plan's sign expression against the original's, and against a naive vector-cleared plan that is shown to get it wrong.
- Sampling equivalence: 30 seeded random noisy circuits and the `coherent_d3_r3` fixture are reordered by a test-only walk that moves movable ops across `NOISE` sites (bypassing today's overly conservative `can_swap` noise clause) or across ordinary `can_swap`-legal neighbors, then sampled 20000 shots before and after with different seeds; every record column mean, every detector column mean, and every consecutive-pair record parity agree within a 6-sigma cross-binomial tolerance.
- Legality oracle: for 30 seeded random noisy circuits, a fixed noise realization is built by replacing each fired noise line with its explicit Pauli and dropping the rest; the same reordering, mapped onto the resulting noise-free HIR by skipping the removed `NOISE` ops, is checked to satisfy `can_swap` for every pair it inverted relative to original order -- i.e. it is a legal reordering of the noise-free circuit, which is the soundness argument from the issue turned into a test.
- Pass maintenance and validation: `StatevectorSqueezePass` keeps the vector parallel and attached to its op through a real reorder; `PeepholeFusionPass` fuses normally on a consistent vector and leaves the HIR untouched on an inconsistent one; `RemoveNoisePass` and `DropNonUnitaryPass` clear it; malformed vectors (wrong size, a barrier entry that disagrees with its schedule count, an entry above the noise-site count) throw `std::invalid_argument`.
- As a sanity check on the test suite itself, I temporarily disabled the correction and reran: exactly the four hand-built sign-correction tests and the sampling-equivalence test failed (33 assertions), while inertness, legality-oracle, pass-maintenance, and validation tests kept passing, as expected since they don't depend on the correction being active.

## Test commands

- `cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -G Ninja && cmake --build build-debug -j8` -- succeeds, no warnings.
- `ctest --test-dir build-debug -j8` -- `100% tests passed, 0 tests failed out of 947`.
- `SKBUILD_CMAKE_BUILD_TYPE=Debug uv pip install -e . --no-cache --reinstall-package clifft --python .venv/bin/python` -- installs a Debug extension (`with debug_info, not stripped`), version stamp matches the pushed tip (`0.9.1.dev33+gee4325cf5`, non-dirty).
- `SKBUILD_CMAKE_BUILD_TYPE=Debug uv run --python .venv/bin/python pytest tests/python -x -q` -- `1385 passed, 7 skipped`.
- `uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure` -- all hooks pass.
