### PR TITLE
test: establish shared CPU oracle conformance coverage

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -53,6 +53,66 @@ All procedural generators are centralized in [`utils_fuzzing.py`](https://github
 
 ## External Cross-Validation Oracles
 
+### Shared compiler conformance
+
+`tests/python/utils_conformance.py` defines the compiler profiles used by the
+Qiskit statevector suite and the small end-to-end corpus in
+`test_compiler_conformance.py`. Each profile constructs a fresh pass manager;
+the default profile calls the production factory rather than copying its pass
+list. The unoptimized profile disables HIR passes, not planning or executable
+preparation.
+
+The Qiskit suite keeps its existing circuits, seeds, and amplitude assertions
+and runs them under both profiles. The small corpus also compares every
+terminal measurement record's probability with Qiskit, then samples through
+single-shot, packed-capacity-65, and automatic CPU execution. Sampling checks
+complete record distributions and checks detector and observable bits against
+the returned records. References are computed independently of Clifft and
+cached by source within each worker. Compiled sampling programs are reused
+across execution modes.
+
+Two designated circuits require the default pipeline to reduce peak active
+width. One needs peephole cancellation; the other needs squeezing. Disabling
+either pass must fail its witness even when all output probabilities remain
+correct. The mirror case has a known all-zero outcome, but its elimination
+does not count as evidence that later execution paths ran.
+
+The pass-inventory check requires every registered pass to have a witness or
+an explicit exclusion. The current exclusions remove noise or nonunitary
+operations, changing the expected behavior. Add an explicit compiler profile
+and an exercise witness when covering an opt-in pass. New cases then run
+across compatible shared profiles. A new semantic feature still needs cases
+that actually exercise it.
+
+The noiseless oracle accepts only its supported unitary syntax, comments, and
+`TICK`. It rejects noise, measurements, resets, feedback, other annotations,
+and unsupported syntax instead of silently changing the circuit. This corpus
+does not yet provide a noisy, mid-circuit joint-distribution reference or GPU
+execution coverage. GPU adapters must declare their supported operations and
+precision; absence of a required GPU should fail a hardware CI job rather
+than skip all execution tests.
+
+#### Runtime and review
+
+Keep the PR corpus bounded. Measure before/after timings with the same build,
+worker count, and host conditions, including cost across the CI matrix.
+`pytest --durations=20` helps locate expensive tests; timing assertions do not
+belong in semantic correctness tests. Larger random sweeps can run separately.
+Do not reduce statistical sensitivity merely to meet a time budget.
+
+When consolidating tests, map each old case, seed, oracle, assertion, and
+execution mode to its replacement before removing it. Keep distinct bug
+regressions and structural or resource-lifetime tests. Some overlap is useful;
+coverage of the same lines alone does not establish redundancy.
+
+Review the source of expected results, explicit configuration selection, and
+exercise witnesses alongside coverage reports. Useful negative controls
+include removing a pass from the default factory, corrupting returned records,
+and adding an unaccounted pass to the inventory. Such controls test whether
+assertions can detect defects; line or branch coverage only shows execution.
+
+### Existing reference suites
+
 End-to-end Python tests compare Clifft against independent references whenever
 practical. These tests validate the full symbolic sampling pipeline rather
 than isolated implementation details.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -65,11 +65,19 @@ preparation.
 The Qiskit suite keeps its existing circuits, seeds, and amplitude assertions
 and runs them under both profiles. The small corpus also compares every
 terminal measurement record's probability with Qiskit, then samples through
-single-shot, packed-capacity-65, and automatic CPU execution. Sampling checks
+single-shot, packed-capacity-65, and automatic CPU execution with one worker
+so host-dependent thread counts do not change the tested configuration. Sampling checks
 complete record distributions and checks detector and observable bits against
 the returned records. References are computed independently of Clifft and
 cached by source within each worker. Compiled sampling programs are reused
 across execution modes.
+
+A separate analytic case checks every output row exactly at 63, 64, 65, 66,
+129, 130, 131, and 2049 shots. Its 65 measurement columns contain nonzero bits
+on both sides of a word boundary, and its detector and observable rows differ.
+These checks detect unwritten final rows and incorrect output mappings that
+could be too small to affect a statistical histogram. They cover output
+boundaries; the non-Clifford corpus provides the active-state checks.
 
 Two designated circuits require the default pipeline to reduce peak active
 width. One needs peephole cancellation; the other needs squeezing. Disabling
@@ -94,6 +102,28 @@ than skip all execution tests.
 
 #### Runtime and review
 
+The adapter's configuration-forwarding test alone does not prove which native
+executor ran. The existing policy tests in `tests/test_batch_executor.cc`
+check automatic selection and explicit capacities. For a direct execution
+audit, build the Python extension with Debug symbols and run a designated
+case under a debugger, for example:
+
+```bash
+uv pip install --reinstall-package clifft -e . -Ccmake.build-type=Debug
+gdb --args .venv/bin/python -m pytest -q \
+  'tests/python/test_compiler_conformance.py::test_samples_and_annotations_match_independent_oracle[mixed-pauli-default-packed-65]'
+```
+
+Set pending breakpoints on `clifft::sampling::Executor::run_shot()` and
+`clifft::sampling::BatchExecutor::run_batch(clifft::SeedRoot const&, unsigned int, unsigned int)`.
+Run each compiler profile with `single-shot`, `packed-65`, and `automatic`.
+The single-shot configuration must enter the scalar executor; capacity 65
+must enter the packed executor. The current automatic policy chooses packed
+execution for this case at 8193 shots. Record what actually ran when that
+policy changes. This audit supplies execution evidence; the independent
+oracle assertions supply semantic evidence. It does not validate other
+platforms, GPU execution, or every automatic-selection branch.
+
 Keep the PR corpus bounded. Measure before/after timings with the same build,
 worker count, and host conditions, including cost across the CI matrix.
 `pytest --durations=20` helps locate expensive tests; timing assertions do not
@@ -106,10 +136,29 @@ regressions and structural or resource-lifetime tests. Some overlap is useful;
 coverage of the same lines alone does not establish redundancy.
 
 Review the source of expected results, explicit configuration selection, and
-exercise witnesses alongside coverage reports. Useful negative controls
-include removing a pass from the default factory, corrupting returned records,
-and adding an unaccounted pass to the inventory. Such controls test whether
-assertions can detect defects; line or branch coverage only shows execution.
+exercise witnesses alongside coverage reports. Committed negative controls
+remove each pass from the default factory, zero the last row of each boundary
+output, corrupt correlations, bias legal outcomes, and add an unaccounted pass.
+Run them with `pytest tests/python/test_compiler_conformance.py -k 'rejects or detects'`.
+These controls test whether assertions can detect defects; line or branch
+coverage only shows execution.
+
+#### Extending the corpus
+
+Each new pass, public sampling mode, or backend needs a compatible execution
+configuration, an independent expectation, and a designated case that proves
+its intended transformation or execution path occurs. Include a reproducible
+negative control for a representative defect and explain exclusions. Test
+interactions with the production pipeline, not only the feature in isolation.
+
+Keep the noisy reference bounded and independent of production HIR and plans.
+Validate its supported operations against analytic cases, Aer, or Stim as
+applicable. Stateful sampler call sequences, output formats, postselection
+accounting, and backend resource contracts need focused checks in addition to
+shared distribution checks. GPU hardware jobs must exercise each claimed
+execution tier with appropriate precision tolerances. Larger scheduled
+campaigns should retain the circuit, seed, configuration, and expected/actual
+results on failure so discoveries can become small permanent regressions.
 
 ### Existing reference suites
 

--- a/tests/python/test_compiler_conformance.py
+++ b/tests/python/test_compiler_conformance.py
@@ -49,6 +49,15 @@ CASES = (
     ),
 )
 
+# Nonzero records on both sides of a word boundary expose unwritten output
+# tails that an aggregate statistical check could tolerate.
+BOUNDARY_SOURCE = (
+    "X 0 2 63 64\nM "
+    + " ".join(map(str, range(65)))
+    + "\nDETECTOR rec[-65] rec[-64]\nDETECTOR rec[-2] rec[-1]"
+    + "\nOBSERVABLE_INCLUDE(0) rec[-64]\nOBSERVABLE_INCLUDE(1) rec[-1]"
+)
+
 # These passes deliberately change the reference distribution; they need
 # their own contract tests instead of this original-circuit equivalence test.
 EXCLUDED_PASSES = {
@@ -111,6 +120,42 @@ def test_samples_and_annotations_match_independent_oracle(
     np.testing.assert_array_equal(result.observables, result.measurements[:, -1:])
 
 
+def _assert_boundary_outputs(result: clifft.SampleResult, shots: int) -> None:
+    expected_record = np.zeros(65, dtype=np.uint8)
+    expected_record[[0, 2, 63, 64]] = 1
+    np.testing.assert_array_equal(
+        result.measurements, np.broadcast_to(expected_record, (shots, 65))
+    )
+    np.testing.assert_array_equal(result.detectors, np.broadcast_to([1, 0], (shots, 2)))
+    np.testing.assert_array_equal(result.observables, np.broadcast_to([0, 1], (shots, 2)))
+
+
+@pytest.fixture(scope="module")
+def boundary_program(compiler: CompilerProfile) -> Any:
+    return compiler.compile(BOUNDARY_SOURCE)
+
+
+@pytest.mark.parametrize("mode", CPU_SAMPLING_MODES, ids=lambda mode: mode.name)
+@pytest.mark.parametrize("shots", [63, 64, 65, 66, 129, 130, 131, 2049])
+def test_deterministic_outputs_cross_word_and_batch_boundaries(
+    boundary_program: Any, mode: CpuSamplingMode, shots: int
+) -> None:
+    # The automatic policy currently uses 2048 lanes for this narrow plan;
+    # 2049 therefore checks its partial batch as well as capacity 65 tails.
+    result = mode.sample(boundary_program, shots, seed=1907)
+    _assert_boundary_outputs(result, shots)
+
+
+@pytest.mark.parametrize("output", ["measurements", "detectors", "observables"])
+def test_boundary_check_rejects_an_unwritten_final_row(output: str) -> None:
+    mode = next(mode for mode in CPU_SAMPLING_MODES if mode.name == "packed-65")
+    result = mode.sample(DEFAULT.compile(BOUNDARY_SOURCE), 131, seed=1907)
+    _assert_boundary_outputs(result, 131)
+    getattr(result, output)[-1] = 0
+    with pytest.raises(AssertionError):
+        _assert_boundary_outputs(result, 131)
+
+
 @pytest.mark.parametrize(
     "witness", [case for case in CASES if case.witness_for], ids=lambda c: c.name
 )
@@ -118,6 +163,28 @@ def test_default_pipeline_really_transforms_witness(witness: UnitaryCase) -> Non
     baseline = UNOPTIMIZED.compile(witness.measured_source)
     optimized = DEFAULT.compile(witness.measured_source)
     assert optimized.peak_active_width < baseline.peak_active_width, witness.witness_for
+
+
+@pytest.mark.parametrize(
+    "witness", [case for case in CASES if case.witness_for], ids=lambda c: c.name
+)
+def test_pass_witness_rejects_a_missing_transformation(
+    witness: UnitaryCase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    remaining_pass = (
+        clifft.StatevectorSqueezePass
+        if witness.witness_for == "PeepholeFusionPass"
+        else clifft.PeepholeFusionPass
+    )
+
+    def remaining_pipeline() -> Any:
+        manager = clifft.HirPassManager()
+        manager.add(remaining_pass())
+        return manager
+
+    monkeypatch.setattr(clifft, "default_hir_pass_manager", remaining_pipeline)
+    with pytest.raises(AssertionError, match=witness.witness_for):
+        test_default_pipeline_really_transforms_witness(witness)
 
 
 def _assert_pass_inventory(registry: dict[str, dict[str, object]]) -> None:
@@ -151,6 +218,15 @@ def test_joint_check_detects_wrong_correlations_with_correct_marginals() -> None
     assert_joint_distribution(correlated, [0.5, 0, 0, 0.5])
     with pytest.raises(AssertionError):
         assert_joint_distribution(anticorrelated, [0.5, 0, 0, 0.5])
+
+
+def test_joint_check_detects_bias_without_impossible_outcomes() -> None:
+    # Both outcomes are legal, so this must fail the statistical bound rather
+    # than the exact-zero support check used by the correlation control.
+    biased = np.zeros((8192, 1), dtype=np.uint8)
+    biased[:2048] = 1
+    with pytest.raises(AssertionError, match="Joint distribution differs"):
+        assert_joint_distribution(biased, [0.5, 0.5])
 
 
 @pytest.mark.parametrize(
@@ -227,4 +303,4 @@ def test_sampling_mode_forwards_its_configuration(
     program = object()
     monkeypatch.setattr(clifft, "sample", lambda *args, **kwargs: calls.append((args, kwargs)))
     mode.sample(program, 8193, 1907)
-    assert calls == [((program, 8193), {"seed": 1907, "batch_size": mode.batch_size})]
+    assert calls == [((program, 8193), {"seed": 1907, "threads": 1, "batch_size": mode.batch_size})]

--- a/tests/python/test_compiler_conformance.py
+++ b/tests/python/test_compiler_conformance.py
@@ -1,0 +1,230 @@
+"""Small independent-oracle corpus shared across compiler and sampling modes."""
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from utils_conformance import (
+    COMPILER_PROFILES,
+    CPU_SAMPLING_MODES,
+    DEFAULT,
+    UNOPTIMIZED,
+    CompilerProfile,
+    CpuSamplingMode,
+    assert_joint_distribution,
+    unitary_reference,
+)
+from utils_pass_registry import registered_hir_passes
+from utils_qiskit import stim_to_qiskit_noiseless
+
+import clifft
+
+
+@dataclass(frozen=True)
+class UnitaryCase:
+    name: str
+    source: str
+    num_qubits: int
+    witness_for: str | None = None
+
+    @property
+    def measured_source(self) -> str:
+        return self.source + "\nM " + " ".join(map(str, range(self.num_qubits)))
+
+
+CASES = (
+    # Neither pass alone can satisfy the other pass's width-reduction witness.
+    UnitaryCase("fusion", "H 0\nT 0\nT_DAG 0\nH 0", 1, "PeepholeFusionPass"),
+    UnitaryCase("squeeze", "H 0 1\nT 0 1\nH 0 1", 2, "StatevectorSqueezePass"),
+    UnitaryCase("bell", "H 0\nCX 0 1\nT 0", 2),
+    UnitaryCase(
+        "mixed-pauli", "R_X(0.3) 0\nR_Y(0.2) 1\nH 2\nCX 1 2\nR_PAULI(0.17) X0*Y1*Z2\nH 0 1", 3
+    ),
+    UnitaryCase(
+        "mirror",
+        "H 0\nT 0\nCX 0 1\nH 1\nT 1\nCX 1 2\nR_X(0.3) 2\n"
+        "R_X(-0.3) 2\nCX 1 2\nT_DAG 1\nH 1\nCX 0 1\nT_DAG 0\nH 0",
+        3,
+    ),
+)
+
+# These passes deliberately change the reference distribution; they need
+# their own contract tests instead of this original-circuit equivalence test.
+EXCLUDED_PASSES = {
+    "RemoveNoisePass": "Removes noise, changing the noisy circuit's distribution.",
+    "DropNonUnitaryPass": "Removes measurements and other nonunitary operations.",
+}
+
+
+@pytest.fixture(scope="module", params=CASES, ids=lambda case: case.name)
+def case(request: pytest.FixtureRequest) -> UnitaryCase:
+    return cast(UnitaryCase, request.param)
+
+
+@pytest.fixture(scope="module", params=COMPILER_PROFILES, ids=lambda profile: profile.name)
+def compiler(request: pytest.FixtureRequest) -> CompilerProfile:
+    return cast(CompilerProfile, request.param)
+
+
+@pytest.fixture(scope="module")
+def probabilities(case: UnitaryCase) -> np.ndarray:
+    return np.abs(unitary_reference(case.source)) ** 2
+
+
+@pytest.fixture(scope="module")
+def program(case: UnitaryCase, compiler: CompilerProfile) -> Any:
+    return compiler.compile(case.measured_source)
+
+
+@pytest.fixture(scope="module")
+def annotated_program(case: UnitaryCase, compiler: CompilerProfile) -> Any:
+    return compiler.compile(
+        case.measured_source
+        + f"\nDETECTOR rec[-{case.num_qubits}] rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]"
+    )
+
+
+def test_exact_records_match_independent_oracle(
+    case: UnitaryCase, program: Any, probabilities: np.ndarray
+) -> None:
+    assert program.num_measurements == case.num_qubits
+    records = [format(i, f"0{case.num_qubits}b")[::-1] for i in range(1 << case.num_qubits)]
+    actual = clifft.record_probabilities(program, records)
+    np.testing.assert_allclose(actual, probabilities, atol=1e-12, rtol=0)
+    if case.name == "mirror":
+        np.testing.assert_allclose(probabilities, [1] + [0] * (len(probabilities) - 1), atol=1e-12)
+
+
+@pytest.mark.parametrize("mode", CPU_SAMPLING_MODES, ids=lambda mode: mode.name)
+def test_samples_and_annotations_match_independent_oracle(
+    case: UnitaryCase, annotated_program: Any, probabilities: np.ndarray, mode: CpuSamplingMode
+) -> None:
+    # 8193 shots leave a partial final batch with capacity 65. Whole-record
+    # comparisons distinguish Bell correlations that marginals cannot.
+    result = mode.sample(annotated_program, 8193, seed=1907)
+    assert result.measurements.shape == (8193, case.num_qubits)
+    assert_joint_distribution(result.measurements, probabilities)
+    np.testing.assert_array_equal(
+        result.detectors, (result.measurements[:, 0] ^ result.measurements[:, -1])[:, None]
+    )
+    np.testing.assert_array_equal(result.observables, result.measurements[:, -1:])
+
+
+@pytest.mark.parametrize(
+    "witness", [case for case in CASES if case.witness_for], ids=lambda c: c.name
+)
+def test_default_pipeline_really_transforms_witness(witness: UnitaryCase) -> None:
+    baseline = UNOPTIMIZED.compile(witness.measured_source)
+    optimized = DEFAULT.compile(witness.measured_source)
+    assert optimized.peak_active_width < baseline.peak_active_width, witness.witness_for
+
+
+def _assert_pass_inventory(registry: dict[str, dict[str, object]]) -> None:
+    witnesses = {case.witness_for for case in CASES if case.witness_for}
+    declared = witnesses | EXCLUDED_PASSES.keys()
+    assert set(registry) == declared, (
+        f"Pass coverage decision required: missing={set(registry) - declared}, "
+        f"stale={declared - set(registry)}"
+    )
+    assert all(EXCLUDED_PASSES.values())
+    for name in witnesses:
+        assert registry[name]["default_enabled"], f"{name} needs an explicit opt-in profile"
+
+
+def test_every_registered_pass_has_a_coverage_decision() -> None:
+    _assert_pass_inventory(registered_hir_passes())
+
+
+def test_coverage_guard_rejects_an_unaccounted_pass() -> None:
+    registry = registered_hir_passes()
+    registry["UnaccountedPass"] = {"default_enabled": True}
+    with pytest.raises(AssertionError, match="Pass coverage decision required"):
+        _assert_pass_inventory(registry)
+
+
+def test_joint_check_detects_wrong_correlations_with_correct_marginals() -> None:
+    correlated = np.tile(np.array([[0, 0], [1, 1]], dtype=np.uint8), (4096, 1))
+    anticorrelated = correlated.copy()
+    anticorrelated[:, 1] ^= 1
+    np.testing.assert_array_equal(correlated.mean(axis=0), anticorrelated.mean(axis=0))
+    assert_joint_distribution(correlated, [0.5, 0, 0, 0.5])
+    with pytest.raises(AssertionError):
+        assert_joint_distribution(anticorrelated, [0.5, 0, 0, 0.5])
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    [
+        "X_ERROR(0.1) 0",
+        "Y_ERROR(0.1) 0",
+        "Z_ERROR(0.1) 0",
+        "DEPOLARIZE1(0.1) 0",
+        "DEPOLARIZE2(0.1) 0 1",
+        "PAULI_CHANNEL_1(0.1,0,0) 0",
+        "CORRELATED_ERROR(0.1) X0",
+        "ELSE_CORRELATED_ERROR(0.1) X0",
+        "M 0",
+        "MPP X0",
+        "R 0",
+        "MR 0",
+        "CX rec[-1] 0",
+        "READOUT_NOISE(0.1) rec[-1]",
+        "LEVEL_TRANSITION[jump] 0",
+        "LEAKAGE(0.1) 0",
+        "LOSS(0.1) 0",
+        "REPEAT 2 {",
+        "}",
+        "UNKNOWN 0",
+        "H !0",
+        "H 0 garbage",
+        "H",
+        "CX 0",
+        "T(0.25) 0",
+        "R_Z 0",
+        "R_Z(nan) 0",
+        "U3(0.1) 0",
+        "R_PAULI(0.3) X0 Y1",
+        "R_PAULI(0.3) X0*Y0",
+        "R_PAULI(0.3) X0*Y1garbage",
+    ],
+)
+def test_noiseless_oracle_rejects_unsupported_input(instruction: str) -> None:
+    with pytest.raises(ValueError):
+        stim_to_qiskit_noiseless("H 0\n" + instruction)
+
+
+def test_noiseless_oracle_accepts_comments_and_ticks() -> None:
+    reference = unitary_reference("H 0\nT 0")
+    actual = unitary_reference("# preparation\nH 0 # comment\nTICK\nT 0\n")
+    np.testing.assert_allclose(actual, reference, atol=1e-12)
+
+
+def test_default_profile_uses_fresh_production_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    managers = []
+    received = []
+
+    def factory() -> Any:
+        manager = clifft.HirPassManager()
+        managers.append(manager)
+        return manager
+
+    monkeypatch.setattr(clifft, "default_hir_pass_manager", factory)
+    monkeypatch.setattr(
+        clifft, "compile", lambda source, *, hir_passes: received.append(hir_passes)
+    )
+    DEFAULT.compile("H 0")
+    DEFAULT.compile("H 0")
+    assert len(managers) == 2 and managers[0] is not managers[1]
+    assert received == managers
+
+
+@pytest.mark.parametrize("mode", CPU_SAMPLING_MODES, ids=lambda mode: mode.name)
+def test_sampling_mode_forwards_its_configuration(
+    mode: CpuSamplingMode, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = []
+    program = object()
+    monkeypatch.setattr(clifft, "sample", lambda *args, **kwargs: calls.append((args, kwargs)))
+    mode.sample(program, 8193, 1907)
+    assert calls == [((program, 8193), {"seed": 1907, "batch_size": mode.batch_size})]

--- a/tests/python/test_pass_docs.py
+++ b/tests/python/test_pass_docs.py
@@ -1,50 +1,12 @@
 """Ensure optimization pass docs stay aligned with the C++ pass registry."""
 
 import ast
-import re
-from pathlib import Path
 from typing import Any
 
-ROOT = Path(__file__).resolve().parent.parent.parent
-PASS_REGISTRY = ROOT / "src" / "clifft" / "optimizer" / "pass_registry.h"
+from utils_pass_registry import ROOT
+from utils_pass_registry import registered_hir_passes as _extract_cpp_passes
+
 DOCS_MACROS = ROOT / "docs" / "macros.py"
-
-
-def _extract_cpp_passes() -> dict[str, dict[str, object]]:
-    """Extract registered optimization pass metadata from pass_registry.h."""
-    text = PASS_REGISTRY.read_text()
-    match = re.search(
-        r"inline\s+const\s+PassInfo\s+kRegisteredPasses\[\]\s*=\s*\{(.*?)\};",
-        text,
-        re.DOTALL,
-    )
-    assert match, f"Could not find kRegisteredPasses in {PASS_REGISTRY}"
-
-    passes: dict[str, dict[str, object]] = {}
-    for entry_match in re.finditer(r"\{(.*?)\},", match.group(1), re.DOTALL):
-        entry = entry_match.group(1)
-        name_match = re.search(r'\.name\s*=\s*"([^"]+)"', entry)
-        default_match = re.search(r"\.default_enabled\s*=\s*(true|false)", entry)
-        record_order_match = re.search(
-            r"\.record_order\s*=\s*k(Preserves|Breaks)RecordOrder", entry
-        )
-        prefix_match = re.search(
-            r"\.instrument_prefix\s*=\s*k(Preserves|MayChange)InstrumentPrefix", entry
-        )
-
-        assert name_match, f"Registered pass entry missing .name: {entry}"
-        assert default_match, f"Registered pass entry missing .default_enabled: {entry}"
-        assert record_order_match, f"Registered pass entry missing .record_order: {entry}"
-        assert prefix_match, f"Registered pass entry missing .instrument_prefix: {entry}"
-
-        passes[name_match.group(1)] = {
-            "kind": "HIR",
-            "default_enabled": default_match.group(1) == "true",
-            "preserves_record_order": record_order_match.group(1) == "Preserves",
-            "preserves_instrument_prefix": prefix_match.group(1) == "Preserves",
-        }
-
-    return passes
 
 
 def _extract_docs_passes() -> dict[str, dict[str, Any]]:

--- a/tests/python/test_qiskit_aer.py
+++ b/tests/python/test_qiskit_aer.py
@@ -15,19 +15,22 @@ from conftest import (
     random_clifford_t_circuit,
     random_dense_clifford_t_circuit,
 )
-from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
+from utils_conformance import COMPILER_PROFILES, CompilerProfile, unitary_reference
+
+import clifft
 
 
 class _StatevectorBackendMixin:
-    """Run each independent oracle through both final-state implementations."""
+    """Run the existing oracle corpus through each declared compiler profile."""
 
     statevector: Callable[[str], npt.NDArray[np.complex128]]
 
-    @pytest.fixture(autouse=True)
-    def _select_statevector_backend(
-        self, statevector_from_circuit: Callable[[str], npt.NDArray[np.complex128]]
-    ) -> None:
-        self.statevector = statevector_from_circuit
+    @pytest.fixture(autouse=True, params=COMPILER_PROFILES, ids=lambda profile: profile.name)
+    def _select_statevector_backend(self, request: pytest.FixtureRequest) -> None:
+        profile: CompilerProfile = request.param
+        self.statevector = lambda source: np.asarray(
+            clifft.get_statevector(profile.compile(source))
+        )
 
 
 class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
@@ -37,48 +40,42 @@ class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
         """H|0> = |+> matches Qiskit."""
         circuit = "H 0"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_single_t(self) -> None:
         """H-T circuit matches Qiskit."""
         circuit = "H 0\nT 0"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_t_dagger(self) -> None:
         """H-T_DAG circuit matches Qiskit."""
         circuit = "H 0\nT_DAG 0"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_bell_plus_t(self) -> None:
         """Bell state + T gate matches Qiskit."""
         circuit = "H 0\nCX 0 1\nT 0"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_two_t_equals_s(self) -> None:
         """T*T = S identity matches Qiskit."""
         circuit = "H 0\nT 0\nT 0"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_four_t_equals_z(self) -> None:
         """T^4 = Z identity matches Qiskit."""
         circuit = "H 0\nT 0\nT 0\nT 0\nT 0"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     @pytest.mark.parametrize("num_qubits", [2, 3, 4, 5])
@@ -87,8 +84,7 @@ class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
         """Random Clifford+T circuits up to 5 qubits match Qiskit."""
         circuit = random_clifford_t_circuit(num_qubits, depth=15, seed=seed)
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv, msg=f"{num_qubits}q seed={seed}\n{circuit}")
 
     @pytest.mark.parametrize("seed", range(3))
@@ -97,8 +93,7 @@ class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
         for num_qubits in [6]:
             circuit = random_clifford_t_circuit(num_qubits, depth=20, seed=seed)
             clifft_sv = self.statevector(circuit)
-            qc = stim_to_qiskit_noiseless(circuit)
-            qiskit_sv = qiskit_statevector(qc)
+            qiskit_sv = unitary_reference(circuit)
             assert_statevectors_equiv(
                 clifft_sv, qiskit_sv, msg=f"{num_qubits}q seed={seed}\n{circuit}"
             )
@@ -120,32 +115,28 @@ class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
             ]
         )
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_ch_gate(self) -> None:
         """CH parser rewrite matches Qiskit."""
         circuit = "H 0\nCH 0 1"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_ccz_gate(self) -> None:
         """CCZ parser rewrite matches Qiskit."""
         circuit = "H 0\nH 1\nH 2\nCCZ 0 1 2"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_ccx_gate(self) -> None:
         """CCX parser rewrite matches Qiskit."""
         circuit = "H 0\nH 1\nCCX 0 1 2"
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
     def test_deep_t_circuit(self) -> None:
@@ -156,8 +147,7 @@ class TestQiskitStatevectorOracle(_StatevectorBackendMixin):
             lines.append("CX 0 1")
         circuit = "\n".join(lines)
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv)
 
 
@@ -174,8 +164,7 @@ class TestDenseCliffordTFuzzer(_StatevectorBackendMixin):
         """Dense Clifford+T circuits at 3-5 qubits match Qiskit."""
         circuit = random_dense_clifford_t_circuit(num_qubits, depth=30, seed=seed)
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(
             clifft_sv, qiskit_sv, msg=f"dense {num_qubits}q seed={seed}\n{circuit}"
         )
@@ -185,8 +174,7 @@ class TestDenseCliffordTFuzzer(_StatevectorBackendMixin):
         """Dense Clifford+T at 6 qubits match Qiskit."""
         circuit = random_dense_clifford_t_circuit(6, depth=40, seed=seed)
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv, msg=f"dense 6q seed={seed}")
 
     @pytest.mark.parametrize("seed", range(3))
@@ -194,8 +182,7 @@ class TestDenseCliffordTFuzzer(_StatevectorBackendMixin):
         """Deep circuits (depth=100) stress T-gate phase arithmetic."""
         circuit = random_dense_clifford_t_circuit(4, depth=100, seed=seed, two_qubit_prob=0.3)
         clifft_sv = self.statevector(circuit)
-        qc = stim_to_qiskit_noiseless(circuit)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(circuit)
         assert_statevectors_equiv(clifft_sv, qiskit_sv, msg=f"deep 4q seed={seed}")
 
 
@@ -206,8 +193,7 @@ class TestArbitraryRotations(_StatevectorBackendMixin):
         """Compile with Clifft and compare projective amplitudes to Qiskit."""
         clifft_sv = self.statevector(stim_text)
 
-        qc = stim_to_qiskit_noiseless(stim_text)
-        qiskit_sv = qiskit_statevector(qc)
+        qiskit_sv = unitary_reference(stim_text)
 
         assert_statevectors_equiv(
             clifft_sv,

--- a/tests/python/utils_conformance.py
+++ b/tests/python/utils_conformance.py
@@ -33,7 +33,8 @@ class CpuSamplingMode:
     batch_size: int | str
 
     def sample(self, program: Any, shots: int, seed: int) -> Any:
-        return clifft.sample(program, shots, seed=seed, batch_size=self.batch_size)
+        # Host-dependent worker counts can change automatic batch selection.
+        return clifft.sample(program, shots, seed=seed, threads=1, batch_size=self.batch_size)
 
 
 CPU_SAMPLING_MODES = (

--- a/tests/python/utils_conformance.py
+++ b/tests/python/utils_conformance.py
@@ -1,0 +1,78 @@
+"""Shared compiler configurations and independent sampling assertions."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+from utils_qiskit import qiskit_statevector, stim_to_qiskit_noiseless
+
+import clifft
+
+
+@dataclass(frozen=True)
+class CompilerProfile:
+    name: str
+    make_passes: Callable[[], Any]
+
+    def compile(self, source: str) -> Any:
+        # Pass instances may carry mutable state; never cache a pass manager.
+        return clifft.compile(source, hir_passes=self.make_passes())
+
+
+UNOPTIMIZED = CompilerProfile("unoptimized", lambda: None)
+DEFAULT = CompilerProfile("default", lambda: clifft.default_hir_pass_manager())
+COMPILER_PROFILES = (UNOPTIMIZED, DEFAULT)
+
+
+@dataclass(frozen=True)
+class CpuSamplingMode:
+    name: str
+    batch_size: int | str
+
+    def sample(self, program: Any, shots: int, seed: int) -> Any:
+        return clifft.sample(program, shots, seed=seed, batch_size=self.batch_size)
+
+
+CPU_SAMPLING_MODES = (
+    CpuSamplingMode("single-shot", 1),
+    CpuSamplingMode("packed-65", 65),
+    CpuSamplingMode("automatic", "auto"),
+)
+
+
+@lru_cache(maxsize=256)
+def unitary_reference(source: str) -> npt.NDArray[np.complex128]:
+    """Calculate once per source per worker, independently of compiler profiles."""
+    state = qiskit_statevector(stim_to_qiskit_noiseless(source))
+    state.setflags(write=False)
+    return state
+
+
+def assert_joint_distribution(measurements: npt.NDArray[np.uint8], expected: npt.ArrayLike) -> None:
+    """Compare a small complete record histogram, with a family-wise error bound."""
+    probabilities = np.asarray(expected, dtype=np.float64)
+    assert measurements.ndim == 2 and 0 < measurements.shape[0]
+    shots, width = measurements.shape
+    assert width <= 10, "joint enumeration is deliberately bounded to small records"
+    assert np.all((measurements == 0) | (measurements == 1))
+    assert probabilities.shape == (1 << width,)
+    assert np.all(np.isfinite(probabilities)) and np.all(probabilities >= 0)
+    np.testing.assert_allclose(probabilities.sum(), 1, atol=1e-12, rtol=0)
+
+    keys = measurements.astype(np.int64) @ (1 << np.arange(width))
+    counts = np.bincount(keys, minlength=len(probabilities))
+    frequencies = counts / shots
+    # Bernstein's bound, unioned over all bins, keeps the test meaningful
+    # without a normal approximation for rare outcomes. The 1e-7 budget is
+    # per comparison, not per bin; exact zero has a stricter check below.
+    log_bound = np.log(2 * len(probabilities) / 1e-7)
+    variance = probabilities * np.maximum(1 - probabilities, 0)
+    tolerance = np.sqrt(2 * variance * log_bound / shots) + 2 * log_bound / (3 * shots)
+    np.testing.assert_array_equal(counts[probabilities == 0], 0)
+    assert np.all(np.abs(frequencies - probabilities) <= tolerance), (
+        f"Joint distribution differs: expected={probabilities}, "
+        f"observed={frequencies}, tolerance={tolerance}"
+    )

--- a/tests/python/utils_pass_registry.py
+++ b/tests/python/utils_pass_registry.py
@@ -1,0 +1,44 @@
+"""Read the production pass inventory for documentation and coverage guards."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+PASS_REGISTRY = ROOT / "src" / "clifft" / "optimizer" / "pass_registry.h"
+
+
+def registered_hir_passes() -> dict[str, dict[str, object]]:
+    text = PASS_REGISTRY.read_text()
+    match = re.search(
+        r"inline\s+const\s+PassInfo\s+kRegisteredPasses\[\]\s*=\s*\{(.*?)\};",
+        text,
+        re.DOTALL,
+    )
+    assert match, f"Could not find kRegisteredPasses in {PASS_REGISTRY}"
+
+    passes: dict[str, dict[str, object]] = {}
+    for entry_match in re.finditer(r"\{(.*?)\},", match.group(1), re.DOTALL):
+        entry = entry_match.group(1)
+        name_match = re.search(r'\.name\s*=\s*"([^"]+)"', entry)
+        default_match = re.search(r"\.default_enabled\s*=\s*(true|false)", entry)
+        record_order_match = re.search(
+            r"\.record_order\s*=\s*k(Preserves|Breaks)RecordOrder", entry
+        )
+        prefix_match = re.search(
+            r"\.instrument_prefix\s*=\s*k(Preserves|MayChange)InstrumentPrefix", entry
+        )
+
+        assert name_match, f"Registered pass entry missing .name: {entry}"
+        assert default_match, f"Registered pass entry missing .default_enabled: {entry}"
+        assert record_order_match, f"Registered pass entry missing .record_order: {entry}"
+        assert prefix_match, f"Registered pass entry missing .instrument_prefix: {entry}"
+
+        passes[name_match.group(1)] = {
+            "kind": "HIR",
+            "default_enabled": default_match.group(1) == "true",
+            "preserves_record_order": record_order_match.group(1) == "Preserves",
+            "preserves_instrument_prefix": prefix_match.group(1) == "Preserves",
+        }
+
+    assert passes, f"No passes extracted from {PASS_REGISTRY}"
+    return passes

--- a/tests/python/utils_qiskit.py
+++ b/tests/python/utils_qiskit.py
@@ -8,12 +8,14 @@ Supported gates: H, S, S_DAG, T, T_DAG, X, Y, Z, CX, CY, CZ, CH, CCZ, CCX,
 M, MX, MY, R, RX, MR, MRX, R_X, R_Y, R_Z, U3, R_XX, R_YY, R_ZZ,
 R_PAULI.
 All rotation angles use half-turn units (alpha * pi = radians).
-Noise instructions and annotations (TICK, DETECTOR, etc.) are skipped.
+The legacy stim_to_qiskit converter skips noise and annotations. The noiseless
+oracle rejects nonunitary operations and unsupported syntax instead.
 """
 
 from __future__ import annotations
 
 import re
+from math import isfinite
 
 import numpy as np
 from qiskit import QuantumCircuit
@@ -76,9 +78,10 @@ def qiskit_statevector(qc: QuantumCircuit) -> np.ndarray:
 
 
 def stim_to_qiskit_noiseless(stim_text: str) -> QuantumCircuit:
-    """Convert a .stim circuit to Qiskit, stripping all measurements.
+    """Convert the supported unitary subset without dropping physical operations.
 
-    Useful for statevector comparison where measurements would collapse state.
+    Noise, measurements, resets, feedback, and unsupported syntax are errors:
+    silently removing them would make the oracle validate a different circuit.
 
     Args:
         stim_text: Circuit in .stim text format.
@@ -86,7 +89,7 @@ def stim_to_qiskit_noiseless(stim_text: str) -> QuantumCircuit:
     Returns:
         Qiskit QuantumCircuit with only unitary gates (no measurements).
     """
-    num_qubits = _find_num_qubits(stim_text)
+    num_qubits = _find_num_qubits(stim_text, unitary_only=True)
     qc = QuantumCircuit(num_qubits)
 
     for line in stim_text.strip().split("\n"):
@@ -94,15 +97,9 @@ def stim_to_qiskit_noiseless(stim_text: str) -> QuantumCircuit:
         if not line or line.startswith("#"):
             continue
 
-        gate, args, targets, pauli_targets = _parse_line(line)
+        gate, args, targets, pauli_targets = _parse_line(line, unitary_only=True)
         if gate is None:
             continue
-
-        if gate in ("M", "MX", "MY", "MR", "MRX", "MRY", "R", "RX", "RY"):
-            raise ValueError(
-                f"Gate '{gate}' not supported in noiseless statevector oracle. "
-                "Measurements and resets collapse state."
-            )
 
         _apply_gate(qc, gate, args, targets, pauli_targets, 0)
 
@@ -112,6 +109,18 @@ def stim_to_qiskit_noiseless(stim_text: str) -> QuantumCircuit:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+# Target group size and parameter count for the exact unitary translator.
+# R_PAULI accepts one product instead of groups of integer qubit targets.
+_UNITARY_ARITIES = {
+    **dict.fromkeys(("H", "S", "S_DAG", "T", "T_DAG", "X", "Y", "Z"), (1, 0)),
+    **dict.fromkeys(("CX", "CY", "CZ", "CH"), (2, 0)),
+    **dict.fromkeys(("CCX", "CCZ"), (3, 0)),
+    **dict.fromkeys(("R_X", "R_Y", "R_Z"), (1, 1)),
+    **dict.fromkeys(("U3", "U"), (1, 3)),
+    **dict.fromkeys(("R_XX", "RXX", "R_YY", "RYY", "R_ZZ", "RZZ"), (2, 1)),
+    "R_PAULI": (0, 1),
+}
 
 # Gates that are annotations/noise and should be skipped
 _SKIP_GATES = frozenset(
@@ -153,6 +162,8 @@ _GATE_LINE_RE = re.compile(
 
 def _parse_line(
     line: str,
+    *,
+    unitary_only: bool = False,
 ) -> tuple[str | None, list[float], list[int], list[tuple[str, int]]]:
     """Parse a single stim line into (gate, args, qubit_targets, pauli_targets).
 
@@ -169,6 +180,8 @@ def _parse_line(
 
     m = _GATE_LINE_RE.match(line)
     if not m:
+        if unitary_only:
+            raise ValueError(f"Unsupported syntax in noiseless statevector oracle: {line}")
         return None, [], [], []
 
     gate = m.group(1).upper()
@@ -178,6 +191,28 @@ def _parse_line(
     args: list[float] = []
     if args_str:
         args = [float(x.strip()) for x in args_str.split(",")]
+
+    if unitary_only:
+        if gate == "TICK" and not args and not rest:
+            return None, [], [], []
+        if gate not in _UNITARY_ARITIES:
+            raise ValueError(f"Gate '{gate}' not supported in noiseless statevector oracle")
+        group_size, num_args = _UNITARY_ARITIES[gate]
+        if len(args) != num_args or not all(isfinite(arg) for arg in args):
+            raise ValueError(f"Invalid arguments in noiseless statevector oracle: {line}")
+        tokens = rest.split()
+        if group_size == 0:
+            if len(tokens) != 1 or not re.fullmatch(r"[XYZ]\d+(?:\*[XYZ]\d+)*", tokens[0]):
+                raise ValueError(f"Expected one Pauli product in noiseless oracle: {line}")
+            qubits = [int(q) for q in re.findall(r"[XYZ](\d+)", tokens[0])]
+            if len(set(qubits)) != len(qubits):
+                raise ValueError(f"Repeated qubit in noiseless Pauli oracle: {line}")
+        elif (
+            not tokens
+            or len(tokens) % group_size
+            or any(not re.fullmatch(r"\d+", token) for token in tokens)
+        ):
+            raise ValueError(f"Invalid targets in noiseless statevector oracle: {line}")
 
     if gate in _SKIP_GATES:
         return None, [], [], []
@@ -201,7 +236,7 @@ def _parse_line(
     return gate, args, targets, pauli_targets
 
 
-def _find_num_qubits(stim_text: str) -> int:
+def _find_num_qubits(stim_text: str, *, unitary_only: bool = False) -> int:
     """Find the number of qubits (max qubit index + 1).
 
     Returns at least 1 even for empty circuits to avoid creating a
@@ -212,7 +247,7 @@ def _find_num_qubits(stim_text: str) -> int:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        gate, _, targets, pauli_targets = _parse_line(line)
+        gate, _, targets, pauli_targets = _parse_line(line, unitary_only=unitary_only)
         if gate is None:
             continue
         if targets:
@@ -316,8 +351,8 @@ def _apply_gate(
             clbit_idx += 1
     elif gate == "MX":
         # Stim MX semantics: H-measure-H preserves X-basis eigenstate.
-        # The post-measurement H is correct for matching Stim's state update,
-        # though stim_to_qiskit_noiseless() skips measurements entirely.
+        # The post-measurement H is correct for matching Stim's state update.
+        # The noiseless oracle rejects measurements instead.
         for q in targets:
             qc.h(q)
             qc.measure(q, clbit_idx)


### PR DESCRIPTION
Compiler and sampler changes can pass focused tests while missing integration regressions: the independent statevector corpus previously disabled HIR optimization, and aggregate sampling checks can miss incorrect correlations or a few unwritten tail rows. This PR runs reusable independent expectations through the production-default and unoptimized CPU configurations, with explicit transformation witnesses and exact output-boundary checks.

This is the first CPU foundation increment of #475. It changes tests and development documentation only.

## Coverage

| Coverage | Implementation and expectation |
|---|---|
| Existing Qiskit corpus | Preserve all 123 circuits/seeds/assertions under each of two compiler profiles: 246 cases. Compare phase-aligned amplitudes against Aer. The default profile calls the real factory with fresh pass instances. |
| Small shared sampling corpus | Five circuits cover fusion, squeezing, Bell correlations, mixed Pauli rotations, and a mirror. Check all terminal-record probabilities against Aer, then complete record histograms and detector/observable mappings: 10 exact checks and 30 sampling configurations. |
| CPU execution configurations | Single-shot, packed capacity 65, and automatic selection, each explicitly using one worker. References are cached by source/worker; compiled sampling programs are reused across modes. |
| Exact output boundaries | A separate analytic circuit has 65 measurement columns with nonzero bits on both sides of a word boundary and distinct detector/observable rows. Check every row at 63, 64, 65, 66, 129, 130, 131, and 2049 shots across both compiler profiles and all three modes: 48 configurations. |
| Actual transformations | Separate witnesses require peephole and squeeze effects. Removing either pass must fail its witness even when the circuit's semantics remain correct. |
| Compatibility and coverage declarations | Every registered pass needs a coverage decision. Noise/nonunitary removal passes are explicitly excluded from original-distribution equivalence. The noiseless translator rejects unsupported physical operations and malformed syntax instead of silently changing the input. |

No existing test cases or semantic assertions were removed. The original Qiskit collection was compared one-for-one with both new profiles after normalizing profile IDs. Consolidation is limited to shared registry reading and reference calculation; focused regressions and other oracle suites retain their purposes.

## Tests of the assertions

Committed negative controls verify that the suite detects:

- Either intended pass missing from the production-default factory.
- A zeroed final measurement, detector, or observable row in a partial batch.
- Wrong correlations with unchanged individual-bit marginals.
- Biased probabilities among legal outcomes, independently of the exact-zero support check.
- An unaccounted registered pass.

Run these controls with:

```bash
uv run --no-sync pytest tests/python/test_compiler_conformance.py -k 'rejects or detects' -q
```

These are targeted controls, not a comprehensive mutation score. The boundary circuit validates output extraction; the non-Clifford corpus supplies active-state semantics checks.

## Native execution evidence

The adapter test checks argument forwarding; native path execution was checked separately. With a Debug extension, GDB breakpoints on `Executor::run_shot()` and the ordinary `BatchExecutor::run_batch(...)` observed the following for the actual mixed-Pauli pytest case at 8193 shots:

| Compiler profile | Single-shot | Packed 65 | Automatic |
|---|---|---|---|
| Production default | Scalar only | Packed only | Packed only |
| Unoptimized | Scalar only | Packed only | Packed only |

All six pytest cases passed while traced. The development testing guide includes the build command, pytest selector, and breakpoint instructions for repeating this audit. Existing native policy/execution tests were also run. This is local execution evidence, not a claim about every automatic-selection branch or platform; no production instrumentation or new public API was introduced.

## Validation

- Release Python suite: **1,648 passed, 7 skipped**, also passing with `CLIFFT_FORCE_ISA=scalar`.
- Changed Python suites with a Debug extension: **385 passed**.
- Existing native packed/selection/thread-layout tests: **20 passed**.
- All **123 original Qiskit collection cases** verified present under **both** profiles.
- Repository-required pre-commit, including mypy: passed.
- GPU execution remains unvalidated by this PR; GPU-dependent tests are among the skips. No new C++ coverage build was performed.

Commands:

```bash
uv run --no-sync pytest tests/python/ -q -n 4
CLIFFT_FORCE_ISA=scalar uv run --no-sync pytest tests/python/ -q -n 4
uv run --no-sync pytest tests/python/test_compiler_conformance.py tests/python/test_qiskit_aer.py tests/python/test_pass_docs.py -q
cmake -S . -B build/native-tests -G Ninja -DCMAKE_BUILD_TYPE=Debug
cmake --build build/native-tests --parallel 8
ctest --test-dir build/native-tests --output-on-failure -R 'Packed|Threaded fixed-row|Sampling thread layouts' --parallel 4
uv run --frozen --only-group dev pre-commit run --all-files --show-diff-on-failure
```

### Runtime budget

Three interleaved main/changed full-suite runs on the same VM, Python 3.14.2, GCC 13 Release extension, four pytest workers, locked dependencies. Production sources are identical between revisions; the same extension was used for both suites.

| Median measurement | Main baseline | This PR |
|---|---:|---:|
| Process wall time | 8.902 s | 9.314 s |
| Total child CPU time | 27.309 s | 28.002 s |
| Passing cases | 1,390 | 1,648 |

The local increase is **0.412 s wall time (4.6%)** and **0.693 s CPU time (2.5%)**. Existing CI runs the full Python suite six times per PR, plus two wheel-suite runs on pushes to main. Multiplying the local deltas by the six PR runs gives approximately 2.5 summed runner-seconds and 4.2 CPU-seconds; this is cost accounting, not a prediction for the different CI hosts/builds. No CI jobs or timing assertions were added.

## Scope after this increment

#475 now defines a finite CPU foundation milestone: bounded noisy/mid-circuit joint coverage, actual opt-in scheduling adoption, explicit compatibility/negative controls, and a measured PR corpus plus scheduled CPU campaign. The noisy reference is the next priority. Sampling interfaces and GPU execution consume that foundation within their own feature series; hardware availability and wholesale test migration do not block this PR.

This corpus does not yet supply shared noisy/mid-circuit, postselection, retained-sampler, or GPU conformance. Existing focused tests remain in place. Review expectation provenance, strict translation, bit ordering, actual-path evidence, statistical sensitivity, and every proposed exclusion alongside the green test results.
