### PR TITLE
feat(optimizer): exact active-width schedule search with certificates

### DIFF
--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(clifft_core STATIC
     optimizer/peephole.cc
     optimizer/pass_factory.cc
     optimizer/remove_noise_pass.cc
+    optimizer/schedule_dependence.cc
     optimizer/statevector_squeeze_pass.cc
     sampling/plan.cc
     sampling/plan_inspection.cc

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(clifft_core STATIC
     tableau/tableau.cc
     frontend/frontend.cc
     optimizer/hir_pass_manager.cc
+    optimizer/active_width_analysis.cc
     optimizer/drop_non_unitary_pass.cc
     optimizer/commutation.cc
     optimizer/peephole.cc

--- a/src/clifft/CMakeLists.txt
+++ b/src/clifft/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(clifft_core STATIC
     optimizer/pass_factory.cc
     optimizer/remove_noise_pass.cc
     optimizer/schedule_dependence.cc
+    optimizer/active_width_search.cc
     optimizer/statevector_squeeze_pass.cc
     sampling/plan.cc
     sampling/plan_inspection.cc

--- a/src/clifft/frontend/hir.h
+++ b/src/clifft/frontend/hir.h
@@ -460,6 +460,33 @@ struct HirModule {
     /// invalidated the map for that op.
     std::vector<std::vector<uint32_t>> source_map;
 
+    // Every NOISE channel is presampled: its symbol's value exists before
+    // the action stream, not at the schedule position where the planner
+    // happens to consume it. That is what lets an operation cross a NOISE
+    // op at all -- the crossing only changes which presampled symbols the
+    // planner must fold into the operation's sign, not when noise is
+    // sampled. logical_noise_prefix[i], when non-empty, is the number of
+    // NOISE ops that logically precede ops[i] in the original circuit, and
+    // the planner resolves ops[i]'s noise-dependent sign from that count
+    // instead of from ops[i]'s position among the NOISE ops before it in
+    // `ops`. Noise sites themselves never move, so a logical position is
+    // always expressible as a plain site count.
+    //
+    // Empty means schedule semantics: every operation's logical position
+    // equals its schedule position, i.e. today's behavior with nothing
+    // reordered across noise.
+    //
+    // Contract for passes, mirroring source_map: an entry travels with its
+    // operation, and a pass that deletes an operation drops its entry. A
+    // pass that removes NOISE ops must clear the vector entirely, because
+    // once the sites are gone there is nothing left for a stale entry to
+    // correct for. A pass that absorbs a virtual Clifford gate into later
+    // operation and noise-site masks must not run while an entry disagrees
+    // with its schedule position, because the correction it implies
+    // compares an operation's mask against noise-site masks that the frame
+    // change may have moved into a different basis.
+    std::vector<uint32_t> logical_noise_prefix;
+
     std::optional<Tableau> final_tableau;
 
     // Hidden measurement slot trace() assigned to the requested node's
@@ -480,6 +507,31 @@ struct HirModule {
             }
         }
         return true;
+    }
+
+    /// True when logical_noise_prefix is materialized and parallel to ops.
+    /// An empty ops list is never considered materialized, since an empty
+    /// vector cannot then be distinguished from the schedule-semantics
+    /// sentinel.
+    [[nodiscard]] bool has_logical_noise_prefix() const {
+        return !ops.empty() && logical_noise_prefix.size() == ops.size();
+    }
+
+    /// Fills logical_noise_prefix with each operation's schedule-order
+    /// noise count, making today's implicit schedule semantics explicit.
+    /// A no-op when the vector is already non-empty.
+    void materialize_logical_noise_prefix() {
+        if (!logical_noise_prefix.empty()) {
+            return;
+        }
+        logical_noise_prefix.reserve(ops.size());
+        uint32_t schedule_count = 0;
+        for (const HeisenbergOp& op : ops) {
+            logical_noise_prefix.push_back(schedule_count);
+            if (op.op_type() == OpType::NOISE) {
+                ++schedule_count;
+            }
+        }
     }
 
     // --- Mask accessors ---

--- a/src/clifft/optimizer/active_width_analysis.cc
+++ b/src/clifft/optimizer/active_width_analysis.cc
@@ -1,0 +1,306 @@
+#include "clifft/optimizer/active_width_analysis.h"
+
+#include "clifft/optimizer/commutation.h"
+
+#include <algorithm>
+#include <cassert>
+#include <span>
+
+namespace clifft {
+
+namespace {
+
+PauliString pauli_body(const HirModule& hir, const HeisenbergOp& op) {
+    PauliString result(hir.num_qubits);
+    result.mut_x().xor_with(hir.destab_mask(op));
+    result.mut_z().xor_with(hir.stab_mask(op));
+    return result;
+}
+
+// The (x, z) mask pair is treated as one combined GF(2) vector of length
+// 2 * domain, with x occupying [0, domain) and z occupying [domain, 2 *
+// domain), domain = words_per_row * 64. Bits at or beyond num_qubits within
+// each half are always zero -- PauliString and the generator storage both
+// keep that padding clear -- so they are inert dead space at the top of
+// each half and are never selected as a pivot.
+uint32_t combined_domain(uint32_t words_per_row) {
+    return words_per_row * 64;
+}
+
+bool combined_bit_get(MaskView x, MaskView z, uint32_t domain, uint32_t bit) {
+    return bit < domain ? x.bit_get(bit) : z.bit_get(bit - domain);
+}
+
+uint32_t combined_lowest_bit(MaskView x, MaskView z, uint32_t domain) {
+    const uint32_t x_bit = x.lowest_bit();
+    if (x_bit < domain) {
+        return x_bit;
+    }
+    return domain + z.lowest_bit();
+}
+
+}  // namespace
+
+DormantSubspace::DormantSubspace(uint32_t num_qubits)
+    : num_qubits_(num_qubits),
+      words_per_row_((num_qubits + 63) / 64),
+      dimension_(num_qubits),
+      gen_x_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      gen_z_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      echelon_x_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      echelon_z_(static_cast<size_t>(num_qubits) * words_per_row_, 0),
+      echelon_pivot_(num_qubits, 0),
+      scratch_x_(words_per_row_, 0),
+      scratch_z_(words_per_row_, 0) {
+    // S starts as the span of Z on every qubit: generator q is Z_q.
+    for (uint32_t q = 0; q < num_qubits; ++q) {
+        row_z(q).bit_set(q, true);
+    }
+}
+
+MaskView DormantSubspace::row_x(uint32_t index) const {
+    return MaskView{std::span<const uint64_t>(
+        gen_x_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MaskView DormantSubspace::row_z(uint32_t index) const {
+    return MaskView{std::span<const uint64_t>(
+        gen_z_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::row_x(uint32_t index) {
+    return MutableMaskView{std::span<uint64_t>(
+        gen_x_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::row_z(uint32_t index) {
+    return MutableMaskView{std::span<uint64_t>(
+        gen_z_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::echelon_row_x(uint32_t index) const {
+    return MutableMaskView{std::span<uint64_t>(
+        echelon_x_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+MutableMaskView DormantSubspace::echelon_row_z(uint32_t index) const {
+    return MutableMaskView{std::span<uint64_t>(
+        echelon_z_.data() + static_cast<size_t>(index) * words_per_row_, words_per_row_)};
+}
+
+std::optional<uint32_t> DormantSubspace::find_anticommuting_generator(const PauliString& p) const {
+    assert(p.num_qubits() == num_qubits_ && "Pauli body must share the subspace's qubit count");
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        if (anti_commute(row_x(i), row_z(i), p.x(), p.z())) {
+            return i;
+        }
+    }
+    return std::nullopt;
+}
+
+bool DormantSubspace::commutes_with_all(const PauliString& p) const {
+    return !find_anticommuting_generator(p).has_value();
+}
+
+void DormantSubspace::intersect_with_pivot(const PauliString& p, uint32_t pivot) {
+    assert(pivot < dimension_ && "pivot must be a live generator index");
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        if (i == pivot) {
+            continue;
+        }
+        if (anti_commute(row_x(i), row_z(i), p.x(), p.z())) {
+            row_x(i).xor_with(row_x(pivot));
+            row_z(i).xor_with(row_z(pivot));
+        }
+    }
+    const uint32_t last = dimension_ - 1;
+    if (pivot != last) {
+        std::ranges::copy(row_x(last).words, row_x(pivot).words.begin());
+        std::ranges::copy(row_z(last).words, row_z(pivot).words.begin());
+    }
+    --dimension_;
+    echelon_dirty_ = true;
+}
+
+void DormantSubspace::append_generator(const PauliString& p) {
+    assert(dimension_ < num_qubits_ && "S is already Lagrangian; nothing can extend it");
+    std::ranges::copy(p.x().words, row_x(dimension_).words.begin());
+    std::ranges::copy(p.z().words, row_z(dimension_).words.begin());
+    ++dimension_;
+    echelon_dirty_ = true;
+}
+
+bool DormantSubspace::apply_rotation(const PauliString& axis) {
+    const std::optional<uint32_t> pivot = find_anticommuting_generator(axis);
+    if (!pivot.has_value()) {
+        return false;
+    }
+    intersect_with_pivot(axis, *pivot);
+    return true;
+}
+
+DormantSubspace::MeasurementEffect DormantSubspace::apply_measurement(const PauliString& body) {
+    const std::optional<uint32_t> pivot = find_anticommuting_generator(body);
+    if (pivot.has_value()) {
+        intersect_with_pivot(body, *pivot);
+        append_generator(body);
+        return MeasurementEffect::DormantRandom;
+    }
+    if (contains(body)) {
+        return MeasurementEffect::Classical;
+    }
+    append_generator(body);
+    return MeasurementEffect::Active;
+}
+
+std::optional<uint32_t> DormantSubspace::reduce_against_membership_cache(
+    MutableMaskView work_x, MutableMaskView work_z) const {
+    const uint32_t domain = combined_domain(words_per_row_);
+    for (uint32_t row = 0; row < echelon_dimension_; ++row) {
+        const uint32_t pivot = echelon_pivot_[row];
+        if (combined_bit_get(work_x, work_z, domain, pivot)) {
+            work_x.xor_with(echelon_row_x(row));
+            work_z.xor_with(echelon_row_z(row));
+        }
+    }
+    const uint32_t remainder = combined_lowest_bit(work_x, work_z, domain);
+    if (remainder >= 2 * domain) {
+        return std::nullopt;
+    }
+    return remainder;
+}
+
+void DormantSubspace::rebuild_membership_cache_if_dirty() const {
+    if (!echelon_dirty_) {
+        return;
+    }
+    echelon_dimension_ = 0;
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        std::ranges::copy(row_x(i).words, echelon_row_x(echelon_dimension_).words.begin());
+        std::ranges::copy(row_z(i).words, echelon_row_z(echelon_dimension_).words.begin());
+        const std::optional<uint32_t> pivot = reduce_against_membership_cache(
+            echelon_row_x(echelon_dimension_), echelon_row_z(echelon_dimension_));
+        // The generator list is maintained as a basis by intersect_with_pivot
+        // and append_generator, so inserting an already-independent vector
+        // into the echelon form can never reduce it to zero.
+        assert(pivot.has_value() && "generator list was not linearly independent");
+        echelon_pivot_[echelon_dimension_] = pivot.value_or(0);
+        ++echelon_dimension_;
+    }
+    echelon_dirty_ = false;
+}
+
+bool DormantSubspace::contains(const PauliString& p) const {
+    assert(p.num_qubits() == num_qubits_ && "Pauli body must share the subspace's qubit count");
+    rebuild_membership_cache_if_dirty();
+    // Reduce a scratch copy; the cached echelon rows stay put for reuse by
+    // later contains() calls.
+    std::ranges::copy(p.x().words, scratch_x_.begin());
+    std::ranges::copy(p.z().words, scratch_z_.begin());
+    const std::optional<uint32_t> remainder =
+        reduce_against_membership_cache(MutableMaskView{scratch_x_}, MutableMaskView{scratch_z_});
+    return !remainder.has_value();
+}
+
+namespace {
+
+void record_transition(ActiveWidthTrace& trace, uint32_t& width, WidthEffect effect,
+                       uint32_t after) {
+    trace.transitions.push_back(WidthTransition{width, after, effect});
+    width = after;
+    trace.peak_width = std::max(trace.peak_width, width);
+}
+
+void analyze_rotation(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace,
+                      ActiveWidthTrace& trace, uint32_t& width) {
+    const PauliString body = pauli_body(hir, op);
+    if (subspace.apply_rotation(body)) {
+        record_transition(trace, width, WidthEffect::RotationPromote, subspace.active_width());
+    } else if (subspace.contains(body)) {
+        record_transition(trace, width, WidthEffect::RotationStabilizer, width);
+    } else {
+        record_transition(trace, width, WidthEffect::RotationNeutral, width);
+    }
+}
+
+void analyze_measurement(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace,
+                         ActiveWidthTrace& trace, uint32_t& width) {
+    const PauliString body = pauli_body(hir, op);
+    switch (subspace.apply_measurement(body)) {
+        case DormantSubspace::MeasurementEffect::DormantRandom:
+            record_transition(trace, width, WidthEffect::MeasureDormantRandom, width);
+            return;
+        case DormantSubspace::MeasurementEffect::Classical:
+            record_transition(trace, width, WidthEffect::MeasureClassical, width);
+            return;
+        case DormantSubspace::MeasurementEffect::Active:
+            record_transition(trace, width, WidthEffect::MeasureActive, subspace.active_width());
+            return;
+    }
+    assert(false && "unreachable DormantSubspace::MeasurementEffect");
+}
+
+void analyze_instrument(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace,
+                        ActiveWidthTrace& trace, uint32_t& width) {
+    const PauliString body = pauli_body(hir, op);
+    const InstrumentSite& site =
+        hir.instrument_sites.at(static_cast<uint32_t>(op.instrument_site_idx()));
+
+    if (!subspace.commutes_with_all(body)) {
+        const bool traps = hir.neglect_instrument_damping ||
+                           site.probabilities.p_fire[0] == site.probabilities.p_fire[1];
+        if (traps) {
+            record_transition(trace, width, WidthEffect::InstrumentDormantTrap, width);
+            return;
+        }
+        [[maybe_unused]] const bool promoted = subspace.apply_rotation(body);
+        assert(promoted && "instrument body must anticommute with S here");
+        record_transition(trace, width, WidthEffect::InstrumentActivate, subspace.active_width());
+        return;
+    }
+    if (subspace.contains(body)) {
+        record_transition(trace, width, WidthEffect::InstrumentClassical, width);
+        return;
+    }
+    record_transition(trace, width, WidthEffect::InstrumentActive, width);
+}
+
+}  // namespace
+
+ActiveWidthTrace analyze_active_width(const HirModule& hir) {
+    ActiveWidthTrace trace;
+    DormantSubspace subspace(hir.num_qubits);
+    trace.initial_width = subspace.active_width();
+    trace.peak_width = trace.initial_width;
+    trace.transitions.reserve(hir.ops.size());
+
+    uint32_t width = trace.initial_width;
+    for (const HeisenbergOp& op : hir.ops) {
+        switch (op.op_type()) {
+            case OpType::T_GATE:
+            case OpType::PHASE_ROTATION:
+                analyze_rotation(hir, op, subspace, trace, width);
+                break;
+            case OpType::MEASURE:
+                analyze_measurement(hir, op, subspace, trace, width);
+                break;
+            case OpType::INSTRUMENT:
+                analyze_instrument(hir, op, subspace, trace, width);
+                break;
+            case OpType::CONDITIONAL_PAULI:
+            case OpType::NOISE:
+            case OpType::READOUT_NOISE:
+            case OpType::DETECTOR:
+            case OpType::OBSERVABLE:
+            case OpType::EXP_VAL:
+            case OpType::NUM_OP_TYPES:
+                record_transition(trace, width, WidthEffect::None, width);
+                break;
+        }
+    }
+
+    trace.final_width = width;
+    return trace;
+}
+
+}  // namespace clifft

--- a/src/clifft/optimizer/active_width_analysis.cc
+++ b/src/clifft/optimizer/active_width_analysis.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <span>
+#include <utility>
 
 namespace clifft {
 
@@ -151,6 +152,18 @@ DormantSubspace::MeasurementEffect DormantSubspace::apply_measurement(const Paul
     }
     append_generator(body);
     return MeasurementEffect::Active;
+}
+
+std::vector<PauliString> DormantSubspace::generators() const {
+    std::vector<PauliString> result;
+    result.reserve(dimension_);
+    for (uint32_t i = 0; i < dimension_; ++i) {
+        PauliString generator(num_qubits_);
+        generator.mut_x().xor_with(row_x(i));
+        generator.mut_z().xor_with(row_z(i));
+        result.push_back(std::move(generator));
+    }
+    return result;
 }
 
 std::optional<uint32_t> DormantSubspace::reduce_against_membership_cache(

--- a/src/clifft/optimizer/active_width_analysis.h
+++ b/src/clifft/optimizer/active_width_analysis.h
@@ -76,6 +76,14 @@ class DormantSubspace {
     // unchanged.
     MeasurementEffect apply_measurement(const PauliString& body);
 
+    // Returns the current generators of S as unsigned Pauli bodies (S is an
+    // unsigned isotropic subspace; no sign is tracked). apply_rotation and
+    // apply_measurement can leave S with different generators depending on
+    // pivot choice, so two DormantSubspace instances describe the same
+    // subspace exactly when each one's generators are all contained in the
+    // other, not when this list matches element-for-element.
+    [[nodiscard]] std::vector<PauliString> generators() const;
+
   private:
     [[nodiscard]] MaskView row_x(uint32_t index) const;
     [[nodiscard]] MaskView row_z(uint32_t index) const;

--- a/src/clifft/optimizer/active_width_analysis.h
+++ b/src/clifft/optimizer/active_width_analysis.h
@@ -1,0 +1,171 @@
+#pragma once
+
+// Structural active-width analysis for the Heisenberg IR.
+//
+// The sampling planner's active width is a pure function of one GF(2)
+// linear-algebra object: the unsigned isotropic subspace S of dormant
+// stabilizer generators, initialized to the span of Z on every qubit. Every
+// planner decision -- promote a coordinate, collapse one, or leave the
+// active state untouched -- reduces to whether an operation's Pauli body
+// anticommutes with a generator of S, or, when it commutes with all of
+// them, whether it already lies in S. This module recomputes that same
+// sequence of decisions directly from HIR-frame Pauli masks, using GF(2)
+// elimination in place of the planner's coordinate-frame bookkeeping
+// (promoted-qubit tracking, pivot selection, inverse tableau caching).
+//
+// The payoff is a width predictor cheap enough to evaluate repeatedly: code
+// exploring alternative HIR operation orders can score a candidate order's
+// peak active width without materializing a coordinate frame or an
+// executable plan for it. This file never mutates the HIR and performs no
+// execution; it only answers what the width trace of a fixed operation
+// sequence would look like.
+
+#include "clifft/frontend/hir.h"
+#include "clifft/tableau/pauli_string.h"
+#include "clifft/util/mask_view.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace clifft {
+
+// Tracks the unsigned isotropic subspace S of dormant stabilizer generators
+// in fixed HIR (initial-frame) coordinates. This is the same subspace the
+// sampling planner evolves through its coordinate frame, but represented
+// directly as a GF(2) generator list rather than a physical-to-current basis
+// change, so deciding whether a Pauli anticommutes with S or lies in it
+// costs linear algebra instead of tableau composition.
+//
+// dimension + active_width() == num_qubits always: S is a maximal isotropic
+// (Lagrangian) subspace exactly when active_width() == 0, and every unit the
+// active width grows shrinks S by exactly one dimension.
+class DormantSubspace {
+  public:
+    explicit DormantSubspace(uint32_t num_qubits);
+
+    DormantSubspace(const DormantSubspace&) = default;
+    DormantSubspace& operator=(const DormantSubspace&) = default;
+    DormantSubspace(DormantSubspace&&) = default;
+    DormantSubspace& operator=(DormantSubspace&&) = default;
+
+    [[nodiscard]] uint32_t active_width() const { return num_qubits_ - dimension_; }
+
+    // True when `p` commutes with every current generator of S.
+    [[nodiscard]] bool commutes_with_all(const PauliString& p) const;
+
+    // True when `p` is a product of generators of S, equivalently an element
+    // of S. S is abelian, so an anticommuting Pauli is never in S; callers
+    // that already know commutes_with_all(p) is true use this to tell a
+    // stabilizer Pauli from a width-neutral active one.
+    [[nodiscard]] bool contains(const PauliString& p) const;
+
+    // Applies the planner's rotation bookkeeping for an operation with Pauli
+    // body `axis`: if `axis` anticommutes with a generator of S, replaces S
+    // with S intersect axis-perp (dimension drops by one, active width grows
+    // by one) and returns true. Otherwise leaves S unchanged and returns
+    // false.
+    bool apply_rotation(const PauliString& axis);
+
+    enum class MeasurementEffect : uint8_t { DormantRandom, Classical, Active };
+
+    // Applies the planner's measurement-collapse bookkeeping to `body` and
+    // reports which branch it took. DormantRandom replaces one generator
+    // with `body` (active width unchanged); Active adds `body` as a new,
+    // independent generator (active width drops by one); Classical leaves S
+    // unchanged.
+    MeasurementEffect apply_measurement(const PauliString& body);
+
+  private:
+    [[nodiscard]] MaskView row_x(uint32_t index) const;
+    [[nodiscard]] MaskView row_z(uint32_t index) const;
+    [[nodiscard]] MutableMaskView row_x(uint32_t index);
+    [[nodiscard]] MutableMaskView row_z(uint32_t index);
+    [[nodiscard]] MutableMaskView echelon_row_x(uint32_t index) const;
+    [[nodiscard]] MutableMaskView echelon_row_z(uint32_t index) const;
+
+    [[nodiscard]] std::optional<uint32_t> find_anticommuting_generator(const PauliString& p) const;
+
+    // Replaces S with S intersect p-perp given that generator `pivot`
+    // anticommutes with p: XORs every other anticommuting generator with the
+    // pivot row, then drops the pivot row. Invalidates the membership cache.
+    void intersect_with_pivot(const PauliString& p, uint32_t pivot);
+
+    // Appends `p` as a new, independent generator. Only valid when p is not
+    // already in S, which callers establish before invoking this.
+    void append_generator(const PauliString& p);
+
+    // Reduces the (work_x, work_z) vector against the cached echelon basis
+    // in place and returns the pivot bit of the nonzero remainder, or
+    // nullopt when it reduces to zero (the vector was in the cached span).
+    [[nodiscard]] std::optional<uint32_t> reduce_against_membership_cache(
+        MutableMaskView work_x, MutableMaskView work_z) const;
+
+    // Rebuilds the GF(2) echelon basis from the current generator list when
+    // a change has invalidated it. apply_rotation's promoting branch and
+    // apply_measurement's DormantRandom branch never query membership, so a
+    // run of promotions between two contains() calls rebuilds only once.
+    void rebuild_membership_cache_if_dirty() const;
+
+    uint32_t num_qubits_;
+    uint32_t words_per_row_;
+    uint32_t dimension_;
+    std::vector<uint64_t> gen_x_;
+    std::vector<uint64_t> gen_z_;
+
+    mutable std::vector<uint64_t> echelon_x_;
+    mutable std::vector<uint64_t> echelon_z_;
+    mutable std::vector<uint32_t> echelon_pivot_;
+    mutable uint32_t echelon_dimension_ = 0;
+    mutable bool echelon_dirty_ = true;
+    mutable std::vector<uint64_t> scratch_x_;
+    mutable std::vector<uint64_t> scratch_z_;
+};
+
+// Per-operation classification of how an HIR op moves the active width.
+// Values correspond 1:1 with the sampling planner's action taxonomy (see
+// sampling/plan.h): the Rotation* values classify a T_GATE or
+// PHASE_ROTATION, Measure* a MEASURE, and Instrument* an INSTRUMENT. None
+// covers every op that leaves the active state untouched (NOISE,
+// READOUT_NOISE, CONDITIONAL_PAULI, DETECTOR, OBSERVABLE, EXP_VAL).
+enum class WidthEffect : uint8_t {
+    None,
+    RotationStabilizer,     // p in S: the planner emits no action.
+    RotationNeutral,        // p commutes with S but p not in S: RotateActivePauli.
+    RotationPromote,        // p anticommutes with S: PromoteDormantRotation.
+    MeasureClassical,       // p in S: RecordClassical.
+    MeasureDormantRandom,   // p anticommutes with S: MeasureDormantRandom.
+    MeasureActive,          // p commutes with S but p not in S: MeasureActivePauli.
+    InstrumentClassical,    // p in S: InstrumentMode::Classical.
+    InstrumentActive,       // p commutes with S but p not in S: InstrumentMode::Active.
+    InstrumentActivate,     // p anticommutes with S, damping applies: InstrumentMode::Activate.
+    InstrumentDormantTrap,  // p anticommutes with S, damping neglected:
+                            // InstrumentMode::DormantTrap.
+};
+
+struct WidthTransition {
+    uint32_t before = 0;
+    uint32_t after = 0;
+    WidthEffect effect = WidthEffect::None;
+};
+
+struct ActiveWidthTrace {
+    uint32_t initial_width = 0;
+    uint32_t peak_width = 0;
+    uint32_t final_width = 0;
+    std::vector<WidthTransition> transitions;
+};
+
+// Recomputes the sampling planner's active-width trace directly from HIR,
+// without building a coordinate frame or symbolic Pauli frame and without
+// mutating `hir`. Produces exactly one transition per HIR op, in op order.
+//
+// Unlike the planner, this analysis never throws on width overflow: it
+// predicts the structural trace rather than committing to build a dense
+// coefficient state, so it has no reason to enforce
+// sampling::kDenseActiveWidthLimit. A caller that needs the planner's
+// executable output still goes through sampling::plan_sampling, which
+// enforces that limit itself.
+[[nodiscard]] ActiveWidthTrace analyze_active_width(const HirModule& hir);
+
+}  // namespace clifft

--- a/src/clifft/optimizer/active_width_search.cc
+++ b/src/clifft/optimizer/active_width_search.cc
@@ -1,0 +1,447 @@
+#include "clifft/optimizer/active_width_search.h"
+
+#include "clifft/optimizer/active_width_analysis.h"
+#include "clifft/tableau/pauli_string.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <numeric>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace clifft {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Op-level width effect, mirroring analyze_active_width's own dispatch
+// (active_width_analysis.cc) against the same public DormantSubspace
+// surface. That function threads a single ActiveWidthTrace through a fixed
+// op order; this search instead needs to classify a ready op without
+// committing to it (closure and candidate gathering try several before
+// picking one) and, separately, to commit once a choice is made, so the
+// dispatch is split into a pure predicate and a mutating apply rather than
+// reusing analyze_active_width's trace-building form directly.
+// ---------------------------------------------------------------------------
+
+PauliString pauli_body(const HirModule& hir, const HeisenbergOp& op) {
+    PauliString result(hir.num_qubits);
+    result.mut_x().xor_with(hir.destab_mask(op));
+    result.mut_z().xor_with(hir.stab_mask(op));
+    return result;
+}
+
+// True when executing `op` against `subspace` would raise the active width:
+// a T_GATE/PHASE_ROTATION whose axis does not commute with every generator
+// of S, or an INSTRUMENT that takes the Activate branch. Pure query (no
+// mutation), so closure and candidate gathering can test many ready ops
+// before committing to one. Must keep classifying identically to apply_op's
+// own branches below.
+bool is_expanding(const HirModule& hir, const HeisenbergOp& op, const DormantSubspace& subspace) {
+    switch (op.op_type()) {
+        case OpType::T_GATE:
+        case OpType::PHASE_ROTATION:
+            return !subspace.commutes_with_all(pauli_body(hir, op));
+        case OpType::INSTRUMENT: {
+            const PauliString body = pauli_body(hir, op);
+            if (subspace.commutes_with_all(body)) {
+                return false;  // Classical or Active: non-expanding.
+            }
+            const InstrumentSite& site =
+                hir.instrument_sites.at(static_cast<uint32_t>(op.instrument_site_idx()));
+            const bool traps = hir.neglect_instrument_damping ||
+                               site.probabilities.p_fire[0] == site.probabilities.p_fire[1];
+            return !traps;  // Activate iff it does not trap.
+        }
+        default:
+            return false;
+    }
+}
+
+// Applies `op`'s effect to `subspace` (rotation, measurement, or the same
+// four-branch instrument rule analyze_active_width uses; every other op
+// type is inert) and returns whether it was expanding. Safe to call on any
+// ready op regardless of its classification: apply_rotation and
+// apply_measurement already decide their own branch from the current
+// subspace, so calling this on a non-expanding op is simply a no-op (or a
+// width-decreasing collapse for a measurement) rather than an error.
+bool apply_op(const HirModule& hir, const HeisenbergOp& op, DormantSubspace& subspace) {
+    switch (op.op_type()) {
+        case OpType::T_GATE:
+        case OpType::PHASE_ROTATION:
+            return subspace.apply_rotation(pauli_body(hir, op));
+        case OpType::MEASURE:
+            subspace.apply_measurement(pauli_body(hir, op));
+            return false;
+        case OpType::INSTRUMENT: {
+            const PauliString body = pauli_body(hir, op);
+            if (!subspace.commutes_with_all(body)) {
+                const InstrumentSite& site =
+                    hir.instrument_sites.at(static_cast<uint32_t>(op.instrument_site_idx()));
+                const bool traps = hir.neglect_instrument_damping ||
+                                   site.probabilities.p_fire[0] == site.probabilities.p_fire[1];
+                if (!traps) {
+                    [[maybe_unused]] const bool promoted = subspace.apply_rotation(body);
+                    assert(promoted && "instrument body must anticommute with S here");
+                    return true;
+                }
+            }
+            return false;
+        }
+        default:
+            return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exact executed-op bitset memo key. See active_width_search.h for why the
+// key must be the literal bitset rather than a hash digest treated as an
+// identity.
+// ---------------------------------------------------------------------------
+
+void bitset_set(std::vector<uint64_t>& bits, uint32_t index) {
+    bits[index / 64] |= (uint64_t{1} << (index % 64));
+}
+
+void bitset_clear(std::vector<uint64_t>& bits, uint32_t index) {
+    bits[index / 64] &= ~(uint64_t{1} << (index % 64));
+}
+
+// Hash for bucketing only. std::unordered_set's own key equality
+// (std::vector<uint64_t>::operator==, exact and element-wise) is what
+// decides identity; two bitsets that hash alike but differ are still kept
+// apart as distinct keys.
+struct BitsetHash {
+    size_t operator()(const std::vector<uint64_t>& bits) const noexcept {
+        size_t seed = bits.size();
+        for (uint64_t word : bits) {
+            seed ^= std::hash<uint64_t>{}(word) + 0x9E3779B97F4A7C15ULL + (seed << 6) + (seed >> 2);
+        }
+        return seed;
+    }
+};
+
+using FailedNodeMemo = std::unordered_set<std::vector<uint64_t>, BitsetHash>;
+
+// ---------------------------------------------------------------------------
+// Incremental readiness bookkeeping.
+// ---------------------------------------------------------------------------
+
+// Tracks which ops are executed and which are ready (every predecessor
+// executed) as one mutable structure shared by the whole DFS, updated via
+// execute()/undo() pairs bracketing each recursive call. Readiness and the
+// executed set are both pure functions of the executed-op set alone (see
+// active_width_search.h's confluence note), so undo() only has to reverse
+// exactly what its matching execute() call did, never recompute anything
+// from scratch.
+class SearchFrontier {
+  public:
+    explicit SearchFrontier(const ScheduleDependence& dependence)
+        : dependence_(&dependence),
+          executed_((dependence.num_ops() + 63) / 64, 0),
+          remaining_preds_(dependence.num_ops()) {
+        for (uint32_t op = 0; op < dependence.num_ops(); ++op) {
+            remaining_preds_[op] = static_cast<uint32_t>(dependence.predecessors(op).size());
+            if (remaining_preds_[op] == 0) {
+                ready_.insert(op);
+            }
+        }
+    }
+
+    [[nodiscard]] const std::set<uint32_t>& ready() const { return ready_; }
+    [[nodiscard]] const std::vector<uint64_t>& executed_bits() const { return executed_; }
+    [[nodiscard]] size_t executed_count() const { return executed_count_; }
+
+    // Marks `op` executed and returns the successors that newly became
+    // ready as a result, which undo() needs to reverse this call exactly.
+    std::vector<uint32_t> execute(uint32_t op) {
+        assert(ready_.contains(op) && "execute() called on a non-ready op");
+        ready_.erase(op);
+        bitset_set(executed_, op);
+        ++executed_count_;
+        std::vector<uint32_t> newly_ready;
+        for (uint32_t succ : dependence_->successors(op)) {
+            if (--remaining_preds_[succ] == 0) {
+                ready_.insert(succ);
+                newly_ready.push_back(succ);
+            }
+        }
+        return newly_ready;
+    }
+
+    // Reverses exactly the execute(op) call that returned `newly_ready`.
+    void undo(uint32_t op, const std::vector<uint32_t>& newly_ready) {
+        for (uint32_t succ : dependence_->successors(op)) {
+            ++remaining_preds_[succ];
+        }
+        for (uint32_t r : newly_ready) {
+            ready_.erase(r);
+        }
+        bitset_clear(executed_, op);
+        --executed_count_;
+        ready_.insert(op);
+    }
+
+  private:
+    const ScheduleDependence* dependence_;
+    std::vector<uint64_t> executed_;
+    std::vector<uint32_t> remaining_preds_;
+    std::set<uint32_t> ready_;
+    size_t executed_count_ = 0;
+};
+
+// An executed op paired with the successors execute() found newly ready:
+// everything undo() needs to reverse that one call.
+using UndoStep = std::pair<uint32_t, std::vector<uint32_t>>;
+
+void undo_all(SearchFrontier& frontier, const std::vector<UndoStep>& log) {
+    for (auto it = log.rbegin(); it != log.rend(); ++it) {
+        frontier.undo(it->first, it->second);
+    }
+}
+
+// Lowest-index ready op that is not expanding, or nullopt when every
+// currently ready op (if any) is expanding.
+std::optional<uint32_t> find_ready_non_expanding(const HirModule& hir,
+                                                 const SearchFrontier& frontier,
+                                                 const DormantSubspace& subspace) {
+    for (uint32_t op : frontier.ready()) {
+        if (!is_expanding(hir, hir.ops[op], subspace)) {
+            return op;
+        }
+    }
+    return std::nullopt;
+}
+
+// Executes every ready non-expanding op, lowest index first, until none is
+// ready: the closure step the search's correctness depends on (see
+// active_width_search.h). Appends each executed op, in execution order, to
+// `order` and logs it in `log` for the caller to undo later if needed.
+void run_closure(const HirModule& hir, SearchFrontier& frontier, DormantSubspace& subspace,
+                 std::vector<uint32_t>& order, std::vector<UndoStep>& log) {
+    while (const std::optional<uint32_t> op = find_ready_non_expanding(hir, frontier, subspace)) {
+        log.emplace_back(*op, frontier.execute(*op));
+        order.push_back(*op);
+        [[maybe_unused]] const bool expanding = apply_op(hir, hir.ops[*op], subspace);
+        assert(!expanding && "find_ready_non_expanding chose an op apply_op treats as expanding");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Threshold feasibility DFS.
+// ---------------------------------------------------------------------------
+
+enum class SearchOutcome : uint8_t { Success, Infeasible, Unknown };
+
+struct SearchContext {
+    const HirModule& hir;
+    const ScheduleDependence& dependence;
+    uint64_t node_budget;
+    uint32_t threshold = 0;
+    uint64_t explored = 0;
+    FailedNodeMemo memo;
+};
+
+// One branch at a search node: the ready expanding op chosen to execute
+// next, plus everything closure swept in immediately after it, precomputed
+// once so ranking candidates never has to redo the work for whichever one
+// is ultimately chosen.
+struct Candidate {
+    // DormantSubspace has no default constructor, so this struct needs one
+    // too: subspace_after always starts as a copy of the parent node's
+    // subspace, never a fresh empty one.
+    explicit Candidate(const DormantSubspace& initial_subspace)
+        : subspace_after(initial_subspace) {}
+
+    uint32_t first_op = 0;
+    uint32_t width_after_closure = 0;
+    std::vector<uint32_t> ops;
+    DormantSubspace subspace_after;
+};
+
+// Executes `first_op` (already confirmed ready, expanding, and within
+// threshold by the caller) and closes the result, against the shared
+// `frontier`, then undoes both so the frontier is back to its caller-visible
+// state on return -- this only evaluates what committing to `first_op` would
+// look like, for ranking purposes, and does not itself commit to it.
+Candidate simulate_candidate(const HirModule& hir, SearchFrontier& frontier,
+                             const DormantSubspace& subspace, uint32_t first_op) {
+    Candidate candidate(subspace);
+    candidate.first_op = first_op;
+    std::vector<UndoStep> log;
+
+    log.emplace_back(first_op, frontier.execute(first_op));
+    candidate.ops.push_back(first_op);
+    [[maybe_unused]] const bool expanding =
+        apply_op(hir, hir.ops[first_op], candidate.subspace_after);
+    assert(expanding && "simulate_candidate called on an op the caller did not classify expanding");
+
+    run_closure(hir, frontier, candidate.subspace_after, candidate.ops, log);
+    candidate.width_after_closure = candidate.subspace_after.active_width();
+
+    undo_all(frontier, log);
+    return candidate;
+}
+
+// Recursion depth is bounded by the number of expanding ops on the deepest
+// path, since every recursive call consumes at least one (its chosen
+// candidate); that is small for the corpus this search targets (see
+// active_width_search.h), so plain recursion is used rather than an
+// explicit stack.
+SearchOutcome dfs(SearchContext& ctx, SearchFrontier& frontier, const DormantSubspace& subspace,
+                  std::vector<uint32_t>& order) {
+    if (frontier.executed_count() == ctx.dependence.num_ops()) {
+        return SearchOutcome::Success;
+    }
+    if (ctx.memo.contains(frontier.executed_bits())) {
+        return SearchOutcome::Infeasible;
+    }
+    if (ctx.explored >= ctx.node_budget) {
+        return SearchOutcome::Unknown;
+    }
+    ++ctx.explored;
+
+    // The frontier is always closed on entry (every path here ran
+    // run_closure last), so every ready op is expanding by construction;
+    // is_expanding is still checked explicitly below rather than assumed,
+    // so this loop stays correct even if that invariant is ever weakened.
+    //
+    // Snapshot the ready set before iterating: simulate_candidate() below
+    // mutates and restores frontier's own ready set via execute()/undo(), so
+    // iterating frontier.ready() directly here would iterate a std::set
+    // while a nested call erases and reinserts the very element the outer
+    // iterator is standing on, which is undefined behavior even though the
+    // set's contents end up value-equal afterward.
+    const std::vector<uint32_t> ready_ops(frontier.ready().begin(), frontier.ready().end());
+    std::vector<Candidate> candidates;
+    for (uint32_t op : ready_ops) {
+        if (!is_expanding(ctx.hir, ctx.hir.ops[op], subspace)) {
+            continue;
+        }
+        if (subspace.active_width() + 1 > ctx.threshold) {
+            continue;
+        }
+        candidates.push_back(simulate_candidate(ctx.hir, frontier, subspace, op));
+    }
+    if (candidates.empty()) {
+        ctx.memo.insert(frontier.executed_bits());
+        return SearchOutcome::Infeasible;
+    }
+
+    // Heuristic order: try the candidate whose execution plus closure
+    // reaches the lowest width first, ties by lower op index. first_op is
+    // unique per candidate, so this fully orders the list regardless of
+    // sort stability.
+    std::ranges::sort(candidates, [](const Candidate& a, const Candidate& b) {
+        if (a.width_after_closure != b.width_after_closure) {
+            return a.width_after_closure < b.width_after_closure;
+        }
+        return a.first_op < b.first_op;
+    });
+
+    for (Candidate& candidate : candidates) {
+        std::vector<UndoStep> log;
+        log.reserve(candidate.ops.size());
+        for (uint32_t op : candidate.ops) {
+            log.emplace_back(op, frontier.execute(op));
+        }
+        order.insert(order.end(), candidate.ops.begin(), candidate.ops.end());
+
+        const SearchOutcome outcome = dfs(ctx, frontier, candidate.subspace_after, order);
+        if (outcome == SearchOutcome::Success) {
+            return SearchOutcome::Success;
+        }
+
+        order.resize(order.size() - candidate.ops.size());
+        undo_all(frontier, log);
+
+        if (outcome == SearchOutcome::Unknown) {
+            // Giving up partway through a subtree is not the same as
+            // proving every candidate infeasible, so this node is not
+            // memoized, and there is no reason to try the remaining
+            // (already-budget-starved) candidates either.
+            return SearchOutcome::Unknown;
+        }
+    }
+
+    ctx.memo.insert(frontier.executed_bits());
+    return SearchOutcome::Infeasible;
+}
+
+// Runs the threshold-ctx.threshold feasibility search from a fresh initial
+// closure, sharing ctx's node budget and failed-node memo with whatever
+// thresholds the outer loop already tried. On success, `witness_order` holds
+// a complete linear extension of ctx.dependence.
+SearchOutcome feasible(SearchContext& ctx, std::vector<uint32_t>& witness_order) {
+    SearchFrontier frontier(ctx.dependence);
+    DormantSubspace subspace(ctx.hir.num_qubits);
+    witness_order.clear();
+
+    // The root closure is never undone: it is the fixed starting point for
+    // this whole feasible() call, not a candidate that might be backed out
+    // of, so its undo log is simply discarded once run_closure returns.
+    std::vector<UndoStep> discarded_log;
+    run_closure(ctx.hir, frontier, subspace, witness_order, discarded_log);
+
+    return dfs(ctx, frontier, subspace, witness_order);
+}
+
+}  // namespace
+
+WidthSearchResult search_width_schedule(const HirModule& hir, const ScheduleDependence& dependence,
+                                        WidthSearchOptions options) {
+    if (dependence.num_ops() != hir.ops.size()) {
+        throw std::invalid_argument(
+            "search_width_schedule: dependence relation was not built from this HIR's operation "
+            "count");
+    }
+
+    const ActiveWidthTrace incumbent = analyze_active_width(hir);
+
+    WidthSearchResult result;
+    result.incumbent_peak = incumbent.peak_width;
+    result.upper_bound = incumbent.peak_width;
+    result.lower_bound = incumbent.final_width;
+    result.noise_transparent = dependence.noise_transparent();
+    result.best_order.resize(hir.ops.size());
+    std::iota(result.best_order.begin(), result.best_order.end(), uint32_t{0});
+
+    SearchContext ctx{hir, dependence, options.node_budget, 0, 0, {}};
+
+    // final_width can never exceed peak_width (it is one of the widths the
+    // peak maxes over), so lower_bound <= upper_bound holds from the start
+    // and upper_bound - 1 below never underflows.
+    while (result.upper_bound > result.lower_bound) {
+        ctx.threshold = result.upper_bound - 1;
+        std::vector<uint32_t> witness_order;
+        const SearchOutcome outcome = feasible(ctx, witness_order);
+
+        if (outcome == SearchOutcome::Success) {
+            // The threshold only bounds candidates from above, so the
+            // witness's actual peak can undercut ctx.threshold; report that
+            // achieved value, not the threshold that produced it, and
+            // resume searching one below it.
+            HirModule witness_hir = hir;
+            apply_schedule(witness_hir, dependence, witness_order);
+            result.best_order = std::move(witness_order);
+            result.upper_bound = analyze_active_width(witness_hir).peak_width;
+            continue;
+        }
+        if (outcome == SearchOutcome::Infeasible) {
+            result.lower_bound = ctx.threshold + 1;
+            break;
+        }
+        result.budget_exhausted = true;
+        break;
+    }
+
+    result.explored_nodes = ctx.explored;
+    return result;
+}
+
+}  // namespace clifft

--- a/src/clifft/optimizer/active_width_search.h
+++ b/src/clifft/optimizer/active_width_search.h
@@ -1,0 +1,160 @@
+#pragma once
+
+// Exact, budgeted search for the schedule of an HIR that minimizes peak
+// active width, over the trace class ScheduleDependence defines.
+//
+// Definitions, over the dependence DAG (predecessors/successors, ops 0..N-1
+// in original index order):
+//
+//   ready       every predecessor of the op has already executed.
+//   expanding   executing the op would raise the active width k: a T_GATE or
+//               PHASE_ROTATION whose axis does not commute with every
+//               generator of the current DormantSubspace S, or an
+//               INSTRUMENT that takes the Activate branch (see
+//               active_width_analysis.h's WidthEffect). Every other ready op
+//               is non-expanding: any MEASURE, any rotation whose axis
+//               commutes with S, and every other op type.
+//   closure     starting from a set of executed ops, repeatedly execute the
+//               lowest-index ready non-expanding op until none remains.
+//
+// Closure theorem: some schedule that minimizes peak active width executes
+// every ready non-expanding op as soon as it is ready. Sketch: readiness
+// only grows as ops execute, a rotation that currently commutes with S stays
+// commuting under any op independent of it (S only shrinks along directions
+// that anticommute with something already executed), and no non-expanding
+// op's execution can make another already-ready non-expanding op expanding,
+// so delaying a ready non-expanding op can only ever leave the peak the same
+// or larger, never smaller. Consequently a search only has to branch on
+// which ready expanding op to execute next; closure fills in the rest
+// deterministically. An INSTRUMENT is a positional barrier under
+// ScheduleDependence (commutation.cc's can_swap refuses to reorder anything
+// across one), so every op before it in original order is transitively its
+// predecessor and every op after it is transitively its successor -- when it
+// is ready, it is therefore the only ready op, and this search executes it
+// regardless of whether it is expanding (an Activate instrument that would
+// exceed the current threshold simply fails that search node, the same as
+// any other over-threshold candidate).
+//
+// Confluence: the subspace S reached by executing a given set of ops is the
+// same regardless of the order they executed in (independent GF(2) updates
+// commute), so a search state is fully determined by its set of executed
+// ops, not by the sequence that reached it. That is what makes the
+// executed-op bitset below a sound memoization key: two different branches
+// that happen to execute the same set of ops are provably the same state,
+// including for feasibility purposes, even though this search only ever
+// compares bitsets exactly and never tries to prove that fact directly.
+//
+// Threshold feasibility: for a fixed bound B, a depth-first search from the
+// initial closed state where a node's candidates are its ready expanding ops
+// whose execution would not push k above B (tried in the order most likely
+// to succeed first: lowest resulting k, ties by lower op index), recursing
+// on each until one reaches every op executed. A node with no candidate
+// left, none of which is ready and within budget, is infeasible; that
+// verdict is memoized by the exact executed-op bitset so any other branch
+// that reaches the identical set of executed ops is pruned immediately
+// rather than re-explored. The memo key must be exact, not a hash digest
+// used as an identity: two distinct executed-op sets that happened to hash
+// alike would otherwise be treated as one, and if one of them is genuinely
+// feasible while the memoized one is not, the collision would misreport a
+// feasible bound as infeasible. A node whose subtree is only partly explored
+// when the shared node budget runs out reports unknown instead and is never
+// memoized as failed, since giving up is not the same as proving
+// infeasibility.
+//
+// Outer loop: starting from the incumbent HIR's own order (peak from
+// analyze_active_width), repeatedly ask whether some schedule reaches one
+// less than the best peak proven achievable so far. Each yes lowers the
+// achievable bound to that schedule's actual peak (which can undercut the
+// threshold that was asked for, since the threshold only bounds candidates
+// from above); each exhaustive no proves nothing tighter is possible and
+// stops the search with matching bounds; running out of budget stops the
+// search with the bounds it had already proven. The node budget and the
+// failed-node memo are both shared across every threshold this loop tries,
+// not reset per threshold, because a set of executed ops proven to have no
+// completion within a looser bound also has none within any tighter one --
+// the candidate list at a lower threshold is a subset of the candidate list
+// at a higher one -- so carrying both forward only ever prunes more, never
+// incorrectly.
+
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/schedule_dependence.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace clifft {
+
+struct WidthSearchOptions {
+    // Cumulative cap on search-tree nodes expanded across the whole outer
+    // loop (every threshold attempted below the incumbent peak shares this
+    // one budget; it is not reset per threshold). A memo hit does not count
+    // as an expansion, since it does no new work.
+    uint64_t node_budget = 200000;
+};
+
+// The result of a bounded exact search for the minimum peak active width of
+// `hir` over the legal schedules of a given ScheduleDependence.
+//
+// Certificate scope: `optimal()` certifies a minimum over the trace class of
+// this exact HIR under the dependence relation it was searched with --
+// i.e., over every linear extension of that relation, scored by the
+// sampling planner's own structural width model (analyze_active_width /
+// DormantSubspace). It says nothing about schedules reachable only through
+// a rewrite that exposes new gate fusion, about amplitude-level stabilizers
+// the structural planner does not track, or about any other circuit that
+// merely samples the same distribution as this one.
+struct WidthSearchResult {
+    // A linear extension of the dependence relation the caller passed to
+    // search_width_schedule(), applicable via apply_schedule(). Records the
+    // full order the winning search node executed ops in: the initial
+    // closure, then each chosen expanding op immediately followed by the
+    // non-expanding ops its execution made ready. Equals the identity order
+    // (0, 1, ..., num_ops() - 1) when no schedule bettered the incumbent.
+    std::vector<uint32_t> best_order;
+
+    // Peak active width of `hir` in its order as given (analyze_active_width
+    // on the unmodified HIR), before this search looked for anything better.
+    uint32_t incumbent_peak = 0;
+
+    // Best proven-achievable peak: incumbent_peak, or a witness schedule's
+    // actual peak if the search found and confirmed one lower.
+    uint32_t upper_bound = 0;
+
+    // Best proven lower bound on the peak of any legal schedule: starts at
+    // the order-invariant final active width (every legal schedule ends
+    // with the same DormantSubspace, so its width is a valid floor on the
+    // peak) and rises to threshold + 1 whenever threshold is proven
+    // exhaustively infeasible.
+    uint32_t lower_bound = 0;
+
+    // Total search-tree nodes expanded across every threshold this search
+    // tried, sharing WidthSearchOptions::node_budget.
+    uint64_t explored_nodes = 0;
+
+    // True when the node budget ran out before the last threshold attempted
+    // was resolved either way. lower_bound is then whatever it was already
+    // proven to be (possibly still its initial value); upper_bound may still
+    // improve with a larger budget.
+    bool budget_exhausted = false;
+
+    // Copied from the ScheduleDependence this search ran against, so a
+    // caller holding only the result can tell which relation the bounds and
+    // certificate above apply to.
+    bool noise_transparent = false;
+
+    // True exactly when lower_bound == upper_bound: the achievable peak is
+    // proven minimal over the certificate scope documented above.
+    [[nodiscard]] bool optimal() const { return lower_bound == upper_bound; }
+};
+
+// Searches for a legal schedule of `hir` (per `dependence`, which must have
+// been built from an HIR with the same operation count) that minimizes peak
+// active width, budgeted by `options.node_budget`. Never mutates `hir`; a
+// caller that wants the improvement applies best_order itself via
+// apply_schedule(). Throws std::invalid_argument if `dependence` was not
+// built from an HIR with hir.ops.size() operations.
+[[nodiscard]] WidthSearchResult search_width_schedule(const HirModule& hir,
+                                                      const ScheduleDependence& dependence,
+                                                      WidthSearchOptions options = {});
+
+}  // namespace clifft

--- a/src/clifft/optimizer/drop_non_unitary_pass.cc
+++ b/src/clifft/optimizer/drop_non_unitary_pass.cc
@@ -50,6 +50,9 @@ void DropNonUnitaryPass::run(HirModule& hir) {
     hir.detector_targets.clear();
     hir.observable_targets.clear();
     hir.noise_channel_masks = PauliMaskArena{};
+    // With every noise site gone there is nothing left for a logical
+    // position to correct for.
+    hir.logical_noise_prefix.clear();
 
     hir.num_measurements = 0;
     hir.num_hidden_measurements = 0;

--- a/src/clifft/optimizer/peephole.cc
+++ b/src/clifft/optimizer/peephole.cc
@@ -344,11 +344,46 @@ size_t eliminate_terminal_measurement_phases(HirModule& hir, std::vector<uint8_t
 
 }  // namespace
 
+namespace {
+
+// True when every operation's logical_noise_prefix entry equals its
+// schedule position, i.e. nothing has yet been reordered across a noise
+// site. An empty vector (schedule semantics) trivially satisfies this.
+bool logical_noise_prefix_is_consistent(const HirModule& hir) {
+    if (!hir.has_logical_noise_prefix()) {
+        return true;
+    }
+    uint32_t schedule_count = 0;
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        if (hir.logical_noise_prefix[i] != schedule_count) {
+            return false;
+        }
+        if (hir.ops[i].op_type() == OpType::NOISE) {
+            ++schedule_count;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
 void PeepholeFusionPass::run(HirModule& hir) {
     cancellations_ = 0;
     fusions_ = 0;
 
+    // Virtual S and Pauli absorption below conjugates every later operation
+    // and noise-site mask in schedule order. The planner's logical-noise
+    // correction compares an operation's mask against noise-site masks that
+    // may then sit in a different Clifford frame than the one they were
+    // recorded against, unless every mask is still at its schedule
+    // position. Bail out rather than risk that mismatch; fusion on an
+    // already-consistent vector proceeds exactly as before.
+    if (!logical_noise_prefix_is_consistent(hir)) {
+        return;
+    }
+
     bool has_source_map = hir.source_map.size() == hir.ops.size();
+    bool has_lnp = hir.has_logical_noise_prefix();
 
     bool changed = true;
     while (changed) {
@@ -571,6 +606,9 @@ void PeepholeFusionPass::run(HirModule& hir) {
                         if (has_source_map) {
                             hir.source_map[write] = std::move(hir.source_map[read]);
                         }
+                        if (has_lnp) {
+                            hir.logical_noise_prefix[write] = hir.logical_noise_prefix[read];
+                        }
                     }
                     ++write;
                 }
@@ -578,6 +616,9 @@ void PeepholeFusionPass::run(HirModule& hir) {
             hir.ops.erase(hir.ops.begin() + static_cast<ptrdiff_t>(write), hir.ops.end());
             if (has_source_map) {
                 hir.source_map.resize(write);
+            }
+            if (has_lnp) {
+                hir.logical_noise_prefix.resize(write);
             }
         }
     }

--- a/src/clifft/optimizer/remove_noise_pass.cc
+++ b/src/clifft/optimizer/remove_noise_pass.cc
@@ -31,6 +31,9 @@ void RemoveNoisePass::run(HirModule& hir) {
     // be dropped without dropping the arena itself. Replace with an empty
     // arena so the slots don't sit around as dead weight after removal.
     hir.noise_channel_masks = PauliMaskArena{};
+    // With every noise site gone there is nothing left for a logical
+    // position to correct for.
+    hir.logical_noise_prefix.clear();
 }
 
 }  // namespace clifft

--- a/src/clifft/optimizer/schedule_dependence.cc
+++ b/src/clifft/optimizer/schedule_dependence.cc
@@ -1,0 +1,212 @@
+#include "clifft/optimizer/schedule_dependence.h"
+
+#include "clifft/optimizer/commutation.h"
+
+#include <algorithm>
+#include <cassert>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace clifft {
+
+namespace {
+
+bool is_movable_op(OpType type) {
+    return type == OpType::T_GATE || type == OpType::PHASE_ROTATION || type == OpType::MEASURE;
+}
+
+// True when no edge is needed between the ops at i < j: either they pass
+// the ordinary commutation test, or noise transparency specifically waives
+// it for a NOISE-versus-movable pair. See the file comment for why the
+// second clause is sound.
+bool allowed(const HirModule& hir, const HeisenbergOp& left, const HeisenbergOp& right,
+             bool noise_transparent) {
+    if (can_swap(left, right, hir)) {
+        return true;
+    }
+    if (!noise_transparent) {
+        return false;
+    }
+    const bool left_noise = left.op_type() == OpType::NOISE;
+    const bool right_noise = right.op_type() == OpType::NOISE;
+    const bool left_movable = is_movable_op(left.op_type());
+    const bool right_movable = is_movable_op(right.op_type());
+    return (left_noise && right_movable) || (right_noise && left_movable);
+}
+
+// Groups (key, value) pairs into CSR form: offsets[k]..offsets[k + 1]
+// indexes into `indices` for every value recorded under key k. std::pair's
+// default order is lexicographic, so sorting by (key, value) both groups
+// equal keys together and, within each group, leaves values ascending.
+void group_into_csr(size_t num_keys, std::vector<std::pair<uint32_t, uint32_t>> pairs,
+                    std::vector<uint32_t>& offsets, std::vector<uint32_t>& indices) {
+    std::ranges::sort(pairs);
+    offsets.assign(num_keys + 1, 0);
+    for (const auto& entry : pairs) {
+        ++offsets[entry.first + 1];
+    }
+    for (size_t i = 0; i < num_keys; ++i) {
+        offsets[i + 1] += offsets[i];
+    }
+    indices.clear();
+    indices.reserve(pairs.size());
+    for (const auto& entry : pairs) {
+        indices.push_back(entry.second);
+    }
+}
+
+}  // namespace
+
+ScheduleDependence ScheduleDependence::build(const HirModule& hir,
+                                             ScheduleDependenceOptions options) {
+    const size_t n = hir.ops.size();
+    ScheduleDependence dep;
+    dep.noise_transparent_ = options.noise_transparent;
+    dep.movable_.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        dep.movable_[i] = is_movable_op(hir.ops[i].op_type());
+    }
+
+    // (from, to) edges, gathered in two structurally different passes below
+    // and only grouped into per-op adjacency (by group_into_csr) once both
+    // are collected, since neither pass alone produces edges in an order
+    // that is already sorted the way the other direction needs.
+    std::vector<std::pair<uint32_t, uint32_t>> edges;
+
+    // Chain consecutive fixed ops so every fixed op keeps its original
+    // relative order, regardless of what can_swap would say about any one
+    // pair of them.
+    std::optional<uint32_t> previous_fixed;
+    for (uint32_t j = 0; j < n; ++j) {
+        if (dep.movable_[j]) {
+            continue;
+        }
+        if (previous_fixed.has_value()) {
+            edges.emplace_back(*previous_fixed, j);
+        }
+        previous_fixed = j;
+    }
+
+    // O(N^2) can_swap calls in the worst case: acceptable for this
+    // prototype (see the file comment).
+    for (uint32_t i = 0; i < n; ++i) {
+        for (uint32_t j = i + 1; j < n; ++j) {
+            if (!dep.movable_[i] && !dep.movable_[j]) {
+                continue;  // both fixed: handled by the chain above
+            }
+            if (allowed(hir, hir.ops[i], hir.ops[j], dep.noise_transparent_)) {
+                continue;
+            }
+            edges.emplace_back(i, j);
+        }
+    }
+
+    // Successors group by "from", ascending "to": exactly (from, to)
+    // lexicographic order, which is what `edges` already sorts to.
+    group_into_csr(n, edges, dep.succ_offsets_, dep.succ_indices_);
+
+    // Predecessors group by "to", ascending "from": swap each pair first so
+    // the same helper's (key, value) = (first, second) grouping applies.
+    std::vector<std::pair<uint32_t, uint32_t>> reversed_edges;
+    reversed_edges.reserve(edges.size());
+    for (const auto& [from, to] : edges) {
+        reversed_edges.emplace_back(to, from);
+    }
+    group_into_csr(n, std::move(reversed_edges), dep.pred_offsets_, dep.pred_indices_);
+
+    return dep;
+}
+
+bool ScheduleDependence::is_movable(size_t op) const {
+    assert(op < movable_.size());
+    return movable_[op];
+}
+
+std::span<const uint32_t> ScheduleDependence::predecessors(size_t op) const {
+    assert(op < num_ops());
+    return std::span<const uint32_t>(pred_indices_)
+        .subspan(pred_offsets_[op], pred_offsets_[op + 1] - pred_offsets_[op]);
+}
+
+std::span<const uint32_t> ScheduleDependence::successors(size_t op) const {
+    assert(op < num_ops());
+    return std::span<const uint32_t>(succ_indices_)
+        .subspan(succ_offsets_[op], succ_offsets_[op + 1] - succ_offsets_[op]);
+}
+
+bool ScheduleDependence::is_linear_extension(std::span<const uint32_t> order) const {
+    const size_t n = num_ops();
+    if (order.size() != n) {
+        return false;
+    }
+    // position[op] == n means "not seen yet"; every valid position is < n,
+    // so this sentinel also catches an out-of-range entry sharing the slot
+    // an in-range duplicate would otherwise collide on.
+    std::vector<uint32_t> position(n, static_cast<uint32_t>(n));
+    for (size_t pos = 0; pos < order.size(); ++pos) {
+        const uint32_t op = order[pos];
+        if (op >= n || position[op] != n) {
+            return false;
+        }
+        position[op] = static_cast<uint32_t>(pos);
+    }
+    for (size_t op = 0; op < n; ++op) {
+        for (uint32_t succ : successors(op)) {
+            if (position[op] >= position[succ]) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void apply_schedule(HirModule& hir, const ScheduleDependence& dependence,
+                    std::span<const uint32_t> order) {
+    if (dependence.num_ops() != hir.ops.size()) {
+        throw std::invalid_argument(
+            "apply_schedule: dependence relation was not built from this HIR's operation count");
+    }
+    if (!dependence.is_linear_extension(order)) {
+        throw std::invalid_argument(
+            "apply_schedule: order is not a linear extension of the dependence relation");
+    }
+
+    if (dependence.noise_transparent()) {
+        hir.materialize_logical_noise_prefix();
+    }
+
+    const bool has_source_map = hir.source_map.size() == hir.ops.size();
+    const bool has_lnp = hir.has_logical_noise_prefix();
+
+    std::vector<HeisenbergOp> new_ops;
+    new_ops.reserve(hir.ops.size());
+    std::vector<std::vector<uint32_t>> new_source_map;
+    std::vector<uint32_t> new_lnp;
+    if (has_source_map) {
+        new_source_map.reserve(hir.ops.size());
+    }
+    if (has_lnp) {
+        new_lnp.reserve(hir.ops.size());
+    }
+
+    for (uint32_t idx : order) {
+        new_ops.push_back(hir.ops[idx]);
+        if (has_source_map) {
+            new_source_map.push_back(std::move(hir.source_map[idx]));
+        }
+        if (has_lnp) {
+            new_lnp.push_back(hir.logical_noise_prefix[idx]);
+        }
+    }
+
+    hir.ops = std::move(new_ops);
+    if (has_source_map) {
+        hir.source_map = std::move(new_source_map);
+    }
+    if (has_lnp) {
+        hir.logical_noise_prefix = std::move(new_lnp);
+    }
+}
+
+}  // namespace clifft

--- a/src/clifft/optimizer/schedule_dependence.h
+++ b/src/clifft/optimizer/schedule_dependence.h
@@ -1,0 +1,146 @@
+#pragma once
+
+// Conservative dependence relation over HIR operations, and the machinery
+// to commit one legal reordering back into an HirModule.
+//
+// The relation is a DAG over op indices 0..N-1 with edges i -> j for i < j.
+// A legal schedule is any topological order of this DAG: a "linear
+// extension" in is_linear_extension()'s sense. apply_schedule() below
+// commits one such order into an HirModule. Because can_swap() (see
+// commutation.h) is symmetric, two ops with no edge between them in either
+// direction are mutually independent, so the set of linear extensions is
+// exactly the trace class reachable from the original order by adjacent
+// transpositions of independent ops. That is the same guarantee the
+// squeeze pass already leans on pairwise, one swap at a time; this module
+// makes it explicit and total so a scheduler can search over it directly.
+//
+// The relation is conservative, not exact, because can_swap() itself is
+// conservative: it decides purely from each op's own inline Pauli mask (or,
+// for NOISE, its noise-site channel masks), and it refuses to cross EXP_VAL
+// and INSTRUMENT unconditionally, since both are positional side-table
+// references. Two ops that commute for a reason can_swap cannot see (for
+// example, two rotations that would act on disjoint qubits after upstream
+// cancellation this analysis does not perform) still get an edge here. That
+// can only cost a scheduler some legal reorderings, never grant an illegal
+// one -- soundness here is inherited entirely from can_swap's own.
+//
+// Only T_GATE, PHASE_ROTATION, and MEASURE ever move: every other op type
+// keeps its original relative order, via edges chaining each consecutive
+// pair of fixed ops regardless of what can_swap would say about that pair
+// specifically. This mirrors the sampling planner's own requirements
+// (sampling/planner.cc): NOISE and INSTRUMENT sites must arrive in circuit
+// order or the planner throws, and DETECTOR, OBSERVABLE, READOUT_NOISE, and
+// CONDITIONAL_PAULI read classical state whose validity depends on that
+// same fixed order.
+//
+// Noise transparency (ScheduleDependenceOptions::noise_transparent) is an
+// optional relaxation on top: with it set, no edge is placed between a
+// NOISE op and a movable one solely because their Pauli masks anticommute.
+// This is sound because every NOISE channel is presampled -- its symbol's
+// value exists before the action stream runs, independent of where in the
+// schedule a planner happens to consume it -- and because the sampling
+// planner resolves an operation's noise-dependent sign from its logical
+// (original-circuit) position rather than its schedule position whenever
+// HirModule::logical_noise_prefix records the two as different. For any
+// fixed noise realization, a noise-transparent reorder is a legal can_swap
+// reorder of the noise-free circuit with that realization's Pauli errors
+// absorbed into downstream signs; averaged over the presampled
+// distribution it preserves the sampling distribution exactly, not only on
+// average.
+//
+// Cost: build() makes an O(N^2) can_swap call in the worst case, one per
+// pair with at least one movable endpoint. That is acceptable for this
+// prototype; a real scheduler would want cheap pruning (for example,
+// bounding the pairwise scan by qubit overlap) before running on the
+// largest circuits in the corpus.
+
+#include "clifft/frontend/hir.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace clifft {
+
+// Controls how much freedom the relation grants around NOISE ops. See the
+// file comment for why the relaxation is sound.
+struct ScheduleDependenceOptions {
+    bool noise_transparent = true;
+};
+
+// A DAG of "must not reorder" edges over one HIR's op indices, built once
+// and queried repeatedly by a scheduler or by apply_schedule() below. See
+// the file comment for the relation's exact rules and soundness argument.
+class ScheduleDependence {
+  public:
+    [[nodiscard]] static ScheduleDependence build(const HirModule& hir,
+                                                  ScheduleDependenceOptions options = {});
+
+    [[nodiscard]] size_t num_ops() const { return movable_.size(); }
+
+    // True for T_GATE, PHASE_ROTATION, and MEASURE; false for every other
+    // op type, which the relation pins to its original neighbors.
+    [[nodiscard]] bool is_movable(size_t op) const;
+
+    // Ops that must precede `op` in any legal schedule, sorted ascending.
+    [[nodiscard]] std::span<const uint32_t> predecessors(size_t op) const;
+
+    // Ops that must follow `op` in any legal schedule, sorted ascending.
+    [[nodiscard]] std::span<const uint32_t> successors(size_t op) const;
+
+    [[nodiscard]] bool noise_transparent() const { return noise_transparent_; }
+
+    // True when `order` is a permutation of 0..num_ops()-1 (every op
+    // appears exactly once) that places every predecessor before its
+    // successor for every edge in the relation. Legal schedules are
+    // exactly the orders this accepts.
+    [[nodiscard]] bool is_linear_extension(std::span<const uint32_t> order) const;
+
+  private:
+    ScheduleDependence() = default;
+
+    bool noise_transparent_ = false;
+    std::vector<bool> movable_;
+
+    // CSR adjacency: op i's entries occupy indices
+    // [offsets[i], offsets[i + 1]) of the matching indices vector, both
+    // sized num_ops() + 1.
+    std::vector<uint32_t> pred_offsets_;
+    std::vector<uint32_t> pred_indices_;
+    std::vector<uint32_t> succ_offsets_;
+    std::vector<uint32_t> succ_indices_;
+};
+
+// Reorders hir.ops (and its parallel side tables) in place to `order`, a
+// linear extension of `dependence`. Throws std::invalid_argument if
+// `dependence` was not built from an HIR with the same operation count as
+// `hir`, or if `order` is not a linear extension of `dependence`.
+//
+// ops, source_map (when parallel to ops), and logical_noise_prefix (when
+// present) are permuted together so every side-table entry travels with
+// the operation it describes -- the same contract StatevectorSqueezePass
+// and PeepholeFusionPass already honor for source_map and
+// logical_noise_prefix.
+//
+// When `dependence` is noise-transparent, this calls
+// hir.materialize_logical_noise_prefix() before permuting anything. That
+// materialization is the mechanism that makes a NOISE-crossing reorder
+// sound: it freezes each operation's current (pre-reorder, i.e. logical)
+// position as data that then travels with the operation, so the planner
+// can still resolve its noise-dependent sign from that original position
+// after the move. Without noise transparency, an edge between a NOISE op
+// and a movable one is omitted only when plain can_swap allows it, which
+// happens only when the movable operation commutes with every channel at
+// that site -- a crossing that needs no sign correction at all, since a
+// commuting channel contributes nothing to that correction regardless of
+// position. Materializing anyway would still leave behind a
+// logical_noise_prefix that PeepholeFusionPass reads as inconsistent with
+// schedule position (even though the missing correction is semantically
+// zero) and so refuses to fuse across, for no benefit. Skipping
+// materialization when it is not needed leaves the vector exactly as it
+// was -- typically empty -- keeping that pass fully usable afterward.
+void apply_schedule(HirModule& hir, const ScheduleDependence& dependence,
+                    std::span<const uint32_t> order);
+
+}  // namespace clifft

--- a/src/clifft/optimizer/statevector_squeeze_pass.cc
+++ b/src/clifft/optimizer/statevector_squeeze_pass.cc
@@ -32,6 +32,7 @@ bool can_bypass_to(const HirModule& hir, size_t moving, size_t target) {
 
 void StatevectorSqueezePass::run(HirModule& hir) {
     bool has_sm = hir.source_map.size() == hir.ops.size();
+    bool has_lnp = hir.has_logical_noise_prefix();
 
     // EXP_VAL acts as a hard barrier via can_swap(), so neither sweep
     // will move operations across an expectation value probe.
@@ -46,6 +47,9 @@ void StatevectorSqueezePass::run(HirModule& hir) {
             std::swap(hir.ops[curr - 1], hir.ops[curr]);
             if (has_sm) {
                 std::swap(hir.source_map[curr - 1], hir.source_map[curr]);
+            }
+            if (has_lnp) {
+                std::swap(hir.logical_noise_prefix[curr - 1], hir.logical_noise_prefix[curr]);
             }
             --curr;
         }
@@ -90,6 +94,14 @@ void StatevectorSqueezePass::run(HirModule& hir) {
                                 hir.source_map.begin() + static_cast<std::ptrdiff_t>(curr + 1),
                                 hir.source_map.begin() + static_cast<std::ptrdiff_t>(target + 1));
                         }
+                        if (has_lnp) {
+                            std::rotate(hir.logical_noise_prefix.begin() +
+                                            static_cast<std::ptrdiff_t>(curr),
+                                        hir.logical_noise_prefix.begin() +
+                                            static_cast<std::ptrdiff_t>(curr + 1),
+                                        hir.logical_noise_prefix.begin() +
+                                            static_cast<std::ptrdiff_t>(target + 1));
+                        }
                         --*target_it;
                         curr = target;
                         continue;
@@ -101,6 +113,10 @@ void StatevectorSqueezePass::run(HirModule& hir) {
                     std::swap(hir.ops[curr], hir.ops[curr + 1]);
                     if (has_sm) {
                         std::swap(hir.source_map[curr], hir.source_map[curr + 1]);
+                    }
+                    if (has_lnp) {
+                        std::swap(hir.logical_noise_prefix[curr],
+                                  hir.logical_noise_prefix[curr + 1]);
                     }
                     auto crossed =
                         std::upper_bound(non_expansions.begin(), non_expansions.end(), curr);

--- a/src/clifft/sampling/planner.cc
+++ b/src/clifft/sampling/planner.cc
@@ -5,6 +5,7 @@
 #include "clifft/util/numeric.h"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -23,6 +24,18 @@ using Pauli = internal::PlannerPauli;
 using Tableau = internal::PlannerTableau;
 using internal::CoordinateFrame;
 using internal::SymbolicPauliFrame;
+
+// Symplectic inner product over runtime-width mask views: true when the two
+// Pauli strings anti-commute. optimizer/commutation.h has the same helper,
+// but sampling/ has no other dependency on optimizer/, so this stays a
+// local copy rather than introducing one.
+bool anti_commute(MaskView x1, MaskView z1, MaskView x2, MaskView z2) {
+    int parity = 0;
+    for (uint32_t i = 0; i < x1.num_words(); ++i) {
+        parity += std::popcount((x1.words[i] & z2.words[i]) ^ (z1.words[i] & x2.words[i]));
+    }
+    return (parity & 1) != 0;
+}
 
 Pauli pauli_from_hir(const HirModule& hir, const HeisenbergOp& op) {
     Pauli result(hir.num_qubits);
@@ -55,13 +68,60 @@ struct ResolvedPauli {
     AffineBool sign;
 };
 
+// An operation's schedule position and logical position, both expressed as
+// noise-site counts: how many NOISE ops the planner has processed in
+// schedule order when it reaches the operation (schedule_count) versus how
+// many logically precede the operation in the original circuit
+// (logical_prefix). The two agree unless HirModule::logical_noise_prefix
+// moved the operation across a noise site.
+struct NoiseCrossing {
+    uint32_t schedule_count = 0;
+    uint32_t logical_prefix = 0;
+};
+
+// The affine correction an operation picks up for every site it logically
+// crossed. The symbolic frame already folded each site's channels in at
+// that site's schedule position. For a site between an operation's schedule
+// and logical positions, that frame contribution is exactly wrong for the
+// operation's logical position: either missing (the operation moved earlier
+// than the site) or spurious (it moved later than the site). XORing the
+// same site's channel symbols back in fixes both directions, since XOR is
+// its own inverse.
+AffineBool logical_noise_correction(const HirModule& hir, const Pauli& initial_body,
+                                    std::span<const uint32_t> noise_site_symbol_base,
+                                    NoiseCrossing crossing) {
+    AffineBool correction;
+    const uint32_t begin = std::min(crossing.schedule_count, crossing.logical_prefix);
+    const uint32_t end = std::max(crossing.schedule_count, crossing.logical_prefix);
+    for (uint32_t site = begin; site < end; ++site) {
+        const NoiseSite& noise_site = hir.noise_sites[site];
+        uint32_t local_index = 0;
+        for (const NoiseChannel& channel : noise_site.channels) {
+            if (channel.prob == 0.0) {
+                continue;
+            }
+            const PauliMaskView channel_view = hir.noise_channel_masks.at(channel.mask);
+            if (anti_commute(initial_body.x(), initial_body.z(), channel_view.x(),
+                             channel_view.z())) {
+                correction ^=
+                    AffineBool::symbol(SymbolId{noise_site_symbol_base[site] + local_index});
+            }
+            ++local_index;
+        }
+    }
+    return correction;
+}
+
 ResolvedPauli resolve_pauli(const Pauli& initial_body, const AffineBool& initial_sign,
-                            CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame) {
+                            CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame,
+                            const HirModule& hir, std::span<const uint32_t> noise_site_symbol_base,
+                            NoiseCrossing crossing) {
     AffineBool sign = initial_sign;
     sign ^= symbolic_frame.sign_for(initial_body);
     Pauli body = coordinates.to_current(initial_body);
     sign ^= body.sign();
     body.set_sign(false);
+    sign ^= logical_noise_correction(hir, initial_body, noise_site_symbol_base, crossing);
     return ResolvedPauli{std::move(body), std::move(sign)};
 }
 
@@ -183,6 +243,12 @@ struct PendingObservable {
 struct PlanningRequirements {
     uint32_t symbol_count = 0;
     bool supports_final_state_queries = true;
+    // noise_site_symbol_base[site] is the symbol count reserved before that
+    // site's own nonzero channels, i.e. the value plan.symbols.size() will
+    // have when the main loop's NOISE case starts pushing that site's
+    // symbols. Indexed by NoiseSiteIdx; sized to hir.noise_sites.size() even
+    // though only sites actually reached by a NOISE op are meaningful.
+    std::vector<uint32_t> noise_site_symbol_base;
 };
 
 bool operation_supports_final_state_queries(OpType type) {
@@ -206,6 +272,7 @@ bool operation_supports_final_state_queries(OpType type) {
 
 PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
     PlanningRequirements result;
+    result.noise_site_symbol_base.assign(hir.noise_sites.size(), 0);
     auto add = [&](size_t amount) {
         if (amount > std::numeric_limits<uint32_t>::max() - result.symbol_count) {
             throw std::length_error("sampling planner symbol count exceeds uint32 range");
@@ -227,6 +294,7 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
                 if (site_index >= hir.noise_sites.size()) {
                     throw std::invalid_argument("sampling planner noise site is out of range");
                 }
+                result.noise_site_symbol_base[site_index] = result.symbol_count;
                 const NoiseSite& site = hir.noise_sites[site_index];
                 add(std::ranges::count_if(site.channels, [](const NoiseChannel& channel) {
                     return channel.prob != 0.0;
@@ -248,6 +316,44 @@ PlanningRequirements inspect_planning_requirements(const HirModule& hir) {
         }
     }
     return result;
+}
+
+// Validates logical_noise_prefix before any symbol is reserved. NOISE sites
+// are always processed in circuit order (checked separately, below), so
+// their logical position is always their schedule position; the same holds
+// for every other operation that is not a T_GATE, PHASE_ROTATION, or
+// MEASURE, since the optimizer never moves those across a noise site. Only
+// those three op types may legitimately disagree with their schedule count.
+void validate_logical_noise_prefix(const HirModule& hir) {
+    if (hir.logical_noise_prefix.empty()) {
+        return;
+    }
+    if (hir.logical_noise_prefix.size() != hir.ops.size()) {
+        throw std::invalid_argument(
+            "sampling planner logical noise prefix size does not match the operation count");
+    }
+    const auto num_noise_sites = static_cast<uint32_t>(hir.noise_sites.size());
+    uint32_t schedule_count = 0;
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        const HeisenbergOp& op = hir.ops[i];
+        const uint32_t entry = hir.logical_noise_prefix[i];
+        if (entry > num_noise_sites) {
+            throw std::invalid_argument("sampling planner logical noise prefix at operation " +
+                                        std::to_string(i) + " exceeds the noise site count");
+        }
+        const OpType type = op.op_type();
+        const bool may_cross_noise =
+            type == OpType::T_GATE || type == OpType::PHASE_ROTATION || type == OpType::MEASURE;
+        if (!may_cross_noise && entry != schedule_count) {
+            throw std::invalid_argument(
+                "sampling planner logical noise prefix at operation " + std::to_string(i) +
+                " must equal its schedule position for an operation that cannot move across "
+                "noise");
+        }
+        if (type == OpType::NOISE) {
+            ++schedule_count;
+        }
+    }
 }
 
 void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
@@ -273,8 +379,11 @@ void initialize_site_metadata(const HirModule& hir, SamplingPlan& plan) {
 
 bool process_rotation(const Pauli& body, double half_turns, const AffineBool& sign,
                       SamplingPlan& plan, uint32_t& active_width, CoordinateFrame& coordinates,
-                      SymbolicPauliFrame& symbolic_frame, std::span<const uint32_t> source_lines) {
-    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame);
+                      SymbolicPauliFrame& symbolic_frame, const HirModule& hir,
+                      std::span<const uint32_t> noise_site_symbol_base, NoiseCrossing crossing,
+                      std::span<const uint32_t> source_lines) {
+    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame, hir,
+                                           noise_site_symbol_base, crossing);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (!dormant_pivot.has_value()) {
         const ActivePauli active = active_projection(resolved.body, active_width);
@@ -308,8 +417,11 @@ bool process_rotation(const Pauli& body, double half_turns, const AffineBool& si
 AffineBool process_measurement(const Pauli& body, const AffineBool& sign, RecordSlot record,
                                SymbolId branch, SamplingPlan& plan, uint32_t& active_width,
                                CoordinateFrame& coordinates, SymbolicPauliFrame& symbolic_frame,
-                               std::span<const uint32_t> source_lines) {
-    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame);
+                               const HirModule& hir,
+                               std::span<const uint32_t> noise_site_symbol_base,
+                               NoiseCrossing crossing, std::span<const uint32_t> source_lines) {
+    ResolvedPauli resolved = resolve_pauli(body, sign, coordinates, symbolic_frame, hir,
+                                           noise_site_symbol_base, crossing);
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
     if (dormant_pivot.has_value()) {
         coordinates.measure_dormant(resolved.body, *dormant_pivot);
@@ -363,6 +475,7 @@ AffineBool process_measurement(const Pauli& body, const AffineBool& sign, Record
 }
 
 void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t next_noise_site,
+                        uint32_t logical_prefix, std::span<const uint32_t> noise_site_symbol_base,
                         SamplingPlan& plan, uint32_t& active_width, CoordinateFrame& coordinates,
                         SymbolicPauliFrame& symbolic_frame,
                         std::span<const uint32_t> source_lines) {
@@ -374,7 +487,8 @@ void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t n
     const Pauli destination_flip = pauli_from_mask(hir, hir_site.destination_flip_mask);
     const InstrumentDistribution& distribution = plan.instrument_distributions.at(index(site));
     ResolvedPauli resolved =
-        resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame);
+        resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame, hir,
+                      noise_site_symbol_base, NoiseCrossing{next_noise_site, logical_prefix});
     const std::optional<uint32_t> dormant_pivot = first_x_at_or_above(resolved.body, active_width);
 
     InstrumentMode mode = InstrumentMode::Classical;
@@ -436,6 +550,8 @@ void process_instrument(const HirModule& hir, const HeisenbergOp& op, uint32_t n
 }  // namespace
 
 SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
+    validate_logical_noise_prefix(hir);
+
     SamplingPlan plan;
     plan.num_qubits = hir.num_qubits;
     plan.num_visible_records = hir.num_measurements;
@@ -456,6 +572,7 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
     // The packed symbolic frame needs its row count up front. Count only;
     // operations and their Paulis are consumed directly from HIR below.
     const PlanningRequirements requirements = inspect_planning_requirements(hir);
+    const std::span<const uint32_t> noise_site_symbol_base(requirements.noise_site_symbol_base);
     plan.symbols.reserve(requirements.symbol_count);
     initialize_site_metadata(hir, plan);
     if (requirements.supports_final_state_queries) {
@@ -506,30 +623,36 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
         const HeisenbergOp& op = hir.ops[i];
         const std::span<const uint32_t> source_lines =
             plan.source_map.has_value() ? source_lines_for(hir, i) : std::span<const uint32_t>{};
+        // Absent when the vector is not materialized: every operation's
+        // logical position is then its schedule position, which keeps the
+        // logical_noise_correction interval empty and the plan unchanged.
+        const uint32_t logical_prefix =
+            hir.has_logical_noise_prefix() ? hir.logical_noise_prefix[i] : next_noise_site;
+        const NoiseCrossing crossing{next_noise_site, logical_prefix};
         supports_final_state_queries &= operation_supports_final_state_queries(op.op_type());
         switch (op.op_type()) {
             case OpType::T_GATE: {
                 const double half_turns = op.is_dagger() ? -0.25 : 0.25;
                 const Pauli body = pauli_from_hir(hir, op);
-                final_coordinates_changed |=
-                    process_rotation(body, half_turns, AffineBool(hir.sign(op)), plan, active_width,
-                                     coordinates, symbolic_frame, source_lines);
+                final_coordinates_changed |= process_rotation(
+                    body, half_turns, AffineBool(hir.sign(op)), plan, active_width, coordinates,
+                    symbolic_frame, hir, noise_site_symbol_base, crossing, source_lines);
                 break;
             }
             case OpType::PHASE_ROTATION: {
                 const Pauli body = pauli_from_hir(hir, op);
-                final_coordinates_changed |=
-                    process_rotation(body, op.alpha(), AffineBool(hir.sign(op)), plan, active_width,
-                                     coordinates, symbolic_frame, source_lines);
+                final_coordinates_changed |= process_rotation(
+                    body, op.alpha(), AffineBool(hir.sign(op)), plan, active_width, coordinates,
+                    symbolic_frame, hir, noise_site_symbol_base, crossing, source_lines);
                 break;
             }
             case OpType::MEASURE: {
                 const RecordSlot record{static_cast<uint32_t>(op.meas_record_idx())};
                 const SymbolId branch = reserve_symbol(plan);
                 const Pauli body = pauli_from_hir(hir, op);
-                const AffineBool outcome =
-                    process_measurement(body, AffineBool(hir.sign(op)), record, branch, plan,
-                                        active_width, coordinates, symbolic_frame, source_lines);
+                const AffineBool outcome = process_measurement(
+                    body, AffineBool(hir.sign(op)), record, branch, plan, active_width, coordinates,
+                    symbolic_frame, hir, noise_site_symbol_base, crossing, source_lines);
                 assign_record(record, outcome, i);
                 break;
             }
@@ -550,6 +673,9 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                 }
                 ++next_noise_site;
                 const NoiseSite& hir_site = hir.noise_sites[site_index];
+                assert(plan.symbols.size() == requirements.noise_site_symbol_base[site_index] &&
+                       "sampling planner symbol prepass disagrees with the schedule-order "
+                       "allocation it precomputed for this noise site");
                 PresampledNoiseSite& plan_site = plan.presampled_noise_sites[site_index];
                 plan_site.outcomes.reserve(hir_site.channels.size());
                 for (const NoiseChannel& channel : hir_site.channels) {
@@ -600,8 +726,8 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                     throw std::invalid_argument(
                         "sampling planner instrument omits its destination flip");
                 }
-                process_instrument(hir, op, next_noise_site, plan, active_width, coordinates,
-                                   symbolic_frame, source_lines);
+                process_instrument(hir, op, next_noise_site, logical_prefix, noise_site_symbol_base,
+                                   plan, active_width, coordinates, symbolic_frame, source_lines);
                 ++next_instrument_site;
                 break;
             }
@@ -652,7 +778,8 @@ SamplingPlan plan_sampling(const HirModule& hir, SamplingPlanOptions options) {
                 }
                 const Pauli body = pauli_from_hir(hir, op);
                 ResolvedPauli resolved =
-                    resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame);
+                    resolve_pauli(body, AffineBool(hir.sign(op)), coordinates, symbolic_frame, hir,
+                                  noise_site_symbol_base, crossing);
                 const bool is_zero = first_x_at_or_above(resolved.body, active_width).has_value();
                 append_action(
                     plan,

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -7,11 +7,14 @@
 #include "clifft/noncomp/model.h"
 #include "clifft/noncomp/policy.h"
 #include "clifft/noncomp/sample.h"
+#include "clifft/optimizer/active_width_analysis.h"
+#include "clifft/optimizer/active_width_search.h"
 #include "clifft/optimizer/drop_non_unitary_pass.h"
 #include "clifft/optimizer/hir_pass_manager.h"
 #include "clifft/optimizer/pass_factory.h"
 #include "clifft/optimizer/peephole.h"
 #include "clifft/optimizer/remove_noise_pass.h"
+#include "clifft/optimizer/schedule_dependence.h"
 #include "clifft/optimizer/statevector_squeeze_pass.h"
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
@@ -148,6 +151,38 @@ clifft::HirModule prepare_qasm2_for_lowering(const std::string& qasm_text, bool 
     clifft::Qasm2Import imported = clifft::parse_qasm2(qasm_text);
     return prepare_circuit_for_lowering(imported.circuit, normalize_syndromes, hir_passes,
                                         expected_detectors, expected_observables);
+}
+
+// Lower-case names for active_width_trace()'s per-op 'effects' list. Python
+// tooling consumes these as plain strings rather than an enum, so this
+// mapping -- not clifft::WidthEffect's own C++ identifiers -- is what that
+// output format actually commits to.
+const char* width_effect_to_str(clifft::WidthEffect effect) {
+    switch (effect) {
+        case clifft::WidthEffect::None:
+            return "none";
+        case clifft::WidthEffect::RotationStabilizer:
+            return "rotation_stabilizer";
+        case clifft::WidthEffect::RotationNeutral:
+            return "rotation_neutral";
+        case clifft::WidthEffect::RotationPromote:
+            return "rotation_promote";
+        case clifft::WidthEffect::MeasureClassical:
+            return "measure_classical";
+        case clifft::WidthEffect::MeasureDormantRandom:
+            return "measure_dormant_random";
+        case clifft::WidthEffect::MeasureActive:
+            return "measure_active";
+        case clifft::WidthEffect::InstrumentClassical:
+            return "instrument_classical";
+        case clifft::WidthEffect::InstrumentActive:
+            return "instrument_active";
+        case clifft::WidthEffect::InstrumentActivate:
+            return "instrument_activate";
+        case clifft::WidthEffect::InstrumentDormantTrap:
+            return "instrument_dormant_trap";
+    }
+    return "unknown";
 }
 
 }  // namespace
@@ -748,6 +783,84 @@ NB_MODULE(_clifft_core, m) {
     m.def(
         "default_hir_pass_manager", []() { return clifft::default_hir_pass_manager(); },
         nb::rv_policy::move, "Return an HirPassManager pre-loaded with the default passes.");
+
+    m.def(
+        "active_width_trace",
+        [](const clifft::HirModule& hir) {
+            clifft::ActiveWidthTrace trace;
+            {
+                nb::gil_scoped_release release;
+                trace = clifft::analyze_active_width(hir);
+            }
+            nb::list widths;
+            nb::list effects;
+            for (const clifft::WidthTransition& transition : trace.transitions) {
+                widths.append(transition.after);
+                effects.append(width_effect_to_str(transition.effect));
+            }
+            nb::dict d;
+            d["initial"] = trace.initial_width;
+            d["peak"] = trace.peak_width;
+            d["final"] = trace.final_width;
+            d["widths"] = widths;
+            d["effects"] = effects;
+            return d;
+        },
+        nb::arg("hir"),
+        "Structural active-width trace of an HIR module, without lowering it "
+        "to an executable program.\n\n"
+        "Returns a dict with 'initial', 'peak', and 'final' width, plus "
+        "per-op 'widths' (the width after each op) and 'effects' (a "
+        "lower-case effect name per op).");
+
+    m.def(
+        "search_width_schedule",
+        [](clifft::HirModule& hir, bool noise_transparent, uint64_t node_budget, bool apply) {
+            clifft::ScheduleDependenceOptions dependence_options;
+            dependence_options.noise_transparent = noise_transparent;
+            clifft::WidthSearchOptions search_options;
+            search_options.node_budget = node_budget;
+
+            clifft::WidthSearchResult result;
+            {
+                nb::gil_scoped_release release;
+                const clifft::ScheduleDependence dependence =
+                    clifft::ScheduleDependence::build(hir, dependence_options);
+                result = clifft::search_width_schedule(hir, dependence, search_options);
+                if (apply && result.upper_bound < result.incumbent_peak) {
+                    clifft::apply_schedule(hir, dependence, result.best_order);
+                }
+            }
+
+            nb::dict d;
+            d["incumbent_peak"] = result.incumbent_peak;
+            d["upper_bound"] = result.upper_bound;
+            d["lower_bound"] = result.lower_bound;
+            d["optimal"] = result.optimal();
+            d["explored_nodes"] = result.explored_nodes;
+            d["budget_exhausted"] = result.budget_exhausted;
+            d["noise_transparent"] = result.noise_transparent;
+            d["order"] = nb::cast(result.best_order);
+            return d;
+        },
+        nb::arg("hir"), nb::kw_only(), nb::arg("noise_transparent") = true,
+        nb::arg("node_budget") = uint64_t{200000}, nb::arg("apply") = true,
+        "Exact, budgeted search for the schedule of `hir` that minimizes peak "
+        "active width.\n\n"
+        "Certifies a minimum ('optimal' True in the result) over the trace "
+        "class of this exact HIR under the searched dependence relation, "
+        "scored by the sampling planner's own structural width model; it "
+        "says nothing about schedules reachable only through a rewrite that "
+        "exposes new gate fusion, about amplitude-level stabilizers the "
+        "structural planner does not track, or about any other circuit that "
+        "merely samples the same distribution as this one.\n\n"
+        "With apply=True (the default), applies the found schedule to `hir` "
+        "in place when it improves on the incumbent peak; otherwise `hir` is "
+        "left untouched.\n\n"
+        "Returns a dict with 'incumbent_peak', 'upper_bound', 'lower_bound', "
+        "'optimal', 'explored_nodes', 'budget_exhausted', "
+        "'noise_transparent', and 'order' (the schedule found, as op "
+        "indices).");
 
     nb::class_<clifft::sampling::ExecutablePlan>(m, "Program",
                                                  "A reusable compiled sampling program")

--- a/src/python/clifft/__init__.py
+++ b/src/python/clifft/__init__.py
@@ -47,6 +47,7 @@ from clifft._clifft_core import (
     Target,
     _basis_probabilities_from_bitmasks,
     _record_probabilities_from_records,
+    active_width_trace,
     compute_reference_syndrome,
     default_hir_pass_manager,
     get_statevector,
@@ -60,6 +61,7 @@ from clifft._clifft_core import (
     sample_k,
     sample_k_survivors,
     sample_survivors,
+    search_width_schedule,
     trace,
     version,
 )
@@ -365,6 +367,7 @@ __all__ = [
     "SampleResult",
     "StatevectorSqueezePass",
     "Target",
+    "active_width_trace",
     "basis_probabilities",
     "compile",
     "compute_reference_syndrome",
@@ -383,6 +386,7 @@ __all__ = [
     "sample_k",
     "sample_k_survivors",
     "sample_survivors",
+    "search_width_schedule",
     "trace",
     "version",
 ]

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/tableau/tableau.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/frontend/frontend.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/hir_pass_manager.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/active_width_analysis.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/drop_non_unitary_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/commutation.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/peephole.cc

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/peephole.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/pass_factory.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/remove_noise_pass.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/schedule_dependence.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan_inspection.cc

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(clifft_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/pass_factory.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/remove_noise_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/schedule_dependence.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/active_width_search.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/optimizer/statevector_squeeze_pass.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../clifft/sampling/plan_inspection.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(clifft_tests
     test_source_map.cc
     test_logical_noise_prefix.cc
     test_schedule_dependence.cc
+    test_active_width_search.cc
     test_importance_sampling.cc
     test_runtime_isa.cc
     test_shot_parallel.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(clifft_tests
     test_active_width_analysis.cc
     test_source_map.cc
     test_logical_noise_prefix.cc
+    test_schedule_dependence.cc
     test_importance_sampling.cc
     test_runtime_isa.cc
     test_shot_parallel.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(clifft_tests
     test_sampling_kernels.cc
     test_interleaved_batch_kernels.cc
     test_optimizer.cc
+    test_active_width_analysis.cc
     test_source_map.cc
     test_importance_sampling.cc
     test_runtime_isa.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(clifft_tests
     test_interleaved_batch_kernels.cc
     test_optimizer.cc
     test_source_map.cc
+    test_logical_noise_prefix.cc
     test_importance_sampling.cc
     test_runtime_isa.cc
     test_shot_parallel.cc

--- a/tests/python/test_active_width_search.py
+++ b/tests/python/test_active_width_search.py
@@ -1,0 +1,108 @@
+"""Tests for the active_width_trace and search_width_schedule bindings."""
+
+from pathlib import Path
+from typing import Any
+
+from conftest import cross_binomial_tolerance
+
+import clifft
+
+_FIXTURES = Path(__file__).parents[1] / "fixtures"
+
+# Same set test_active_width_analysis.cc's fixture differential test uses;
+# the production pipeline is what plans successfully on every one of them.
+_ALL_FIXTURES = [
+    "coherent_d3_r3.stim",
+    "coherent_d5_r5.stim",
+    "cultivation_d5.stim",
+    "surface_d7_r7_p001.stim",
+    "qv10.stim",
+    "surface_d11_r11_p001.stim",
+    "surface_d5_r5_p05.stim",
+    "target_qec.stim",
+]
+
+
+def _production_hir(name: str) -> Any:
+    circuit = (_FIXTURES / name).read_text()
+    hir = clifft.trace(clifft.parse(circuit))
+    clifft.default_hir_pass_manager().run(hir)
+    return hir
+
+
+def _assert_column_probabilities_match(reference: Any, candidate: Any, *, label: str) -> None:
+    # Same six-sigma cross-binomial column comparison
+    # test_squeeze_benchmark_integration.py's three-way oracle uses.
+    assert reference.shape == candidate.shape
+    shots = reference.shape[0]
+    reference_probabilities = reference.mean(axis=0, dtype=float)
+    candidate_probabilities = candidate.mean(axis=0, dtype=float)
+    for column, (reference_probability, candidate_probability) in enumerate(
+        zip(reference_probabilities, candidate_probabilities, strict=True)
+    ):
+        pooled = float((reference_probability + candidate_probability) / 2.0)
+        tolerance = cross_binomial_tolerance(pooled, shots, sigma=6.0)
+        difference = abs(float(reference_probability - candidate_probability))
+        assert difference < tolerance, (
+            f"{label} column {column}: {reference_probability:.5f} vs "
+            f"{candidate_probability:.5f}, difference {difference:.6f} "
+            f">= tolerance {tolerance:.6f}"
+        )
+
+
+def test_active_width_trace_peak_matches_lowered_program() -> None:
+    for fixture in _ALL_FIXTURES:
+        hir = _production_hir(fixture)
+        trace = clifft.active_width_trace(hir)
+
+        assert trace["peak"] == clifft.lower(hir).peak_active_width, fixture
+        assert len(trace["widths"]) == hir.num_ops, fixture
+        assert len(trace["effects"]) == hir.num_ops, fixture
+        assert trace["initial"] <= trace["peak"], fixture
+        assert trace["final"] <= trace["peak"], fixture
+
+
+def test_search_width_schedule_certifies_coherent_d3_r3() -> None:
+    hir = _production_hir("coherent_d3_r3.stim")
+    result = clifft.search_width_schedule(hir, noise_transparent=True, apply=False)
+
+    assert result["incumbent_peak"] == 5
+    assert result["upper_bound"] == 4
+    assert result["lower_bound"] == 4
+    assert result["optimal"] is True
+    assert result["noise_transparent"] is True
+
+
+def test_search_width_schedule_apply_lowers_peak_and_preserves_sampling() -> None:
+    unoptimized_hir = _production_hir("coherent_d3_r3.stim")
+    unoptimized_program = clifft.lower(unoptimized_hir)
+    assert unoptimized_program.peak_active_width == 5
+
+    optimized_hir = _production_hir("coherent_d3_r3.stim")
+    result = clifft.search_width_schedule(optimized_hir, noise_transparent=True, apply=True)
+    assert result["upper_bound"] == 4
+
+    optimized_program = clifft.lower(optimized_hir)
+    assert optimized_program.peak_active_width == 4
+
+    shots = 20_000
+    unoptimized_result = clifft.sample(unoptimized_program, shots, seed=90_001)
+    optimized_result = clifft.sample(optimized_program, shots, seed=90_002)
+
+    for field in ("measurements", "detectors", "observables"):
+        _assert_column_probabilities_match(
+            getattr(unoptimized_result, field),
+            getattr(optimized_result, field),
+            label=field,
+        )
+
+
+def test_search_width_schedule_apply_false_leaves_hir_unchanged() -> None:
+    hir = _production_hir("coherent_d3_r3.stim")
+    before_peak = clifft.lower(hir).peak_active_width
+
+    result = clifft.search_width_schedule(hir, noise_transparent=True, apply=False)
+    assert result["upper_bound"] < result["incumbent_peak"]
+
+    after_peak = clifft.lower(hir).peak_active_width
+    assert after_peak == before_peak

--- a/tests/sampling_equivalence_helpers.h
+++ b/tests/sampling_equivalence_helpers.h
@@ -1,0 +1,209 @@
+#pragma once
+
+// Shared helpers for tests that reorder HIR operations and must confirm the
+// reordered program samples the same distribution as the original: a random
+// noisy-circuit generator plus a statistical equivalence check. Split out of
+// test_logical_noise_prefix.cc so test_schedule_dependence.cc can reuse both
+// without duplicating them.
+
+#include "clifft/frontend/hir.h"
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/sampling/sampler.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace clifft::test {
+
+// ---------------------------------------------------------------------------
+// Random noisy circuit generation
+// ---------------------------------------------------------------------------
+
+// A generated circuit plus, for each NOISE line, enough information to
+// realize a fixed firing outcome for it later (used by legality-oracle style
+// tests that replay a fixed noise realization).
+struct GeneratedCircuit {
+    struct NoiseLine {
+        size_t line_index = 0;
+        uint32_t qubit = 0;
+        bool is_depolarize1 = false;
+        double prob = 0.0;
+    };
+
+    std::vector<std::string> lines;
+    std::vector<NoiseLine> noise_lines;
+};
+
+inline double next_unit(std::mt19937& rng) {
+    return static_cast<double>(rng() >> 11) * 0x1.0p-53;
+}
+
+// Deterministic generator over a small gate set: T, T_DAG, R_Z at a few
+// angles, M, MX, MR, R, X_ERROR, DEPOLARIZE1, and DETECTORs referencing
+// earlier records. Every generated line is individually valid, so the
+// circuit as a whole always parses and traces.
+inline GeneratedCircuit generate_noisy_circuit(std::mt19937& rng, uint32_t num_qubits,
+                                               uint32_t num_ops) {
+    static const double kAngles[] = {0.125, 0.25, 0.375, 0.625, 0.75, 0.875};
+    static const double kNoiseProbs[] = {0.05, 0.1, 0.2, 0.3};
+
+    GeneratedCircuit circuit;
+    uint32_t measurement_count = 0;
+    for (uint32_t op = 0; op < num_ops; ++op) {
+        const uint32_t q = rng() % num_qubits;
+        switch (rng() % 9) {
+            case 0:
+                circuit.lines.push_back("T " + std::to_string(q));
+                break;
+            case 1:
+                circuit.lines.push_back("T_DAG " + std::to_string(q));
+                break;
+            case 2:
+                circuit.lines.push_back("R_Z(" +
+                                        std::to_string(kAngles[rng() % std::size(kAngles)]) + ") " +
+                                        std::to_string(q));
+                break;
+            case 3:
+                circuit.lines.push_back("M " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 4:
+                circuit.lines.push_back("MX " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 5:
+                circuit.lines.push_back("MR " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 6:
+                circuit.lines.push_back("R " + std::to_string(q));
+                break;
+            case 7: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                circuit.lines.push_back("X_ERROR(" + std::to_string(prob) + ") " +
+                                        std::to_string(q));
+                circuit.noise_lines.push_back(
+                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/false, prob});
+                break;
+            }
+            case 8: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                circuit.lines.push_back("DEPOLARIZE1(" + std::to_string(prob) + ") " +
+                                        std::to_string(q));
+                circuit.noise_lines.push_back(
+                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/true, prob});
+                break;
+            }
+            default:
+                break;
+        }
+        if (measurement_count > 0 && (rng() % 5) == 0) {
+            const uint32_t back = 1 + (rng() % measurement_count);
+            circuit.lines.push_back("DETECTOR rec[-" + std::to_string(back) + "]");
+        }
+    }
+    return circuit;
+}
+
+inline std::string join_lines(const std::vector<std::string>& lines) {
+    std::string text;
+    for (const std::string& line : lines) {
+        text += line;
+        text += '\n';
+    }
+    return text;
+}
+
+inline std::string generate_noisy_source(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    return join_lines(generate_noisy_circuit(rng, num_qubits, num_ops).lines);
+}
+
+// ---------------------------------------------------------------------------
+// Sampling equivalence
+// ---------------------------------------------------------------------------
+
+inline double tolerance_at_6_sigma(double mean_a, double mean_b, uint32_t shots) {
+    // A floor keeps the tolerance from collapsing to zero for a column that
+    // is (near-)deterministic in both samples.
+    constexpr double kMinP = 1e-3;
+    const double pooled = std::clamp(0.5 * (mean_a + mean_b), kMinP, 1.0 - kMinP);
+    return 6.0 * std::sqrt(2.0 * pooled * (1.0 - pooled) / shots);
+}
+
+inline double column_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t column,
+                          uint32_t shots) {
+    uint64_t ones = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        ones += values[static_cast<size_t>(shot) * num_columns + column];
+    }
+    return static_cast<double>(ones) / shots;
+}
+
+inline double parity_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t col_a,
+                          uint32_t col_b, uint32_t shots) {
+    uint64_t ones = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const uint8_t a = values[static_cast<size_t>(shot) * num_columns + col_a];
+        const uint8_t b = values[static_cast<size_t>(shot) * num_columns + col_b];
+        ones += static_cast<uint8_t>(a ^ b);
+    }
+    return static_cast<double>(ones) / shots;
+}
+
+inline void check_columns_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
+                                uint32_t num_columns, uint32_t shots, const char* label) {
+    for (uint32_t col = 0; col < num_columns; ++col) {
+        const double mean_a = column_mean(a, num_columns, col, shots);
+        const double mean_b = column_mean(b, num_columns, col, shots);
+        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
+        INFO(label << " column " << col << ": " << mean_a << " vs " << mean_b << ", tol " << tol);
+        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
+    }
+}
+
+inline void check_parities_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
+                                 uint32_t num_columns, uint32_t shots, const char* label) {
+    for (uint32_t col = 0; col + 1 < num_columns; ++col) {
+        const double mean_a = parity_mean(a, num_columns, col, col + 1, shots);
+        const double mean_b = parity_mean(b, num_columns, col, col + 1, shots);
+        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
+        INFO(label << " parity (" << col << "," << col + 1 << "): " << mean_a << " vs " << mean_b
+                   << ", tol " << tol);
+        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
+    }
+}
+
+// Samples `original` and `reordered` with different seeds and requires every
+// record column mean, every detector column mean, and every consecutive-pair
+// record parity to agree within a cross-binomial tolerance. The point is
+// distributional equality, not bit-exact records.
+inline void check_sampling_equivalent(const HirModule& original, const HirModule& reordered,
+                                      uint32_t shots, uint64_t seed_a, uint64_t seed_b) {
+    const clifft::sampling::ExecutablePlan plan_a(clifft::sampling::plan_sampling(original));
+    const clifft::sampling::ExecutablePlan plan_b(clifft::sampling::plan_sampling(reordered));
+    REQUIRE(plan_a.num_visible_records() == plan_b.num_visible_records());
+    REQUIRE(plan_a.num_detectors() == plan_b.num_detectors());
+
+    const clifft::sampling::SamplingResult result_a =
+        clifft::sampling::sample(plan_a, shots, seed_a);
+    const clifft::sampling::SamplingResult result_b =
+        clifft::sampling::sample(plan_b, shots, seed_b);
+
+    check_columns_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
+                        shots, "record");
+    check_columns_agree(result_a.detectors, result_b.detectors, plan_a.num_detectors(), shots,
+                        "detector");
+    check_parities_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
+                         shots, "record");
+}
+
+}  // namespace clifft::test

--- a/tests/test_active_width_analysis.cc
+++ b/tests/test_active_width_analysis.cc
@@ -1,0 +1,446 @@
+// Differential and unit tests for the structural active-width analysis.
+//
+// The core property under test is that analyze_active_width(hir) reproduces
+// the sampling planner's width trace exactly, without building a coordinate
+// frame. The differential helper below compares peak width, the sequence of
+// width changes in op order, and per-effect action counts between a
+// SamplingPlan and an ActiveWidthTrace built from the same HIR.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/active_width_analysis.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/peephole.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/tableau/pauli_string.h"
+
+#include "instrument_test_helpers.h"
+#include "test_helpers.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace clifft;
+using clifft::sampling::ApplyInstrument;
+using clifft::sampling::InstrumentMode;
+using clifft::sampling::MeasureActivePauli;
+using clifft::sampling::MeasureDormantRandom;
+using clifft::sampling::PlannedAction;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::RotateActivePauli;
+using clifft::sampling::SamplingPlan;
+
+namespace {
+
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
+// Runs every comparison the differential tests rely on: peak width, the
+// sequence of width changes in op order, and per-effect action counts.
+// Takes an already-computed plan so a caller decides separately whether a
+// throw from plan_sampling() itself is acceptable for this HIR variant.
+void require_trace_matches_plan(const HirModule& hir, const SamplingPlan& plan) {
+    const ActiveWidthTrace trace = analyze_active_width(hir);
+
+    REQUIRE(trace.transitions.size() == hir.ops.size());
+    REQUIRE(trace.initial_width == plan.initial_active_width);
+    REQUIRE(trace.peak_width == plan.peak_active_width);
+
+    std::vector<std::pair<uint32_t, uint32_t>> plan_changes;
+    for (const PlannedAction& action : plan.actions) {
+        if (action.active_before != action.active_after) {
+            plan_changes.emplace_back(action.active_before, action.active_after);
+        }
+    }
+    std::vector<std::pair<uint32_t, uint32_t>> trace_changes;
+    for (const WidthTransition& transition : trace.transitions) {
+        if (transition.before != transition.after) {
+            trace_changes.emplace_back(transition.before, transition.after);
+        }
+    }
+    REQUIRE(trace_changes == plan_changes);
+
+    const uint32_t plan_final_width =
+        plan.actions.empty() ? plan.initial_active_width : plan.actions.back().active_after;
+    REQUIRE(trace.final_width == plan_final_width);
+
+    size_t plan_promote = 0;
+    size_t plan_rotate_neutral = 0;
+    size_t plan_measure_active = 0;
+    size_t plan_measure_dormant = 0;
+    size_t plan_record_classical = 0;
+    for (const PlannedAction& action : plan.actions) {
+        if (std::holds_alternative<PromoteDormantRotation>(action.action)) {
+            ++plan_promote;
+        } else if (std::holds_alternative<RotateActivePauli>(action.action)) {
+            ++plan_rotate_neutral;
+        } else if (std::holds_alternative<MeasureActivePauli>(action.action)) {
+            ++plan_measure_active;
+        } else if (std::holds_alternative<MeasureDormantRandom>(action.action)) {
+            ++plan_measure_dormant;
+        } else if (std::holds_alternative<RecordClassical>(action.action)) {
+            ++plan_record_classical;
+        }
+    }
+
+    size_t trace_promote = 0;
+    size_t trace_neutral = 0;
+    size_t trace_measure_active = 0;
+    size_t trace_measure_dormant = 0;
+    size_t trace_classical = 0;
+    for (const WidthTransition& transition : trace.transitions) {
+        switch (transition.effect) {
+            case WidthEffect::RotationPromote:
+                ++trace_promote;
+                break;
+            case WidthEffect::RotationNeutral:
+                ++trace_neutral;
+                break;
+            case WidthEffect::MeasureActive:
+                ++trace_measure_active;
+                break;
+            case WidthEffect::MeasureDormantRandom:
+                ++trace_measure_dormant;
+                break;
+            case WidthEffect::MeasureClassical:
+                ++trace_classical;
+                break;
+            default:
+                break;
+        }
+    }
+
+    REQUIRE(plan_promote == trace_promote);
+    REQUIRE(plan_rotate_neutral == trace_neutral);
+    REQUIRE(plan_measure_active == trace_measure_active);
+    REQUIRE(plan_measure_dormant == trace_measure_dormant);
+    REQUIRE(plan_record_classical == trace_classical);
+}
+
+// Best-effort variant of the above for HIR that may legitimately overflow
+// the planner's dense active-width limit (raw or peephole-only HIR for a
+// wide circuit, before the squeeze pass narrows the peak). Returns whether
+// the comparison actually ran.
+bool require_trace_matches_plan_if_plannable(const HirModule& hir) {
+    SamplingPlan plan;
+    try {
+        plan = clifft::sampling::plan_sampling(hir);
+    } catch (const std::exception&) {
+        return false;
+    }
+    require_trace_matches_plan(hir, plan);
+    return true;
+}
+
+HirModule run_peephole_only(const HirModule& source) {
+    HirModule hir = source;
+    HirPassManager passes;
+    passes.add_pass(std::make_unique<PeepholeFusionPass>());
+    passes.run(hir);
+    return hir;
+}
+
+HirModule run_production_pipeline(const HirModule& source) {
+    HirModule hir = source;
+    clifft::default_hir_pass_manager().run(hir);
+    return hir;
+}
+
+// Deterministic Stim-source generator over a small gate set: H, S, CNOT, T,
+// T_DAG, R_Z at a few angles, M, MX, MR, R, DEPOLARIZE1, X_ERROR, and
+// DETECTOR referencing an earlier record. Every generated line is
+// individually valid, so the circuit as a whole always parses and traces.
+std::string random_stim_circuit(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    static const double kAngles[] = {0.1, 0.125, 0.25, 0.3, 0.5, 0.7, 0.75, 1.25, 1.5, 1.75};
+    static const double kNoiseProbs[] = {0.01, 0.02, 0.05, 0.1, 0.2};
+
+    std::string source;
+    uint32_t measurement_count = 0;
+    for (uint32_t op = 0; op < num_ops; ++op) {
+        const uint32_t q = rng() % num_qubits;
+        switch (rng() % 12) {
+            case 0:
+                source += "H " + std::to_string(q) + "\n";
+                break;
+            case 1:
+                source += "S " + std::to_string(q) + "\n";
+                break;
+            case 2: {
+                uint32_t partner = rng() % num_qubits;
+                if (partner == q) {
+                    partner = (partner + 1) % num_qubits;
+                }
+                source += "CNOT " + std::to_string(q) + " " + std::to_string(partner) + "\n";
+                break;
+            }
+            case 3:
+                source += "T " + std::to_string(q) + "\n";
+                break;
+            case 4:
+                source += "T_DAG " + std::to_string(q) + "\n";
+                break;
+            case 5:
+                source += "R_Z(" + std::to_string(kAngles[rng() % std::size(kAngles)]) + ") " +
+                          std::to_string(q) + "\n";
+                break;
+            case 6:
+                source += "M " + std::to_string(q) + "\n";
+                ++measurement_count;
+                break;
+            case 7:
+                source += "MX " + std::to_string(q) + "\n";
+                ++measurement_count;
+                break;
+            case 8:
+                source += "MR " + std::to_string(q) + "\n";
+                ++measurement_count;
+                break;
+            case 9:
+                source += "R " + std::to_string(q) + "\n";
+                break;
+            case 10:
+                source += "DEPOLARIZE1(" +
+                          std::to_string(kNoiseProbs[rng() % std::size(kNoiseProbs)]) + ") " +
+                          std::to_string(q) + "\n";
+                break;
+            case 11:
+                source += "X_ERROR(" + std::to_string(kNoiseProbs[rng() % std::size(kNoiseProbs)]) +
+                          ") " + std::to_string(q) + "\n";
+                break;
+            default:
+                break;
+        }
+        if (measurement_count > 0 && (rng() % 5) == 0) {
+            const uint32_t back = 1 + (rng() % measurement_count);
+            source += "DETECTOR rec[-" + std::to_string(back) + "]\n";
+        }
+    }
+    return source;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Differential tests against the planner
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Active width analysis matches the planner on fixture circuits", "[active_width]") {
+    const std::vector<std::string> mandatory_fixtures = {
+        "coherent_d3_r3.stim",
+        "coherent_d5_r5.stim",
+        "cultivation_d5.stim",
+        "surface_d7_r7_p001.stim",
+    };
+    const std::vector<std::string> all_fixtures = {
+        "coherent_d3_r3.stim",     "coherent_d5_r5.stim", "cultivation_d5.stim",
+        "surface_d7_r7_p001.stim", "qv10.stim",           "surface_d11_r11_p001.stim",
+        "surface_d5_r5_p05.stim",  "target_qec.stim",
+    };
+
+    for (const std::string& fixture : all_fixtures) {
+        const bool mandatory = std::find(mandatory_fixtures.begin(), mandatory_fixtures.end(),
+                                         fixture) != mandatory_fixtures.end();
+        DYNAMIC_SECTION(fixture) {
+            const Circuit circuit = parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/" + fixture);
+            const HirModule raw = trace(circuit);
+            const HirModule peephole_only = run_peephole_only(raw);
+            const HirModule production = run_production_pipeline(raw);
+
+            // Raw and peephole-only HIR for a wide circuit can legitimately
+            // exceed the planner's dense active-width limit before the
+            // squeeze pass narrows the peak. That is an existing planner
+            // limitation orthogonal to this analysis, so treat it as a
+            // skip rather than a failure.
+            if (!require_trace_matches_plan_if_plannable(raw)) {
+                WARN("raw HIR exceeded the planner's dense active-width limit for " << fixture);
+            }
+            if (!require_trace_matches_plan_if_plannable(peephole_only)) {
+                WARN("peephole-only HIR exceeded the planner's dense active-width limit for "
+                     << fixture);
+            }
+
+            // The production pipeline is what real sampling runs, so every
+            // listed fixture must plan and match on it.
+            if (!require_trace_matches_plan_if_plannable(production)) {
+                if (mandatory) {
+                    FAIL("mandatory fixture's production pipeline could not be planned: "
+                         << fixture);
+                } else {
+                    WARN("production pipeline could not be planned for " << fixture);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Active width analysis matches the planner on random circuits", "[active_width]") {
+    constexpr uint32_t kActiveWidthFuzzSeed = 0x41770;
+    constexpr int kTrials = 400;
+
+    std::mt19937 rng(kActiveWidthFuzzSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 9);
+        const uint32_t num_ops = 20 + static_cast<uint32_t>(trial % 30);
+        const std::string source = random_stim_circuit(rng, num_qubits, num_ops);
+        CAPTURE(trial, num_qubits, num_ops, source);
+
+        const HirModule raw = trace(parse(source));
+        const HirModule peephole_only = run_peephole_only(raw);
+        const HirModule production = run_production_pipeline(raw);
+
+        // Active width can never exceed num_qubits (<= 12 here), far below
+        // the planner's dense-state limit, so every variant must plan.
+        require_trace_matches_plan(raw, clifft::sampling::plan_sampling(raw));
+        require_trace_matches_plan(peephole_only, clifft::sampling::plan_sampling(peephole_only));
+        require_trace_matches_plan(production, clifft::sampling::plan_sampling(production));
+    }
+}
+
+TEST_CASE("Active width analysis matches instrument modes across all four branches",
+          "[active_width]") {
+    struct InstrumentCase {
+        const char* name;
+        const char* circuit;
+        bool neglect_damping;
+        InstrumentMode expected_mode;
+        WidthEffect expected_effect;
+    };
+    const InstrumentCase cases[] = {
+        {"classical", "LEVEL_TRANSITION[jump] 0", false, InstrumentMode::Classical,
+         WidthEffect::InstrumentClassical},
+        {"activate", "H 0\nT 0\nH 1\nLEVEL_TRANSITION[jump] 1\nM 1", false,
+         InstrumentMode::Activate, WidthEffect::InstrumentActivate},
+        {"active", "H 0\nT 0\nLEVEL_TRANSITION[jump] 0", false, InstrumentMode::Active,
+         WidthEffect::InstrumentActive},
+        {"dormant trap", "H 0\nLEVEL_TRANSITION[jump] 0", true, InstrumentMode::DormantTrap,
+         WidthEffect::InstrumentDormantTrap},
+    };
+
+    for (const InstrumentCase& test_case : cases) {
+        DYNAMIC_SECTION(test_case.name) {
+            const InstrumentTraceOptions options =
+                clifft::test::source_dependent_jump_options(test_case.neglect_damping);
+            const HirModule hir = trace(parse(test_case.circuit), &options);
+
+            const SamplingPlan plan = clifft::sampling::plan_sampling(hir);
+            const PlannedAction* instrument_action = nullptr;
+            const ApplyInstrument* instrument = nullptr;
+            for (const PlannedAction& action : plan.actions) {
+                if (const auto* candidate = std::get_if<ApplyInstrument>(&action.action)) {
+                    instrument_action = &action;
+                    instrument = candidate;
+                    break;
+                }
+            }
+            REQUIRE(instrument != nullptr);
+            REQUIRE(instrument->mode == test_case.expected_mode);
+
+            const auto instrument_op = std::ranges::find_if(
+                hir.ops, [](const HeisenbergOp& op) { return op.op_type() == OpType::INSTRUMENT; });
+            REQUIRE(instrument_op != hir.ops.end());
+            const auto op_index = static_cast<size_t>(instrument_op - hir.ops.begin());
+
+            const ActiveWidthTrace ir_trace = analyze_active_width(hir);
+            REQUIRE(op_index < ir_trace.transitions.size());
+            const WidthTransition& transition = ir_trace.transitions[op_index];
+
+            REQUIRE(transition.effect == test_case.expected_effect);
+            REQUIRE(transition.before == instrument_action->active_before);
+            REQUIRE(transition.after == instrument_action->active_after);
+
+            require_trace_matches_plan(hir, plan);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DormantSubspace unit tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("DormantSubspace widths across a promote-heavy two-qubit sequence", "[active_width]") {
+    DormantSubspace subspace(2);
+    std::vector<uint32_t> widths{subspace.active_width()};
+
+    REQUIRE(subspace.apply_rotation(PauliString::from_text("+XX")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_rotation(PauliString::from_text("+ZY")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YY")) ==
+            DormantSubspace::MeasurementEffect::Active);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YI")) ==
+            DormantSubspace::MeasurementEffect::Active);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(widths == std::vector<uint32_t>{0, 1, 2, 1, 0});
+}
+
+TEST_CASE("DormantSubspace widths across a collapse-then-promote two-qubit sequence",
+          "[active_width]") {
+    DormantSubspace subspace(2);
+    std::vector<uint32_t> widths{subspace.active_width()};
+
+    REQUIRE(subspace.apply_rotation(PauliString::from_text("+ZY")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YY")) ==
+            DormantSubspace::MeasurementEffect::DormantRandom);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE_FALSE(subspace.apply_rotation(PauliString::from_text("+XX")));
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(subspace.apply_measurement(PauliString::from_text("+YI")) ==
+            DormantSubspace::MeasurementEffect::Active);
+    widths.push_back(subspace.active_width());
+
+    REQUIRE(widths == std::vector<uint32_t>{0, 1, 1, 1, 0});
+}
+
+TEST_CASE("DormantSubspace treats a rotation or measurement inside S as inert", "[active_width]") {
+    SECTION("a lone generator") {
+        DormantSubspace subspace(2);
+        const PauliString z0 = PauliString::from_text("+ZI");
+
+        REQUIRE(subspace.commutes_with_all(z0));
+        REQUIRE(subspace.contains(z0));
+
+        REQUIRE_FALSE(subspace.apply_rotation(z0));
+        REQUIRE(subspace.active_width() == 0);
+        REQUIRE(subspace.contains(z0));
+
+        REQUIRE(subspace.apply_measurement(z0) == DormantSubspace::MeasurementEffect::Classical);
+        REQUIRE(subspace.active_width() == 0);
+    }
+
+    SECTION("a product of generators") {
+        DormantSubspace subspace(2);
+        const PauliString zz = PauliString::from_text("+ZZ");
+
+        REQUIRE(subspace.commutes_with_all(zz));
+        REQUIRE(subspace.contains(zz));
+
+        REQUIRE_FALSE(subspace.apply_rotation(zz));
+        REQUIRE(subspace.active_width() == 0);
+        REQUIRE(subspace.contains(zz));
+
+        REQUIRE(subspace.apply_measurement(zz) == DormantSubspace::MeasurementEffect::Classical);
+        REQUIRE(subspace.active_width() == 0);
+    }
+}

--- a/tests/test_active_width_search.cc
+++ b/tests/test_active_width_search.cc
@@ -1,0 +1,428 @@
+// Tests for search_width_schedule: the exact, budgeted search for the
+// minimum peak active width over the legal schedules of an HIR.
+//
+// The core cross-check is brute force agreement: on circuits small enough to
+// enumerate every linear extension directly, the closure-based search (which
+// only ever branches on expanding ops) must still land on the same optimum
+// as trying every legal order. That is the closure theorem active_width_search.h
+// documents, exercised rather than just asserted.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/active_width_analysis.h"
+#include "clifft/optimizer/active_width_search.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/schedule_dependence.h"
+#include "clifft/tableau/pauli_string.h"
+
+#include "sampling_equivalence_helpers.h"
+#include "test_helpers.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <span>
+#include <string>
+#include <vector>
+
+using namespace clifft;
+using namespace clifft::test;
+
+namespace {
+
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+// Non-Clifford R_XX(0.3), R_ZY(0.3), M_YY (record 0), M_YI (record 1) --
+// the same circuit test_schedule_dependence.cc's four-operation regression
+// uses. Its original order has peak active width 2; reordering to
+// [1, 2, 0, 3] drops the peak to 1.
+HirModule make_four_op_circuit() {
+    HirModule hir(2, 4);
+    hir.num_measurements = 2;
+    append_phase_rotation(hir, X(0) | X(1), 0, false, 0.3);                  // R_XX
+    append_phase_rotation(hir, X(1), Z(0) | Z(1), false, 0.3);               // R_ZY
+    append_measure(hir, X(0) | X(1), Z(0) | Z(1), false, MeasRecordIdx{0});  // M_YY
+    append_measure(hir, X(0), Z(0), false, MeasRecordIdx{1});                // M_YI
+    return hir;
+}
+
+// Two copies of make_four_op_circuit()'s pattern on disjoint qubit pairs
+// (0, 1) and (2, 3). Each pair alone resolves in a single search node (its
+// one accepted branch's own closure sweep finishes it, since both of its
+// remaining ops are MEASURE and therefore never expanding); with both pairs
+// present, closing out one pair's branch leaves the other pair entirely
+// unexecuted (disjoint qubits mean neither pair's ops ever depend on or
+// close out the other's), so resolving the whole circuit needs at least one
+// further node. That gap is what the budget test below depends on: a
+// single-pair circuit would already finish within one node regardless of
+// the budget, so it could never demonstrate a budget running out.
+HirModule make_two_independent_widgets_circuit() {
+    HirModule hir(4, 8);
+    hir.num_measurements = 4;
+    append_phase_rotation(hir, X(0) | X(1), 0, false, 0.3);                  // R_XX on 0,1
+    append_phase_rotation(hir, X(1), Z(0) | Z(1), false, 0.3);               // R_ZY on 0,1
+    append_measure(hir, X(0) | X(1), Z(0) | Z(1), false, MeasRecordIdx{0});  // M_YY on 0,1
+    append_measure(hir, X(0), Z(0), false, MeasRecordIdx{1});                // M_YI on 0,1
+    append_phase_rotation(hir, X(2) | X(3), 0, false, 0.3);                  // R_XX on 2,3
+    append_phase_rotation(hir, X(3), Z(2) | Z(3), false, 0.3);               // R_ZY on 2,3
+    append_measure(hir, X(2) | X(3), Z(2) | Z(3), false, MeasRecordIdx{2});  // M_YY on 2,3
+    append_measure(hir, X(2), Z(2), false, MeasRecordIdx{3});                // M_YI on 2,3
+    return hir;
+}
+
+HirModule coherent_d3_r3_production() {
+    const Circuit circuit =
+        clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/coherent_d3_r3.stim");
+    HirModule hir = clifft::trace(circuit);
+    clifft::default_hir_pass_manager().run(hir);  // PeepholeFusionPass then StatevectorSqueezePass
+    return hir;
+}
+
+std::vector<uint32_t> identity_order(size_t n) {
+    std::vector<uint32_t> order(n);
+    std::iota(order.begin(), order.end(), uint32_t{0});
+    return order;
+}
+
+// ---------------------------------------------------------------------------
+// Brute force oracle: peak active width of an explicit op order, and
+// exhaustive enumeration of every linear extension of a dependence relation.
+// ---------------------------------------------------------------------------
+
+// Peak active width of hir.ops replayed in `order` (a permutation of
+// 0..hir.ops.size()-1), without copying or reordering the HIR. Mirrors
+// analyze_active_width's rotation/measurement dispatch directly against
+// DormantSubspace's public surface; this file's circuit generator never
+// emits INSTRUMENT, so that branch is not needed here (mirroring
+// test_schedule_dependence.cc's final_subspace helper, which makes the same
+// simplification for the same reason).
+uint32_t peak_width_for_order(const HirModule& hir, std::span<const uint32_t> order) {
+    DormantSubspace subspace(hir.num_qubits);
+    uint32_t peak = subspace.active_width();
+    for (uint32_t idx : order) {
+        const HeisenbergOp& op = hir.ops[idx];
+        const bool is_rotation =
+            op.op_type() == OpType::T_GATE || op.op_type() == OpType::PHASE_ROTATION;
+        const bool is_measurement = op.op_type() == OpType::MEASURE;
+        if (!is_rotation && !is_measurement) {
+            continue;
+        }
+        PauliString body(hir.num_qubits);
+        body.mut_x().xor_with(hir.destab_mask(op));
+        body.mut_z().xor_with(hir.stab_mask(op));
+        if (is_measurement) {
+            subspace.apply_measurement(body);
+        } else {
+            subspace.apply_rotation(body);
+        }
+        peak = std::max(peak, subspace.active_width());
+    }
+    return peak;
+}
+
+struct BruteForceState {
+    const HirModule& hir;
+    const ScheduleDependence& dep;
+    std::vector<uint32_t> remaining_preds;
+    std::vector<bool> executed;
+    std::vector<uint32_t> order;
+    uint32_t best_peak = std::numeric_limits<uint32_t>::max();
+    size_t leaves = 0;
+    size_t leaf_cap = 0;
+    bool capped = false;
+};
+
+void brute_force_recurse(BruteForceState& state) {
+    const size_t n = state.dep.num_ops();
+    if (state.order.size() == n) {
+        ++state.leaves;
+        if (state.leaves > state.leaf_cap) {
+            state.capped = true;
+            return;
+        }
+        state.best_peak = std::min(state.best_peak, peak_width_for_order(state.hir, state.order));
+        return;
+    }
+    for (uint32_t op = 0; op < n; ++op) {
+        if (state.capped) {
+            return;
+        }
+        if (state.executed[op] || state.remaining_preds[op] != 0) {
+            continue;
+        }
+        state.executed[op] = true;
+        state.order.push_back(op);
+        for (uint32_t succ : state.dep.successors(op)) {
+            --state.remaining_preds[succ];
+        }
+
+        brute_force_recurse(state);
+
+        for (uint32_t succ : state.dep.successors(op)) {
+            ++state.remaining_preds[succ];
+        }
+        state.order.pop_back();
+        state.executed[op] = false;
+    }
+}
+
+struct BruteForceResult {
+    uint32_t min_peak = 0;
+    // False when the leaf cap below was hit before every linear extension
+    // was tried -- an escape hatch alongside the movable-op-count skip for
+    // the rare small-op-count circuit whose movable ops are nonetheless
+    // mostly mutually independent (for example several same-axis rotations
+    // on one qubit with nothing interleaved to constrain their order).
+    bool completed = false;
+};
+
+BruteForceResult brute_force_min_peak(const HirModule& hir, const ScheduleDependence& dep,
+                                      size_t leaf_cap) {
+    BruteForceState state{hir,
+                          dep,
+                          std::vector<uint32_t>(dep.num_ops()),
+                          std::vector<bool>(dep.num_ops(), false),
+                          {},
+                          std::numeric_limits<uint32_t>::max(),
+                          0,
+                          leaf_cap,
+                          false};
+    for (uint32_t op = 0; op < dep.num_ops(); ++op) {
+        state.remaining_preds[op] = static_cast<uint32_t>(dep.predecessors(op).size());
+    }
+    brute_force_recurse(state);
+    return {state.best_peak, !state.capped};
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Brute force agreement
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Search finds the same optimum as brute force enumeration on small circuits",
+          "[width_search]") {
+    constexpr uint32_t kSeed = 0x77A5F17;
+    constexpr int kTrials = 150;
+    constexpr uint32_t kMaxMovableOps = 9;
+    // Nine fully independent movable ops alone already permute 9! = 362880
+    // ways, so this cap (not the movable-op count) is what actually bounds
+    // enumeration cost; it exists purely to keep this test fast; see
+    // BruteForceResult::completed.
+    constexpr size_t kLeafCap = 3000;
+
+    std::mt19937 rng(kSeed);
+    int checked = 0;
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 2 + static_cast<uint32_t>(trial % 3);
+        const uint32_t num_ops = 6 + static_cast<uint32_t>(trial % 9);
+        const std::string source = generate_noisy_source(rng, num_qubits, num_ops);
+
+        const HirModule hir = clifft::trace(clifft::parse(source));
+        uint32_t movable_count = 0;
+        for (const HeisenbergOp& op : hir.ops) {
+            const OpType type = op.op_type();
+            if (type == OpType::T_GATE || type == OpType::PHASE_ROTATION ||
+                type == OpType::MEASURE) {
+                ++movable_count;
+            }
+        }
+        if (movable_count > kMaxMovableOps) {
+            continue;
+        }
+
+        for (const bool noise_transparent : {false, true}) {
+            CAPTURE(trial, source, noise_transparent);
+
+            ScheduleDependenceOptions options;
+            options.noise_transparent = noise_transparent;
+            const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+
+            const BruteForceResult brute = brute_force_min_peak(hir, dep, kLeafCap);
+            if (!brute.completed) {
+                continue;
+            }
+
+            const WidthSearchResult result = search_width_schedule(hir, dep);
+            REQUIRE(result.upper_bound == brute.min_peak);
+            REQUIRE(result.lower_bound == brute.min_peak);
+            REQUIRE(result.optimal());
+            REQUIRE(dep.is_linear_extension(result.best_order));
+            REQUIRE(peak_width_for_order(hir, result.best_order) == brute.min_peak);
+            ++checked;
+        }
+    }
+
+    // A sanity floor on how much the movable-op-count and leaf-count skips
+    // actually let through, so a parameter change cannot silently degrade
+    // this test into checking almost nothing.
+    REQUIRE(checked >= 60);
+}
+
+// ---------------------------------------------------------------------------
+// Four-operation regression
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Search finds the optimal schedule for the four operation circuit", "[width_search]") {
+    const HirModule hir = make_four_op_circuit();
+    REQUIRE(analyze_active_width(hir).peak_width == 2);
+
+    const ScheduleDependence dep = ScheduleDependence::build(hir);
+    const WidthSearchResult result = search_width_schedule(hir, dep);
+
+    REQUIRE(result.incumbent_peak == 2);
+    REQUIRE(result.upper_bound == 1);
+    REQUIRE(result.lower_bound == 1);
+    REQUIRE(result.optimal());
+
+    HirModule reordered = hir;
+    apply_schedule(reordered, dep, result.best_order);
+    const ActiveWidthTrace reordered_trace = analyze_active_width(reordered);
+    std::vector<uint32_t> widths{reordered_trace.initial_width};
+    for (const WidthTransition& transition : reordered_trace.transitions) {
+        widths.push_back(transition.after);
+    }
+    REQUIRE(widths == std::vector<uint32_t>{0, 1, 1, 1, 0});
+}
+
+// ---------------------------------------------------------------------------
+// Never worse than the incumbent
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Search never reports a worse upper bound than the incumbent", "[width_search]") {
+    constexpr uint32_t kSeed = 0x0B4D9C1;
+    constexpr int kTrials = 60;
+
+    std::mt19937 rng(kSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 7);
+        const uint32_t num_ops = 15 + static_cast<uint32_t>(trial % 25);
+        const std::string source = generate_noisy_source(rng, num_qubits, num_ops);
+        const HirModule hir = clifft::trace(clifft::parse(source));
+
+        for (const bool noise_transparent : {false, true}) {
+            CAPTURE(trial, source, noise_transparent);
+
+            ScheduleDependenceOptions options;
+            options.noise_transparent = noise_transparent;
+            const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+            const WidthSearchResult result = search_width_schedule(hir, dep);
+
+            REQUIRE(result.upper_bound <= result.incumbent_peak);
+            if (result.upper_bound == result.incumbent_peak) {
+                REQUIRE(result.best_order == identity_order(hir.ops.size()));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Budget behaviour
+// ---------------------------------------------------------------------------
+
+TEST_CASE("An exhausted node budget is reported rather than thrown", "[width_search]") {
+    const HirModule hir = make_two_independent_widgets_circuit();
+    const ScheduleDependence dep = ScheduleDependence::build(hir);
+
+    WidthSearchOptions options;
+    options.node_budget = 1;
+    WidthSearchResult result;
+    REQUIRE_NOTHROW(result = search_width_schedule(hir, dep, options));
+
+    REQUIRE(result.budget_exhausted);
+    REQUIRE(result.upper_bound == result.incumbent_peak);
+    REQUIRE(result.lower_bound == analyze_active_width(hir).final_width);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture certificates
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Search certifies coherent_d3_r3's peak under both relation options", "[width_search]") {
+    const HirModule hir = coherent_d3_r3_production();
+    WidthSearchOptions options;
+    options.node_budget = 200000;
+
+    SECTION("without noise transparency the production peak is already optimal") {
+        ScheduleDependenceOptions dep_options;
+        dep_options.noise_transparent = false;
+        const ScheduleDependence dep = ScheduleDependence::build(hir, dep_options);
+        const WidthSearchResult result = search_width_schedule(hir, dep, options);
+
+        INFO("explored_nodes=" << result.explored_nodes
+                               << " budget_exhausted=" << result.budget_exhausted);
+        REQUIRE(result.optimal());
+        REQUIRE(result.incumbent_peak == 5);
+        REQUIRE(result.upper_bound == 5);
+        REQUIRE(result.lower_bound == 5);
+    }
+
+    SECTION("noise transparency lets the search certify a lower peak") {
+        ScheduleDependenceOptions dep_options;
+        dep_options.noise_transparent = true;
+        const ScheduleDependence dep = ScheduleDependence::build(hir, dep_options);
+        const WidthSearchResult result = search_width_schedule(hir, dep, options);
+
+        INFO("explored_nodes=" << result.explored_nodes
+                               << " budget_exhausted=" << result.budget_exhausted);
+        REQUIRE(result.optimal());
+        REQUIRE(result.incumbent_peak == 5);
+        REQUIRE(result.upper_bound == 4);
+        REQUIRE(result.lower_bound == 4);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sampling equivalence of the found schedule
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Applying the search's noise-transparent schedule preserves sampling statistics",
+          "[width_search]") {
+    constexpr uint32_t kShots = 20000;
+
+    SECTION("coherent_d3_r3 fixture") {
+        const HirModule hir = coherent_d3_r3_production();
+
+        ScheduleDependenceOptions options;
+        options.noise_transparent = true;
+        const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+        const WidthSearchResult result = search_width_schedule(hir, dep);
+
+        HirModule reordered = hir;
+        apply_schedule(reordered, dep, result.best_order);
+        check_sampling_equivalent(hir, reordered, kShots, 0x51D1, 0x51D2);
+    }
+
+    SECTION("random noisy circuits") {
+        constexpr int kTrials = 10;
+        std::mt19937 circuit_rng(0x5A17C2);
+        std::mt19937 control_rng(0x5EED172);
+        for (int trial = 0; trial < kTrials; ++trial) {
+            const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 7);
+            const uint32_t num_ops = 15 + static_cast<uint32_t>(trial % 25);
+            const std::string source = generate_noisy_source(circuit_rng, num_qubits, num_ops);
+            CAPTURE(trial, source);
+
+            const HirModule hir = clifft::trace(clifft::parse(source));
+            ScheduleDependenceOptions options;
+            options.noise_transparent = true;
+            const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+            const WidthSearchResult result = search_width_schedule(hir, dep);
+
+            HirModule reordered = hir;
+            apply_schedule(reordered, dep, result.best_order);
+            check_sampling_equivalent(hir, reordered, kShots, control_rng(), control_rng());
+        }
+    }
+}

--- a/tests/test_logical_noise_prefix.cc
+++ b/tests/test_logical_noise_prefix.cc
@@ -1,0 +1,815 @@
+// Tests for HirModule::logical_noise_prefix: the side vector that lets the
+// sampling planner resolve an operation's noise-dependent sign from its
+// logical (original-circuit) position instead of its schedule position, so
+// a T_GATE, PHASE_ROTATION, or MEASURE can move across a NOISE op.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/commutation.h"
+#include "clifft/optimizer/drop_non_unitary_pass.h"
+#include "clifft/optimizer/hir_pass_manager.h"
+#include "clifft/optimizer/pass_factory.h"
+#include "clifft/optimizer/peephole.h"
+#include "clifft/optimizer/remove_noise_pass.h"
+#include "clifft/optimizer/statevector_squeeze_pass.h"
+#include "clifft/sampling/executable_plan.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/sampling/sampler.h"
+
+#include "test_helpers.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace clifft;
+using clifft::sampling::AffineBool;
+using clifft::sampling::ExecutablePlan;
+using clifft::sampling::PromoteDormantRotation;
+using clifft::sampling::RecordClassical;
+using clifft::sampling::SamplingPlan;
+using clifft::sampling::SymbolId;
+
+namespace {
+
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
+template <typename T>
+const T& action_as(const SamplingPlan& plan, size_t index) {
+    return std::get<T>(plan.actions.at(index).action);
+}
+
+// ---------------------------------------------------------------------------
+// Random noisy circuit generation
+// ---------------------------------------------------------------------------
+
+// A generated circuit plus, for each NOISE line, enough information to
+// realize a fixed firing outcome for it later (the legality-oracle test).
+struct GeneratedCircuit {
+    struct NoiseLine {
+        size_t line_index = 0;
+        uint32_t qubit = 0;
+        bool is_depolarize1 = false;
+        double prob = 0.0;
+    };
+
+    std::vector<std::string> lines;
+    std::vector<NoiseLine> noise_lines;
+};
+
+double next_unit(std::mt19937& rng) {
+    return static_cast<double>(rng() >> 11) * 0x1.0p-53;
+}
+
+// Deterministic generator over a small gate set: T, T_DAG, R_Z at a few
+// angles, M, MX, MR, R, X_ERROR, DEPOLARIZE1, and DETECTORs referencing
+// earlier records. Every generated line is individually valid, so the
+// circuit as a whole always parses and traces.
+GeneratedCircuit generate_noisy_circuit(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    static const double kAngles[] = {0.125, 0.25, 0.375, 0.625, 0.75, 0.875};
+    static const double kNoiseProbs[] = {0.05, 0.1, 0.2, 0.3};
+
+    GeneratedCircuit circuit;
+    uint32_t measurement_count = 0;
+    for (uint32_t op = 0; op < num_ops; ++op) {
+        const uint32_t q = rng() % num_qubits;
+        switch (rng() % 9) {
+            case 0:
+                circuit.lines.push_back("T " + std::to_string(q));
+                break;
+            case 1:
+                circuit.lines.push_back("T_DAG " + std::to_string(q));
+                break;
+            case 2:
+                circuit.lines.push_back("R_Z(" +
+                                        std::to_string(kAngles[rng() % std::size(kAngles)]) + ") " +
+                                        std::to_string(q));
+                break;
+            case 3:
+                circuit.lines.push_back("M " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 4:
+                circuit.lines.push_back("MX " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 5:
+                circuit.lines.push_back("MR " + std::to_string(q));
+                ++measurement_count;
+                break;
+            case 6:
+                circuit.lines.push_back("R " + std::to_string(q));
+                break;
+            case 7: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                circuit.lines.push_back("X_ERROR(" + std::to_string(prob) + ") " +
+                                        std::to_string(q));
+                circuit.noise_lines.push_back(
+                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/false, prob});
+                break;
+            }
+            case 8: {
+                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
+                circuit.lines.push_back("DEPOLARIZE1(" + std::to_string(prob) + ") " +
+                                        std::to_string(q));
+                circuit.noise_lines.push_back(
+                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/true, prob});
+                break;
+            }
+            default:
+                break;
+        }
+        if (measurement_count > 0 && (rng() % 5) == 0) {
+            const uint32_t back = 1 + (rng() % measurement_count);
+            circuit.lines.push_back("DETECTOR rec[-" + std::to_string(back) + "]");
+        }
+    }
+    return circuit;
+}
+
+std::string join_lines(const std::vector<std::string>& lines) {
+    std::string text;
+    for (const std::string& line : lines) {
+        text += line;
+        text += '\n';
+    }
+    return text;
+}
+
+std::string generate_noisy_source(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
+    return join_lines(generate_noisy_circuit(rng, num_qubits, num_ops).lines);
+}
+
+// Replaces every noise line with the explicit Pauli its fixed realization
+// fired, or drops the line if it did not fire. Uses its own RNG stream so
+// the realization is reproducible but independent of any reordering draws.
+std::vector<std::string> realize_noise(const GeneratedCircuit& circuit, std::mt19937& rng) {
+    std::vector<uint8_t> drop(circuit.lines.size(), 0);
+    std::vector<std::string> replacement(circuit.lines.size());
+    for (const GeneratedCircuit::NoiseLine& noise : circuit.noise_lines) {
+        const double roll = next_unit(rng);
+        if (noise.is_depolarize1) {
+            if (roll >= noise.prob) {
+                drop[noise.line_index] = 1;
+                continue;
+            }
+            static const char* const paulis[] = {"X", "Y", "Z"};
+            replacement[noise.line_index] =
+                std::string(paulis[rng() % 3]) + " " + std::to_string(noise.qubit);
+        } else {
+            if (roll >= noise.prob) {
+                drop[noise.line_index] = 1;
+                continue;
+            }
+            replacement[noise.line_index] = "X " + std::to_string(noise.qubit);
+        }
+    }
+
+    std::vector<std::string> realized;
+    realized.reserve(circuit.lines.size());
+    for (size_t i = 0; i < circuit.lines.size(); ++i) {
+        if (drop[i]) {
+            continue;
+        }
+        realized.push_back(replacement[i].empty() ? circuit.lines[i] : replacement[i]);
+    }
+    return realized;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline helpers, mirroring tests/test_active_width_analysis.cc
+// ---------------------------------------------------------------------------
+
+HirModule run_peephole_only(const HirModule& source) {
+    HirModule hir = source;
+    HirPassManager passes;
+    passes.add_pass(std::make_unique<PeepholeFusionPass>());
+    passes.run(hir);
+    return hir;
+}
+
+HirModule run_production_pipeline(const HirModule& source) {
+    HirModule hir = source;
+    clifft::default_hir_pass_manager().run(hir);
+    return hir;
+}
+
+// ---------------------------------------------------------------------------
+// Inertness
+// ---------------------------------------------------------------------------
+
+// Materializing logical_noise_prefix must never change what plan_sampling
+// produces: an empty vector and a freshly materialized one both describe
+// schedule semantics, just with the counts spelled out explicitly. A HIR
+// that the planner cannot plan at all (legitimately, e.g. a raw or
+// peephole-only wide circuit that has not been through the squeeze pass
+// yet) is skipped rather than failed, matching the active-width analysis
+// tests' precedent for the same class of fixture.
+void check_inert_if_plannable(const HirModule& hir) {
+    SamplingPlan schedule_plan;
+    try {
+        schedule_plan = clifft::sampling::plan_sampling(hir);
+    } catch (const std::exception&) {
+        return;
+    }
+    HirModule materialized = hir;
+    materialized.materialize_logical_noise_prefix();
+    const SamplingPlan materialized_plan = clifft::sampling::plan_sampling(materialized);
+    REQUIRE(schedule_plan.inspect() == materialized_plan.inspect());
+}
+
+TEST_CASE("Logical noise prefix is inert on fixture circuits", "[logical_noise_prefix]") {
+    static const char* const fixtures[] = {
+        "coherent_d3_r3.stim",     "coherent_d5_r5.stim", "cultivation_d5.stim",
+        "surface_d7_r7_p001.stim", "qv10.stim",           "surface_d11_r11_p001.stim",
+        "surface_d5_r5_p05.stim",  "target_qec.stim",
+    };
+    for (const char* fixture : fixtures) {
+        DYNAMIC_SECTION(fixture) {
+            const Circuit circuit =
+                clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/" + fixture);
+            const HirModule raw = clifft::trace(circuit);
+            check_inert_if_plannable(raw);
+            check_inert_if_plannable(run_peephole_only(raw));
+            check_inert_if_plannable(run_production_pipeline(raw));
+        }
+    }
+}
+
+TEST_CASE("Logical noise prefix is inert on random noisy circuits", "[logical_noise_prefix]") {
+    constexpr uint32_t kSeed = 0x1e94a1;
+    constexpr int kTrials = 200;
+    std::mt19937 rng(kSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 6);
+        const uint32_t num_ops = 15 + static_cast<uint32_t>(trial % 25);
+        const std::string source = generate_noisy_source(rng, num_qubits, num_ops);
+        CAPTURE(trial, num_qubits, num_ops, source);
+
+        const HirModule raw = clifft::trace(clifft::parse(source));
+        check_inert_if_plannable(raw);
+        check_inert_if_plannable(run_peephole_only(raw));
+        check_inert_if_plannable(run_production_pipeline(raw));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exact sign correction
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Logical noise prefix corrects a measurement moved earlier than its noise site",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("H 0\nZ_ERROR(0.3) 0\nMX 0\n"));
+    REQUIRE(original.ops.size() == 2);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[1].op_type() == OpType::MEASURE);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    REQUIRE(original_plan.actions.size() == 1);
+    const SymbolId original_noise =
+        original_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<RecordClassical>(original_plan, 0).outcome ==
+            AffineBool::symbol(original_noise));
+
+    // Reorder to H 0; MX 0; Z_ERROR(0.3) 0, keeping the measurement's
+    // logical prefix at 1: it still logically follows the noise site.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);
+    reordered.logical_noise_prefix = {1, 0};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    REQUIRE(reordered_plan.actions.size() == 1);
+    const SymbolId reordered_noise =
+        reordered_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<RecordClassical>(reordered_plan, 0).outcome ==
+            AffineBool::symbol(reordered_noise));
+
+    // With the vector cleared (naive schedule semantics), the identical
+    // reordered ops resolve to the wrong, constant outcome.
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<RecordClassical>(naive_plan, 0).outcome == AffineBool(false));
+}
+
+TEST_CASE("Logical noise prefix corrects a rotation moved earlier than its noise site",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("H 0\nX_ERROR(0.3) 0\nT 0\nM 0\n"));
+    REQUIRE(original.ops.size() == 3);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[1].op_type() == OpType::T_GATE);
+    REQUIRE(original.ops[2].op_type() == OpType::MEASURE);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    const SymbolId original_noise =
+        original_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<PromoteDormantRotation>(original_plan, 0).sign ==
+            AffineBool::symbol(original_noise));
+
+    // Move T before X_ERROR, keeping its logical prefix at 1.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [T_GATE, NOISE, MEASURE]
+    reordered.logical_noise_prefix = {1, 0, 1};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    const SymbolId reordered_noise =
+        reordered_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<PromoteDormantRotation>(reordered_plan, 0).sign ==
+            AffineBool::symbol(reordered_noise));
+
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<PromoteDormantRotation>(naive_plan, 0).sign == AffineBool(false));
+}
+
+TEST_CASE("Logical noise prefix corrects a rotation moved later than its noise site",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("H 0\nT 0\nX_ERROR(0.3) 0\nM 0\n"));
+    REQUIRE(original.ops.size() == 3);
+    REQUIRE(original.ops[0].op_type() == OpType::T_GATE);
+    REQUIRE(original.ops[1].op_type() == OpType::NOISE);
+    REQUIRE(original.ops[2].op_type() == OpType::MEASURE);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    // No noise logically precedes T in the original circuit.
+    REQUIRE(action_as<PromoteDormantRotation>(original_plan, 0).sign == AffineBool(false));
+
+    // Move T after X_ERROR, keeping its logical prefix at 0: the site never
+    // logically preceded it, even though it now sits after it in schedule.
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [NOISE, T_GATE, MEASURE]
+    reordered.logical_noise_prefix = {0, 0, 1};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    REQUIRE(action_as<PromoteDormantRotation>(reordered_plan, 0).sign == AffineBool(false));
+
+    // Naive schedule semantics incorrectly picks up the noise dependency.
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    const SymbolId naive_noise = naive_plan.presampled_noise_sites.at(0).outcomes.at(0).symbol;
+    REQUIRE(action_as<PromoteDormantRotation>(naive_plan, 0).sign ==
+            AffineBool::symbol(naive_noise));
+}
+
+TEST_CASE("Logical noise prefix folds in exactly the anticommuting DEPOLARIZE1 channels",
+          "[logical_noise_prefix]") {
+    const HirModule original = clifft::trace(clifft::parse("DEPOLARIZE1(0.3) 0\nM 0\n"));
+    REQUIRE(original.ops.size() == 2);
+    REQUIRE(original.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(original.noise_sites.at(0).channels.size() == 3);
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(original);
+    // Two of DEPOLARIZE1's three channels (X, Y) anticommute with the pure
+    // Z body a plain M measures; the third (Z) commutes.
+    REQUIRE(action_as<RecordClassical>(original_plan, 0).outcome.terms().size() == 2);
+
+    HirModule reordered = original;
+    std::swap(reordered.ops[0], reordered.ops[1]);  // [MEASURE, NOISE]
+    reordered.logical_noise_prefix = {1, 0};
+
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    const auto& reordered_outcomes = reordered_plan.presampled_noise_sites.at(0).outcomes;
+    REQUIRE(reordered_outcomes.size() == 3);
+
+    // Build the expected outcome from this plan's own channel symbols
+    // rather than assuming a fixed channel order.
+    AffineBool expected;
+    const std::vector<NoiseChannel>& channels = reordered.noise_sites.at(0).channels;
+    for (size_t ch = 0; ch < channels.size(); ++ch) {
+        const PauliMaskView mask = reordered.noise_channel_masks.at(channels[ch].mask);
+        if (mask.x().bit_get(0)) {  // anticommutes with the pure Z body iff X is set
+            expected ^= AffineBool::symbol(reordered_outcomes[ch].symbol);
+        }
+    }
+    REQUIRE(expected.terms().size() == 2);
+    REQUIRE(action_as<RecordClassical>(reordered_plan, 0).outcome == expected);
+
+    HirModule naive = reordered;
+    naive.logical_noise_prefix.clear();
+    const SamplingPlan naive_plan = clifft::sampling::plan_sampling(naive);
+    REQUIRE(action_as<RecordClassical>(naive_plan, 0).outcome == AffineBool(false));
+}
+
+// ---------------------------------------------------------------------------
+// Reordering helper shared by sampling-equivalence and legality-oracle tests
+// ---------------------------------------------------------------------------
+
+bool is_movable_across_noise(const HeisenbergOp& op) {
+    return op.op_type() == OpType::T_GATE || op.op_type() == OpType::PHASE_ROTATION ||
+           op.op_type() == OpType::MEASURE;
+}
+
+// Swaps hir.ops[i] and hir.ops[i+1], carrying every parallel side vector
+// along with its own operation: source_map and logical_noise_prefix when
+// present, and the caller's own original-index bookkeeping.
+void swap_adjacent_ops(HirModule& hir, std::vector<size_t>& original_index, size_t i) {
+    std::swap(hir.ops[i], hir.ops[i + 1]);
+    std::swap(original_index[i], original_index[i + 1]);
+    if (hir.source_map.size() == hir.ops.size()) {
+        std::swap(hir.source_map[i], hir.source_map[i + 1]);
+    }
+    if (hir.has_logical_noise_prefix()) {
+        std::swap(hir.logical_noise_prefix[i], hir.logical_noise_prefix[i + 1]);
+    }
+}
+
+// Randomly walks movable operations (T_GATE, PHASE_ROTATION, MEASURE) one
+// position left or right at a time: unconditionally across an adjacent
+// NOISE op (bypassing can_swap's noise clause -- the crossing this feature
+// makes sound), or otherwise only when can_swap allows it. Materializes
+// logical_noise_prefix first so every moved operation keeps the entry it
+// started with. original_index must start as 0..ops.size()-1; after the
+// walk, original_index[i] is the original position of the op now at i.
+void randomly_reorder_across_noise(HirModule& hir, std::vector<size_t>& original_index,
+                                   std::mt19937& rng, int iterations) {
+    hir.materialize_logical_noise_prefix();
+    for (int iter = 0; iter < iterations && hir.ops.size() >= 2; ++iter) {
+        std::vector<size_t> movable;
+        for (size_t i = 0; i < hir.ops.size(); ++i) {
+            if (is_movable_across_noise(hir.ops[i])) {
+                movable.push_back(i);
+            }
+        }
+        if (movable.empty()) {
+            return;
+        }
+        const size_t i = movable[rng() % movable.size()];
+        const bool go_right = (rng() % 2) == 0;
+        if (go_right && i + 1 < hir.ops.size()) {
+            const bool neighbor_is_noise = hir.ops[i + 1].op_type() == OpType::NOISE;
+            if (neighbor_is_noise || can_swap(hir.ops[i], hir.ops[i + 1], hir)) {
+                swap_adjacent_ops(hir, original_index, i);
+            }
+        } else if (!go_right && i > 0) {
+            const bool neighbor_is_noise = hir.ops[i - 1].op_type() == OpType::NOISE;
+            if (neighbor_is_noise || can_swap(hir.ops[i - 1], hir.ops[i], hir)) {
+                swap_adjacent_ops(hir, original_index, i - 1);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sampling equivalence
+// ---------------------------------------------------------------------------
+
+double tolerance_at_6_sigma(double mean_a, double mean_b, uint32_t shots) {
+    // A floor keeps the tolerance from collapsing to zero for a column that
+    // is (near-)deterministic in both samples.
+    constexpr double kMinP = 1e-3;
+    const double pooled = std::clamp(0.5 * (mean_a + mean_b), kMinP, 1.0 - kMinP);
+    return 6.0 * std::sqrt(2.0 * pooled * (1.0 - pooled) / shots);
+}
+
+double column_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t column,
+                   uint32_t shots) {
+    uint64_t ones = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        ones += values[static_cast<size_t>(shot) * num_columns + column];
+    }
+    return static_cast<double>(ones) / shots;
+}
+
+double parity_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t col_a,
+                   uint32_t col_b, uint32_t shots) {
+    uint64_t ones = 0;
+    for (uint32_t shot = 0; shot < shots; ++shot) {
+        const uint8_t a = values[static_cast<size_t>(shot) * num_columns + col_a];
+        const uint8_t b = values[static_cast<size_t>(shot) * num_columns + col_b];
+        ones += static_cast<uint8_t>(a ^ b);
+    }
+    return static_cast<double>(ones) / shots;
+}
+
+void check_columns_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
+                         uint32_t num_columns, uint32_t shots, const char* label) {
+    for (uint32_t col = 0; col < num_columns; ++col) {
+        const double mean_a = column_mean(a, num_columns, col, shots);
+        const double mean_b = column_mean(b, num_columns, col, shots);
+        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
+        INFO(label << " column " << col << ": " << mean_a << " vs " << mean_b << ", tol " << tol);
+        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
+    }
+}
+
+void check_parities_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
+                          uint32_t num_columns, uint32_t shots, const char* label) {
+    for (uint32_t col = 0; col + 1 < num_columns; ++col) {
+        const double mean_a = parity_mean(a, num_columns, col, col + 1, shots);
+        const double mean_b = parity_mean(b, num_columns, col, col + 1, shots);
+        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
+        INFO(label << " parity (" << col << "," << col + 1 << "): " << mean_a << " vs " << mean_b
+                   << ", tol " << tol);
+        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
+    }
+}
+
+// Samples `original` and `reordered` with different seeds and requires
+// every record column mean, every detector column mean, and every
+// consecutive-pair record parity to agree within a cross-binomial tolerance.
+// The point is distributional equality, not bit-exact records.
+void check_sampling_equivalent(const HirModule& original, const HirModule& reordered,
+                               uint32_t shots, uint64_t seed_a, uint64_t seed_b) {
+    const ExecutablePlan plan_a(clifft::sampling::plan_sampling(original));
+    const ExecutablePlan plan_b(clifft::sampling::plan_sampling(reordered));
+    REQUIRE(plan_a.num_visible_records() == plan_b.num_visible_records());
+    REQUIRE(plan_a.num_detectors() == plan_b.num_detectors());
+
+    const clifft::sampling::SamplingResult result_a =
+        clifft::sampling::sample(plan_a, shots, seed_a);
+    const clifft::sampling::SamplingResult result_b =
+        clifft::sampling::sample(plan_b, shots, seed_b);
+
+    check_columns_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
+                        shots, "record");
+    check_columns_agree(result_a.detectors, result_b.detectors, plan_a.num_detectors(), shots,
+                        "detector");
+    check_parities_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
+                         shots, "record");
+}
+
+TEST_CASE("Logical noise prefix preserves the sampling distribution across noise-crossing reorders",
+          "[logical_noise_prefix]") {
+    constexpr uint32_t kShots = 20000;
+
+    SECTION("random circuits") {
+        constexpr uint32_t kTrials = 30;
+        std::mt19937 circuit_rng(0xC0FFEE);
+        std::mt19937 control_rng(0x51DE9A1);
+        for (uint32_t trial = 0; trial < kTrials; ++trial) {
+            const uint32_t num_qubits = 4 + (trial % 5);
+            const uint32_t num_ops = 25 + (trial % 20);
+            const std::string source = generate_noisy_source(circuit_rng, num_qubits, num_ops);
+            CAPTURE(trial, num_qubits, num_ops, source);
+
+            const HirModule original = clifft::trace(clifft::parse(source));
+            HirModule reordered = original;
+            std::vector<size_t> original_index(reordered.ops.size());
+            std::iota(original_index.begin(), original_index.end(), 0);
+            std::mt19937 reorder_rng(control_rng());
+            randomly_reorder_across_noise(reordered, original_index, reorder_rng,
+                                          8 * static_cast<int>(reordered.ops.size()) + 8);
+
+            check_sampling_equivalent(original, reordered, kShots, control_rng(), control_rng());
+        }
+    }
+
+    SECTION("coherent_d3_r3 fixture") {
+        const Circuit circuit =
+            clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/coherent_d3_r3.stim");
+        const HirModule original = clifft::trace(circuit);
+        HirModule reordered = original;
+        std::vector<size_t> original_index(reordered.ops.size());
+        std::iota(original_index.begin(), original_index.end(), 0);
+        std::mt19937 reorder_rng(0x517EE7);
+        randomly_reorder_across_noise(reordered, original_index, reorder_rng,
+                                      8 * static_cast<int>(reordered.ops.size()) + 8);
+
+        check_sampling_equivalent(original, reordered, kShots, 0x1234, 0x5678);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legality oracle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A logical-noise-prefix reorder is a legal can_swap reordering of the realized circuit",
+          "[logical_noise_prefix]") {
+    constexpr uint32_t kTrials = 30;
+    std::mt19937 circuit_rng(0xA11CE);
+    for (uint32_t trial = 0; trial < kTrials; ++trial) {
+        const uint32_t num_qubits = 4 + (trial % 5);
+        const uint32_t num_ops = 20 + (trial % 20);
+        const GeneratedCircuit generated = generate_noisy_circuit(circuit_rng, num_qubits, num_ops);
+        const std::string noisy_source = join_lines(generated.lines);
+        CAPTURE(trial, num_qubits, num_ops, noisy_source);
+
+        HirModule noisy = clifft::trace(clifft::parse(noisy_source));
+        std::vector<uint8_t> is_noise_original(noisy.ops.size());
+        for (size_t i = 0; i < noisy.ops.size(); ++i) {
+            is_noise_original[i] = noisy.ops[i].op_type() == OpType::NOISE ? 1 : 0;
+        }
+
+        std::vector<size_t> original_index(noisy.ops.size());
+        std::iota(original_index.begin(), original_index.end(), 0);
+        std::mt19937 reorder_rng(0xB0B0 + trial);
+        randomly_reorder_across_noise(noisy, original_index, reorder_rng,
+                                      6 * static_cast<int>(noisy.ops.size()) + 6);
+
+        std::mt19937 realize_rng(0xFACADE + trial);
+        const std::string realized_source = join_lines(realize_noise(generated, realize_rng));
+        CAPTURE(realized_source);
+        const HirModule realized = clifft::trace(clifft::parse(realized_source));
+
+        // Map each non-noise original index to its position in the
+        // noise-free realized HIR by counting how many earlier original
+        // positions were noise sites.
+        std::vector<size_t> orig_to_realized(is_noise_original.size(), 0);
+        size_t realized_cursor = 0;
+        for (size_t i = 0; i < is_noise_original.size(); ++i) {
+            if (!is_noise_original[i]) {
+                orig_to_realized[i] = realized_cursor++;
+            }
+        }
+        REQUIRE(realized_cursor == realized.ops.size());
+
+        // The reordering is legal exactly when every pair that ended up
+        // inverted relative to original order is a can_swap-legal
+        // transposition: that is a sufficient condition for reachability by
+        // adjacent transpositions, since any sequence of legal adjacent
+        // swaps that sorts the permutation back to original order must, at
+        // some point, swap every such pair directly.
+        for (size_t p = 0; p < original_index.size(); ++p) {
+            if (is_noise_original[original_index[p]]) {
+                continue;
+            }
+            for (size_t q = p + 1; q < original_index.size(); ++q) {
+                if (is_noise_original[original_index[q]]) {
+                    continue;
+                }
+                const size_t orig_a = original_index[p];
+                const size_t orig_b = original_index[q];
+                if (orig_a <= orig_b) {
+                    continue;  // not inverted relative to original order
+                }
+                const size_t ra = orig_to_realized[orig_a];
+                const size_t rb = orig_to_realized[orig_b];
+                CAPTURE(p, q, orig_a, orig_b, ra, rb);
+                CHECK(can_swap(realized.ops[rb], realized.ops[ra], realized));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass maintenance
+// ---------------------------------------------------------------------------
+
+TEST_CASE("StatevectorSqueezePass keeps logical_noise_prefix parallel and attached to its op",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse(R"(
+        T 0
+        T 1
+        H 1
+        DEPOLARIZE1(0.1) 0
+        M 1
+        M 0
+    )"));
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    hir.materialize_logical_noise_prefix();
+
+    // source_map (the source line) uniquely tags each surviving op here, so
+    // pairing it with logical_noise_prefix lets us confirm the entry
+    // followed the same op through however the pass permutes them.
+    auto snapshot = [](const HirModule& module) {
+        std::vector<std::pair<std::vector<uint32_t>, uint32_t>> tagged;
+        for (size_t i = 0; i < module.ops.size(); ++i) {
+            tagged.emplace_back(module.source_map[i], module.logical_noise_prefix[i]);
+        }
+        std::ranges::sort(tagged);
+        return tagged;
+    };
+    const auto before = snapshot(hir);
+
+    StatevectorSqueezePass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.has_logical_noise_prefix());
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    REQUIRE(snapshot(hir) == before);
+}
+
+TEST_CASE("PeepholeFusionPass fuses normally when logical_noise_prefix is consistent",
+          "[logical_noise_prefix]") {
+    HirModule with_prefix = clifft::trace(clifft::parse("H 0\nT 0\nT 0\nM 0\n"));
+    with_prefix.materialize_logical_noise_prefix();
+    HirModule without_prefix = clifft::trace(clifft::parse("H 0\nT 0\nT 0\nM 0\n"));
+
+    PeepholeFusionPass pass_with;
+    pass_with.run(with_prefix);
+    PeepholeFusionPass pass_without;
+    pass_without.run(without_prefix);
+
+    REQUIRE(clifft::sampling::plan_sampling(with_prefix).inspect() ==
+            clifft::sampling::plan_sampling(without_prefix).inspect());
+    if (!with_prefix.ops.empty()) {
+        REQUIRE(with_prefix.has_logical_noise_prefix());
+    }
+}
+
+TEST_CASE("PeepholeFusionPass leaves an inconsistent logical_noise_prefix unchanged",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("H 0\nZ_ERROR(0.3) 0\nT 0\nT 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.ops.size() == 4);
+    REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+    REQUIRE(hir.ops[1].op_type() == OpType::T_GATE);
+    // Force the first T to look like it logically precedes the noise site,
+    // which the schedule count (1) disagrees with.
+    hir.logical_noise_prefix[1] = 0;
+
+    const size_t ops_before = hir.ops.size();
+    const std::vector<uint32_t> prefix_before = hir.logical_noise_prefix;
+
+    PeepholeFusionPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.ops.size() == ops_before);
+    REQUIRE(hir.logical_noise_prefix == prefix_before);
+    size_t t_gate_count = 0;
+    for (const HeisenbergOp& op : hir.ops) {
+        t_gate_count += op.op_type() == OpType::T_GATE ? 1 : 0;
+    }
+    REQUIRE(t_gate_count == 2);  // the fusable pair was not fused
+}
+
+TEST_CASE("RemoveNoisePass clears logical_noise_prefix", "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.has_logical_noise_prefix());
+
+    RemoveNoisePass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.logical_noise_prefix.empty());
+    REQUIRE(hir.noise_sites.empty());
+}
+
+TEST_CASE("DropNonUnitaryPass clears logical_noise_prefix", "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nT 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.has_logical_noise_prefix());
+
+    DropNonUnitaryPass pass;
+    pass.run(hir);
+
+    REQUIRE(hir.logical_noise_prefix.empty());
+    REQUIRE(hir.noise_sites.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Logical noise prefix validation rejects a wrong-size vector", "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\n"));
+    REQUIRE(hir.ops.size() == 2);
+    hir.logical_noise_prefix = {0};
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+TEST_CASE("Logical noise prefix validation rejects a DETECTOR entry that disagrees with schedule",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\nDETECTOR rec[-1]\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.ops.back().op_type() == OpType::DETECTOR);
+    hir.logical_noise_prefix.back() = 0;  // was 1
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+TEST_CASE(
+    "Logical noise prefix validation rejects a NOISE entry that disagrees with its site index",
+    "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    REQUIRE(hir.ops.front().op_type() == OpType::NOISE);
+    hir.logical_noise_prefix.front() = 1;  // only one noise site exists; must be 0
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+TEST_CASE("Logical noise prefix validation rejects an entry above the noise site count",
+          "[logical_noise_prefix]") {
+    HirModule hir = clifft::trace(clifft::parse("Z_ERROR(0.3) 0\nT 0\nM 0\n"));
+    hir.materialize_logical_noise_prefix();
+    const auto t_gate = std::ranges::find_if(
+        hir.ops, [](const HeisenbergOp& op) { return op.op_type() == OpType::T_GATE; });
+    REQUIRE(t_gate != hir.ops.end());
+    const size_t t_index = static_cast<size_t>(t_gate - hir.ops.begin());
+    hir.logical_noise_prefix[t_index] = 2;  // only one noise site exists
+
+    REQUIRE_THROWS_AS(clifft::sampling::plan_sampling(hir), std::invalid_argument);
+}
+
+}  // namespace

--- a/tests/test_logical_noise_prefix.cc
+++ b/tests/test_logical_noise_prefix.cc
@@ -13,24 +13,20 @@
 #include "clifft/optimizer/peephole.h"
 #include "clifft/optimizer/remove_noise_pass.h"
 #include "clifft/optimizer/statevector_squeeze_pass.h"
-#include "clifft/sampling/executable_plan.h"
 #include "clifft/sampling/plan.h"
 #include "clifft/sampling/planner.h"
-#include "clifft/sampling/sampler.h"
 
+#include "sampling_equivalence_helpers.h"
 #include "test_helpers.h"
 
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <memory>
 #include <numeric>
 #include <random>
-#include <span>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -38,8 +34,8 @@
 #include <vector>
 
 using namespace clifft;
+using namespace clifft::test;
 using clifft::sampling::AffineBool;
-using clifft::sampling::ExecutablePlan;
 using clifft::sampling::PromoteDormantRotation;
 using clifft::sampling::RecordClassical;
 using clifft::sampling::SamplingPlan;
@@ -59,103 +55,10 @@ const T& action_as(const SamplingPlan& plan, size_t index) {
 // ---------------------------------------------------------------------------
 // Random noisy circuit generation
 // ---------------------------------------------------------------------------
-
-// A generated circuit plus, for each NOISE line, enough information to
-// realize a fixed firing outcome for it later (the legality-oracle test).
-struct GeneratedCircuit {
-    struct NoiseLine {
-        size_t line_index = 0;
-        uint32_t qubit = 0;
-        bool is_depolarize1 = false;
-        double prob = 0.0;
-    };
-
-    std::vector<std::string> lines;
-    std::vector<NoiseLine> noise_lines;
-};
-
-double next_unit(std::mt19937& rng) {
-    return static_cast<double>(rng() >> 11) * 0x1.0p-53;
-}
-
-// Deterministic generator over a small gate set: T, T_DAG, R_Z at a few
-// angles, M, MX, MR, R, X_ERROR, DEPOLARIZE1, and DETECTORs referencing
-// earlier records. Every generated line is individually valid, so the
-// circuit as a whole always parses and traces.
-GeneratedCircuit generate_noisy_circuit(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
-    static const double kAngles[] = {0.125, 0.25, 0.375, 0.625, 0.75, 0.875};
-    static const double kNoiseProbs[] = {0.05, 0.1, 0.2, 0.3};
-
-    GeneratedCircuit circuit;
-    uint32_t measurement_count = 0;
-    for (uint32_t op = 0; op < num_ops; ++op) {
-        const uint32_t q = rng() % num_qubits;
-        switch (rng() % 9) {
-            case 0:
-                circuit.lines.push_back("T " + std::to_string(q));
-                break;
-            case 1:
-                circuit.lines.push_back("T_DAG " + std::to_string(q));
-                break;
-            case 2:
-                circuit.lines.push_back("R_Z(" +
-                                        std::to_string(kAngles[rng() % std::size(kAngles)]) + ") " +
-                                        std::to_string(q));
-                break;
-            case 3:
-                circuit.lines.push_back("M " + std::to_string(q));
-                ++measurement_count;
-                break;
-            case 4:
-                circuit.lines.push_back("MX " + std::to_string(q));
-                ++measurement_count;
-                break;
-            case 5:
-                circuit.lines.push_back("MR " + std::to_string(q));
-                ++measurement_count;
-                break;
-            case 6:
-                circuit.lines.push_back("R " + std::to_string(q));
-                break;
-            case 7: {
-                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
-                circuit.lines.push_back("X_ERROR(" + std::to_string(prob) + ") " +
-                                        std::to_string(q));
-                circuit.noise_lines.push_back(
-                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/false, prob});
-                break;
-            }
-            case 8: {
-                const double prob = kNoiseProbs[rng() % std::size(kNoiseProbs)];
-                circuit.lines.push_back("DEPOLARIZE1(" + std::to_string(prob) + ") " +
-                                        std::to_string(q));
-                circuit.noise_lines.push_back(
-                    {circuit.lines.size() - 1, q, /*is_depolarize1=*/true, prob});
-                break;
-            }
-            default:
-                break;
-        }
-        if (measurement_count > 0 && (rng() % 5) == 0) {
-            const uint32_t back = 1 + (rng() % measurement_count);
-            circuit.lines.push_back("DETECTOR rec[-" + std::to_string(back) + "]");
-        }
-    }
-    return circuit;
-}
-
-std::string join_lines(const std::vector<std::string>& lines) {
-    std::string text;
-    for (const std::string& line : lines) {
-        text += line;
-        text += '\n';
-    }
-    return text;
-}
-
-std::string generate_noisy_source(std::mt19937& rng, uint32_t num_qubits, uint32_t num_ops) {
-    return join_lines(generate_noisy_circuit(rng, num_qubits, num_ops).lines);
-}
+//
+// GeneratedCircuit, generate_noisy_circuit, join_lines, generate_noisy_source,
+// and next_unit live in sampling_equivalence_helpers.h, shared with
+// test_schedule_dependence.cc.
 
 // Replaces every noise line with the explicit Pauli its fixed realization
 // fired, or drops the line if it did not fire. Uses its own RNG stream so
@@ -471,81 +374,10 @@ void randomly_reorder_across_noise(HirModule& hir, std::vector<size_t>& original
 // ---------------------------------------------------------------------------
 // Sampling equivalence
 // ---------------------------------------------------------------------------
-
-double tolerance_at_6_sigma(double mean_a, double mean_b, uint32_t shots) {
-    // A floor keeps the tolerance from collapsing to zero for a column that
-    // is (near-)deterministic in both samples.
-    constexpr double kMinP = 1e-3;
-    const double pooled = std::clamp(0.5 * (mean_a + mean_b), kMinP, 1.0 - kMinP);
-    return 6.0 * std::sqrt(2.0 * pooled * (1.0 - pooled) / shots);
-}
-
-double column_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t column,
-                   uint32_t shots) {
-    uint64_t ones = 0;
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        ones += values[static_cast<size_t>(shot) * num_columns + column];
-    }
-    return static_cast<double>(ones) / shots;
-}
-
-double parity_mean(std::span<const uint8_t> values, uint32_t num_columns, uint32_t col_a,
-                   uint32_t col_b, uint32_t shots) {
-    uint64_t ones = 0;
-    for (uint32_t shot = 0; shot < shots; ++shot) {
-        const uint8_t a = values[static_cast<size_t>(shot) * num_columns + col_a];
-        const uint8_t b = values[static_cast<size_t>(shot) * num_columns + col_b];
-        ones += static_cast<uint8_t>(a ^ b);
-    }
-    return static_cast<double>(ones) / shots;
-}
-
-void check_columns_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
-                         uint32_t num_columns, uint32_t shots, const char* label) {
-    for (uint32_t col = 0; col < num_columns; ++col) {
-        const double mean_a = column_mean(a, num_columns, col, shots);
-        const double mean_b = column_mean(b, num_columns, col, shots);
-        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
-        INFO(label << " column " << col << ": " << mean_a << " vs " << mean_b << ", tol " << tol);
-        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
-    }
-}
-
-void check_parities_agree(std::span<const uint8_t> a, std::span<const uint8_t> b,
-                          uint32_t num_columns, uint32_t shots, const char* label) {
-    for (uint32_t col = 0; col + 1 < num_columns; ++col) {
-        const double mean_a = parity_mean(a, num_columns, col, col + 1, shots);
-        const double mean_b = parity_mean(b, num_columns, col, col + 1, shots);
-        const double tol = tolerance_at_6_sigma(mean_a, mean_b, shots);
-        INFO(label << " parity (" << col << "," << col + 1 << "): " << mean_a << " vs " << mean_b
-                   << ", tol " << tol);
-        CHECK_THAT(mean_a, Catch::Matchers::WithinAbs(mean_b, tol));
-    }
-}
-
-// Samples `original` and `reordered` with different seeds and requires
-// every record column mean, every detector column mean, and every
-// consecutive-pair record parity to agree within a cross-binomial tolerance.
-// The point is distributional equality, not bit-exact records.
-void check_sampling_equivalent(const HirModule& original, const HirModule& reordered,
-                               uint32_t shots, uint64_t seed_a, uint64_t seed_b) {
-    const ExecutablePlan plan_a(clifft::sampling::plan_sampling(original));
-    const ExecutablePlan plan_b(clifft::sampling::plan_sampling(reordered));
-    REQUIRE(plan_a.num_visible_records() == plan_b.num_visible_records());
-    REQUIRE(plan_a.num_detectors() == plan_b.num_detectors());
-
-    const clifft::sampling::SamplingResult result_a =
-        clifft::sampling::sample(plan_a, shots, seed_a);
-    const clifft::sampling::SamplingResult result_b =
-        clifft::sampling::sample(plan_b, shots, seed_b);
-
-    check_columns_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
-                        shots, "record");
-    check_columns_agree(result_a.detectors, result_b.detectors, plan_a.num_detectors(), shots,
-                        "detector");
-    check_parities_agree(result_a.measurements, result_b.measurements, plan_a.num_visible_records(),
-                         shots, "record");
-}
+//
+// tolerance_at_6_sigma, column_mean, parity_mean, check_columns_agree,
+// check_parities_agree, and check_sampling_equivalent live in
+// sampling_equivalence_helpers.h, shared with test_schedule_dependence.cc.
 
 TEST_CASE("Logical noise prefix preserves the sampling distribution across noise-crossing reorders",
           "[logical_noise_prefix]") {

--- a/tests/test_schedule_dependence.cc
+++ b/tests/test_schedule_dependence.cc
@@ -1,0 +1,476 @@
+// Tests for ScheduleDependence and apply_schedule: the conservative
+// dependence relation over HIR operations that bounds which reorderings a
+// scheduler may use, and the machinery that commits one such reordering
+// back into an HirModule.
+
+#include "clifft/circuit/parser.h"
+#include "clifft/frontend/frontend.h"
+#include "clifft/frontend/hir.h"
+#include "clifft/optimizer/active_width_analysis.h"
+#include "clifft/optimizer/commutation.h"
+#include "clifft/optimizer/schedule_dependence.h"
+#include "clifft/sampling/plan.h"
+#include "clifft/sampling/planner.h"
+#include "clifft/tableau/pauli_string.h"
+
+#include "sampling_equivalence_helpers.h"
+#include "test_helpers.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <optional>
+#include <random>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace clifft;
+using namespace clifft::test;
+using clifft::sampling::SamplingPlan;
+
+namespace {
+
+#ifndef CLIFFT_FIXTURES_DIR
+#define CLIFFT_FIXTURES_DIR "tests/fixtures"
+#endif
+
+// Independent copy of the movable-op classification from
+// schedule_dependence.cc, so the oracle tests below do not lean on the
+// class under test to define what "movable" means.
+bool is_movable_ref(OpType type) {
+    return type == OpType::T_GATE || type == OpType::PHASE_ROTATION || type == OpType::MEASURE;
+}
+
+// Deterministic generator over a small gate set: T, T_DAG, R_Z, M, MX, MR,
+// R, X_ERROR, DEPOLARIZE1, and DETECTORs. Wraps the shared generator with
+// this file's qubit-count convention (4 to 10, per the relation's movable
+// op mix) so every call site does not have to repeat the modulus.
+std::string random_noisy_source(std::mt19937& rng, int trial) {
+    const uint32_t num_qubits = 4 + static_cast<uint32_t>(trial % 7);
+    const uint32_t num_ops = 15 + static_cast<uint32_t>(trial % 25);
+    return clifft::test::generate_noisy_source(rng, num_qubits, num_ops);
+}
+
+// Draws a uniformly random linear extension by repeatedly picking a
+// uniformly random ready op (one with no unscheduled predecessor) -- a
+// randomized Kahn's algorithm. Every ScheduleDependence is acyclic by
+// construction (every edge i -> j has i < j), so this always terminates
+// with a full permutation.
+std::vector<uint32_t> random_linear_extension(const ScheduleDependence& dep, std::mt19937& rng) {
+    const size_t n = dep.num_ops();
+    std::vector<uint32_t> remaining_preds(n);
+    std::vector<uint32_t> ready;
+    for (size_t op = 0; op < n; ++op) {
+        remaining_preds[op] = static_cast<uint32_t>(dep.predecessors(op).size());
+        if (remaining_preds[op] == 0) {
+            ready.push_back(static_cast<uint32_t>(op));
+        }
+    }
+
+    std::vector<uint32_t> order;
+    order.reserve(n);
+    while (!ready.empty()) {
+        const size_t pick = rng() % ready.size();
+        const uint32_t op = ready[pick];
+        ready[pick] = ready.back();
+        ready.pop_back();
+        order.push_back(op);
+        for (uint32_t succ : dep.successors(op)) {
+            if (--remaining_preds[succ] == 0) {
+                ready.push_back(succ);
+            }
+        }
+    }
+    return order;
+}
+
+// Replays a T_GATE/PHASE_ROTATION/MEASURE-only walk over `hir` through a
+// fresh DormantSubspace, using the same per-op-type dispatch
+// analyze_active_width uses (active_width_analysis.cc). Every other op type
+// leaves S untouched there, which is all this file's generator ever
+// produces (it never emits INSTRUMENT, the one op type with a nontrivial
+// "leaves S untouched" story of its own).
+DormantSubspace final_subspace(const HirModule& hir) {
+    DormantSubspace subspace(hir.num_qubits);
+    for (const HeisenbergOp& op : hir.ops) {
+        const bool is_rotation =
+            op.op_type() == OpType::T_GATE || op.op_type() == OpType::PHASE_ROTATION;
+        const bool is_measurement = op.op_type() == OpType::MEASURE;
+        if (!is_rotation && !is_measurement) {
+            continue;
+        }
+        PauliString body(hir.num_qubits);
+        body.mut_x().xor_with(hir.destab_mask(op));
+        body.mut_z().xor_with(hir.stab_mask(op));
+        if (is_measurement) {
+            subspace.apply_measurement(body);
+        } else {
+            subspace.apply_rotation(body);
+        }
+    }
+    return subspace;
+}
+
+// For every pair with at least one movable op, the relation must place an
+// edge exactly when allowed(i, j) is false: allowed is can_swap, extended
+// by the noise-transparency carve-out for a NOISE-versus-movable pair.
+// Fixed-fixed pairs are exempted here (checked separately below) since the
+// relation only chains consecutive ones, not every pair.
+void check_edges_match_can_swap(const HirModule& hir, bool noise_transparent) {
+    ScheduleDependenceOptions options;
+    options.noise_transparent = noise_transparent;
+    const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+
+    REQUIRE(dep.num_ops() == hir.ops.size());
+    REQUIRE(dep.noise_transparent() == noise_transparent);
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        REQUIRE(dep.is_movable(i) == is_movable_ref(hir.ops[i].op_type()));
+    }
+
+    for (size_t i = 0; i < hir.ops.size(); ++i) {
+        const bool i_movable = is_movable_ref(hir.ops[i].op_type());
+        for (size_t j = i + 1; j < hir.ops.size(); ++j) {
+            const bool j_movable = is_movable_ref(hir.ops[j].op_type());
+            if (!i_movable && !j_movable) {
+                continue;
+            }
+
+            const bool has_edge =
+                std::ranges::binary_search(dep.predecessors(j), static_cast<uint32_t>(i));
+            const bool noise_pair =
+                noise_transparent && ((hir.ops[i].op_type() == OpType::NOISE && j_movable) ||
+                                      (hir.ops[j].op_type() == OpType::NOISE && i_movable));
+            CAPTURE(i, j, noise_pair);
+            if (noise_pair) {
+                REQUIRE_FALSE(has_edge);
+                continue;
+            }
+            REQUIRE(has_edge == !can_swap(hir.ops[i], hir.ops[j], hir));
+        }
+    }
+
+    // Every consecutive pair of fixed ops is chained.
+    std::optional<uint32_t> previous_fixed;
+    for (uint32_t k = 0; k < hir.ops.size(); ++k) {
+        if (is_movable_ref(hir.ops[k].op_type())) {
+            continue;
+        }
+        if (previous_fixed.has_value()) {
+            CAPTURE(*previous_fixed, k);
+            REQUIRE(std::ranges::binary_search(dep.predecessors(k), *previous_fixed));
+        }
+        previous_fixed = k;
+    }
+}
+
+// Builds both relations for `hir`, draws two independent random linear
+// extensions of each, applies each to its own copy, and requires the
+// resulting DormantSubspace to agree: same active width, and every
+// generator of one contained in the other. This is the confluence property
+// that makes searching over the relation's linear extensions well defined.
+void check_confluence(const HirModule& hir, bool noise_transparent, std::mt19937& order_rng) {
+    ScheduleDependenceOptions options;
+    options.noise_transparent = noise_transparent;
+    const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+
+    const std::vector<uint32_t> order_a = random_linear_extension(dep, order_rng);
+    const std::vector<uint32_t> order_b = random_linear_extension(dep, order_rng);
+    REQUIRE(dep.is_linear_extension(order_a));
+    REQUIRE(dep.is_linear_extension(order_b));
+
+    HirModule hir_a = hir;
+    apply_schedule(hir_a, dep, order_a);
+    HirModule hir_b = hir;
+    apply_schedule(hir_b, dep, order_b);
+
+    const ActiveWidthTrace trace_a = analyze_active_width(hir_a);
+    const ActiveWidthTrace trace_b = analyze_active_width(hir_b);
+    REQUIRE(trace_a.final_width == trace_b.final_width);
+
+    const DormantSubspace subspace_a = final_subspace(hir_a);
+    const DormantSubspace subspace_b = final_subspace(hir_b);
+    REQUIRE(subspace_a.active_width() == trace_a.final_width);
+    REQUIRE(subspace_b.active_width() == trace_b.final_width);
+
+    const std::vector<PauliString> gens_a = subspace_a.generators();
+    const std::vector<PauliString> gens_b = subspace_b.generators();
+    REQUIRE(gens_a.size() == gens_b.size());
+    for (const PauliString& g : gens_b) {
+        REQUIRE(subspace_a.contains(g));
+    }
+    for (const PauliString& g : gens_a) {
+        REQUIRE(subspace_b.contains(g));
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Relation matches can_swap
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Schedule dependence edges match can_swap on random noisy circuits",
+          "[schedule_dependence]") {
+    constexpr uint32_t kSeed = 0x5C4ED;
+    constexpr int kTrials = 200;
+
+    std::mt19937 rng(kSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const std::string source = random_noisy_source(rng, trial);
+        CAPTURE(trial, source);
+
+        const HirModule hir = clifft::trace(clifft::parse(source));
+        check_edges_match_can_swap(hir, /*noise_transparent=*/false);
+        check_edges_match_can_swap(hir, /*noise_transparent=*/true);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Random linear extensions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A random linear extension keeps fixed ops in order and rejects an inversion",
+          "[schedule_dependence]") {
+    constexpr uint32_t kCircuitSeed = 0x11FE1;
+    constexpr uint32_t kOrderSeed = 0x11FE2;
+    constexpr int kTrials = 60;
+
+    std::mt19937 circuit_rng(kCircuitSeed);
+    std::mt19937 order_rng(kOrderSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const std::string source = random_noisy_source(circuit_rng, trial);
+        CAPTURE(trial, source);
+
+        const HirModule hir = clifft::trace(clifft::parse(source));
+        const ScheduleDependence dep = ScheduleDependence::build(hir);
+        const std::vector<uint32_t> order = random_linear_extension(dep, order_rng);
+
+        REQUIRE(order.size() == hir.ops.size());
+        REQUIRE(dep.is_linear_extension(order));
+
+        std::vector<uint32_t> position(hir.ops.size());
+        for (size_t pos = 0; pos < order.size(); ++pos) {
+            position[order[pos]] = static_cast<uint32_t>(pos);
+        }
+
+        std::optional<uint32_t> previous_fixed;
+        for (uint32_t i = 0; i < hir.ops.size(); ++i) {
+            if (is_movable_ref(hir.ops[i].op_type())) {
+                continue;
+            }
+            if (previous_fixed.has_value()) {
+                REQUIRE(position[*previous_fixed] < position[i]);
+            }
+            previous_fixed = i;
+        }
+
+        // A deliberately inverted dependent pair is rejected: take a real
+        // edge i -> j and swap the two ops' slots in the (still valid)
+        // order, which places j before i and must violate that edge.
+        for (uint32_t j = 0; j < hir.ops.size(); ++j) {
+            const std::span<const uint32_t> preds = dep.predecessors(j);
+            if (preds.empty()) {
+                continue;
+            }
+            const uint32_t i = preds[0];
+            std::vector<uint32_t> broken = order;
+            std::swap(broken[position[i]], broken[position[j]]);
+            REQUIRE_FALSE(dep.is_linear_extension(broken));
+            break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Confluence of the structural subspace
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Different linear extensions reach the same final structural subspace",
+          "[schedule_dependence]") {
+    constexpr uint32_t kCircuitSeed = 0x9A5E1;
+    constexpr uint32_t kOrderSeed = 0x9A5E2;
+    constexpr int kTrials = 100;
+
+    std::mt19937 circuit_rng(kCircuitSeed);
+    std::mt19937 order_rng(kOrderSeed);
+    for (int trial = 0; trial < kTrials; ++trial) {
+        const std::string source = random_noisy_source(circuit_rng, trial);
+        const HirModule hir = clifft::trace(clifft::parse(source));
+
+        for (const bool noise_transparent : {false, true}) {
+            CAPTURE(trial, source, noise_transparent);
+            check_confluence(hir, noise_transparent, order_rng);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Four-operation regression
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Reordering a four operation circuit reduces its peak active width",
+          "[schedule_dependence]") {
+    // Non-Clifford R_XX(0.3), R_ZY(0.3), M_YY (record 0), M_YI (record 1).
+    // Mask bits follow PauliString::from_text's convention (character index
+    // q maps to qubit q), matching the equivalent DormantSubspace-only
+    // cases in test_active_width_analysis.cc.
+    HirModule hir(2, 4);
+    hir.num_measurements = 2;
+    clifft::test::append_phase_rotation(hir, X(0) | X(1), 0, false, 0.3);                  // R_XX
+    clifft::test::append_phase_rotation(hir, X(1), Z(0) | Z(1), false, 0.3);               // R_ZY
+    clifft::test::append_measure(hir, X(0) | X(1), Z(0) | Z(1), false, MeasRecordIdx{0});  // M_YY
+    clifft::test::append_measure(hir, X(0), Z(0), false, MeasRecordIdx{1});                // M_YI
+
+    const ActiveWidthTrace original_trace = analyze_active_width(hir);
+    std::vector<uint32_t> original_widths{original_trace.initial_width};
+    for (const WidthTransition& transition : original_trace.transitions) {
+        original_widths.push_back(transition.after);
+    }
+    REQUIRE(original_widths == std::vector<uint32_t>{0, 1, 2, 1, 0});
+
+    const ScheduleDependence dep = ScheduleDependence::build(hir);
+    const std::vector<uint32_t> order = {1, 2, 0, 3};
+    REQUIRE(dep.is_linear_extension(order));
+
+    HirModule reordered = hir;
+    apply_schedule(reordered, dep, order);
+
+    const ActiveWidthTrace reordered_trace = analyze_active_width(reordered);
+    std::vector<uint32_t> reordered_widths{reordered_trace.initial_width};
+    for (const WidthTransition& transition : reordered_trace.transitions) {
+        reordered_widths.push_back(transition.after);
+    }
+    REQUIRE(reordered_widths == std::vector<uint32_t>{0, 1, 1, 1, 0});
+
+    const SamplingPlan original_plan = clifft::sampling::plan_sampling(hir);
+    const SamplingPlan reordered_plan = clifft::sampling::plan_sampling(reordered);
+    REQUIRE(original_plan.peak_active_width == original_trace.peak_width);
+    REQUIRE(reordered_plan.peak_active_width == reordered_trace.peak_width);
+    REQUIRE(original_plan.peak_active_width == 2);
+    REQUIRE(reordered_plan.peak_active_width == 1);
+}
+
+// ---------------------------------------------------------------------------
+// apply_schedule
+// ---------------------------------------------------------------------------
+
+TEST_CASE("apply_schedule rejects an order that is not a linear extension",
+          "[schedule_dependence]") {
+    SECTION("inverted dependent pair") {
+        HirModule hir = clifft::trace(clifft::parse("X_ERROR(0.3) 0\nM 0\nDETECTOR rec[-1]\n"));
+        REQUIRE(hir.ops.size() == 3);
+        REQUIRE(hir.ops[0].op_type() == OpType::NOISE);
+        REQUIRE(hir.ops[1].op_type() == OpType::MEASURE);
+        REQUIRE(hir.ops[2].op_type() == OpType::DETECTOR);
+
+        // With noise transparency off, the plain X_ERROR/Z-measurement
+        // anticommutation makes NOISE -> MEASURE a real edge.
+        ScheduleDependenceOptions options;
+        options.noise_transparent = false;
+        const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+        REQUIRE_FALSE(can_swap(hir.ops[0], hir.ops[1], hir));
+
+        const std::vector<uint32_t> bad_order = {1, 0, 2};
+        REQUIRE_THROWS_AS(apply_schedule(hir, dep, bad_order), std::invalid_argument);
+    }
+
+    SECTION("wrong length order") {
+        HirModule hir = clifft::trace(clifft::parse("M 0\nM 0\n"));
+        const ScheduleDependence dep = ScheduleDependence::build(hir);
+        const std::vector<uint32_t> short_order = {0};
+        REQUIRE_THROWS_AS(apply_schedule(hir, dep, short_order), std::invalid_argument);
+    }
+
+    SECTION("dependence built from a different operation count") {
+        HirModule small = clifft::trace(clifft::parse("M 0\n"));
+        const ScheduleDependence dep = ScheduleDependence::build(small);
+
+        HirModule other = clifft::trace(clifft::parse("M 0\nM 0\n"));
+        const std::vector<uint32_t> order = {0};
+        REQUIRE_THROWS_AS(apply_schedule(other, dep, order), std::invalid_argument);
+    }
+}
+
+TEST_CASE("apply_schedule carries source_map and logical_noise_prefix with their ops",
+          "[schedule_dependence]") {
+    std::mt19937 circuit_rng(0xF00D1);
+    const std::string source = clifft::test::generate_noisy_source(circuit_rng, 6, 30);
+    CAPTURE(source);
+
+    HirModule hir = clifft::trace(clifft::parse(source));
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    hir.materialize_logical_noise_prefix();
+
+    // source_map (the source line) uniquely tags each op here, so pairing
+    // it with logical_noise_prefix confirms the entry followed the same op
+    // through however apply_schedule permutes them.
+    auto tagged_snapshot = [](const HirModule& module) {
+        std::vector<std::pair<std::vector<uint32_t>, uint32_t>> tagged;
+        for (size_t i = 0; i < module.ops.size(); ++i) {
+            tagged.emplace_back(module.source_map[i], module.logical_noise_prefix[i]);
+        }
+        std::ranges::sort(tagged);
+        return tagged;
+    };
+    const auto before = tagged_snapshot(hir);
+
+    ScheduleDependenceOptions options;
+    options.noise_transparent = true;
+    const ScheduleDependence dep = ScheduleDependence::build(hir, options);
+    std::mt19937 order_rng(0xBEEF1);
+    const std::vector<uint32_t> order = random_linear_extension(dep, order_rng);
+
+    apply_schedule(hir, dep, order);
+
+    REQUIRE(hir.source_map.size() == hir.ops.size());
+    REQUIRE(hir.has_logical_noise_prefix());
+    REQUIRE(tagged_snapshot(hir) == before);
+}
+
+TEST_CASE("A random linear extension under noise transparency is sampling equivalent",
+          "[schedule_dependence]") {
+    constexpr uint32_t kShots = 20000;
+
+    SECTION("random circuits") {
+        constexpr int kTrials = 20;
+        std::mt19937 circuit_rng(0x5A17C);
+        std::mt19937 control_rng(0x5EED17);
+        for (int trial = 0; trial < kTrials; ++trial) {
+            const std::string source = random_noisy_source(circuit_rng, trial);
+            CAPTURE(trial, source);
+
+            const HirModule original = clifft::trace(clifft::parse(source));
+            ScheduleDependenceOptions options;
+            options.noise_transparent = true;
+            const ScheduleDependence dep = ScheduleDependence::build(original, options);
+            std::mt19937 order_rng(control_rng());
+            const std::vector<uint32_t> order = random_linear_extension(dep, order_rng);
+
+            HirModule reordered = original;
+            apply_schedule(reordered, dep, order);
+
+            clifft::test::check_sampling_equivalent(original, reordered, kShots, control_rng(),
+                                                    control_rng());
+        }
+    }
+
+    SECTION("coherent_d3_r3 fixture") {
+        const Circuit circuit =
+            clifft::parse_file(std::string(CLIFFT_FIXTURES_DIR) + "/coherent_d3_r3.stim");
+        const HirModule original = clifft::trace(circuit);
+
+        ScheduleDependenceOptions options;
+        options.noise_transparent = true;
+        const ScheduleDependence dep = ScheduleDependence::build(original, options);
+        std::mt19937 order_rng(0x517EE7);
+        const std::vector<uint32_t> order = random_linear_extension(dep, order_rng);
+
+        HirModule reordered = original;
+        apply_schedule(reordered, dep, order);
+
+        clifft::test::check_sampling_equivalent(original, reordered, kShots, 0x1234, 0x5678);
+    }
+}


### PR DESCRIPTION
Prototype work on the `feature/active-width-scheduling` branch toward #458; review can be less strict than for `main`. Stacked on #461; the diff includes #459, #460, and #461 until they merge.

## Algorithm

`search_width_schedule` replays HIR ops through a `DormantSubspace` exactly as `analyze_active_width` does, over the dependence DAG `ScheduleDependence::build` produces. An op is *ready* once every predecessor has executed; a ready op is *expanding* if executing it would raise the active width `k` (a `T_GATE`/`PHASE_ROTATION` whose axis does not commute with the current subspace `S`, or an `INSTRUMENT` in the Activate branch) and *non-expanding* otherwise (any `MEASURE`, any commuting rotation, and every other op type). *Closure* repeatedly executes the lowest-index ready non-expanding op until none remains; because independent GF(2) updates commute, the resulting subspace and executed-op set are order-independent, so a search state is fully identified by its set of executed ops rather than by how it was reached. The closure theorem (some peak-minimizing schedule executes every ready non-expanding op immediately) means the search only has to branch on which ready expanding op fires next -- an `INSTRUMENT`, being a positional barrier under `ScheduleDependence` (`can_swap` refuses to reorder anything across one), is always the only ready op when it is ready, so it is never actually a branch point, just a forced move that can fail the node if it would exceed the current threshold.

Threshold feasibility for a bound `B` is a depth-first search from the initial closed state: at each node the candidates are the ready expanding ops whose execution would not push `k` above `B`, tried in the order most likely to succeed (lowest width after that candidate's own closure sweep, ties by lower op index); a node with no viable candidate is infeasible and is memoized by its exact executed-op bitset (an `unordered_set<vector<uint64_t>>` with a real hash used only for bucketing, never as an identity) so any other branch reaching the same set of executed ops is pruned for free. The outer loop starts from the incumbent's own peak and threshold-searches downward, sharing one node budget and one failed-node memo across every threshold it tries (a set proven infeasible at a looser bound is also infeasible at any tighter one, since the tighter bound's candidate list is a subset of the looser one's), lowering `upper_bound` to each witness's actual achieved peak (which can undercut the threshold that found it) and raising `lower_bound` to `threshold + 1` on the first exhaustive failure, until the two meet (`optimal()`) or the shared budget runs out.

## Certificate scope

`optimal()` certifies a minimum over the trace class of the exact HIR passed in, under the given `ScheduleDependence` relation, scored by the sampling planner's own structural width model. It says nothing about schedules reachable only through a rewrite that exposes new gate fusion, about amplitude-level stabilizers the structural planner does not track, or about any other circuit that merely samples the same distribution as this one.

## Validation

- **Brute force agreement**: 150 seeded random noisy circuits with at most 9 movable ops (skipping the rare circuit whose linear-extension count still exceeds a 3000-leaf enumeration cap kept low to hold this test to ~8s -- see the code comment for why the movable-op cap alone does not bound enumeration cost), enumerated exhaustively and cross-checked against the search under both relation options: `upper_bound`, `lower_bound`, and `best_order`'s actual peak all agree with the brute-force minimum, and `optimal()` holds. This also exercises the closure theorem directly: the search only ever branches on expanding ops, yet it always lands on the same optimum as trying every legal order.
- **Four-operation regression**: the `R_XX, R_ZY, M_YY, M_YI` HIR from `test_schedule_dependence.cc` drops from incumbent peak 2 to a certified optimal 1, with `apply_schedule(best_order)` reproducing the `0, 1, 1, 1, 0` trace.
- **Never worse than the incumbent**, plus **budget behaviour** (an exhausted budget reports `budget_exhausted`, `upper_bound == incumbent_peak`, `lower_bound` at the order-invariant final width, and never throws -- checked on a purpose-built two-independent-widget circuit, since the four-operation circuit above turns out to resolve within a single search node regardless of budget).
- **coherent_d3_r3 fixture certificates**: after `PeepholeFusionPass` + `StatevectorSqueezePass`, the search certifies the incumbent peak 5 as optimal without noise transparency (71 nodes explored), and certifies 4 with it (64 nodes explored) -- matching the corpus table in #458 exactly, and well inside the 200000-node budget.
- **Sampling equivalence**: applying the noise-transparent `best_order` to a copy of coherent_d3_r3 and of 10 random noisy circuits preserves sampling statistics (20000 shots, 6 sigma) against the original.
- Python: `active_width_trace`'s peak matches `clifft.lower(hir).peak_active_width` on all 8 in-tree fixtures; `search_width_schedule` reproduces the same coherent_d3_r3 certificate (incumbent 5, bounds 4/4) and, with `apply=True`, the lowered program's `peak_active_width` drops to 4 while `clifft.sample` statistics still match the unoptimized program; a separate test confirms `apply=False` leaves the HIR untouched.

A real bug did turn up during development: iterating `SearchFrontier`'s live `std::set` of ready ops while a nested call mutated and restored that same set (to rank candidates) invalidated the outer iterator and segfaulted. That was a memory-safety bug in the implementation, not a disagreement between the search and the brute-force oracle on any actual answer -- fixed by snapshotting the ready set into a plain vector before iterating. Once fixed, the brute-force cross-check never disagreed with the search's claimed bounds.

## Test commands and results

```
cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -G Ninja && cmake --build build-debug -j$(nproc) && ctest --test-dir build-debug --output-on-failure
# 100% tests passed, 0 tests failed out of 966

./build-debug/tests/clifft_tests "[width_search]" --durations yes
# All tests passed (1009 assertions in 6 test cases); slowest case (brute
# force agreement) 8.1s, every other case under 0.7s

uv venv .venv
SKBUILD_CMAKE_BUILD_TYPE=Debug uv pip install -e . --no-cache --reinstall-package clifft --python .venv/bin/python
uv run --python .venv/bin/python pytest tests/python -x -q
# 1389 passed, 7 skipped

uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
# all hooks passed (clang-format, ruff, ruff-format, mypy, trailing-whitespace,
# end-of-file-fixer, check-yaml, check-added-large-files, check-merge-conflict, actionlint)

just build-wasm   # docker emsdk, confirms src/wasm/CMakeLists.txt registration
# [100%] Built target clifft_wasm
```
