### PR TITLE
docs: explain structural active width and scheduling

### DIFF
--- a/docs/guide/cpu-execution.md
+++ b/docs/guide/cpu-execution.md
@@ -177,7 +177,8 @@ choose a layout from peak width alone.
 `ActiveWidthSchedulePass` is an opt-in HIR pass, not part of the default
 pipeline, that reorders Heisenberg IR operations to reduce peak active
 width, then a dense-work estimate; it never leaves a circuit worse than it
-found it. See [Active-Width Scheduling](../theory/active-width.md) for the
+found it by peak active width and then by estimated dense work. See
+[Active-Width Scheduling](../theory/active-width.md) for the
 structural model it searches over. Enable it by building a custom
 `HirPassManager` that runs it last, after `PeepholeFusionPass` and
 `StatevectorSqueezePass`, and passing that manager to `hir_passes`:

--- a/docs/guide/cpu-execution.md
+++ b/docs/guide/cpu-execution.md
@@ -194,11 +194,11 @@ pm.add(clifft.ActiveWidthSchedulePass())
 program = clifft.compile("H 0\nT 0\nM 0", hir_passes=pm)
 ```
 
-On most circuits this costs single-digit milliseconds, but circuits with
-many simultaneously-ready, mutually independent non-Clifford rotations can
-push compile time higher -- about 600 ms on the largest circuit in the
-measured `clifft-paper` QEC corpus, a cost paid once per compiled program
-rather than once per shot. See
+Across the measured `clifft-paper` QEC corpus this costs roughly 2 ms to
+600 ms, growing with the number of simultaneously-ready, mutually
+independent non-Clifford rotations, with the largest cost on the
+five-round distance-5 coherent circuit -- a cost paid once per compiled
+program rather than once per shot. See
 [Measured Effect](../theory/active-width.md#measured-effect) for the full
 per-circuit table.
 

--- a/docs/guide/cpu-execution.md
+++ b/docs/guide/cpu-execution.md
@@ -174,10 +174,11 @@ choose a layout from peak width alone.
 
 ## Compile-time scheduling
 
-`ActiveWidthSchedulePass` is an opt-in HIR pass, not part of the default
-pipeline, that reorders Heisenberg IR operations to reduce peak active
-width, then a dense-work estimate; it never leaves a circuit worse than it
-found it by peak active width and then by estimated dense work. See
+`ActiveWidthSchedulePass` is an opt-in HIR pass that reorders Heisenberg IR
+operations to lower peak active width first and an estimate of dense work
+second. It accepts a new order only when peak width falls, or when peak width
+is unchanged and estimated dense work falls; otherwise it leaves the circuit as
+it found it. Its search is bounded by a deterministic work budget. See
 [Active-Width Scheduling](../theory/active-width.md) for the
 structural model it searches over. Enable it by building a custom
 `HirPassManager` that runs it last, after `PeepholeFusionPass` and
@@ -194,8 +195,8 @@ pm.add(clifft.ActiveWidthSchedulePass())
 program = clifft.compile("H 0\nT 0\nM 0", hir_passes=pm)
 ```
 
-Across the measured `clifft-paper` QEC corpus this costs roughly 2 ms to
-600 ms, growing with the number of simultaneously-ready, mutually
+Across the measured `clifft-paper` QEC corpus this costs roughly 1 ms to
+40 ms, growing with the number of simultaneously-ready, mutually
 independent non-Clifford rotations, with the largest cost on the
 five-round distance-5 coherent circuit -- a cost paid once per compiled
 program rather than once per shot. See

--- a/docs/guide/cpu-execution.md
+++ b/docs/guide/cpu-execution.md
@@ -171,3 +171,35 @@ and `1024`, using the production worker budget and result options.
 
 Use `program.peak_active_width` as a first-order cost indicator, but do not
 choose a layout from peak width alone.
+
+## Compile-time scheduling
+
+`ActiveWidthSchedulePass` is an opt-in HIR pass, not part of the default
+pipeline, that reorders Heisenberg IR operations to reduce peak active
+width, then a dense-work estimate; it never leaves a circuit worse than it
+found it. See [Active-Width Scheduling](../theory/active-width.md) for the
+structural model it searches over. Enable it by building a custom
+`HirPassManager` that runs it last, after `PeepholeFusionPass` and
+`StatevectorSqueezePass`, and passing that manager to `hir_passes`:
+
+```python
+import clifft
+
+pm = clifft.HirPassManager()
+pm.add(clifft.PeepholeFusionPass())
+pm.add(clifft.StatevectorSqueezePass())
+pm.add(clifft.ActiveWidthSchedulePass())
+
+program = clifft.compile("H 0\nT 0\nM 0", hir_passes=pm)
+```
+
+On most circuits this costs single-digit milliseconds, but circuits with
+many simultaneously-ready, mutually independent non-Clifford rotations can
+push compile time higher -- about 600 ms on the largest circuit in the
+measured `clifft-paper` QEC corpus, a cost paid once per compiled program
+rather than once per shot. See
+[Measured Effect](../theory/active-width.md#measured-effect) for the full
+per-circuit table.
+
+See [Optimization Passes](../reference/passes.md) for every available pass
+and its default.

--- a/docs/guide/leakage-and-loss.md
+++ b/docs/guide/leakage-and-loss.md
@@ -371,8 +371,9 @@ circuit and model together and compiles internally.
 Each continuation uses the default optimization passes that preserve
 measurement-record order and explicitly opt in to instrument-prefix stability.
 At the HIR stage, this means `PeepholeFusionPass`;
-`StatevectorSqueezePass` is omitted because it can move measurements. See
-[Optimization Passes](../reference/passes.md) for the available HIR passes.
+`StatevectorSqueezePass` and `ActiveWidthSchedulePass` are omitted because
+both can move measurements. See [Optimization Passes](../reference/passes.md)
+for the available HIR passes.
 
 This restriction matters because resolving a trapped transition may add a
 forced, hidden trace-out measurement. Moving another measurement across that

--- a/docs/reference/passes.md
+++ b/docs/reference/passes.md
@@ -20,6 +20,7 @@ import clifft
 pm = clifft.HirPassManager()
 pm.add(clifft.PeepholeFusionPass())
 pm.add(clifft.StatevectorSqueezePass())
+pm.add(clifft.ActiveWidthSchedulePass())
 ```
 
 Optimization passes end at the HIR boundary; `SamplingPlan` is not a second

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -75,8 +75,10 @@ move; all other operations retain their relative order. `EXP_VAL` and
 
 The plain relation uses `can_swap` to decide which pairs may exchange order.
 Two rotations or measurements may swap when their Pauli bodies commute.
-[Noise transparency](#noise-transparency) additionally permits them to cross
-`NOISE` operations, with sign corrections described below.
+Measurements cannot cross classical consumers of their records, and rotations
+cannot cross anticommuting feedback Paulis.
+[Noise transparency](#noise-transparency) additionally permits rotations and
+measurements to cross `NOISE` operations, with sign corrections described below.
 
 Suppose $p$ and $q$ commute. Their width updates commute as well:
 
@@ -155,10 +157,10 @@ operation across such a site would add or remove a sign contribution.
 
 Noise transparency preserves that contribution using the operation's
 **logical position**: its position before reordering. Each `NOISE` channel
-is presampled, so its outcome is available regardless of where the site
-appears in the schedule. The HIR's `logical_noise_prefix` records how many
-noise sites originally preceded each operation. This metadata moves with the
-operation, allowing the planner to correct its sign after reordering.
+is presampled, so its outcome is available regardless of where in the schedule
+the operations that depend on it run. The HIR's `logical_noise_prefix` records
+how many noise sites originally preceded each operation. This metadata moves
+with the operation, allowing the planner to correct its sign after reordering.
 
 For a fixed noise realization, absorb the realized Pauli errors into the
 downstream signs. A noise-transparent schedule is then a legal reordering of

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -24,8 +24,9 @@ $p$ updates $S$ by one of two rules, depending on the operation type:
 ```text
 rotation about p:    S <- S cap p-perp          k -> k+1 iff p is not in S-perp
 measurement of p:     S <- (S cap p-perp) + <p>  k -> k-1 iff p is in S-perp but not in S
-noise, feedback, detector, observable, readout,
-and every other non-rotation, non-measurement op: S unchanged
+transition instrument, Activate branch: same as rotation about p
+noise, feedback, detector, observable, readout, every other instrument
+branch, and every other op: S unchanged
 ```
 
 Here $S^\perp$ is the symplectic-orthogonal complement of $S$: the set of
@@ -51,7 +52,10 @@ the formula actually changes $\dim S$:
 
 Every other HIR operation type -- noise, feedback, detectors, observables,
 readout corrections -- reads or writes classical state only and leaves $S$
-untouched.
+untouched. A transition instrument leaves $S$ untouched the same way on
+every branch except `Activate`; taking the `Activate` branch, it instead
+follows the rotation rule above, promoting a coordinate exactly as a
+rotation would.
 
 ### Pivot Independence
 
@@ -226,22 +230,25 @@ HIR's own width trace, lexicographically by peak active width and then by a
 dense-work estimate (the planning-time proxy $\sum 2^{w}$ over actions that
 touch the active array, at the width $w$ each one runs at). The pass applies
 its candidate only when that comparison is strictly better; otherwise the
-HIR is left byte-for-byte untouched. This "never worse than the incumbent"
-guarantee is what makes the pass safe to run unconditionally: unlike the
-exact search, it carries no certificate of optimality, only a guarantee that
-it cannot regress the circuit it started from.
+HIR is left byte-for-byte untouched. This "never worse than the incumbent,
+by peak active width and then by estimated dense work" guarantee is what
+makes the pass safe to run unconditionally: unlike the exact search, it
+carries no certificate of optimality, only a guarantee that it cannot
+regress the circuit's peak active width or, short of an improvement there,
+its estimated dense work. It is not a guarantee about compile time or about
+measured sampling throughput.
 
 ## Measured Effect
 
 Measured once, single host, Release build, at commit `d169751b`: sampling
 throughput with the production pipeline (`PeepholeFusionPass` then
-`StatevectorSqueezePass`) versus the production pipeline plus the opt-in
-`ActiveWidthSchedulePass` (at its default options), on the `clifft-paper`
+`StatevectorSqueezePass`) versus production plus the opt-in schedule pass
+(`ActiveWidthSchedulePass`, at its default options), on the `clifft-paper`
 QEC corpus at commit `db7dc9f`, best of 3 timed batches after warmup. "Plan
 work" is the planner's own $\sum 2^{k}$ over dense actions -- the same
 quantity `estimate_dense_work` approximates ahead of planning.
 
-| Circuit | Production: peak / plan work / shots per s | Default pipeline: peak / plan work / shots per s | Pass wall time |
+| Circuit | Production: peak / plan work / shots per s | Production + schedule pass: peak / plan work / shots per s | Pass wall time |
 |---|---|---|---|
 | coherent d3 r3 | 5 / 1247 / 1.08M | 4 / 381 / 2.03M | 17 ms |
 | coherent d5 r1 | 12 / 35875 / 82k | 0 / 0 / 3.8M | 2 ms |

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -218,14 +218,33 @@ work. By default, the pass also moves width-neutral rotations rightward past
 independent non-expanding operations to improve executable-plan rotation
 fusion.
 
+The search is bounded by `search_budget`, measured in operations executed
+through closure sweeps and candidate replays as a multiple of the HIR's
+operation count, with two graduated responses. Once the running count exceeds
+half the budget, the remaining lower-ranked schedules in the current
+generation are dropped unscored and the next cut keeps a single survivor.
+Once it exceeds the full budget, each step also scores only the lowest-index
+ready expanding operation. The worst case therefore costs the budget plus a
+few traces regardless of circuit shape, including circuits with many
+simultaneously ready rotations. Counting operations rather than time keeps
+the schedule, and therefore the plan, reproducible across machines. The
+default of 16 comes from measuring peak and dense work across the corpus
+below and larger circuits: narrowing the beam at any point from four traces
+on reached the unbounded search's peak everywhere, eight traces was the
+smallest point that also kept every dense-work gain, and a full budget of
+twice that leaves the greedy remainder enough room to keep scoring
+candidates on the circuits that cross it. The pass reports the count as
+`swept_ops`.
+
 The dense-work estimate sums $2^w$ over actions that touch the active array,
 using the width $w$ at which each action runs. The pass replaces the input HIR
 only if the candidate has a lower peak, or the same peak and lower estimated
 dense work. Otherwise it leaves the HIR untouched. This does not guarantee an
 optimal schedule or improved sampling throughput.
 
-The pass is opt-in because scheduling can be expensive on large, highly
-branching HIRs. Run it last in the HIR pipeline, after `PeepholeFusionPass` and
+The pass is opt-in. Its search cost is bounded by `search_budget`, but the
+dependence build and the traces it needs still add a few passes over the
+HIR. Run it last in the HIR pipeline, after `PeepholeFusionPass` and
 `StatevectorSqueezePass`. A noise-transparent reorder can prevent later
 peephole fusion. See [Optimization Passes](../reference/passes.md) for pipeline
 configuration and the measurements below for compile-time costs.
@@ -235,18 +254,19 @@ configuration and the measurements below for compile-time costs.
 The following measurements compare the production pipeline
 (`PeepholeFusionPass` then `StatevectorSqueezePass`) with production plus
 `ActiveWidthSchedulePass` at its default options. They use a Release build at
-commit `d169751b` and the `clifft-paper` QEC corpus at commit `db7dc9f`, on one
-host. Throughput is the best of three timed batches after warmup. "Plan work"
-is the planner's $\sum 2^k$ over dense actions, which `estimate_dense_work`
-approximates before planning.
+commit `8f69b3c3` and the `clifft-paper` QEC corpus at commit `db7dc9f`, on one
+host with one thread. "Dense work" is `estimate_dense_work` over the HIR each
+pipeline produces, the quantity the pass minimizes second. Throughput is the
+best of three timed batches of 4096 shots after one warmup batch. Pass wall
+time is the best of three runs of the pass alone on the prepared HIR.
 
-| Circuit | Production: peak / plan work / shots per s | Production + schedule pass: peak / plan work / shots per s | Pass wall time |
+| Circuit | Production: peak / dense work / shots per s | Production + schedule pass: peak / dense work / shots per s | Pass wall time |
 |---|---|---|---|
-| coherent d3 r3 | 5 / 1247 / 1.08M | 4 / 381 / 2.03M | 17 ms |
-| coherent d5 r1 | 12 / 35875 / 82k | 0 / 0 / 3.8M | 2 ms |
-| coherent d5 r5 | 13 / 1.99e6 / 2099 | 13 / 7.8e5 / 4938 | 600 ms |
-| distillation | 5 / 155 / 1.12M | 3 / 71 / 1.18M | 6 ms |
-| cultivation d5 | 10 / 56618 / 58k | 10 / 54710 / 60k | 90 ms |
+| coherent d3 r3 | 5 / 1390 / 0.97M | 4 / 420 / 1.84M | 3 ms |
+| coherent d5 r1 | 12 / 39970 / 81k | 0 / 0 / 3.4M | 1 ms |
+| coherent d5 r5 | 13 / 2.19e6 / 2103 | 13 / 8.6e5 / 5204 | 36 ms |
+| distillation | 5 / 186 / 1.01M | 3 / 86 / 1.15M | 1 ms |
+| cultivation d5 | 10 / 58686 / 58.6k | 10 / 56778 / 63.8k | 7 ms |
 
 Reducing dense work improves throughput when it dominates shot cost, as on
 coherent d3 r3 and coherent d5 r5. Distillation gains little despite a lower
@@ -254,6 +274,19 @@ peak: its frame, record, and detector work dominate. On coherent d5 r1, the
 pass moves every rotation behind a commuting measurement, making the
 coherent noise invisible in the output distribution and reducing active
 width to zero.
+
+Pass wall time is dominated by the beam search itself, not by building the
+dependence relation, which keeps only edges that no chain of other edges
+already implies. On circuits an order of magnitude larger than this corpus,
+a 70k-operation distillation circuit on 539 qubits, 80k-operation random
+Clifford+T circuits on 136 to 186 qubits, and a 100k-operation noisy CCZ
+circuit on 834 qubits, the pass takes 1 s to 2.3 s single-threaded under the
+default budget, of which the dependence build is 0.35 s to 0.7 s. On the
+distillation circuits every step has exactly one ready expanding rotation, so
+the trace class contains a single schedule up to closure and the pass reports
+the incumbent unchanged; on the CCZ circuit it lowers the peak from 8 to 5,
+the certified minimum of that trace class, and the budget cuts the search from
+35 traces to 10.
 
 Exact search certified cultivation d3 at peak 4 (a smaller fixture, not shown)
 and cultivation d5 at peak 10 under both the plain and noise-transparent

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -1,0 +1,275 @@
+# Active-Width Scheduling
+
+The active width $k$ introduced in the [Theoretical Overview](overview.md) is
+not just an outcome the compiler reports: it is the value of one GF(2)
+linear-algebra object, tracked as the Heisenberg IR is walked in some order.
+This page describes that object, the structural facts that make it possible
+to search over legal reorderings of an HIR exactly, and what the compiler's
+scheduling passes do with that search space.
+
+## The Structural Width Model
+
+Fix an HIR with $n$ qubits. At every point while walking its operations, the
+compiler tracks the **dormant subspace** $S$: an unsigned, isotropic (pairwise
+commuting) subspace of the $2n$-dimensional GF(2) space of Pauli bodies,
+initialized to the span of $Z$ on every qubit. "Isotropic" here just means
+every two elements of $S$ commute as Paulis, so $S$ can always be extended to
+a full stabilizer group; $S$ starts at its maximum possible dimension, $n$,
+one generator per qubit.
+
+The active width is $S$'s codimension, $k = n - \dim S$: how far $S$ currently
+falls short of full rank. A rotation or measurement with unsigned Pauli body
+$p$ updates $S$ by one of two rules, depending on the operation type:
+
+```text
+rotation about p:    S <- S cap p-perp          k -> k+1 iff p is not in S-perp
+measurement of p:     S <- (S cap p-perp) + <p>  k -> k-1 iff p is in S-perp but not in S
+noise, feedback, detector, observable, readout,
+and every other non-rotation, non-measurement op: S unchanged
+```
+
+Here $S^\perp$ is the symplectic-orthogonal complement of $S$: the set of
+Pauli bodies that commute with every generator of $S$. Both update rules are
+uniform formulas, not case splits; the width only moves on the branch where
+the formula actually changes $\dim S$:
+
+- **Rotation.** If $p$ commutes with all of $S$, $S \cap p^\perp = S$ and
+  nothing changes: either $p \in S$ (the rotation is a global phase the
+  planner emits no action for) or $p \notin S$ (the rotation acts on the
+  active coordinate array without growing it). If $p$ anticommutes with some
+  generator, intersecting drops $\dim S$ by exactly one and $k$ grows by one:
+  a dormant coordinate is promoted into the active array.
+- **Measurement.** Intersecting first mirrors the rotation rule, then
+  $\langle p \rangle$ is added back. If $p$ anticommutes with some generator
+  of $S$, the intersection's one-dimensional loss is immediately restored by
+  re-adding $p$, netting to no change: a random outcome in dormant space that
+  never touches the active array. If $p$ commutes with all of $S$ but was not
+  already in it, adding it is a genuine rank increase: $\dim S$ grows by one
+  and $k$ shrinks by one, an active coordinate collapsing out of the dense
+  state. If $p$ was already in $S$, adding it again changes nothing: a
+  deterministic classical outcome.
+
+Every other HIR operation type -- noise, feedback, detectors, observables,
+readout corrections -- reads or writes classical state only and leaves $S$
+untouched.
+
+### Pivot Independence
+
+An implementation represents $S$ by some list of generators, and rewriting
+that list in place (choosing a different pivot row during elimination) is
+exactly what both update rules above do internally. Two representations
+describe the same $S$ exactly when each one's generators are all contained in
+the other's span, not when the generator lists match element-for-element.
+Every question this page's model ever asks of $S$ -- does $p$ commute with
+all of it, is $p$ already in it -- is a question about the *subspace*, so it
+has the same answer no matter which generators happen to represent $S$ at the
+time. Consequently the width trace of a fixed operation sequence is
+independent of pivot choice: a coordinate-frame implementation and a
+from-scratch GF(2) elimination over the same ops necessarily agree on every
+width transition, even though they may never choose the same intermediate
+generators.
+
+### Confluence and the Order-Invariant Final Width
+
+Fix two operations with unsigned Pauli bodies $p$ and $q$ that commute with
+each other, $p \in q^\perp$. Applying their updates to $S$ in either order
+reaches the same subspace. For two rotations this is immediate: intersection
+commutes, $(S \cap p^\perp) \cap q^\perp = (S \cap q^\perp) \cap p^\perp$.
+For two measurements, apply $p$'s update first:
+$S_1 = (S \cap p^\perp) + \langle p \rangle$. Because $p \in q^\perp$, every
+element of $\langle p \rangle$ already lies in $q^\perp$, so intersecting
+$S_1$ with $q^\perp$ only filters the $S \cap p^\perp$ part:
+$S_1 \cap q^\perp = (S \cap p^\perp \cap q^\perp) + \langle p \rangle$, and
+adding $\langle q \rangle$ back gives
+$(S \cap p^\perp \cap q^\perp) + \langle p \rangle + \langle q \rangle$.
+Running $q$'s update first and then $p$'s reaches the same set by the
+identical argument with $p$ and $q$ exchanged, valid since commutation is
+symmetric ($q \in p^\perp$ too). The same reduction handles one rotation and
+one measurement: a rotation's update is the special case of a measurement's
+with no $\langle \cdot \rangle$ term ever added.
+
+Two rotations or measurements are independent under the dependence relation
+-- free to swap in a legal schedule -- exactly when their bodies commute
+(see [Noise Transparency](#noise-transparency) below for the one relaxation
+to that rule, around `NOISE` operations). So the identity above applies to
+every swap a search or scheduling pass can actually make: the subspace
+reached by executing a given *set* of operations is therefore the same
+regardless of the order they executed in.
+
+This is what makes reordering worth searching over at all: the final width
+after executing every operation in an HIR is invariant across every legal
+reordering, so a scheduler cannot make the exit state worse, only change how
+$k$ moves on the way there. A search state is fully determined by its set of
+already-executed operations, not by the sequence that reached it -- so two
+different partial schedules that happen to have executed the same operations
+are provably equivalent, which is what lets a search memoize on that set
+instead of re-exploring every path to it.
+
+## The Closure Theorem
+
+Call an operation **ready** once every operation that must precede it has
+executed, and **expanding** if executing it now would grow $k$: a
+`RotationPromote` (a rotation whose body anticommutes with some generator of
+$S$), or a transition instrument taking its `Activate` branch. Every other
+ready operation is **non-expanding**: any measurement, any rotation that
+currently commutes with $S$, and every other fixed operation.
+
+Delaying a ready non-expanding operation can only ever leave the eventual
+peak the same or larger, never smaller. Consider swapping a ready
+non-expanding operation earlier, past some operation it is independent of
+(and therefore free to swap, by the previous section). If it is a
+measurement, its own update never raises $k$ -- that is what non-expanding
+means -- so firing it sooner can only lower, never raise, the width at every
+point it now precedes; and because independent updates commute, the final
+$S$ after both operations execute is unchanged either way. If it is a
+width-neutral rotation, persistence keeps it neutral across the swap: its
+body already commutes with $S$, and, by independence, with the other
+operation's body too, so it still commutes with $S$ once that operation has
+updated it -- moving it earlier changes no width at all. Either way, moving
+a ready non-expanding operation earlier never raises any intermediate width,
+so repeating this exchange shows some peak-minimizing schedule executes
+every ready non-expanding operation as soon as it is ready -- a repeated
+step called **closure**: sweep the lowest-index ready non-expanding
+operation, over and over, until none remains.
+
+In plain terms, closure means a scheduler never has to decide whether to
+fire a measurement or a width-neutral rotation; that choice is already
+forced. The only operation type that is both fixed in program order and can
+be expanding is a transition instrument taking its `Activate` branch: an
+`INSTRUMENT` is a positional barrier under the dependence relation, so
+whenever it is ready it is also the only ready operation, and firing it is
+forced rather than chosen. The only real decision left, at any point in a
+schedule, is *which* ready expanding rotation to fire next when more than
+one is available -- everything else follows deterministically from closure.
+
+## Noise Transparency
+
+The dependence relation a scheduler searches over is conservative by
+default: it keeps every operation in its original position relative to a
+noise operation whose channel does not commute with it. The reason is
+mechanical: the planner folds a noise site's symbols into an operation's
+sign only when it reaches that operation after the site, in schedule order,
+so moving an operation across the site would silently drop or add that
+contribution. This can be relaxed. Every noise channel is presampled: its
+Boolean outcome exists before the action stream runs, independent of where
+in a schedule a planner happens to consume it. If the planner instead
+resolves an operation's noise-dependent sign from that operation's
+*logical* (original, pre-reorder) position rather than its position in the
+reordered schedule, then for any fixed noise realization a
+noise-transparent reorder is just an ordinary legal reordering of the
+noise-free circuit with that realization's Pauli errors absorbed into
+downstream signs -- and ordinary legal reorderings are already known to
+preserve the sampling distribution. For every fixed noise realization the
+reordered and original schedules have the same distribution over the
+remaining randomness, so they agree for the presampled mixture as well.
+
+This is the same symbolic-frame idea the sampler already uses for
+measurement and feedback signs, described in
+[Planning Pauli-Frame Effects as Symbolic Signs](overview.md#planning-pauli-frame-effects-as-symbolic-signs):
+each stochastic event gets a Boolean symbol, and a sign is an affine formula
+over the symbols relevant to it. Noise transparency reuses exactly that
+mechanism, keyed to an operation's logical rather than scheduled position.
+
+## Exact Certificates
+
+The exact search this section describes is not part of the shipped
+library: it lives as a research tool under
+`research/active_width_certificates/` on the repository's research branch.
+The certificates quoted on this page, including the ones in
+[Measured Effect](#measured-effect), were produced with that tool.
+
+Given the dependence relation above, an exact search can ask: does some
+legal reordering of this HIR reach a strictly lower peak active width than a
+given threshold? Because of closure, the search only ever branches on which
+ready expanding operation to fire next, and because of confluence, the set
+of already-executed operations is a sound key for memoizing infeasible
+branches. A bounded, budgeted version of this search produces a witness
+schedule together with a proven lower bound; when the two meet, the schedule
+is certified optimal.
+
+That certificate has a specific, narrow scope. It is a minimum over the
+**trace class** of one exact HIR -- every linear extension of the dependence
+relation the search ran with -- scored by the same structural width model
+described above. It says nothing about:
+
+- schedules reachable only through a *rewrite* that exposes new gate fusion
+  the HIR does not already contain,
+- amplitude-level stabilizers that a purely structural analysis does not
+  track, or
+- any other circuit that merely samples the same output distribution as
+  this one.
+
+A schedule outside the searched trace class, a rewritten circuit, or a
+distributionally-equivalent but structurally different circuit may still do
+better; the certificate is silent about all three.
+
+## `ActiveWidthSchedulePass`
+
+Exact search does not scale to every circuit worth compiling: its budget can
+exhaust before proving anything on a large or highly branching HIR. The
+compiler's scheduling pass trades that certificate for scalability: a beam
+search over the same closure/readiness trace class. At each step it extends
+every partial schedule currently in the beam by each of its own ready
+expanding operations, pools every resulting candidate from every kept
+schedule into one generation, and keeps only the best-scoring `beam_width`
+of them across that whole generation -- not the best child of each parent,
+but the best children overall -- ranked by the peak width each candidate's
+closure sweep reaches, then by the width the sweep settles at, then by how
+many operations the sweep executed (more is preferred), with a final
+tie-break on operation index for determinism. The pass is opt-in -- off by
+default -- because its compile-time cost on a large, highly branching HIR
+is not yet bounded to a small multiple of the rest of the pipeline (see
+[Measured Effect](#measured-effect)).
+
+Whatever schedule the pass settles on, it is compared against the input
+HIR's own width trace, lexicographically by peak active width and then by a
+dense-work estimate (the planning-time proxy $\sum 2^{w}$ over actions that
+touch the active array, at the width $w$ each one runs at). The pass applies
+its candidate only when that comparison is strictly better; otherwise the
+HIR is left byte-for-byte untouched. This "never worse than the incumbent"
+guarantee is what makes the pass safe to run unconditionally: unlike the
+exact search, it carries no certificate of optimality, only a guarantee that
+it cannot regress the circuit it started from.
+
+## Measured Effect
+
+Measured once, single host, Release build, at commit `d169751b`: sampling
+throughput with the production pipeline (`PeepholeFusionPass` then
+`StatevectorSqueezePass`) versus the production pipeline plus the opt-in
+`ActiveWidthSchedulePass` (at its default options), on the `clifft-paper`
+QEC corpus at commit `db7dc9f`, best of 3 timed batches after warmup. "Plan
+work" is the planner's own $\sum 2^{k}$ over dense actions -- the same
+quantity `estimate_dense_work` approximates ahead of planning.
+
+| Circuit | Production: peak / plan work / shots per s | Default pipeline: peak / plan work / shots per s | Pass wall time |
+|---|---|---|---|
+| coherent d3 r3 | 5 / 1247 / 1.08M | 4 / 381 / 2.03M | 17 ms |
+| coherent d5 r1 | 12 / 35875 / 82k | 0 / 0 / 3.8M | 2 ms |
+| coherent d5 r5 | 13 / 1.99e6 / 2099 | 13 / 7.8e5 / 4938 | 600 ms |
+| distillation | 5 / 155 / 1.12M | 3 / 71 / 1.18M | 6 ms |
+| cultivation d5 | 10 / 56618 / 58k | 10 / 54710 / 60k | 90 ms |
+
+Lower dense work turns into throughput wherever dense work dominates the
+shot cost, as on coherent d3 r3 and coherent d5 r5. Peak width alone is not a
+throughput predictor: distillation loses two units of width but gains
+almost nothing, because its per-shot cost is dominated by frame, record, and
+detector work rather than dense active-state work. Coherent d5 r1's coherent
+noise is invisible in the output distribution once every rotation lands
+behind a commuting measurement, so the pass finds a schedule with zero
+active width at all. Cultivation d5 is where this page's certificates
+matter most for reading the table correctly: the exact search certifies
+cultivation d3's peak of 4 (a smaller, related fixture, not shown above) as
+optimal for its trace class, but on d5 the same search exhausts its node
+budget without settling either bound, so d5 carries no certificate. The
+pass finds a slightly cheaper schedule at the same peak here -- a real
+improvement, not evidence that no better schedule exists.
+
+## References
+
+- Bradley A. Chase and Farrokh Labib, "Clifft: Fast Exact Simulation of
+  Near-Clifford Quantum Circuits," [arXiv:2604.27058](https://arxiv.org/abs/2604.27058),
+  2026.
+- Wang Fang, Huazhe Lou, and Riling Li, "SymFT: Universal Fault-Tolerant
+  Quantum Circuit Simulation via Symbolic Clifford-Pauli Frames and Stabilizer
+  Coordinates," [arXiv:2607.28600](https://arxiv.org/abs/2607.28600)
+  (quant-ph), 2026.

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -1,252 +1,242 @@
 # Active-Width Scheduling
 
-The active width $k$ introduced in the [Theoretical Overview](overview.md) is
-not just an outcome the compiler reports: it is the value of one GF(2)
-linear-algebra object, tracked as the Heisenberg IR is walked in some order.
-This page describes that object, the structural facts that make it possible
-to search over legal reorderings of an HIR exactly, and what the compiler's
-scheduling passes do with that search space.
+Legal reordering can reduce peak active width without changing the sampling
+distribution. Clifft tracks width using a subspace of Pauli operators. This
+page derives that model, explains which reorderings are allowed, and describes
+the opt-in `ActiveWidthSchedulePass`.
+
+For the active-state representation and its role in simulation cost, see the
+[Theoretical Overview](overview.md).
 
 ## The Structural Width Model
 
-Fix an HIR with $n$ qubits. At every point while walking its operations, the
-compiler tracks the **dormant subspace** $S$: an unsigned, isotropic (pairwise
-commuting) subspace of the $2n$-dimensional GF(2) space of Pauli bodies,
-initialized to the span of $Z$ on every qubit. "Isotropic" here just means
-every two elements of $S$ commute as Paulis, so $S$ can always be extended to
-a full stabilizer group; $S$ starts at its maximum possible dimension, $n$,
-one generator per qubit.
+For an HIR with $n$ qubits, the compiler tracks a **dormant subspace** $S$ of
+unsigned Pauli bodies. These bodies form vectors in $\mathrm{GF}(2)^{2n}$.
+Every pair in $S$ commutes: in symplectic terminology, $S$ is *isotropic* and
+has dimension at most $n$. Initially,
 
-The active width is $S$'s codimension, $k = n - \dim S$: how far $S$ currently
-falls short of full rank. A rotation or measurement with unsigned Pauli body
-$p$ updates $S$ by one of two rules, depending on the operation type:
+$$
+S = \operatorname{span}\{Z_0, \ldots, Z_{n-1}\}.
+$$
 
-```text
-rotation about p:    S <- S cap p-perp          k -> k+1 iff p is not in S-perp
-measurement of p:     S <- (S cap p-perp) + <p>  k -> k-1 iff p is in S-perp but not in S
-transition instrument, Activate branch: same as rotation about p
-noise, feedback, detector, observable, readout, every other instrument
-branch, and every other op: S unchanged
-```
+The active width counts the missing dormant directions:
 
-Here $S^\perp$ is the symplectic-orthogonal complement of $S$: the set of
-Pauli bodies that commute with every generator of $S$. Both update rules are
-uniform formulas, not case splits; the width only moves on the branch where
-the formula actually changes $\dim S$:
+$$
+k = n - \dim S.
+$$
 
-- **Rotation.** If $p$ commutes with all of $S$, $S \cap p^\perp = S$ and
-  nothing changes: either $p \in S$ (the rotation is a global phase the
-  planner emits no action for) or $p \notin S$ (the rotation acts on the
-  active coordinate array without growing it). If $p$ anticommutes with some
-  generator, intersecting drops $\dim S$ by exactly one and $k$ grows by one:
-  a dormant coordinate is promoted into the active array.
-- **Measurement.** Intersecting first mirrors the rotation rule, then
-  $\langle p \rangle$ is added back. If $p$ anticommutes with some generator
-  of $S$, the intersection's one-dimensional loss is immediately restored by
-  re-adding $p$, netting to no change: a random outcome in dormant space that
-  never touches the active array. If $p$ commutes with all of $S$ but was not
-  already in it, adding it is a genuine rank increase: $\dim S$ grows by one
-  and $k$ shrinks by one, an active coordinate collapsing out of the dense
-  state. If $p$ was already in $S$, adding it again changes nothing: a
-  deterministic classical outcome.
+Let $p^\perp$ denote the Pauli bodies that commute with $p$, and $S^\perp$
+those that commute with every element of $S$. A rotation about $p$ and a
+measurement of $p$ update the subspace as follows:
 
-Every other HIR operation type -- noise, feedback, detectors, observables,
-readout corrections -- reads or writes classical state only and leaves $S$
-untouched. A transition instrument leaves $S$ untouched the same way on
-every branch except `Activate`; taking the `Activate` branch, it instead
-follows the rotation rule above, promoting a coordinate exactly as a
-rotation would.
+$$
+\begin{aligned}
+R_p(S) &= S \cap p^\perp, \\
+M_p(S) &= (S \cap p^\perp) + \langle p \rangle.
+\end{aligned}
+$$
+
+Here $\langle p \rangle$ is the span of $p$.
+
+- **Rotation.** If $p \notin S^\perp$, the intersection removes one dimension
+  and $k$ increases by one: a dormant coordinate becomes active. Otherwise
+  the width is unchanged. When $p \in S$, the rotation is a global phase and
+  the planner emits no action; when $p \in S^\perp \setminus S$, it acts on
+  the existing active array.
+- **Measurement.** If $p \notin S^\perp$, the intersection removes one
+  dimension and adding $p$ restores it. This gives a random dormant outcome
+  without changing $k$. If $p \in S^\perp \setminus S$, adding $p$ increases
+  the dimension and reduces $k$ by one: an active coordinate collapses. If
+  $p \in S$, neither the subspace nor the width changes, and the outcome is
+  deterministic.
+
+A transition instrument classified as `Activate` uses the rotation update.
+Its other modes leave $S$ unchanged. All remaining HIR operations, including
+noise, feedback, readout corrections, detectors, and observables, also leave
+$S$ unchanged.
 
 ### Pivot Independence
 
-An implementation represents $S$ by some list of generators, and rewriting
-that list in place (choosing a different pivot row during elimination) is
-exactly what both update rules above do internally. Two representations
-describe the same $S$ exactly when each one's generators are all contained in
-the other's span, not when the generator lists match element-for-element.
-Every question this page's model ever asks of $S$ -- does $p$ commute with
-all of it, is $p$ already in it -- is a question about the *subspace*, so it
-has the same answer no matter which generators happen to represent $S$ at the
-time. Consequently the width trace of a fixed operation sequence is
-independent of pivot choice: a coordinate-frame implementation and a
-from-scratch GF(2) elimination over the same ops necessarily agree on every
-width transition, even though they may never choose the same intermediate
-generators.
+The update rules depend on the subspace, not on the basis used to represent
+it. Changing an elimination pivot changes the generator list but not its
+span. Membership and commutation tests therefore give the same answers for
+any basis of $S$.
+
+For a fixed operation sequence, a coordinate-frame implementation and a
+separate GF(2) elimination must agree on every width transition, even if their
+intermediate generators differ.
 
 ### Confluence and the Order-Invariant Final Width
 
-Fix two operations with unsigned Pauli bodies $p$ and $q$ that commute with
-each other, $p \in q^\perp$. Applying their updates to $S$ in either order
-reaches the same subspace. For two rotations this is immediate: intersection
-commutes, $(S \cap p^\perp) \cap q^\perp = (S \cap q^\perp) \cap p^\perp$.
-For two measurements, apply $p$'s update first:
-$S_1 = (S \cap p^\perp) + \langle p \rangle$. Because $p \in q^\perp$, every
-element of $\langle p \rangle$ already lies in $q^\perp$, so intersecting
-$S_1$ with $q^\perp$ only filters the $S \cap p^\perp$ part:
-$S_1 \cap q^\perp = (S \cap p^\perp \cap q^\perp) + \langle p \rangle$, and
-adding $\langle q \rangle$ back gives
-$(S \cap p^\perp \cap q^\perp) + \langle p \rangle + \langle q \rangle$.
-Running $q$'s update first and then $p$'s reaches the same set by the
-identical argument with $p$ and $q$ exchanged, valid since commutation is
-symmetric ($q \in p^\perp$ too). The same reduction handles one rotation and
-one measurement: a rotation's update is the special case of a measurement's
-with no $\langle \cdot \rangle$ term ever added.
+The scheduler represents ordering constraints as a dependence graph. A legal
+schedule is a topological order of that graph. Only rotations and measurements
+move; all other operations retain their relative order. `EXP_VAL` and
+`INSTRUMENT` are barriers that no operation may cross.
 
-Two rotations or measurements are independent under the dependence relation
--- free to swap in a legal schedule -- exactly when their bodies commute
-(see [Noise Transparency](#noise-transparency) below for the one relaxation
-to that rule, around `NOISE` operations). So the identity above applies to
-every swap a search or scheduling pass can actually make: the subspace
-reached by executing a given *set* of operations is therefore the same
-regardless of the order they executed in.
+The plain relation uses `can_swap` to decide which pairs may exchange order.
+Two rotations or measurements may swap when their Pauli bodies commute.
+[Noise transparency](#noise-transparency) additionally permits them to cross
+`NOISE` operations, with sign corrections described below.
 
-This is what makes reordering worth searching over at all: the final width
-after executing every operation in an HIR is invariant across every legal
-reordering, so a scheduler cannot make the exit state worse, only change how
-$k$ moves on the way there. A search state is fully determined by its set of
-already-executed operations, not by the sequence that reached it -- so two
-different partial schedules that happen to have executed the same operations
-are provably equivalent, which is what lets a search memoize on that set
-instead of re-exploring every path to it.
+Suppose $p$ and $q$ commute. Their width updates commute as well:
+
+$$
+\begin{aligned}
+R_q(R_p(S))
+  &= S \cap p^\perp \cap q^\perp
+   = R_p(R_q(S)), \\
+M_q(M_p(S))
+  &= (S \cap p^\perp \cap q^\perp) + \langle p \rangle + \langle q \rangle
+   = M_p(M_q(S)), \\
+R_q(M_p(S))
+  &= (S \cap p^\perp \cap q^\perp) + \langle p \rangle
+   = M_p(R_q(S)).
+\end{aligned}
+$$
+
+The rotation identity follows from intersecting subspaces in either order.
+For the measurement identities, commutation gives
+$\langle p \rangle \subseteq q^\perp$, so intersecting with $q^\perp$ leaves
+the added span of $p$ intact. The same argument applies with $p$ and $q$
+exchanged.
+
+These identities cover swaps between movable operations. Other permitted
+swaps involve operations that leave $S$ unchanged. Thus any two legal
+prefixes that execute the same set of operations reach the same dormant
+subspace and current width. This property is **confluence**. In particular,
+the final width is invariant under legal reordering, though the intermediate
+widths may differ.
+
+Confluence does not make the full search state independent of its history.
+The peak reached so far and the accumulated dense work depend on the path.
+A search can share subspace and readiness information by executed set, but
+must retain the cost information needed by its objective.
 
 ## The Closure Theorem
 
-Call an operation **ready** once every operation that must precede it has
-executed, and **expanding** if executing it now would grow $k$: a
-`RotationPromote` (a rotation whose body anticommutes with some generator of
-$S$), or a transition instrument taking its `Activate` branch. Every other
-ready operation is **non-expanding**: any measurement, any rotation that
-currently commutes with $S$, and every other fixed operation.
+An operation is **ready** when all its predecessors have executed. It is
+**expanding** if executing it now would increase $k$: a rotation whose body
+anticommutes with some generator of $S$, or an instrument classified as
+`Activate`. All other ready operations are **non-expanding**.
 
-Delaying a ready non-expanding operation can only ever leave the eventual
-peak the same or larger, never smaller. Consider swapping a ready
-non-expanding operation earlier, past some operation it is independent of
-(and therefore free to swap, by the previous section). If it is a
-measurement, its own update never raises $k$ -- that is what non-expanding
-means -- so firing it sooner can only lower, never raise, the width at every
-point it now precedes; and because independent updates commute, the final
-$S$ after both operations execute is unchanged either way. If it is a
-width-neutral rotation, persistence keeps it neutral across the swap: its
-body already commutes with $S$, and, by independence, with the other
-operation's body too, so it still commutes with $S$ once that operation has
-updated it -- moving it earlier changes no width at all. Either way, moving
-a ready non-expanding operation earlier never raises any intermediate width,
-so repeating this exchange shows some peak-minimizing schedule executes
-every ready non-expanding operation as soon as it is ready -- a repeated
-step called **closure**: sweep the lowest-index ready non-expanding
-operation, over and over, until none remains.
+**Closure theorem.** Some peak-minimizing schedule executes ready
+non-expanding operations before choosing a ready expanding operation.
 
-In plain terms, closure means a scheduler never has to decide whether to
-fire a measurement or a width-neutral rotation; that choice is already
-forced. The only operation type that is both fixed in program order and can
-be expanding is a transition instrument taking its `Activate` branch: an
-`INSTRUMENT` is a positional barrier under the dependence relation, so
-whenever it is ready it is also the only ready operation, and firing it is
-forced rather than chosen. The only real decision left, at any point in a
-schedule, is *which* ready expanding rotation to fire next when more than
-one is available -- everything else follows deterministically from closure.
+To see why, take a legal continuation and move a ready non-expanding operation
+to its front. Readiness means every operation it crosses is independent of it.
+
+- For a measurement, confluence lets us view each reordered prefix as the
+  measurement applied after that prefix's other operations. A measurement
+  never increases width, so this prefix has no greater width than it had
+  before the move. The subspaces coincide once both orders have executed the
+  same operations.
+- A width-neutral rotation stays neutral through independent updates. Its
+  body commutes with $S$ and with every Pauli body added by an independent
+  measurement. Intersections cannot break that commutation. Moving the
+  rotation earlier therefore changes no width.
+- Other non-expanding operations leave $S$ unchanged and can likewise move
+  earlier when independent.
+
+Repeating this exchange produces **closure**: execute the lowest-index ready
+non-expanding operation until none remains. The index rule makes the sweep
+deterministic. The theorem concerns peak width; it does not establish minimum
+dense work.
+
+After closure, the scheduler chooses among ready expanding rotations. An
+expanding instrument offers no choice: as a barrier, it is the only ready
+operation when it becomes ready.
 
 ## Noise Transparency
 
-Without noise transparency, the dependence relation a scheduler searches
-over is conservative: it keeps every operation in its original position
-relative to a noise operation whose channel does not commute with it. The
-reason is mechanical: the planner folds a noise site's symbols into an
-operation's sign only when it reaches that operation after the site, in
-schedule order, so moving an operation across the site would silently drop
-or add that contribution. This can be relaxed. Every noise channel is
-presampled: its Boolean outcome exists before the action stream runs,
-independent of where in a schedule a planner happens to consume it. If the
-planner instead resolves an operation's noise-dependent sign from that
-operation's *logical* (original, pre-reorder) position rather than its
-position in the reordered schedule, then for any fixed noise realization a
-noise-transparent reorder is just an ordinary legal reordering of the
-noise-free circuit with that realization's Pauli errors absorbed into
-downstream signs -- and ordinary legal reorderings are already known to
-preserve the sampling distribution. For every fixed noise realization the
-reordered and original schedules have the same distribution over the
-remaining randomness, so they agree for the presampled mixture as well.
+In the plain dependence relation, an operation cannot cross a noise site if
+it anticommutes with one of that site's channels. The planner normally folds
+noise symbols into later operations' signs in schedule order. Moving an
+operation across such a site would add or remove a sign contribution.
 
-This is the same symbolic-frame idea the sampler already uses for
-measurement and feedback signs, described in
-[Planning Pauli-Frame Effects as Symbolic Signs](overview.md#planning-pauli-frame-effects-as-symbolic-signs):
-each stochastic event gets a Boolean symbol, and a sign is an affine formula
-over the symbols relevant to it. Noise transparency reuses exactly that
-mechanism, keyed to an operation's logical rather than scheduled position.
+Noise transparency preserves that contribution using the operation's
+**logical position**: its position before reordering. Each `NOISE` channel
+is presampled, so its outcome is available regardless of where the site
+appears in the schedule. The HIR's `logical_noise_prefix` records how many
+noise sites originally preceded each operation. This metadata moves with the
+operation, allowing the planner to correct its sign after reordering.
+
+For a fixed noise realization, absorb the realized Pauli errors into the
+downstream signs. A noise-transparent schedule is then a legal reordering of
+that noise-free circuit, with the same distribution over the remaining
+randomness. This holds for each realization, so averaging over the noise
+distribution preserves the full sampling distribution.
+
+The correction uses the existing symbolic-frame machinery: signs are affine
+expressions in Boolean event symbols. See
+[Planning Pauli-Frame Effects as Symbolic Signs](overview.md#planning-pauli-frame-effects-as-symbolic-signs).
 
 ## Exact Certificates
 
-The exact search this section describes is not part of the shipped
-library: it lives as a research tool under
-`research/active_width_certificates/` on the repository's research branch.
-The certificates quoted on this page, including the ones in
-[Measured Effect](#measured-effect), were produced with that tool.
+The exact search is a research tool, not part of the shipped library. It lives
+under `research/active_width_certificates/` on the repository's research branch
+and produced the certificates reported below.
 
-Given the dependence relation above, an exact search can ask: does some
-legal reordering of this HIR reach a strictly lower peak active width than a
-given threshold? Because of closure, the search only ever branches on which
-ready expanding operation to fire next, and because of confluence, the set
-of already-executed operations is a sound key for memoizing infeasible
-branches. A bounded, budgeted version of this search produces a witness
-schedule together with a proven lower bound; when the two meet, the schedule
-is certified optimal.
+The search asks whether any legal schedule stays below a proposed peak-width
+threshold. Closure limits branching to ready expanding operations. Among
+prefixes that respect the threshold, confluence makes the executed set a
+valid key for memoizing failed continuations. A budgeted search can return a
+witness schedule and a proven lower bound; when they meet, the schedule is
+certified optimal.
 
-That certificate has a specific, narrow scope. It is a minimum over the
-**trace class** of one exact HIR -- every linear extension of the dependence
-relation the search ran with -- scored by the same structural width model
-described above. It says nothing about:
+The certificate applies only to one HIR, the dependence relation used, and
+the structural width model above. The legal schedules under that relation
+form the HIR's **trace class**. The certificate does not cover:
 
-- schedules reachable only through a *rewrite* that exposes new gate fusion
-  the HIR does not already contain,
-- amplitude-level stabilizers that a purely structural analysis does not
-  track, or
-- any other circuit that merely samples the same output distribution as
-  this one.
+- circuit rewrites that expose new gate fusion;
+- amplitude-level stabilizers absent from the structural model; or
+- other circuits with the same output distribution.
 
-A schedule outside the searched trace class, a rewritten circuit, or a
-distributionally-equivalent but structurally different circuit may still do
-better; the certificate is silent about all three.
+These alternatives may reach a lower peak than any schedule in the searched
+trace class.
 
 ## `ActiveWidthSchedulePass`
 
-Exact search does not scale to every circuit worth compiling: its budget can
-exhaust before proving anything on a large or highly branching HIR. The
-compiler's scheduling pass trades that certificate for scalability: a beam
-search over the same closure/readiness trace class. At each step it extends
-every partial schedule currently in the beam by each of its own ready
-expanding operations, pools every resulting candidate from every kept
-schedule into one generation, and keeps only the best-scoring `beam_width`
-of them across that whole generation -- not the best child of each parent,
-but the best children overall -- ranked by the peak width each candidate's
-closure sweep reaches, then by the width the sweep settles at, then by how
-many operations the sweep executed (more is preferred), with a final
-tie-break on operation index for determinism. The pass is opt-in -- off by
-default -- because its compile-time cost on a large, highly branching HIR
-is not yet bounded to a small multiple of the rest of the pipeline (see
-[Measured Effect](#measured-effect)).
+`ActiveWidthSchedulePass` uses a beam search to limit the number of partial
+schedules retained. It starts with closure, then repeats these steps:
 
-Whatever schedule the pass settles on, it is compared against the input
-HIR's own width trace, lexicographically by peak active width and then by a
-dense-work estimate (the planning-time proxy $\sum 2^{w}$ over actions that
-touch the active array, at the width $w$ each one runs at). The pass applies
-its candidate only when that comparison is strictly better; otherwise the
-HIR is left byte-for-byte untouched. This "never worse than the incumbent,
-by peak active width and then by estimated dense work" guarantee is what
-makes the pass safe to run unconditionally: unlike the exact search, it
-carries no certificate of optimality, only a guarantee that it cannot
-regress the circuit's peak active width or, short of an improvement there,
-its estimated dense work. It is not a guarantee about compile time or about
-measured sampling throughput.
+1. Extend each retained schedule by each of its ready expanding operations.
+   Apply closure to every candidate.
+2. Group candidates by executed set. Discard a candidate if another in its
+   group is no worse in both peak and dense work, and strictly better in at
+   least one. Resolve exact cost ties by comparing the full operation
+   sequences.
+3. Rank all remaining candidates by peak reached, width after closure, number
+   of operations executed in this step (more is preferred), and expanding
+   operation index.
+4. Keep at most `beam_width` candidates across the whole generation. Record
+   completed schedules and continue extending the rest.
+
+The best completed schedule is chosen by peak width, then estimated dense
+work. By default, the pass also moves width-neutral rotations rightward past
+independent non-expanding operations to improve executable-plan rotation
+fusion.
+
+The dense-work estimate sums $2^w$ over actions that touch the active array,
+using the width $w$ at which each action runs. The pass replaces the input HIR
+only if the candidate has a lower peak, or the same peak and lower estimated
+dense work. Otherwise it leaves the HIR untouched. This does not guarantee an
+optimal schedule or improved sampling throughput.
+
+The pass is opt-in because scheduling can be expensive on large, highly
+branching HIRs. Run it last in the HIR pipeline, after `PeepholeFusionPass` and
+`StatevectorSqueezePass`. A noise-transparent reorder can prevent later
+peephole fusion. See [Optimization Passes](../reference/passes.md) for pipeline
+configuration and the measurements below for compile-time costs.
 
 ## Measured Effect
 
-Measured once, single host, Release build, at commit `d169751b`: sampling
-throughput with the production pipeline (`PeepholeFusionPass` then
-`StatevectorSqueezePass`) versus production plus the opt-in schedule pass
-(`ActiveWidthSchedulePass`, at its default options), on the `clifft-paper`
-QEC corpus at commit `db7dc9f`, best of 3 timed batches after warmup. "Plan
-work" is the planner's own $\sum 2^{k}$ over dense actions -- the same
-quantity `estimate_dense_work` approximates ahead of planning.
+The following measurements compare the production pipeline
+(`PeepholeFusionPass` then `StatevectorSqueezePass`) with production plus
+`ActiveWidthSchedulePass` at its default options. They use a Release build at
+commit `d169751b` and the `clifft-paper` QEC corpus at commit `db7dc9f`, on one
+host. Throughput is the best of three timed batches after warmup. "Plan work"
+is the planner's $\sum 2^k$ over dense actions, which `estimate_dense_work`
+approximates before planning.
 
 | Circuit | Production: peak / plan work / shots per s | Production + schedule pass: peak / plan work / shots per s | Pass wall time |
 |---|---|---|---|
@@ -256,23 +246,19 @@ quantity `estimate_dense_work` approximates ahead of planning.
 | distillation | 5 / 155 / 1.12M | 3 / 71 / 1.18M | 6 ms |
 | cultivation d5 | 10 / 56618 / 58k | 10 / 54710 / 60k | 90 ms |
 
-Lower dense work turns into throughput wherever dense work dominates the
-shot cost, as on coherent d3 r3 and coherent d5 r5. Peak width alone is not a
-throughput predictor: distillation loses two units of width but gains
-almost nothing, because its per-shot cost is dominated by frame, record, and
-detector work rather than dense active-state work. Coherent d5 r1's coherent
-noise is invisible in the output distribution once every rotation lands
-behind a commuting measurement, so the pass finds a schedule with zero
-active width at all. This page's certificates matter most for reading
-cultivation d5 and coherent d5 r5 correctly. The exact search certifies
-cultivation d3 at peak 4 (a smaller, related fixture, not shown above) and
-cultivation d5 at peak 10 under both relations, so both are intrinsic to
-their trace classes: no legal reordering reaches a lower peak. The pass's
-small dense-work gain on cultivation d5 is at that certified peak, not a
-step toward a lower one. Coherent d5 r5 is the one corpus circuit whose
-certificate did not complete within the exact search's 200k-node budget,
-so the 13 reported for it above is an upper bound, not a certified
-optimum.
+Reducing dense work improves throughput when it dominates shot cost, as on
+coherent d3 r3 and coherent d5 r5. Distillation gains little despite a lower
+peak: its frame, record, and detector work dominate. On coherent d5 r1, the
+pass moves every rotation behind a commuting measurement, making the
+coherent noise invisible in the output distribution and reducing active
+width to zero.
+
+Exact search certified cultivation d3 at peak 4 (a smaller fixture, not shown)
+and cultivation d5 at peak 10 under both the plain and noise-transparent
+relations. The dense-work gain on cultivation d5 is therefore at its minimum
+peak within either trace class. Coherent d5 r5 was the only corpus circuit
+whose certificate did not complete within the 200k-node budget; its reported
+peak of 13 remains an upper bound, not a certified optimum.
 
 ## References
 

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -148,18 +148,18 @@ one is available -- everything else follows deterministically from closure.
 
 ## Noise Transparency
 
-The dependence relation a scheduler searches over is conservative by
-default: it keeps every operation in its original position relative to a
-noise operation whose channel does not commute with it. The reason is
-mechanical: the planner folds a noise site's symbols into an operation's
-sign only when it reaches that operation after the site, in schedule order,
-so moving an operation across the site would silently drop or add that
-contribution. This can be relaxed. Every noise channel is presampled: its
-Boolean outcome exists before the action stream runs, independent of where
-in a schedule a planner happens to consume it. If the planner instead
-resolves an operation's noise-dependent sign from that operation's
-*logical* (original, pre-reorder) position rather than its position in the
-reordered schedule, then for any fixed noise realization a
+Without noise transparency, the dependence relation a scheduler searches
+over is conservative: it keeps every operation in its original position
+relative to a noise operation whose channel does not commute with it. The
+reason is mechanical: the planner folds a noise site's symbols into an
+operation's sign only when it reaches that operation after the site, in
+schedule order, so moving an operation across the site would silently drop
+or add that contribution. This can be relaxed. Every noise channel is
+presampled: its Boolean outcome exists before the action stream runs,
+independent of where in a schedule a planner happens to consume it. If the
+planner instead resolves an operation's noise-dependent sign from that
+operation's *logical* (original, pre-reorder) position rather than its
+position in the reordered schedule, then for any fixed noise realization a
 noise-transparent reorder is just an ordinary legal reordering of the
 noise-free circuit with that realization's Pauli errors absorbed into
 downstream signs -- and ordinary legal reorderings are already known to

--- a/docs/theory/active-width.md
+++ b/docs/theory/active-width.md
@@ -256,13 +256,16 @@ almost nothing, because its per-shot cost is dominated by frame, record, and
 detector work rather than dense active-state work. Coherent d5 r1's coherent
 noise is invisible in the output distribution once every rotation lands
 behind a commuting measurement, so the pass finds a schedule with zero
-active width at all. Cultivation d5 is where this page's certificates
-matter most for reading the table correctly: the exact search certifies
-cultivation d3's peak of 4 (a smaller, related fixture, not shown above) as
-optimal for its trace class, but on d5 the same search exhausts its node
-budget without settling either bound, so d5 carries no certificate. The
-pass finds a slightly cheaper schedule at the same peak here -- a real
-improvement, not evidence that no better schedule exists.
+active width at all. This page's certificates matter most for reading
+cultivation d5 and coherent d5 r5 correctly. The exact search certifies
+cultivation d3 at peak 4 (a smaller, related fixture, not shown above) and
+cultivation d5 at peak 10 under both relations, so both are intrinsic to
+their trace classes: no legal reordering reaches a lower peak. The pass's
+small dense-work gain on cultivation d5 is at that certified peak, not a
+step toward a lower one. Coherent d5 r5 is the one corpus circuit whose
+certificate did not complete within the exact search's 200k-node budget,
+so the 13 reported for it above is an upper bound, not a certified
+optimum.
 
 ## References
 

--- a/docs/theory/overview.md
+++ b/docs/theory/overview.md
@@ -210,7 +210,10 @@ basis. These operations form the Heisenberg IR, or HIR.
 
 HIR passes use Pauli algebra and dataflow to fuse or cancel operations and,
 when safe, shorten how long coordinates must remain active. This reduces the
-work handed to the planner without fixing a runtime representation.
+work handed to the planner without fixing a runtime representation. Passes
+that reorder operations to shorten active lifetimes, including
+`ActiveWidthSchedulePass`, rely on a structural model of active width
+described in [Active-Width Scheduling](active-width.md).
 
 ### Coordinate Planning
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
   - Theory:
     - Overview: theory/overview.md
     - Architecture: theory/architecture.md
+    - Active-Width Scheduling: theory/active-width.md
     - Basis-State Probabilities: theory/basis_probabilities.md
     - Noncomputational States: theory/noncomputational.md
   - Reference:


### PR DESCRIPTION
Prototype work on the `feature/active-width-scheduling` branch toward #458; review can be less strict than for `main`. Stacked on #471 (which stacks on #460); this PR's base is #471's branch, so the diff shows only the docs commits. Docs only; carries the corrected theory page from #468.

## Pages touched

- `docs/theory/active-width.md` (new) -- the dormant-subspace width model, pivot independence, confluence, the closure theorem, noise transparency, exact certificates, `ActiveWidthSchedulePass`, and the measured-effect table. Carries the theory-page corrections from #468 (commit `5c3a67de`) unchanged, and additionally: states in the `ActiveWidthSchedulePass` section that the pass is opt-in (off by default) rather than describing the now-removed exact-repair option (`active_width_search.h/.cc` and `ActiveWidthScheduleOptions::exact_node_budget`/`maybe_exact_repair` were deleted outright in #471, not deprecated); states in "Exact Certificates" that the exact search is not part of the shipped library and lives as a research tool under `research/active_width_certificates/` on the repository's research branch; rewords the "Measured Effect" intro from "the default pipeline" to "the production pipeline plus the opt-in `ActiveWidthSchedulePass`". The measured-effect table itself is untouched.
- `docs/theory/overview.md` -- the HIR Optimization link to the new page no longer calls the pass "the default scheduling pass"; names `ActiveWidthSchedulePass` instead.
- `docs/guide/cpu-execution.md` -- new "Compile-time scheduling" subsection: the pass is opt-in, shows how to enable it with a custom `HirPassManager` (`PeepholeFusionPass`, `StatevectorSqueezePass`, then `ActiveWidthSchedulePass`), states the measured ~600 ms compile cost on the largest corpus circuit, and states the never-worse-than-incumbent guarantee. Drops the old claim that `clifft.compile()` runs it by default.
- `docs/guide/leakage-and-loss.md` -- carried unchanged from the reviewed branch; the omitted-passes sentence already names both `StatevectorSqueezePass` and `ActiveWidthSchedulePass` and gives a reason (both can move measurements) that holds regardless of either pass's default-enabled status.
- `docs/reference/passes.md` -- carried unchanged; the custom-pipeline example that adds `ActiveWidthSchedulePass` is correct for an opt-in pass, and the generated pass table renders it disabled by default (verified below).
- `mkdocs.yml` -- adds the Theory nav entry for the new page.

`docs/macros.py` and `docs/reference/python-api.md` are untouched here; both are already handled on `aw2/schedule-pass` (#471).

## Verification

```
uv run --group docs --python .venv/bin/python mkdocs build --strict
# Documentation built in 1.77 seconds, exit code 0

uv run --python .venv/bin/python pytest --codeblocks docs/ README.md -q
# 40 passed, 5 skipped in 3.57s

uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
# all hooks passed (clang-format, ruff, ruff-format, mypy, trailing-whitespace,
# end-of-file-fixer, check-yaml, check-added-large-files, check-merge-conflict, actionlint)
```

Also spot-checked the built site: `docs/reference/passes.md`'s generated `ActiveWidthSchedulePass` table row renders `**Default** | ❌ Disabled`, and the "Default HIR pipeline" numbered list at the top of that page lists only `PeepholeFusionPass` and `StatevectorSqueezePass`.

Assisted-by: Claude (Sonnet 5) <noreply@anthropic.com>


## Rebased onto the pass-cost and search-budget commits

Rebased onto #471's head `8f69b3c3`. New commit `c05d797d`: the `ActiveWidthSchedulePass` section describes `search_budget` (its unit, the two graduated thresholds, why it is counted in ops, how the default of 16 was chosen) and the opt-in paragraph no longer calls scheduling unbounded; the guide states the exact acceptance rule in plain prose; the Measured Effect table is re-measured at `8f69b3c3` with the default options on one host (columns are peak / `estimate_dense_work` / shots per s, best of three 4096-shot batches after warmup, plus pass wall time as the best of three runs of the pass alone: 3 / 1 / 36 / 1 / 7 ms); the large-circuit paragraph adds the 100k-op CCZ circuit (peak 8 to 5, the certified minimum, budget cuts the search from 35 to 10 traces) and the wide-ready-set case; the guide's cost range is updated. Verified: strict mkdocs build exit 0, code blocks 40 passed / 5 skipped, pre-commit clean.
