### PR TITLE
fix(executor): clear every symbol between shots after a resumed continuation

### DIFF
--- a/src/clifft/sampling/executor.cc
+++ b/src/clifft/sampling/executor.cc
@@ -216,13 +216,11 @@ ReplayResult Executor::replay_shot(std::span<const uint8_t> forced_records,
 
 void Executor::reset_shot() noexcept {
     state_.reset_parallel(intra_shot_workers_, intra_shot_min_active_width_);
-    // Validation guarantees that every mutable symbol and output is overwritten
-    // before use on a completed shot. Only nonfiring noise symbols need restoring.
-    for (uint32_t symbol : previous_presampled_ones_) {
-        assert(symbol < symbols_.size() && symbols_[symbol] == 1 &&
-               "tracked presampled symbols must be set");
-        symbols_[symbol] = 0;
-    }
+    // A continuation assigns symbols under its own numbering, so after a
+    // resumed shot a stale true value can sit at an index the root plan never
+    // overwrites before the next resume replays the prefix. Clear every
+    // symbol rather than only the tracked nonfiring noise symbols.
+    std::ranges::fill(symbols_, uint8_t{0});
     previous_presampled_ones_.clear();
     initialize_expression_registers(*plan_, 0);
     std::ranges::fill(forced_record_mask_, uint8_t{0});

--- a/tests/python/test_noncomp.py
+++ b/tests/python/test_noncomp.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from conftest import noncomp_classifier_matrix_with_column, noncomp_transition_matrix
+from conftest import (
+    binomial_tolerance,
+    noncomp_classifier_matrix_with_column,
+    noncomp_transition_matrix,
+)
 
 import clifft
 from clifft import noncomp
@@ -534,6 +538,34 @@ def test_loss_only_exact_damping_stays_at_stabilizer_cost(noncomp_sampling_api):
     assert (meas[lost] == 1).all()
     assert lost.any() and (~lost).any()
     assert abs(lost.mean() - 0.3) < 4 * (0.3 * 0.7 / 4000) ** 0.5
+
+
+def test_shots_after_a_resumed_continuation_keep_noise_statistics(noncomp_sampling_api):
+    """Every shot of a multi-shot call sees the same noise statistics.
+
+    A shot that traps resumes on a continuation whose symbol numbering
+    differs from the root plan's, so the next shot must start from cleared
+    symbols: a value left behind at an index the root plan treats as a
+    nonfiring noise symbol would otherwise be replayed as a fired error at
+    that shot's own resume. Qubit 2 never touches the lossy Bell pair, so its
+    readout flips exactly when an odd number of its two X_ERROR sites fire.
+    """
+    circuit = (
+        "H 0\nCX 0 1\nLOSS(0.5) 1\nX_ERROR(0.02) 2\nX_ERROR(0.02) 2\nLOSS(0.5) 0\n" "M 0\nM 1\nM 2"
+    )
+    cls = noncomp.Classifier([[1, 0, 1, 0, 1], [0, 1, 0, 1, 0]])  # a lost qubit reads 0
+    model = noncomp.Model(classifier=cls)
+    shots = 8000
+    r = noncomp_sampling_api(circuit, model, shots=shots, seed=23)
+    lost = r.final_status == LOST_KIND
+    assert lost[:, :2].any() and (~lost[:, :2]).any()
+    assert not lost[:, 2].any()
+    p_flip = 2 * 0.02 * 0.98
+    assert abs(r.measurements[:, 2].mean() - p_flip) < binomial_tolerance(p_flip, shots)
+    # Each Bell half reads 1 only when it survives and its partner's loss or
+    # the Bell correlation leaves it uniformly random: probability 1/4.
+    for qubit in (0, 1):
+        assert abs(r.measurements[:, qubit].mean() - 0.25) < binomial_tolerance(0.25, shots)
 
 
 def test_loss_on_many_coherent_qubits_compiles_flat(noncomp_sampling_api):

--- a/tests/python/test_noncomp_reset.py
+++ b/tests/python/test_noncomp_reset.py
@@ -1,0 +1,69 @@
+"""Noise and continuation histories must not change subsequent shots."""
+
+import numpy as np
+import pytest
+import stim
+from conftest import cross_binomial_tolerance
+
+from clifft import noncomp
+
+
+@pytest.mark.parametrize("annotation", ["LOSS", "LEAKAGE"])
+@pytest.mark.parametrize("damping", ["exact", "neglect"])
+@pytest.mark.parametrize(
+    "noise",
+    [
+        "X_ERROR(0.02) 2\nX_ERROR(0.02) 2\nX_ERROR(0.04) 3",
+        "DEPOLARIZE1(0.12) 2 3",
+        "DEPOLARIZE2(0.15) 2 3",
+        "PAULI_CHANNEL_1(0.02,0.03,0.04) 2 3",
+    ],
+    ids=["bit-flips", "depolarize-one", "depolarize-two", "categorical"],
+)
+def test_noisy_continuations_preserve_spectators_and_seeded_rows(annotation, damping, noise):
+    # Spectators never interact with the trapping Bell pair. Stim can therefore
+    # independently check their joint distribution even though it has no loss model.
+    circuit = "\n".join(
+        [
+            "H 0\nCX 0 1",
+            noise,
+            f"{annotation}(0.5) 1",
+            noise,
+            f"{annotation}(0.5) 0",
+            noise,
+            "M(0.03) 0 1 2 3",
+            "DETECTOR rec[-2]\nDETECTOR rec[-1]",
+            "OBSERVABLE_INCLUDE(0) rec[-2] rec[-1]",
+        ]
+    )
+    classifier = noncomp.Classifier([[1, 0, 1, 0, 0.3], [0, 1, 0, 1, 0.4], [0, 0, 0, 0, 0.3]])
+    model = noncomp.Model(classifier=classifier, damping=damping)
+    shots = 8192
+    serial = noncomp.sample(circuit, model, shots=shots, seed=23, threads=1)
+    parallel = noncomp.sample(circuit, model, shots=shots, seed=23, threads=3)
+    for field in ("measurements", "detectors", "observables", "final_status", "heralds"):
+        np.testing.assert_array_equal(
+            getattr(serial, field), getattr(parallel, field), err_msg=field
+        )
+
+    computational = serial.final_status == noncomp.QubitStatus.COMPUTATIONAL
+    for qubit in (0, 1):
+        assert computational[:, qubit].any()
+        assert (~computational[:, qubit]).any()
+    assert computational[:, :2].all(axis=1).any()
+    assert (~computational[:, :2]).all(axis=1).any()
+    assert computational[:, 2:].all()
+    np.testing.assert_array_equal(serial.detectors, serial.measurements[:, 2:])
+    np.testing.assert_array_equal(
+        serial.observables[:, 0], serial.measurements[:, 2] ^ serial.measurements[:, 3]
+    )
+
+    reference_circuit = stim.Circuit("\n".join([noise, noise, noise, "M(0.03) 2 3"]))
+    reference = reference_circuit.compile_sampler(seed=71).sample(shots)
+    expected = np.bincount(reference[:, 0] + 2 * reference[:, 1], minlength=4) / shots
+    actual = (
+        np.bincount(serial.measurements[:, 2] + 2 * serial.measurements[:, 3], minlength=4) / shots
+    )
+    for outcome in range(4):
+        pooled = float((actual[outcome] + expected[outcome]) / 2)
+        assert abs(actual[outcome] - expected[outcome]) < cross_binomial_tolerance(pooled, shots)

--- a/tests/test_sampling_executor.cc
+++ b/tests/test_sampling_executor.cc
@@ -4,6 +4,7 @@
 #include "clifft/sampling/planner.h"
 #include "clifft/sampling/sampler.h"
 #include "clifft/sampling/state_queries.h"
+#include "clifft/util/fault_sampling.h"
 #include "clifft/util/intra_shot_parallel.h"
 #include "clifft/util/noise_sampling.h"
 #include "clifft/util/numeric.h"
@@ -103,6 +104,28 @@ SamplingPlan dormant_trap_plan() {
 
 SamplingPlan plan_from(std::string_view circuit_text) {
     return clifft::sampling::plan_sampling(clifft::trace(clifft::parse(circuit_text)));
+}
+
+void reseed_for_shot(Executor& executor, uint32_t shot) {
+    const auto words = clifft::derive_state(clifft::seed_root_from_seed(23), shot,
+                                            clifft::kSamplingExecutorDomain);
+    executor.reseed_full(words[0], words[1], words[2], words[3]);
+}
+
+void require_same_completed_shot(const Executor& reused, const Executor& fresh) {
+    REQUIRE_FALSE(reused.pending_trap().has_value());
+    REQUIRE_FALSE(fresh.pending_trap().has_value());
+    REQUIRE_FALSE(reused.discarded());
+    REQUIRE_FALSE(fresh.discarded());
+    REQUIRE(std::ranges::equal(reused.visible_records(), fresh.visible_records()));
+    REQUIRE(std::ranges::equal(reused.hidden_records(), fresh.hidden_records()));
+    REQUIRE(std::ranges::equal(reused.symbols(), fresh.symbols()));
+    REQUIRE(std::ranges::equal(reused.detectors(), fresh.detectors()));
+    REQUIRE(std::ranges::equal(reused.observables(), fresh.observables()));
+    REQUIRE(std::ranges::equal(reused.exp_vals(), fresh.exp_vals()));
+    REQUIRE(reused.state().active_width() == fresh.state().active_width());
+    REQUIRE(std::ranges::equal(reused.state().real(), fresh.state().real()));
+    REQUIRE(std::ranges::equal(reused.state().imag(), fresh.state().imag()));
 }
 
 SamplingPlan categorical_noise_plan() {
@@ -608,6 +631,76 @@ TEST_CASE("Sampling expression registers preserve noisy postselection") {
     REQUIRE(std::ranges::all_of(result.observables, [](uint8_t value) { return value == 0; }));
 }
 
+TEST_CASE("Sampling reused executors match fresh shots after early exits") {
+    const auto hir =
+        clifft::trace(clifft::parse("M 2\nX_ERROR(0.5) 0\nM 0\nDETECTOR rec[-1]\n"
+                                    "H 1\nT 1\nM 1\nOBSERVABLE_INCLUDE(0) rec[-1]\nEXP_VAL Z1"));
+    const std::array<uint8_t, 1> postselection{1};
+    const ExecutablePlan plan(
+        clifft::sampling::plan_sampling(hir, {.postselection_mask = postselection}));
+    const std::array<uint8_t, 1> no_noise{0};
+    const std::array<uint8_t, 1> noise{1};
+    const std::array<double, 1> probabilities{0.5};
+
+    for (const std::string_view history :
+         {"postselection", "unreachable replay", "conditioned postselection"}) {
+        for (uint32_t shot = 0; shot < 16; ++shot) {
+            for (const std::string_view mode : {"sampled", "presampled", "replay", "conditioned"}) {
+                CAPTURE(history, shot, mode);
+                Executor reused(plan);
+                reused.run_shot(no_noise);
+                REQUIRE_FALSE(reused.discarded());
+
+                if (history == "postselection") {
+                    reused.run_shot(noise);
+                    REQUIRE(reused.discarded());
+                    REQUIRE(reused.visible_records()[1] == 1);
+                } else if (history == "unreachable replay") {
+                    const ReplayResult result =
+                        reused.replay_shot(std::array<uint8_t, 3>{1, 0, 0}, noise);
+                    REQUIRE_FALSE(result.reachable);
+                    REQUIRE(reused.visible_records()[0] == 0);
+                } else {
+                    clifft::KFaultSampler faults(probabilities, 1);
+                    reused.run_shot(faults);
+                    REQUIRE(reused.discarded());
+                }
+
+                Executor fresh(plan);
+                reseed_for_shot(reused, shot);
+                reseed_for_shot(fresh, shot);
+                if (mode == "sampled") {
+                    reused.run_shot();
+                    fresh.run_shot();
+                } else if (mode == "presampled") {
+                    reused.run_shot(no_noise);
+                    fresh.run_shot(no_noise);
+                } else if (mode == "replay") {
+                    const std::array<uint8_t, 3> records{0, 0, static_cast<uint8_t>(shot % 2)};
+                    const auto actual = reused.replay_shot(records, no_noise);
+                    const auto expected = fresh.replay_shot(records, no_noise);
+                    REQUIRE(actual.reachable);
+                    REQUIRE(expected.reachable);
+                    REQUIRE(actual.log_probability == expected.log_probability);
+                } else {
+                    clifft::KFaultSampler reused_faults(probabilities, 0);
+                    clifft::KFaultSampler fresh_faults(probabilities, 0);
+                    reused.run_shot(reused_faults);
+                    fresh.run_shot(fresh_faults);
+                }
+                REQUIRE(reused.discarded() == fresh.discarded());
+                if (fresh.discarded()) {
+                    // The suffix of a discarded shot is intentionally not observable.
+                    REQUIRE(std::ranges::equal(reused.visible_records().first(2),
+                                               fresh.visible_records().first(2)));
+                } else {
+                    require_same_completed_shot(reused, fresh);
+                }
+            }
+        }
+    }
+}
+
 TEST_CASE("Sampling replay applies active measurement dust policy") {
     SECTION("dust on the one branch") {
         const ExecutablePlan dusty(active_then_dormant_plan(1e-10));
@@ -1097,6 +1190,141 @@ TEST_CASE("Sampling continuation reconstructs expressions from true prefix symbo
     executor.resume(executable);
     REQUIRE_FALSE(executor.pending_trap().has_value());
     REQUIRE(executor.visible_records()[0] == 1);
+}
+
+TEST_CASE("Sampling reused executors match fresh shots after continuation renumbering") {
+    SamplingPlan root_plan;
+    root_plan.num_qubits = 2;
+    root_plan.num_visible_records = 1;
+    root_plan.symbols = {SymbolKind::Presampled};
+    root_plan.presampled_noise_sites = {PresampledNoiseSite{0.25, {{SymbolId{0}, 0.25}}}};
+    root_plan.instrument_distributions = {InstrumentDistribution{{0.5, 0.5}, {}},
+                                          InstrumentDistribution{{1.0, 1.0}, {}}};
+    root_plan.actions = {
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{
+                InstrumentSiteId{0}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{0}, 0, 0}},
+        PlannedAction{
+            0, 0,
+            ApplyInstrument{
+                InstrumentSiteId{1}, InstrumentMode::DormantTrap, {}, AffineBool{}, std::nullopt}},
+        PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{1}, 1, 1}},
+        PlannedAction{0, 0, RecordClassical{AffineBool::symbol(SymbolId{0}), RecordSlot{0}}},
+    };
+
+    // Only the suffix changes identity: its noise slot becomes a true derived
+    // symbol. A later shot that skips the first trap must restore the noise baseline.
+    SamplingPlan changed_plan = root_plan;
+    changed_plan.symbols[0] = SymbolKind::Derived;
+    changed_plan.presampled_noise_sites.clear();
+    changed_plan.actions[3] = PlannedAction{0, 0, InstrumentBoundary{InstrumentSiteId{1}, 0, 1}};
+    changed_plan.actions.insert(changed_plan.actions.begin() + 2,
+                                PlannedAction{0, 0, DefineSymbol{SymbolId{0}, AffineBool(true)}});
+    const ExecutablePlan root(root_plan);
+    const ExecutablePlan changed(changed_plan);
+
+    auto finish_shot = [&](Executor& executor) {
+        executor.run_shot();
+        REQUIRE(executor.pending_trap().has_value());
+        const bool renumbered = index(executor.pending_trap()->site) == 0;
+        if (renumbered) {
+            executor.resume(changed);
+            REQUIRE(executor.pending_trap().has_value());
+            REQUIRE(index(executor.pending_trap()->site) == 1);
+        }
+        executor.resume(renumbered ? changed : root);
+        return renumbered;
+    };
+
+    Executor reused(root);
+    bool previous_renumbered = false;
+    bool saw_nonfiring_noise_after_renumbering = false;
+    for (uint32_t shot = 0; shot < 64; ++shot) {
+        CAPTURE(shot);
+        Executor fresh(root);
+        reseed_for_shot(reused, shot);
+        reseed_for_shot(fresh, shot);
+        const bool expected_renumbered = finish_shot(fresh);
+        const bool actual_renumbered = finish_shot(reused);
+        REQUIRE(actual_renumbered == expected_renumbered);
+        saw_nonfiring_noise_after_renumbering |=
+            previous_renumbered && !expected_renumbered && fresh.visible_records()[0] == 0;
+        require_same_completed_shot(reused, fresh);
+        previous_renumbered = actual_renumbered;
+        reused.return_to_root_plan();
+    }
+    REQUIRE(saw_nonfiring_noise_after_renumbering);
+}
+
+TEST_CASE("Sampling reused executors match fresh shots after continuation storage grows") {
+    SamplingPlan root_plan = dormant_trap_plan();
+    root_plan.num_qubits = 4;
+    root_plan.num_visible_records = 1;
+    root_plan.num_exp_vals = 1;
+    root_plan.actions.push_back(PlannedAction{0, 0, RecordClassical{AffineBool{}, RecordSlot{0}}});
+    root_plan.actions.push_back(PlannedAction{
+        0, 0,
+        WriteExpectationValue{ActiveExpectation{ActivePauli{}, AffineBool{}}, ExpValSlot{0}}});
+
+    auto continuation_plan = [&](uint32_t width) {
+        SamplingPlan plan = root_plan;
+        plan.actions.resize(2);
+        plan.peak_active_width = width;
+        plan.num_hidden_records = 1;
+        plan.symbols = {SymbolKind::Unused, SymbolKind::Branch, SymbolKind::Branch};
+        plan.actions.push_back(PlannedAction{
+            0, 0,
+            MeasureDormantRandom{3, SymbolId{1}, AffineBool::symbol(SymbolId{1}), RecordSlot{1}}});
+        for (uint32_t active = 0; active < width; ++active) {
+            plan.actions.push_back(
+                PlannedAction{active, active + 1, PromoteDormantRotation{0.25, AffineBool{}}});
+        }
+        plan.actions.push_back(PlannedAction{
+            width, width - 1,
+            MeasureActivePauli{{1, 0},
+                               0,
+                               SymbolId{2},
+                               AffineBool::symbol(SymbolId{2}) ^ AffineBool::symbol(SymbolId{1}),
+                               RecordSlot{0}}});
+        plan.actions.push_back(PlannedAction{
+            width - 1, width - 1,
+            WriteExpectationValue{
+                ActiveExpectation{ActivePauli{0, width > 1 ? uint64_t{1} : uint64_t{0}},
+                                  AffineBool::symbol(SymbolId{1})},
+                ExpValSlot{0}}});
+        return plan;
+    };
+    const ExecutablePlan root(root_plan);
+    const ExecutablePlan wide(continuation_plan(3));
+    const ExecutablePlan narrow(continuation_plan(1));
+    Executor reused(root);
+    for (uint32_t shot = 0; shot < 12; ++shot) {
+        CAPTURE(shot);
+        Executor fresh(root);
+        reseed_for_shot(reused, shot);
+        reseed_for_shot(fresh, shot);
+        reused.run_shot();
+        fresh.run_shot();
+        REQUIRE(reused.pending_trap().has_value());
+        REQUIRE(fresh.pending_trap().has_value());
+        REQUIRE(reused.state().active_width() == 0);
+        REQUIRE(reused.hidden_records().empty());
+        const ExecutablePlan& continuation = shot % 2 == 0 ? wide : narrow;
+        const auto forced =
+            shot % 3 == 2
+                ? std::nullopt
+                : std::make_optional(ForcedTraceOut{RecordSlot{1}, static_cast<uint8_t>(shot % 3)});
+        reused.resume(continuation, forced);
+        fresh.resume(continuation, forced);
+        require_same_completed_shot(reused, fresh);
+        if (forced.has_value()) {
+            REQUIRE(reused.hidden_records()[0] == forced->source);
+        }
+        REQUIRE(reused.state().capacity() == 8);
+        reused.return_to_root_plan();
+    }
 }
 
 TEST_CASE("Sampling continuation consumes a forced hidden source record") {


### PR DESCRIPTION
## Summary

`noncomp.sample` could bias every shot after the first in a multi-shot call when the circuit has Pauli noise and a shot traps into a continuation (loss or leakage). A lossy Bell pair next to an untouched third qubit carrying two `X_ERROR(0.02)` sites read that qubit as 1 about 15% of the time over an 8000-shot call instead of the expected 3.9%; single-shot calls were correct.

## Cause

`Executor::reset_shot` restored only the tracked nonfiring noise symbols, on the premise that every other symbol is overwritten before use within one plan. A continuation assigns symbols under its own numbering, so after a resumed shot a stale true value can remain at an index that the root plan treats as a nonfiring presampled noise symbol and never rewrites. The next `resume()` replays every true prefix symbol into the continuation's expression registers, so the stale value acted as a fired noise event.

## Fix

Clear every symbol in `reset_shot`. This is O(number of symbols) per shot and not measurable against the per-shot work of a trapping trajectory.

## Test

`test_shots_after_a_resumed_continuation_keep_noise_statistics` samples the circuit above for 8000 shots in one call and checks the third qubit's readout rate against the odd-flip probability at 5 sigma, plus the 1/4 readout rate of each Bell half. It fails on the previous executor (deviation 0.11 against a tolerance of 0.011) and passes with the fix. The rest of `test_noncomp*` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
